### PR TITLE
P4-C8 Regression Guard — research.yaml Backward Compat

### DIFF
--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -77,6 +77,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_research_recipe_diag.py` | Tests for research recipe diagnostic output |
 | `test_research_campaign_rules.py` | Contract tests for research-campaign.yaml semantic rules |
 | `test_research_campaign_structure.py` | Structural assertions for the bundled research-campaign.yaml |
+| `test_research_yaml_backward_compat.py` | Regression guard: research.yaml loads cleanly, validates with zero errors, and retains RecipeKind.STANDARD |
 | `test_research_review_recipe.py` | Tests for research-review sub-recipe structure |
 | `test_research_stage_data_step.py` | Tests for stage-data step in research recipes |
 | `test_research_sub_recipes.py` | Tests for research sub-recipe YAML structure (design, implement, review, archive) |

--- a/tests/recipe/test_research_yaml_backward_compat.py
+++ b/tests/recipe/test_research_yaml_backward_compat.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.schema import RecipeKind
+from autoskillit.recipe.validator import validate_recipe
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestResearchYamlBackwardCompat:
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        return load_recipe(builtin_recipes_dir() / "research.yaml")
+
+    def test_research_yaml_loads_without_error(self, recipe):
+        assert recipe is not None
+
+    def test_research_yaml_validates_with_no_errors(self, recipe):
+        errors = validate_recipe(recipe)
+        assert errors == []
+
+    def test_research_yaml_kind_is_standard(self, recipe):
+        assert recipe.kind == RecipeKind.STANDARD


### PR DESCRIPTION
## Summary

Create `tests/recipe/test_research_yaml_backward_compat.py` — a focused regression guard that ensures `research.yaml` loads cleanly, passes `validate_recipe()` with zero errors, and retains `RecipeKind.STANDARD` after P2/P3 structural changes. This provides genuine new coverage: the existing `test_bundled_recipes_research.py` validates structure but never asserts `RecipeKind.STANDARD`.

## Changed Files

### New (★)

- `tests/recipe/test_research_yaml_backward_compat.py`

### Modified (●)

- `tests/recipe/CLAUDE.md`

## Technical Notes

The test file enforces a backward-compat contract: `research.yaml` must load cleanly, validate with no errors, and retain `RecipeKind.STANDARD` before and after P1-A1 (which adds a 'categories' field). No assertions reference the 'categories' field to remain stable across that change.

Closes #1719

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-195226-751551/.autoskillit/temp/make-plan/p4_c8_regression_guard_research_yaml_backward_compat_plan_2026-05-06_195226.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 991 | 4.0k | 364.9k | 37.2k | 41 | 26.0k | 2m 53s |
| verify | claude-sonnet-4-6 | 1 | 30 | 7.3k | 387.3k | 39.2k | 61 | 28.0k | 5m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 190.3k | 2.7k | 422.0k | 35.0k | 31 | 49.9k | 5m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 83.1k | 4.5k | 273.2k | 35.0k | 29 | 47.7k | 2m 3s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.0k | 1.1k | 178.6k | 29.8k | 14 | 41.9k | 43s |
| **Total** | | | 321.5k | 19.6k | 1.6M | 39.2k | | 193.5k | 16m 6s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 26 | 16230.2 | 1918.2 | 103.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **26** | 62534.3 | 7443.0 | 754.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 991 | 4.0k | 364.9k | 26.0k | 2m 53s |
| claude-sonnet-4-6 | 1 | 30 | 7.3k | 387.3k | 28.0k | 5m 8s |
| MiniMax-M2.7-highspeed | 3 | 320.5k | 8.3k | 873.7k | 139.5k | 8m 4s |