### PR TITLE
Add Extension Bundles to SkillResult

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -197,6 +197,7 @@ from .types import RetryReason as RetryReason
 from .types import SessionOutcome as SessionOutcome
 from .types import SessionSkillManager as SessionSkillManager
 from .types import ProviderOutcome as ProviderOutcome
+from .types import InfraOutcome as InfraOutcome
 from .types import RecipeIdentity as RecipeIdentity
 from .types import SessionTelemetry as SessionTelemetry
 from .types import SessionType as SessionType

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -25,3 +25,7 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 ## Architecture Notes
 
 Internal dependency DAG: enums -> constants -> subprocess -> results -> protocols -> helpers. All modules have zero `autoskillit` imports outside this sub-package (IL-0 hard constraint). Production code imports from `autoskillit.core`, not from this package directly.
+
+## Extension Bundle Pattern
+
+New feature fields go on frozen dataclass bundles (`InfraOutcome`, `ProviderOutcome`), not flat on `SkillResult`. Bundles are embedded as `field(default_factory=...)` on `SkillResult`. The `to_json()` method flattens bundle fields to top-level JSON keys for backward compatibility.

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -279,10 +279,10 @@ class SkillResult:
             "lifespan_started": self.lifespan_started,
             "provider_fallback": self.provider.fallback_activated,
             "provider_used": self.provider.provider_used,
+            "infra_exit_category": self.infra.exit_category,
         }
         if self.worktree_path is not None:
             data["worktree_path"] = self.worktree_path
-        data["infra_exit_category"] = self.infra.exit_category
         data["order_id"] = self.order_id
         return json.dumps(data, default=lambda o: o.value if isinstance(o, Enum) else str(o))
 

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -26,6 +26,7 @@ __all__ = [
     "FailureRecord",
     "SessionTelemetry",
     "ProviderOutcome",
+    "InfraOutcome",
     "RecipeIdentity",
     "SkillResult",
     "CleanupResult",
@@ -198,6 +199,13 @@ class ProviderOutcome:
 
 
 @dataclass(frozen=True)
+class InfraOutcome:
+    """Infrastructure exit classification bundle."""
+
+    exit_category: str = ""
+
+
+@dataclass(frozen=True)
 class RecipeIdentity:
     """Typed bundle of recipe identification fields for session logging.
 
@@ -245,12 +253,10 @@ class SkillResult:
     last_stop_reason: str = ""
     lifespan_started: bool = False
     """True when the headless session called an MCP tool (heuristic for server lifespan)."""
-    provider_used: str = field(default="")
-    """Provider identifier stamped by _build_skill_result (e.g. 'anthropic', 'vertex')."""
-    provider_fallback: bool = False
-    """True when this result was produced by a fallback provider (not the primary)."""
-    infra_exit_category: str = ""
-    """Infrastructure exit classification (InfraExitCategory value)."""
+    provider: ProviderOutcome = field(default_factory=ProviderOutcome.none_used)
+    """Provider execution outcome bundle."""
+    infra: InfraOutcome = field(default_factory=InfraOutcome)
+    """Infrastructure exit classification bundle."""
 
     def to_json(self) -> str:
         data: dict[str, Any] = {
@@ -271,12 +277,12 @@ class SkillResult:
             "fs_writes_detected": self.fs_writes_detected,
             "last_stop_reason": self.last_stop_reason,
             "lifespan_started": self.lifespan_started,
-            "provider_fallback": self.provider_fallback,
-            "provider_used": self.provider_used,
+            "provider_fallback": self.provider.fallback_activated,
+            "provider_used": self.provider.provider_used,
         }
         if self.worktree_path is not None:
             data["worktree_path"] = self.worktree_path
-        data["infra_exit_category"] = self.infra_exit_category
+        data["infra_exit_category"] = self.infra.exit_category
         data["order_id"] = self.order_id
         return json.dumps(data, default=lambda o: o.value if isinstance(o, Enum) else str(o))
 

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -359,8 +359,9 @@ async def _execute_claude_headless(
             )
             return dataclasses.replace(
                 _crashed,
-                provider_used=current_provider_name,
-                provider_fallback=fallback_activated,
+                provider=ProviderOutcome(
+                    provider_used=current_provider_name, fallback_activated=fallback_activated
+                ),
             )
         except BaseException:
             logger.warning("headless_runner_cancelled", exc_info=True)
@@ -594,8 +595,9 @@ async def _execute_claude_headless(
         logger.debug("token_log_record_failed", exc_info=True)
     skill_result = dataclasses.replace(
         skill_result,
-        provider_used=current_provider_name,
-        provider_fallback=fallback_activated,
+        provider=ProviderOutcome(
+            provider_used=current_provider_name, fallback_activated=fallback_activated
+        ),
     )
     return skill_result
 

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -12,7 +12,9 @@ from autoskillit.core import (
     CliSubtype,
     FailureRecord,
     InfraExitCategory,
+    InfraOutcome,
     KillReason,
+    ProviderOutcome,
     RetryReason,
     SessionOutcome,
     SessionTelemetry,
@@ -197,7 +199,9 @@ def _build_skill_result(
                     stderr=result.stderr if result.stderr else "",
                     token_usage=stale_session.token_usage,
                     last_stop_reason=stale_session.last_stop_reason,
-                    provider_used=provider_used,
+                    provider=ProviderOutcome(
+                        provider_used=provider_used, fallback_activated=False
+                    ),
                 )
         # No valid result in stdout — fall through to original stale response
         _capture_failure(
@@ -223,7 +227,7 @@ def _build_skill_result(
             retry_reason=RetryReason.STALE,
             stderr="",
             token_usage=None,
-            provider_used=provider_used,
+            provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
         )
         return _apply_budget_guard(stale_sr, skill_command, audit, max_consecutive_retries)
 
@@ -260,7 +264,9 @@ def _build_skill_result(
                     token_usage=idle_session.token_usage,
                     last_stop_reason=idle_session.last_stop_reason,
                     lifespan_started=idle_session.lifespan_started,
-                    provider_used=provider_used,
+                    provider=ProviderOutcome(
+                        provider_used=provider_used, fallback_activated=False
+                    ),
                 )
         _capture_failure(
             skill_command,
@@ -289,7 +295,7 @@ def _build_skill_result(
             stderr="",
             token_usage=idle_session.token_usage,
             lifespan_started=idle_session.lifespan_started,
-            provider_used=provider_used,
+            provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
         )
         return _apply_budget_guard(idle_sr, skill_command, audit, max_consecutive_retries)
 
@@ -523,8 +529,8 @@ def _build_skill_result(
             fs_writes_detected=fs_writes_detected,
             last_stop_reason=session.last_stop_reason,
             lifespan_started=session.lifespan_started,
-            provider_used=provider_used,
-            infra_exit_category=infra_category.value,
+            provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
+            infra=InfraOutcome(exit_category=infra_category.value),
         )
     else:
         sr = SkillResult(
@@ -546,8 +552,8 @@ def _build_skill_result(
             kill_reason=result.kill_reason,
             last_stop_reason=session.last_stop_reason,
             lifespan_started=session.lifespan_started,
-            provider_used=provider_used,
-            infra_exit_category=infra_category.value,
+            provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
+            infra=InfraOutcome(exit_category=infra_category.value),
         )
     sr = _apply_budget_guard(sr, skill_command, audit, max_consecutive_retries)
 

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -223,7 +223,7 @@ def _is_abandon_reason(skill_result: SkillResult) -> bool:
         return True
     if (
         skill_result.retry_reason == RetryReason.RESUME
-        and skill_result.infra_exit_category == InfraExitCategory.CONTEXT_EXHAUSTED
+        and skill_result.infra.exit_category == InfraExitCategory.CONTEXT_EXHAUSTED
     ):
         return True
     return False
@@ -443,7 +443,7 @@ async def _run_dispatch(
                 dispatched_pid=_dispatched_pid[0] if _dispatched_pid else 0,
                 reason=FleetErrorCode.FLEET_L3_TIMEOUT,
                 kill_reason=skill_result.retry_reason or "",
-                infra_exit_category=skill_result.infra_exit_category or "",
+                infra_exit_category=skill_result.infra.exit_category or "",
                 token_usage=skill_result.token_usage or {},
                 started_at=started_at,
                 ended_at=ended_at,
@@ -496,7 +496,7 @@ async def _run_dispatch(
             dispatched_pid=_dispatched_pid[0] if _dispatched_pid else 0,
             reason=reason,
             kill_reason=skill_result.retry_reason or "",
-            infra_exit_category=skill_result.infra_exit_category or "",
+            infra_exit_category=skill_result.infra.exit_category or "",
             token_usage=skill_result.token_usage or {},
             started_at=started_at,
             ended_at=ended_at,

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -203,8 +203,8 @@ def persist_run_skill_state(skill_result: SkillResult, project_dir: Path) -> Non
             pid=os.getpid(),
             boot_id="",
             starttime_ticks=0,
-            infra_exit_category=skill_result.infra_exit_category
-            if skill_result.infra_exit_category
+            infra_exit_category=skill_result.infra.exit_category
+            if skill_result.infra.exit_category
             else None,
         )
         state_dir = ensure_project_temp(project_dir) / "session_state"

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import json
+from dataclasses import FrozenInstanceError
 from typing import Any, ClassVar
 
 import pytest
@@ -9,8 +10,10 @@ import pytest
 from autoskillit.core.types import (
     ChannelConfirmation,
     CIRunScope,
+    InfraOutcome,
     MergeFailedStep,
     MergeState,
+    ProviderOutcome,
     RestartScope,
     RetryReason,
     SessionOutcome,
@@ -421,11 +424,11 @@ class TestSkillResultCrashedFactory:
 
     def test_crashed_sets_provider_used_empty_string(self):
         result = SkillResult.crashed(exception=RuntimeError("boom"))
-        assert result.provider_used == ""
+        assert result.provider.provider_used == ""
 
     def test_crashed_sets_provider_fallback_false(self):
         result = SkillResult.crashed(exception=RuntimeError("boom"))
-        assert result.provider_fallback is False
+        assert result.provider.fallback_activated is False
 
 
 class TestSkillResultProviderFields:
@@ -443,15 +446,16 @@ class TestSkillResultProviderFields:
 
     def test_provider_used_defaults_to_empty_string(self):
         sr = SkillResult(**self._BASE_KWARGS)
-        assert sr.provider_used == ""
+        assert sr.provider.provider_used == ""
 
     def test_provider_fallback_defaults_to_false(self):
         sr = SkillResult(**self._BASE_KWARGS)
-        assert sr.provider_fallback is False
+        assert sr.provider.fallback_activated is False
 
     def test_to_json_includes_provider_used_when_non_empty(self):
         sr = SkillResult(
-            **self._BASE_KWARGS, provider_used="anthropic-vertex", provider_fallback=True
+            **self._BASE_KWARGS,
+            provider=ProviderOutcome(provider_used="anthropic-vertex", fallback_activated=True),
         )
         data = json.loads(sr.to_json())
         assert data["provider_used"] == "anthropic-vertex"
@@ -464,12 +468,127 @@ class TestSkillResultProviderFields:
         assert data["provider_used"] == ""
 
     def test_to_json_includes_provider_fallback_when_true(self):
-        sr = SkillResult(**self._BASE_KWARGS, provider_fallback=True)
+        sr = SkillResult(
+            **self._BASE_KWARGS,
+            provider=ProviderOutcome(provider_used="", fallback_activated=True),
+        )
         data = json.loads(sr.to_json())
         assert "provider_fallback" in data
         assert data["provider_fallback"] is True
 
     def test_provider_used_round_trips_via_json(self):
-        sr = SkillResult(**self._BASE_KWARGS, provider_used="bedrock-us")
+        sr = SkillResult(
+            **self._BASE_KWARGS,
+            provider=ProviderOutcome(provider_used="bedrock-us", fallback_activated=False),
+        )
         data = json.loads(sr.to_json())
         assert data["provider_used"] == "bedrock-us"
+
+
+class TestInfraOutcome:
+    def test_default_exit_category_is_empty(self):
+        outcome = InfraOutcome()
+        assert outcome.exit_category == ""
+
+    def test_custom_exit_category(self):
+        outcome = InfraOutcome(exit_category="context_exhausted")
+        assert outcome.exit_category == "context_exhausted"
+
+    def test_frozen_rejects_mutation(self):
+        outcome = InfraOutcome(exit_category="completed")
+        with pytest.raises(FrozenInstanceError):
+            outcome.exit_category = "api_error"
+
+
+class TestSkillResultExtensionBundles:
+    _BASE_KWARGS: ClassVar[dict[str, Any]] = {
+        "success": True,
+        "result": "ok",
+        "session_id": "",
+        "subtype": "success",
+        "is_error": False,
+        "exit_code": 0,
+        "needs_retry": False,
+        "retry_reason": RetryReason.NONE,
+        "stderr": "",
+    }
+
+    def test_provider_bundle_defaults_to_none_used(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        assert sr.provider == ProviderOutcome.none_used()
+        assert sr.provider.provider_used == ""
+        assert sr.provider.fallback_activated is False
+
+    def test_infra_bundle_defaults_to_empty(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        assert sr.infra == InfraOutcome()
+        assert sr.infra.exit_category == ""
+
+    def test_provider_bundle_accepts_custom_value(self):
+        sr = SkillResult(
+            **self._BASE_KWARGS,
+            provider=ProviderOutcome(provider_used="anthropic", fallback_activated=True),
+        )
+        assert sr.provider.provider_used == "anthropic"
+        assert sr.provider.fallback_activated is True
+
+    def test_infra_bundle_accepts_custom_value(self):
+        sr = SkillResult(
+            **self._BASE_KWARGS,
+            infra=InfraOutcome(exit_category="api_error"),
+        )
+        assert sr.infra.exit_category == "api_error"
+
+    def test_flat_provider_used_removed(self):
+        assert "provider_used" not in [f.name for f in dataclasses.fields(SkillResult)]
+
+    def test_flat_provider_fallback_removed(self):
+        assert "provider_fallback" not in [f.name for f in dataclasses.fields(SkillResult)]
+
+    def test_flat_infra_exit_category_removed(self):
+        assert "infra_exit_category" not in [f.name for f in dataclasses.fields(SkillResult)]
+
+    def test_to_json_emits_flat_provider_used_key(self):
+        sr = SkillResult(
+            **self._BASE_KWARGS,
+            provider=ProviderOutcome(provider_used="vertex", fallback_activated=False),
+        )
+        data = json.loads(sr.to_json())
+        assert data["provider_used"] == "vertex"
+
+    def test_to_json_emits_flat_provider_fallback_key(self):
+        sr = SkillResult(
+            **self._BASE_KWARGS,
+            provider=ProviderOutcome(provider_used="anthropic", fallback_activated=True),
+        )
+        data = json.loads(sr.to_json())
+        assert data["provider_fallback"] is True
+
+    def test_to_json_emits_flat_infra_exit_category_key(self):
+        sr = SkillResult(
+            **self._BASE_KWARGS,
+            infra=InfraOutcome(exit_category="context_exhausted"),
+        )
+        data = json.loads(sr.to_json())
+        assert data["infra_exit_category"] == "context_exhausted"
+
+    def test_to_json_provider_empty_defaults(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        data = json.loads(sr.to_json())
+        assert data["provider_used"] == ""
+        assert data["provider_fallback"] is False
+        assert data["infra_exit_category"] == ""
+
+    def test_replace_infra_bundle(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        sr2 = dataclasses.replace(sr, infra=InfraOutcome(exit_category="api_error"))
+        assert sr2.infra.exit_category == "api_error"
+        assert sr.infra.exit_category == ""
+
+    def test_replace_provider_bundle(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        sr2 = dataclasses.replace(
+            sr, provider=ProviderOutcome(provider_used="vertex", fallback_activated=True)
+        )
+        assert sr2.provider.provider_used == "vertex"
+        assert sr2.provider.fallback_activated is True

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -160,8 +160,8 @@ class TestProviderFieldsReachFlush:
             step_name="implement",
         )
 
-        assert result.provider_fallback is True
-        assert result.provider_used == "anthropic"
+        assert result.provider.fallback_activated is True
+        assert result.provider.provider_used == "anthropic"
         assert len(flush_calls) == 1
         outcome = flush_calls[0]["provider_outcome"]
         assert outcome.provider_used == "anthropic"

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -934,13 +934,13 @@ class TestBuildSkillResultCrossValidation:
         "infra_exit_category",
     }
 
-    def test_expected_skill_keys_includes_provider_used(self):
+    def test_expected_skill_keys_includes_provider(self):
         import dataclasses
 
         from autoskillit.core.types import SkillResult
 
         skill_result_field_names = {f.name for f in dataclasses.fields(SkillResult)}
-        assert "provider_used" in skill_result_field_names
+        assert "provider" in skill_result_field_names
 
     def test_empty_stdout_exit_zero_is_failure(self):
         """Exit 0 with empty stdout is NOT success — output was lost."""

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -129,8 +129,8 @@ class TestProviderFallbackLoop:
         )
 
         assert call_count[0] == 2
-        assert result.provider_fallback is True
-        assert result.provider_used == "anthropic"
+        assert result.provider.fallback_activated is True
+        assert result.provider.provider_used == "anthropic"
 
     @pytest.mark.anyio
     async def test_budget_exhausted_triggers_fallback(self, minimal_ctx, tmp_path, monkeypatch):
@@ -157,8 +157,8 @@ class TestProviderFallbackLoop:
         )
 
         assert call_count[0] == 2
-        assert result.provider_fallback is True
-        assert result.provider_used == "anthropic"
+        assert result.provider.fallback_activated is True
+        assert result.provider.provider_used == "anthropic"
 
     @pytest.mark.anyio
     async def test_no_fallback_env_suppresses_retry(self, minimal_ctx, tmp_path, monkeypatch):
@@ -182,7 +182,7 @@ class TestProviderFallbackLoop:
         )
 
         assert call_count[0] == 1
-        assert result.provider_fallback is False
+        assert result.provider.fallback_activated is False
 
     @pytest.mark.anyio
     async def test_anthropic_provider_never_falls_back(self, minimal_ctx, tmp_path, monkeypatch):
@@ -209,4 +209,4 @@ class TestProviderFallbackLoop:
         )
 
         assert call_count[0] == 1
-        assert result.provider_fallback is False
+        assert result.provider.fallback_activated is False

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -253,8 +253,8 @@ async def test_no_fallback_env_returns_empty_provider_used(
         stale_threshold=5.0,
     )
 
-    assert result.provider_used == ""
-    assert result.provider_fallback is False
+    assert result.provider.provider_used == ""
+    assert result.provider.fallback_activated is False
 
 
 @pytest.mark.anyio
@@ -295,8 +295,8 @@ async def test_provider_name_stamps_provider_used_on_result(
         provider_name="bedrock",
     )
 
-    assert result.provider_used == "bedrock"
-    assert result.provider_fallback is False
+    assert result.provider.provider_used == "bedrock"
+    assert result.provider.fallback_activated is False
 
 
 def test_headless_executor_protocol_includes_provider_params() -> None:
@@ -326,9 +326,9 @@ def test_build_skill_result_stamps_provider_used_on_result() -> None:
 
     sub_result = _sr(stdout="result: done\n", returncode=0)
     sr = _build_skill_result(sub_result, provider_used="vertex")
-    assert sr.provider_used == "vertex"
+    assert sr.provider.provider_used == "vertex"
     sr_default = _build_skill_result(sub_result)
-    assert sr_default.provider_used == ""
+    assert sr_default.provider.provider_used == ""
 
 
 def test_build_skill_result_provider_used_survives_budget_guard() -> None:
@@ -345,4 +345,4 @@ def test_build_skill_result_provider_used_survives_budget_guard() -> None:
         max_consecutive_retries=3,
         provider_used="bedrock",
     )
-    assert sr.provider_used == "bedrock"
+    assert sr.provider.provider_used == "bedrock"

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -9,6 +9,8 @@ import structlog
 
 from autoskillit.core.types import (
     ChannelConfirmation,
+    InfraExitCategory,
+    InfraOutcome,
     RetryReason,
     SubprocessResult,
     TerminationReason,
@@ -819,7 +821,6 @@ class TestFullChainZeroWriteGate:
 
 def test_skill_result_to_json_includes_infra_exit_category():
     """infra_exit_category is serialized when non-empty."""
-    from autoskillit.core.types import InfraExitCategory
 
     sr = SkillResult(
         success=False,
@@ -831,7 +832,7 @@ def test_skill_result_to_json_includes_infra_exit_category():
         needs_retry=True,
         retry_reason=RetryReason.RESUME,
         stderr="",
-        infra_exit_category=InfraExitCategory.CONTEXT_EXHAUSTED,
+        infra=InfraOutcome(exit_category=InfraExitCategory.CONTEXT_EXHAUSTED),
     )
     data = json.loads(sr.to_json())
     assert data["infra_exit_category"] == "context_exhausted"

--- a/tests/fleet/test_dispatch_outcome_classifier.py
+++ b/tests/fleet/test_dispatch_outcome_classifier.py
@@ -6,7 +6,7 @@ import dataclasses
 
 import pytest
 
-from autoskillit.core import FleetErrorCode, SkillResult
+from autoskillit.core import FleetErrorCode, InfraOutcome, SkillResult
 from autoskillit.fleet import DispatchStatus
 from autoskillit.fleet._api import classify_dispatch_outcome
 from autoskillit.fleet.result_parser import L3ParseResult
@@ -118,7 +118,7 @@ class TestReasonAwareResumePolicy:
         skill_result = dataclasses.replace(
             skill_result,
             retry_reason="resume",
-            infra_exit_category="context_exhausted",
+            infra=InfraOutcome(exit_category="context_exhausted"),
         )
         status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
         assert status == DispatchStatus.FAILURE
@@ -129,7 +129,7 @@ class TestReasonAwareResumePolicy:
         skill_result = dataclasses.replace(
             skill_result,
             retry_reason="resume",
-            infra_exit_category="api_error",
+            infra=InfraOutcome(exit_category="api_error"),
         )
         status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
         assert status == DispatchStatus.RESUMABLE
@@ -140,7 +140,7 @@ class TestReasonAwareResumePolicy:
         skill_result = dataclasses.replace(
             skill_result,
             retry_reason="resume",
-            infra_exit_category="process_killed",
+            infra=InfraOutcome(exit_category="process_killed"),
         )
         status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
         assert status == DispatchStatus.RESUMABLE


### PR DESCRIPTION
## Summary

Migrate flat provider and infra fields from `SkillResult` into frozen dataclass bundles. Create `InfraOutcome` to absorb `infra_exit_category`, and embed the existing `ProviderOutcome` directly on `SkillResult` to replace the flat `provider_used` and `provider_fallback` fields. Serialization output remains unchanged (same JSON keys) for backward compatibility with on-disk session logs and hook formatters.

## Requirements

- REQ-BUNDLE-001: Create `InfraOutcome` frozen dataclass to absorb `infra_exit_category` (and future infra fields)
- REQ-BUNDLE-002: Migrate `provider_used` and `provider_fallback` flat fields on `SkillResult` into the existing `ProviderOutcome` bundle (if not already bundled)
- REQ-BUNDLE-003: Update all consumers of the flat fields to use bundle accessors (e.g., `result.infra.exit_category`)
- REQ-BUNDLE-004: Update serialization paths (`to_json()` or equivalent) to handle nested bundles
- REQ-BUNDLE-005: Ensure backward compat for any serialized data on disk (session logs, telemetry)
- REQ-BUNDLE-006: All existing tests must continue to pass
- REQ-BUNDLE-007: Document the pattern in `core/types/CLAUDE.md` — new feature fields go on bundles, not flat on SkillResult

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-191434-693062/.autoskillit/temp/make-plan/add_extension_bundles_to_skillresult_plan_2026-05-06_191700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 74 | 11.0k | 387.2k | 95.8k | 83 | 41.7k | 5m 55s |
| verify | claude-opus-4-6 | 1 | 1.0k | 14.2k | 2.6M | 85.0k | 135 | 72.2k | 6m 58s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.8M | 18.7k | 2.6M | 82.5k | 254 | 178.7k | 13m 30s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 143.0k | 3.7k | 354.2k | 29.8k | 26 | 15.2k | 1m 25s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 122.0k | 1.6k | 294.7k | 29.8k | 24 | 15.0k | 51s |
| review_pr | claude-sonnet-4-6 | 1 | 126 | 30.0k | 732.8k | 76.3k | 74 | 64.2k | 7m 14s |
| resolve_review | claude-opus-4-6 | 1 | 44 | 7.1k | 758.6k | 55.6k | 39 | 42.9k | 7m 28s |
| **Total** | | | 4.1M | 86.3k | 7.7M | 95.8k | | 429.9k | 43m 24s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 251 | 10494.4 | 711.9 | 74.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 379284.5 | 21430.5 | 3526.0 |
| **Total** | **253** | 30621.4 | 1699.2 | 340.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 74 | 11.0k | 387.2k | 41.7k | 5m 55s |
| claude-opus-4-6 | 1 | 1.0k | 14.2k | 2.6M | 72.2k | 6m 58s |
| MiniMax-M2.7-highspeed | 3 | 4.1M | 24.0k | 3.3M | 208.9k | 15m 47s |