### PR TITLE
fix: add per-run directory scoping to batch_create_issues

### DIFF
--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -96,6 +96,9 @@ from autoskillit.recipe.repository import DefaultRecipeRepository  # noqa: E402
 from autoskillit.recipe.rules import rules_actions as _rules_actions  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_blocks as _rules_blocks  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_bypass as _rules_bypass  # noqa: E402 F401
+from autoskillit.recipe.rules import (  # noqa: E402
+    rules_callable_scope as _rules_callable_scope,  # noqa: F401
+)
 from autoskillit.recipe.rules import rules_campaign as _rules_campaign  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_ci as _rules_ci  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_clone as _rules_clone  # noqa: E402 F401

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -615,7 +615,10 @@ def create_audit_run_dir(temp_dir: str) -> dict[str, str]:
         raise ValueError("temp_dir must be a non-empty path")
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_dir = Path(temp_dir) / "validate-audit" / f"run-{stamp}-{secrets.token_hex(4)}"
-    run_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        run_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ValueError(f"cannot create audit run directory {run_dir}: {exc}") from exc
     return {"audit_run_dir": str(run_dir)}
 
 
@@ -636,6 +639,10 @@ def batch_create_issues(
         raise ValueError(f"workspace must be an existing directory, got: {workspace!r}")
     if audit_run_dir:
         temp_dir = Path(audit_run_dir)
+        if not temp_dir.is_dir():
+            raise ValueError(
+                f"audit_run_dir must be an existing directory, got: {audit_run_dir!r}"
+            )
     else:
         temp_dir = Path(workspace) / ".autoskillit" / "temp" / "validate-audit"
     ticket_bodies = sorted(temp_dir.glob("ticket_body_*.md"))

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import re
+import secrets
 import subprocess
 import time
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 from autoskillit.core import atomic_write
@@ -602,15 +603,41 @@ def _ensure_and_resolve_labels(cwd: str, owner: str, repo_name: str) -> list[str
     return [repo["impl"]["id"], repo["enh"]["id"]]
 
 
+def create_audit_run_dir(temp_dir: str) -> dict[str, str]:
+    """Create a unique per-run directory for validate-audit outputs.
+
+    Follows the same pattern as ``create_run_dir`` in planner/manifests.py:
+    creates ``{temp_dir}/validate-audit/run-{stamp}-{hex}/`` so that each
+    pipeline invocation writes to an isolated subdirectory, preventing cross-run
+    file accumulation in the flat ``validate-audit/`` namespace.
+    """
+    if not temp_dir:
+        raise ValueError("temp_dir must be a non-empty path")
+    stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    run_dir = Path(temp_dir) / "validate-audit" / f"run-{stamp}-{secrets.token_hex(4)}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return {"audit_run_dir": str(run_dir)}
+
+
 def batch_create_issues(
     workspace: str,
     chunk_size: str = "20",
     timeout: int = 120,
+    audit_run_dir: str = "",
 ) -> dict[str, str]:
-    """Batch-create GitHub issues from validated ticket body files via GraphQL."""
+    """Batch-create GitHub issues from validated ticket body files via GraphQL.
+
+    The ``audit_run_dir`` parameter scopes file discovery to a per-run directory
+    (created by ``create_audit_run_dir``). When provided, only ticket body files
+    within that directory are processed. When empty, falls back to the
+    workspace-derived path for direct CLI invocation compatibility.
+    """
     if not workspace or not Path(workspace).is_dir():
         raise ValueError(f"workspace must be an existing directory, got: {workspace!r}")
-    temp_dir = Path(workspace) / ".autoskillit" / "temp" / "validate-audit"
+    if audit_run_dir:
+        temp_dir = Path(audit_run_dir)
+    else:
+        temp_dir = Path(workspace) / ".autoskillit" / "temp" / "validate-audit"
     ticket_bodies = sorted(temp_dir.glob("ticket_body_*.md"))
     if not ticket_bodies:
         return {"issue_urls": "", "issue_count": "0"}

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (27 rule files).
+Semantic validation rule modules for recipe analysis (28 rule files).
 
 ## Files
 
@@ -10,6 +10,7 @@ Semantic validation rule modules for recipe analysis (27 rule files).
 | `rules_actions.py` | Semantic rules for `stop`/`route`/`confirm` action-type steps |
 | `rules_blocks.py` | Block-level budget rules; loads `block_budgets.yaml` at import |
 | `rules_bypass.py` | Rules for `skip_when_false` bypass routing contracts |
+| `rules_callable_scope.py` | Enforces scoped directory args for file-discovering callables (e.g. `batch_create_issues` → `audit_run_dir`) |
 | `rules_campaign.py` | Campaign recipe validation: dispatch names, ingredient refs |
 | `rules_ci.py` | CI polling patterns: PR state handling, CI step ordering |
 | `rules_clone.py` | Clone/push dataflow rules: missing remote URL, local-strategy capture |
@@ -37,4 +38,4 @@ Semantic validation rule modules for recipe analysis (27 rule files).
 
 ## Architecture Notes
 
-Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 27 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.
+Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 28 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (28 rule files).
+Semantic validation rule modules for recipe analysis (29 rule files).
 
 ## Files
 
@@ -38,4 +38,4 @@ Semantic validation rule modules for recipe analysis (28 rule files).
 
 ## Architecture Notes
 
-Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 28 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.
+Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 29 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.

--- a/src/autoskillit/recipe/rules/rules_callable_scope.py
+++ b/src/autoskillit/recipe/rules/rules_callable_scope.py
@@ -7,7 +7,6 @@ from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 # Callables that discover files via glob and require a scoped directory argument.
-# Map: callable suffix -> required scoping parameter name.
 SCOPED_CALLABLES: dict[str, str] = {
     "batch_create_issues": "audit_run_dir",
 }
@@ -36,8 +35,9 @@ def _check_callable_scoped_discovery(ctx: ValidationContext) -> list[RuleFinding
         if step.tool != "run_python":
             continue
         callable_val = str(step.with_args.get("callable", ""))
-        for callable_suffix, required_key in SCOPED_CALLABLES.items():
-            if callable_suffix in callable_val:
+        callable_leaf = callable_val.rsplit(".", 1)[-1]
+        for callable_name, required_key in SCOPED_CALLABLES.items():
+            if callable_leaf == callable_name:
                 if required_key not in step.with_args:
                     findings.append(
                         RuleFinding(
@@ -45,7 +45,7 @@ def _check_callable_scoped_discovery(ctx: ValidationContext) -> list[RuleFinding
                             severity=Severity.ERROR,
                             step_name=step_name,
                             message=(
-                                f"step '{step_name}': {callable_suffix} call is "
+                                f"step '{step_name}': {callable_name} call is "
                                 f"missing '{required_key}' in with args. Without a "
                                 f"scoped directory, the callable will glob all files "
                                 f"including those from prior runs."

--- a/src/autoskillit/recipe/rules/rules_callable_scope.py
+++ b/src/autoskillit/recipe/rules/rules_callable_scope.py
@@ -1,0 +1,54 @@
+"""Semantic rules for run_python callable scoping requirements."""
+
+from __future__ import annotations
+
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+# Callables that discover files via glob and require a scoped directory argument.
+# Map: callable suffix -> required scoping parameter name.
+SCOPED_CALLABLES: dict[str, str] = {
+    "batch_create_issues": "audit_run_dir",
+}
+
+
+@semantic_rule(
+    name="callable-requires-scoped-discovery",
+    description=(
+        "run_python steps calling file-discovering callables must pass "
+        "a scoped directory argument (audit_run_dir or similar) to prevent "
+        "cross-run file accumulation."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_callable_scoped_discovery(ctx: ValidationContext) -> list[RuleFinding]:
+    """Error when a file-discovering callable is called without its required scoping parameter.
+
+    batch_create_issues uses an unscoped glob on the flat validate-audit/ directory.
+    Without audit_run_dir, it cannot distinguish current-run files from prior-run files,
+    causing duplicate issue creation on re-runs.
+
+    Other callables in SCOPED_CALLABLES follow the same pattern.
+    """
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_python":
+            continue
+        callable_val = str(step.with_args.get("callable", ""))
+        for callable_suffix, required_key in SCOPED_CALLABLES.items():
+            if callable_suffix in callable_val:
+                if required_key not in step.with_args:
+                    findings.append(
+                        RuleFinding(
+                            rule="callable-requires-scoped-discovery",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"step '{step_name}': {callable_suffix} call is missing "
+                                f"'{required_key}' in with args. Without a scoped directory, "
+                                f"the callable will glob all files including those from prior runs."
+                            ),
+                        )
+                    )
+    return findings

--- a/src/autoskillit/recipe/rules/rules_callable_scope.py
+++ b/src/autoskillit/recipe/rules/rules_callable_scope.py
@@ -45,9 +45,10 @@ def _check_callable_scoped_discovery(ctx: ValidationContext) -> list[RuleFinding
                             severity=Severity.ERROR,
                             step_name=step_name,
                             message=(
-                                f"step '{step_name}': {callable_suffix} call is missing "
-                                f"'{required_key}' in with args. Without a scoped directory, "
-                                f"the callable will glob all files including those from prior runs."
+                                f"step '{step_name}': {callable_suffix} call is "
+                                f"missing '{required_key}' in with args. Without a "
+                                f"scoped directory, the callable will glob all files "
+                                f"including those from prior runs."
                             ),
                         )
                     )

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2610,11 +2610,22 @@ callable_contracts:
     - name: chunk_size
       type: str
       required: false
+    - name: audit_run_dir
+      type: directory_path
+      required: false
     outputs:
     - name: issue_urls
       type: str
     - name: issue_count
       type: str
+  autoskillit.recipe._cmd_rpc.create_audit_run_dir:
+    inputs:
+    - name: temp_dir
+      type: directory_path
+      required: true
+    outputs:
+    - name: audit_run_dir
+      type: directory_path
 
 tool_output_contracts:
   wait_for_ci:

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -143,7 +143,7 @@ steps:
       slot frees, dispatch the next queued validation immediately.
 
       Skip validation for any audit that failed in the audit dispatch phase.
-      Each validation writes to ${{ context.audit_run_dir }}/validate-audit/:
+      Each validation writes to ${{ context.audit_run_dir }}/:
       - validated_report_{source}_{timestamp}.md (first line: "validated: true")
       - contested_findings_{source}_{timestamp}.md (only if contested > 0)
       - validation_summary_{source}_{timestamp}.md (always written)

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -123,11 +123,9 @@ steps:
     model: ""
     description: "Validate each audit report in parallel"
     with:
-      skill_command: "/autoskillit:validate-audit"
+      skill_command: "/autoskillit:validate-audit --audit-run-dir ${{ context.audit_run_dir }}"
       cwd: "${{ inputs.workspace }}"
       step_name: "validate_audits"
-      env:
-        AUTOSKILLIT_AUDIT_RUN_DIR: "${{ context.audit_run_dir }}"
     note: >
       PREFER-COMPLETION VALIDATION — Start validating as each audit finishes.
       Do not wait for all audits to complete before beginning validation.

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -55,6 +55,19 @@ steps:
     retries: 0
     on_exhausted: escalate_stop
 
+  init_audit_run:
+    tool: run_python
+    description: "Create a unique per-run directory for this audit pipeline"
+    with:
+      callable: "autoskillit.recipe._cmd_rpc.create_audit_run_dir"
+      temp_dir: "{{AUTOSKILLIT_TEMP}}"
+    capture:
+      audit_run_dir: "${{ result.audit_run_dir }}"
+    on_success: run_audits
+    on_failure: escalate_stop
+    retries: 0
+    on_exhausted: escalate_stop
+
   run_audits:
     tool: run_skill
     model: ""
@@ -113,6 +126,8 @@ steps:
       skill_command: "/autoskillit:validate-audit"
       cwd: "${{ inputs.workspace }}"
       step_name: "validate_audits"
+      env:
+        AUTOSKILLIT_AUDIT_RUN_DIR: "${{ context.audit_run_dir }}"
     note: >
       PREFER-COMPLETION VALIDATION — Start validating as each audit finishes.
       Do not wait for all audits to complete before beginning validation.
@@ -130,9 +145,11 @@ steps:
       slot frees, dispatch the next queued validation immediately.
 
       Skip validation for any audit that failed in the audit dispatch phase.
-      Each validation writes to {{AUTOSKILLIT_TEMP}}/validate-audit/:
+      Each validation writes to ${{ context.audit_run_dir }}/validate-audit/:
       - validated_report_{source}_{timestamp}.md (first line: "validated: true")
       - contested_findings_{source}_{timestamp}.md (only if contested > 0)
+      - validation_summary_{source}_{timestamp}.md (always written)
+      - ticket_body_{source}_{N}_{timestamp}.md (one per ticket group)
 
       After all complete, discover the validated_report_*.md files from session
       output. Record paths for the issue creation wave.
@@ -152,6 +169,7 @@ steps:
     with:
       callable: "autoskillit.recipe._cmd_rpc.batch_create_issues"
       workspace: "${{ inputs.workspace }}"
+      audit_run_dir: "${{ context.audit_run_dir }}"
       timeout: 120
     note: >
       BATCHED ISSUE CREATION via GraphQL — The callable discovers all

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -39,11 +39,16 @@ validated report carries a `validated: true` marker to signal downstream process
   If no files exist under any of these directories, print an error message and exit
   with a non-zero status.
 
+- `AUDOSKILLIT_AUDIT_RUN_DIR` — optional environment variable. When set, all output
+  files are written under `$AUDOSKILLIT_AUDIT_RUN_DIR/validate-audit/` instead of
+  `{{AUTOSKILLIT_TEMP}}/validate-audit/`. The recipe sets this to the per-run
+  directory created by `init_audit_run` to prevent cross-run file accumulation.
+
 ## Critical Constraints
 
 **NEVER:**
 - Modify any source code files
-- Create files outside `{{AUTOSKILLIT_TEMP}}/validate-audit/`
+- Create files outside `$AUDOSKILLIT_AUDIT_RUN_DIR/validate-audit/` (when set) or `{{AUTOSKILLIT_TEMP}}/validate-audit/` (fallback)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 - Write output files before synthesizing ALL subagent results
 - Subagents must NOT create their own files — they return findings in response text only
@@ -227,7 +232,17 @@ After all agents return:
 
 ### Step 5 — Generate Output Files
 
-Ensure `{{AUTOSKILLIT_TEMP}}/validate-audit/` exists (`mkdir -p`).
+Set the output base directory. When `AUDOSKILLIT_AUDIT_RUN_DIR` is set (by the
+recipe's `init_audit_run` step), files are written to the per-run directory to
+prevent cross-run accumulation:
+
+```bash
+AUDIT_BASE_DIR="${AUDOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}}"
+mkdir -p "$AUDIT_BASE_DIR/validate-audit"
+```
+
+**File 1 — Validated report**
+Path: `$AUDIT_BASE_DIR/validate-audit/validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md`
 
 **File 1 — Validated report**
 Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md`
@@ -264,7 +279,7 @@ Format: original finding text, VALID verdict badge, severity adjustment note if 
 ```
 
 **File 2 — Contested findings** (write only when `N_contested > 0`)
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `$AUDIT_BASE_DIR/validate-audit/contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md`
 
 Structure:
 
@@ -286,7 +301,7 @@ Structure:
 Write the full audit trail to a separate file. This file is NOT part of the issue body —
 it is posted as a comment after issue creation.
 
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `$AUDIT_BASE_DIR/validate-audit/validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md`
 
 Structure:
 
@@ -434,11 +449,11 @@ For each ticket group in the grouping manifest:
    - A subset Summary Table (only the rows for included finding IDs)
    - Only the `## Validated Findings` sub-sections for included finding IDs
    - A footer: `*Part of validated {source} audit — see full report for remaining tickets.*`
-3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit/ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md`
+3. Write to: `$AUDIT_BASE_DIR/validate-audit/ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md`
    where `{N}` is 1-indexed from the grouping manifest.
 
 Also write the grouping manifest itself to:
-`{{AUTOSKILLIT_TEMP}}/validate-audit/grouping_manifest_{source}_{YYYY-MM-DD_HHMMSS}.md`
+`$AUDIT_BASE_DIR/validate-audit/grouping_manifest_{source}_{YYYY-MM-DD_HHMMSS}.md`
 
 The grouping manifest file is the structured text returned by the ticket grouper subagent,
 prefixed with:
@@ -489,10 +504,11 @@ rule and the validation summary content, write the combined text to a temp file,
 
 ## Output Location
 
-All output files are written relative to the current working directory under `{{AUTOSKILLIT_TEMP}}/validate-audit/`:
+All output files are written under `$AUDIT_BASE_DIR/validate-audit/` where
+`AUDIT_BASE_DIR="${AUDOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}}"`:
 
 ```
-{{AUTOSKILLIT_TEMP}}/validate-audit/
+$AUDIT_BASE_DIR/validate-audit/
 ├── validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md      (always written; VALID findings only)
 ├── contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md    (when N_contested > 0)
 ├── validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md    (always written; audit trail)

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -39,8 +39,8 @@ validated report carries a `validated: true` marker to signal downstream process
   If no files exist under any of these directories, print an error message and exit
   with a non-zero status.
 
-- `AUDOSKILLIT_AUDIT_RUN_DIR` — optional environment variable. When set, all output
-  files are written under `$AUDOSKILLIT_AUDIT_RUN_DIR/validate-audit/` instead of
+- `AUTOSKILLIT_AUDIT_RUN_DIR` — optional environment variable. When set, all output
+  files are written under `$AUTOSKILLIT_AUDIT_RUN_DIR/validate-audit/` instead of
   `{{AUTOSKILLIT_TEMP}}/validate-audit/`. The recipe sets this to the per-run
   directory created by `init_audit_run` to prevent cross-run file accumulation.
 
@@ -48,7 +48,7 @@ validated report carries a `validated: true` marker to signal downstream process
 
 **NEVER:**
 - Modify any source code files
-- Create files outside `$AUDOSKILLIT_AUDIT_RUN_DIR/validate-audit/` (when set) or `{{AUTOSKILLIT_TEMP}}/validate-audit/` (fallback)
+- Create files outside `$AUTOSKILLIT_AUDIT_RUN_DIR/validate-audit/` (when set) or `{{AUTOSKILLIT_TEMP}}/validate-audit/` (fallback)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 - Write output files before synthesizing ALL subagent results
 - Subagents must NOT create their own files — they return findings in response text only
@@ -232,12 +232,12 @@ After all agents return:
 
 ### Step 5 — Generate Output Files
 
-Set the output base directory. When `AUDOSKILLIT_AUDIT_RUN_DIR` is set (by the
+Set the output base directory. When `AUTOSKILLIT_AUDIT_RUN_DIR` is set (by the
 recipe's `init_audit_run` step), files are written to the per-run directory to
 prevent cross-run accumulation:
 
 ```bash
-AUDIT_BASE_DIR="${AUDOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}}"
+AUDIT_BASE_DIR="${AUTOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}}"
 mkdir -p "$AUDIT_BASE_DIR/validate-audit"
 ```
 
@@ -505,7 +505,7 @@ rule and the validation summary content, write the combined text to a temp file,
 ## Output Location
 
 All output files are written under `$AUDIT_BASE_DIR/validate-audit/` where
-`AUDIT_BASE_DIR="${AUDOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}}"`:
+`AUDIT_BASE_DIR="${AUTOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}}"`:
 
 ```
 $AUDIT_BASE_DIR/validate-audit/

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -40,9 +40,11 @@ validated report carries a `validated: true` marker to signal downstream process
   with a non-zero status.
 
 - `AUTOSKILLIT_AUDIT_RUN_DIR` — optional environment variable. When set, all output
-  files are written under `$AUTOSKILLIT_AUDIT_RUN_DIR/validate-audit/` instead of
+  files are written directly under `$AUTOSKILLIT_AUDIT_RUN_DIR/` instead of
   `{{AUTOSKILLIT_TEMP}}/validate-audit/`. The recipe sets this to the per-run
-  directory created by `init_audit_run` to prevent cross-run file accumulation.
+  directory created by `init_audit_run` (which already includes the
+  `validate-audit/run-{stamp}-{hex}` path segments) to prevent cross-run file
+  accumulation.
 
 ## Critical Constraints
 
@@ -237,15 +239,12 @@ recipe's `init_audit_run` step), files are written to the per-run directory to
 prevent cross-run accumulation:
 
 ```bash
-AUDIT_BASE_DIR="${AUTOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}}"
-mkdir -p "$AUDIT_BASE_DIR/validate-audit"
+AUDIT_BASE_DIR="${AUTOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}/validate-audit}"
+mkdir -p "$AUDIT_BASE_DIR"
 ```
 
 **File 1 — Validated report**
-Path: `$AUDIT_BASE_DIR/validate-audit/validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md`
-
-**File 1 — Validated report**
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `$AUDIT_BASE_DIR/validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md`
 
 Structure:
 
@@ -279,7 +278,7 @@ Format: original finding text, VALID verdict badge, severity adjustment note if 
 ```
 
 **File 2 — Contested findings** (write only when `N_contested > 0`)
-Path: `$AUDIT_BASE_DIR/validate-audit/contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `$AUDIT_BASE_DIR/contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md`
 
 Structure:
 
@@ -301,7 +300,7 @@ Structure:
 Write the full audit trail to a separate file. This file is NOT part of the issue body —
 it is posted as a comment after issue creation.
 
-Path: `$AUDIT_BASE_DIR/validate-audit/validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `$AUDIT_BASE_DIR/validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md`
 
 Structure:
 
@@ -449,11 +448,11 @@ For each ticket group in the grouping manifest:
    - A subset Summary Table (only the rows for included finding IDs)
    - Only the `## Validated Findings` sub-sections for included finding IDs
    - A footer: `*Part of validated {source} audit — see full report for remaining tickets.*`
-3. Write to: `$AUDIT_BASE_DIR/validate-audit/ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md`
+3. Write to: `$AUDIT_BASE_DIR/ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md`
    where `{N}` is 1-indexed from the grouping manifest.
 
 Also write the grouping manifest itself to:
-`$AUDIT_BASE_DIR/validate-audit/grouping_manifest_{source}_{YYYY-MM-DD_HHMMSS}.md`
+`$AUDIT_BASE_DIR/grouping_manifest_{source}_{YYYY-MM-DD_HHMMSS}.md`
 
 The grouping manifest file is the structured text returned by the ticket grouper subagent,
 prefixed with:
@@ -504,11 +503,11 @@ rule and the validation summary content, write the combined text to a temp file,
 
 ## Output Location
 
-All output files are written under `$AUDIT_BASE_DIR/validate-audit/` where
-`AUDIT_BASE_DIR="${AUTOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}}"`:
+All output files are written under `$AUDIT_BASE_DIR/` where
+`AUDIT_BASE_DIR="${AUTOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}/validate-audit}"`:
 
 ```
-$AUDIT_BASE_DIR/validate-audit/
+$AUDIT_BASE_DIR/
 ├── validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md      (always written; VALID findings only)
 ├── contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md    (when N_contested > 0)
 ├── validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md    (always written; audit trail)

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -691,7 +691,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         _analysis_detectors) add 6 files, bringing the count to 47.
         _skill_helpers.py extracts the shared _get_skill_category_map helper from
         rules_skills.py and rules_features.py to eliminate duplication,
-        bringing the count to 48. Exempt at 48 files.
+        bringing the count to 48.
+        rules/rules_callable_scope.py adds the callable-requires-scoped-discovery
+        rule enforcing scoped directory arguments for file-discovering callables,
+        bringing the rules/ count to 29. Exempt at 48 files.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
@@ -796,7 +799,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 9,
         "pipeline": 12,
         "fleet": 12,
-        "recipe/rules": 28,
+        "recipe/rules": 29,
         "server/tools": 16,
         "hooks/guards": 21,
     }

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -278,7 +278,7 @@ def test_retry_reason_value_count_is_14() -> None:
 
 
 def test_semantic_rule_family_count_is_25() -> None:
-    assert _count_semantic_rule_files() == 27
+    assert _count_semantic_rule_files() == 28
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -165,7 +165,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 261),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 443),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 444),
     # _session_state.py — session state persistence (ephemeral process-scoped state)
     ("src/autoskillit/execution/session/_session_state.py", 65),
 }

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -89,6 +89,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_blocks.py` | Tests for blocks semantic validation rule |
 | `test_rules_bypass.py` | Tests for bypass semantic validation rule |
 | `test_rules_callable_inputs.py` | Tests for callable_inputs semantic validation rule |
+| `test_rules_callable_scope.py` | Tests for callable-requires-scoped-discovery semantic validation rule |
 | `test_rules_campaign.py` | Tests for campaign semantic validation rule |
 | `test_rules_ci.py` | Tests for CI semantic validation rule |
 | `test_rules_clone.py` | Tests for clone semantic validation rule |

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -614,7 +614,6 @@ def test_batch_create_issues_scoped_to_audit_run_dir(tmp_path):
                 {"number": 5, "url": "https://github.com/org/repo/issues/5"},
             ]
         )
-        # After fix: audit_run_dir parameter directs glob to the scoped directory
         result = batch_create_issues(workspace=str(tmp_path), audit_run_dir=str(run2_dir))
 
     assert result["issue_count"] == "2", (

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -15,6 +15,7 @@ from autoskillit.recipe._cmd_rpc import (
     check_eject_limit,
     commit_guard,
     compute_branch,
+    create_audit_run_dir,
     emit_fallback_map,
     ensure_results,
     export_local_bundle,
@@ -653,6 +654,24 @@ def test_batch_create_issues_audit_run_dir_only(tmp_path):
     assert result["issue_count"] == "1", (
         "batch_create_issues should only process files in audit_run_dir"
     )
+
+
+def test_batch_create_issues_audit_run_dir_not_a_directory(tmp_path):
+    """batch_create_issues raises ValueError when audit_run_dir does not exist."""
+    bogus = str(tmp_path / "nonexistent")
+    with pytest.raises(ValueError, match="audit_run_dir must be an existing directory"):
+        batch_create_issues(workspace=str(tmp_path), audit_run_dir=bogus)
+
+
+def test_create_audit_run_dir_wraps_os_error(tmp_path, monkeypatch):
+    """create_audit_run_dir wraps OSError with a descriptive ValueError."""
+    monkeypatch.setattr(Path, "mkdir", _raise_os_error)
+    with pytest.raises(ValueError, match="cannot create audit run directory"):
+        create_audit_run_dir(temp_dir=str(tmp_path))
+
+
+def _raise_os_error(*_args, **_kwargs):
+    raise OSError("Permission denied")
 
 
 @patch("autoskillit.recipe._cmd_rpc.subprocess.run")

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -514,6 +514,152 @@ def test_wait_for_direct_merge_int_pr_number(mock_sleep, mock_run):
     assert mock_run.call_count >= 1
 
 
+# ─── Multi-run accumulation tests for batch_create_issues ────────────────────
+
+
+def test_batch_create_issues_ignores_prior_run_files(tmp_path):
+    """batch_create_issues must only process files from the current run, not prior runs.
+
+    Reproduces the bug: without audit_run_dir scoping, the callable globs ALL
+    ticket_body_*.md files in the flat validate-audit/ directory, including those
+    written by previous pipeline runs. The issue_count should reflect only the
+    files present when the callable is invoked.
+    """
+    va_dir = tmp_path / ".autoskillit" / "temp" / "validate-audit"
+    va_dir.mkdir(parents=True)
+
+    # Simulate Run 1: 3 ticket bodies
+    for n in range(1, 4):
+        (va_dir / f"ticket_body_tests_{n}_2026-05-05_120000.md").write_text(
+            f"# Issue {n}\n\nBody from Run 1."
+        )
+
+    # Call batch_create_issues — should return 3 issues
+    with (
+        patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc.time.sleep"),
+    ):
+        mock_run.side_effect = _make_side_effect(
+            issue_data=[
+                {"number": 1, "url": "https://github.com/org/repo/issues/1"},
+                {"number": 2, "url": "https://github.com/org/repo/issues/2"},
+                {"number": 3, "url": "https://github.com/org/repo/issues/3"},
+            ]
+        )
+        result = batch_create_issues(workspace=str(tmp_path))
+
+    assert result["issue_count"] == "3"
+
+    # Simulate Run 2: 2 MORE ticket bodies added (total 5 in directory)
+    for n in range(4, 6):
+        (va_dir / f"ticket_body_tests_{n}_2026-05-06_130000.md").write_text(
+            f"# Issue {n}\n\nBody from Run 2."
+        )
+
+    # Call batch_create_issues WITHOUT audit_run_dir — current (buggy) behavior
+    # returns 5, but we need it to return 2 when only run-2 files are present
+    with (
+        patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc.time.sleep"),
+    ):
+        mock_run.side_effect = _make_side_effect(
+            issue_data=[
+                {"number": 4, "url": "https://github.com/org/repo/issues/4"},
+                {"number": 5, "url": "https://github.com/org/repo/issues/5"},
+            ]
+        )
+        result = batch_create_issues(workspace=str(tmp_path))
+
+    # BUG: without audit_run_dir, this returns "5" (all files in directory)
+    # After the fix, this should still return "5" because audit_run_dir is not
+    # provided — but the test documents the expected behavior after fix:
+    # when audit_run_dir IS provided, only files within that dir are processed.
+    # This test FAILS today because the function has no audit_run_dir parameter.
+    assert result["issue_count"] == "5", (
+        "Without audit_run_dir, batch_create_issues counts ALL files in the directory"
+    )
+
+
+def test_batch_create_issues_scoped_to_audit_run_dir(tmp_path):
+    """batch_create_issues with audit_run_dir must only process files in that directory.
+
+    This is the key test for the fix: when audit_run_dir is provided, the callable
+    must glob within that specific run directory, not the flat validate-audit/ dir.
+    """
+    va_dir = tmp_path / ".autoskillit" / "temp" / "validate-audit"
+    va_dir.mkdir(parents=True)
+
+    # Create two per-run subdirectories (simulating two pipeline runs)
+    run1_dir = va_dir / "run-20260505-120000-aabb1122"
+    run2_dir = va_dir / "run-20260506-130000-ccdd3344"
+    run1_dir.mkdir()
+    run2_dir.mkdir()
+
+    # Run 1 files
+    for n in range(1, 4):
+        (run1_dir / f"ticket_body_tests_{n}_2026-05-05_120000.md").write_text(
+            f"# Issue {n}\n\nBody from Run 1."
+        )
+
+    # Run 2 files
+    for n in range(4, 6):
+        (run2_dir / f"ticket_body_tests_{n}_2026-05-06_130000.md").write_text(
+            f"# Issue {n}\n\nBody from Run 2."
+        )
+
+    # Call batch_create_issues scoped to run2_dir only
+    with (
+        patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc.time.sleep"),
+    ):
+        mock_run.side_effect = _make_side_effect(
+            issue_data=[
+                {"number": 4, "url": "https://github.com/org/repo/issues/4"},
+                {"number": 5, "url": "https://github.com/org/repo/issues/5"},
+            ]
+        )
+        # After fix: audit_run_dir parameter directs glob to the scoped directory
+        result = batch_create_issues(workspace=str(tmp_path), audit_run_dir=str(run2_dir))
+
+    assert result["issue_count"] == "2", (
+        "batch_create_issues should only process files in audit_run_dir, not the parent directory"
+    )
+
+
+def test_batch_create_issues_audit_run_dir_only(tmp_path):
+    """batch_create_issues with only audit_run_dir (no workspace-derived fallback).
+
+    When audit_run_dir is provided, it must be used as the sole discovery path,
+    completely ignoring the workspace-derived path.
+    """
+    va_dir = tmp_path / ".autoskillit" / "temp" / "validate-audit"
+    va_dir.mkdir(parents=True)
+
+    # Files in the workspace-derived path (should be IGNORED)
+    for n in range(1, 4):
+        (va_dir / f"ticket_body_tests_{n}_2026-05-05_120000.md").write_text(
+            "# Stale Issue\n\nShould be ignored."
+        )
+
+    # Files in the audit_run_dir (should be processed)
+    scoped_dir = va_dir / "run-20260506-130000-ccdd3344"
+    scoped_dir.mkdir()
+    (scoped_dir / "ticket_body_tests_1_2026-05-06_130000.md").write_text("# Active Issue\n\nBody.")
+
+    with (
+        patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc.time.sleep"),
+    ):
+        mock_run.side_effect = _make_side_effect(
+            issue_data=[{"number": 99, "url": "https://github.com/org/repo/issues/99"}]
+        )
+        result = batch_create_issues(workspace=str(tmp_path), audit_run_dir=str(scoped_dir))
+
+    assert result["issue_count"] == "1", (
+        "batch_create_issues should only process files in audit_run_dir"
+    )
+
+
 @patch("autoskillit.recipe._cmd_rpc.subprocess.run")
 @patch("autoskillit.recipe._cmd_rpc.time.sleep")
 def test_force_push_int_review_pr_number(mock_sleep, mock_run, tmp_path):

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -556,25 +556,20 @@ def test_batch_create_issues_ignores_prior_run_files(tmp_path):
             f"# Issue {n}\n\nBody from Run 2."
         )
 
-    # Call batch_create_issues WITHOUT audit_run_dir — current (buggy) behavior
-    # returns 5, but we need it to return 2 when only run-2 files are present
+    # Call batch_create_issues WITHOUT audit_run_dir — globs all 5 files
     with (
         patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
         patch("autoskillit.recipe._cmd_rpc.time.sleep"),
     ):
         mock_run.side_effect = _make_side_effect(
             issue_data=[
-                {"number": 4, "url": "https://github.com/org/repo/issues/4"},
-                {"number": 5, "url": "https://github.com/org/repo/issues/5"},
+                {"number": i, "url": f"https://github.com/org/repo/issues/{i}"}
+                for i in range(1, 6)
             ]
         )
         result = batch_create_issues(workspace=str(tmp_path))
 
-    # BUG: without audit_run_dir, this returns "5" (all files in directory)
-    # After the fix, this should still return "5" because audit_run_dir is not
-    # provided — but the test documents the expected behavior after fix:
-    # when audit_run_dir IS provided, only files within that dir are processed.
-    # This test FAILS today because the function has no audit_run_dir parameter.
+    # Without audit_run_dir, batch_create_issues counts ALL files in the directory
     assert result["issue_count"] == "5", (
         "Without audit_run_dir, batch_create_issues counts ALL files in the directory"
     )

--- a/tests/recipe/test_full_audit_recipe.py
+++ b/tests/recipe/test_full_audit_recipe.py
@@ -48,6 +48,7 @@ def test_full_audit_recipe_step_names() -> None:
     recipe = load_recipe(RECIPE_PATH)
     expected = {
         "checkout",
+        "init_audit_run",
         "run_audits",
         "validate_audits",
         "create_issues",

--- a/tests/recipe/test_rules_callable_scope.py
+++ b/tests/recipe/test_rules_callable_scope.py
@@ -1,0 +1,92 @@
+"""Tests for callable-requires-scoped-discovery semantic rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types import Severity
+from autoskillit.recipe.validator import run_semantic_rules
+from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_callable_requires_scoped_discovery_flags_batch_create_issues():
+    """Rule must ERROR when batch_create_issues step lacks audit_run_dir.
+
+    Reproduces the bug: batch_create_issues uses an unscoped glob on the flat
+    validate-audit/ directory. Without audit_run_dir, it cannot distinguish
+    current-run files from prior-run files.
+    """
+    recipe = _make_workflow(
+        {
+            "init": {
+                "tool": "run_python",
+                "with": {
+                    "callable": "autoskillit.recipe._cmd_rpc.batch_create_issues",
+                    "workspace": "${{ inputs.workspace }}",
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done"},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    scoped_rule_findings = [f for f in findings if f.rule == "callable-requires-scoped-discovery"]
+    assert len(scoped_rule_findings) >= 1, (
+        "callable-requires-scoped-discovery must fire when batch_create_issues "
+        "is called without audit_run_dir"
+    )
+    assert all(f.severity == Severity.ERROR for f in scoped_rule_findings)
+
+
+def test_callable_requires_scoped_discovery_passes_with_audit_run_dir():
+    """Rule must NOT fire when batch_create_issues receives audit_run_dir.
+
+    audit_run_dir scopes the glob to a per-run directory, preventing cross-run
+    file accumulation.
+    """
+    recipe = _make_workflow(
+        {
+            "init": {
+                "tool": "run_python",
+                "with": {
+                    "callable": "autoskillit.recipe._cmd_rpc.batch_create_issues",
+                    "workspace": "${{ inputs.workspace }}",
+                    "audit_run_dir": "${{ context.audit_run_dir }}",
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done"},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    scoped_rule_findings = [f for f in findings if f.rule == "callable-requires-scoped-discovery"]
+    assert len(scoped_rule_findings) == 0, (
+        "callable-requires-scoped-discovery must not fire when audit_run_dir is provided"
+    )
+
+
+def test_callable_requires_scoped_discovery_not_fired_for_other_callables():
+    """Rule must only fire for known file-discovering callables.
+
+    Unknown callables that are not in SCOPED_CALLABLES should not trigger the rule.
+    """
+    recipe = _make_workflow(
+        {
+            "init": {
+                "tool": "run_python",
+                "with": {
+                    "callable": "autoskillit.planner.create_run_dir",
+                    "temp_dir": "{{AUTOSKILLIT_TEMP}}",
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done"},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    scoped_rule_findings = [f for f in findings if f.rule == "callable-requires-scoped-discovery"]
+    assert len(scoped_rule_findings) == 0, (
+        "callable-requires-scoped-discovery must not fire for create_run_dir"
+    )

--- a/tests/recipe/test_rules_callable_scope.py
+++ b/tests/recipe/test_rules_callable_scope.py
@@ -33,8 +33,8 @@ def test_callable_requires_scoped_discovery_flags_batch_create_issues():
     )
     findings = run_semantic_rules(recipe)
     scoped_rule_findings = [f for f in findings if f.rule == "callable-requires-scoped-discovery"]
-    assert len(scoped_rule_findings) >= 1, (
-        "callable-requires-scoped-discovery must fire when batch_create_issues "
+    assert len(scoped_rule_findings) == 1, (
+        "callable-requires-scoped-discovery must fire exactly once when batch_create_issues "
         "is called without audit_run_dir"
     )
     assert all(f.severity == Severity.ERROR for f in scoped_rule_findings)


### PR DESCRIPTION
## Summary

`batch_create_issues` in `src/autoskillit/recipe/_cmd_rpc.py:613-614` uses `temp_dir.glob("ticket_body_*.md")` on the flat shared directory `{workspace}/.autoskillit/temp/validate-audit/`, which accumulates files from all prior runs. On the second run of `full-audit` on the same workspace, duplicate GitHub issues are created for stale findings.

The root architectural weakness is a **broken data lineage**: the `validate-audit` skill produces ticket body files but never surfaces their paths as output tokens. The recipe's `capture_list` mechanism — the canonical data flow pipeline — is bypassed entirely. The `batch_create_issues` callable then reconstructs file discovery via an unscoped glob, creating an implicit coupling to a shared filesystem namespace instead of receiving explicit paths through the recipe's typed data pipeline.

The fix introduces **per-run directory scoping** (the `planner.yaml` pattern) to `full-audit.yaml`, a new **semantic rule** enforcing that file-discovering callables receive scoped directory arguments, and **multi-run accumulation tests** as a new test pattern.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260506-215617-587039/.autoskillit/temp/rectify/rectify_batch_create_issues_unscoped_glob_2026-05-06_220000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 90 | 6.8k | 291.9k | 73.7k | 152 | 30.0k | 5m 26s |
| rectify | claude-sonnet-4-6 | 1 | 2.8k | 10.8k | 708.3k | 94.5k | 162 | 58.1k | 8m 14s |
| dry_walkthrough | claude-opus-4-6 | 1 | 47 | 10.0k | 997.1k | 66.5k | 91 | 53.4k | 4m 48s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.5M | 24.3k | 2.2M | 79.0k | 206 | 208.4k | 10m 44s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 153.2k | 4.0k | 354.4k | 29.8k | 25 | 15.3k | 1m 51s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 97.8k | 1.7k | 354.4k | 29.8k | 25 | 15.1k | 56s |
| review_pr | claude-sonnet-4-6 | 2 | 576 | 62.2k | 895.1k | 83.7k | 65 | 135.5k | 14m 48s |
| resolve_review | claude-opus-4-6 | 2 | 137 | 35.5k | 5.2M | 100.0k | 137 | 205.2k | 21m 26s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 131 | 5.8k | 761.1k | 68.8k | 41 | 56.0k | 2m 3s |
| **Total** | | | 3.7M | 161.0k | 11.8M | 100.0k | | 777.1k | 1h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 397 | 5577.3 | 525.0 | 61.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 84 | 61974.2 | 2443.2 | 422.4 |
| ci_conflict_fix | 1036 | 734.7 | 54.1 | 5.6 |
| **Total** | **1517** | 7766.9 | 512.2 | 106.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 2.9k | 17.6k | 1.0M | 88.1k | 13m 40s |
| claude-opus-4-6 | 2 | 110 | 20.4k | 3.3M | 125.8k | 15m 10s |
| MiniMax-M2.7-highspeed | 3 | 3.7M | 29.9k | 2.9M | 238.7k | 13m 31s |