### PR TITLE
Implementation Plan: P5-A4-WP1 — Add dispatch_id to PerDispatchEntry in fleet/summary.py

### DIFF
--- a/src/autoskillit/fleet/summary.py
+++ b/src/autoskillit/fleet/summary.py
@@ -60,6 +60,7 @@ class PerDispatchEntry:
     elapsed_seconds: float
     token_usage: DispatchTokenUsage
     dispatched_session_id: str
+    dispatch_id: str
 
 
 @dataclass(frozen=True)
@@ -198,6 +199,7 @@ def parse_campaign_summary(text: str, campaign_id: str) -> CampaignParseResult:
                 dispatched_session_id=e.get("dispatched_session_id")
                 or e.get("l3_session_id")
                 or e.get("l2_session_id", ""),
+                dispatch_id=e.get("dispatch_id", ""),
             )
             for e in data["per_dispatch"]
         ]
@@ -249,6 +251,7 @@ def serialize_campaign_summary(summary: CampaignSummary) -> str:
                     "cache_creation": e.token_usage.cache_creation,
                 },
                 "dispatched_session_id": e.dispatched_session_id,
+                "dispatch_id": e.dispatch_id,
             }
             for e in summary.per_dispatch
         ],

--- a/tests/fleet/test_summary.py
+++ b/tests/fleet/test_summary.py
@@ -34,6 +34,7 @@ _VALID_SUMMARY_DICT: dict = {
                 "cache_creation": 10,
             },
             "dispatched_session_id": "sess-abc",
+            "dispatch_id": "disp-001",
         },
         {
             "name": "dispatch-2",
@@ -46,6 +47,7 @@ _VALID_SUMMARY_DICT: dict = {
                 "cache_creation": 0,
             },
             "dispatched_session_id": "sess-def",
+            "dispatch_id": "disp-002",
         },
     ],
     "error_records": [
@@ -258,3 +260,35 @@ class TestCampaignSummarySchema:
         assert isinstance(result, ParseFailure)
         assert result.kind == ParseFailureKind.FIELD_ERROR
         assert "elapsed_seconds" in result.message
+
+    def test_per_dispatch_entry_dispatch_id_roundtrip(self) -> None:
+        from autoskillit.fleet import (
+            CampaignSummary,
+            parse_campaign_summary,
+            serialize_campaign_summary,
+        )
+
+        result = parse_campaign_summary(_VALID_SENTINEL_TEXT, _VALID_CAMPAIGN_ID)
+        assert isinstance(result, CampaignSummary)
+        assert result.per_dispatch[0].dispatch_id == "disp-001"
+        assert result.per_dispatch[1].dispatch_id == "disp-002"
+
+        serialized = serialize_campaign_summary(result)
+        restored = parse_campaign_summary(serialized, _VALID_CAMPAIGN_ID)
+        assert isinstance(restored, CampaignSummary)
+        assert restored.per_dispatch[0].dispatch_id == "disp-001"
+        assert restored.per_dispatch[1].dispatch_id == "disp-002"
+
+    def test_per_dispatch_entry_dispatch_id_defaults_to_empty_string(self) -> None:
+        import copy
+
+        from autoskillit.fleet import CampaignSummary, parse_campaign_summary
+
+        d = copy.deepcopy(_VALID_SUMMARY_DICT)
+        for entry in d["per_dispatch"]:
+            entry.pop("dispatch_id", None)
+        text = _make_sentinel_text(d)
+        result = parse_campaign_summary(text, _VALID_CAMPAIGN_ID)
+        assert isinstance(result, CampaignSummary)
+        assert result.per_dispatch[0].dispatch_id == ""
+        assert result.per_dispatch[1].dispatch_id == ""


### PR DESCRIPTION
## Summary

Add a `dispatch_id: str` field to the `PerDispatchEntry` frozen dataclass so that dispatch identity is carried through the full serialize-to-parse round-trip. The field defaults to empty string for backward compatibility with old summaries that lack the key. No changes to `_REQUIRED_TOP_KEYS` or `validate_campaign_summary()`.

## Requirements

## Goal

Add dispatch_id: str to PerDispatchEntry so that dispatch identity is carried through the full serialize-to-parse round-trip, making it queryable from any consumer of CampaignSummary.

## Context

- Phase: Per-Dispatch Telemetry Gaps (Milestone: 5-per-dispatch-telemetry-gaps)
- Assignment: P5-A4 (GAP 4 — Add dispatch_id to PerDispatchEntry in fleet/summary.py)
- Depends on: None
- Depended on by: None

## Deliverables

- `src/autoskillit/fleet/summary.py`
- `tests/fleet/test_summary.py`

## Technical Steps

1. Edit src/autoskillit/fleet/summary.py: add `dispatch_id: str` field to the PerDispatchEntry frozen dataclass after the `l2_session_id: str` field (line 62). New field order: name, status, elapsed_seconds, token_usage, l2_session_id, dispatch_id.
2. Edit src/autoskillit/fleet/summary.py: in parse_campaign_summary(), inside the list comprehension that constructs PerDispatchEntry objects, add `dispatch_id=e.get('dispatch_id', ''),` after the existing `l2_session_id=e.get('l2_session_id', ''),` line (around line 198).
3. Edit src/autoskillit/fleet/summary.py: in serialize_campaign_summary(), inside the per-dispatch dict comprehension, add `'dispatch_id': e.dispatch_id,` after the existing `'l2_session_id': e.l2_session_id,` line (around line 247).
4. Do NOT modify _REQUIRED_TOP_KEYS (lines 110-122) — it governs the outer summary dict only. Do NOT modify validate_campaign_summary() — dispatch_id is a per-dispatch field and no per-dispatch key validation exists.
5. Edit tests/fleet/test_summary.py: add `'dispatch_id': 'disp-001',` to the first per-dispatch entry dict in _VALID_SUMMARY_DICT (after `'l2_session_id': 'sess-abc',`).
6. Edit tests/fleet/test_summary.py: add `'dispatch_id': 'disp-002',` to the second per-dispatch entry dict in _VALID_SUMMARY_DICT (after `'l2_session_id': 'sess-def',`).
7. Add test method test_per_dispatch_entry_dispatch_id_roundtrip to TestCampaignSummarySchema: (a) call parse_campaign_summary(_VALID_SENTINEL_TEXT, _VALID_CAMPAIGN_ID), assert result.per_dispatch[0].dispatch_id == 'disp-001' and result.per_dispatch[1].dispatch_id == 'disp-002'; (b) call serialize_campaign_summary(result), then parse_campaign_summary on the output; (c) assert both dispatch_id values survive the full round-trip.
8. Add test method test_per_dispatch_entry_dispatch_id_defaults_to_empty_string: verify that a per-dispatch entry dict without a 'dispatch_id' key produces dispatch_id == '' (confirming backward-compatible parsing of old summaries).

## Acceptance Criteria

- PerDispatchEntry dataclass has a dispatch_id: str field (verified via dataclasses.fields()).
- parse_campaign_summary populates dispatch_id from e.get('dispatch_id', '') — non-empty value is preserved, missing key defaults to empty string.
- serialize_campaign_summary emits 'dispatch_id' key in each per-dispatch dict.
- Full round-trip: serialize_campaign_summary(parse_campaign_summary(text)) produces a re-parseable sentinel where per_dispatch[i].dispatch_id equals the original value.
- Backward compatibility: a per-dispatch dict without 'dispatch_id' key parses without error and yields dispatch_id == ''.
- _VALID_SUMMARY_DICT in tests has dispatch_id in both per-dispatch entries ('disp-001' and 'disp-002').
- test_per_dispatch_entry_dispatch_id_roundtrip passes.
- test_per_dispatch_entry_dispatch_id_defaults_to_empty_string passes.
- No changes to _REQUIRED_TOP_KEYS or validate_campaign_summary().
- All existing tests in TestCampaignSummarySchema continue to pass.

Closes #1726

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-215641-008214/.autoskillit/temp/make-plan/p5_a4_wp1_add_dispatch_id_plan_2026-05-06_215641.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 66 | 5.5k | 343.5k | 39.2k | 28 | 29.1k | 3m 3s |
| verify | claude-sonnet-4-6 | 1 | 697 | 7.2k | 273.2k | 49.4k | 49 | 36.7k | 4m 24s |
| implement* | MiniMax-M2.7-highspeed | 1 | 397.9k | 4.8k | 771.4k | 29.8k | 64 | 16.2k | 6m 32s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 48.2k | 4.4k | 175.8k | 29.8k | 17 | 15.3k | 1m 30s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 62.5k | 2.2k | 235.4k | 29.8k | 16 | 15.0k | 54s |
| **Total** | | | 509.4k | 24.1k | 1.8M | 49.4k | | 112.3k | 16m 24s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 37 | 20848.0 | 438.2 | 130.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **37** | 48627.4 | 3036.3 | 652.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 66 | 5.5k | 343.5k | 29.1k | 3m 3s |
| claude-sonnet-4-6 | 1 | 697 | 7.2k | 273.2k | 36.7k | 4m 24s |
| MiniMax-M2.7-highspeed | 3 | 508.6k | 11.4k | 1.2M | 46.5k | 8m 56s |