### PR TITLE
planner-elaborate-wps SKILL.md lacks explicit deliverable count constraint (max=5)

### DIFF
--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -217,6 +217,7 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
     )
     items = []
     index_entries = []
+    errors: list[str] = []
     for f in result_files:
         try:
             raw = json.loads(f.read_text())
@@ -227,7 +228,8 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
         try:
             data = validate_wp_result(raw, allow_stub=bool(raw.get("elaboration_failed")))
         except (ValueError, KeyError) as exc:
-            raise ValueError(f"Invalid WP result in {f}: {exc}") from exc
+            errors.append(f"{f.name}: {exc}")
+            continue
         items.append(
             {
                 "id": data["id"],
@@ -238,6 +240,12 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
             }
         )
         index_entries.append(_build_index_entry(data))
+
+    if errors:
+        detail = "; ".join(errors)
+        raise ValueError(
+            f"{len(errors)} WP validation error{'s' if len(errors) != 1 else ''}: {detail}"
+        )
 
     items.sort(key=lambda i: _natural_sort_key(str(i["id"])))
     index_entries.sort(key=lambda e: _natural_sort_key(str(e["id"])))

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -93,11 +93,13 @@ Each L0 receives a self-contained prompt that:
 3. Lists all sibling WPs in short-form for dependency detection
 4. Provides phase goal and scope
 5. Instructs the L0 to use Grep/Glob/Read for codebase analysis (no sub-subagents)
-6. Instructs the L0 to return results as JSON between triple-backtick json fences
+6. Instructs the L0 to produce exactly 1–5 deliverables (hard constraint — validate_wp_result rejects out-of-range counts)
+7. Instructs the L0 to return results as JSON between triple-backtick json fences
 
 Each L0 MUST:
 - Use Grep/Glob/Read for codebase analysis (no sub-subagent spawning — they are actual leaf nodes)
 - Elaborate the WP with all mandatory fields
+- Produce exactly 1–5 deliverables — if the WP naturally spans more than 5 files, group related files into logical deliverables (e.g., "test suite for module X" rather than individual test files)
 - Return structured JSON between ` ```json ` and ` ``` ` delimiters
 
 Expected L0 return schema:
@@ -112,7 +114,7 @@ Expected L0 return schema:
   "apis_defined": ["..."],
   "apis_consumed": ["..."],
   "depends_on": ["..."],
-  "deliverables": ["1-5 files"],
+  "deliverables": ["(exactly 1–5 items, hard limit) file_or_logical_group", "..."],
   "acceptance_criteria": ["..."]
 }
 ```

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -163,7 +163,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 311),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 253),
+    ("src/autoskillit/planner/manifests.py", 261),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc.py", 443),
     # _session_state.py — session state persistence (ephemeral process-scoped state)

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -734,8 +734,12 @@ def test_finalize_wp_manifest_accumulates_all_validation_errors(tmp_path: Path) 
     # Valid WP (should not appear in error)
     write_json(wp_dir / "P1-A1-WP3_result.json", make_wp_result("P1-A1-WP3"))
 
-    with pytest.raises(ValueError, match=r"2 WP validation errors"):
+    with pytest.raises(ValueError, match=r"2 WP validation errors") as exc_info:
         finalize_wp_manifest(str(wp_dir), str(tmp_path))
+
+    msg = str(exc_info.value)
+    assert "P1-A1-WP1_result.json" in msg
+    assert "P1-A1-WP2_result.json" in msg
 
 
 def test_finalize_wp_manifest_single_validation_error_message(tmp_path: Path) -> None:

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from tests.planner.conftest import make_assignment_result, make_phase_result, make_wp_result
+from tests.planner.conftest import (
+    make_assignment_result,
+    make_phase_result,
+    make_wp_result,
+    write_json,
+)
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -690,3 +696,60 @@ def test_expand_wps_wp_index_path_in_work_packages(tmp_path):
     assert len(ctx_files) >= 1
     ctx = json.loads(ctx_files[0].read_text())
     assert "work_packages" in ctx["wp_index_path"]
+
+
+def _raw_wp(wp_id: str, **overrides: Any) -> dict[str, Any]:
+    """Build a raw WP dict WITHOUT running validate_wp_result (allows invalid data)."""
+    base: dict[str, Any] = {
+        "id": wp_id,
+        "name": f"WP {wp_id}",
+        "summary": "",
+        "goal": "",
+        "deliverables": [f"src/mod_{wp_id}.py"],
+        "technical_steps": [],
+        "files_touched": [],
+        "apis_defined": [],
+        "apis_consumed": [],
+        "depends_on": [],
+        "acceptance_criteria": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_finalize_wp_manifest_accumulates_all_validation_errors(tmp_path: Path) -> None:
+    """When multiple WP result files fail validation, all errors appear in the exception."""
+    from autoskillit.planner.manifests import finalize_wp_manifest
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+
+    # WP with 0 deliverables (violates lower bound) — use _raw_wp to bypass validation
+    write_json(wp_dir / "P1-A1-WP1_result.json", _raw_wp("P1-A1-WP1", deliverables=[]))
+    # WP with 6 deliverables (violates upper bound)
+    write_json(
+        wp_dir / "P1-A1-WP2_result.json",
+        _raw_wp("P1-A1-WP2", deliverables=[f"f{i}.py" for i in range(6)]),
+    )
+    # Valid WP (should not appear in error)
+    write_json(wp_dir / "P1-A1-WP3_result.json", make_wp_result("P1-A1-WP3"))
+
+    with pytest.raises(ValueError, match=r"2 WP validation errors"):
+        finalize_wp_manifest(str(wp_dir), str(tmp_path))
+
+
+def test_finalize_wp_manifest_single_validation_error_message(tmp_path: Path) -> None:
+    """Single validation error still produces a clear message."""
+    from autoskillit.planner.manifests import finalize_wp_manifest
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+
+    # Use _raw_wp to bypass make_wp_result validation for out-of-bounds deliverable count
+    write_json(
+        wp_dir / "P1-A1-WP1_result.json",
+        _raw_wp("P1-A1-WP1", deliverables=[f"f{i}.py" for i in range(6)]),
+    )
+
+    with pytest.raises(ValueError, match=r"1 WP validation error"):
+        finalize_wp_manifest(str(wp_dir), str(tmp_path))


### PR DESCRIPTION
## Summary

The `planner-elaborate-wps` skill's SKILL.md fails to communicate the deliverable count constraint (1-5) to L0 subagents. The Python validation layer enforces `DELIVERABLE_BOUNDS = (1, 5)` at `schema.py:164` via `validate_wp_result()`, but the elaboration prompt only shows `"deliverables": ["1-5 files"]` as a schema example — which reads as a type description, not a count constraint. This causes `finalize_wp_manifest` to fail when an L0 produces >5 deliverables.

The fix adds explicit count constraint instructions to the L0 prompt section of SKILL.md (mirroring the pattern from `planner-elaborate-assignments/SKILL.md` lines 87/94), annotates the schema example, and makes `finalize_wp_manifest` accumulate all validation errors instead of failing on the first.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-210507-779877/.autoskillit/temp/make-plan/planner-elaborate-wps_deliverable_count_constraint_plan_2026-05-06_210507.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 4.1k | 7.7k | 627.8k | 47.9k | 62 | 39.1k | 4m 45s |
| verify | claude-opus-4-6 | 1 | 45 | 8.3k | 946.1k | 70.4k | 80 | 57.4k | 6m 43s |
| implement* | MiniMax-M2.7-highspeed | 1 | 604.2k | 6.3k | 835.9k | 35.1k | 63 | 61.3k | 3m 24s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 68.1k | 3.2k | 178.6k | 29.8k | 20 | 42.2k | 1m 12s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 45.0k | 1.3k | 205.5k | 29.8k | 15 | 14.9k | 52s |
| review_pr | claude-opus-4-6 | 1 | 38 | 13.8k | 408.5k | 48.8k | 26 | 38.5k | 3m 28s |
| resolve_review | claude-opus-4-6 | 1 | 45 | 5.8k | 821.5k | 54.8k | 33 | 41.8k | 4m 15s |
| **Total** | | | 721.5k | 46.3k | 4.0M | 70.4k | | 295.1k | 24m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 81 | 10319.5 | 756.3 | 77.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 136909.7 | 6964.5 | 965.0 |
| **Total** | **87** | 46251.5 | 3392.3 | 532.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 4.2k | 20.2k | 2.4M | 131.9k | 16m 41s |
| MiniMax-M2.7-highspeed | 3 | 717.3k | 10.8k | 1.2M | 118.4k | 5m 28s |