### PR TITLE
fleet/state.py — Size reduction and DispatchRecord Factory

### DIFF
--- a/src/autoskillit/fleet/CLAUDE.md
+++ b/src/autoskillit/fleet/CLAUDE.md
@@ -16,7 +16,10 @@ IL-2 fleet campaign layer — parallel issue dispatch, semaphore, sidecar, liven
 | `_sidecar_rpc.py` | `run_python`-callable entry points: `write_sidecar_entry`, `get_remaining_issues` |
 | `_findings_rpc.py` | `run_python`-callable entry points: `parse_and_resume`, `load_execution_map` |
 | `_checkpoint_bridge.py` | `checkpoint_from_sidecar` — converts `IssueSidecarEntry` list to `SessionCheckpoint` |
-| `state.py` | Campaign state persistence — `DispatchRecord`, `DispatchStatus`, atomic writes, resume algorithm |
+| `state.py` | Campaign state I/O and mutations — `read_state`, `_write_state`, `mark_dispatch_*`, re-exports from `state_types`, `state_gates`, `state_recovery` |
+| `state_types.py` | Campaign state types — `DispatchStatus`, `DispatchRecord`, `CampaignState`, `ResumeDecision`, `GateRecordResult`, constants |
+| `state_gates.py` | Gate dispatch recording — `record_gate_outcome` |
+| `state_recovery.py` | Crash recovery + resume — `has_failed_dispatch`, `crash_recover_dispatch`, `resume_campaign_from_state` |
 | `summary.py` | Campaign summary schema v1: frozen dataclasses, sentinel parser, validator |
 
 ## Architecture Notes

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -8,141 +8,36 @@ from __future__ import annotations
 
 import fcntl
 import json
-import threading
 import time
-from dataclasses import asdict, dataclass, field
-from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import (
-    FleetErrorCode,
-    InfraExitCategory,
-    RetryReason,
-    get_logger,
-    write_versioned_json,
+from autoskillit.core import get_logger, write_versioned_json
+from autoskillit.fleet.state_gates import record_gate_outcome  # noqa: F401
+from autoskillit.fleet.state_recovery import (  # noqa: F401
+    crash_recover_dispatch,
+    has_failed_dispatch,
+    resume_campaign_from_state,
+)
+from autoskillit.fleet.state_types import (  # noqa: F401 — re-exported
+    _ABANDON_KILL_REASONS,
+    _ALLOWED_TRANSITIONS,
+    _COMPLETED_STATUSES,
+    _INFRASTRUCTURE_FAILURE_REASONS,
+    _SCHEMA_VERSION,
+    _VISIBLE_IN_BLOCK_STATUSES,
+    FLEET_HALTED_SENTINEL,
+    TERMINAL_DISPATCH_STATUSES,
+    CampaignState,
+    DispatchRecord,
+    DispatchStatus,
+    GateRecordResult,
+    ResumeDecision,
+    _resume_lock,
+    _validate_transition,
 )
 
 logger = get_logger(__name__)
-
-_resume_lock = threading.Lock()
-
-_SCHEMA_VERSION = 4
-
-FLEET_HALTED_SENTINEL = "fleet_halted_on_failure"
-
-
-class DispatchStatus(StrEnum):
-    """Status of a single dispatch within a campaign."""
-
-    PENDING = "pending"
-    RUNNING = "running"
-    SUCCESS = "success"
-    FAILURE = "failure"
-    INTERRUPTED = "interrupted"
-    RESUMABLE = "resumable"
-    SKIPPED = "skipped"
-    REFUSED = "refused"
-    RELEASED = "released"
-
-
-@dataclass
-class DispatchRecord:
-    """Runtime state of a single dispatch within a campaign.
-
-    Mutable: status and metadata fields are updated as the dispatch progresses.
-    """
-
-    name: str
-    status: DispatchStatus = DispatchStatus.PENDING
-    dispatch_id: str = ""
-    campaign_id: str = ""
-    caller_session_id: str = ""
-    dispatched_session_id: str = ""
-    dispatched_session_log_dir: str = ""
-    dispatched_pid: int = 0
-    dispatched_starttime_ticks: int = 0
-    dispatched_boot_id: str = ""
-    reason: str = ""
-    kill_reason: str = ""
-    infra_exit_category: str = ""
-    token_usage: dict[str, Any] = field(default_factory=dict)
-    started_at: float = 0.0
-    ended_at: float = 0.0
-    sidecar_path: str | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class CampaignState:
-    """Top-level campaign state file content."""
-
-    schema_version: int
-    campaign_id: str
-    campaign_name: str
-    manifest_path: str
-    started_at: float
-    dispatches: list[DispatchRecord] = field(default_factory=list)
-    captured_values: dict[str, str] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
-class ResumeDecision:
-    """Result of the resume algorithm."""
-
-    next_dispatch_name: str
-    completed_dispatches_block: str
-    is_resumable: bool = False
-    dispatched_session_id: str = ""
-    kill_reason: str = ""
-
-
-_ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
-    DispatchStatus.PENDING: frozenset(
-        {
-            DispatchStatus.RUNNING,
-            DispatchStatus.SUCCESS,
-            DispatchStatus.FAILURE,
-            DispatchStatus.SKIPPED,
-            DispatchStatus.REFUSED,
-            DispatchStatus.RELEASED,
-        }
-    ),
-    DispatchStatus.RUNNING: frozenset(
-        {
-            DispatchStatus.SUCCESS,
-            DispatchStatus.FAILURE,
-            DispatchStatus.INTERRUPTED,
-            DispatchStatus.RESUMABLE,
-        }
-    ),
-    DispatchStatus.RESUMABLE: frozenset(
-        {
-            DispatchStatus.RUNNING,
-            DispatchStatus.SUCCESS,
-            DispatchStatus.FAILURE,
-            DispatchStatus.INTERRUPTED,
-        }
-    ),
-    # Retryable settled state: only explicit retry (→ PENDING) is allowed
-    DispatchStatus.FAILURE: frozenset({DispatchStatus.PENDING}),
-    # Terminal states: no further transitions permitted
-    DispatchStatus.SUCCESS: frozenset(),
-    DispatchStatus.INTERRUPTED: frozenset(),
-    DispatchStatus.SKIPPED: frozenset(),
-    DispatchStatus.REFUSED: frozenset(),
-    DispatchStatus.RELEASED: frozenset(),
-}
-
-
-def _validate_transition(current: str, new: str, dispatch_name: str) -> None:
-    """Raise ValueError if the status transition is not allowed."""
-    allowed = _ALLOWED_TRANSITIONS.get(current)
-    if allowed is not None and new not in allowed:
-        msg = f"Invalid transition for dispatch '{dispatch_name}': {current!r} -> {new!r}"
-        raise ValueError(msg)
 
 
 def write_initial_state(
@@ -166,34 +61,8 @@ def write_initial_state(
     write_versioned_json(state_path, payload, schema_version=_SCHEMA_VERSION)
 
 
-_INFRASTRUCTURE_FAILURE_REASONS: frozenset[str] = frozenset(
-    {
-        FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK,
-    }
-)
-
-
-def has_failed_dispatch(state_path: Path) -> bool:
-    """Check whether any dispatch has a FAILURE status attributable to logic (not infrastructure).
-
-    Infrastructure failures (e.g. fleet_l3_no_result_block) represent transient L3
-    disconnections and do not halt the campaign. Logic failures (e.g. completed_clean
-    with success=false) represent genuine task failures and do halt the campaign.
-
-    Returns False when the file is missing or corrupted (fail-open).
-    """
-    if not state_path.exists():
-        return False
-    state = read_state(state_path)
-    if state is None:
-        return False
-    return any(
-        d.status == DispatchStatus.FAILURE and d.reason not in _INFRASTRUCTURE_FAILURE_REASONS
-        for d in state.dispatches
-    )
-
-
 def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
+    """Clear a dispatch record for retry."""
     _validate_transition(d.status, DispatchStatus.PENDING, d.name)
     d.status = DispatchStatus.PENDING
     d.reason = ""
@@ -250,38 +119,7 @@ def read_state(state_path: Path) -> CampaignState | None:
     except (OSError, json.JSONDecodeError):
         return None
     try:
-        dispatches = [
-            DispatchRecord(
-                name=d["name"],
-                status=DispatchStatus(d.get("status", DispatchStatus.PENDING)),
-                dispatch_id=d.get("dispatch_id", ""),
-                campaign_id=d.get("campaign_id", ""),
-                caller_session_id=d.get("caller_session_id", ""),
-                dispatched_session_id=d.get("dispatched_session_id")
-                or d.get("l3_session_id")
-                or d.get("l2_session_id", ""),
-                dispatched_session_log_dir=d.get("dispatched_session_log_dir")
-                or d.get("l3_session_log_dir")
-                or d.get("l2_session_log_dir", ""),
-                dispatched_pid=d.get("dispatched_pid")
-                if d.get("dispatched_pid") is not None
-                else d.get("l3_pid") or d.get("l2_pid", 0),
-                dispatched_starttime_ticks=d.get("dispatched_starttime_ticks")
-                if d.get("dispatched_starttime_ticks") is not None
-                else d.get("l3_starttime_ticks") or d.get("l2_starttime_ticks", 0),
-                dispatched_boot_id=d.get("dispatched_boot_id")
-                or d.get("l3_boot_id")
-                or d.get("l2_boot_id", ""),
-                reason=d.get("reason", ""),
-                kill_reason=d.get("kill_reason", ""),
-                infra_exit_category=d.get("infra_exit_category", ""),
-                token_usage=d.get("token_usage", {}),
-                started_at=d.get("started_at", 0.0),
-                ended_at=d.get("ended_at", 0.0),
-                sidecar_path=d.get("sidecar_path"),
-            )
-            for d in data["dispatches"]
-        ]
+        dispatches = [DispatchRecord.from_dict(d) for d in data["dispatches"]]
         return CampaignState(
             schema_version=data["schema_version"],
             campaign_id=data["campaign_id"],
@@ -383,88 +221,6 @@ def mark_dispatch_resumable(
     _write_state(state_path, state)
 
 
-@dataclass(frozen=True)
-class GateRecordResult:
-    """Result of a gate dispatch recording attempt."""
-
-    success: bool
-    dispatch_name: str
-    status: str = ""
-    error_code: str = ""
-    error_message: str = ""
-
-
-def record_gate_outcome(
-    state_path: Path,
-    dispatch_name: str,
-    approved: bool,
-) -> GateRecordResult:
-    """Record the outcome of a gate dispatch to the campaign state file.
-
-    Returns a GateRecordResult with success/failure and error details.
-
-    Thread-safe: _resume_lock (intra-process) + fcntl.flock(LOCK_EX)
-    (cross-process) prevent concurrent callers from corrupting state.
-    """
-    with _resume_lock:
-        lock_path = state_path.with_suffix(".lock")
-        with open(lock_path, "wb") as _flock_handle:
-            fcntl.flock(_flock_handle, fcntl.LOCK_EX)
-
-            state = read_state(state_path)
-            if state is None:
-                return GateRecordResult(
-                    success=False,
-                    dispatch_name=dispatch_name,
-                    error_code="fleet_gate_no_campaign",
-                    error_message=f"Campaign state file missing or corrupted: {state_path}",
-                )
-
-            match = next((d for d in state.dispatches if d.name == dispatch_name), None)
-            if match is None:
-                return GateRecordResult(
-                    success=False,
-                    dispatch_name=dispatch_name,
-                    error_code="fleet_gate_unknown_dispatch",
-                    error_message=f"Dispatch '{dispatch_name}' not found in campaign state.",
-                )
-
-            if match.status != DispatchStatus.PENDING:
-                return GateRecordResult(
-                    success=False,
-                    dispatch_name=dispatch_name,
-                    error_code="fleet_gate_already_recorded",
-                    error_message=(
-                        f"Dispatch '{dispatch_name}' is already {match.status.value}, not PENDING."
-                    ),
-                )
-
-            status = DispatchStatus.SUCCESS if approved else DispatchStatus.FAILURE
-            now = time.time()
-            new_record = DispatchRecord(
-                name=dispatch_name,
-                status=status,
-                reason="gate_approved" if approved else "gate_rejected",
-                started_at=now,
-                ended_at=now,
-            )
-            for i, d in enumerate(state.dispatches):
-                if d.name == new_record.name:
-                    _validate_transition(d.status, new_record.status, d.name)
-                    state.dispatches[i] = new_record
-                    _write_state(state_path, state)
-                    break
-            else:
-                state.dispatches.append(new_record)
-                _write_state(state_path, state)
-
-            return GateRecordResult(
-                success=True,
-                dispatch_name=dispatch_name,
-                status=status.value,
-            )
-
-
 def append_dispatch_record(
     state_path: Path,
     record: DispatchRecord,
@@ -485,29 +241,6 @@ def append_dispatch_record(
             return
     state.dispatches.append(record)
     _write_state(state_path, state)
-
-
-_COMPLETED_STATUSES = frozenset(
-    {DispatchStatus.SUCCESS, DispatchStatus.SKIPPED, DispatchStatus.FAILURE}
-)
-
-_VISIBLE_IN_BLOCK_STATUSES = _COMPLETED_STATUSES | frozenset(
-    {
-        DispatchStatus.INTERRUPTED,
-        DispatchStatus.REFUSED,
-        DispatchStatus.RELEASED,
-        DispatchStatus.RUNNING,
-    }
-)
-
-TERMINAL_DISPATCH_STATUSES: frozenset[str] = frozenset(
-    {
-        DispatchStatus.SUCCESS,
-        DispatchStatus.FAILURE,
-        DispatchStatus.SKIPPED,
-        DispatchStatus.RELEASED,
-    }
-)
 
 
 def build_protected_campaign_ids(project_dir: Path) -> frozenset[str]:
@@ -590,172 +323,6 @@ def read_all_campaign_captures(
             logger.warning("read_all_campaign_captures: skipping %s: %s", path, exc)
             continue
     return result
-
-
-_ABANDON_KILL_REASONS: frozenset[str] = frozenset(
-    {
-        RetryReason.STALE,
-        RetryReason.THINKING_STALL,
-        RetryReason.PATH_CONTAMINATION,
-        RetryReason.CLONE_CONTAMINATION,
-    }
-)
-
-
-def _is_abandon_kill_reason(kill_reason: str, infra_exit_category: str) -> bool:
-    """Check if stored kill metadata indicates resume would be futile."""
-    if kill_reason in _ABANDON_KILL_REASONS:
-        return True
-    if (
-        kill_reason == RetryReason.RESUME
-        and infra_exit_category == InfraExitCategory.CONTEXT_EXHAUSTED
-    ):
-        return True
-    return False
-
-
-def crash_recover_dispatch(
-    state_path: Path,
-    record: DispatchRecord,
-    reason: str = "stale_running_on_resume",
-) -> DispatchStatus | None:
-    """Recover a stale RUNNING dispatch to RESUMABLE or INTERRUPTED; None if both writes fail."""
-    from autoskillit.fleet.sidecar import read_sidecar_from_path  # noqa: PLC0415
-
-    sidecar = Path(record.sidecar_path) if record.sidecar_path else None
-    if sidecar is not None and sidecar.exists():
-        try:
-            raw_lines = [ln.strip() for ln in sidecar.read_text().splitlines() if ln.strip()]
-        except OSError:
-            logger.warning("crash_recover_dispatch: sidecar vanished during read", exc_info=True)
-        else:
-            if not raw_lines or read_sidecar_from_path(sidecar):
-                if _is_abandon_kill_reason(record.kill_reason, record.infra_exit_category):
-                    try:
-                        mark_dispatch_interrupted(state_path, record.name, reason=reason)
-                        return DispatchStatus.INTERRUPTED
-                    except Exception:
-                        logger.warning(
-                            "crash_recover_dispatch: failed to mark dispatch interrupted",
-                            exc_info=True,
-                        )
-                        return None
-                try:
-                    mark_dispatch_resumable(state_path, record.name, sidecar_path=str(sidecar))
-                    return DispatchStatus.RESUMABLE
-                except Exception:
-                    logger.warning(
-                        "crash_recover_dispatch: failed to mark dispatch resumable",
-                        exc_info=True,
-                    )
-    try:
-        mark_dispatch_interrupted(state_path, record.name, reason=reason)
-        return DispatchStatus.INTERRUPTED
-    except Exception:
-        logger.warning(
-            "crash_recover_dispatch: failed to mark dispatch interrupted", exc_info=True
-        )
-        return None
-
-
-def resume_campaign_from_state(
-    state_path: Path,
-    continue_on_failure: bool,
-    *,
-    reset_on_retry: bool = False,
-) -> ResumeDecision | None:
-    """Determine the next dispatch for a resumed campaign.
-
-    Algorithm:
-      1. Read state.json; return None if absent or corrupted.
-      2. Find first dispatch not in {success, skipped}.
-      3. If running exists and stale, mark it interrupted; skip alive ones.
-      4. If failure exists and continue_on_failure=False, return None
-         with reason fleet_halted_on_failure (encoded via a sentinel).
-         When reset_on_retry=True, reset all FAILURE dispatches to PENDING instead.
-      5. Return ResumeDecision with next_dispatch_name and completed block.
-
-    Returns None if the state file is missing/corrupted. Returns a
-    ResumeDecision with next_dispatch_name="" if all dispatches are
-    complete or the campaign is halted.
-
-    Thread-safe: _resume_lock (intra-process) + fcntl.flock(LOCK_EX)
-    (cross-process) prevent concurrent callers from corrupting state.
-    """
-    from autoskillit.fleet import is_dispatch_session_alive
-
-    with _resume_lock:
-        lock_path = state_path.with_suffix(".lock")
-        with open(lock_path, "wb") as _flock_handle:
-            fcntl.flock(_flock_handle, fcntl.LOCK_EX)
-
-            state = read_state(state_path)
-            if state is None:
-                return None
-
-            # Phase 1: crash recovery — skip live sessions, recover stale ones
-            for d in state.dispatches:
-                if d.status == DispatchStatus.RUNNING:
-                    if is_dispatch_session_alive(d):
-                        continue
-                    new_status = crash_recover_dispatch(state_path, d)
-                    if new_status is not None:
-                        d.status = new_status
-                        d.reason = "stale_running_on_resume"
-
-            # Phase 2: check for failure halt
-            did_reset = False
-            for d in state.dispatches:
-                if d.status == DispatchStatus.FAILURE and not continue_on_failure:
-                    if reset_on_retry:
-                        _clear_dispatch_for_retry(d)
-                        did_reset = True
-                    else:
-                        return ResumeDecision(
-                            next_dispatch_name="",
-                            completed_dispatches_block=FLEET_HALTED_SENTINEL,
-                        )
-            if did_reset:
-                _write_state(state_path, state)
-
-            # Phase 3: build completed dispatches block and find next
-            # RESUMABLE is selected before PENDING; RUNNING (alive) dispatches are skipped
-            completed_lines: list[str] = []
-            next_name = ""
-            is_resumable = False
-            resumable_dispatched_session_id = ""
-            resumable_kill_reason = ""
-            for d in state.dispatches:
-                if d.status in _VISIBLE_IN_BLOCK_STATUSES:
-                    completed_lines.append(f"- {d.name}: {d.status}")
-                elif d.status == DispatchStatus.RESUMABLE and not next_name:
-                    next_name = d.name
-                    is_resumable = True
-                    resumable_dispatched_session_id = d.dispatched_session_id
-                    resumable_kill_reason = d.kill_reason
-                elif (
-                    d.status
-                    not in {
-                        DispatchStatus.INTERRUPTED,
-                        DispatchStatus.RUNNING,
-                        DispatchStatus.REFUSED,
-                        DispatchStatus.RELEASED,
-                        DispatchStatus.FAILURE,
-                        DispatchStatus.RESUMABLE,
-                    }
-                    and not next_name
-                ):
-                    next_name = d.name
-
-            completed_block = "\n".join(completed_lines) if completed_lines else ""
-
-            return ResumeDecision(
-                next_dispatch_name=next_name,
-                completed_dispatches_block=completed_block,
-                is_resumable=is_resumable,
-                dispatched_session_id=resumable_dispatched_session_id,
-                kill_reason=resumable_kill_reason,
-            )
 
 
 def normalize_dispatch_token_usage(raw: dict[str, Any]) -> dict[str, int]:

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -13,19 +13,19 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, write_versioned_json
-from autoskillit.fleet.state_gates import record_gate_outcome  # noqa: F401
-from autoskillit.fleet.state_recovery import (  # noqa: F401
+from autoskillit.fleet.state_gates import record_gate_outcome
+from autoskillit.fleet.state_recovery import (
     crash_recover_dispatch,
     has_failed_dispatch,
     resume_campaign_from_state,
 )
-from autoskillit.fleet.state_types import (  # noqa: F401 — re-exported
-    _ABANDON_KILL_REASONS,
-    _ALLOWED_TRANSITIONS,
-    _COMPLETED_STATUSES,
-    _INFRASTRUCTURE_FAILURE_REASONS,
-    _SCHEMA_VERSION,
-    _VISIBLE_IN_BLOCK_STATUSES,
+from autoskillit.fleet.state_types import (
+    _ABANDON_KILL_REASONS,  # noqa: F401
+    _ALLOWED_TRANSITIONS,  # noqa: F401
+    _COMPLETED_STATUSES,  # noqa: F401
+    _INFRASTRUCTURE_FAILURE_REASONS,  # noqa: F401
+    _SCHEMA_VERSION,  # noqa: F401
+    _VISIBLE_IN_BLOCK_STATUSES,  # noqa: F401
     FLEET_HALTED_SENTINEL,
     TERMINAL_DISPATCH_STATUSES,
     CampaignState,
@@ -36,6 +36,34 @@ from autoskillit.fleet.state_types import (  # noqa: F401 — re-exported
     _resume_lock,
     _validate_transition,
 )
+
+__all__ = [
+    # re-exported from state_gates
+    "record_gate_outcome",
+    # re-exported from state_recovery
+    "crash_recover_dispatch",
+    "has_failed_dispatch",
+    "resume_campaign_from_state",
+    # re-exported from state_types
+    "FLEET_HALTED_SENTINEL",
+    "TERMINAL_DISPATCH_STATUSES",
+    "CampaignState",
+    "DispatchRecord",
+    "DispatchStatus",
+    "GateRecordResult",
+    "ResumeDecision",
+    # local
+    "write_initial_state",
+    "read_state",
+    "mark_dispatch_running",
+    "mark_dispatch_interrupted",
+    "mark_dispatch_resumable",
+    "reset_failed_dispatch",
+    "append_dispatch_record",
+    "build_protected_campaign_ids",
+    "write_captured_values",
+    "read_all_campaign_captures",
+]
 
 logger = get_logger(__name__)
 

--- a/src/autoskillit/fleet/state_gates.py
+++ b/src/autoskillit/fleet/state_gates.py
@@ -77,9 +77,6 @@ def record_gate_outcome(
                     state.dispatches[i] = new_record
                     _write_state(state_path, state)
                     break
-            else:
-                state.dispatches.append(new_record)
-                _write_state(state_path, state)
 
             return GateRecordResult(
                 success=True,

--- a/src/autoskillit/fleet/state_gates.py
+++ b/src/autoskillit/fleet/state_gates.py
@@ -1,0 +1,88 @@
+"""Gate dispatch recording."""
+
+from __future__ import annotations
+
+import fcntl
+import time
+from pathlib import Path
+
+from autoskillit.fleet.state_types import (
+    DispatchRecord,
+    DispatchStatus,
+    GateRecordResult,
+    _resume_lock,
+    _validate_transition,
+)
+
+
+def record_gate_outcome(
+    state_path: Path,
+    dispatch_name: str,
+    approved: bool,
+) -> GateRecordResult:
+    """Record the outcome of a gate dispatch to the campaign state file.
+
+    Returns a GateRecordResult with success/failure and error details.
+
+    Thread-safe: _resume_lock (intra-process) + fcntl.flock(LOCK_EX)
+    (cross-process) prevent concurrent callers from corrupting state.
+    """
+    from autoskillit.fleet.state import _write_state, read_state  # noqa: PLC0415
+
+    with _resume_lock:
+        lock_path = state_path.with_suffix(".lock")
+        with open(lock_path, "wb") as _flock_handle:
+            fcntl.flock(_flock_handle, fcntl.LOCK_EX)
+
+            state = read_state(state_path)
+            if state is None:
+                return GateRecordResult(
+                    success=False,
+                    dispatch_name=dispatch_name,
+                    error_code="fleet_gate_no_campaign",
+                    error_message=f"Campaign state file missing or corrupted: {state_path}",
+                )
+
+            match = next((d for d in state.dispatches if d.name == dispatch_name), None)
+            if match is None:
+                return GateRecordResult(
+                    success=False,
+                    dispatch_name=dispatch_name,
+                    error_code="fleet_gate_unknown_dispatch",
+                    error_message=f"Dispatch '{dispatch_name}' not found in campaign state.",
+                )
+
+            if match.status != DispatchStatus.PENDING:
+                return GateRecordResult(
+                    success=False,
+                    dispatch_name=dispatch_name,
+                    error_code="fleet_gate_already_recorded",
+                    error_message=(
+                        f"Dispatch '{dispatch_name}' is already {match.status.value}, not PENDING."
+                    ),
+                )
+
+            status = DispatchStatus.SUCCESS if approved else DispatchStatus.FAILURE
+            now = time.time()
+            new_record = DispatchRecord(
+                name=dispatch_name,
+                status=status,
+                reason="gate_approved" if approved else "gate_rejected",
+                started_at=now,
+                ended_at=now,
+            )
+            for i, d in enumerate(state.dispatches):
+                if d.name == new_record.name:
+                    _validate_transition(d.status, new_record.status, d.name)
+                    state.dispatches[i] = new_record
+                    _write_state(state_path, state)
+                    break
+            else:
+                state.dispatches.append(new_record)
+                _write_state(state_path, state)
+
+            return GateRecordResult(
+                success=True,
+                dispatch_name=dispatch_name,
+                status=status.value,
+            )

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -92,6 +92,10 @@ def crash_recover_dispatch(
                         "crash_recover_dispatch: failed to mark dispatch resumable",
                         exc_info=True,
                     )
+    logger.debug(
+        "crash_recover_dispatch: no sidecar for %s — falling back to interrupted",
+        record.name,
+    )
     try:
         mark_dispatch_interrupted(state_path, record.name, reason=reason)
         return DispatchStatus.INTERRUPTED

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -3,22 +3,18 @@
 from __future__ import annotations
 
 import fcntl
-import json
-import time
 from pathlib import Path
 
-from autoskillit.core import InfraExitCategory, RetryReason, get_logger, write_versioned_json
+from autoskillit.core import InfraExitCategory, RetryReason, get_logger
 from autoskillit.fleet.state_types import (
     _ABANDON_KILL_REASONS,
     _INFRASTRUCTURE_FAILURE_REASONS,
     _VISIBLE_IN_BLOCK_STATUSES,
     FLEET_HALTED_SENTINEL,
-    CampaignState,
     DispatchRecord,
     DispatchStatus,
     ResumeDecision,
     _resume_lock,
-    _validate_transition,
 )
 
 logger = get_logger(__name__)
@@ -65,6 +61,10 @@ def crash_recover_dispatch(
 ) -> DispatchStatus | None:
     """Recover a stale RUNNING dispatch to RESUMABLE or INTERRUPTED; None if both writes fail."""
     from autoskillit.fleet.sidecar import read_sidecar_from_path  # noqa: PLC0415
+    from autoskillit.fleet.state import (  # noqa: PLC0415
+        mark_dispatch_interrupted,
+        mark_dispatch_resumable,
+    )
 
     sidecar = Path(record.sidecar_path) if record.sidecar_path else None
     if sidecar is not None and sidecar.exists():
@@ -102,50 +102,6 @@ def crash_recover_dispatch(
         return None
 
 
-def mark_dispatch_interrupted(
-    state_path: Path,
-    dispatch_name: str,
-    *,
-    reason: str,
-) -> None:
-    """Atomically mark a dispatch as interrupted with a reason."""
-    state = read_state(state_path)
-    if state is None:
-        raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
-    for d in state.dispatches:
-        if d.name == dispatch_name:
-            _validate_transition(d.status, DispatchStatus.INTERRUPTED, d.name)
-            d.status = DispatchStatus.INTERRUPTED
-            d.reason = reason
-            d.ended_at = time.time()
-            break
-    else:
-        raise ValueError(f"Dispatch '{dispatch_name}' not found in state")
-    _write_state(state_path, state)
-
-
-def mark_dispatch_resumable(
-    state_path: Path,
-    dispatch_name: str,
-    *,
-    sidecar_path: str,
-) -> None:
-    """Atomically transition a RUNNING dispatch to RESUMABLE, preserving the sidecar path."""
-    state = read_state(state_path)
-    if state is None:
-        raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
-    for d in state.dispatches:
-        if d.name == dispatch_name:
-            _validate_transition(d.status, DispatchStatus.RESUMABLE, d.name)
-            d.status = DispatchStatus.RESUMABLE
-            d.sidecar_path = sidecar_path
-            d.ended_at = time.time()
-            break
-    else:
-        raise ValueError(f"Dispatch '{dispatch_name}' not found in state")
-    _write_state(state_path, state)
-
-
 def resume_campaign_from_state(
     state_path: Path,
     continue_on_failure: bool,
@@ -170,7 +126,12 @@ def resume_campaign_from_state(
     Thread-safe: _resume_lock (intra-process) + fcntl.flock(LOCK_EX)
     (cross-process) prevent concurrent callers from corrupting state.
     """
-    from autoskillit.fleet import is_dispatch_session_alive
+    from autoskillit.fleet import is_dispatch_session_alive  # noqa: PLC0415
+    from autoskillit.fleet.state import (  # noqa: PLC0415
+        _clear_dispatch_for_retry,
+        _write_state,
+        read_state,
+    )
 
     with _resume_lock:
         lock_path = state_path.with_suffix(".lock")
@@ -240,55 +201,3 @@ def resume_campaign_from_state(
                 dispatched_session_id=resumable_dispatched_session_id,
                 kill_reason=resumable_kill_reason,
             )
-
-
-def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
-    """Clear a dispatch record for retry."""
-    _validate_transition(d.status, DispatchStatus.PENDING, d.name)
-    d.status = DispatchStatus.PENDING
-    d.reason = ""
-    d.dispatch_id = ""
-    d.dispatched_session_id = ""
-    d.dispatched_session_log_dir = ""
-    d.dispatched_pid = 0
-    d.dispatched_starttime_ticks = 0
-    d.dispatched_boot_id = ""
-    d.token_usage = {}
-    d.started_at = 0.0
-    d.ended_at = 0.0
-    d.sidecar_path = None
-
-
-def _write_state(state_path: Path, state: CampaignState) -> None:
-    """Internal: atomic write of full state to disk."""
-    payload = {
-        "campaign_id": state.campaign_id,
-        "campaign_name": state.campaign_name,
-        "manifest_path": state.manifest_path,
-        "started_at": state.started_at,
-        "dispatches": [d.to_dict() for d in state.dispatches],
-        "captured_values": state.captured_values,
-    }
-    write_versioned_json(state_path, payload, schema_version=state.schema_version)
-
-
-def read_state(state_path: Path) -> CampaignState | None:
-    """Load campaign state from disk."""
-    try:
-        data = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    try:
-        dispatches = [DispatchRecord.from_dict(d) for d in data["dispatches"]]
-        return CampaignState(
-            schema_version=data["schema_version"],
-            campaign_id=data["campaign_id"],
-            campaign_name=data["campaign_name"],
-            manifest_path=data["manifest_path"],
-            started_at=data["started_at"],
-            dispatches=dispatches,
-            captured_values=data.get("captured_values", {}),
-        )
-    except (KeyError, ValueError, TypeError) as exc:
-        logger.warning("read_state: schema mismatch or corrupt payload in %s: %s", state_path, exc)
-        return None

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -1,0 +1,294 @@
+"""Crash recovery and campaign resume logic."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import time
+from pathlib import Path
+
+from autoskillit.core import InfraExitCategory, RetryReason, get_logger, write_versioned_json
+from autoskillit.fleet.state_types import (
+    _ABANDON_KILL_REASONS,
+    _INFRASTRUCTURE_FAILURE_REASONS,
+    _VISIBLE_IN_BLOCK_STATUSES,
+    FLEET_HALTED_SENTINEL,
+    CampaignState,
+    DispatchRecord,
+    DispatchStatus,
+    ResumeDecision,
+    _resume_lock,
+    _validate_transition,
+)
+
+logger = get_logger(__name__)
+
+
+def has_failed_dispatch(state_path: Path) -> bool:
+    """Check whether any dispatch has a FAILURE status attributable to logic (not infrastructure).
+
+    Infrastructure failures (e.g. fleet_l3_no_result_block) represent transient L3
+    disconnections and do not halt the campaign. Logic failures (e.g. completed_clean
+    with success=false) represent genuine task failures and do halt the campaign.
+
+    Returns False when the file is missing or corrupted (fail-open).
+    """
+    from autoskillit.fleet.state import read_state  # noqa: PLC0415
+
+    if not state_path.exists():
+        return False
+    state = read_state(state_path)
+    if state is None:
+        return False
+    return any(
+        d.status == DispatchStatus.FAILURE and d.reason not in _INFRASTRUCTURE_FAILURE_REASONS
+        for d in state.dispatches
+    )
+
+
+def _is_abandon_kill_reason(kill_reason: str, infra_exit_category: str) -> bool:
+    """Check if stored kill metadata indicates resume would be futile."""
+    if kill_reason in _ABANDON_KILL_REASONS:
+        return True
+    if (
+        kill_reason == RetryReason.RESUME
+        and infra_exit_category == InfraExitCategory.CONTEXT_EXHAUSTED
+    ):
+        return True
+    return False
+
+
+def crash_recover_dispatch(
+    state_path: Path,
+    record: DispatchRecord,
+    reason: str = "stale_running_on_resume",
+) -> DispatchStatus | None:
+    """Recover a stale RUNNING dispatch to RESUMABLE or INTERRUPTED; None if both writes fail."""
+    from autoskillit.fleet.sidecar import read_sidecar_from_path  # noqa: PLC0415
+
+    sidecar = Path(record.sidecar_path) if record.sidecar_path else None
+    if sidecar is not None and sidecar.exists():
+        try:
+            raw_lines = [ln.strip() for ln in sidecar.read_text().splitlines() if ln.strip()]
+        except OSError:
+            logger.warning("crash_recover_dispatch: sidecar vanished during read", exc_info=True)
+        else:
+            if not raw_lines or read_sidecar_from_path(sidecar):
+                if _is_abandon_kill_reason(record.kill_reason, record.infra_exit_category):
+                    try:
+                        mark_dispatch_interrupted(state_path, record.name, reason=reason)
+                        return DispatchStatus.INTERRUPTED
+                    except Exception:
+                        logger.warning(
+                            "crash_recover_dispatch: failed to mark dispatch interrupted",
+                            exc_info=True,
+                        )
+                        return None
+                try:
+                    mark_dispatch_resumable(state_path, record.name, sidecar_path=str(sidecar))
+                    return DispatchStatus.RESUMABLE
+                except Exception:
+                    logger.warning(
+                        "crash_recover_dispatch: failed to mark dispatch resumable",
+                        exc_info=True,
+                    )
+    try:
+        mark_dispatch_interrupted(state_path, record.name, reason=reason)
+        return DispatchStatus.INTERRUPTED
+    except Exception:
+        logger.warning(
+            "crash_recover_dispatch: failed to mark dispatch interrupted", exc_info=True
+        )
+        return None
+
+
+def mark_dispatch_interrupted(
+    state_path: Path,
+    dispatch_name: str,
+    *,
+    reason: str,
+) -> None:
+    """Atomically mark a dispatch as interrupted with a reason."""
+    state = read_state(state_path)
+    if state is None:
+        raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
+    for d in state.dispatches:
+        if d.name == dispatch_name:
+            _validate_transition(d.status, DispatchStatus.INTERRUPTED, d.name)
+            d.status = DispatchStatus.INTERRUPTED
+            d.reason = reason
+            d.ended_at = time.time()
+            break
+    else:
+        raise ValueError(f"Dispatch '{dispatch_name}' not found in state")
+    _write_state(state_path, state)
+
+
+def mark_dispatch_resumable(
+    state_path: Path,
+    dispatch_name: str,
+    *,
+    sidecar_path: str,
+) -> None:
+    """Atomically transition a RUNNING dispatch to RESUMABLE, preserving the sidecar path."""
+    state = read_state(state_path)
+    if state is None:
+        raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
+    for d in state.dispatches:
+        if d.name == dispatch_name:
+            _validate_transition(d.status, DispatchStatus.RESUMABLE, d.name)
+            d.status = DispatchStatus.RESUMABLE
+            d.sidecar_path = sidecar_path
+            d.ended_at = time.time()
+            break
+    else:
+        raise ValueError(f"Dispatch '{dispatch_name}' not found in state")
+    _write_state(state_path, state)
+
+
+def resume_campaign_from_state(
+    state_path: Path,
+    continue_on_failure: bool,
+    *,
+    reset_on_retry: bool = False,
+) -> ResumeDecision | None:
+    """Determine the next dispatch for a resumed campaign.
+
+    Algorithm:
+      1. Read state.json; return None if absent or corrupted.
+      2. Find first dispatch not in {success, skipped}.
+      3. If running exists and stale, mark it interrupted; skip alive ones.
+      4. If failure exists and continue_on_failure=False, return None
+         with reason fleet_halted_on_failure (encoded via a sentinel).
+         When reset_on_retry=True, reset all FAILURE dispatches to PENDING instead.
+      5. Return ResumeDecision with next_dispatch_name and completed block.
+
+    Returns None if the state file is missing/corrupted. Returns a
+    ResumeDecision with next_dispatch_name="" if all dispatches are
+    complete or the campaign is halted.
+
+    Thread-safe: _resume_lock (intra-process) + fcntl.flock(LOCK_EX)
+    (cross-process) prevent concurrent callers from corrupting state.
+    """
+    from autoskillit.fleet import is_dispatch_session_alive
+
+    with _resume_lock:
+        lock_path = state_path.with_suffix(".lock")
+        with open(lock_path, "wb") as _flock_handle:
+            fcntl.flock(_flock_handle, fcntl.LOCK_EX)
+
+            state = read_state(state_path)
+            if state is None:
+                return None
+
+            for d in state.dispatches:
+                if d.status == DispatchStatus.RUNNING:
+                    if is_dispatch_session_alive(d):
+                        continue
+                    new_status = crash_recover_dispatch(state_path, d)
+                    if new_status is not None:
+                        d.status = new_status
+                        d.reason = "stale_running_on_resume"
+
+            did_reset = False
+            for d in state.dispatches:
+                if d.status == DispatchStatus.FAILURE and not continue_on_failure:
+                    if reset_on_retry:
+                        _clear_dispatch_for_retry(d)
+                        did_reset = True
+                    else:
+                        return ResumeDecision(
+                            next_dispatch_name="",
+                            completed_dispatches_block=FLEET_HALTED_SENTINEL,
+                        )
+            if did_reset:
+                _write_state(state_path, state)
+
+            completed_lines: list[str] = []
+            next_name = ""
+            is_resumable = False
+            resumable_dispatched_session_id = ""
+            resumable_kill_reason = ""
+            for d in state.dispatches:
+                if d.status in _VISIBLE_IN_BLOCK_STATUSES:
+                    completed_lines.append(f"- {d.name}: {d.status}")
+                elif d.status == DispatchStatus.RESUMABLE and not next_name:
+                    next_name = d.name
+                    is_resumable = True
+                    resumable_dispatched_session_id = d.dispatched_session_id
+                    resumable_kill_reason = d.kill_reason
+                elif (
+                    d.status
+                    not in {
+                        DispatchStatus.INTERRUPTED,
+                        DispatchStatus.RUNNING,
+                        DispatchStatus.REFUSED,
+                        DispatchStatus.RELEASED,
+                        DispatchStatus.FAILURE,
+                        DispatchStatus.RESUMABLE,
+                    }
+                    and not next_name
+                ):
+                    next_name = d.name
+
+            completed_block = "\n".join(completed_lines) if completed_lines else ""
+
+            return ResumeDecision(
+                next_dispatch_name=next_name,
+                completed_dispatches_block=completed_block,
+                is_resumable=is_resumable,
+                dispatched_session_id=resumable_dispatched_session_id,
+                kill_reason=resumable_kill_reason,
+            )
+
+
+def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
+    """Clear a dispatch record for retry."""
+    _validate_transition(d.status, DispatchStatus.PENDING, d.name)
+    d.status = DispatchStatus.PENDING
+    d.reason = ""
+    d.dispatch_id = ""
+    d.dispatched_session_id = ""
+    d.dispatched_session_log_dir = ""
+    d.dispatched_pid = 0
+    d.dispatched_starttime_ticks = 0
+    d.dispatched_boot_id = ""
+    d.token_usage = {}
+    d.started_at = 0.0
+    d.ended_at = 0.0
+    d.sidecar_path = None
+
+
+def _write_state(state_path: Path, state: CampaignState) -> None:
+    """Internal: atomic write of full state to disk."""
+    payload = {
+        "campaign_id": state.campaign_id,
+        "campaign_name": state.campaign_name,
+        "manifest_path": state.manifest_path,
+        "started_at": state.started_at,
+        "dispatches": [d.to_dict() for d in state.dispatches],
+        "captured_values": state.captured_values,
+    }
+    write_versioned_json(state_path, payload, schema_version=state.schema_version)
+
+
+def read_state(state_path: Path) -> CampaignState | None:
+    """Load campaign state from disk."""
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    try:
+        dispatches = [DispatchRecord.from_dict(d) for d in data["dispatches"]]
+        return CampaignState(
+            schema_version=data["schema_version"],
+            campaign_id=data["campaign_id"],
+            campaign_name=data["campaign_name"],
+            manifest_path=data["manifest_path"],
+            started_at=data["started_at"],
+            dispatches=dispatches,
+            captured_values=data.get("captured_values", {}),
+        )
+    except (KeyError, ValueError, TypeError) as exc:
+        logger.warning("read_state: schema mismatch or corrupt payload in %s: %s", state_path, exc)
+        return None

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -1,0 +1,218 @@
+"""Campaign state types and constants."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from autoskillit.core import FleetErrorCode, RetryReason
+
+_resume_lock = threading.Lock()
+
+_SCHEMA_VERSION = 4
+
+FLEET_HALTED_SENTINEL = "fleet_halted_on_failure"
+
+
+class DispatchStatus(StrEnum):
+    """Status of a single dispatch within a campaign."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILURE = "failure"
+    INTERRUPTED = "interrupted"
+    RESUMABLE = "resumable"
+    SKIPPED = "skipped"
+    REFUSED = "refused"
+    RELEASED = "released"
+
+
+@dataclass
+class DispatchRecord:
+    """Runtime state of a single dispatch within a campaign.
+
+    Mutable: status and metadata fields are updated as the dispatch progresses.
+    """
+
+    name: str
+    status: DispatchStatus = DispatchStatus.PENDING
+    dispatch_id: str = ""
+    campaign_id: str = ""
+    caller_session_id: str = ""
+    dispatched_session_id: str = ""
+    dispatched_session_log_dir: str = ""
+    dispatched_pid: int = 0
+    dispatched_starttime_ticks: int = 0
+    dispatched_boot_id: str = ""
+    reason: str = ""
+    kill_reason: str = ""
+    infra_exit_category: str = ""
+    token_usage: dict[str, Any] = field(default_factory=dict)
+    started_at: float = 0.0
+    ended_at: float = 0.0
+    sidecar_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DispatchRecord:
+        pid_raw = d.get("dispatched_pid")
+        ticks_raw = d.get("dispatched_starttime_ticks")
+        return cls(
+            name=d["name"],
+            status=DispatchStatus(d.get("status", DispatchStatus.PENDING)),
+            dispatch_id=d.get("dispatch_id", ""),
+            campaign_id=d.get("campaign_id", ""),
+            caller_session_id=d.get("caller_session_id", ""),
+            dispatched_session_id=(
+                d.get("dispatched_session_id")
+                or d.get("l3_session_id")
+                or d.get("l2_session_id", "")
+            ),
+            dispatched_session_log_dir=(
+                d.get("dispatched_session_log_dir")
+                or d.get("l3_session_log_dir")
+                or d.get("l2_session_log_dir", "")
+            ),
+            dispatched_pid=(
+                pid_raw if pid_raw is not None else d.get("l3_pid") or d.get("l2_pid", 0)
+            ),
+            dispatched_starttime_ticks=(
+                ticks_raw
+                if ticks_raw is not None
+                else d.get("l3_starttime_ticks") or d.get("l2_starttime_ticks", 0)
+            ),
+            dispatched_boot_id=(
+                d.get("dispatched_boot_id") or d.get("l3_boot_id") or d.get("l2_boot_id", "")
+            ),
+            reason=d.get("reason", ""),
+            kill_reason=d.get("kill_reason", ""),
+            infra_exit_category=d.get("infra_exit_category", ""),
+            token_usage=d.get("token_usage", {}),
+            started_at=d.get("started_at", 0.0),
+            ended_at=d.get("ended_at", 0.0),
+            sidecar_path=d.get("sidecar_path"),
+        )
+
+
+@dataclass
+class CampaignState:
+    """Top-level campaign state file content."""
+
+    schema_version: int
+    campaign_id: str
+    campaign_name: str
+    manifest_path: str
+    started_at: float
+    dispatches: list[DispatchRecord] = field(default_factory=list)
+    captured_values: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ResumeDecision:
+    """Result of the resume algorithm."""
+
+    next_dispatch_name: str
+    completed_dispatches_block: str
+    is_resumable: bool = False
+    dispatched_session_id: str = ""
+    kill_reason: str = ""
+
+
+_ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
+    DispatchStatus.PENDING: frozenset(
+        {
+            DispatchStatus.RUNNING,
+            DispatchStatus.SUCCESS,
+            DispatchStatus.FAILURE,
+            DispatchStatus.SKIPPED,
+            DispatchStatus.REFUSED,
+            DispatchStatus.RELEASED,
+        }
+    ),
+    DispatchStatus.RUNNING: frozenset(
+        {
+            DispatchStatus.SUCCESS,
+            DispatchStatus.FAILURE,
+            DispatchStatus.INTERRUPTED,
+            DispatchStatus.RESUMABLE,
+        }
+    ),
+    DispatchStatus.RESUMABLE: frozenset(
+        {
+            DispatchStatus.RUNNING,
+            DispatchStatus.SUCCESS,
+            DispatchStatus.FAILURE,
+            DispatchStatus.INTERRUPTED,
+        }
+    ),
+    DispatchStatus.FAILURE: frozenset({DispatchStatus.PENDING}),
+    DispatchStatus.SUCCESS: frozenset(),
+    DispatchStatus.INTERRUPTED: frozenset(),
+    DispatchStatus.SKIPPED: frozenset(),
+    DispatchStatus.REFUSED: frozenset(),
+    DispatchStatus.RELEASED: frozenset(),
+}
+
+
+def _validate_transition(current: str, new: str, dispatch_name: str) -> None:
+    """Raise ValueError if the status transition is not allowed."""
+    allowed = _ALLOWED_TRANSITIONS.get(current)
+    if allowed is not None and new not in allowed:
+        msg = f"Invalid transition for dispatch '{dispatch_name}': {current!r} -> {new!r}"
+        raise ValueError(msg)
+
+
+_INFRASTRUCTURE_FAILURE_REASONS: frozenset[str] = frozenset(
+    {
+        FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK,
+    }
+)
+
+
+@dataclass(frozen=True)
+class GateRecordResult:
+    """Result of a gate dispatch recording attempt."""
+
+    success: bool
+    dispatch_name: str
+    status: str = ""
+    error_code: str = ""
+    error_message: str = ""
+
+
+_COMPLETED_STATUSES = frozenset(
+    {DispatchStatus.SUCCESS, DispatchStatus.SKIPPED, DispatchStatus.FAILURE}
+)
+
+_VISIBLE_IN_BLOCK_STATUSES = _COMPLETED_STATUSES | frozenset(
+    {
+        DispatchStatus.INTERRUPTED,
+        DispatchStatus.REFUSED,
+        DispatchStatus.RELEASED,
+        DispatchStatus.RUNNING,
+    }
+)
+
+TERMINAL_DISPATCH_STATUSES: frozenset[str] = frozenset(
+    {
+        DispatchStatus.SUCCESS,
+        DispatchStatus.FAILURE,
+        DispatchStatus.SKIPPED,
+        DispatchStatus.RELEASED,
+    }
+)
+
+
+_ABANDON_KILL_REASONS: frozenset[str] = frozenset(
+    {
+        RetryReason.STALE,
+        RetryReason.THINKING_STALL,
+        RetryReason.PATH_CONTAMINATION,
+        RetryReason.CLONE_CONTAMINATION,
+    }
+)

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -79,12 +79,18 @@ class DispatchRecord:
                 or d.get("l2_session_log_dir", "")
             ),
             dispatched_pid=(
-                pid_raw if pid_raw is not None else d.get("l3_pid") or d.get("l2_pid", 0)
+                pid_raw
+                if pid_raw is not None
+                else (l3_pid if (l3_pid := d.get("l3_pid")) is not None else d.get("l2_pid", 0))
             ),
             dispatched_starttime_ticks=(
                 ticks_raw
                 if ticks_raw is not None
-                else d.get("l3_starttime_ticks") or d.get("l2_starttime_ticks", 0)
+                else (
+                    l3_ticks
+                    if (l3_ticks := d.get("l3_starttime_ticks")) is not None
+                    else d.get("l2_starttime_ticks", 0)
+                )
             ),
             dispatched_boot_id=(
                 d.get("dispatched_boot_id") or d.get("l3_boot_id") or d.get("l2_boot_id", "")

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -787,7 +787,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         configurable asyncio.BoundedSemaphore implementation of the FleetLock protocol.
         Placed in fleet/ rather than server/ to preserve conservative test-filter cascade
         narrowing: changes to fleet/_semaphore.py only cascade to fleet/ tests, not to
-        server/ tests. Exempt at 11 files.
+        server/ tests. state.py was decomposed into state_types.py, state_gates.py, and
+        state_recovery.py to reduce the 757-line monolith and centralize deserialization
+        logic on DispatchRecord.from_dict. Exempt at 15 files.
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 14,
@@ -798,7 +800,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "cli": 18,
         "hooks": 9,
         "pipeline": 12,
-        "fleet": 12,
+        "fleet": 15,
         "recipe/rules": 29,
         "server/tools": 16,
         "hooks/guards": 21,

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -16,7 +16,7 @@ from autoskillit.fleet import (
     resume_campaign_from_state,
     write_initial_state,
 )
-from autoskillit.fleet.state import _validate_transition
+from autoskillit.fleet.state_types import _validate_transition
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -54,6 +54,123 @@ class TestInitialState:
         for d in state.dispatches:
             assert d.status == DispatchStatus.PENDING
 
+    def test_read_state_round_trips_through_from_dict(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        dispatches = [DispatchRecord(name=n) for n in ("a", "b")]
+        write_initial_state(sp, "cid", "cname", "/m.yaml", dispatches)
+        state = read_state(sp)
+        assert state is not None
+        assert [d.name for d in state.dispatches] == ["a", "b"]
+        assert all(d.status == DispatchStatus.PENDING for d in state.dispatches)
+
+
+class TestDispatchRecordFromDict:
+    def test_from_dict_canonical_fields(self) -> None:
+        d = {
+            "name": "build-docs",
+            "status": "running",
+            "dispatch_id": "abc",
+            "caller_session_id": "c1",
+            "dispatched_session_id": "s1",
+            "dispatched_session_log_dir": "/log",
+            "dispatched_pid": 1234,
+            "dispatched_starttime_ticks": 9999,
+            "dispatched_boot_id": "b1",
+            "reason": "started",
+            "kill_reason": "",
+            "infra_exit_category": "",
+            "token_usage": {"input": 100},
+            "started_at": 1.0,
+            "ended_at": 2.0,
+            "sidecar_path": "/s.jsonl",
+        }
+        rec = DispatchRecord.from_dict(d)
+        assert rec.name == "build-docs"
+        assert rec.status == DispatchStatus.RUNNING
+        assert rec.dispatched_session_id == "s1"
+        assert rec.dispatched_pid == 1234
+        assert rec.sidecar_path == "/s.jsonl"
+
+    def test_from_dict_legacy_l2_fields(self) -> None:
+        d = {
+            "name": "t",
+            "l2_session_id": "l2s",
+            "l2_session_log_dir": "/l2",
+            "l2_pid": 555,
+            "l2_starttime_ticks": 111,
+            "l2_boot_id": "l2b",
+        }
+        rec = DispatchRecord.from_dict(d)
+        assert rec.dispatched_session_id == "l2s"
+        assert rec.dispatched_pid == 555
+        assert rec.dispatched_starttime_ticks == 111
+        assert rec.dispatched_boot_id == "l2b"
+
+    def test_from_dict_l3_takes_priority_over_l2(self) -> None:
+        d = {
+            "name": "t",
+            "l3_session_id": "l3s",
+            "l2_session_id": "l2s",
+            "l3_pid": 333,
+            "l2_pid": 222,
+        }
+        rec = DispatchRecord.from_dict(d)
+        assert rec.dispatched_session_id == "l3s"
+        assert rec.dispatched_pid == 333
+
+    def test_from_dict_canonical_takes_priority_over_l3(self) -> None:
+        d = {"name": "t", "dispatched_session_id": "canon", "l3_session_id": "l3s"}
+        rec = DispatchRecord.from_dict(d)
+        assert rec.dispatched_session_id == "canon"
+
+    def test_from_dict_minimal_dict(self) -> None:
+        rec = DispatchRecord.from_dict({"name": "minimal"})
+        assert rec.name == "minimal"
+        assert rec.status == DispatchStatus.PENDING
+        assert rec.dispatched_pid == 0
+        assert rec.token_usage == {}
+        assert rec.sidecar_path is None
+
+    def test_from_dict_pid_zero_not_falsy(self) -> None:
+        d = {"name": "t", "dispatched_pid": 0, "l3_pid": 999}
+        rec = DispatchRecord.from_dict(d)
+        assert rec.dispatched_pid == 0
+
+    def test_from_dict_starttime_ticks_zero_not_falsy(self) -> None:
+        d = {"name": "t", "dispatched_starttime_ticks": 0, "l3_starttime_ticks": 888}
+        rec = DispatchRecord.from_dict(d)
+        assert rec.dispatched_starttime_ticks == 0
+
+
+class TestStateDecompositionImports:
+    def test_state_types_importable(self) -> None:
+        from autoskillit.fleet.state_types import (
+            DispatchRecord,
+            DispatchStatus,
+        )
+
+        assert DispatchStatus.PENDING == "pending"
+        assert hasattr(DispatchRecord, "from_dict")
+
+    def test_state_gates_importable(self) -> None:
+        from autoskillit.fleet.state_gates import record_gate_outcome
+
+        assert callable(record_gate_outcome)
+
+    def test_state_recovery_importable(self) -> None:
+        from autoskillit.fleet.state_recovery import (
+            resume_campaign_from_state,
+        )
+
+        assert callable(resume_campaign_from_state)
+
+    def test_backward_compat_from_state_module(self) -> None:
+        from autoskillit.fleet.state import (
+            read_state,
+        )
+
+        assert callable(read_state)
+
 
 class TestAppendDispatchRecord:
     def test_append_dispatch_record_updates_status(self, tmp_path: Path) -> None:

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -56,12 +56,46 @@ class TestInitialState:
 
     def test_read_state_round_trips_through_from_dict(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
-        dispatches = [DispatchRecord(name=n) for n in ("a", "b")]
+        dispatches = [
+            DispatchRecord(
+                name="a",
+                status=DispatchStatus.RUNNING,
+                dispatch_id="d1",
+                caller_session_id="c1",
+                dispatched_session_id="s1",
+                dispatched_session_log_dir="/log",
+                dispatched_pid=1234,
+                dispatched_starttime_ticks=9999,
+                dispatched_boot_id="b1",
+                reason="started",
+                kill_reason="",
+                infra_exit_category="",
+                token_usage={"input": 100},
+                started_at=1.0,
+                ended_at=2.0,
+                sidecar_path="/s.jsonl",
+            ),
+            DispatchRecord(name="b"),
+        ]
         write_initial_state(sp, "cid", "cname", "/m.yaml", dispatches)
         state = read_state(sp)
         assert state is not None
         assert [d.name for d in state.dispatches] == ["a", "b"]
-        assert all(d.status == DispatchStatus.PENDING for d in state.dispatches)
+        a = state.dispatches[0]
+        assert a.status == DispatchStatus.RUNNING
+        assert a.dispatch_id == "d1"
+        assert a.caller_session_id == "c1"
+        assert a.dispatched_session_id == "s1"
+        assert a.dispatched_session_log_dir == "/log"
+        assert a.dispatched_pid == 1234
+        assert a.dispatched_starttime_ticks == 9999
+        assert a.dispatched_boot_id == "b1"
+        assert a.reason == "started"
+        assert a.token_usage == {"input": 100}
+        assert a.started_at == 1.0
+        assert a.ended_at == 2.0
+        assert a.sidecar_path == "/s.jsonl"
+        assert state.dispatches[1].status == DispatchStatus.PENDING
 
 
 class TestDispatchRecordFromDict:
@@ -87,8 +121,19 @@ class TestDispatchRecordFromDict:
         rec = DispatchRecord.from_dict(d)
         assert rec.name == "build-docs"
         assert rec.status == DispatchStatus.RUNNING
+        assert rec.dispatch_id == "abc"
+        assert rec.caller_session_id == "c1"
         assert rec.dispatched_session_id == "s1"
+        assert rec.dispatched_session_log_dir == "/log"
         assert rec.dispatched_pid == 1234
+        assert rec.dispatched_starttime_ticks == 9999
+        assert rec.dispatched_boot_id == "b1"
+        assert rec.reason == "started"
+        assert rec.kill_reason == ""
+        assert rec.infra_exit_category == ""
+        assert rec.token_usage == {"input": 100}
+        assert rec.started_at == 1.0
+        assert rec.ended_at == 2.0
         assert rec.sidecar_path == "/s.jsonl"
 
     def test_from_dict_legacy_l2_fields(self) -> None:
@@ -102,6 +147,7 @@ class TestDispatchRecordFromDict:
         }
         rec = DispatchRecord.from_dict(d)
         assert rec.dispatched_session_id == "l2s"
+        assert rec.dispatched_session_log_dir == "/l2"
         assert rec.dispatched_pid == 555
         assert rec.dispatched_starttime_ticks == 111
         assert rec.dispatched_boot_id == "l2b"
@@ -111,12 +157,21 @@ class TestDispatchRecordFromDict:
             "name": "t",
             "l3_session_id": "l3s",
             "l2_session_id": "l2s",
+            "l3_session_log_dir": "/l3",
+            "l2_session_log_dir": "/l2",
             "l3_pid": 333,
             "l2_pid": 222,
+            "l3_starttime_ticks": 300,
+            "l2_starttime_ticks": 200,
+            "l3_boot_id": "l3b",
+            "l2_boot_id": "l2b",
         }
         rec = DispatchRecord.from_dict(d)
         assert rec.dispatched_session_id == "l3s"
+        assert rec.dispatched_session_log_dir == "/l3"
         assert rec.dispatched_pid == 333
+        assert rec.dispatched_starttime_ticks == 300
+        assert rec.dispatched_boot_id == "l3b"
 
     def test_from_dict_canonical_takes_priority_over_l3(self) -> None:
         d = {"name": "t", "dispatched_session_id": "canon", "l3_session_id": "l3s"}


### PR DESCRIPTION
## Summary

Two-phase refactoring of `fleet/state.py` (757 lines):

1. **P9-F1**: Add `DispatchRecord.from_dict(d)` classmethod that encapsulates the legacy field-name fallback chains (`l2_*` / `l3_*` -> `dispatched_*`) currently inlined in `read_state()`. This eliminates duplicated `.get()` calls (e.g. `dispatched_pid` is fetched twice) and centralizes deserialization logic on the type itself.

2. **P8-F4**: Extract `state.py` into four files — `state_types.py` (types + constants), `state_gates.py` (gate recording), `state_recovery.py` (crash recovery + resume), and a slimmed `state.py` (I/O + mutations + re-exports). `state.py` re-exports all public symbols so existing `from autoskillit.fleet.state import X` imports remain valid.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-230444-166308/.autoskillit/temp/make-plan/fleet_state_size_reduction_and_dispatch_record_factory_plan_2026-05-06_230900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.2k | 18.0k | 620.9k | 67.1k | 54 | 60.6k | 8m 7s |
| verify | claude-opus-4-6 | 1 | 41 | 13.5k | 835.8k | 84.3k | 43 | 71.3k | 4m 44s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.7M | 26.8k | 1.9M | 89.0k | 130 | 71.0k | 17m 58s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 155.4k | 3.8k | 341.6k | 28.7k | 32 | 15.3k | 1m 37s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 45.0k | 1.5k | 198.0k | 28.7k | 14 | 15.0k | 45s |
| review_pr | claude-sonnet-4-6 | 1 | 102 | 40.4k | 627.6k | 97.0k | 46 | 88.0k | 8m 45s |
| resolve_review | claude-sonnet-4-6 | 2 | 530 | 38.3k | 4.7M | 113.7k | 154 | 216.1k | 18m 34s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 339 | 18.0k | 2.5M | 84.3k | 103 | 71.9k | 6m 51s |
| **Total** | | | 2.9M | 160.2k | 11.6M | 113.7k | | 609.1k | 1h 7m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 1204 | 1567.5 | 58.9 | 22.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 124 | 37651.4 | 1742.9 | 308.9 |
| ci_conflict_fix | 1962 | 1254.5 | 36.7 | 9.2 |
| **Total** | **3290** | 3538.4 | 185.1 | 48.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 3.2k | 31.4k | 1.5M | 131.9k | 12m 51s |
| MiniMax-M2.7-highspeed | 3 | 2.9M | 32.1k | 2.4M | 101.2k | 20m 20s |
| claude-sonnet-4-6 | 1 | 224 | 13.0k | 1.5M | 69.0k | 7m 1s |