### PR TITLE
Lazy Import MockSubprocessRunner in conftest.py

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -131,9 +131,9 @@ _LARGE_CHANGESET_THRESHOLD: int = 30
 
 # Modules in this set trigger a full 17-directory cascade. A core/ module belongs
 # here if:
-# (a) it is imported at the top level of tests/conftest.py or tests/fakes.py, OR
-# (b) its types have concrete implementations in tests/fakes.py (protocol satisfaction),
-# because conftest.py imports fakes, making any signature break cascade to all dirs.
+# (a) it is imported at the top level of tests/conftest.py, OR
+# (b) its types have concrete implementations in tests/fakes.py (protocol satisfaction)
+#     AND fakes.py is imported at module level by test files across most directories.
 # If neither condition holds, use MODULE_CASCADE_CORE with an explicit narrower cascade.
 _CORE_UNIVERSAL_MODULES: frozenset[str] = frozenset(
     {
@@ -148,7 +148,6 @@ _CORE_UNIVERSAL_MODULES: frozenset[str] = frozenset(
         "_type_protocols_infra",
         "_type_enums",
         "_type_subprocess",
-        "_type_results",
     }
 )
 
@@ -190,6 +189,23 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "session_registry": frozenset({"core"}),
     "tool_sequence_analysis": frozenset({"core", "execution", "server", "cli"}),
     "_type_checkpoint": frozenset({"core", "execution", "fleet", "server"}),
+    "_type_results": frozenset(
+        {
+            "core",
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "fleet",
+            "server",
+            "cli",
+            "_llm_triage",
+            "_test_filter",
+            "hook_registry",
+            "smoke_utils",
+        }
+    ),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ from autoskillit.core.types import (
     TerminationReason,
 )
 from tests._helpers import _flush_structlog_proxy_caches
-from tests.fakes import MockSubprocessRunner
 
 _LAYER_DIRS: frozenset[str] = frozenset(
     {
@@ -304,6 +303,7 @@ def tool_ctx(monkeypatch, tmp_path):
     from autoskillit.pipeline.gate import DefaultGateState
     from autoskillit.server import _state
     from autoskillit.server._factory import make_context
+    from tests.fakes import MockSubprocessRunner
 
     mock_runner = MockSubprocessRunner()
     ctx = make_context(
@@ -331,6 +331,7 @@ def tool_ctx_marketplace(monkeypatch, tmp_path):
     from autoskillit.pipeline.gate import DefaultGateState
     from autoskillit.server import _state
     from autoskillit.server._factory import make_context
+    from tests.fakes import MockSubprocessRunner
 
     fake_cache = tmp_path / "marketplace_cache"
     fake_cache.mkdir()

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -31,7 +31,6 @@ class TestCoreUniversalModules:
             "_type_protocols_infra",
             "_type_enums",
             "_type_subprocess",
-            "_type_results",
         }
         assert required <= _CORE_UNIVERSAL_MODULES
 
@@ -91,6 +90,7 @@ class TestModuleCascadeCore:
             "session_registry",
             "tool_sequence_analysis",
             "_type_checkpoint",
+            "_type_results",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
 
@@ -111,6 +111,25 @@ class TestModuleCascadeCore:
         assert "_type_checkpoint" in MODULE_CASCADE_CORE
         assert MODULE_CASCADE_CORE["_type_checkpoint"] == frozenset(
             {"core", "execution", "fleet", "server"}
+        )
+
+    def test_type_results_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_results"] == frozenset(
+            {
+                "core",
+                "execution",
+                "pipeline",
+                "workspace",
+                "recipe",
+                "migration",
+                "fleet",
+                "server",
+                "cli",
+                "_llm_triage",
+                "_test_filter",
+                "hook_registry",
+                "smoke_utils",
+            }
         )
 
 
@@ -136,6 +155,7 @@ class TestBuildTestScopeCoreCascade:
         "cli",
         "hooks",
         "skills",
+        "planner",
         "arch",
         "contracts",
         "infra",
@@ -346,6 +366,22 @@ class TestBuildTestScopeCoreCascade:
         for excluded in ["cli", "config", "pipeline", "workspace", "recipe", "migration", "hooks"]:
             assert excluded not in dir_names, (
                 f"_type_checkpoint cascade should not include {excluded}"
+            )
+
+    def test_type_results_narrow_routing(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_results.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "execution", "server", "fleet", "migration"]:
+            assert pkg in dir_names, f"_type_results cascade should include {pkg}"
+        for excluded in ["config", "hooks", "skills", "planner"]:
+            assert excluded not in dir_names, (
+                f"_type_results cascade should not include {excluded}"
             )
 
 


### PR DESCRIPTION
## Summary

Break the module-level `conftest.py → fakes.py → core/types/_type_results` import chain by converting the `MockSubprocessRunner` import in `tests/conftest.py` from module-level to function-level (lazy) inside the two fixtures that use it. Then move `_type_results` from `_CORE_UNIVERSAL_MODULES` to `MODULE_CASCADE_CORE` with a 13-directory cascade, removing 4 false-positive directories (config, hooks, skills, planner) that never use any `_type_results` type.

## Requirements

- REQ-FIX-001: Remove the module-level `from tests.fakes import MockSubprocessRunner` at `tests/conftest.py:19`
- REQ-FIX-002: Add `from tests.fakes import MockSubprocessRunner` inside the `tool_ctx` fixture body (~line 308)
- REQ-FIX-003: Add `from tests.fakes import MockSubprocessRunner` inside the `tool_ctx_marketplace` fixture body (~line 338)
- REQ-FIX-004: After the lazy import change, move `_type_results` from `_CORE_UNIVERSAL_MODULES` to `MODULE_CASCADE_CORE` in `tests/_test_filter.py` with a 13-directory cascade (all current dirs minus `config`, `hooks`, `skills`, `planner`)
- REQ-FIX-005: All existing tests must continue to pass

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-191436-358331/.autoskillit/temp/make-plan/lazy_import_mocksubprocessrunner_plan_2026-05-06_191700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 78 | 9.6k | 581.7k | 57.1k | 85 | 48.3k | 12m 6s |
| verify | claude-sonnet-4-6 | 1 | 1.4k | 20.7k | 1.0M | 71.5k | 131 | 58.4k | 11m 42s |
| implement* | MiniMax-M2.7-highspeed | 1 | 549.3k | 7.3k | 770.8k | 29.8k | 63 | 16.1k | 2m 42s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 50.3k | 2.3k | 175.7k | 29.8k | 16 | 15.2k | 52s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.4k | 1.6k | 205.4k | 29.8k | 14 | 15.0k | 46s |
| review_pr | claude-sonnet-4-6 | 1 | 108 | 12.9k | 479.1k | 47.9k | 36 | 35.3k | 3m 34s |
| resolve_review | claude-opus-4-6 | 1 | 40 | 4.7k | 521.1k | 48.4k | 29 | 35.6k | 5m 59s |
| resolve_queue_merge_conflicts | claude-sonnet-4-6 | 1 | 179 | 16.5k | 1.2M | 77.4k | 60 | 64.6k | 3m 57s |
| **Total** | | | 647.8k | 75.6k | 5.0M | 77.4k | | 288.6k | 41m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 65 | 11858.1 | 247.0 | 111.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| resolve_queue_merge_conflicts | 667 | 1792.2 | 96.9 | 24.7 |
| **Total** | **732** | 6786.9 | 394.2 | 103.3 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 1.4k | 30.3k | 1.6M | 106.7k | 23m 49s |
| MiniMax-M2.7-highspeed | 3 | 646.0k | 11.2k | 1.2M | 46.3k | 4m 20s |