### PR TITLE
[P5-A3-WP1] Add dispatch_id_filter axis to pipeline log iteration

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_logging.py
+++ b/src/autoskillit/core/types/_type_protocols_logging.py
@@ -43,6 +43,7 @@ class AuditLog(Protocol):
         kitchen_id_filter: str = "",
         campaign_id_filter: str = "",
         order_id_filter: str = "",
+        dispatch_id_filter: str = "",
     ) -> int: ...
 
 
@@ -80,6 +81,7 @@ class TokenLog(Protocol):
         kitchen_id_filter: str = "",
         campaign_id_filter: str = "",
         order_id_filter: str = "",
+        dispatch_id_filter: str = "",
     ) -> int: ...
 
 
@@ -104,6 +106,7 @@ class TimingLog(Protocol):
         kitchen_id_filter: str = "",
         campaign_id_filter: str = "",
         order_id_filter: str = "",
+        dispatch_id_filter: str = "",
     ) -> int: ...
 
 

--- a/src/autoskillit/pipeline/audit.py
+++ b/src/autoskillit/pipeline/audit.py
@@ -103,8 +103,7 @@ def _iter_session_log_entries(
                             sessions where a single order spans multiple clone directories.
                             All active filters apply as AND logic.
         dispatch_id_filter: If non-empty, only yield sessions whose ``dispatch_id`` field
-                            matches this string exactly. Uses ``.get()`` for backward
-                            compatibility with pre-existing index entries lacking the field.
+                            matches this string exactly.
                             All active filters apply as AND logic.
 
     Yields:

--- a/src/autoskillit/pipeline/audit.py
+++ b/src/autoskillit/pipeline/audit.py
@@ -71,6 +71,7 @@ def _iter_session_log_entries(
     kitchen_id_filter: str = "",
     campaign_id_filter: str = "",
     order_id_filter: str = "",
+    dispatch_id_filter: str = "",
 ) -> Iterator[Path]:
     """Yield per-session file paths from sessions.jsonl that pass the filters.
 
@@ -100,6 +101,10 @@ def _iter_session_log_entries(
         order_id_filter:    If non-empty, only yield sessions whose ``order_id`` field
                             matches this string exactly. Supersedes cwd_filter for fleet
                             sessions where a single order spans multiple clone directories.
+                            All active filters apply as AND logic.
+        dispatch_id_filter: If non-empty, only yield sessions whose ``dispatch_id`` field
+                            matches this string exactly. Uses ``.get()`` for backward
+                            compatibility with pre-existing index entries lacking the field.
                             All active filters apply as AND logic.
 
     Yields:
@@ -149,6 +154,9 @@ def _iter_session_log_entries(
             continue
 
         if order_id_filter and idx.get("order_id") != order_id_filter:
+            continue
+
+        if dispatch_id_filter and idx.get("dispatch_id") != dispatch_id_filter:
             continue
 
         dir_name = idx.get("dir_name", "")
@@ -252,6 +260,7 @@ class DefaultAuditLog:
         kitchen_id_filter: str = "",
         campaign_id_filter: str = "",
         order_id_filter: str = "",
+        dispatch_id_filter: str = "",
     ) -> int:
         """Reconstruct failure records from persisted session logs.
 
@@ -264,6 +273,7 @@ class DefaultAuditLog:
             Falls back to pipeline_id for sessions written before the rename.
         campaign_id_filter: if non-empty, only sessions whose campaign_id matches are loaded.
         order_id_filter: if non-empty, only sessions whose order_id matches are loaded.
+        dispatch_id_filter: if non-empty, only sessions whose dispatch_id matches are loaded.
 
         Returns the count of session directories successfully loaded.
         """
@@ -276,6 +286,7 @@ class DefaultAuditLog:
             kitchen_id_filter,
             campaign_id_filter,
             order_id_filter,
+            dispatch_id_filter,
         ):
             try:
                 data = json.loads(al_path.read_text(encoding="utf-8"))

--- a/src/autoskillit/pipeline/timings.py
+++ b/src/autoskillit/pipeline/timings.py
@@ -110,6 +110,7 @@ class DefaultTimingLog:
         kitchen_id_filter: str = "",
         campaign_id_filter: str = "",
         order_id_filter: str = "",
+        dispatch_id_filter: str = "",
     ) -> int:
         """Reconstruct timing entries from persisted session logs.
 
@@ -122,6 +123,7 @@ class DefaultTimingLog:
             Falls back to pipeline_id for sessions written before the rename.
         campaign_id_filter: if non-empty, only sessions whose campaign_id matches are loaded.
         order_id_filter: if non-empty, only sessions whose order_id matches are loaded.
+        dispatch_id_filter: if non-empty, only sessions whose dispatch_id matches are loaded.
 
         Returns the count of session directories successfully loaded.
         """
@@ -134,6 +136,7 @@ class DefaultTimingLog:
             kitchen_id_filter,
             campaign_id_filter,
             order_id_filter,
+            dispatch_id_filter,
         ):
             try:
                 data = json.loads(st_path.read_text(encoding="utf-8"))

--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -263,6 +263,7 @@ class DefaultTokenLog:
         kitchen_id_filter: str = "",
         campaign_id_filter: str = "",
         order_id_filter: str = "",
+        dispatch_id_filter: str = "",
     ) -> int:
         """Reconstruct token entries from persisted session logs.
 
@@ -276,6 +277,7 @@ class DefaultTokenLog:
             Falls back to pipeline_id for sessions written before the rename.
         campaign_id_filter: if non-empty, only sessions whose campaign_id matches are loaded.
         order_id_filter: if non-empty, only sessions whose order_id matches are loaded.
+        dispatch_id_filter: if non-empty, only sessions whose dispatch_id matches are loaded.
 
         Returns the count of session directories successfully loaded.
         """
@@ -288,6 +290,7 @@ class DefaultTokenLog:
             kitchen_id_filter,
             campaign_id_filter,
             order_id_filter,
+            dispatch_id_filter,
         ):
             try:
                 data = json.loads(tu_path.read_text(encoding="utf-8"))

--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -651,3 +651,125 @@ def test_iter_session_log_entries_order_id_filter(tmp_path):
     assert len(results) == 2
     dir_names = {p.parent.name for p in results}
     assert dir_names == {"oid-a1", "oid-a2"}
+
+
+def _write_audit_session_dispatch_id(
+    log_root: Path,
+    dir_name: str,
+    records: list,
+    dispatch_id: str = "",
+    timestamp: str = "2026-05-01T00:00:00+00:00",
+) -> None:
+    """Write audit session with dispatch_id in the index entry."""
+    from pathlib import Path as _Path
+
+    session_dir = _Path(log_root) / "sessions" / dir_name
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "audit_log.json").write_text(json.dumps(records))
+    index_entry = {
+        "dir_name": dir_name,
+        "timestamp": timestamp,
+        "session_id": dir_name,
+        "dispatch_id": dispatch_id,
+    }
+    with (_Path(log_root) / "sessions.jsonl").open("a") as f:
+        f.write(json.dumps(index_entry) + "\n")
+
+
+def test_iter_session_log_entries_dispatch_id_filter(tmp_path):
+    """dispatch_id_filter selects only sessions with matching dispatch_id."""
+    from autoskillit.pipeline.audit import _iter_session_log_entries
+
+    _write_audit_session_dispatch_id(
+        tmp_path, "did-a1", [_valid_failure_record_dict()], dispatch_id="d-abc"
+    )
+    _write_audit_session_dispatch_id(
+        tmp_path, "did-a2", [_valid_failure_record_dict()], dispatch_id="d-abc"
+    )
+    _write_audit_session_dispatch_id(
+        tmp_path, "did-xyz", [_valid_failure_record_dict()], dispatch_id="d-xyz"
+    )
+
+    results = list(
+        _iter_session_log_entries(
+            tmp_path, since="", filename="audit_log.json", dispatch_id_filter="d-abc"
+        )
+    )
+    assert len(results) == 2
+    dir_names = {p.parent.name for p in results}
+    assert dir_names == {"did-a1", "did-a2"}
+
+
+def test_iter_session_log_entries_dispatch_id_filter_empty_passes_all(tmp_path):
+    """Empty dispatch_id_filter passes all sessions through."""
+    from autoskillit.pipeline.audit import _iter_session_log_entries
+
+    _write_audit_session_dispatch_id(
+        tmp_path, "did-a1", [_valid_failure_record_dict()], dispatch_id="d-abc"
+    )
+    _write_audit_session_dispatch_id(
+        tmp_path, "did-a2", [_valid_failure_record_dict()], dispatch_id="d-xyz"
+    )
+
+    results = list(
+        _iter_session_log_entries(
+            tmp_path, since="", filename="audit_log.json", dispatch_id_filter=""
+        )
+    )
+    assert len(results) == 2
+
+
+def test_iter_session_log_entries_dispatch_id_combined_with_order_id(tmp_path):
+    """dispatch_id_filter AND order_id_filter apply as AND logic."""
+    from pathlib import Path as _Path
+
+    from autoskillit.pipeline.audit import _iter_session_log_entries
+
+    for dir_name, dispatch_id, order_id in [
+        ("both-match", "d1", "o1"),
+        ("dispatch-only", "d1", "o2"),
+        ("order-only", "d2", "o1"),
+    ]:
+        session_dir = _Path(tmp_path) / "sessions" / dir_name
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / "audit_log.json").write_text(json.dumps([_valid_failure_record_dict()]))
+        index_entry = {
+            "dir_name": dir_name,
+            "timestamp": "2026-05-01T00:00:00+00:00",
+            "session_id": dir_name,
+            "dispatch_id": dispatch_id,
+            "order_id": order_id,
+        }
+        with (_Path(tmp_path) / "sessions.jsonl").open("a") as f:
+            f.write(json.dumps(index_entry) + "\n")
+
+    results = list(
+        _iter_session_log_entries(
+            tmp_path,
+            since="",
+            filename="audit_log.json",
+            dispatch_id_filter="d1",
+            order_id_filter="o1",
+        )
+    )
+    assert len(results) == 1
+    assert results[0].parent.name == "both-match"
+
+
+def test_audit_load_dispatch_id_filter(tmp_path):
+    """DefaultAuditLog.load_from_log_dir respects dispatch_id_filter."""
+    from autoskillit.pipeline.audit import DefaultAuditLog
+
+    _write_audit_session_dispatch_id(
+        tmp_path, "d1-a", [_valid_failure_record_dict()], dispatch_id="d1"
+    )
+    _write_audit_session_dispatch_id(
+        tmp_path, "d1-b", [_valid_failure_record_dict()], dispatch_id="d1"
+    )
+    _write_audit_session_dispatch_id(
+        tmp_path, "d2-a", [_valid_failure_record_dict()], dispatch_id="d2"
+    )
+
+    log = DefaultAuditLog()
+    n = log.load_from_log_dir(tmp_path, dispatch_id_filter="d1")
+    assert n == 2

--- a/tests/pipeline/test_timings.py
+++ b/tests/pipeline/test_timings.py
@@ -437,3 +437,42 @@ def test_timing_load_campaign_id_filter(tmp_path):
     log3 = DefaultTimingLog()
     n3 = log3.load_from_log_dir(tmp_path, campaign_id_filter="")
     assert n3 == 3
+
+
+def _write_timing_session_dispatch_id(
+    log_root: Path,
+    dir_name: str,
+    dispatch_id: str,
+    timestamp: str = "2026-05-01T00:00:00+00:00",
+) -> None:
+    """Write a step_timing session with dispatch_id in the index."""
+    session_dir = log_root / "sessions" / dir_name
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "step_timing.json").write_text(
+        json.dumps({"step_name": "implement", "total_seconds": 10.0})
+    )
+    index_entry = {
+        "dir_name": dir_name,
+        "timestamp": timestamp,
+        "campaign_id": "",
+        "dispatch_id": dispatch_id,
+    }
+    with (log_root / "sessions.jsonl").open("a") as f:
+        f.write(json.dumps(index_entry) + "\n")
+
+
+def test_timing_load_dispatch_id_filter(tmp_path):
+    """DefaultTimingLog.load_from_log_dir respects dispatch_id_filter."""
+    from autoskillit.pipeline.timings import DefaultTimingLog
+
+    _write_timing_session_dispatch_id(tmp_path, "d1-a", dispatch_id="d1")
+    _write_timing_session_dispatch_id(tmp_path, "d1-b", dispatch_id="d1")
+    _write_timing_session_dispatch_id(tmp_path, "d2-a", dispatch_id="d2")
+
+    log = DefaultTimingLog()
+    n = log.load_from_log_dir(tmp_path, dispatch_id_filter="d1")
+    assert n == 2
+
+    log2 = DefaultTimingLog()
+    n2 = log2.load_from_log_dir(tmp_path, dispatch_id_filter="")
+    assert n2 == 3

--- a/tests/pipeline/test_tokens_filters.py
+++ b/tests/pipeline/test_tokens_filters.py
@@ -435,3 +435,46 @@ def test_load_from_log_dir_order_id_filter_cross_cwd(tmp_path):
     assert "rectify" in step_names
     assert "implement" in step_names
     assert "review" not in step_names
+
+
+def _write_token_session_dispatch_id(
+    log_root: Path,
+    dir_name: str,
+    dispatch_id: str,
+    timestamp: str = "2026-05-01T00:00:00+00:00",
+) -> None:
+    """Write a token_usage session with dispatch_id in the index."""
+    session_dir = log_root / "sessions" / dir_name
+    session_dir.mkdir(parents=True, exist_ok=True)
+    tu_data = {
+        "step_name": "implement",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "timing_seconds": 5.0,
+    }
+    (session_dir / "token_usage.json").write_text(json.dumps(tu_data))
+    index_entry = {
+        "dir_name": dir_name,
+        "timestamp": timestamp,
+        "session_id": dir_name,
+        "dispatch_id": dispatch_id,
+    }
+    with (log_root / "sessions.jsonl").open("a") as f:
+        f.write(json.dumps(index_entry) + "\n")
+
+
+def test_token_load_dispatch_id_filter(tmp_path):
+    """DefaultTokenLog.load_from_log_dir respects dispatch_id_filter."""
+    _write_token_session_dispatch_id(tmp_path, "d1-a", dispatch_id="d1")
+    _write_token_session_dispatch_id(tmp_path, "d1-b", dispatch_id="d1")
+    _write_token_session_dispatch_id(tmp_path, "d2-a", dispatch_id="d2")
+
+    log = DefaultTokenLog()
+    n = log.load_from_log_dir(tmp_path, dispatch_id_filter="d1")
+    assert n == 2
+
+    log2 = DefaultTokenLog()
+    n2 = log2.load_from_log_dir(tmp_path, dispatch_id_filter="")
+    assert n2 == 3


### PR DESCRIPTION
## Summary

Add `dispatch_id_filter: str = ""` as a first-class filter parameter to `_iter_session_log_entries()` and all three `load_from_log_dir()` methods (DefaultAuditLog, DefaultTokenLog, DefaultTimingLog), plus their Protocol stubs. This enables callers to scope telemetry queries to a single fleet dispatch without post-hoc client-side filtering. The filter uses `.get("dispatch_id")` for backward compatibility with pre-existing index entries.

Closes #1724

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-215641-782121/.autoskillit/temp/make-plan/p5_a3_wp1_dispatch_id_filter_plan_2026-05-06_220000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 68 | 8.6k | 529.4k | 53.0k | 60 | 45.5k | 4m 49s |
| verify | claude-opus-4-6 | 1 | 45 | 8.3k | 760.8k | 50.9k | 108 | 44.3k | 7m 18s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.3M | 11.4k | 1.2M | 29.8k | 102 | 54.4k | 4m 48s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 113.2k | 2.7k | 294.9k | 29.8k | 20 | 15.3k | 1m 26s |
| compose_pr | claude-sonnet-4-6 | 1 | 59 | 2.1k | 160.1k | 26.1k | 15 | 13.1k | 44s |
| **Total** | | | 1.4M | 33.1k | 3.0M | 53.0k | | 172.6k | 19m 6s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 224 | 5437.6 | 242.7 | 51.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **224** | 13229.0 | 770.6 | 147.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 113 | 16.9k | 1.3M | 89.8k | 12m 8s |
| MiniMax-M2.7-highspeed | 2 | 1.4M | 14.1k | 1.5M | 69.6k | 6m 14s |
| claude-sonnet-4-6 | 1 | 59 | 2.1k | 160.1k | 13.1k | 44s |