### PR TITLE
Close cascade gaps — classify _type_checkpoint stem and add CLAUDE.md manifest entry

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -149,3 +149,5 @@ src/autoskillit/core/__init__.pyi:
   - core/
   - arch/
   - contracts/
+
+tests/**/CLAUDE.md: []

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -189,6 +189,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "readiness": frozenset({"core", "server"}),
     "session_registry": frozenset({"core"}),
     "tool_sequence_analysis": frozenset({"core", "execution", "server", "cli"}),
+    "_type_checkpoint": frozenset({"core", "execution", "fleet", "server"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -913,10 +913,13 @@ class TestManifestLoadManifest:
         manifest = manifest_load_manifest(MANIFEST_PATH)
         assert isinstance(manifest, dict)
         assert len(manifest) >= 22
+        non_empty_count = 0
         for pattern, dirs in manifest.items():
             assert isinstance(dirs, list)
-            assert len(dirs) > 0
             assert all(isinstance(d, str) for d in dirs)
+            if len(dirs) > 0:
+                non_empty_count += 1
+        assert non_empty_count >= 22
 
     def test_load_manifest_missing_file_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -433,6 +433,7 @@ class TestBuildTestScope:
             manifest=manifest,
             tests_root=tests_root,
         )
+        assert result is not None
         assert result is not FullRunReason.UNMAPPED_FILE
 
 

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -422,6 +422,19 @@ class TestBuildTestScope:
         dir_names = {p.name for p in result}
         assert dir_names == {"arch", "contracts", "infra", "docs"}
 
+    def test_scope_tests_claude_md_not_unmapped(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        for d in ["core", "arch", "contracts"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        manifest = {"tests/**/CLAUDE.md": []}
+        result = build_test_scope(
+            changed_files={"tests/core/CLAUDE.md"},
+            mode=FilterMode.CONSERVATIVE,
+            manifest=manifest,
+            tests_root=tests_root,
+        )
+        assert result is not FullRunReason.UNMAPPED_FILE
+
 
 # ---------------------------------------------------------------------------
 # Conservative vs Aggressive Tests (M1–M4)
@@ -819,6 +832,16 @@ class TestApplyManifest:
         manifest = {"docs/**/*.md": ["docs"]}
         result = apply_manifest({"docs/developer/SETUP.md"}, manifest)
         assert result == {"docs"}
+
+    def test_apply_manifest_tests_claude_md_empty_cascade(self) -> None:
+        manifest = {"tests/**/CLAUDE.md": []}
+        result = apply_manifest({"tests/core/CLAUDE.md"}, manifest)
+        assert result == set()
+
+    def test_apply_manifest_tests_nested_claude_md(self) -> None:
+        manifest = {"tests/**/CLAUDE.md": []}
+        result = apply_manifest({"tests/execution/CLAUDE.md"}, manifest)
+        assert result == set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -90,6 +90,7 @@ class TestModuleCascadeCore:
             "session_provenance",
             "session_registry",
             "tool_sequence_analysis",
+            "_type_checkpoint",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
 
@@ -104,6 +105,12 @@ class TestModuleCascadeCore:
     def test_type_protocols_workspace_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_protocols_workspace"] == frozenset(
             {"core", "pipeline", "recipe", "workspace"}
+        )
+
+    def test_type_checkpoint_entry_exists(self) -> None:
+        assert "_type_checkpoint" in MODULE_CASCADE_CORE
+        assert MODULE_CASCADE_CORE["_type_checkpoint"] == frozenset(
+            {"core", "execution", "fleet", "server"}
         )
 
 
@@ -323,6 +330,22 @@ class TestBuildTestScopeCoreCascade:
         for excluded in ["cli", "server", "execution", "fleet", "migration", "hooks"]:
             assert excluded not in dir_names, (
                 f"_type_protocols_workspace cascade should not include {excluded}"
+            )
+
+    def test_type_checkpoint_narrow_routing(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_checkpoint.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "execution", "fleet", "server"]:
+            assert pkg in dir_names, f"_type_checkpoint cascade should include {pkg}"
+        for excluded in ["cli", "config", "pipeline", "workspace", "recipe", "migration", "hooks"]:
+            assert excluded not in dir_names, (
+                f"_type_checkpoint cascade should not include {excluded}"
             )
 
 


### PR DESCRIPTION
## Summary

Add `_type_checkpoint` to `MODULE_CASCADE_CORE` in `tests/_test_filter.py` with its verified importer set `{"core", "execution", "fleet", "server"}`, and add a `tests/**/CLAUDE.md` glob entry to `.autoskillit/test-filter-manifest.yaml` mapping to `[]` (empty — no cascade needed for test documentation edits). This eliminates the last unclassified core type stem and prevents manifest-miss full runs when test CLAUDE.md files are edited.

## Requirements

- REQ-GAP-001: Add `_type_checkpoint` to `MODULE_CASCADE_CORE` in `tests/_test_filter.py` with cascade to `{"execution", "fleet", "core"}` (its actual importers)
- REQ-GAP-002: Add `tests/*/CLAUDE.md` (or `tests/**/CLAUDE.md`) to `NON_PYTHON_MANIFEST` mapping to `[]` (empty — no cascade needed for documentation file edits)
- REQ-GAP-003: All existing tests must continue to pass

## Expected Impact

- `.autoskillit/test-filter-manifest.yaml`
- `tests/_test_filter.py`
- `tests/test_test_filter.py`
- `tests/test_test_filter_core_cascade.py`

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
- `.autoskillit/test-filter-manifest.yaml`
- `tests/_test_filter.py`
- `tests/test_test_filter.py`
- `tests/test_test_filter_core_cascade.py`

Closes #2035

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-191435-653775/.autoskillit/temp/make-plan/close_cascade_gaps_type_checkpoint_plan_2026-05-06_191500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 1.5k | 7.6k | 830.7k | 52.7k | 74 | 43.1k | 5m 41s |
| verify | claude-opus-4-6 | 1 | 39 | 13.8k | 1.0M | 71.2k | 69 | 59.6k | 5m 46s |
| implement* | MiniMax-M2.7-highspeed | 1 | 353.3k | 4.4k | 473.3k | 29.8k | 44 | 16.2k | 1m 53s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 60.4k | 3.1k | 205.5k | 29.8k | 21 | 15.2k | 1m 22s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 38.2k | 1.7k | 175.7k | 29.8k | 15 | 15.0k | 44s |
| review_pr | claude-sonnet-4-6 | 1 | 179 | 17.9k | 306.6k | 49.9k | 28 | 40.1k | 3m 46s |
| resolve_review | claude-opus-4-6 | 1 | 41 | 5.0k | 590.3k | 49.9k | 35 | 37.0k | 3m 42s |
| **Total** | | | 453.6k | 53.4k | 3.6M | 71.2k | | 226.3k | 22m 57s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 49 | 9658.3 | 330.3 | 89.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 590337.0 | 37002.0 | 4953.0 |
| **Total** | **50** | 72356.9 | 4525.3 | 1068.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 1.6k | 25.1k | 2.5M | 137.3k | 15m 22s |
| MiniMax-M2.7-highspeed | 3 | 451.9k | 9.2k | 854.4k | 46.5k | 3m 59s |