### PR TITLE
P5-A1-WP1 Add cache tokens to index_entry + dispatch/campaign IDs to token_usage.json

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -550,6 +550,8 @@ class TokenUsageFileEntry(TypedDict):
     loc_deletions: int
     provider_used: str
     model_identifier: str
+    dispatch_id: str
+    campaign_id: str
 
 
 class SessionIndexEntry(TypedDict):

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -397,6 +397,8 @@ def flush_session_log(
             "turn_count": token_usage.get("turn_count", 0),
             "provider_used": provider_outcome.provider_used,
             "model_identifier": model_identifier or _primary_model_identifier(token_usage),
+            "dispatch_id": dispatch_id,
+            "campaign_id": campaign_id,
         }
         atomic_write(session_dir / "token_usage.json", json.dumps(tu_data))
 

--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -58,6 +58,8 @@ TOKEN_USAGE_FILE_KEYS: frozenset[str] = frozenset(
         "loc_deletions",
         "provider_used",
         "model_identifier",
+        "dispatch_id",
+        "campaign_id",
     }
 )
 

--- a/tests/contracts/test_token_summary_contracts.py
+++ b/tests/contracts/test_token_summary_contracts.py
@@ -122,6 +122,8 @@ def test_flush_to_hook_cross_seam(tmp_path):
         "turn_count": 3,
         "provider_used": "test-provider",
         "model_identifier": "test-model",
+        "dispatch_id": "test-dispatch",
+        "campaign_id": "test-campaign",
     }
     (session_dir / "token_usage.json").write_text(json.dumps(tu_data))
 

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -758,6 +758,48 @@ def test_token_usage_file_entry_type_matches_written_fields(tmp_path):
     assert set(data.keys()) == expected_keys
 
 
+def test_token_usage_json_includes_dispatch_and_campaign_ids(tmp_path):
+    """flush_session_log writes dispatch_id and campaign_id to token_usage.json."""
+    _flush(
+        tmp_path,
+        step_name="implement",
+        dispatch_id="d-abc-123",
+        campaign_id="c-xyz-789",
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 20,
+        },
+        timing_seconds=5.0,
+        proc_snapshots=None,
+        success=True,
+    )
+    tu = json.loads((tmp_path / "sessions" / "test-session-001" / "token_usage.json").read_text())
+    assert tu["dispatch_id"] == "d-abc-123"
+    assert tu["campaign_id"] == "c-xyz-789"
+
+
+def test_token_usage_json_dispatch_campaign_default_empty(tmp_path):
+    """dispatch_id and campaign_id present as empty strings when omitted."""
+    _flush(
+        tmp_path,
+        step_name="plan",
+        token_usage={
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+        timing_seconds=2.0,
+        proc_snapshots=None,
+        success=True,
+    )
+    tu = json.loads((tmp_path / "sessions" / "test-session-001" / "token_usage.json").read_text())
+    assert tu["dispatch_id"] == ""
+    assert tu["campaign_id"] == ""
+
+
 def test_flush_co_writes_provenance_record(tmp_path, monkeypatch):
     """flush_session_log writes a provenance record when cwd is non-empty."""
     monkeypatch.delenv("AUTOSKILLIT_STATE_DIR", raising=False)

--- a/tests/infra/_token_summary_helpers.py
+++ b/tests/infra/_token_summary_helpers.py
@@ -82,6 +82,8 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
             "loc_deletions": entry.get("loc_deletions", 0),
             "peak_context": entry.get("peak_context", 0),
             "turn_count": entry.get("turn_count", 0),
+            "dispatch_id": entry.get("dispatch_id", ""),
+            "campaign_id": entry.get("campaign_id", ""),
         }
         if "model_identifier" in entry:
             token_data["model_identifier"] = entry["model_identifier"]

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -115,8 +115,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/execution/session_log.py", 305),
     ("src/autoskillit/execution/session_log.py", 368),
     ("src/autoskillit/execution/session_log.py", 372),
-    ("src/autoskillit/execution/session_log.py", 401),
-    ("src/autoskillit/execution/session_log.py", 404),
+    ("src/autoskillit/execution/session_log.py", 403),
+    ("src/autoskillit/execution/session_log.py", 406),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),


### PR DESCRIPTION
## Summary

Add `dispatch_id` and `campaign_id` to the `tu_data` dict written to `token_usage.json` by `flush_session_log()`. Part A (cache tokens in `index_entry`) is already implemented — lines 441-446 of `session_log.py` already contain `cache_creation_input_tokens` and `cache_read_input_tokens` with the correct guard pattern. Only Part B remains: propagating `dispatch_id` and `campaign_id` (already in-scope as function parameters) into the `tu_data` dict, and updating the `TokenUsageFileEntry` TypedDict contract and `TOKEN_USAGE_FILE_KEYS` frozenset to match.

Closes #1722

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-195226-832089/.autoskillit/temp/make-plan/p5_a1_wp1_cache_tokens_dispatch_ids_plan_2026-05-06_195226.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 89 | 7.7k | 1.1M | 61.1k | 65 | 51.3k | 5m 36s |
| verify | claude-opus-4-6 | 1 | 1.3k | 8.0k | 994.3k | 58.6k | 72 | 45.9k | 5m 33s |
| implement* | MiniMax-M2.7-highspeed | 1 | 434.2k | 6.0k | 711.6k | 29.8k | 66 | 16.1k | 6m 2s |
| fix | claude-opus-4-6 | 2 | 82 | 6.1k | 918.6k | 44.4k | 49 | 55.4k | 13m 49s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 85.6k | 3.9k | 265.1k | 29.8k | 27 | 15.2k | 1m 29s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.2k | 1.3k | 175.8k | 29.8k | 14 | 15.0k | 38s |
| **Total** | | | 558.5k | 33.0k | 4.2M | 61.1k | | 198.9k | 33m 10s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 52 | 13684.0 | 308.7 | 116.2 |
| fix | 4 | 229641.2 | 13851.2 | 1525.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **56** | 74290.9 | 3551.5 | 590.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 1.5k | 21.8k | 3.0M | 152.6k | 25m 0s |
| MiniMax-M2.7-highspeed | 3 | 557.0k | 11.2k | 1.2M | 46.3k | 8m 10s |