### PR TITLE
Split _type_results.py: Extract Execution-Scoped Types

### DIFF
--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -10,7 +10,8 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 | `_type_enums.py` | All `StrEnum` discriminators (`RetryReason`, `KillReason`, `Severity`, etc.) |
 | `_type_constants.py` | Shared constants: tool lists, env var names, version string |
 | `_type_subprocess.py` | `SubprocessResult` dataclass and `SubprocessRunner` protocol |
-| `_type_results.py` | Core result dataclasses: `SkillResult`, `LoadResult`, `FailureRecord`, `WriteBehaviorSpec`, `SessionTelemetry` |
+| `_type_results_execution.py` | Execution-scoped result dataclasses: `SessionTelemetry`, `ProviderOutcome`, `RecipeIdentity`, `CIRunScope` |
+| `_type_results.py` | Core result dataclasses: `SkillResult`, `LoadResult`, `FailureRecord`, `WriteBehaviorSpec` |
 | `_type_protocols_logging.py` | Protocols: `AuditLog`, `TokenLog`, `TimingLog`, `McpResponseLog`, `GitHubApiLog`, `SupportsDebug`, `SupportsLogger` |
 | `_type_protocols_execution.py` | Protocols: `TestRunner`, `HeadlessExecutor`, `OutputPatternResolver`, `WriteExpectedResolver` |
 | `_type_protocols_github.py` | Protocols: `GitHubFetcher`, `CIWatcher`, `MergeQueueWatcher` |
@@ -24,7 +25,7 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 
 ## Architecture Notes
 
-Internal dependency DAG: enums -> constants -> subprocess -> results -> protocols -> helpers. All modules have zero `autoskillit` imports outside this sub-package (IL-0 hard constraint). Production code imports from `autoskillit.core`, not from this package directly.
+Internal dependency DAG: enums -> constants -> subprocess -> results_execution -> results -> protocols -> helpers. All modules have zero `autoskillit` imports outside this sub-package (IL-0 hard constraint). Production code imports from `autoskillit.core`, not from this package directly.
 
 ## Extension Bundle Pattern
 

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -10,8 +10,8 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 | `_type_enums.py` | All `StrEnum` discriminators (`RetryReason`, `KillReason`, `Severity`, etc.) |
 | `_type_constants.py` | Shared constants: tool lists, env var names, version string |
 | `_type_subprocess.py` | `SubprocessResult` dataclass and `SubprocessRunner` protocol |
-| `_type_results_execution.py` | Execution-scoped result dataclasses: `SessionTelemetry`, `ProviderOutcome`, `RecipeIdentity`, `CIRunScope` |
-| `_type_results.py` | Core result dataclasses: `SkillResult`, `LoadResult`, `FailureRecord`, `WriteBehaviorSpec` |
+| `_type_results_execution.py` | Execution-scoped result dataclasses: `SessionTelemetry`, `RecipeIdentity`, `CIRunScope` |
+| `_type_results.py` | Core result dataclasses: `SkillResult`, `ProviderOutcome`, `LoadResult`, `FailureRecord`, `WriteBehaviorSpec` |
 | `_type_protocols_logging.py` | Protocols: `AuditLog`, `TokenLog`, `TimingLog`, `McpResponseLog`, `GitHubApiLog`, `SupportsDebug`, `SupportsLogger` |
 | `_type_protocols_execution.py` | Protocols: `TestRunner`, `HeadlessExecutor`, `OutputPatternResolver`, `WriteExpectedResolver` |
 | `_type_protocols_github.py` | Protocols: `GitHubFetcher`, `CIWatcher`, `MergeQueueWatcher` |
@@ -25,7 +25,7 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 
 ## Architecture Notes
 
-Internal dependency DAG: enums -> constants -> subprocess -> results_execution -> results -> protocols -> helpers. All modules have zero `autoskillit` imports outside this sub-package (IL-0 hard constraint). Production code imports from `autoskillit.core`, not from this package directly.
+Internal dependency DAG: enums -> constants -> subprocess -> results_execution; enums -> results -> protocols -> helpers. All modules have zero `autoskillit` imports outside this sub-package (IL-0 hard constraint). Production code imports from `autoskillit.core`, not from this package directly.
 
 ## Extension Bundle Pattern
 

--- a/src/autoskillit/core/types/__init__.py
+++ b/src/autoskillit/core/types/__init__.py
@@ -30,6 +30,8 @@ from ._type_protocols_workspace import *  # noqa: F401, F403
 from ._type_protocols_workspace import __all__ as _protocols_workspace_all
 from ._type_results import *  # noqa: F401, F403
 from ._type_results import __all__ as _results_all
+from ._type_results_execution import *  # noqa: F401, F403
+from ._type_results_execution import __all__ as _results_execution_all
 from ._type_resume import *  # noqa: F401, F403
 from ._type_resume import __all__ as _resume_all
 from ._type_subprocess import *  # noqa: F401, F403
@@ -47,6 +49,7 @@ __all__ = (
     + _protocols_workspace_all
     + _protocols_recipe_all
     + _protocols_infra_all
+    + _results_execution_all
     + _results_all
     + _resume_all
     + _subprocess_all

--- a/src/autoskillit/core/types/__init__.py
+++ b/src/autoskillit/core/types/__init__.py
@@ -49,8 +49,8 @@ __all__ = (
     + _protocols_workspace_all
     + _protocols_recipe_all
     + _protocols_infra_all
-    + _results_execution_all
     + _results_all
+    + _results_execution_all
     + _resume_all
     + _subprocess_all
 )

--- a/src/autoskillit/core/types/_type_protocols_github.py
+++ b/src/autoskillit/core/types/_type_protocols_github.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
-from ._type_results import CIRunScope
+from ._type_results_execution import CIRunScope
 
 __all__ = ["GitHubFetcher", "CIWatcher", "MergeQueueWatcher"]
 

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -1,7 +1,7 @@
-"""Core result dataclasses.
+"""Core result dataclasses — universal types.
 
-Zero autoskillit imports outside this sub-package. Provides LoadResult, SkillResult,
-CleanupResult, and related dataclasses.
+Execution-scoped types (SessionTelemetry, ProviderOutcome, RecipeIdentity,
+CIRunScope) live in _type_results_execution.py for narrower test cascade.
 """
 
 from __future__ import annotations
@@ -12,8 +12,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Generic, Literal, TypedDict, TypeVar
 
-from ._type_constants import KNOWN_CI_EVENTS
 from ._type_enums import KillReason, RetryReason, SessionOutcome
+from ._type_results_execution import ProviderOutcome
 
 T = TypeVar("T")
 
@@ -24,13 +24,9 @@ __all__ = [
     "ValidatedAddDir",
     "WriteBehaviorSpec",
     "FailureRecord",
-    "SessionTelemetry",
-    "ProviderOutcome",
     "InfraOutcome",
-    "RecipeIdentity",
     "SkillResult",
     "CleanupResult",
-    "CIRunScope",
     "CloneSuccessResult",
     "CloneGateUncommitted",
     "CloneGateUnpublished",
@@ -144,77 +140,10 @@ class FailureRecord:
 
 
 @dataclass(frozen=True)
-class SessionTelemetry:
-    """Typed bundle of all per-session telemetry fields passed to flush_session_log.
-
-    All fields are required — constructing without any field is a TypeError,
-    making omissions visible at construction time rather than silently defaulting
-    to None and skipping the corresponding write gate inside flush_session_log.
-    """
-
-    token_usage: dict[str, Any] | None
-    timing_seconds: float | None
-    audit_record: dict[str, Any] | None
-    github_api_usage: dict[str, Any] | None
-    github_api_requests: int
-    loc_insertions: int
-    loc_deletions: int
-
-    @classmethod
-    def empty(cls) -> SessionTelemetry:
-        """Zero-value sentinel for error paths where no telemetry is available."""
-        return cls(
-            token_usage=None,
-            timing_seconds=None,
-            audit_record=None,
-            github_api_usage=None,
-            github_api_requests=0,
-            loc_insertions=0,
-            loc_deletions=0,
-        )
-
-
-@dataclass(frozen=True)
-class ProviderOutcome:
-    """Typed bundle of provider execution outcome fields.
-
-    All fields are required — constructing without any field is a TypeError,
-    making omissions visible at construction time rather than silently defaulting.
-    """
-
-    provider_used: str
-    fallback_activated: bool
-
-    @classmethod
-    def none_used(cls) -> ProviderOutcome:
-        """Sentinel for paths where no provider selection occurred."""
-        return cls(provider_used="", fallback_activated=False)
-
-
-@dataclass(frozen=True)
 class InfraOutcome:
     """Infrastructure exit classification bundle."""
 
     exit_category: str = ""
-
-
-@dataclass(frozen=True)
-class RecipeIdentity:
-    """Typed bundle of recipe identification fields for session logging.
-
-    All fields required — prevents silent empty-string drift when new recipe
-    fields are added to flush_session_log but not wired from callers.
-    """
-
-    name: str
-    content_hash: str
-    composite_hash: str
-    version: str
-
-    @classmethod
-    def empty(cls) -> RecipeIdentity:
-        """Sentinel for sessions not driven by a recipe."""
-        return cls(name="", content_hash="", composite_hash="", version="")
 
 
 @dataclass
@@ -340,26 +269,6 @@ class CleanupResult:
             "failed": [{"path": p, "error": e} for p, e in self.failed],
             "skipped": self.skipped,
         }
-
-
-@dataclass(frozen=True)
-class CIRunScope:
-    """Immutable scope parameters that uniquely identify which CI workflow runs are relevant.
-
-    Passed as a single argument through the CIWatcher protocol so that adding a new
-    scope axis requires changing only this dataclass and the API params builder —
-    not every method signature in the call chain.
-    """
-
-    workflow: str | None = None  # workflow filename, e.g. "tests.yml"
-    head_sha: str | None = None  # commit SHA to pin results to
-    event: str | None = None  # trigger event, e.g. "push", "pull_request"
-
-    def __post_init__(self) -> None:
-        if self.event is not None and self.event not in KNOWN_CI_EVENTS:
-            raise ValueError(
-                f"Invalid CI event {self.event!r}. Valid events: {sorted(KNOWN_CI_EVENTS)}"
-            )
 
 
 class CloneSuccessResult(TypedDict):

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -1,7 +1,9 @@
 """Core result dataclasses — universal types.
 
-Execution-scoped types (SessionTelemetry, ProviderOutcome, RecipeIdentity,
-CIRunScope) live in _type_results_execution.py for narrower test cascade.
+Execution-scoped types (SessionTelemetry, RecipeIdentity, CIRunScope) live in
+_type_results_execution.py for narrower test cascade. ProviderOutcome stays here
+because SkillResult.provider references it, and SkillResult is consumed by 13+
+directories — a cross-import would undermine the cascade narrowing.
 """
 
 from __future__ import annotations
@@ -13,7 +15,6 @@ from pathlib import Path
 from typing import Any, Generic, Literal, TypedDict, TypeVar
 
 from ._type_enums import KillReason, RetryReason, SessionOutcome
-from ._type_results_execution import ProviderOutcome
 
 T = TypeVar("T")
 
@@ -24,6 +25,7 @@ __all__ = [
     "ValidatedAddDir",
     "WriteBehaviorSpec",
     "FailureRecord",
+    "ProviderOutcome",
     "InfraOutcome",
     "SkillResult",
     "CleanupResult",
@@ -137,6 +139,23 @@ class FailureRecord:
 
     def to_dict(self) -> dict:  # type: ignore[type-arg]
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class ProviderOutcome:
+    """Typed bundle of provider execution outcome fields.
+
+    All fields are required — constructing without any field is a TypeError,
+    making omissions visible at construction time rather than silently defaulting.
+    """
+
+    provider_used: str
+    fallback_activated: bool
+
+    @classmethod
+    def none_used(cls) -> ProviderOutcome:
+        """Sentinel for paths where no provider selection occurred."""
+        return cls(provider_used="", fallback_activated=False)
 
 
 @dataclass(frozen=True)

--- a/src/autoskillit/core/types/_type_results_execution.py
+++ b/src/autoskillit/core/types/_type_results_execution.py
@@ -3,7 +3,8 @@
 Narrow-cascade peer of _type_results.py. These types are consumed primarily by
 execution/, server/, and pipeline/ — not by workspace/, recipe/, migration/, or
 the root-level utility modules. Splitting them here means changes cascade to
-4 test directories instead of 13.
+4 test directories instead of 13. ProviderOutcome lives in _type_results.py
+because SkillResult.provider references it (universal consumer surface).
 
 Zero autoskillit imports outside this sub-package (IL-0).
 """
@@ -17,7 +18,6 @@ from ._type_constants import KNOWN_CI_EVENTS
 
 __all__ = [
     "SessionTelemetry",
-    "ProviderOutcome",
     "RecipeIdentity",
     "CIRunScope",
 ]
@@ -52,23 +52,6 @@ class SessionTelemetry:
             loc_insertions=0,
             loc_deletions=0,
         )
-
-
-@dataclass(frozen=True)
-class ProviderOutcome:
-    """Typed bundle of provider execution outcome fields.
-
-    All fields are required — constructing without any field is a TypeError,
-    making omissions visible at construction time rather than silently defaulting.
-    """
-
-    provider_used: str
-    fallback_activated: bool
-
-    @classmethod
-    def none_used(cls) -> ProviderOutcome:
-        """Sentinel for paths where no provider selection occurred."""
-        return cls(provider_used="", fallback_activated=False)
 
 
 @dataclass(frozen=True)

--- a/src/autoskillit/core/types/_type_results_execution.py
+++ b/src/autoskillit/core/types/_type_results_execution.py
@@ -1,0 +1,110 @@
+"""Execution-scoped result dataclasses.
+
+Narrow-cascade peer of _type_results.py. These types are consumed primarily by
+execution/, server/, and pipeline/ — not by workspace/, recipe/, migration/, or
+the root-level utility modules. Splitting them here means changes cascade to
+4 test directories instead of 13.
+
+Zero autoskillit imports outside this sub-package (IL-0).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ._type_constants import KNOWN_CI_EVENTS
+
+__all__ = [
+    "SessionTelemetry",
+    "ProviderOutcome",
+    "RecipeIdentity",
+    "CIRunScope",
+]
+
+
+@dataclass(frozen=True)
+class SessionTelemetry:
+    """Typed bundle of all per-session telemetry fields passed to flush_session_log.
+
+    All fields are required — constructing without any field is a TypeError,
+    making omissions visible at construction time rather than silently defaulting
+    to None and skipping the corresponding write gate inside flush_session_log.
+    """
+
+    token_usage: dict[str, Any] | None
+    timing_seconds: float | None
+    audit_record: dict[str, Any] | None
+    github_api_usage: dict[str, Any] | None
+    github_api_requests: int
+    loc_insertions: int
+    loc_deletions: int
+
+    @classmethod
+    def empty(cls) -> SessionTelemetry:
+        """Zero-value sentinel for error paths where no telemetry is available."""
+        return cls(
+            token_usage=None,
+            timing_seconds=None,
+            audit_record=None,
+            github_api_usage=None,
+            github_api_requests=0,
+            loc_insertions=0,
+            loc_deletions=0,
+        )
+
+
+@dataclass(frozen=True)
+class ProviderOutcome:
+    """Typed bundle of provider execution outcome fields.
+
+    All fields are required — constructing without any field is a TypeError,
+    making omissions visible at construction time rather than silently defaulting.
+    """
+
+    provider_used: str
+    fallback_activated: bool
+
+    @classmethod
+    def none_used(cls) -> ProviderOutcome:
+        """Sentinel for paths where no provider selection occurred."""
+        return cls(provider_used="", fallback_activated=False)
+
+
+@dataclass(frozen=True)
+class RecipeIdentity:
+    """Typed bundle of recipe identification fields for session logging.
+
+    All fields required — prevents silent empty-string drift when new recipe
+    fields are added to flush_session_log but not wired from callers.
+    """
+
+    name: str
+    content_hash: str
+    composite_hash: str
+    version: str
+
+    @classmethod
+    def empty(cls) -> RecipeIdentity:
+        """Sentinel for sessions not driven by a recipe."""
+        return cls(name="", content_hash="", composite_hash="", version="")
+
+
+@dataclass(frozen=True)
+class CIRunScope:
+    """Immutable scope parameters that uniquely identify which CI workflow runs are relevant.
+
+    Passed as a single argument through the CIWatcher protocol so that adding a new
+    scope axis requires changing only this dataclass and the API params builder —
+    not every method signature in the call chain.
+    """
+
+    workflow: str | None = None
+    head_sha: str | None = None
+    event: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.event is not None and self.event not in KNOWN_CI_EVENTS:
+            raise ValueError(
+                f"Invalid CI event {self.event!r}. Valid events: {sorted(KNOWN_CI_EVENTS)}"
+            )

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -206,6 +206,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
             "smoke_utils",
         }
     ),
+    "_type_results_execution": frozenset({"core", "execution", "server", "pipeline"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -791,7 +791,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 29,
         "execution": 18,
         "core": 20,
-        "core/types": 15,
+        "core/types": 16,
         "cli": 18,
         "hooks": 9,
         "pipeline": 12,

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -27,6 +27,7 @@ class TestCoreSubpackages:
             "_type_protocols_logging",
             "_type_protocols_recipe",
             "_type_protocols_workspace",
+            "_type_results_execution",
         }
         actual = {p.stem for p in (SRC / "core" / "types").glob("_type_*.py")}
         assert actual == expected

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -34,4 +34,5 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_type_protocol_shards.py` | Type protocol shards guard |
 | `test_types.py` | Tests for shared type contracts — enum exhaustiveness |
 | `test_types_structure.py` | Tests for core/types.py split into focused sub-modules (P8-F2) |
+| `test_type_results_execution.py` | Tests for _type_results_execution.py — execution-scoped types |
 | `test_version_snapshot.py` | Tests for core/_version_snapshot.py |

--- a/tests/core/test_type_results_execution.py
+++ b/tests/core/test_type_results_execution.py
@@ -21,17 +21,19 @@ class TestExecutionTypesImport:
     def test_ci_run_scope_importable(self):
         from autoskillit.core.types._type_results_execution import CIRunScope
 
-        assert CIRunScope() is not None
+        assert CIRunScope().workflow is None
 
     def test_backward_compat_via_core_gateway(self):
         """All moved types are still importable from autoskillit.core."""
+        import inspect
+
         from autoskillit.core import (
             CIRunScope,
             RecipeIdentity,
             SessionTelemetry,
         )
 
-        assert all(cls is not None for cls in [SessionTelemetry, RecipeIdentity, CIRunScope])
+        assert all(inspect.isclass(cls) for cls in [SessionTelemetry, RecipeIdentity, CIRunScope])
 
 
 class TestExecutionTypesNotInResults:

--- a/tests/core/test_type_results_execution.py
+++ b/tests/core/test_type_results_execution.py
@@ -1,0 +1,69 @@
+"""Tests for core/types/_type_results_execution.py — execution-scoped type module."""
+
+import pytest
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+class TestExecutionTypesImport:
+    """Each execution-scoped type is importable from the new module."""
+
+    def test_session_telemetry_importable(self):
+        from autoskillit.core.types._type_results_execution import SessionTelemetry
+
+        assert hasattr(SessionTelemetry, "empty")
+
+    def test_provider_outcome_importable(self):
+        from autoskillit.core.types._type_results_execution import ProviderOutcome
+
+        assert hasattr(ProviderOutcome, "none_used")
+
+    def test_recipe_identity_importable(self):
+        from autoskillit.core.types._type_results_execution import RecipeIdentity
+
+        assert hasattr(RecipeIdentity, "empty")
+
+    def test_ci_run_scope_importable(self):
+        from autoskillit.core.types._type_results_execution import CIRunScope
+
+        assert CIRunScope() is not None
+
+    def test_backward_compat_via_core_gateway(self):
+        """All moved types are still importable from autoskillit.core."""
+        from autoskillit.core import (
+            CIRunScope,
+            ProviderOutcome,
+            RecipeIdentity,
+            SessionTelemetry,
+        )
+
+        assert all(
+            cls is not None
+            for cls in [SessionTelemetry, ProviderOutcome, RecipeIdentity, CIRunScope]
+        )
+
+
+class TestExecutionTypesNotInResults:
+    """Moved types must no longer appear in _type_results.__all__."""
+
+    def test_moved_types_absent_from_results_all(self):
+        from autoskillit.core.types._type_results import __all__ as results_all
+
+        moved = {"SessionTelemetry", "ProviderOutcome", "RecipeIdentity", "CIRunScope"}
+        overlap = moved & set(results_all)
+        assert not overlap, f"Types still in _type_results.__all__: {overlap}"
+
+    def test_present_in_execution_all(self):
+        from autoskillit.core.types._type_results_execution import (
+            __all__ as exec_all,
+        )
+
+        expected = {"SessionTelemetry", "ProviderOutcome", "RecipeIdentity", "CIRunScope"}
+        assert expected == set(exec_all)
+
+    def test_skill_result_still_uses_provider_outcome(self):
+        """SkillResult.provider field default_factory references ProviderOutcome across modules."""
+        from autoskillit.core import ProviderOutcome, SkillResult
+
+        sr = SkillResult.crashed(Exception("test"))
+        assert isinstance(sr.provider, ProviderOutcome)

--- a/tests/core/test_type_results_execution.py
+++ b/tests/core/test_type_results_execution.py
@@ -13,11 +13,6 @@ class TestExecutionTypesImport:
 
         assert hasattr(SessionTelemetry, "empty")
 
-    def test_provider_outcome_importable(self):
-        from autoskillit.core.types._type_results_execution import ProviderOutcome
-
-        assert hasattr(ProviderOutcome, "none_used")
-
     def test_recipe_identity_importable(self):
         from autoskillit.core.types._type_results_execution import RecipeIdentity
 
@@ -32,15 +27,11 @@ class TestExecutionTypesImport:
         """All moved types are still importable from autoskillit.core."""
         from autoskillit.core import (
             CIRunScope,
-            ProviderOutcome,
             RecipeIdentity,
             SessionTelemetry,
         )
 
-        assert all(
-            cls is not None
-            for cls in [SessionTelemetry, ProviderOutcome, RecipeIdentity, CIRunScope]
-        )
+        assert all(cls is not None for cls in [SessionTelemetry, RecipeIdentity, CIRunScope])
 
 
 class TestExecutionTypesNotInResults:
@@ -49,20 +40,25 @@ class TestExecutionTypesNotInResults:
     def test_moved_types_absent_from_results_all(self):
         from autoskillit.core.types._type_results import __all__ as results_all
 
-        moved = {"SessionTelemetry", "ProviderOutcome", "RecipeIdentity", "CIRunScope"}
+        moved = {"SessionTelemetry", "RecipeIdentity", "CIRunScope"}
         overlap = moved & set(results_all)
         assert not overlap, f"Types still in _type_results.__all__: {overlap}"
+
+    def test_provider_outcome_in_results_all(self):
+        from autoskillit.core.types._type_results import __all__ as results_all
+
+        assert "ProviderOutcome" in results_all
 
     def test_present_in_execution_all(self):
         from autoskillit.core.types._type_results_execution import (
             __all__ as exec_all,
         )
 
-        expected = {"SessionTelemetry", "ProviderOutcome", "RecipeIdentity", "CIRunScope"}
+        expected = {"SessionTelemetry", "RecipeIdentity", "CIRunScope"}
         assert expected == set(exec_all)
 
     def test_skill_result_still_uses_provider_outcome(self):
-        """SkillResult.provider field default_factory references ProviderOutcome across modules."""
+        """SkillResult.provider field default_factory references ProviderOutcome."""
         from autoskillit.core import ProviderOutcome, SkillResult
 
         sr = SkillResult.crashed(Exception("test"))

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -222,7 +222,7 @@ def _assistant_ndjson(
 
 
 def _flush(tmp_path: Path, **overrides) -> None:
-    from autoskillit.core.types._type_results import (
+    from autoskillit.core.types._type_results_execution import (
         ProviderOutcome,
         RecipeIdentity,
         SessionTelemetry,

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -222,8 +222,8 @@ def _assistant_ndjson(
 
 
 def _flush(tmp_path: Path, **overrides) -> None:
+    from autoskillit.core.types._type_results import ProviderOutcome
     from autoskillit.core.types._type_results_execution import (
-        ProviderOutcome,
         RecipeIdentity,
         SessionTelemetry,
     )

--- a/tests/execution/test_flush_completeness_guard.py
+++ b/tests/execution/test_flush_completeness_guard.py
@@ -7,7 +7,8 @@ import json
 
 import pytest
 
-from autoskillit.core.types._type_results_execution import ProviderOutcome, RecipeIdentity
+from autoskillit.core.types._type_results import ProviderOutcome
+from autoskillit.core.types._type_results_execution import RecipeIdentity
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 

--- a/tests/execution/test_flush_completeness_guard.py
+++ b/tests/execution/test_flush_completeness_guard.py
@@ -7,7 +7,7 @@ import json
 
 import pytest
 
-from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity
+from autoskillit.core.types._type_results_execution import ProviderOutcome, RecipeIdentity
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -60,7 +60,7 @@ class TestFlushOutputCompleteness:
     """Every ProviderOutcome field must appear in flush output."""
 
     def test_provider_outcome_fields_written_to_summary(self, tmp_path):
-        from autoskillit.core.types._type_results import SessionTelemetry
+        from autoskillit.core.types._type_results_execution import SessionTelemetry
         from autoskillit.execution.session_log import flush_session_log
 
         outcome = ProviderOutcome(provider_used="test-provider", fallback_activated=True)
@@ -85,7 +85,7 @@ class TestFlushOutputCompleteness:
         assert summary["provider_fallback"] is True
 
     def test_recipe_identity_fields_written_to_index(self, tmp_path):
-        from autoskillit.core.types._type_results import SessionTelemetry
+        from autoskillit.core.types._type_results_execution import SessionTelemetry
         from autoskillit.execution.session_log import flush_session_log
 
         identity = RecipeIdentity(

--- a/tests/execution/test_linux_tracing_pty_integration.py
+++ b/tests/execution/test_linux_tracing_pty_integration.py
@@ -99,7 +99,7 @@ async def test_pty_wrapped_tracing_produces_no_script_snapshots_in_proc_trace_js
     Test 1.10 (partial): after the fix, every row in proc_trace.jsonl self-identifies
     the tracked process, and 'script' must never appear there.
     """
-    from autoskillit.core.types._type_results import (
+    from autoskillit.core.types._type_results_execution import (
         ProviderOutcome,
         RecipeIdentity,
         SessionTelemetry,

--- a/tests/execution/test_linux_tracing_pty_integration.py
+++ b/tests/execution/test_linux_tracing_pty_integration.py
@@ -99,8 +99,8 @@ async def test_pty_wrapped_tracing_produces_no_script_snapshots_in_proc_trace_js
     Test 1.10 (partial): after the fix, every row in proc_trace.jsonl self-identifies
     the tracked process, and 'script' must never appear there.
     """
+    from autoskillit.core.types._type_results import ProviderOutcome
     from autoskillit.core.types._type_results_execution import (
-        ProviderOutcome,
         RecipeIdentity,
         SessionTelemetry,
     )

--- a/tests/execution/test_provider_outcome_container.py
+++ b/tests/execution/test_provider_outcome_container.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from autoskillit.core.types._type_results import ProviderOutcome
+from autoskillit.core.types._type_results_execution import ProviderOutcome
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 

--- a/tests/execution/test_provider_outcome_container.py
+++ b/tests/execution/test_provider_outcome_container.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from autoskillit.core.types._type_results_execution import ProviderOutcome
+from autoskillit.core.types._type_results import ProviderOutcome
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -10,7 +10,11 @@ from datetime import UTC, datetime
 
 import pytest
 
-from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
+from autoskillit.core.types._type_results_execution import (
+    ProviderOutcome,
+    RecipeIdentity,
+    SessionTelemetry,
+)
 from autoskillit.execution.session_log import (
     flush_session_log,
 )

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -10,8 +10,8 @@ from datetime import UTC, datetime
 
 import pytest
 
+from autoskillit.core.types._type_results import ProviderOutcome
 from autoskillit.core.types._type_results_execution import (
-    ProviderOutcome,
     RecipeIdentity,
     SessionTelemetry,
 )

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.core.types._type_results import ProviderOutcome
 from autoskillit.core.types._type_results_execution import (
-    ProviderOutcome,
     RecipeIdentity,
     SessionTelemetry,
 )

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
+from autoskillit.core.types._type_results_execution import (
+    ProviderOutcome,
+    RecipeIdentity,
+    SessionTelemetry,
+)
 from autoskillit.execution.session_log import (
     flush_session_log,
     read_telemetry_clear_marker,
@@ -688,7 +692,7 @@ def test_flush_helper_builds_and_passes_session_telemetry():
     import tempfile
     import unittest.mock as mock
 
-    from autoskillit.core.types._type_results import SessionTelemetry
+    from autoskillit.core.types._type_results_execution import SessionTelemetry
 
     captured: dict = {}
 

--- a/tests/execution/test_session_log_integration.py
+++ b/tests/execution/test_session_log_integration.py
@@ -11,8 +11,8 @@ from datetime import UTC, datetime, timedelta
 import anyio
 import pytest
 
+from autoskillit.core.types._type_results import ProviderOutcome
 from autoskillit.core.types._type_results_execution import (
-    ProviderOutcome,
     RecipeIdentity,
     SessionTelemetry,
 )

--- a/tests/execution/test_session_log_integration.py
+++ b/tests/execution/test_session_log_integration.py
@@ -11,7 +11,11 @@ from datetime import UTC, datetime, timedelta
 import anyio
 import pytest
 
-from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
+from autoskillit.core.types._type_results_execution import (
+    ProviderOutcome,
+    RecipeIdentity,
+    SessionTelemetry,
+)
 from tests.execution.conftest import _ALLOCATE_60MB_SCRIPT
 
 pytestmark = [

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
+from autoskillit.core.types._type_results_execution import (
+    ProviderOutcome,
+    RecipeIdentity,
+    SessionTelemetry,
+)
 from autoskillit.execution.linux_tracing import read_boot_id, read_starttime_ticks
 from autoskillit.execution.session_log import (
     flush_session_log,

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.core.types._type_results import ProviderOutcome
 from autoskillit.core.types._type_results_execution import (
-    ProviderOutcome,
     RecipeIdentity,
     SessionTelemetry,
 )

--- a/tests/server/test_server_version_telemetry.py
+++ b/tests/server/test_server_version_telemetry.py
@@ -149,8 +149,8 @@ class TestInitializeClearMarker:
     def test_initialize_uses_clear_marker_as_since_bound(self, tool_ctx, tmp_path, monkeypatch):
         from datetime import UTC, datetime, timedelta
 
+        from autoskillit.core.types._type_results import ProviderOutcome
         from autoskillit.core.types._type_results_execution import (
-            ProviderOutcome,
             RecipeIdentity,
             SessionTelemetry,
         )

--- a/tests/server/test_server_version_telemetry.py
+++ b/tests/server/test_server_version_telemetry.py
@@ -149,7 +149,7 @@ class TestInitializeClearMarker:
     def test_initialize_uses_clear_marker_as_since_bound(self, tool_ctx, tmp_path, monkeypatch):
         from datetime import UTC, datetime, timedelta
 
-        from autoskillit.core.types._type_results import (
+        from autoskillit.core.types._type_results_execution import (
             ProviderOutcome,
             RecipeIdentity,
             SessionTelemetry,

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -641,7 +641,7 @@ class TestRunHeadlessCoreFlushTelemetry:
     async def test_flush_telemetry_kwargs_exhaustive(self, tool_ctx, monkeypatch):
         """headless.py passes a SessionTelemetry bundle covering all telemetry fields."""
         import autoskillit.execution.session_log as sl_mod
-        from autoskillit.core.types._type_results import SessionTelemetry
+        from autoskillit.core.types._type_results_execution import SessionTelemetry
 
         calls = []
 

--- a/tests/server/test_tools_github_api_tracking.py
+++ b/tests/server/test_tools_github_api_tracking.py
@@ -2,8 +2,8 @@ from unittest.mock import patch
 
 import pytest
 
+from autoskillit.core.types._type_results import ProviderOutcome
 from autoskillit.core.types._type_results_execution import (
-    ProviderOutcome,
     RecipeIdentity,
     SessionTelemetry,
 )

--- a/tests/server/test_tools_github_api_tracking.py
+++ b/tests/server/test_tools_github_api_tracking.py
@@ -2,7 +2,11 @@ from unittest.mock import patch
 
 import pytest
 
-from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
+from autoskillit.core.types._type_results_execution import (
+    ProviderOutcome,
+    RecipeIdentity,
+    SessionTelemetry,
+)
 from autoskillit.core.types._type_subprocess import SubprocessResult, TerminationReason
 from tests.fakes import MockSubprocessRunner
 

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -91,6 +91,7 @@ class TestModuleCascadeCore:
             "tool_sequence_analysis",
             "_type_checkpoint",
             "_type_results",
+            "_type_results_execution",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
 


### PR DESCRIPTION
## Summary

Extract four execution-scoped types (`SessionTelemetry`, `ProviderOutcome`, `RecipeIdentity`, `CIRunScope`) from `core/types/_type_results.py` into a new peer module `core/types/_type_results_execution.py`. The re-export hub (`types/__init__.py`) star-imports the new module, so all downstream `from autoskillit.core import X` paths continue to work unchanged. The test filter cascade for the new file targets 4 directories instead of the original 13, reducing unnecessary test runs when only execution-scoped types change.

## Requirements

- REQ-SPLIT-001: Create `src/autoskillit/core/types/_type_results_execution.py` with the execution-scoped types
- REQ-SPLIT-002: Add `from ._type_results_execution import *` to `core/types/__init__.py` for backward compat
- REQ-SPLIT-003: Add `_type_results_execution` to `MODULE_CASCADE_CORE` in `tests/_test_filter.py` with cascade to `{"execution", "server", "pipeline", "fleet", "cli"}`
- REQ-SPLIT-004: Update `__all__` in `_type_results.py` to remove moved types
- REQ-SPLIT-005: Update `core/__init__.pyi` if needed
- REQ-SPLIT-006: All existing tests must continue to pass — no consumer import changes needed (re-export preserves `from autoskillit.core import X`)

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-224109-386997/.autoskillit/temp/make-plan/split_type_results_execution_plan_2026-05-06_224500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.0k | 16.2k | 835.2k | 76.5k | 58 | 63.3k | 6m 30s |
| verify | claude-sonnet-4-6 | 1 | 56 | 12.4k | 1.7M | 78.1k | 188 | 64.9k | 10m 42s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.4M | 12.3k | 1.3M | 67.2k | 95 | 100.6k | 5m 1s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 124.0k | 3.9k | 341.5k | 28.7k | 24 | 15.1k | 1m 41s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.5k | 1.5k | 198.0k | 28.7k | 14 | 15.0k | 44s |
| review_pr | claude-sonnet-4-6 | 2 | 2.0k | 53.2k | 808.5k | 70.6k | 70 | 117.3k | 16m 45s |
| resolve_review | claude-opus-4-6 | 2 | 117 | 36.9k | 3.6M | 101.2k | 147 | 172.7k | 23m 20s |
| **Total** | | | 1.5M | 136.4k | 8.7M | 101.2k | | 549.0k | 1h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 292 | 4426.2 | 344.7 | 42.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 103 | 34732.6 | 1676.4 | 358.2 |
| **Total** | **395** | 22125.9 | 1389.8 | 345.4 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 3.1k | 26.9k | 2.6M | 167.6k | 24m 9s |
| claude-sonnet-4-6 | 1 | 56 | 12.4k | 1.7M | 64.9k | 10m 42s |
| MiniMax-M2.7-highspeed | 3 | 1.5M | 17.8k | 1.8M | 130.8k | 7m 27s |