### PR TITLE
P5-A1-WP2 — Test cache tokens + dispatch/campaign IDs in session_log_flush

### DIFF
--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -540,6 +540,8 @@ def test_flush_index_token_fields_zero_when_no_step(tmp_path):
     assert entry["step_name"] == ""
     assert entry["input_tokens"] == 0
     assert entry["output_tokens"] == 0
+    assert entry["cache_creation_input_tokens"] == 0
+    assert entry["cache_read_input_tokens"] == 0
 
 
 def test_token_usage_json_schema(tmp_path):
@@ -556,6 +558,8 @@ def test_token_usage_json_schema(tmp_path):
         timing_seconds=15.0,
         proc_snapshots=None,
         success=False,
+        dispatch_id="disp-abc",
+        campaign_id="camp-xyz",
     )
     tu = json.loads((tmp_path / "sessions" / "test-session-001" / "token_usage.json").read_text())
     assert tu["session_label"] == "plan"
@@ -566,6 +570,8 @@ def test_token_usage_json_schema(tmp_path):
     assert tu["timing_seconds"] == 15.0
     assert tu["peak_context"] == 0
     assert tu["turn_count"] == 0
+    assert tu["dispatch_id"] == "disp-abc"
+    assert tu["campaign_id"] == "camp-xyz"
 
 
 def test_token_usage_json_includes_peak_context_and_turn_count(tmp_path):


### PR DESCRIPTION
## Summary

Extend two existing test functions in `tests/execution/test_session_log_flush.py` to close coverage gaps left after P5-A1-WP1 added cache tokens and dispatch/campaign IDs to the production flush path. No production code changes. No new test functions. No conftest changes.

Two edits remain:
1. Add `cache_creation_input_tokens == 0` and `cache_read_input_tokens == 0` assertions to `test_flush_index_token_fields_zero_when_no_step`.
2. Add `dispatch_id='disp-abc'` and `campaign_id='camp-xyz'` overrides to the `_flush()` call in `test_token_usage_json_schema`, plus two corresponding assertions.

Closes #1723

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-215640-031193/.autoskillit/temp/make-plan/p5_a1_wp2_test_cache_dispatch_campaign_plan_2026-05-06_220600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 66 | 7.2k | 427.1k | 49.0k | 34 | 38.4k | 4m 6s |
| verify | claude-opus-4-6 | 1 | 36 | 4.9k | 690.7k | 49.4k | 31 | 36.9k | 2m 46s |
| implement* | MiniMax-M2.7-highspeed | 1 | 210.6k | 2.9k | 446.7k | 29.8k | 33 | 43.0k | 5m 13s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 48.5k | 2.1k | 175.8k | 29.8k | 16 | 15.3k | 1m 3s |
| compose_pr | claude-sonnet-4-6 | 1 | 59 | 1.9k | 159.4k | 25.9k | 15 | 12.9k | 1m 10s |
| **Total** | | | 259.3k | 19.0k | 1.9M | 49.4k | | 146.5k | 14m 21s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 6 | 74442.5 | 7166.8 | 480.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **6** | 316616.2 | 24409.8 | 3173.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 102 | 12.2k | 1.1M | 75.2k | 6m 53s |
| MiniMax-M2.7-highspeed | 2 | 259.1k | 5.0k | 622.5k | 58.3k | 6m 17s |
| claude-sonnet-4-6 | 1 | 59 | 1.9k | 159.4k | 12.9k | 1m 10s |