### PR TITLE
[FIX] Rectify: Artifact-Dependent Routing Immunity + Batch Failure Gate

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -576,17 +576,17 @@ CONTEXT LIMIT ROUTING — run_skill only (check BEFORE on_failure):
     if defined, fall through to on_failure otherwise.
   - If lifespan_started is false, fall through to on_failure — no progress was made.
 - When run_skill returns "needs_retry: true" AND "retry_reason: early_stop":
-  - If "worktree_path" is present in the result AND the step defines on_context_limit:
-    the model created a worktree and made progress but stopped before emitting the
-    completion marker. Partial progress exists on disk. Follow on_context_limit.
-  - If "worktree_path" is absent OR the step has no on_context_limit: fall through
-    to on_failure — no recoverable worktree evidence.
+  - If "has_progress_evidence" is true in the result AND the step defines on_context_limit:
+    the model made progress (wrote files or created a worktree) but stopped before emitting
+    the completion marker. Partial progress exists on disk. Follow on_context_limit.
+  - If "has_progress_evidence" is false OR the step has no on_context_limit: fall through
+    to on_failure — no recoverable progress evidence.
 - When run_skill returns "needs_retry: true" AND "retry_reason: zero_writes":
-  - If "worktree_path" is present in the result AND the step defines on_context_limit:
-    the model created a worktree but made no Write/Edit tool calls (may have committed
+  - If "has_progress_evidence" is true in the result AND the step defines on_context_limit:
+    the model made filesystem contact but made no Write/Edit tool calls (may have committed
     via CLI). Partial progress may exist on disk. Follow on_context_limit.
-  - If "worktree_path" is absent OR the step has no on_context_limit: fall through
-    to on_failure — no recoverable worktree evidence.
+  - If "has_progress_evidence" is false OR the step has no on_context_limit: fall through
+    to on_failure — no recoverable progress evidence.
 - WORKTREE-STALE CARVE-OUT: When the step invokes a worktree-creating skill
   (implement-worktree-no-merge, implement-worktree, implement-experiment) and returns
   retry_reason=stale (or retry_reason=resume with subtype=stale), re-execute the step

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -268,6 +268,7 @@ class SkillResult:
             "write_path_warnings": self.write_path_warnings,
             "write_call_count": self.write_call_count,
             "fs_writes_detected": self.fs_writes_detected,
+            "has_progress_evidence": self.has_progress_evidence,
             "last_stop_reason": self.last_stop_reason,
             "lifespan_started": self.lifespan_started,
             "provider_fallback": self.provider.fallback_activated,
@@ -321,6 +322,18 @@ class SkillResult:
         if self.needs_retry:
             return SessionOutcome.RETRIABLE
         return SessionOutcome.FAILED
+
+    @property
+    def has_progress_evidence(self) -> bool:
+        """Whether any evidence of meaningful progress exists.
+
+        Synthesizes worktree_path, fs_writes_detected, and write_call_count
+        into a single routing-ready signal. Used by routing rules instead of
+        checking individual artifact fields.
+        """
+        return (
+            self.worktree_path is not None or self.fs_writes_detected or self.write_call_count > 0
+        )
 
 
 @dataclass

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -443,13 +443,8 @@ async def _execute_claude_headless(
         if (
             skill_result.needs_retry
             and skill_result.session_id
-            and (
-                skill_result.retry_reason == RetryReason.CONTRACT_RECOVERY
-                or (
-                    skill_result.retry_reason == RetryReason.EARLY_STOP
-                    and provider_extras is not None
-                )
-            )
+            and skill_result.retry_reason
+            in (RetryReason.CONTRACT_RECOVERY, RetryReason.EARLY_STOP)
         ):
             nudge_success = await _attempt_contract_nudge(
                 skill_result,

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -220,6 +220,7 @@ steps:
       review_path: "${{ context.review_path }}"
     on_success: implement
     on_failure: release_issue_failure
+    on_context_limit: implement
     note: "SEQUENTIAL EXECUTION: For each plan_part, run the FULL cycle — verify → implement → test → merge — for that part before advancing to the next part. Never run verify for all parts first. If review produced a report, context.review_path is available — pass it as an additional arg to dry-walkthrough."
 
   implement:
@@ -411,6 +412,7 @@ steps:
   prepare_pr:
     tool: run_skill
     model: ""
+    retries: 1
     with:
       skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -427,7 +429,8 @@ steps:
         route: compose_pr
       - route: release_issue_failure
     on_failure: release_issue_failure
-    on_context_limit: release_issue_failure
+    on_context_limit: prepare_pr
+    on_exhausted: release_issue_failure
     optional: true
     skip_when_false: "inputs.open_pr"
     note: >

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -429,6 +429,7 @@ steps:
   prepare_pr:
     tool: run_skill
     model: ""
+    retries: 1
     with:
       skill_command: "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -445,7 +446,8 @@ steps:
         route: compose_pr
       - route: release_issue_failure
     on_failure: release_issue_failure
-    on_context_limit: release_issue_failure
+    on_context_limit: prepare_pr
+    on_exhausted: release_issue_failure
     optional: true
     skip_when_false: "inputs.open_pr"
     note: >

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -85,14 +85,15 @@ When `run_skill` returns `needs_retry=true` for **any step**:
   but prior tool calls suggest partial progress on disk.
 - **If `retry_reason: idle_stall` AND `lifespan_started` is false** → fall through to `on_failure`.
   No progress was made.
-- **If `retry_reason: early_stop` AND `worktree_path` is present in the result AND the step
-  defines `on_context_limit`** → follow `on_context_limit`. The model created a worktree and
-  made progress but stopped before emitting the completion marker. Partial progress exists on disk.
-- **If `retry_reason: early_stop` AND `worktree_path` is absent** → fall through to `on_failure`.
-- **If `retry_reason: zero_writes` AND `worktree_path` is present in the result AND the step
-  defines `on_context_limit`** → follow `on_context_limit`. The model created a worktree but
-  made no Write/Edit tool calls. Partial progress may exist on disk.
-- **If `retry_reason: zero_writes` AND `worktree_path` is absent** → fall through to `on_failure`.
+- **If `retry_reason: early_stop` AND `has_progress_evidence` is true in the result AND the step
+  defines `on_context_limit`** → follow `on_context_limit`. The model made progress (wrote files
+  or created a worktree) but stopped before emitting the completion marker. Partial progress
+  exists on disk.
+- **If `retry_reason: early_stop` AND `has_progress_evidence` is false** → fall through to `on_failure`.
+- **If `retry_reason: zero_writes` AND `has_progress_evidence` is true in the result AND the step
+  defines `on_context_limit`** → follow `on_context_limit`. The model made filesystem contact
+  but made no Write/Edit tool calls. Partial progress may exist on disk.
+- **If `retry_reason: zero_writes` AND `has_progress_evidence` is false** → fall through to `on_failure`.
 - **If `retry_reason: stale`** → decrement the `retries` counter for this step.
   Re-execute the same step if retries remain. If retries are exhausted, fall through
   to `on_failure`. Do NOT route to `on_context_limit` — stale is a transient failure,
@@ -131,10 +132,10 @@ Summary: `needs_retry=true` + `retry_reason=resume` + `subtype=stale` → re-exe
          `needs_retry=true` + `retry_reason=thinking_stall` + `lifespan_started=false` → `on_failure`.
          `needs_retry=true` + `retry_reason=idle_stall` + `lifespan_started=true` + step has `on_context_limit` → follow `on_context_limit`.
          `needs_retry=true` + `retry_reason=idle_stall` + `lifespan_started=false` → `on_failure`.
-         `needs_retry=true` + `retry_reason=early_stop` + `worktree_path` present + step has `on_context_limit` → follow `on_context_limit`.
-         `needs_retry=true` + `retry_reason=early_stop` + `worktree_path` absent → `on_failure`.
-         `needs_retry=true` + `retry_reason=zero_writes` + `worktree_path` present + step has `on_context_limit` → follow `on_context_limit`.
-         `needs_retry=true` + `retry_reason=zero_writes` + `worktree_path` absent → `on_failure`.
+         `needs_retry=true` + `retry_reason=early_stop` + `has_progress_evidence=true` + step has `on_context_limit` → follow `on_context_limit`.
+         `needs_retry=true` + `retry_reason=early_stop` + `has_progress_evidence=false` → `on_failure`.
+         `needs_retry=true` + `retry_reason=zero_writes` + `has_progress_evidence=true` + step has `on_context_limit` → follow `on_context_limit`.
+         `needs_retry=true` + `retry_reason=zero_writes` + `has_progress_evidence=false` → `on_failure`.
          `needs_retry=true` + `retry_reason=stale` → decrement retries counter → `on_failure` when exhausted (no partial progress, not a context limit).
          `needs_retry=true` + `retry_reason=stale` + worktree-creating step → one-shot re-execute (bypasses retries budget; on_failure if repeated stale).
 

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -192,7 +192,13 @@ Processing X issues:
 1. **Check pre_claimed_urls:** If `issue_url` is NOT in `pre_claimed_urls` → skip
    (excluded by upfront claim phase — another session holds it).
 
-2. **Optionally append pickup status to issue body** (if `--status-updates` is active):
+2. **Pre-dispatch check:** Before executing the recipe for this issue, check if any
+   previously completed issue in the CURRENT batch has `status: failure`. If so, skip
+   this issue with `status: skipped` and continue to the next issue in the batch.
+   This prevents wasted compute on issues within the same batch after a failure,
+   while still allowing the batch failure gate below to capture the full failure count.
+
+3. **Optionally append pickup status to issue body** (if `--status-updates` is active):
    ```bash
    PROCESS_BODY_FILE="{{AUTOSKILLIT_TEMP}}/process-issues/status_{number}_$(date +%s).md"
    mkdir -p "$(dirname "$PROCESS_BODY_FILE")"
@@ -203,7 +209,7 @@ Processing X issues:
    sleep 1
    ```
 
-3. **Determine recipe name and `run_name`:**
+4. **Determine recipe name and `run_name`:**
 
    | `recipe` field | Recipe to load | `run_name` | PR Title Prefix |
    |---------------|----------------|------------|-----------------|
@@ -216,7 +222,7 @@ Processing X issues:
    The `run_name` encodes recipe origin for the `open-pr` skill, which derives
    the PR title prefix from it by convention (see `open-pr` SKILL.md).
 
-4. **Load the recipe:**
+5. **Load the recipe:**
    ```
    load_recipe("{recipe_name}")
    ```
@@ -224,7 +230,7 @@ Processing X issues:
    follow each step in the recipe, calling the specified MCP tool with the
    specified `with:` arguments.
 
-5. **Execute the recipe** with these ingredient values:
+6. **Execute the recipe** with these ingredient values:
    - `task`: the issue title (the recipe's `make-plan` step detects `issue_url`
      and fetches full content internally)
    - `issue_url`: the constructed issue URL
@@ -239,7 +245,7 @@ Processing X issues:
    `upfront_claimed` ingredient) and recognize the pre-existing label as a
    valid reentry, returning `claimed=true` to proceed normally.
 
-6. **After recipe returns** (any outcome), append to completed_urls:
+7. **After recipe returns** (any outcome), append to completed_urls:
    ```
    completed_urls.append(issue_url)
    ```
@@ -247,7 +253,7 @@ Processing X issues:
    - On success path (`done` step reached): `{issue_number, recipe, status: success, pr_url}`
    - On failure path (`escalate_stop` reached): `{issue_number, recipe, status: failure, error}`
 
-7. **Optionally append completion status to issue body** (if `--status-updates` is active):
+8. **Optionally append completion status to issue body** (if `--status-updates` is active):
    ```bash
    PROCESS_BODY_FILE="{{AUTOSKILLIT_TEMP}}/process-issues/status_{number}_$(date +%s).md"
    mkdir -p "$(dirname "$PROCESS_BODY_FILE")"
@@ -267,6 +273,15 @@ For each url in uncompleted:
 Log: "Released N upfront-claimed issues due to fatal failure"
 Propagate the error
 ```
+
+**Batch failure gate (mandatory):** After all issues in the current batch have been
+processed, count the number of issues with `status: failure`. If ANY issue in this
+batch has `status: failure`:
+  1. Log: "Batch {N} had {count} failure(s). Halting batch processing."
+  2. Skip all remaining batches.
+  3. Proceed directly to Step 4 (Summary Report), recording unprocessed issues
+     from remaining batches as `status: skipped`.
+  4. Call `release_issue()` for each pre-claimed but unprocessed issue URL.
 
 **3c. After all issues in batch complete** (if `--merge-batch` is active):
 

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -195,8 +195,9 @@ Processing X issues:
 2. **Pre-dispatch check:** Before executing the recipe for this issue, check if any
    previously completed issue in the CURRENT batch has `status: failure`. If so, skip
    this issue with `status: skipped` and continue to the next issue in the batch.
-   This prevents wasted compute on issues within the same batch after a failure,
-   while still allowing the batch failure gate below to capture the full failure count.
+   This prevents wasted compute on issues within the same batch after a failure.
+   Skipped issues are recorded as `status: skipped` (not `status: failure`), so the
+   batch failure gate below counts only the original failure(s) that triggered the skip.
 
 3. **Optionally append pickup status to issue body** (if `--status-updates` is active):
    ```bash

--- a/tests/cli/test_routing_completeness.py
+++ b/tests/cli/test_routing_completeness.py
@@ -35,8 +35,8 @@ _EXPECTED_ROUTES: dict[RetryReason, tuple[str, str | None]] = {
     RetryReason.PATH_CONTAMINATION: ("on_failure", None),
     RetryReason.THINKING_STALL: ("on_context_limit", "lifespan_started"),
     RetryReason.IDLE_STALL: ("on_context_limit", "lifespan_started"),
-    RetryReason.EARLY_STOP: ("on_context_limit", "worktree_path"),
-    RetryReason.ZERO_WRITES: ("on_context_limit", "worktree_path"),
+    RetryReason.EARLY_STOP: ("on_context_limit", "has_progress_evidence"),
+    RetryReason.ZERO_WRITES: ("on_context_limit", "has_progress_evidence"),
 }
 
 

--- a/tests/contracts/test_sous_chef_routing.py
+++ b/tests/contracts/test_sous_chef_routing.py
@@ -375,7 +375,7 @@ def test_skill_md_covers_all_prompts_routing_reasons() -> None:
 
 
 class TestWorktreeEarlyStopCarveout:
-    """SKILL.md routing contract: early_stop must check worktree_path evidence."""
+    """SKILL.md routing contract: early_stop must check has_progress_evidence."""
 
     def test_early_stop_references_worktree_path(self) -> None:
         skill_md = _sous_chef_text()
@@ -383,8 +383,8 @@ class TestWorktreeEarlyStopCarveout:
         idx = routing_section.find("early_stop")
         assert idx != -1
         window = routing_section[idx : idx + 500]
-        assert "worktree_path" in window, (
-            "early_stop routing rule must reference worktree_path evidence"
+        assert "has_progress_evidence" in window, (
+            "early_stop routing rule must reference has_progress_evidence"
         )
 
     def test_early_stop_with_worktree_routes_to_on_context_limit(self) -> None:
@@ -399,7 +399,7 @@ class TestWorktreeEarlyStopCarveout:
 
 
 class TestWorktreeZeroWritesCarveout:
-    """SKILL.md routing contract: zero_writes must check worktree_path evidence."""
+    """SKILL.md routing contract: zero_writes must check has_progress_evidence."""
 
     def test_zero_writes_references_worktree_path(self) -> None:
         skill_md = _sous_chef_text()
@@ -407,8 +407,8 @@ class TestWorktreeZeroWritesCarveout:
         idx = routing_section.find("zero_writes")
         assert idx != -1
         window = routing_section[idx : idx + 500]
-        assert "worktree_path" in window, (
-            "zero_writes routing rule must reference worktree_path evidence"
+        assert "has_progress_evidence" in window, (
+            "zero_writes routing rule must reference has_progress_evidence"
         )
 
     def test_zero_writes_with_worktree_routes_to_on_context_limit(self) -> None:

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -931,6 +931,7 @@ class TestBuildSkillResultCrossValidation:
         "write_path_warnings",
         "write_call_count",
         "fs_writes_detected",
+        "has_progress_evidence",
         "infra_exit_category",
     }
 

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -132,6 +132,14 @@ class TestExecuteClaudeHeadlessIdleEnv:
         from autoskillit.execution.headless import run_headless_core
 
         monkeypatch.setenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", "not-a-number")
+
+        async def _no_nudge(*_a, **_kw):
+            return None
+
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._attempt_contract_nudge",
+            _no_nudge,
+        )
         minimal_ctx.config.run_skill.idle_output_timeout = 45
 
         runner = MockSubprocessRunner()

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -506,6 +506,7 @@ class TestSkillResult:
             "write_path_warnings",
             "write_call_count",
             "fs_writes_detected",
+            "has_progress_evidence",
             "infra_exit_category",
         }
         assert set(parsed.keys()) == expected

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -109,6 +109,22 @@ _SUCCESS_JSON = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _suppress_nudge(monkeypatch):
+    """Prevent the contract-nudge gate from firing on mock EARLY_STOP results.
+
+    Server command-building tests use mock results that lack the per-invocation
+    completion marker, causing _retry_fsm to classify them as EARLY_STOP. With
+    the widened nudge gate (no provider_extras guard), the nudge fires and
+    appends an extra runner call that breaks call_args_list[-1] assertions.
+    """
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("autoskillit.execution.headless._attempt_contract_nudge", _noop)
+
+
 @pytest.fixture
 def build_ctx(tmp_path):
     """Factory: build_ctx(**overrides) → minimal ToolContext with overrides applied."""


### PR DESCRIPTION
## Summary

The orchestration layer makes routing and recovery decisions based on the presence of specific artifacts (`worktree_path`, `provider_extras`) rather than on generalized progress evidence. This creates a recurring class of bug where skills that complete work but lack the specific artifact are routed to terminal failure. Separately, the `process-issues` batch loop iterates unconditionally — batch N+1 dispatches even when batch N has failures.

The architectural fix introduces a **computed `has_progress_evidence` field** on `SkillResult` that synthesizes all evidence signals into a single boolean. Routing rules check this one field instead of artifact-specific names. This makes the routing layer innately immune to future skills that produce progress evidence in forms not yet anticipated. The nudge gate is relaxed to match the nudge function's actual requirements. Recipe steps for non-worktree skills gain proper `on_context_limit` retry routes. The batch loop gains a mandatory failure gate.

Closes #2140

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260506-235945-374750/.autoskillit/temp/rectify/rectify_process_issues_batch_gate_early_stop_routing_2026-05-07_001500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 60 | 8.9k | 580.1k | 71.6k | 152 | 48.1k | 7m 2s |
| rectify | claude-sonnet-4-6 | 1 | 52 | 15.6k | 848.2k | 143.7k | 149 | 74.9k | 10m 46s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 38 | 10.2k | 441.1k | 54.6k | 126 | 39.6k | 6m 55s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.4M | 14.9k | 1.3M | 52.0k | 111 | 61.8k | 7m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 103.2k | 4.1k | 208.3k | 29.8k | 22 | 42.2k | 1m 39s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 69.9k | 1.7k | 265.0k | 29.8k | 21 | 14.9k | 54s |
| review_pr | claude-opus-4-6 | 1 | 26 | 21.7k | 317.5k | 61.7k | 24 | 51.6k | 5m 52s |
| resolve_review | claude-opus-4-6 | 1 | 49 | 8.2k | 1.0M | 56.9k | 47 | 44.4k | 6m 37s |
| **Total** | | | 1.6M | 85.3k | 5.0M | 143.7k | | 377.5k | 47m 6s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 101 | 13354.5 | 612.1 | 147.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 205299.6 | 8886.4 | 1643.6 |
| **Total** | **106** | 47505.2 | 3561.7 | 804.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 150 | 34.7k | 1.9M | 162.5k | 24m 45s |
| MiniMax-M2.7-highspeed | 3 | 1.6M | 20.8k | 1.8M | 118.9k | 9m 50s |
| claude-opus-4-6 | 1 | 76 | 14.5k | 1.9M | 103.5k | 14m 44s |