### PR TITLE
Implementation Plan: P5-A3-WP2 — Test dispatch_id_filter in audit/tokens/timings consumers

### DIFF
--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -705,10 +705,13 @@ def test_iter_session_log_entries_dispatch_id_filter_empty_passes_all(tmp_path):
     from autoskillit.pipeline.audit import _iter_session_log_entries
 
     _write_audit_session_dispatch_id(
-        tmp_path, "did-a1", [_valid_failure_record_dict()], dispatch_id="d-abc"
+        tmp_path, "did-d1", [_valid_failure_record_dict()], dispatch_id="d1"
     )
     _write_audit_session_dispatch_id(
-        tmp_path, "did-a2", [_valid_failure_record_dict()], dispatch_id="d-xyz"
+        tmp_path, "did-d2", [_valid_failure_record_dict()], dispatch_id="d2"
+    )
+    _write_audit_session_dispatch_id(
+        tmp_path, "did-empty", [_valid_failure_record_dict()], dispatch_id=""
     )
 
     results = list(
@@ -716,7 +719,44 @@ def test_iter_session_log_entries_dispatch_id_filter_empty_passes_all(tmp_path):
             tmp_path, since="", filename="audit_log.json", dispatch_id_filter=""
         )
     )
-    assert len(results) == 2
+    assert len(results) == 3
+
+
+def test_iter_entries_dispatch_id_filter_combined_with_campaign_id(tmp_path):
+    """dispatch_id_filter AND campaign_id_filter apply as AND logic."""
+    from pathlib import Path as _Path
+
+    from autoskillit.pipeline.audit import _iter_session_log_entries
+
+    for dir_name, dispatch_id, campaign_id in [
+        ("match", "d1", "c1"),
+        ("wrong-did", "d2", "c1"),
+        ("wrong-cid", "d1", "c2"),
+    ]:
+        session_dir = _Path(tmp_path) / "sessions" / dir_name
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / "audit_log.json").write_text(json.dumps([_valid_failure_record_dict()]))
+        index_entry = {
+            "dir_name": dir_name,
+            "timestamp": "2026-05-01T00:00:00+00:00",
+            "session_id": dir_name,
+            "dispatch_id": dispatch_id,
+            "campaign_id": campaign_id,
+        }
+        with (_Path(tmp_path) / "sessions.jsonl").open("a") as f:
+            f.write(json.dumps(index_entry) + "\n")
+
+    results = list(
+        _iter_session_log_entries(
+            tmp_path,
+            since="",
+            filename="audit_log.json",
+            dispatch_id_filter="d1",
+            campaign_id_filter="c1",
+        )
+    )
+    assert len(results) == 1
+    assert results[0].parent.name == "match"
 
 
 def test_iter_session_log_entries_dispatch_id_combined_with_order_id(tmp_path):

--- a/tests/pipeline/test_timings.py
+++ b/tests/pipeline/test_timings.py
@@ -473,6 +473,10 @@ def test_timing_load_dispatch_id_filter(tmp_path):
     n = log.load_from_log_dir(tmp_path, dispatch_id_filter="d1")
     assert n == 2
 
+    log_d2 = DefaultTimingLog()
+    n_d2 = log_d2.load_from_log_dir(tmp_path, dispatch_id_filter="d2")
+    assert n_d2 == 1
+
     log2 = DefaultTimingLog()
     n2 = log2.load_from_log_dir(tmp_path, dispatch_id_filter="")
     assert n2 == 3

--- a/tests/pipeline/test_tokens_filters.py
+++ b/tests/pipeline/test_tokens_filters.py
@@ -475,6 +475,10 @@ def test_token_load_dispatch_id_filter(tmp_path):
     n = log.load_from_log_dir(tmp_path, dispatch_id_filter="d1")
     assert n == 2
 
+    log_d2 = DefaultTokenLog()
+    n_d2 = log_d2.load_from_log_dir(tmp_path, dispatch_id_filter="d2")
+    assert n_d2 == 1
+
     log2 = DefaultTokenLog()
     n2 = log2.load_from_log_dir(tmp_path, dispatch_id_filter="")
     assert n2 == 3


### PR DESCRIPTION
## Summary

Complete test coverage for `dispatch_id_filter` across all three pipeline log consumers (audit, tokens, timings). P5-A3-WP1 already added the production `dispatch_id_filter` parameter and partial test scaffolding (helpers + basic tests). This WP closes four specific gaps between the existing tests and the issue acceptance criteria:

1. `test_iter_session_log_entries_dispatch_id_filter_empty_passes_all` — expand from 2 sessions to 3 (add a session with empty `dispatch_id`)
2. Add `test_iter_entries_dispatch_id_filter_combined_with_campaign_id` — AND logic between `dispatch_id_filter` and `campaign_id_filter`
3. `test_token_load_dispatch_id_filter` — add missing `d2` filter assertion
4. `test_timing_load_dispatch_id_filter` — add missing `d2` filter assertion

All changes are test-only. No production code changes.

Closes #1725

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-002943-397973/.autoskillit/temp/make-plan/p5-a3-wp2-test-dispatch-id-filter-in-audit-tokens-timings-consumers_plan_2026-05-07_003600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 2 | 157 | 24.8k | 1.6M | 87.8k | 139 | 142.0k | 12m 22s |
| verify | claude-sonnet-4-6 | 1 | 26 | 4.7k | 258.0k | 64.5k | 57 | 31.4k | 3m 54s |
| implement | claude-sonnet-4-6 | 1 | 131 | 6.0k | 547.5k | 44.3k | 46 | 31.5k | 3m 4s |
| prepare_pr | claude-sonnet-4-6 | 1 | 60 | 4.7k | 180.6k | 34.3k | 19 | 22.0k | 1m 39s |
| compose_pr | claude-sonnet-4-6 | 1 | 51 | 2.2k | 135.5k | 26.6k | 14 | 13.6k | 51s |
| **Total** | | | 425 | 42.4k | 2.8M | 87.8k | | 240.5k | 21m 51s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 54 | 10138.1 | 584.2 | 110.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **54** | 51035.6 | 4454.2 | 785.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 5 | 425 | 42.4k | 2.8M | 240.5k | 21m 51s |