### PR TITLE
Rectify: Unbounded Issue Body Composition in Pipeline Callables

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -229,3 +229,5 @@ from .types import resolve_target_skill as resolve_target_skill
 from .types import resume_spec_from_cli as resume_spec_from_cli
 from .types import session_type as session_type
 from .types import truncate_text as truncate_text
+from .types import check_body_size as check_body_size
+from .types import MAX_ISSUE_BODY_CHARS as MAX_ISSUE_BODY_CHARS

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -13,6 +13,7 @@ from typing import NamedTuple
 from ._type_enums import FeatureLifecycle, FleetErrorCode
 
 __all__ = [
+    "MAX_ISSUE_BODY_CHARS",
     "AUTOSKILLIT_INSTALLED_VERSION",
     "AUTOSKILLIT_PRIVATE_ENV_VARS",
     "CONTEXT_EXHAUSTION_MARKER",
@@ -64,6 +65,10 @@ __all__ = [
 ]
 
 AUTOSKILLIT_INSTALLED_VERSION: str = version("autoskillit")
+
+# GitHub API hard limit for issue body is 65,536 chars. Using 50,000 leaves
+# headroom for GitHub's own metadata rendering and prevents search indexer lag.
+MAX_ISSUE_BODY_CHARS: int = 50_000
 
 # Session type environment variable and valid values.
 # String aliases for consumers that cannot import SessionType StrEnum

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -16,6 +16,7 @@ from ._type_constants import (
     AUTOSKILLIT_SKILL_PREFIX,
     FLEET_ERROR_CODES,
     HEADLESS_ENV_VAR,
+    MAX_ISSUE_BODY_CHARS,
     SESSION_TYPE_ENV_VAR,
     SKILL_COMMAND_PREFIX,
 )
@@ -23,6 +24,7 @@ from ._type_enums import SessionType, SkillSource
 from ._type_protocols_workspace import SkillResolver
 
 __all__ = [
+    "check_body_size",
     "extract_path_arg",
     "extract_skill_name",
     "fleet_error",
@@ -135,6 +137,15 @@ def truncate_text(text: str, max_len: int = 5000) -> str:
     if len(text) <= max_len:
         return text
     return f"...[truncated {len(text) - max_len} chars]...\n" + text[-max_len:]
+
+
+def check_body_size(body: str, *, context: str = "") -> None:
+    """Raise ValueError if body exceeds MAX_ISSUE_BODY_CHARS."""
+    if len(body) > MAX_ISSUE_BODY_CHARS:
+        raise ValueError(
+            f"Issue body exceeds {MAX_ISSUE_BODY_CHARS} chars "
+            f"({len(body)} chars){f': {context}' if context else ''}"
+        )
 
 
 def fleet_error(

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -9,7 +9,7 @@ import time
 from datetime import date
 from pathlib import Path
 
-from autoskillit.core import atomic_write
+from autoskillit.core import atomic_write, check_body_size
 
 
 def compute_branch(
@@ -619,13 +619,10 @@ def batch_create_issues(
     for f in ticket_bodies:
         raw = f.read_text()
         m = re.match(r"ticket_body_(\w+)_\d+_(.+)\.md", f.name)
-        source = m.group(1) if m else "unknown"
         ts = m.group(2) if m else ""
         title = _extract_title(raw)
         body = _strip_ticket_body(raw)
-        summary_path = temp_dir / f"validation_summary_{source}_{ts}.md"
-        if summary_path.exists():
-            body += "\n\n---\n\n" + summary_path.read_text()
+        check_body_size(body, context=title)
         parsed.append((title, body, ts))
 
     owner, repo_name, repo_id = _resolve_repo_identity(workspace)

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -12,7 +12,7 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import atomic_write, get_logger
+from autoskillit.core import atomic_write, check_body_size, get_logger
 from autoskillit.pipeline import write_status
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
@@ -557,6 +557,7 @@ async def _file_or_update_github_issue(
                 f"{diag_section}"
             )
             new_body = existing_body + occurrence_section
+            check_body_size(new_body, context=f"occurrence update for issue #{issue_number}")
             update_result = await github_client.update_issue_body(
                 owner, repo, issue_number, new_body
             )
@@ -576,6 +577,7 @@ async def _file_or_update_github_issue(
             "\n\n" + _format_diagnostics_section(diag, condensed=False) if diag is not None else ""
         )
         issue_body = report_text + diag_section
+        check_body_size(issue_body, context="report_bug new issue")
         create_result = await github_client.create_issue(
             owner,
             repo,

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from autoskillit.recipe._cmd_rpc import (
+    _strip_ticket_body,
     batch_create_issues,
     check_dropped_healthy_loop,
     check_eject_limit,
@@ -429,15 +430,16 @@ def test_batch_create_issues_chunks_large_batches(tmp_path):
     assert result["issue_count"] == "25"
 
 
-def test_batch_create_issues_appends_validation_summary(tmp_path):
+def test_batch_create_issues_does_not_append_validation_summary(tmp_path):
+    """Validation summary must not be appended to issue bodies."""
     va_dir = tmp_path / ".autoskillit" / "temp" / "validate-audit"
     va_dir.mkdir(parents=True)
+    # Create a realistic 14K validation summary
+    large_summary = "## Validation Summary\n" + "x" * 14_000
     (va_dir / "ticket_body_tests_1_2026-01-01_120000.md").write_text(
         "# Audit Finding\n\nSome finding."
     )
-    (va_dir / "validation_summary_tests_2026-01-01_120000.md").write_text(
-        "## Validation Summary\nAll clear."
-    )
+    (va_dir / "validation_summary_tests_2026-01-01_120000.md").write_text(large_summary)
     with (
         patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
         patch("autoskillit.recipe._cmd_rpc.time.sleep"),
@@ -450,11 +452,94 @@ def test_batch_create_issues_appends_validation_summary(tmp_path):
         if kwargs.get("input"):
             mutation_call = json.loads(kwargs["input"])
             body = mutation_call["variables"]["i0"]["body"]
-            assert "## Validation Summary" in body
-            assert "All clear." in body
+            # Summary must NOT be in the body
+            assert "## Validation Summary" not in body
+            # Body must be small (under 5K for a 1K input)
+            assert len(body) < 5000, f"body too large: {len(body)}"
             found = True
             break
     assert found, "no createIssue mutation call found in mock_run calls"
+
+
+def test_batch_create_issues_cross_ticket_body_isolation(tmp_path):
+    """None of 3 tickets sharing a source/timestamp may contain the validation summary."""
+    va_dir = tmp_path / ".autoskillit" / "temp" / "validate-audit"
+    va_dir.mkdir(parents=True)
+    # 3 tickets from same source/timestamp
+    for n in range(1, 4):
+        (va_dir / f"ticket_body_tests_{n}_2026-01-01_120000.md").write_text(
+            f"# Title {n}\n\nUnique marker: TICKET_{n}\n\nFinding content."
+        )
+    # 14K aggregate summary
+    (va_dir / "validation_summary_tests_2026-01-01_120000.md").write_text(
+        "## Validation Summary\n" + "y" * 14_000
+    )
+    with (
+        patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc.time.sleep"),
+    ):
+        mock_run.side_effect = _make_side_effect()
+        batch_create_issues(workspace=str(tmp_path))
+    found_bodies = []
+    for call in mock_run.call_args_list:
+        kwargs = call[1]
+        if kwargs.get("input"):
+            mutation_call = json.loads(kwargs["input"])
+            body = mutation_call["variables"]["i0"]["body"]
+            found_bodies.append(body)
+    assert len(found_bodies) == 3, f"expected 3 bodies, got {len(found_bodies)}"
+    for body in found_bodies:
+        assert "## Validation Summary" not in body
+        assert "y" * 100 not in body  # summary filler
+    # Each body must contain its own unique marker
+    for n in range(1, 4):
+        assert f"TICKET_{n}" in found_bodies[n - 1]
+
+
+def test_batch_create_issues_raises_on_oversized_body(tmp_path):
+    """batch_create_issues raises ValueError when a ticket body exceeds MAX_ISSUE_BODY_CHARS."""
+    va_dir = tmp_path / ".autoskillit" / "temp" / "validate-audit"
+    va_dir.mkdir(parents=True)
+    # Body well over 50K
+    (va_dir / "ticket_body_tests_1_2026-01-01_120000.md").write_text(
+        "# Audit Finding\n\n" + "z" * 60_000
+    )
+    with (
+        patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc.time.sleep"),
+    ):
+        mock_run.side_effect = _make_side_effect()
+        with pytest.raises(ValueError, match="Issue body exceeds"):
+            batch_create_issues(workspace=str(tmp_path))
+
+
+def test_strip_ticket_body_removes_metadata(tmp_path):
+    """_strip_ticket_body removes internal metadata and exception sections."""
+    raw = (
+        "validated: true\n"
+        ".autoskillit/path/to/something\n"
+        "contested_findings_001.md\n"
+        "| CONTESTED | some finding |\n"
+        "**Contested:** 2\n"
+        "**Exception warranted:** 1\n"
+        "**Exception note:** some note\n"
+        "## Findings with Exceptions\n"
+        "finding with exception\n"
+        "---\n"
+        "# Actual Finding\n\n"
+        "Valid content here.\n"
+    )
+    result = _strip_ticket_body(raw)
+    assert "validated: true" not in result
+    assert ".autoskillit/" not in result
+    assert "contested_findings_" not in result
+    assert "| CONTESTED |" not in result
+    assert "**Contested:**" not in result
+    assert "**Exception warranted:**" not in result
+    assert "**Exception note:**" not in result
+    assert "## Findings with Exceptions" not in result
+    assert "## Actual Finding" in result
+    assert "Valid content here." in result
 
 
 def test_batch_create_issues_handles_no_tickets(tmp_path):

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -478,15 +478,22 @@ def test_batch_create_issues_cross_ticket_body_isolation(tmp_path):
         patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run,
         patch("autoskillit.recipe._cmd_rpc.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect()
+        mock_run.side_effect = _make_side_effect(
+            issue_data=[
+                {"number": 1, "url": "https://github.com/org/repo/issues/1"},
+                {"number": 2, "url": "https://github.com/org/repo/issues/2"},
+                {"number": 3, "url": "https://github.com/org/repo/issues/3"},
+            ]
+        )
         batch_create_issues(workspace=str(tmp_path))
     found_bodies = []
     for call in mock_run.call_args_list:
         kwargs = call[1]
         if kwargs.get("input"):
             mutation_call = json.loads(kwargs["input"])
-            body = mutation_call["variables"]["i0"]["body"]
-            found_bodies.append(body)
+            for var_key, var_val in mutation_call["variables"].items():
+                if isinstance(var_val, dict) and "body" in var_val:
+                    found_bodies.append(var_val["body"])
     assert len(found_bodies) == 3, f"expected 3 bodies, got {len(found_bodies)}"
     for body in found_bodies:
         assert "## Validation Summary" not in body
@@ -538,7 +545,7 @@ def test_strip_ticket_body_removes_metadata(tmp_path):
     assert "**Exception warranted:**" not in result
     assert "**Exception note:**" not in result
     assert "## Findings with Exceptions" not in result
-    assert "## Actual Finding" in result
+    assert "# Actual Finding" in result
     assert "Valid content here." in result
 
 

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -552,6 +552,43 @@ async def test_report_bug_updates_duplicate_issue_body(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
+async def test_report_bug_raises_on_oversized_duplicate_body(tool_ctx, tmp_path):
+    """When existing body + occurrence section exceeds MAX_ISSUE_BODY_CHARS, raise ValueError."""
+    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx.config.report_bug.github_filing = True
+    tool_ctx.config.github.default_repo = "owner/repo"
+
+    # Existing body is already near the limit
+    existing_body = "x" * 49_000
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = _skill_ok(
+        "## Report\n" + _FINGERPRINT_START + "\nfp\n" + _FINGERPRINT_END
+    )
+    tool_ctx.executor = mock_executor
+
+    mock_gh = AsyncMock()
+    mock_gh.has_token = True
+    mock_gh.search_issues.return_value = {
+        "success": True,
+        "total_count": 1,
+        "items": [
+            {
+                "number": 7,
+                "title": "fp",
+                "html_url": "https://github.com/owner/repo/issues/7",
+                "body": existing_body,
+                "state": "open",
+            }
+        ],
+    }
+    tool_ctx.github_client = mock_gh
+
+    # The occurrence section will push it over MAX_ISSUE_BODY_CHARS
+    with pytest.raises(ValueError, match="Issue body exceeds"):
+        await report_bug("brand new error text", str(tmp_path), severity="blocking")
+
+
+@pytest.mark.anyio
 async def test_report_bug_skips_comment_if_already_present(tool_ctx, tmp_path):
     """If error_context is already in the issue body, no comment is posted."""
     tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -558,8 +558,9 @@ async def test_report_bug_raises_on_oversized_duplicate_body(tool_ctx, tmp_path)
     tool_ctx.config.report_bug.github_filing = True
     tool_ctx.config.github.default_repo = "owner/repo"
 
-    # Existing body is already near the limit
-    existing_body = "x" * 49_000
+    # Existing body must be large enough that adding the occurrence section
+    # (~200 chars of formatting + error context) exceeds MAX_ISSUE_BODY_CHARS (50K).
+    existing_body = "x" * 50_000
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok(
         "## Report\n" + _FINGERPRINT_START + "\nfp\n" + _FINGERPRINT_END

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -583,9 +583,14 @@ async def test_report_bug_raises_on_oversized_duplicate_body(tool_ctx, tmp_path)
     }
     tool_ctx.github_client = mock_gh
 
-    # The occurrence section will push it over MAX_ISSUE_BODY_CHARS
-    with pytest.raises(ValueError, match="Issue body exceeds"):
+    # The occurrence section will push it over MAX_ISSUE_BODY_CHARS.
+    # check_body_size raises ValueError inside _file_or_update_github_issue,
+    # which catches all exceptions and returns them in the result dict.
+    result = json.loads(
         await report_bug("brand new error text", str(tmp_path), severity="blocking")
+    )
+    assert result["github"]["skipped"] is True
+    assert "Issue body exceeds" in result["github"]["reason"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

The codebase has no size governance at the boundary where pipeline-generated content is composed into GitHub API payloads. `batch_create_issues()` concatenates a 14K aggregate audit trail into every per-ticket issue body, but this is a symptom of a broader architectural gap: every issue body composition path in the codebase uses raw string concatenation with no size constraint, no content contract, and no boundary check before sending to the GitHub API (which silently truncates or delays indexing at ~65K chars). The fix removes the contract-violating summary append, then introduces a body-size enforcement protocol at the GitHub API boundary that makes this class of bug structurally impossible.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
None

### Modified (●):
src/autoskillit/core/__init__.pyi
src/autoskillit/core/types/_type_constants.py
src/autoskillit/core/types/_type_helpers.py
src/autoskillit/recipe/_cmd_rpc.py
src/autoskillit/server/tools/tools_github.py
tests/recipe/test_cmd_rpc.py
tests/server/test_tools_report_bug.py

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260506-220418-194249/.autoskillit/temp/rectify/rectify_batch_create_issues_unbounded_body_2026-05-06_220418.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
