### PR TITLE
P4-C3 Unit Tests for Sentinel Capture Extraction Edge Cases

### DIFF
--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -124,6 +124,207 @@ def test_interpolate_multiple_refs_in_one_value():
     assert result == {"path": "foo/bar"}
 
 
+def test_extract_captures_bool_value_uses_json_dumps():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"flag": "${{ result.flag }}"},
+        {"flag": True},
+    )
+    assert result == {"flag": "true"}
+    assert result["flag"] != "True"
+
+
+def test_extract_captures_none_value_uses_json_dumps():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"val": "${{ result.val }}"},
+        {"val": None},
+    )
+    assert result == {"val": "null"}
+    assert result["val"] != "None"
+
+
+def test_extract_captures_float_value_uses_json_dumps():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"pi": "${{ result.pi }}"},
+        {"pi": 3.14},
+    )
+    assert result == {"pi": "3.14"}
+
+
+def test_extract_captures_empty_spec_returns_empty():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures({}, {"anything": "value"})
+    assert result == {}
+
+
+def test_interpolate_campaign_refs_empty_ingredients():
+    from autoskillit.fleet._api import _interpolate_campaign_refs
+
+    result = _interpolate_campaign_refs({}, {"k": "v"})
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Research-campaign capture field tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_research_design_captures():
+    from autoskillit.fleet._api import _extract_captures
+
+    spec = {
+        "worktree_path": "${{ result.worktree_path }}",
+        "research_dir": "${{ result.research_dir }}",
+        "experiment_plan": "${{ result.experiment_plan }}",
+        "visualization_plan_path": "${{ result.visualization_plan_path }}",
+    }
+    payload = {
+        "worktree_path": "/tmp/wt-123",
+        "research_dir": "/tmp/wt-123/research",
+        "experiment_plan": "plan.md",
+        "visualization_plan_path": "/tmp/wt-123/viz.yaml",
+    }
+    result = _extract_captures(spec, payload)
+    assert result == {
+        "worktree_path": "/tmp/wt-123",
+        "research_dir": "/tmp/wt-123/research",
+        "experiment_plan": "plan.md",
+        "visualization_plan_path": "/tmp/wt-123/viz.yaml",
+    }
+
+
+def test_extract_research_implement_capture():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"report_path": "${{ result.report_path }}"},
+        {"report_path": "/tmp/wt-123/report.md"},
+    )
+    assert result == {"report_path": "/tmp/wt-123/report.md"}
+
+
+def test_extract_research_review_captures():
+    from autoskillit.fleet._api import _extract_captures
+
+    spec = {
+        "pr_url": "${{ result.pr_url }}",
+        "all_diagram_paths": "${{ result.all_diagram_paths }}",
+        "report_path_after_finalize": "${{ result.report_path_after_finalize }}",
+    }
+    payload = {
+        "pr_url": "https://github.com/org/repo/pull/42",
+        "all_diagram_paths": "/tmp/diagrams/arch.png",
+        "report_path_after_finalize": "/tmp/wt-123/report-final.md",
+    }
+    result = _extract_captures(spec, payload)
+    assert result == {
+        "pr_url": "https://github.com/org/repo/pull/42",
+        "all_diagram_paths": "/tmp/diagrams/arch.png",
+        "report_path_after_finalize": "/tmp/wt-123/report-final.md",
+    }
+
+
+def test_extract_research_review_all_diagram_paths_list():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"all_diagram_paths": "${{ result.all_diagram_paths }}"},
+        {"all_diagram_paths": ["arch.png", "flow.png"]},
+    )
+    assert result == {"all_diagram_paths": '["arch.png", "flow.png"]'}
+    assert "'" not in result["all_diagram_paths"]
+
+
+def test_extract_research_partial_payload_skips_missing():
+    from autoskillit.fleet._api import _extract_captures
+
+    spec = {
+        "worktree_path": "${{ result.worktree_path }}",
+        "research_dir": "${{ result.research_dir }}",
+        "experiment_plan": "${{ result.experiment_plan }}",
+        "visualization_plan_path": "${{ result.visualization_plan_path }}",
+    }
+    payload = {
+        "worktree_path": "/tmp/wt-123",
+        "experiment_plan": "plan.md",
+    }
+    result = _extract_captures(spec, payload)
+    assert result == {
+        "worktree_path": "/tmp/wt-123",
+        "experiment_plan": "plan.md",
+    }
+    assert "research_dir" not in result
+    assert "visualization_plan_path" not in result
+
+
+def test_extract_empty_string_path_is_captured():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"p": "${{ result.p }}"},
+        {"p": ""},
+    )
+    assert result == {"p": ""}
+
+
+def test_extract_research_capture_all_fields_combined():
+    from autoskillit.fleet._api import _extract_captures
+
+    spec = {
+        "worktree_path": "${{ result.worktree_path }}",
+        "research_dir": "${{ result.research_dir }}",
+        "experiment_plan": "${{ result.experiment_plan }}",
+        "visualization_plan_path": "${{ result.visualization_plan_path }}",
+        "report_path": "${{ result.report_path }}",
+        "pr_url": "${{ result.pr_url }}",
+        "all_diagram_paths": "${{ result.all_diagram_paths }}",
+    }
+    payload = {
+        "worktree_path": "/tmp/wt-123",
+        "research_dir": "/tmp/wt-123/research",
+        "experiment_plan": "plan.md",
+        "visualization_plan_path": "/tmp/wt-123/viz.yaml",
+        "report_path": "/tmp/wt-123/report.md",
+        "pr_url": "https://github.com/org/repo/pull/42",
+        "all_diagram_paths": ["a.png", "b.png"],
+    }
+    result = _extract_captures(spec, payload)
+    assert len(result) == 7
+    assert result["worktree_path"] == "/tmp/wt-123"
+    assert result["all_diagram_paths"] == '["a.png", "b.png"]'
+
+
+def test_interpolate_campaign_worktree_and_report_path():
+    from autoskillit.fleet._api import _interpolate_campaign_refs
+
+    result = _interpolate_campaign_refs(
+        {
+            "wt": "${{ campaign.worktree_path }}",
+            "rpt": "${{ campaign.report_path }}",
+        },
+        {"worktree_path": "/tmp/wt-123", "report_path": "/tmp/wt-123/report.md"},
+    )
+    assert result == {"wt": "/tmp/wt-123", "rpt": "/tmp/wt-123/report.md"}
+
+
+def test_interpolate_campaign_unresolved_research_ref_raises():
+    import pytest
+
+    from autoskillit.fleet._api import _interpolate_campaign_refs
+
+    with pytest.raises(ValueError, match="has not been captured"):
+        _interpolate_campaign_refs(
+            {"plan": "${{ campaign.experiment_plan }}"},
+            {},
+        )
+
+
 # ---------------------------------------------------------------------------
 # Integration path via execute_dispatch
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add 14 pure unit tests to `tests/fleet/test_campaign_capture.py` covering two groups: (1) edge-case type handling in `_extract_captures` (bool, None, float, empty spec) and `_interpolate_campaign_refs` (empty ingredients), and (2) research-campaign-specific capture field tests validating all 7 cross-dispatch handoff fields from `research-campaign.yaml`. All tests are synchronous, pure (no fixtures, no async), and follow the existing import-inside-function style.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-162907-065361/.autoskillit/temp/make-plan/p4_c3_unit_tests_sentinel_capture_plan_2026-05-06_163300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 67 | 6.8k | 443.9k | 45.6k | 33 | 37.0k | 2m 57s |
| verify | claude-opus-4-6 | 1 | 250 | 9.1k | 531.7k | 51.6k | 35 | 38.7k | 3m 38s |
| implement* | MiniMax-M2.7-highspeed | 1 | 259.7k | 6.8k | 499.8k | 48.1k | 40 | 88.0k | 2m 44s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 79.7k | 2.6k | 235.3k | 29.8k | 22 | 15.2k | 56s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 86.6k | 1.5k | 265.0k | 29.8k | 19 | 15.0k | 1m 6s |
| **Total** | | | 426.3k | 26.7k | 2.0M | 51.6k | | 193.9k | 11m 23s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 201 | 2486.6 | 437.9 | 33.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **201** | 9829.2 | 964.5 | 132.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 317 | 15.8k | 975.6k | 75.7k | 6m 36s |
| MiniMax-M2.7-highspeed | 3 | 426.0k | 10.9k | 1.0M | 118.1k | 4m 47s |