### PR TITLE
Implementation Plan: P4-C5 Test Filter Manifest Entry for Sub-Recipes

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -32,6 +32,9 @@ src/autoskillit/recipes/experiment-types/*.yaml:
 src/autoskillit/recipes/methodology-traditions/*.yaml:
   - recipe/
 
+src/autoskillit/recipes/sub-recipes/*.yaml:
+  - recipe/
+
 src/autoskillit/recipe/skill_contracts.yaml:
   - contracts/
   - skills/

--- a/src/autoskillit/recipes/sub-recipes/research.yaml
+++ b/src/autoskillit/recipes/sub-recipes/research.yaml
@@ -3,7 +3,6 @@ description: >
   Research sub-recipe: gather context, analyze findings, and produce a
   structured research report for the parent recipe.
 summary: gather → analyze → report
-autoskillit_version: "0.9.496"
 
 ingredients:
   source_dir:

--- a/src/autoskillit/recipes/sub-recipes/research.yaml
+++ b/src/autoskillit/recipes/sub-recipes/research.yaml
@@ -1,0 +1,17 @@
+name: research
+description: >
+  Research sub-recipe: gather context, analyze findings, and produce a
+  structured research report for the parent recipe.
+summary: gather → analyze → report
+autoskillit_version: "0.9.496"
+
+ingredients:
+  source_dir:
+    description: Source repository (inherited from parent recipe context)
+    required: false
+    default: ""
+  base_branch:
+    description: Merge target branch (inherited from parent recipe context)
+    default: ""
+
+steps: {}

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -929,3 +929,12 @@ class TestManifestApplyManifest:
             ["src/autoskillit/recipes/cook.yaml", "docs/guide.md"], manifest
         )
         assert result == {"recipe/", "docs/"}
+
+    def test_apply_manifest_sub_recipes_yaml(self) -> None:
+        manifest = manifest_load_manifest(MANIFEST_PATH)
+        assert manifest is not None
+        result = manifest_apply_manifest(
+            ["src/autoskillit/recipes/sub-recipes/research.yaml"],
+            manifest,
+        )
+        assert result == {"recipe/"}


### PR DESCRIPTION
## Summary

Add a glob mapping `src/autoskillit/recipes/sub-recipes/*.yaml` to `.autoskillit/test-filter-manifest.yaml` targeting `tests/recipe/`. This ensures CI filtered test runs automatically include recipe tests when sub-recipe YAML files change. The entry is inserted after the existing `methodology-traditions` entry and before `skill_contracts.yaml`, maintaining alphabetical order among recipe subdirectory globs (experiment-types → methodology-traditions → sub-recipes).

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
★ src/autoskillit/recipes/sub-recipes/research.yaml
★ .autoskillit/test-filter-manifest.yaml

### Modified (●):
● tests/test_test_filter.py

Closes #1716

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-184911-698748/.autoskillit/temp/make-plan/p4_c5_test_filter_manifest_sub_recipes_plan_2026-05-06_184911.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 2 | 621 | 11.2k | 1.1M | 44.1k | 74 | 63.8k | 6m 41s |
| verify | claude-opus-4-6 | 2 | 74 | 14.7k | 1.1M | 46.9k | 143 | 67.7k | 9m 22s |
| implement* | MiniMax-M2.7-highspeed | 2 | 1.2M | 12.3k | 1.5M | 29.8k | 116 | 88.7k | 16m 0s |
| retry_worktree* | MiniMax-M2.7-highspeed | 1 | 6.7M | 31.9k | 3.7M | 29.8k | 285 | 45.3k | 24m 0s |
| fix | claude-opus-4-6 | 2 | 109 | 11.3k | 1.9M | 56.1k | 100 | 72.3k | 13m 40s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 91.4k | 3.0k | 297.6k | 29.8k | 22 | 42.0k | 1m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 66.0k | 1.8k | 235.2k | 29.8k | 20 | 15.0k | 56s |
| **Total** | | | 8.1M | 86.1k | 9.8M | 56.1k | | 394.8k | 1h 12m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 12 | 126229.7 | 7391.5 | 1026.5 |
| retry_worktree | 69838 | 53.7 | 0.6 | 0.5 |
| fix | 16 | 118365.2 | 4519.2 | 706.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **69866** | 140.4 | 5.7 | 1.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 804 | 37.1k | 4.0M | 203.8k | 29m 44s |
| MiniMax-M2.7-highspeed | 4 | 8.1M | 49.0k | 5.8M | 191.0k | 42m 18s |