### PR TITLE
Add RecipeKind.FOOD_TRUCK

### DIFF
--- a/src/autoskillit/cli/session/_order.py
+++ b/src/autoskillit/cli/session/_order.py
@@ -108,6 +108,7 @@ def order(
         When True, attempt to restore a previous session.
     """
     from autoskillit.recipe import (
+        NON_INTERACTIVE_KINDS,
         find_recipe_by_name,
         list_recipes,
         load_recipe,
@@ -150,7 +151,6 @@ def order(
         from autoskillit.cli._prompts import _build_open_kitchen_prompt
         from autoskillit.cli.ui._menu import SLOT_ZERO_SELECTED, run_selection_menu
         from autoskillit.recipe import GROUP_LABELS, group_rank
-        from autoskillit.recipe.schema import NON_INTERACTIVE_KINDS  # noqa: PLC0415
 
         available = list_recipes(
             Path.cwd(),
@@ -193,8 +193,6 @@ def order(
 
     _match = find_recipe_by_name(recipe, Path.cwd())
     if _match is None:
-        from autoskillit.recipe.schema import NON_INTERACTIVE_KINDS  # noqa: PLC0415
-
         available = list_recipes(
             Path.cwd(),
             exclude_kinds=NON_INTERACTIVE_KINDS,

--- a/src/autoskillit/cli/session/_order.py
+++ b/src/autoskillit/cli/session/_order.py
@@ -108,7 +108,6 @@ def order(
         When True, attempt to restore a previous session.
     """
     from autoskillit.recipe import (
-        RecipeKind,
         find_recipe_by_name,
         list_recipes,
         load_recipe,
@@ -151,10 +150,11 @@ def order(
         from autoskillit.cli._prompts import _build_open_kitchen_prompt
         from autoskillit.cli.ui._menu import SLOT_ZERO_SELECTED, run_selection_menu
         from autoskillit.recipe import GROUP_LABELS, group_rank
+        from autoskillit.recipe.schema import NON_INTERACTIVE_KINDS  # noqa: PLC0415
 
         available = list_recipes(
             Path.cwd(),
-            exclude_kinds=frozenset({RecipeKind.CAMPAIGN, RecipeKind.FOOD_TRUCK}),
+            exclude_kinds=NON_INTERACTIVE_KINDS,
         ).items
         if not available:
             print("No recipes found. Run 'autoskillit recipes list' to check.")
@@ -193,9 +193,11 @@ def order(
 
     _match = find_recipe_by_name(recipe, Path.cwd())
     if _match is None:
+        from autoskillit.recipe.schema import NON_INTERACTIVE_KINDS  # noqa: PLC0415
+
         available = list_recipes(
             Path.cwd(),
-            exclude_kinds=frozenset({RecipeKind.CAMPAIGN, RecipeKind.FOOD_TRUCK}),
+            exclude_kinds=NON_INTERACTIVE_KINDS,
         ).items
         print(f"Recipe not found: '{recipe}'")
         if available:

--- a/src/autoskillit/cli/session/_order.py
+++ b/src/autoskillit/cli/session/_order.py
@@ -108,6 +108,7 @@ def order(
         When True, attempt to restore a previous session.
     """
     from autoskillit.recipe import (
+        RecipeKind,
         find_recipe_by_name,
         list_recipes,
         load_recipe,
@@ -151,7 +152,10 @@ def order(
         from autoskillit.cli.ui._menu import SLOT_ZERO_SELECTED, run_selection_menu
         from autoskillit.recipe import GROUP_LABELS, group_rank
 
-        available = list_recipes(Path.cwd()).items
+        available = list_recipes(
+            Path.cwd(),
+            exclude_kinds=frozenset({RecipeKind.CAMPAIGN, RecipeKind.FOOD_TRUCK}),
+        ).items
         if not available:
             print("No recipes found. Run 'autoskillit recipes list' to check.")
             sys.exit(1)
@@ -189,7 +193,10 @@ def order(
 
     _match = find_recipe_by_name(recipe, Path.cwd())
     if _match is None:
-        available = list_recipes(Path.cwd()).items
+        available = list_recipes(
+            Path.cwd(),
+            exclude_kinds=frozenset({RecipeKind.CAMPAIGN, RecipeKind.FOOD_TRUCK}),
+        ).items
         print(f"Recipe not found: '{recipe}'")
         if available:
             print("Available recipes:")

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -305,11 +305,15 @@ async def _run_dispatch(
             f"Recipe '{recipe}' could not be loaded: {exc}",
         )
 
-    if full_recipe.kind != "standard":
+    from autoskillit.recipe.schema import RecipeKind  # noqa: PLC0415
+
+    _DISPATCHABLE_KINDS = frozenset({RecipeKind.STANDARD, RecipeKind.FOOD_TRUCK})
+
+    if full_recipe.kind not in _DISPATCHABLE_KINDS:
         return fleet_error(
             FleetErrorCode.FLEET_INVALID_RECIPE_KIND,
             f"Recipe '{recipe}' has kind '{full_recipe.kind}'. "
-            "Only standard recipes can be dispatched as food trucks.",
+            "Only standard and food-truck recipes can be dispatched.",
         )
 
     effective_ingredients = ingredients or {}

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -305,9 +305,7 @@ async def _run_dispatch(
             f"Recipe '{recipe}' could not be loaded: {exc}",
         )
 
-    from autoskillit.recipe.schema import RecipeKind  # noqa: PLC0415
-
-    _DISPATCHABLE_KINDS = frozenset({RecipeKind.STANDARD, RecipeKind.FOOD_TRUCK})
+    _DISPATCHABLE_KINDS = frozenset({"standard", "food-truck"})
 
     if full_recipe.kind not in _DISPATCHABLE_KINDS:
         return fleet_error(

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -96,6 +96,7 @@ from autoskillit.recipe.rules import rules_contracts as _rules_contracts  # noqa
 from autoskillit.recipe.rules import rules_dataflow as _rules_dataflow  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_features as _rules_features  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_fixing as _rules_fixing  # noqa: E402 F401
+from autoskillit.recipe.rules import rules_food_truck as _rules_food_truck  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_graph as _rules_graph  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_inline_script as _rules_inline_script  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_inputs as _rules_inputs  # noqa: E402 F401

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -115,6 +115,7 @@ from autoskillit.recipe.rules import rules_worktree as _rules_worktree  # noqa: 
 from autoskillit.recipe.schema import (  # noqa: E402
     AUTOSKILLIT_VERSION_KEY,
     CAMPAIGN_REF_RE,
+    NON_INTERACTIVE_KINDS,
     CampaignDispatch,
     DataFlowReport,
     Recipe,
@@ -218,6 +219,7 @@ __all__ = [
     "check_rerun_detection",
     "find_prior_runs",
     "CampaignDispatch",
+    "NON_INTERACTIVE_KINDS",
     "RecipeKind",
     "find_campaign_by_name",
     "list_campaign_recipes",

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -165,14 +165,12 @@ def list_all(
         Includes "errors" key when recipes fail to parse.
     """
     from autoskillit.core import is_feature_enabled  # noqa: PLC0415
-    from autoskillit.recipe.schema import RecipeKind  # noqa: PLC0415
+    from autoskillit.recipe.schema import NON_INTERACTIVE_KINDS  # noqa: PLC0415
 
     _pdir = project_dir if project_dir is not None else Path.cwd()
     _features = features or {}
     fleet_enabled = is_feature_enabled("fleet", _features)
-    exclude_kinds = (
-        frozenset() if fleet_enabled else frozenset({RecipeKind.CAMPAIGN, RecipeKind.FOOD_TRUCK})
-    )
+    exclude_kinds = frozenset() if fleet_enabled else NON_INTERACTIVE_KINDS
     result = list_recipes(_pdir, exclude_kinds=exclude_kinds)
     return format_recipe_list_response(result)
 

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -170,7 +170,9 @@ def list_all(
     _pdir = project_dir if project_dir is not None else Path.cwd()
     _features = features or {}
     fleet_enabled = is_feature_enabled("fleet", _features)
-    exclude_kinds = frozenset() if fleet_enabled else frozenset({RecipeKind.CAMPAIGN})
+    exclude_kinds = (
+        frozenset() if fleet_enabled else frozenset({RecipeKind.CAMPAIGN, RecipeKind.FOOD_TRUCK})
+    )
     result = list_recipes(_pdir, exclude_kinds=exclude_kinds)
     return format_recipe_list_response(result)
 

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (26 rule files).
+Semantic validation rule modules for recipe analysis (27 rule files).
 
 ## Files
 
@@ -17,6 +17,7 @@ Semantic validation rule modules for recipe analysis (26 rule files).
 | `rules_contracts.py` | Skill contract completeness rules |
 | `rules_dataflow.py` | Dataflow analysis: pipeline-forbidden tool usage, output chaining |
 | `rules_features.py` | Feature-gated tool/skill reference validation |
+| `rules_food_truck.py` | Food-truck recipe validation: sentinel stop step requirement |
 | `rules_fixing.py` | Conditional-write skill must gate on declared verdict output |
 | `rules_graph.py` | Graph/routing analysis rules |
 | `rules_inline_script.py` | Detects inline shell scripts in `run_cmd` cmd fields |
@@ -36,4 +37,4 @@ Semantic validation rule modules for recipe analysis (26 rule files).
 
 ## Architecture Notes
 
-Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 26 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.
+Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 27 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.

--- a/src/autoskillit/recipe/rules/rules_food_truck.py
+++ b/src/autoskillit/recipe/rules/rules_food_truck.py
@@ -1,0 +1,32 @@
+"""Semantic validation rules for food-truck recipes."""
+
+from __future__ import annotations
+
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+from autoskillit.recipe.schema import RecipeKind
+
+
+@semantic_rule(
+    name="food-truck-has-sentinel-stop",
+    description="Food-truck recipes must have a stop step referencing L3 sentinel",
+    severity=Severity.WARNING,
+)
+def _check_food_truck_has_sentinel_stop(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.FOOD_TRUCK:
+        return []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.action == "stop" and step.message and "sentinel" in step.message.lower():
+            return []
+    return [
+        RuleFinding(
+            rule="food-truck-has-sentinel-stop",
+            severity=Severity.WARNING,
+            step_name="(top-level)",
+            message=(
+                "Food-truck recipe has no stop step referencing L3 sentinel. "
+                "Food trucks must emit a sentinel JSON block on completion."
+            ),
+        )
+    ]

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -20,6 +20,7 @@ CAMPAIGN_REF_RE: Final = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
 class RecipeKind(StrEnum):
     STANDARD = "standard"
     CAMPAIGN = "campaign"
+    FOOD_TRUCK = "food-truck"
 
 
 @dataclass

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -23,6 +23,11 @@ class RecipeKind(StrEnum):
     FOOD_TRUCK = "food-truck"
 
 
+NON_INTERACTIVE_KINDS: Final[frozenset[RecipeKind]] = frozenset(
+    {RecipeKind.CAMPAIGN, RecipeKind.FOOD_TRUCK}
+)
+
+
 @dataclass
 class RecipeIngredient:
     description: str

--- a/src/autoskillit/recipes/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/bem-wrapper.yaml
@@ -3,7 +3,7 @@ description: >-
   Re-fetch open audit issues, run build-execution-map, emit execution map path
   and compact dispatch plan. Used by the promote-to-main campaign to compute
   issue distribution before dispatching implementation L3s.
-kind: standard
+kind: food-truck
 recipe_version: "1.0.0"
 
 requires_packs: [github]

--- a/src/autoskillit/recipes/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.yaml
@@ -2,7 +2,7 @@ name: promote-to-main-wrapper
 description: >-
   Thin wrapper that invokes the promote-to-main skill via run_skill, enabling
   campaign dispatch of integration branch promotions as L2 food trucks.
-kind: standard
+kind: food-truck
 recipe_version: "1.0.0"
 
 requires_packs:
@@ -58,7 +58,9 @@ steps:
 
   done:
     action: stop
-    message: "Promotion complete."
+    message: >-
+      Promotion complete. Emit your L3 sentinel JSON block now with
+      success=true, pr_url, verdict, and category_summary.
 
   escalate_stop:
     action: stop

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -796,7 +796,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 9,
         "pipeline": 12,
         "fleet": 12,
-        "recipe/rules": 27,
+        "recipe/rules": 28,
         "server/tools": 15,
         "hooks/guards": 20,
     }

--- a/tests/cli/test_cook_order_picker.py
+++ b/tests/cli/test_cook_order_picker.py
@@ -79,7 +79,7 @@ class TestCLIOrderPicker:
 
         mock_result = MagicMock()
         mock_result.items = []
-        monkeypatch.setattr(_recipe_mod, "list_recipes", lambda _: mock_result)
+        monkeypatch.setattr(_recipe_mod, "list_recipes", lambda *a, **kw: mock_result)
 
         with pytest.raises(SystemExit) as exc_info:
             cli.order()
@@ -148,7 +148,7 @@ class TestCLIOrderPicker:
         fake_recipe.name = "some-recipe"
         mock_result = MagicMock()
         mock_result.items = [fake_recipe]
-        monkeypatch.setattr(_recipe_mod, "list_recipes", lambda _: mock_result)
+        monkeypatch.setattr(_recipe_mod, "list_recipes", lambda *a, **kw: mock_result)
         monkeypatch.setattr("builtins.input", lambda _prompt="": "99")
 
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -278,7 +278,7 @@ def test_retry_reason_value_count_is_14() -> None:
 
 
 def test_semantic_rule_family_count_is_25() -> None:
-    assert _count_semantic_rule_files() == 26
+    assert _count_semantic_rule_files() == 27
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -480,7 +480,7 @@ class TestMissingRequiredIngredient:
 
     @pytest.mark.anyio
     async def test_task_auto_injected_from_top_level_param(self, tool_ctx, monkeypatch):
-        """Top-level task param auto-injects into effective_ingredients for recipes declaring task."""
+        """top-level task param auto-injects into effective_ingredients when recipe declares it."""
         _setup_dispatch_with_ingredients(
             tool_ctx, monkeypatch, {"task": {"required": True, "default": None}}
         )
@@ -503,7 +503,7 @@ class TestMissingRequiredIngredient:
 
         from autoskillit.fleet._api import execute_dispatch
 
-        raw = await execute_dispatch(
+        await execute_dispatch(
             tool_ctx=tool_ctx,
             recipe="test-recipe",
             task="top-level-value",
@@ -532,7 +532,7 @@ class TestMissingRequiredIngredient:
 
         from autoskillit.fleet._api import execute_dispatch
 
-        raw = await execute_dispatch(
+        await execute_dispatch(
             tool_ctx=tool_ctx,
             recipe="test-recipe",
             task="some-task",

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -545,3 +545,76 @@ class TestMissingRequiredIngredient:
         )
 
         assert "task" not in captured["ingredients"]
+
+
+# ---------------------------------------------------------------------------
+# Group: Recipe kind dispatch gate
+# ---------------------------------------------------------------------------
+
+
+class TestRecipeKindDispatchGate:
+    """Verify that dispatch gate accepts/rejects by RecipeKind."""
+
+    def _setup_food_truck_recipe(self, tool_ctx):
+        """Wire tool_ctx with a food-truck kind recipe."""
+        from autoskillit.fleet import FleetSemaphore
+        from autoskillit.recipe.schema import Recipe, RecipeKind
+        from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        repo = InMemoryRecipeRepository()
+        recipe_info = _make_recipe_info("test-recipe")
+        repo.add_recipe("test-recipe", recipe_info)
+        repo.add_full_recipe(
+            recipe_info.path,
+            Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.FOOD_TRUCK,
+                ingredients={},
+                requires_packs=[],
+            ),
+        )
+        tool_ctx.recipes = repo
+        tool_ctx.executor = InMemoryHeadlessExecutor()
+
+    def _setup_campaign_recipe(self, tool_ctx):
+        """Wire tool_ctx with a campaign kind recipe."""
+        from autoskillit.fleet import FleetSemaphore
+        from autoskillit.recipe.schema import Recipe, RecipeKind
+        from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        repo = InMemoryRecipeRepository()
+        recipe_info = _make_recipe_info("test-recipe")
+        repo.add_recipe("test-recipe", recipe_info)
+        repo.add_full_recipe(
+            recipe_info.path,
+            Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.CAMPAIGN,
+                ingredients={},
+                requires_packs=[],
+            ),
+        )
+        tool_ctx.recipes = repo
+        tool_ctx.executor = InMemoryHeadlessExecutor()
+
+    @pytest.mark.anyio
+    async def test_food_truck_dispatchable(self, tool_ctx, monkeypatch):
+        """T4: FOOD_TRUCK kind is accepted by the dispatch gate (not rejected)."""
+        self._setup_food_truck_recipe(tool_ctx)
+
+        result = await _run(tool_ctx)
+        # Any error OTHER than fleet_invalid_recipe_kind means the gate passed
+        assert result.get("error") != "fleet_invalid_recipe_kind"
+
+    @pytest.mark.anyio
+    async def test_campaign_kind_still_rejected_by_dispatch(self, tool_ctx, monkeypatch):
+        """T5: CAMPAIGN kind is still rejected by the dispatch gate."""
+        self._setup_campaign_recipe(tool_ctx)
+
+        result = await _run(tool_ctx)
+        assert result["success"] is False
+        assert result["error"] == "fleet_invalid_recipe_kind"

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -96,6 +96,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_dataflow_nullable.py` | Tests for dataflow nullable semantic validation rule |
 | `test_rules_dedup.py` | Tests for dedup semantic validation rule |
 | `test_rules_features.py` | Tests for features semantic validation rule |
+| `test_rules_food_truck.py` | Tests for food_truck semantic validation rule |
 | `test_rules_graph.py` | Tests for graph semantic validation rule |
 | `test_rules_inline_script.py` | Tests for inline_script semantic validation rule |
 | `test_rules_inputs.py` | Tests for inputs semantic validation rule |

--- a/tests/recipe/test_bem_wrapper_structure.py
+++ b/tests/recipe/test_bem_wrapper_structure.py
@@ -20,7 +20,7 @@ def test_bem_wrapper_recipe_file_exists():
 def test_bem_wrapper_recipe_loads():
     recipe = _load()
     assert recipe.name == "bem-wrapper"
-    assert recipe.kind == "standard"
+    assert recipe.kind == "food-truck"
 
 
 def test_bem_wrapper_passes_validation():

--- a/tests/recipe/test_io_discovery.py
+++ b/tests/recipe/test_io_discovery.py
@@ -319,6 +319,55 @@ def test_parse_recipe_requires_packs_defaults_to_empty():
     assert recipe.requires_packs == []
 
 
+# ---------------------------------------------------------------------------
+# Food-truck kind tests
+# ---------------------------------------------------------------------------
+
+
+def test_food_truck_excluded_from_order_menu(tmp_path: Path) -> None:
+    """kind: food-truck recipe is excluded when exclude_kinds includes FOOD_TRUCK."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    (recipes_dir / "food-truck-test.yaml").write_text(
+        "name: food-truck-test\ndescription: test\nkind: food-truck\n"
+        "steps:\n  done:\n    action: stop\n    message: sentinel done\n"
+    )
+    result = list_recipes(
+        tmp_path,
+        exclude_kinds=frozenset({RecipeKind.CAMPAIGN, RecipeKind.FOOD_TRUCK}),
+    )
+    names = {r.name for r in result.items}
+    assert "food-truck-test" not in names
+
+
+def test_food_truck_included_when_not_excluded(tmp_path: Path) -> None:
+    """kind: food-truck recipe is included when exclude_kinds does not include FOOD_TRUCK."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    (recipes_dir / "food-truck-test.yaml").write_text(
+        "name: food-truck-test\ndescription: test\nkind: food-truck\n"
+        "steps:\n  done:\n    action: stop\n    message: sentinel done\n"
+    )
+    result = list_recipes(tmp_path)
+    names = {r.name for r in result.items}
+    assert "food-truck-test" in names
+
+
+def test_list_all_excludes_food_truck_when_fleet_off(tmp_path: Path) -> None:
+    """list_all with fleet disabled excludes FOOD_TRUCK kind recipes."""
+    from autoskillit.recipe._api import list_all
+
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    (recipes_dir / "my-food-truck.yaml").write_text(
+        "name: my-food-truck\ndescription: test\nkind: food-truck\n"
+        "steps:\n  done:\n    action: stop\n    message: sentinel done\n"
+    )
+    result = list_all(tmp_path, features={"fleet": False})
+    names = {r["name"] for r in result["recipes"]}
+    assert "my-food-truck" not in names
+
+
 def test_research_recipe_loads_without_error():
     from autoskillit.core.paths import pkg_root
 

--- a/tests/recipe/test_promote_to_main_wrapper.py
+++ b/tests/recipe/test_promote_to_main_wrapper.py
@@ -72,3 +72,8 @@ def test_emit_result_echoes_all_tokens() -> None:
 
 def test_requires_packs_declared() -> None:
     assert _load().requires_packs == ["github"]
+
+
+def test_kind_is_food_truck() -> None:
+    recipe = _load()
+    assert recipe.kind == "food-truck"

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -171,6 +171,29 @@ def test_campaign_rejects_dispatch_of_campaign_recipe(tmp_path: Path):
     assert found[0].severity == Severity.ERROR
 
 
+def test_dispatch_recipe_is_standard_allows_food_truck_target(tmp_path: Path):
+    """Campaign dispatching to a food-truck-kind recipe produces no findings."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-food-truck.yaml",
+        {
+            "name": "target-food-truck",
+            "description": "a food truck",
+            "kind": "food-truck",
+            "kitchen_rules": ["NEVER"],
+            "steps": {"done": {"action": "stop", "message": "sentinel done"}},
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(name="phase-one", recipe="target-food-truck", task="do it"),
+        ]
+    )
+    found = _findings(recipe, "dispatch-recipe-is-standard", project_dir=tmp_path)
+    assert found == []
+
+
 # ---------------------------------------------------------------------------
 # T21: dispatch-recipe-in-declared-packs
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_rules_food_truck.py
+++ b/tests/recipe/test_rules_food_truck.py
@@ -1,0 +1,83 @@
+"""Tests for food-truck semantic validation rules (rules_food_truck.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+import autoskillit.recipe  # noqa: F401 -- triggers rule registration
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import make_validation_context
+from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.schema import Recipe, RecipeKind, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _food_truck_recipe(**kwargs: object) -> Recipe:
+    defaults: dict = {
+        "name": "my-food-truck",
+        "description": "test food truck",
+        "kind": RecipeKind.FOOD_TRUCK,
+        "steps": {"done": RecipeStep(action="stop", message="sentinel done")},
+        "kitchen_rules": ["NEVER"],
+    }
+    defaults.update(kwargs)
+    return Recipe(**defaults)
+
+
+def _standard_recipe(**kwargs: object) -> Recipe:
+    return Recipe(
+        name="standard",
+        description="standard recipe",
+        steps={"done": RecipeStep(action="stop", message="done")},
+        kitchen_rules=["NEVER"],
+        **kwargs,
+    )
+
+
+def _findings(recipe: Recipe, rule: str, **ctx_kwargs: object) -> list:
+    ctx = make_validation_context(recipe, **ctx_kwargs)
+    return [f for f in run_semantic_rules(ctx) if f.rule == rule]
+
+
+# ---------------------------------------------------------------------------
+# T8: food-truck-has-sentinel-stop (fires when missing)
+# ---------------------------------------------------------------------------
+
+
+def test_food_truck_has_sentinel_stop_rule_fires_on_missing_sentinel():
+    """food-truck recipe with no sentinel in stop message triggers a finding."""
+    recipe = _food_truck_recipe(
+        steps={"done": RecipeStep(action="stop", message="Promotion complete.")},
+    )
+    found = _findings(recipe, "food-truck-has-sentinel-stop")
+    assert found
+    assert found[0].severity == Severity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# T9: food-truck-has-sentinel-stop (passes when present)
+# ---------------------------------------------------------------------------
+
+
+def test_food_truck_has_sentinel_stop_rule_passes_when_present():
+    """food-truck recipe with sentinel in stop message produces no findings."""
+    recipe = _food_truck_recipe(
+        steps={
+            "done": RecipeStep(action="stop", message="Done. Emit your L3 sentinel JSON block.")
+        },
+    )
+    found = _findings(recipe, "food-truck-has-sentinel-stop")
+    assert found == []
+
+
+# ---------------------------------------------------------------------------
+# T10: food-truck-has-sentinel-stop (skips standard)
+# ---------------------------------------------------------------------------
+
+
+def test_food_truck_has_sentinel_stop_rule_skips_standard():
+    """Standard recipe produces no findings for the food-truck sentinel rule."""
+    recipe = _standard_recipe()
+    found = _findings(recipe, "food-truck-has-sentinel-stop")
+    assert found == []

--- a/tests/recipe/test_schema.py
+++ b/tests/recipe/test_schema.py
@@ -202,6 +202,18 @@ def test_recipe_step_has_constant_field() -> None:
     assert step.constant is None
 
 
+# ---------------------------------------------------------------------------
+# RecipeKind enum
+# ---------------------------------------------------------------------------
+
+
+def test_food_truck_kind_exists() -> None:
+    """RecipeKind.FOOD_TRUCK exists and equals 'food-truck'."""
+    from autoskillit.recipe.schema import RecipeKind
+
+    assert RecipeKind.FOOD_TRUCK == "food-truck"
+
+
 def test_constant_step_parse_from_yaml() -> None:
     """A constant step is parsed from YAML into RecipeStep.constant."""
     from autoskillit.recipe.io import _parse_step

--- a/tests/recipe/test_schema.py
+++ b/tests/recipe/test_schema.py
@@ -367,7 +367,8 @@ def test_recipe_kind_enum_defined() -> None:
     assert issubclass(RecipeKind, StrEnum)
     assert RecipeKind.STANDARD == "standard"
     assert RecipeKind.CAMPAIGN == "campaign"
-    assert len(RecipeKind) == 2
+    assert RecipeKind.FOOD_TRUCK == "food-truck"
+    assert len(RecipeKind) == 3
 
 
 def test_campaign_dispatch_dataclass() -> None:


### PR DESCRIPTION
## Summary

Add `FOOD_TRUCK = "food-truck"` as a third `RecipeKind` enum value, reclassify `bem-wrapper` and `promote-to-main-wrapper` from `kind: standard` to `kind: food-truck`, and update all filtering/dispatch/validation sites to handle the new kind. This gives campaign-internal recipes a distinct type that is excluded from the interactive `autoskillit order` menu and the `list_all()` MCP tool (when fleet is off), while remaining dispatchable by campaigns via `dispatch_food_truck`.

Closes #1955

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-124317-054907/.autoskillit/temp/make-plan/food_truck_recipe_kind_plan_2026-05-06_140155.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 98 | 14.6k | 1.5M | 84.2k | 108 | 71.0k | 9m 14s |
| verify | claude-opus-4-6 | 1 | 899 | 11.7k | 1.2M | 70.0k | 94 | 57.1k | 8m 49s |
| implement | MiniMax-M2.7-highspeed | 1 | 4.2M | 22.9k | 3.3M | 56.3k | 233 | 177.5k | 10m 54s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 76.9k | 5.1k | 240.6k | 35.0k | 23 | 24.3k | 1m 35s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 45.6k | 1.2k | 205.6k | 29.8k | 15 | 14.9k | 38s |
| review_pr | claude-opus-4-6 | 1 | 47 | 25.7k | 527.1k | 71.4k | 32 | 58.6k | 5m 58s |
| resolve_review | claude-opus-4-6 | 2 | 91 | 11.2k | 1.8M | 62.3k | 83 | 91.6k | 8m 38s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 211 | 13.0k | 1.2M | 62.2k | 62 | 49.4k | 3m 39s |
| diagnose_ci | MiniMax-M2.7-highspeed | 1 | 134.7k | 1.6k | 268.0k | 29.8k | 21 | 41.8k | 1m 4s |
| resolve_ci | claude-opus-4-6 | 1 | 47 | 6.8k | 818.9k | 54.6k | 44 | 80.3k | 6m 13s |
| **Total** | | | 4.4M | 113.9k | 11.0M | 84.2k | | 666.4k | 56m 47s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 318 | 10278.4 | 558.1 | 71.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 32 | 55779.7 | 2862.3 | 351.5 |
| ci_conflict_fix | 2421 | 493.0 | 20.4 | 5.4 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 6 | 136484.2 | 13382.8 | 1129.3 |
| **Total** | **2777** | 3967.4 | 240.0 | 41.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 1.1k | 35.1k | 4.5M | 190.1k | 26m 54s |
| MiniMax-M2.7-highspeed | 3 | 4.3M | 29.1k | 3.7M | 216.7k | 13m 7s |