### PR TITLE
P4-C7 Integration Tests for Dispatch Capture Propagation

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -543,6 +543,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "fleet/test_pack_enforcement.py",
             "fleet/test_pack_enforcement_e2e.py",
             "fleet/test_dispatch_failure_semantics.py",
+            "fleet/test_research_campaign_dispatch.py",
             # Other file-level entries:
             "infra/test_pretty_output_recipe.py",
             "skills/test_planner_skill_contracts.py",

--- a/tests/fleet/CLAUDE.md
+++ b/tests/fleet/CLAUDE.md
@@ -27,6 +27,7 @@ Fleet campaign dispatch, state persistence, and sidecar tests.
 | `test_liveness.py` | Liveness tests for Linux proc helpers |
 | `test_pack_enforcement.py` | Fleet per-recipe tool-surface enforcement tests |
 | `test_pack_enforcement_e2e.py` | Fleet per-recipe tool-surface e2e tests using a real MCP server subprocess |
+| `test_research_campaign_dispatch.py` | Tests for multi-recipe research campaign dispatch capture propagation (Group J) |
 | `test_result_parser.py` | Tests for fleet.result_parser — L2 result block parsing |
 | `test_retry_failed_dispatch.py` | Tests for explicit retry of failed campaign dispatches via FAILURE → PENDING state transition |
 | `test_sidecar.py` | Sidecar tests |

--- a/tests/fleet/_helpers.py
+++ b/tests/fleet/_helpers.py
@@ -31,6 +31,24 @@ def compute_food_truck_tool_surface(recipe_name: str) -> frozenset[str]:
     return frozenset(expected)
 
 
+def _simple_prompt_builder(**kwargs) -> str:
+    return f"prompt-for-{kwargs.get('recipe', 'unknown')}"
+
+
+async def _no_sleep_quota_checker(config, **kwargs) -> dict:
+    return {
+        "should_sleep": False,
+        "sleep_seconds": 0,
+        "utilization": None,
+        "resets_at": None,
+        "window_name": None,
+    }
+
+
+async def _noop_quota_refresher(config, **kwargs) -> None:
+    pass
+
+
 def _make_recipe_info(name: str = "test-recipe", path_prefix: str = "/fake/"):
     from pathlib import Path
 

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -6,31 +6,19 @@ import json
 
 import pytest
 
-from tests.fleet._helpers import _make_recipe_info
+from tests.fleet._helpers import (
+    _make_recipe_info,
+    _no_sleep_quota_checker,
+    _noop_quota_refresher,
+    _simple_prompt_builder,
+)
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
 
-def _simple_prompt_builder(**kwargs) -> str:
-    return f"prompt-for-{kwargs.get('recipe', 'unknown')}"
-
-
-async def _no_sleep_quota_checker(config, **kwargs) -> dict:
-    return {
-        "should_sleep": False,
-        "sleep_seconds": 0,
-        "utilization": None,
-        "resets_at": None,
-        "window_name": None,
-    }
-
-
-async def _noop_quota_refresher(config, **kwargs) -> None:
-    pass
-
-
 def _read_state_file(tool_ctx) -> dict:
     state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    assert len(state_files) == 1, f"Expected 1 state file, found {len(state_files)}: {state_files}"
     return json.loads(state_files[0].read_text())
 
 
@@ -183,7 +171,8 @@ async def test_missing_campaign_ref_returns_fleet_error(tool_ctx):
 
     result = json.loads(raw)
     assert result["success"] is False
-    assert "error" in result
+    assert result["error"] == "FLEET_UNKNOWN_INGREDIENT"
+    assert "campaign.worktree_path" in result["user_visible_message"]
 
 
 @pytest.mark.anyio
@@ -240,3 +229,4 @@ async def test_partial_capture_propagates_only_captured_keys(tool_ctx, monkeypat
     result = json.loads(raw)
     assert result["success"] is False
     assert "error" in result
+    assert "campaign.research_dir" in result["user_visible_message"]

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -171,7 +171,7 @@ async def test_missing_campaign_ref_returns_fleet_error(tool_ctx):
 
     result = json.loads(raw)
     assert result["success"] is False
-    assert result["error"] == "FLEET_UNKNOWN_INGREDIENT"
+    assert result["error"] == "fleet_unknown_ingredient"
     assert "campaign.worktree_path" in result["user_visible_message"]
 
 

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -188,7 +188,7 @@ async def test_missing_campaign_ref_returns_fleet_error(tool_ctx):
 
 @pytest.mark.anyio
 async def test_partial_capture_propagates_only_captured_keys(tool_ctx, monkeypatch):
-    """Design captured only worktree_path; implement requests research_dir which was never captured."""
+    """Design captured only worktree_path; implement requests uncaptured research_dir."""
     from autoskillit.fleet._api import execute_dispatch
     from autoskillit.fleet.result_parser import L3ParseResult
 

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -1,0 +1,242 @@
+"""Tests for multi-recipe research campaign dispatch capture propagation (Group J)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.fleet._helpers import _make_recipe_info
+
+pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+def _simple_prompt_builder(**kwargs) -> str:
+    return f"prompt-for-{kwargs.get('recipe', 'unknown')}"
+
+
+async def _no_sleep_quota_checker(config, **kwargs) -> dict:
+    return {
+        "should_sleep": False,
+        "sleep_seconds": 0,
+        "utilization": None,
+        "resets_at": None,
+        "window_name": None,
+    }
+
+
+async def _noop_quota_refresher(config, **kwargs) -> None:
+    pass
+
+
+def _read_state_file(tool_ctx) -> dict:
+    state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    return json.loads(state_files[0].read_text())
+
+
+def _setup_research_campaign(tool_ctx):
+    from autoskillit.fleet import FleetSemaphore
+    from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeKind
+    from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+    tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+    repo = InMemoryRecipeRepository()
+
+    design_info = _make_recipe_info("research-design")
+    repo.add_recipe("research-design", design_info)
+    repo.add_full_recipe(
+        design_info.path,
+        Recipe(
+            name="research-design",
+            description="Research design phase",
+            kind=RecipeKind.STANDARD,
+            ingredients={},
+        ),
+    )
+
+    impl_info = _make_recipe_info("research-implement")
+    repo.add_recipe("research-implement", impl_info)
+    repo.add_full_recipe(
+        impl_info.path,
+        Recipe(
+            name="research-implement",
+            description="Research implement phase",
+            kind=RecipeKind.STANDARD,
+            ingredients={
+                "worktree_path": RecipeIngredient(description="Path to worktree"),
+                "research_dir": RecipeIngredient(description="Path to research dir"),
+            },
+        ),
+    )
+
+    tool_ctx.recipes = repo
+    tool_ctx.executor = InMemoryHeadlessExecutor()
+
+
+@pytest.mark.anyio
+async def test_design_captured_values_propagate_to_implement_dispatch(tool_ctx, monkeypatch):
+    """End-to-end: design dispatch captures propagate to implement dispatch via state file."""
+    from autoskillit.fleet._api import execute_dispatch
+    from autoskillit.fleet.result_parser import L3ParseResult
+
+    _setup_research_campaign(tool_ctx)
+
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.parse_l3_result_block",
+        lambda **_: L3ParseResult(
+            outcome="completed_clean",
+            payload={
+                "success": True,
+                "worktree_path": "/tmp/wt/proj",
+                "research_dir": "/tmp/wt/proj/.research",
+            },
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        ),
+    )
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-design",
+        task="Design the research",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={
+            "worktree_path": "${{ result.worktree_path }}",
+            "research_dir": "${{ result.research_dir }}",
+        },
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    result = json.loads(raw)
+    assert result["success"] is True
+
+    state_data = _read_state_file(tool_ctx)
+    assert state_data.get("captured_values") == {
+        "worktree_path": "/tmp/wt/proj",
+        "research_dir": "/tmp/wt/proj/.research",
+    }
+
+    received_ingredients: list[dict] = []
+
+    def _capturing_prompt_builder(**kwargs):
+        received_ingredients.append(kwargs.get("ingredients", {}))
+        return "prompt"
+
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.parse_l3_result_block",
+        lambda **kwargs: L3ParseResult(
+            outcome="completed_clean",
+            payload={"success": True},
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        ),
+    )
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-implement",
+        task="Implement the research",
+        ingredients={
+            "worktree_path": "${{ campaign.worktree_path }}",
+            "research_dir": "${{ campaign.research_dir }}",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture=None,
+        prompt_builder=_capturing_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    assert received_ingredients, "prompt_builder was not called"
+    assert received_ingredients[0] == {
+        "worktree_path": "/tmp/wt/proj",
+        "research_dir": "/tmp/wt/proj/.research",
+    }
+
+
+@pytest.mark.anyio
+async def test_missing_campaign_ref_returns_fleet_error(tool_ctx):
+    """Dispatch with ${{ campaign.worktree_path }} and no prior captures returns fleet_error."""
+    from autoskillit.fleet._api import execute_dispatch
+
+    _setup_research_campaign(tool_ctx)
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-implement",
+        task="Implement with missing ref",
+        ingredients={"worktree_path": "${{ campaign.worktree_path }}"},
+        dispatch_name=None,
+        timeout_sec=None,
+        capture=None,
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    result = json.loads(raw)
+    assert result["success"] is False
+    assert "error" in result
+
+
+@pytest.mark.anyio
+async def test_partial_capture_propagates_only_captured_keys(tool_ctx, monkeypatch):
+    """Design captured only worktree_path; implement requests research_dir which was never captured."""
+    from autoskillit.fleet._api import execute_dispatch
+    from autoskillit.fleet.result_parser import L3ParseResult
+
+    _setup_research_campaign(tool_ctx)
+
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.parse_l3_result_block",
+        lambda **kwargs: L3ParseResult(
+            outcome="completed_clean",
+            payload={"success": True, "worktree_path": "/tmp/wt/proj"},
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        ),
+    )
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-design",
+        task="Design with partial capture",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={"worktree_path": "${{ result.worktree_path }}"},
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    result = json.loads(raw)
+    assert result["success"] is True
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-implement",
+        task="Implement with missing research_dir",
+        ingredients={
+            "worktree_path": "${{ campaign.worktree_path }}",
+            "research_dir": "${{ campaign.research_dir }}",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture=None,
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    result = json.loads(raw)
+    assert result["success"] is False
+    assert "error" in result


### PR DESCRIPTION
## Summary

Add `tests/fleet/test_research_campaign_dispatch.py` with a `_setup_research_campaign` helper that registers both `research-design` and `research-implement` recipes via `InMemoryRecipeRepository`, and three tests: one positive-path test verifying end-to-end capture propagation from design to implement dispatch, and two negative-path tests confirming fleet errors for missing/partial campaign references.

Closes #1718

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-175503-915914/.autoskillit/temp/make-plan/p4_c7_integration_tests_dispatch_capture_propagation_plan_2026-05-06_175700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.0k | 8.3k | 1.1M | 87.9k | 101 | 57.0k | 6m 35s |
| verify | claude-opus-4-6 | 1 | 1.5k | 14.3k | 1.8M | 80.7k | 136 | 67.5k | 8m 41s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 8.4k | 1.1M | 29.8k | 101 | 47.0k | 8m 46s |
| fix | claude-opus-4-6 | 1 | 49 | 4.3k | 809.3k | 46.5k | 35 | 36.0k | 3m 3s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 87.9k | 3.4k | 265.1k | 29.8k | 24 | 15.2k | 1m 30s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 83.2k | 1.6k | 324.6k | 29.8k | 23 | 14.9k | 55s |
| **Total** | | | 1.3M | 40.4k | 5.4M | 87.9k | | 237.5k | 29m 32s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 243 | 4520.5 | 193.3 | 34.7 |
| fix | 3 | 269760.7 | 11992.0 | 1421.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **246** | 21748.7 | 965.6 | 164.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 3.0k | 8.3k | 1.1M | 57.0k | 6m 35s |
| claude-opus-4-6 | 2 | 1.5k | 18.6k | 2.6M | 103.5k | 11m 45s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 13.5k | 1.7M | 77.0k | 11m 11s |