### PR TITLE
Perf — Session-scope _resolve_test_config cache (stop cache thrash)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -479,12 +479,6 @@ def _resolve_test_config() -> "AutomationConfig | None":
         return None
 
 
-@pytest.fixture(autouse=True)
-def _clear_resolve_test_config_cache():
-    yield
-    _resolve_test_config.cache_clear()
-
-
 def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
     """Return True if feature_name is enabled for this test run.
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -311,6 +311,7 @@ def test_no_per_test_config_cache_clear_fixture():
     import pytest
 
     conftest_path = Path(__file__).resolve().parent / "conftest.py"
+    assert conftest_path.exists(), f"conftest.py not found at {conftest_path}"
     tree = ast.parse(conftest_path.read_text())
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == "_clear_resolve_test_config_cache":

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -300,3 +300,42 @@ def test_is_test_feature_enabled_disabled_lifecycle_always_false(monkeypatch):
         assert result is False
     finally:
         _resolve_test_config.cache_clear()
+
+
+def test_no_per_test_config_cache_clear_fixture():
+    """The function-scoped autouse fixture that cleared _resolve_test_config cache
+    after every test has been removed. Verify it no longer exists in conftest."""
+    import ast
+    from pathlib import Path
+
+    import pytest
+
+    conftest_path = Path(__file__).resolve().parent / "conftest.py"
+    tree = ast.parse(conftest_path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_clear_resolve_test_config_cache":
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Call):
+                    for kw in decorator.keywords:
+                        if kw.arg == "scope" and isinstance(kw.value, ast.Constant):
+                            if kw.value.value == "session":
+                                return  # session-scoped is ok
+            pytest.fail(
+                "_clear_resolve_test_config_cache still exists as a non-session fixture. "
+                "It should be removed to stop per-test cache thrash."
+            )
+
+
+def test_resolve_test_config_cache_persists_across_calls():
+    """_resolve_test_config LRU cache should persist — calling it twice returns the same object."""
+    from tests.conftest import _resolve_test_config
+
+    _resolve_test_config.cache_clear()
+    try:
+        result1 = _resolve_test_config()
+        result2 = _resolve_test_config()
+        assert result1 is result2, "LRU cache should return the same object on repeated calls"
+        info = _resolve_test_config.cache_info()
+        assert info.hits >= 1, "Expected at least 1 cache hit"
+    finally:
+        _resolve_test_config.cache_clear()


### PR DESCRIPTION
## Summary

Remove the function-scoped autouse `_clear_resolve_test_config_cache` fixture from `tests/conftest.py`. The fixture clears `_resolve_test_config`'s `@lru_cache(maxsize=1)` after every test, forcing `load_config()` (~30.9ms of Dynaconf init + temp file I/O) to re-execute for every feature-gated test. The only 4 tests that need cache invalidation already self-manage via explicit `cache_clear()` in `try/finally` blocks. Removing the fixture lets the LRU cache persist per-worker for the session lifetime — safe under xdist because each worker is a separate process with its own cache.

## Requirements

development, state-lifecycle, concurrency

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None

## Changed Files

### Modified (●):
- tests/conftest.py
- tests/test_conftest.py

Closes #2134

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-000428-044227/.autoskillit/temp/make-plan/perf_session_scope_resolve_test_config_cache_plan_2026-05-07_000428.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 67 | 4.7k | 421.0k | 41.7k | 38 | 31.0k | 3m 3s |
| verify | claude-opus-4-6 | 1 | 36 | 5.4k | 276.6k | 41.3k | 43 | 28.3k | 3m 5s |
| implement* | MiniMax-M2.7-highspeed | 1 | 270.0k | 4.8k | 599.8k | 28.7k | 48 | 34.3k | 2m 10s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 59.8k | 3.6k | 213.7k | 35.0k | 25 | 47.5k | 1m 35s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 36.4k | 1.3k | 148.8k | 29.8k | 14 | 41.9k | 41s |
| review_pr | claude-sonnet-4-6 | 1 | 124 | 15.5k | 566.2k | 49.5k | 39 | 37.0k | 4m 13s |
| resolve_review | claude-opus-4-6 | 1 | 36 | 6.5k | 806.5k | 54.8k | 37 | 41.9k | 10m 14s |
| **Total** | | | 366.4k | 41.7k | 3.0M | 54.8k | | 261.9k | 25m 4s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 45 | 13329.6 | 762.5 | 106.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 806501.0 | 41925.0 | 6512.0 |
| **Total** | **46** | 65926.2 | 5694.5 | 906.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 103 | 10.1k | 697.6k | 59.3k | 6m 9s |
| MiniMax-M2.7-highspeed | 3 | 366.2k | 9.6k | 962.4k | 123.7k | 4m 26s |