### PR TITLE
perf: switch YAML loading to CSafeLoader (11.1x speedup)

### DIFF
--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -22,7 +22,7 @@ from yaml import YAMLError as YAMLError  # explicit re-export for callers and ty
 try:
     from yaml import CSafeLoader as _Loader
 except ImportError:
-    pass
+    _Loader = yaml.SafeLoader  # type: ignore[misc,assignment]
 
 __all__ = [
     "YAMLError",

--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -19,6 +19,11 @@ from typing import Any
 import yaml
 from yaml import YAMLError as YAMLError  # explicit re-export for callers and type checkers
 
+try:
+    from yaml import CSafeLoader as _Loader
+except ImportError:
+    pass
+
 __all__ = [
     "YAMLError",
     "atomic_write",
@@ -187,8 +192,8 @@ def load_yaml(source: os.PathLike[str] | str) -> Any:
     """
     if isinstance(source, os.PathLike):
         with open(source, "rb") as fh:
-            return yaml.safe_load(fh)
-    return yaml.safe_load(source)
+            return yaml.load(fh, Loader=_Loader)
+    return yaml.load(source, Loader=_Loader)
 
 
 def dump_yaml_str(data: Any, **kwargs: Any) -> str:

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -49,6 +49,55 @@ class TestLoadYamlExtended:
         with pytest.raises(YAMLError):
             load_yaml("{bad yaml: [unclosed")
 
+    def test_load_yaml_uses_c_loader_when_available(self, monkeypatch):
+        import yaml as _yaml
+
+        from autoskillit.core.io import load_yaml
+
+        if not getattr(_yaml, "__with_libyaml__", False):
+            pytest.skip("LibYAML not available")
+        captured = {}
+        original_load = _yaml.load
+
+        def spy(data, *, Loader=None, **kw):
+            captured["Loader"] = Loader
+            return original_load(data, Loader=Loader, **kw)
+
+        monkeypatch.setattr("autoskillit.core.io.yaml.load", spy)
+        load_yaml("key: val")
+        assert captured["Loader"] is _yaml.CSafeLoader
+
+    def test_loader_is_csafe_or_safe(self):
+        import yaml as _yaml
+
+        from autoskillit.core.io import _Loader
+
+        if getattr(_yaml, "__with_libyaml__", False):
+            assert _Loader is _yaml.CSafeLoader
+        else:
+            assert _Loader is _yaml.SafeLoader
+
+    def test_load_yaml_path_uses_c_loader(self, tmp_path, monkeypatch):
+        import yaml as _yaml
+
+        from autoskillit.core.io import load_yaml
+
+        if not getattr(_yaml, "__with_libyaml__", False):
+            pytest.skip("LibYAML not available")
+        p = tmp_path / "t.yaml"
+        p.write_text("a: 1\n")
+        captured = {}
+        original_load = _yaml.load
+
+        def spy(data, *, Loader=None, **kw):
+            captured["Loader"] = Loader
+            return original_load(data, Loader=Loader, **kw)
+
+        monkeypatch.setattr("autoskillit.core.io.yaml.load", spy)
+        result = load_yaml(p)
+        assert result == {"a": 1}
+        assert captured["Loader"] is _yaml.CSafeLoader
+
 
 class TestDumpYamlStr:
     def test_roundtrip_with_load_yaml(self):

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -49,22 +49,36 @@ class TestLoadYamlExtended:
         with pytest.raises(YAMLError):
             load_yaml("{bad yaml: [unclosed")
 
-    def test_load_yaml_uses_c_loader_when_available(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "input_kind",
+        ["string", "path"],
+        ids=["str-input", "path-input"],
+    )
+    def test_load_yaml_uses_c_loader_when_available(self, tmp_path, monkeypatch, input_kind):
         import yaml as _yaml
 
         from autoskillit.core.io import load_yaml
 
         if not getattr(_yaml, "__with_libyaml__", False):
             pytest.skip("LibYAML not available")
-        captured = {}
+        captured: dict[str, object] = {}
         original_load = _yaml.load
 
         def spy(data, *, Loader=None, **kw):
+            assert not kw, f"unexpected kwargs passed to yaml.load: {kw}"
             captured["Loader"] = Loader
             return original_load(data, Loader=Loader, **kw)
 
         monkeypatch.setattr("autoskillit.core.io.yaml.load", spy)
-        load_yaml("key: val")
+
+        if input_kind == "path":
+            p = tmp_path / "t.yaml"
+            p.write_text("a: 1\n")
+            result = load_yaml(p)
+            assert result == {"a": 1}
+        else:
+            load_yaml("key: val")
+
         assert captured["Loader"] is _yaml.CSafeLoader
 
     def test_loader_is_csafe_or_safe(self):
@@ -76,27 +90,6 @@ class TestLoadYamlExtended:
             assert _Loader is _yaml.CSafeLoader
         else:
             assert _Loader is _yaml.SafeLoader
-
-    def test_load_yaml_path_uses_c_loader(self, tmp_path, monkeypatch):
-        import yaml as _yaml
-
-        from autoskillit.core.io import load_yaml
-
-        if not getattr(_yaml, "__with_libyaml__", False):
-            pytest.skip("LibYAML not available")
-        p = tmp_path / "t.yaml"
-        p.write_text("a: 1\n")
-        captured = {}
-        original_load = _yaml.load
-
-        def spy(data, *, Loader=None, **kw):
-            captured["Loader"] = Loader
-            return original_load(data, Loader=Loader, **kw)
-
-        monkeypatch.setattr("autoskillit.core.io.yaml.load", spy)
-        result = load_yaml(p)
-        assert result == {"a": 1}
-        assert captured["Loader"] is _yaml.CSafeLoader
 
 
 class TestDumpYamlStr:

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -109,7 +109,7 @@ def _is_yaml_dump(node: ast.expr) -> bool:
 # Any new site that writes a dict payload SHOULD use write_versioned_json.
 _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
-    ("src/autoskillit/core/io.py", 118),
+    ("src/autoskillit/core/io.py", 123),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
     ("src/autoskillit/execution/session_log.py", 305),


### PR DESCRIPTION
## Summary

Replace `yaml.safe_load()` calls in `src/autoskillit/core/io.py:load_yaml()` with `yaml.load(source, Loader=CSafeLoader)`, using LibYAML's C backend for an 11.1x speedup. All YAML loading in the codebase flows through this single function — recipe validation, config loading, experiment type registries, migration loading, and CLI validation all benefit from the improvement.

## Requirements

### Problem

`load_yaml()` in `src/autoskillit/core/io.py:181` uses `yaml.safe_load()`, which defaults to the pure-Python `SafeLoader` even when LibYAML's C backend is available. LibYAML IS compiled in (PyYAML 6.0.3, `__with_libyaml__ = True`), but `yaml.safe_load()` does not use it automatically.

### Measured Impact

Benchmark on 5 real recipe files, 100 iterations:

```
SafeLoader:  8.557s
CSafeLoader: 0.770s
Speedup:     11.1x
```

All YAML loading in the codebase flows through this single function. Recipe validation, config loading, experiment type/methodology tradition loading, migration loading — all benefit.

### Fix

In `src/autoskillit/core/io.py`, change `load_yaml()` to use `CSafeLoader` with fallback:

```python
try:
    from yaml import CSafeLoader as _Loader
except ImportError:
    from yaml import SafeLoader as _Loader

# Then in load_yaml():
data = yaml.load(text, Loader=_Loader)
```

### Risk

Low. CSafeLoader has minor behavioral differences from SafeLoader (stricter timestamp handling, different inf/nan behavior), but these are unlikely to affect recipe/config YAML. Run the full test suite to confirm.

### Files

- `src/autoskillit/core/io.py` — single fix point

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):

- `src/autoskillit/core/io.py`
- `tests/core/test_io.py`
- `tests/infra/test_schema_version_convention.py`

Closes #2133

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-000427-400052/.autoskillit/temp/make-plan/perf_switch_yaml_loading_to_csafeloader_plan_2026-05-07_000427.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 69 | 5.8k | 506.1k | 45.1k | 40 | 35.1k | 4m 4s |
| verify | claude-sonnet-4-6 | 1 | 35 | 6.3k | 276.6k | 49.7k | 53 | 36.6k | 3m 43s |
| implement* | MiniMax-M2.7-highspeed | 1 | 173.7k | 3.6k | 450.1k | 42.9k | 35 | 53.7k | 2m 4s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 48.4k | 2.9k | 175.7k | 29.8k | 19 | 15.1k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.2k | 1.5k | 205.5k | 29.8k | 15 | 15.0k | 42s |
| review_pr | claude-sonnet-4-6 | 2 | 176 | 27.9k | 713.9k | 48.7k | 65 | 73.5k | 7m 31s |
| resolve_review | claude-opus-4-6 | 2 | 94 | 14.3k | 1.4M | 57.2k | 67 | 83.3k | 12m 44s |
| **Total** | | | 269.7k | 62.2k | 3.8M | 57.2k | | 312.3k | 32m 1s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 58 | 7759.8 | 925.6 | 62.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 43 | 33229.8 | 1938.2 | 333.4 |
| **Total** | **101** | 37195.9 | 3092.5 | 616.3 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 116 | 10.0k | 1.2M | 69.3k | 14m 9s |
| claude-sonnet-4-6 | 1 | 35 | 6.3k | 276.6k | 36.6k | 3m 43s |
| MiniMax-M2.7-highspeed | 3 | 269.3k | 8.0k | 831.3k | 83.8k | 3m 58s |