### PR TITLE
Auto-inject top-level `task` into `effective_ingredients` in `_run_dispatch`

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -313,6 +313,8 @@ async def _run_dispatch(
         )
 
     effective_ingredients = ingredients or {}
+    if "task" in full_recipe.ingredients and "task" not in effective_ingredients:
+        effective_ingredients = {"task": task, **effective_ingredients}
     if effective_ingredients:
         unknown = set(effective_ingredients.keys()) - set(full_recipe.ingredients.keys())
         if unknown:

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -477,3 +477,71 @@ class TestMissingRequiredIngredient:
 
         result = await _run(tool_ctx, ingredients={})
         assert result.get("error") != "fleet_missing_ingredient"
+
+    @pytest.mark.anyio
+    async def test_task_auto_injected_from_top_level_param(self, tool_ctx, monkeypatch):
+        """Top-level task param auto-injects into effective_ingredients for recipes declaring task."""
+        _setup_dispatch_with_ingredients(
+            tool_ctx, monkeypatch, {"task": {"required": True, "default": None}}
+        )
+
+        result = await _run(tool_ctx, ingredients={})
+        assert result.get("error") != "fleet_missing_ingredient"
+
+    @pytest.mark.anyio
+    async def test_explicit_ingredient_task_overrides_top_level(self, tool_ctx, monkeypatch):
+        """Explicit ingredients['task'] takes precedence over top-level task param."""
+        _setup_dispatch_with_ingredients(
+            tool_ctx, monkeypatch, {"task": {"required": True, "default": None}}
+        )
+
+        captured = {}
+
+        def _capture_prompt_builder(**kwargs):
+            captured.update(kwargs)
+            return "prompt"
+
+        from autoskillit.fleet._api import execute_dispatch
+
+        raw = await execute_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="top-level-value",
+            ingredients={"task": "override-value"},
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=_capture_prompt_builder,
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+
+        assert captured["ingredients"]["task"] == "override-value"
+
+    @pytest.mark.anyio
+    async def test_task_not_injected_when_not_declared_ingredient(self, tool_ctx, monkeypatch):
+        """Top-level task is NOT injected when recipe has no 'task' ingredient key."""
+        _setup_dispatch_with_ingredients(
+            tool_ctx, monkeypatch, {"other_key": {"required": False, "default": "x"}}
+        )
+
+        captured = {}
+
+        def _capture_prompt_builder(**kwargs):
+            captured.update(kwargs)
+            return "prompt"
+
+        from autoskillit.fleet._api import execute_dispatch
+
+        raw = await execute_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="some-task",
+            ingredients={},
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=_capture_prompt_builder,
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+
+        assert "task" not in captured["ingredients"]


### PR DESCRIPTION
## Summary

`dispatch_food_truck` accepts `task` as a required top-level MCP parameter and passes it through to `_run_dispatch`. However, some recipes (e.g., `implementation.yaml`) also declare `task` as a required ingredient in their YAML. The missing-required-ingredients validation in `_run_dispatch` checks `effective_ingredients` for all required recipe ingredients — but `task` is never copied from the top-level parameter into `effective_ingredients`. This forces callers to redundantly pass `task` in both places or receive a `fleet_missing_ingredient` error.

The fix: after building `effective_ingredients` (line 315 of `fleet/_api.py`) and before the unknown-key/missing-required validation gates, auto-inject the top-level `task` value into `effective_ingredients` when the recipe declares `task` as an ingredient and it is not already present in the caller-supplied `ingredients` dict.

## Requirements

### DISPATCH

**REQ-DISPATCH-001:** When `_run_dispatch` builds `effective_ingredients`, the top-level `task` parameter must be injected into `effective_ingredients` if the recipe declares `task` as an ingredient key and `task` is not already present in the caller-supplied `ingredients` dict.

**REQ-DISPATCH-002:** If the caller explicitly provides `task` inside the `ingredients` dict, that value must take precedence over the top-level `task` parameter (no override of explicit caller intent).

**REQ-DISPATCH-003:** The auto-injection must occur before the missing-required-ingredients validation at `_run_dispatch:296-308`, so that `task` is present in `effective_ingredients` when the check runs.

### TEST

**REQ-TEST-001:** A test must verify that calling `dispatch_food_truck` with `task` as a top-level parameter (and not in `ingredients`) does not produce a `fleet_missing_ingredient` error for recipes that declare `task` as a required ingredient.

**REQ-TEST-002:** A test must verify that an explicit `ingredients={"task": "override"}` value takes precedence over the top-level `task` parameter in the built prompt's ingredient section.

## Conflict Resolution Table

## Changed Files

### Modified (●):

- `src/autoskillit/fleet/_api.py`
- `tests/fleet/test_dispatch_failure_semantics.py`

Closes #1976

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-124316-210165/.autoskillit/temp/make-plan/auto_inject_task_into_effective_ingredients_plan_2026-05-06_124500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.8k | 8.6k | 945.9k | 71.3k | 95 | 48.6k | 4m 49s |
| verify | claude-opus-4-6 | 1 | 29 | 12.9k | 454.5k | 58.9k | 46 | 45.8k | 6m 59s |
| implement | MiniMax-M2.7-highspeed | 1 | 296.7k | 4.5k | 622.2k | 29.8k | 43 | 16.0k | 1m 55s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 77.2k | 3.9k | 208.3k | 29.8k | 19 | 42.1k | 1m 25s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 49.8k | 1.9k | 205.5k | 29.8k | 18 | 15.0k | 44s |
| review_pr | claude-opus-4-6 | 1 | 37 | 7.4k | 342.2k | 43.9k | 25 | 31.0k | 2m 16s |
| **Total** | | | 426.5k | 39.2k | 2.8M | 71.3k | | 198.5k | 18m 10s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 70 | 8888.3 | 228.9 | 64.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **70** | 39694.1 | 2835.9 | 559.4 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 2.8k | 8.6k | 945.9k | 48.6k | 4m 49s |
| claude-opus-4-6 | 1 | 29 | 12.9k | 454.5k | 45.8k | 6m 59s |
| MiniMax-M2.7-highspeed | 3 | 423.6k | 10.3k | 1.0M | 73.1k | 4m 5s |