### PR TITLE
[impl] Relocate Server-Layer TypedDicts from core/types/_type_results.py to server/

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -35,14 +35,7 @@ __all__ = [
     "CloneGateUncommitted",
     "CloneGateUnpublished",
     "CloneResult",
-    "RunSkillResult",
-    "RunCmdResult",
-    "TestCheckResult",
-    "MergeWorktreeResult",
     "ModelTotalEntry",
-    "TokenSummaryResult",
-    "TimingSummaryResult",
-    "KitchenStatusResult",
     "TokenUsageFileEntry",
     "SessionIndexEntry",
 ]
@@ -404,94 +397,6 @@ class CloneGateUnpublished(TypedDict):
 CloneResult = CloneSuccessResult | CloneGateUncommitted | CloneGateUnpublished
 
 
-class _RunSkillResultBase(TypedDict):
-    """Required fields always present in every run_skill response."""
-
-    success: bool
-    exit_code: int
-
-
-class RunSkillResult(_RunSkillResultBase, total=False):
-    """Typed return contract for run_skill — mirrors SkillResult.to_json() output keys."""
-
-    result: str
-    session_id: str
-    subtype: str
-    cli_subtype: str
-    is_error: bool
-    kill_reason: str
-    needs_retry: bool
-    retry_reason: str
-    stderr: str
-    token_usage: dict[str, Any] | None
-    write_path_warnings: list[str]
-    write_call_count: int
-    fs_writes_detected: bool
-    last_stop_reason: str
-    lifespan_started: bool
-    worktree_path: str
-    order_id: str
-    infra_exit_category: str
-
-
-class _RunCmdResultBase(TypedDict):
-    """Required fields always present in every run_cmd response."""
-
-    success: bool
-    exit_code: int
-
-
-class RunCmdResult(_RunCmdResultBase, total=False):
-    """Typed return contract for run_cmd."""
-
-    stdout: str
-    stderr: str
-    error: str
-
-
-class _TestCheckResultBase(TypedDict):
-    """Required field always present in every test_check response."""
-
-    passed: bool
-
-
-class TestCheckResult(_TestCheckResultBase, total=False):
-    """Typed return contract for test_check."""
-
-    stdout: str
-    stderr: str
-    duration_seconds: float
-    filter_mode: str
-    tests_selected: int
-    tests_deselected: int
-    full_run_reason: str
-    error: str
-
-
-class MergeWorktreeResult(TypedDict, total=False):
-    """Typed return contract for merge_worktree — union of all success and error path keys."""
-
-    merge_succeeded: bool
-    merged_branch: str
-    into_branch: str
-    worktree_removed: bool
-    branch_deleted: bool
-    cleanup_succeeded: bool
-    error: str
-    failed_step: str
-    state: str
-    worktree_path: str
-    stderr: str
-    base_branch: str
-    dirty_files: list[str]
-    merge_commits: list[str]
-    test_stdout: str
-    test_stderr: str
-    abort_failed: bool
-    abort_stderr: str
-    poisoned_installs: list[str]
-
-
 class ModelTotalEntry(TypedDict):
     """Per-model aggregate token counts produced by compute_model_totals()."""
 
@@ -502,42 +407,6 @@ class ModelTotalEntry(TypedDict):
     cache_creation_input_tokens: int
     cache_read_input_tokens: int
     elapsed_seconds: float
-
-
-class TokenSummaryResult(TypedDict, total=False):
-    """Typed return contract for get_token_summary (JSON payload path)."""
-
-    steps: list[dict[str, Any]]
-    total: dict[str, Any]
-    mcp_responses: dict[str, Any]
-    model_totals: list[ModelTotalEntry]
-    success: bool
-    error: str
-
-
-class TimingSummaryResult(TypedDict, total=False):
-    """Typed return contract for get_timing_summary (JSON payload path)."""
-
-    steps: list[dict[str, Any]]
-    total: dict[str, Any]
-    success: bool
-    error: str
-
-
-class KitchenStatusResult(TypedDict, total=False):
-    """Typed return contract for kitchen_status."""
-
-    package_version: str
-    plugin_json_version: str
-    versions_match: bool
-    tools_enabled: bool
-    token_usage_verbosity: str
-    quota_guard_enabled: bool
-    github_token_configured: bool
-    github_default_repo: str
-    warning: str
-    success: bool
-    error: str
 
 
 class TokenUsageFileEntry(TypedDict):

--- a/src/autoskillit/server/tools/CLAUDE.md
+++ b/src/autoskillit/server/tools/CLAUDE.md
@@ -7,6 +7,7 @@ MCP `@mcp.tool()` handlers registered on import (14 tool modules).
 | File | Purpose |
 |------|---------|
 | `__init__.py` | Docstring-only — tools register via `@mcp.tool()` on import |
+| `_types.py` | TypedDict definitions for server tool JSON responses (RunSkillResult, RunCmdResult, etc.) |
 | `tools_kitchen.py` | `open_kitchen`, `close_kitchen` (gate lifecycle), `recipe://` MCP resource |
 | `tools_ci.py` | `set_commit_status`, `check_repo_merge_state` |
 | `tools_ci_watch.py` | `wait_for_ci`, `get_ci_status`, `_auto_trigger_ci` |

--- a/src/autoskillit/server/tools/_types.py
+++ b/src/autoskillit/server/tools/_types.py
@@ -1,0 +1,146 @@
+"""Server tool response TypedDicts — typed contracts for MCP tool JSON responses.
+
+These types define the shape of JSON payloads returned by server tool handlers.
+They live here (IL-3) because their only structured consumers are test infrastructure
+and server internals — not cross-layer protocols.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from autoskillit.core.types._type_results import ModelTotalEntry
+
+__all__ = [
+    "RunSkillResult",
+    "RunCmdResult",
+    "TestCheckResult",
+    "MergeWorktreeResult",
+    "TokenSummaryResult",
+    "TimingSummaryResult",
+    "KitchenStatusResult",
+]
+
+
+class _RunSkillResultBase(TypedDict):
+    """Required fields always present in every run_skill response."""
+
+    success: bool
+    exit_code: int
+
+
+class RunSkillResult(_RunSkillResultBase, total=False):
+    """Typed return contract for run_skill — mirrors SkillResult.to_json() output keys."""
+
+    result: str
+    session_id: str
+    subtype: str
+    cli_subtype: str
+    is_error: bool
+    kill_reason: str
+    needs_retry: bool
+    retry_reason: str
+    stderr: str
+    token_usage: dict[str, Any] | None
+    write_path_warnings: list[str]
+    write_call_count: int
+    fs_writes_detected: bool
+    last_stop_reason: str
+    lifespan_started: bool
+    worktree_path: str
+    order_id: str
+    infra_exit_category: str
+
+
+class _RunCmdResultBase(TypedDict):
+    """Required fields always present in every run_cmd response."""
+
+    success: bool
+    exit_code: int
+
+
+class RunCmdResult(_RunCmdResultBase, total=False):
+    """Typed return contract for run_cmd."""
+
+    stdout: str
+    stderr: str
+    error: str
+
+
+class _TestCheckResultBase(TypedDict):
+    """Required field always present in every test_check response."""
+
+    passed: bool
+
+
+class TestCheckResult(_TestCheckResultBase, total=False):
+    """Typed return contract for test_check."""
+
+    stdout: str
+    stderr: str
+    duration_seconds: float
+    filter_mode: str
+    tests_selected: int
+    tests_deselected: int
+    full_run_reason: str
+    error: str
+
+
+class MergeWorktreeResult(TypedDict, total=False):
+    """Typed return contract for merge_worktree — union of all success and error path keys."""
+
+    merge_succeeded: bool
+    merged_branch: str
+    into_branch: str
+    worktree_removed: bool
+    branch_deleted: bool
+    cleanup_succeeded: bool
+    error: str
+    failed_step: str
+    state: str
+    worktree_path: str
+    stderr: str
+    base_branch: str
+    dirty_files: list[str]
+    merge_commits: list[str]
+    test_stdout: str
+    test_stderr: str
+    abort_failed: bool
+    abort_stderr: str
+    poisoned_installs: list[str]
+
+
+class TokenSummaryResult(TypedDict, total=False):
+    """Typed return contract for get_token_summary (JSON payload path)."""
+
+    steps: list[dict[str, Any]]
+    total: dict[str, Any]
+    mcp_responses: dict[str, Any]
+    model_totals: list[ModelTotalEntry]
+    success: bool
+    error: str
+
+
+class TimingSummaryResult(TypedDict, total=False):
+    """Typed return contract for get_timing_summary (JSON payload path)."""
+
+    steps: list[dict[str, Any]]
+    total: dict[str, Any]
+    success: bool
+    error: str
+
+
+class KitchenStatusResult(TypedDict, total=False):
+    """Typed return contract for kitchen_status."""
+
+    package_version: str
+    plugin_json_version: str
+    versions_match: bool
+    tools_enabled: bool
+    token_usage_verbosity: str
+    quota_guard_enabled: bool
+    github_token_configured: bool
+    github_default_repo: str
+    warning: str
+    success: bool
+    error: str

--- a/src/autoskillit/server/tools/_types.py
+++ b/src/autoskillit/server/tools/_types.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
-from autoskillit.core.types._type_results import ModelTotalEntry
+from autoskillit.core import ModelTotalEntry
 
 __all__ = [
     "RunSkillResult",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -797,7 +797,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "pipeline": 12,
         "fleet": 12,
         "recipe/rules": 28,
-        "server/tools": 15,
+        "server/tools": 16,
         "hooks/guards": 21,
     }
     violations: list[str] = []

--- a/tests/infra/conftest.py
+++ b/tests/infra/conftest.py
@@ -17,16 +17,7 @@ class FormatterCoverageDef(NamedTuple):
 
 
 def _build_registry() -> dict[str, FormatterCoverageDef]:
-    from autoskillit.core.types._type_results import (
-        CloneSuccessResult,
-        KitchenStatusResult,
-        MergeWorktreeResult,
-        RunCmdResult,
-        RunSkillResult,
-        TestCheckResult,
-        TimingSummaryResult,
-        TokenSummaryResult,
-    )
+    from autoskillit.core.types._type_results import CloneSuccessResult
     from autoskillit.hooks.formatters.pretty_output_hook import (
         _FMT_CLONE_REPO_RENDERED,
         _FMT_CLONE_REPO_SUPPRESSED,
@@ -53,6 +44,15 @@ def _build_registry() -> dict[str, FormatterCoverageDef]:
     )
     from autoskillit.recipe._api import ListRecipesResult, LoadRecipeResult
     from autoskillit.recipe._recipe_ingredients import OpenKitchenResult
+    from autoskillit.server.tools._types import (
+        KitchenStatusResult,
+        MergeWorktreeResult,
+        RunCmdResult,
+        RunSkillResult,
+        TestCheckResult,
+        TimingSummaryResult,
+        TokenSummaryResult,
+    )
 
     return {
         "run_skill": FormatterCoverageDef(

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -85,6 +85,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_status_mcp_response.py` | Tests for MCP response tracking integration in tools_status handlers |
 | `test_tools_status_quota_and_db.py` | Tests for server status tools: quota events, telemetry writing, and DB access |
 | `test_tools_status_summaries.py` | Tests for server status tools: token and timing summaries |
+| `test_tools_types_module.py` | Tests for server/tools/_types.py TypedDict imports |
 | `test_tools_workspace.py` | Tests for autoskillit server workspace tools |
 | `test_track_response_size.py` | Tests for the track_response_size decorator in autoskillit.server._notify |
 | `test_wire_compat.py` | Wire compatibility tests |

--- a/tests/server/test_tools_types_module.py
+++ b/tests/server/test_tools_types_module.py
@@ -1,0 +1,69 @@
+"""Verify server-layer TypedDicts are importable from server/tools/_types."""
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+class TestServerToolTypesImport:
+    """REQ-RELOC-001: Types exist in server/tools/_types.py."""
+
+    def test_kitchen_status_result_importable(self):
+        from autoskillit.server.tools._types import KitchenStatusResult
+
+        assert hasattr(KitchenStatusResult, "__required_keys__") or hasattr(
+            KitchenStatusResult, "__optional_keys__"
+        )
+
+    def test_token_summary_result_importable(self):
+        from autoskillit.server.tools._types import TokenSummaryResult
+
+        assert "model_totals" in TokenSummaryResult.__annotations__
+
+    def test_timing_summary_result_importable(self):
+        from autoskillit.server.tools._types import TimingSummaryResult
+
+        assert "steps" in TimingSummaryResult.__annotations__
+
+    def test_run_skill_result_importable(self):
+        from autoskillit.server.tools._types import RunSkillResult
+
+        assert "success" in RunSkillResult.__required_keys__
+
+    def test_run_cmd_result_importable(self):
+        from autoskillit.server.tools._types import RunCmdResult
+
+        assert "success" in RunCmdResult.__required_keys__
+
+    def test_test_check_result_importable(self):
+        from autoskillit.server.tools._types import TestCheckResult
+
+        assert "passed" in TestCheckResult.__required_keys__
+
+    def test_merge_worktree_result_importable(self):
+        from autoskillit.server.tools._types import MergeWorktreeResult
+
+        assert "merge_succeeded" in MergeWorktreeResult.__optional_keys__
+
+
+class TestServerToolTypesNotInCore:
+    """REQ-RELOC-002/003: Types removed from core re-export surface."""
+
+    def test_types_not_in_core_types_all(self):
+        from autoskillit.core.types._type_results import __all__ as results_all
+
+        relocated = {
+            "KitchenStatusResult",
+            "TokenSummaryResult",
+            "TimingSummaryResult",
+            "RunSkillResult",
+            "RunCmdResult",
+            "TestCheckResult",
+            "MergeWorktreeResult",
+        }
+        assert relocated.isdisjoint(set(results_all))
+
+    def test_model_total_entry_still_in_core(self):
+        from autoskillit.core.types._type_results import ModelTotalEntry
+
+        assert "model" in ModelTotalEntry.__required_keys__

--- a/tests/server/test_tools_types_module.py
+++ b/tests/server/test_tools_types_module.py
@@ -11,19 +11,17 @@ class TestServerToolTypesImport:
     def test_kitchen_status_result_importable(self):
         from autoskillit.server.tools._types import KitchenStatusResult
 
-        assert hasattr(KitchenStatusResult, "__required_keys__") or hasattr(
-            KitchenStatusResult, "__optional_keys__"
-        )
+        assert "package_version" in KitchenStatusResult.__optional_keys__
 
     def test_token_summary_result_importable(self):
         from autoskillit.server.tools._types import TokenSummaryResult
 
-        assert "model_totals" in TokenSummaryResult.__annotations__
+        assert "model_totals" in TokenSummaryResult.__optional_keys__
 
     def test_timing_summary_result_importable(self):
         from autoskillit.server.tools._types import TimingSummaryResult
 
-        assert "steps" in TimingSummaryResult.__annotations__
+        assert "steps" in TimingSummaryResult.__optional_keys__
 
     def test_run_skill_result_importable(self):
         from autoskillit.server.tools._types import RunSkillResult


### PR DESCRIPTION
## Summary

Move 7 public TypedDicts (`KitchenStatusResult`, `TokenSummaryResult`, `TimingSummaryResult`, `RunSkillResult`, `RunCmdResult`, `TestCheckResult`, `MergeWorktreeResult`) and their 3 private base classes (`_RunSkillResultBase`, `_RunCmdResultBase`, `_TestCheckResultBase`) from `src/autoskillit/core/types/_type_results.py` to a new `src/autoskillit/server/tools/_types.py`. The only import-path consumer is `tests/infra/conftest.py`. No production code imports these types by name.

## Requirements

- REQ-RELOC-001: Create `src/autoskillit/server/tools/_types.py` containing the relocated types
- REQ-RELOC-002: Remove the types from `core/types/_type_results.py` and their `__all__` entries
- REQ-RELOC-003: Remove re-exports from `core/types/__init__.py` for relocated types
- REQ-RELOC-004: Update `core/__init__.pyi` to remove stub entries for relocated types
- REQ-RELOC-005: Update all import paths in consumers (primarily `tests/infra/conftest.py`)
- REQ-RELOC-006: No IL-0 contract violations — verify with `import-linter`
- REQ-RELOC-007: All existing tests must continue to pass

## Conflict Resolution Table

None

Closes #2036

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-210257-256193/.autoskillit/temp/make-plan/relocate_server_layer_typeddicts_plan_2026-05-06_210257.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 1.8k | 8.1k | 807.5k | 56.0k | 69 | 46.9k | 4m 59s |
| verify | claude-opus-4-6 | 1 | 731 | 9.0k | 300.8k | 59.1k | 49 | 46.1k | 4m 46s |
| implement* | MiniMax-M2.7-highspeed | 1 | 836.9k | 11.0k | 1.0M | 55.4k | 82 | 61.7k | 4m 23s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 93.4k | 3.1k | 238.1k | 29.8k | 26 | 42.1k | 1m 24s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 57.2k | 1.6k | 240.5k | 35.1k | 20 | 24.2k | 49s |
| review_pr | claude-sonnet-4-6 | 1 | 126 | 27.9k | 721.3k | 73.9k | 46 | 61.5k | 6m 43s |
| resolve_review | claude-opus-4-6 | 1 | 42 | 3.8k | 645.1k | 49.3k | 28 | 36.8k | 5m 15s |
| **Total** | | | 990.3k | 64.5k | 4.0M | 73.9k | | 319.4k | 28m 20s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 368 | 2811.1 | 167.7 | 29.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 80632.9 | 4603.0 | 476.2 |
| **Total** | **376** | 10605.7 | 849.3 | 171.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 2.6k | 23.0k | 2.0M | 136.2k | 21m 7s |
| MiniMax-M2.7-highspeed | 3 | 987.5k | 15.8k | 1.5M | 128.0k | 6m 36s |