### PR TITLE
Implementation Plan: P5-A5-WP4 — Test normalize_dispatch_token_usage + campaign_id persistence

### DIFF
--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -271,3 +271,68 @@ class TestNormalizeDispatchTokenUsage:
         import autoskillit.fleet
 
         assert "normalize_dispatch_token_usage" in autoskillit.fleet.__all__
+
+
+class TestDispatchRecordSchemaV3:
+    def test_normalize_maps_cache_keys_to_canonical_names(self) -> None:
+        result = normalize_dispatch_token_usage(
+            {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cache_creation_input_tokens": 200,
+                "cache_read_input_tokens": 300,
+            }
+        )
+        assert result["cache_creation"] == 200
+        assert result["cache_read"] == 300
+        assert "cache_creation_input_tokens" not in result
+        assert "cache_read_input_tokens" not in result
+
+    def test_normalize_defaults_missing_cache_keys_to_zero(self) -> None:
+        result = normalize_dispatch_token_usage({"input_tokens": 10, "output_tokens": 5})
+        assert result["cache_creation"] == 0
+        assert result["cache_read"] == 0
+
+    def test_campaign_id_roundtrip_via_dispatch_record(self, tmp_path: Path) -> None:
+        sp = tmp_path / "state.json"
+        write_initial_state(
+            sp,
+            "camp-xyz",
+            "test",
+            "/m.yaml",
+            [DispatchRecord(name="a", campaign_id="camp-xyz")],
+        )
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].campaign_id == "camp-xyz"
+        assert json.loads(sp.read_text())["dispatches"][0]["campaign_id"] == "camp-xyz"
+
+    def test_backward_compat_missing_campaign_id_defaults_to_empty_string(
+        self, tmp_path: Path
+    ) -> None:
+        sp = tmp_path / "state_v1.json"
+        v1_payload = {
+            "schema_version": 1,
+            "campaign_id": "cid-v1",
+            "campaign_name": "old-campaign",
+            "manifest_path": "/m.yaml",
+            "started_at": 0.0,
+            "dispatches": [
+                {
+                    "name": "dispatch-a",
+                    "status": "running",
+                    "dispatch_id": "did-old",
+                    "l2_session_id": "",
+                    "l2_session_log_dir": "",
+                    "l2_pid": 9999,
+                    "reason": "",
+                    "token_usage": {},
+                    "started_at": 0.0,
+                    "ended_at": 0.0,
+                }
+            ],
+        }
+        sp.write_text(json.dumps(v1_payload))
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].campaign_id == ""


### PR DESCRIPTION
## Summary

Add a `TestDispatchRecordSchemaV3` class with four test methods to `tests/fleet/test_state_schema.py`. The tests validate `normalize_dispatch_token_usage` key mapping and 0-defaults, `campaign_id` round-trip via `write_initial_state`/`read_state` with raw JSON verification, and backward-compatible deserialization of v1 payloads missing `campaign_id`.

The existing `TestCampaignIdField` (5 tests) and `TestNormalizeDispatchTokenUsage` (6 tests) — added by WP1/WP2 — cover additional edge cases (string coercion, `DispatchTokenUsage` unpacking, `__all__` membership, `to_dict()` serialization, schema v4 absent-field defaults). The new `TestDispatchRecordSchemaV3` tests differ in specific ways: different input values for normalization, explicit negative assertions on long-form keys, raw JSON on-disk verification for the campaign_id round-trip, and a v1-style (schema_version=1) backward-compat payload. Both class groups remain.

Closes #1729

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/p5_a5_wp4_test_normalize_dispatch_token_usage_campaign_id_plan_2026-05-06_232817.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 68 | 8.0k | 531.7k | 52.0k | 43 | 41.9k | 3m 55s |
| verify | claude-opus-4-6 | 1 | 35 | 5.6k | 294.3k | 55.4k | 29 | 42.4k | 2m 53s |
| implement | claude-sonnet-4-6 | 1 | 93 | 3.5k | 319.7k | 36.3k | 24 | 23.5k | 1m 29s |
| prepare_pr | claude-sonnet-4-6 | 1 | 60 | 4.5k | 176.8k | 31.6k | 19 | 19.8k | 1m 21s |
| compose_pr | claude-sonnet-4-6 | 1 | 59 | 2.0k | 159.1k | 26.3k | 15 | 13.3k | 42s |
| **Total** | | | 315 | 23.6k | 1.5M | 55.4k | | 141.0k | 10m 21s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 65 | 4918.5 | 362.2 | 53.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **65** | 22793.8 | 2169.4 | 363.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 103 | 13.6k | 826.0k | 84.4k | 6m 49s |
| claude-sonnet-4-6 | 3 | 212 | 10.0k | 655.6k | 56.6k | 3m 32s |