### PR TITLE
perf: add mtime/lru_cache to uncached registry loaders

### DIFF
--- a/src/autoskillit/migration/loader.py
+++ b/src/autoskillit/migration/loader.py
@@ -53,14 +53,14 @@ def list_migrations() -> list[MigrationNote]:
     key = (str(mig_dir), mig_dir.stat().st_mtime)
     cached = _migrations_cache.get(key)
     if cached is not None:
-        return cached
+        return list(cached)
     notes: list[MigrationNote] = []
     for f in sorted(mig_dir.iterdir()):
         if f.suffix in (".yaml", ".yml") and f.is_file():
             note = _parse_migration(f)
             notes.append(note)
     _migrations_cache[key] = notes
-    return notes
+    return list(notes)
 
 
 def applicable_migrations(

--- a/src/autoskillit/migration/loader.py
+++ b/src/autoskillit/migration/loader.py
@@ -42,17 +42,24 @@ def _migrations_dir() -> Path:
     return pkg_root() / "migrations"
 
 
+_migrations_cache: dict[tuple[str, float], list[MigrationNote]] = {}
+
+
 def list_migrations() -> list[MigrationNote]:
     """Discover and parse all migration YAML files, sorted by filename."""
     mig_dir = _migrations_dir()
     if not mig_dir.is_dir():
         return []
-
+    key = (str(mig_dir), mig_dir.stat().st_mtime)
+    cached = _migrations_cache.get(key)
+    if cached is not None:
+        return cached
     notes: list[MigrationNote] = []
     for f in sorted(mig_dir.iterdir()):
         if f.suffix in (".yaml", ".yml") and f.is_file():
             note = _parse_migration(f)
             notes.append(note)
+    _migrations_cache[key] = notes
     return notes
 
 

--- a/src/autoskillit/migration/loader.py
+++ b/src/autoskillit/migration/loader.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from packaging.version import Version
 
 from autoskillit.core import load_yaml, pkg_root
-from autoskillit.recipe._registry_utils import dir_mtime
 
 
 @dataclass
@@ -51,7 +50,11 @@ def list_migrations() -> list[MigrationNote]:
     mig_dir = _migrations_dir()
     if not mig_dir.is_dir():
         return []
-    key = (str(mig_dir), dir_mtime(mig_dir))
+    try:
+        mt = mig_dir.stat().st_mtime
+    except OSError:
+        mt = -1.0
+    key = (str(mig_dir), mt)
     cached = _migrations_cache.get(key)
     if cached is not None:
         return list(cached)

--- a/src/autoskillit/migration/loader.py
+++ b/src/autoskillit/migration/loader.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from packaging.version import Version
 
 from autoskillit.core import load_yaml, pkg_root
+from autoskillit.recipe._registry_utils import dir_mtime
 
 
 @dataclass
@@ -50,7 +51,7 @@ def list_migrations() -> list[MigrationNote]:
     mig_dir = _migrations_dir()
     if not mig_dir.is_dir():
         return []
-    key = (str(mig_dir), mig_dir.stat().st_mtime)
+    key = (str(mig_dir), dir_mtime(mig_dir))
     cached = _migrations_cache.get(key)
     if cached is not None:
         return list(cached)

--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -17,6 +17,7 @@ Sub-package: rules/ (see rules/CLAUDE.md).
 | `_recipe_ingredients.py` | `format_ingredients_table` + `LoadRecipeResult` TypedDicts |
 | `_recipe_composition.py` | `_build_active_recipe` + sub-recipe merging |
 | `diagrams.py` | Flow diagram generation + staleness detection |
+| `_registry_utils.py` | `dir_mtime` — shared mtime helper for registry loaders |
 | `experiment_type_registry.py` | `ExperimentTypeSpec`, `load_all_experiment_types` |
 | `methodology_tradition_registry.py` | `MethodologyTraditionSpec`, `VenueAppendixDef`, `load_all_methodology_traditions`, `get_methodology_tradition_by_name`, `is_out_of_scope_tradition` |
 | `methodology_venue_appendix.py` | `AlternateParentDef`, `MLSubAreaFoldingDef`, `VenueAppendixMatch`, `load_ml_sub_area_folding`, `resolve_venue_appendices` — Stage B venue-appendix resolution |

--- a/src/autoskillit/recipe/_registry_utils.py
+++ b/src/autoskillit/recipe/_registry_utils.py
@@ -1,0 +1,15 @@
+"""Shared utilities for recipe registry loaders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_MISSING_MTIME: float = -1.0
+
+
+def dir_mtime(path: Path) -> float:
+    """Return directory mtime, or ``_MISSING_MTIME`` if the path is inaccessible."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return _MISSING_MTIME

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -140,7 +140,7 @@ def load_all_experiment_types(
     )
     cached = _exp_types_cache.get(key)
     if cached is not None:
-        return cached
+        return list(cached)
 
     types = _load_types_from_dir(BUNDLED_EXPERIMENT_TYPES_DIR)
 
@@ -163,7 +163,7 @@ def load_all_experiment_types(
     fallback.sort(key=lambda s: (s.priority, s.name))
     result = non_fallback + fallback
     _exp_types_cache[key] = result
-    return result
+    return list(result)
 
 
 def get_experiment_type_by_name(

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
-from autoskillit.recipe._registry_utils import dir_mtime
+from autoskillit.recipe._registry_utils import _MISSING_MTIME, dir_mtime
 
 logger = get_logger(__name__)
 
@@ -132,7 +132,7 @@ def load_all_experiment_types(
         user_dir = Path(project_dir) / ".autoskillit" / "experiment-types"
         user_mt = dir_mtime(user_dir)
     else:
-        user_mt = 0.0
+        user_mt = _MISSING_MTIME
     key: tuple[str | None, float, float] = (
         str(project_dir) if project_dir is not None else None,
         bundled_mt,

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -103,6 +103,16 @@ def load_types_from_dir(directory: Path) -> dict[str, ExperimentTypeSpec]:
     return _load_types_from_dir(directory)
 
 
+_exp_types_cache: dict[tuple[str | None, float, float], list[ExperimentTypeSpec]] = {}
+
+
+def _dir_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 def load_all_experiment_types(
     project_dir: Path | None = None,
 ) -> list[ExperimentTypeSpec]:
@@ -123,6 +133,21 @@ def load_all_experiment_types(
     Returns:
         Sorted list of ``ExperimentTypeSpec``, fallback entries last.
     """
+    bundled_mt = _dir_mtime(BUNDLED_EXPERIMENT_TYPES_DIR)
+    if project_dir is not None:
+        user_dir = Path(project_dir) / ".autoskillit" / "experiment-types"
+        user_mt = _dir_mtime(user_dir)
+    else:
+        user_mt = 0.0
+    key: tuple[str | None, float, float] = (
+        str(project_dir) if project_dir is not None else None,
+        bundled_mt,
+        user_mt,
+    )
+    cached = _exp_types_cache.get(key)
+    if cached is not None:
+        return cached
+
     types = _load_types_from_dir(BUNDLED_EXPERIMENT_TYPES_DIR)
 
     if project_dir is not None:
@@ -142,7 +167,9 @@ def load_all_experiment_types(
     fallback = [s for s in types.values() if s.is_fallback]
     non_fallback.sort(key=lambda s: (s.priority, s.name))
     fallback.sort(key=lambda s: (s.priority, s.name))
-    return non_fallback + fallback
+    result = non_fallback + fallback
+    _exp_types_cache[key] = result
+    return result
 
 
 def get_experiment_type_by_name(

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
+from autoskillit.recipe._registry_utils import dir_mtime
 
 logger = get_logger(__name__)
 
@@ -106,13 +107,6 @@ def load_types_from_dir(directory: Path) -> dict[str, ExperimentTypeSpec]:
 _exp_types_cache: dict[tuple[str | None, float, float], list[ExperimentTypeSpec]] = {}
 
 
-def _dir_mtime(path: Path) -> float:
-    try:
-        return path.stat().st_mtime
-    except OSError:
-        return 0.0
-
-
 def load_all_experiment_types(
     project_dir: Path | None = None,
 ) -> list[ExperimentTypeSpec]:
@@ -133,10 +127,10 @@ def load_all_experiment_types(
     Returns:
         Sorted list of ``ExperimentTypeSpec``, fallback entries last.
     """
-    bundled_mt = _dir_mtime(BUNDLED_EXPERIMENT_TYPES_DIR)
+    bundled_mt = dir_mtime(BUNDLED_EXPERIMENT_TYPES_DIR)
     if project_dir is not None:
         user_dir = Path(project_dir) / ".autoskillit" / "experiment-types"
-        user_mt = _dir_mtime(user_dir)
+        user_mt = dir_mtime(user_dir)
     else:
         user_mt = 0.0
     key: tuple[str | None, float, float] = (

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -211,6 +211,16 @@ def load_traditions_from_dir(directory: Path) -> dict[str, MethodologyTraditionS
     return _load_traditions_from_dir(directory)
 
 
+_traditions_cache: dict[tuple[str | None, float, float], list[MethodologyTraditionSpec]] = {}
+
+
+def _dir_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 def load_all_methodology_traditions(
     project_dir: Path | None = None,
 ) -> list[MethodologyTraditionSpec]:
@@ -230,6 +240,21 @@ def load_all_methodology_traditions(
     Returns:
         Sorted list of ``MethodologyTraditionSpec``.
     """
+    bundled_mt = _dir_mtime(BUNDLED_METHODOLOGY_TRADITIONS_DIR)
+    if project_dir is not None:
+        user_dir = Path(project_dir) / ".autoskillit" / "methodology-traditions"
+        user_mt = _dir_mtime(user_dir)
+    else:
+        user_mt = 0.0
+    key: tuple[str | None, float, float] = (
+        str(project_dir) if project_dir is not None else None,
+        bundled_mt,
+        user_mt,
+    )
+    cached = _traditions_cache.get(key)
+    if cached is not None:
+        return cached
+
     traditions = _load_traditions_from_dir(BUNDLED_METHODOLOGY_TRADITIONS_DIR)
 
     if project_dir is not None:
@@ -246,6 +271,7 @@ def load_all_methodology_traditions(
         traditions.update(user_traditions)
 
     sorted_traditions = sorted(traditions.values(), key=lambda s: (s.priority, s.name))
+    _traditions_cache[key] = sorted_traditions
     return sorted_traditions
 
 

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -247,7 +247,7 @@ def load_all_methodology_traditions(
     )
     cached = _traditions_cache.get(key)
     if cached is not None:
-        return cached
+        return list(cached)
 
     traditions = _load_traditions_from_dir(BUNDLED_METHODOLOGY_TRADITIONS_DIR)
 
@@ -266,7 +266,7 @@ def load_all_methodology_traditions(
 
     sorted_traditions = sorted(traditions.values(), key=lambda s: (s.priority, s.name))
     _traditions_cache[key] = sorted_traditions
-    return sorted_traditions
+    return list(sorted_traditions)
 
 
 def get_methodology_tradition_by_name(

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
+from autoskillit.recipe._registry_utils import dir_mtime
 
 logger = get_logger(__name__)
 
@@ -214,13 +215,6 @@ def load_traditions_from_dir(directory: Path) -> dict[str, MethodologyTraditionS
 _traditions_cache: dict[tuple[str | None, float, float], list[MethodologyTraditionSpec]] = {}
 
 
-def _dir_mtime(path: Path) -> float:
-    try:
-        return path.stat().st_mtime
-    except OSError:
-        return 0.0
-
-
 def load_all_methodology_traditions(
     project_dir: Path | None = None,
 ) -> list[MethodologyTraditionSpec]:
@@ -240,10 +234,10 @@ def load_all_methodology_traditions(
     Returns:
         Sorted list of ``MethodologyTraditionSpec``.
     """
-    bundled_mt = _dir_mtime(BUNDLED_METHODOLOGY_TRADITIONS_DIR)
+    bundled_mt = dir_mtime(BUNDLED_METHODOLOGY_TRADITIONS_DIR)
     if project_dir is not None:
         user_dir = Path(project_dir) / ".autoskillit" / "methodology-traditions"
-        user_mt = _dir_mtime(user_dir)
+        user_mt = dir_mtime(user_dir)
     else:
         user_mt = 0.0
     key: tuple[str | None, float, float] = (

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
-from autoskillit.recipe._registry_utils import dir_mtime
+from autoskillit.recipe._registry_utils import _MISSING_MTIME, dir_mtime
 
 logger = get_logger(__name__)
 
@@ -239,7 +239,7 @@ def load_all_methodology_traditions(
         user_dir = Path(project_dir) / ".autoskillit" / "methodology-traditions"
         user_mt = dir_mtime(user_dir)
     else:
-        user_mt = 0.0
+        user_mt = _MISSING_MTIME
     key: tuple[str | None, float, float] = (
         str(project_dir) if project_dir is not None else None,
         bundled_mt,

--- a/src/autoskillit/recipe/methodology_venue_appendix.py
+++ b/src/autoskillit/recipe/methodology_venue_appendix.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
-from functools import cache
+from functools import cache, lru_cache
 from pathlib import Path
 
 from autoskillit.core import load_yaml
@@ -66,6 +66,7 @@ def _has_keyword_match(text: str, keywords: tuple[str, ...] | list[str]) -> bool
     return any(_keyword_pattern(kw).search(text) for kw in keywords)
 
 
+@lru_cache(maxsize=1)
 def load_ml_sub_area_folding() -> list[MLSubAreaFoldingDef]:
     yaml_path = BUNDLED_METHODOLOGY_TRADITIONS_DIR / "_ml_sub_area_folding.yaml"
     data = load_yaml(yaml_path)

--- a/src/autoskillit/recipe/methodology_venue_appendix.py
+++ b/src/autoskillit/recipe/methodology_venue_appendix.py
@@ -67,7 +67,7 @@ def _has_keyword_match(text: str, keywords: tuple[str, ...] | list[str]) -> bool
 
 
 @lru_cache(maxsize=1)
-def load_ml_sub_area_folding() -> list[MLSubAreaFoldingDef]:
+def load_ml_sub_area_folding() -> tuple[MLSubAreaFoldingDef, ...]:
     yaml_path = BUNDLED_METHODOLOGY_TRADITIONS_DIR / "_ml_sub_area_folding.yaml"
     data = load_yaml(yaml_path)
     if not isinstance(data, dict):
@@ -127,7 +127,7 @@ def load_ml_sub_area_folding() -> list[MLSubAreaFoldingDef]:
                 alternate_parents=tuple(alternates),
             )
         )
-    return entries
+    return tuple(entries)
 
 
 def _resolve_conditional_parent(

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -791,7 +791,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 14,
-        "recipe": 29,
+        "recipe": 30,
         "execution": 18,
         "core": 20,
         "core/types": 16,

--- a/tests/migration/test_loader.py
+++ b/tests/migration/test_loader.py
@@ -369,3 +369,44 @@ class TestApplicableMigrations:
         )
         result = applicable_migrations(None, "0.2.0")
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# ML13: Caching tests
+# ---------------------------------------------------------------------------
+
+
+class TestListMigrationsCaching:
+    def test_result_is_cached_on_repeat_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mig_dir = _make_migrations_dir(tmp_path)
+        _write_migration(
+            mig_dir / "001_init.yaml",
+            {"from_version": "0.1.0", "to_version": "0.2.0", "changes": []},
+        )
+        monkeypatch.setattr("autoskillit.migration.loader._migrations_dir", lambda: mig_dir)
+        r1 = list_migrations()
+        r2 = list_migrations()
+        assert r1 is r2
+
+    def test_mtime_change_invalidates_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mig_dir = _make_migrations_dir(tmp_path)
+        _write_migration(
+            mig_dir / "001_init.yaml",
+            {"from_version": "0.1.0", "to_version": "0.2.0", "changes": []},
+        )
+        monkeypatch.setattr("autoskillit.migration.loader._migrations_dir", lambda: mig_dir)
+        r1 = list_migrations()
+        import time
+
+        time.sleep(0.05)
+        _write_migration(
+            mig_dir / "002_add.yaml",
+            {"from_version": "0.2.0", "to_version": "0.3.0", "changes": []},
+        )
+        r2 = list_migrations()
+        assert r1 is not r2
+        assert len(r2) == len(r1) + 1

--- a/tests/migration/test_loader.py
+++ b/tests/migration/test_loader.py
@@ -388,7 +388,8 @@ class TestListMigrationsCaching:
         monkeypatch.setattr("autoskillit.migration.loader._migrations_dir", lambda: mig_dir)
         r1 = list_migrations()
         r2 = list_migrations()
-        assert r1 is r2
+        assert r1 == r2
+        assert r1 is not r2
 
     def test_mtime_change_invalidates_cache(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -400,13 +401,14 @@ class TestListMigrationsCaching:
         )
         monkeypatch.setattr("autoskillit.migration.loader._migrations_dir", lambda: mig_dir)
         r1 = list_migrations()
-        import time
+        import os
 
-        time.sleep(0.05)
         _write_migration(
             mig_dir / "002_add.yaml",
             {"from_version": "0.2.0", "to_version": "0.3.0", "changes": []},
         )
+        old_mt = mig_dir.stat().st_mtime
+        os.utime(mig_dir, (old_mt + 2, old_mt + 2))
         r2 = list_migrations()
         assert r1 is not r2
         assert len(r2) == len(r1) + 1

--- a/tests/migration/test_loader.py
+++ b/tests/migration/test_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -401,7 +402,6 @@ class TestListMigrationsCaching:
         )
         monkeypatch.setattr("autoskillit.migration.loader._migrations_dir", lambda: mig_dir)
         r1 = list_migrations()
-        import os
 
         _write_migration(
             mig_dir / "002_add.yaml",

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -602,10 +602,11 @@ _MINIMAL_EXP_TYPE_YAML_2 = {
 
 class TestExperimentTypeCaching:
     def test_bundled_result_is_cached_on_repeat_call(self) -> None:
-        """Two calls with project_dir=None return the same object."""
+        """Two calls with project_dir=None return equal defensive copies."""
         r1 = load_all_experiment_types()
         r2 = load_all_experiment_types()
-        assert r1 is r2
+        assert r1 == r2
+        assert r1 is not r2
 
     def test_mtime_change_invalidates_cache(self, tmp_path: Path) -> None:
         """Adding a file to the user dir changes dir mtime, causing cache miss."""

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -614,10 +615,9 @@ class TestExperimentTypeCaching:
         user_dir.mkdir(parents=True)
         (user_dir / "custom_exp.yaml").write_text(yaml.dump(_MINIMAL_EXP_TYPE_YAML))
         r1 = load_all_experiment_types(project_dir=tmp_path)
-        import time
-
-        time.sleep(0.05)
         (user_dir / "custom_exp_2.yaml").write_text(yaml.dump(_MINIMAL_EXP_TYPE_YAML_2))
+        old_mt = user_dir.stat().st_mtime
+        os.utime(user_dir, (old_mt + 2, old_mt + 2))
         r2 = load_all_experiment_types(project_dir=tmp_path)
         assert r1 is not r2
         assert len(r2) > len(r1)

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -551,3 +551,72 @@ def test_get_experiment_type_by_name_not_found() -> None:
     """get_experiment_type_by_name returns None for an unknown type name."""
     spec = get_experiment_type_by_name("nonexistent")
     assert spec is None
+
+
+# ---------------------------------------------------------------------------
+# T1: Caching tests
+# ---------------------------------------------------------------------------
+
+_MINIMAL_EXP_TYPE_YAML = {
+    "name": "test_exp",
+    "classification_triggers": ["test trigger"],
+    "dimension_weights": {
+        "causal_structure": "H",
+        "variance_protocol": "M",
+        "statistical_corrections": "M",
+        "ecological_validity": "M",
+        "measurement_alignment": "M",
+        "resource_proportionality": "M",
+        "data_acquisition": "M",
+        "agent_implementability": "M",
+    },
+    "applicable_lenses": {},
+    "red_team_focus": {"specific": "test", "severity_cap": "warning"},
+    "l1_severity": {
+        "estimand_clarity": "warning",
+        "hypothesis_falsifiability": "warning",
+    },
+}
+
+_MINIMAL_EXP_TYPE_YAML_2 = {
+    "name": "test_exp_2",
+    "classification_triggers": ["test trigger 2"],
+    "dimension_weights": {
+        "causal_structure": "H",
+        "variance_protocol": "M",
+        "statistical_corrections": "M",
+        "ecological_validity": "M",
+        "measurement_alignment": "M",
+        "resource_proportionality": "M",
+        "data_acquisition": "M",
+        "agent_implementability": "M",
+    },
+    "applicable_lenses": {},
+    "red_team_focus": {"specific": "test", "severity_cap": "warning"},
+    "l1_severity": {
+        "estimand_clarity": "warning",
+        "hypothesis_falsifiability": "warning",
+    },
+}
+
+
+class TestExperimentTypeCaching:
+    def test_bundled_result_is_cached_on_repeat_call(self) -> None:
+        """Two calls with project_dir=None return the same object."""
+        r1 = load_all_experiment_types()
+        r2 = load_all_experiment_types()
+        assert r1 is r2
+
+    def test_mtime_change_invalidates_cache(self, tmp_path: Path) -> None:
+        """Adding a file to the user dir changes dir mtime, causing cache miss."""
+        user_dir = tmp_path / ".autoskillit" / "experiment-types"
+        user_dir.mkdir(parents=True)
+        (user_dir / "custom_exp.yaml").write_text(yaml.dump(_MINIMAL_EXP_TYPE_YAML))
+        r1 = load_all_experiment_types(project_dir=tmp_path)
+        import time
+
+        time.sleep(0.05)
+        (user_dir / "custom_exp_2.yaml").write_text(yaml.dump(_MINIMAL_EXP_TYPE_YAML_2))
+        r2 = load_all_experiment_types(project_dir=tmp_path)
+        assert r1 is not r2
+        assert len(r2) > len(r1)

--- a/tests/recipe/test_methodology_tradition_registry.py
+++ b/tests/recipe/test_methodology_tradition_registry.py
@@ -254,3 +254,64 @@ def test_detection_keywords_are_distinct() -> None:
         kws = frozenset(spec.detection_keywords)
         assert kws not in seen, f"{spec.name} and {seen[kws]} have identical detection_keywords"
         seen[kws] = spec.name
+
+
+# ---------------------------------------------------------------------------
+# T2: Caching tests
+# ---------------------------------------------------------------------------
+
+_MINIMAL_TRADITION_YAML = {
+    "name": "test_tradition",
+    "schema_version": "1.0",
+    "priority": 99,
+    "display_name": "Test Tradition",
+    "canonical_guideline": {
+        "name": "TEST",
+        "governing_body": "test",
+        "stable_for_decade": True,
+        "canonical": True,
+    },
+    "fields_spanned": ["test_field"],
+    "detection_keywords": ["test keyword"],
+    "mandatory_figures": [],
+    "strongly_expected_figures": [],
+    "anti_patterns": [],
+}
+
+_MINIMAL_TRADITION_YAML_2 = {
+    "name": "test_tradition_2",
+    "schema_version": "1.0",
+    "priority": 99,
+    "display_name": "Test Tradition 2",
+    "canonical_guideline": {
+        "name": "TEST2",
+        "governing_body": "test",
+        "stable_for_decade": True,
+        "canonical": True,
+    },
+    "fields_spanned": ["test_field"],
+    "detection_keywords": ["test keyword 2"],
+    "mandatory_figures": [],
+    "strongly_expected_figures": [],
+    "anti_patterns": [],
+}
+
+
+class TestMethodologyTraditionCaching:
+    def test_bundled_result_is_cached_on_repeat_call(self) -> None:
+        r1 = load_all_methodology_traditions()
+        r2 = load_all_methodology_traditions()
+        assert r1 is r2
+
+    def test_mtime_change_invalidates_cache(self, tmp_path: Path) -> None:
+        user_dir = tmp_path / ".autoskillit" / "methodology-traditions"
+        user_dir.mkdir(parents=True)
+        (user_dir / "custom_trad.yaml").write_text(yaml.dump(_MINIMAL_TRADITION_YAML))
+        r1 = load_all_methodology_traditions(project_dir=tmp_path)
+        import time
+
+        time.sleep(0.05)
+        (user_dir / "custom_trad_2.yaml").write_text(yaml.dump(_MINIMAL_TRADITION_YAML_2))
+        r2 = load_all_methodology_traditions(project_dir=tmp_path)
+        assert r1 is not r2
+        assert len(r2) > len(r1)

--- a/tests/recipe/test_methodology_tradition_registry.py
+++ b/tests/recipe/test_methodology_tradition_registry.py
@@ -301,7 +301,8 @@ class TestMethodologyTraditionCaching:
     def test_bundled_result_is_cached_on_repeat_call(self) -> None:
         r1 = load_all_methodology_traditions()
         r2 = load_all_methodology_traditions()
-        assert r1 is r2
+        assert r1 == r2
+        assert r1 is not r2
 
     def test_mtime_change_invalidates_cache(self, tmp_path: Path) -> None:
         user_dir = tmp_path / ".autoskillit" / "methodology-traditions"

--- a/tests/recipe/test_methodology_tradition_registry.py
+++ b/tests/recipe/test_methodology_tradition_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -309,10 +310,9 @@ class TestMethodologyTraditionCaching:
         user_dir.mkdir(parents=True)
         (user_dir / "custom_trad.yaml").write_text(yaml.dump(_MINIMAL_TRADITION_YAML))
         r1 = load_all_methodology_traditions(project_dir=tmp_path)
-        import time
-
-        time.sleep(0.05)
         (user_dir / "custom_trad_2.yaml").write_text(yaml.dump(_MINIMAL_TRADITION_YAML_2))
+        old_mt = user_dir.stat().st_mtime
+        os.utime(user_dir, (old_mt + 2, old_mt + 2))
         r2 = load_all_methodology_traditions(project_dir=tmp_path)
         assert r1 is not r2
         assert len(r2) > len(r1)

--- a/tests/recipe/test_methodology_venue_appendix.py
+++ b/tests/recipe/test_methodology_venue_appendix.py
@@ -450,8 +450,13 @@ class TestEdgeCases:
 
 
 class TestFoldingCaching:
-    def test_result_is_cached_via_lru_cache(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self) -> None:  # type: ignore[misc]
         load_ml_sub_area_folding.cache_clear()
+        yield  # type: ignore[misc]
+        load_ml_sub_area_folding.cache_clear()
+
+    def test_result_is_cached_via_lru_cache(self) -> None:
         r1 = load_ml_sub_area_folding()
         r2 = load_ml_sub_area_folding()
         assert r1 is r2

--- a/tests/recipe/test_methodology_venue_appendix.py
+++ b/tests/recipe/test_methodology_venue_appendix.py
@@ -442,3 +442,19 @@ class TestEdgeCases:
         matches_lower = resolve_venue_appendices(plan_text_lower)
         matches_mixed = resolve_venue_appendices(plan_text_mixed)
         assert {m.sub_area for m in matches_lower} == {m.sub_area for m in matches_mixed}
+
+
+# ---------------------------------------------------------------------------
+# T4: Caching tests
+# ---------------------------------------------------------------------------
+
+
+class TestFoldingCaching:
+    def test_result_is_cached_via_lru_cache(self) -> None:
+        load_ml_sub_area_folding.cache_clear()
+        r1 = load_ml_sub_area_folding()
+        r2 = load_ml_sub_area_folding()
+        assert r1 is r2
+        info = load_ml_sub_area_folding.cache_info()
+        assert info.hits >= 1
+        assert info.misses == 1


### PR DESCRIPTION
## Summary

Four registry-loading functions re-read and re-parse YAML files from disk on every call with no caching. All four load static bundled assets that change only on package updates. This PR adds mtime-keyed dict caches to the three directory-scanning functions and `@lru_cache(maxsize=1)` to the single-file function, consistent with existing caching patterns in the codebase (`DefaultRecipeRepository._get_list()` in `repository.py`, `_block_budgets()` in `rules_blocks.py`).

| Function | Module | Cache Strategy |
|----------|--------|----------------|
| `load_all_experiment_types()` | `recipe/experiment_type_registry.py` | mtime-keyed dict cache |
| `load_all_methodology_traditions()` | `recipe/methodology_tradition_registry.py` | mtime-keyed dict cache |
| `list_migrations()` | `migration/loader.py` | mtime-keyed dict cache |
| `load_ml_sub_area_folding()` | `recipe/methodology_venue_appendix.py` | `@lru_cache(maxsize=1)` |

Closes #2138

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-014202-057975/.autoskillit/temp/make-plan/perf_add_caching_to_uncached_registry_loaders_plan_2026-05-07_015049.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 77 | 18.3k | 521.7k | 55.6k | 73 | 47.9k | 12m 2s |
| verify | claude-sonnet-4-6 | 1 | 30 | 5.3k | 455.4k | 61.9k | 99 | 35.0k | 5m 16s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.4M | 16.3k | 1.2M | 70.4k | 96 | 80.3k | 5m 18s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 88.9k | 3.1k | 235.3k | 29.8k | 20 | 15.3k | 1m 16s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 116.3k | 2.5k | 294.9k | 29.8k | 25 | 15.0k | 1m 1s |
| review_pr | claude-sonnet-4-6 | 2 | 162 | 71.0k | 727.7k | 80.4k | 66 | 135.9k | 14m 59s |
| resolve_review | claude-opus-4-6 | 2 | 195 | 63.5k | 8.5M | 126.8k | 250 | 199.7k | 32m 37s |
| **Total** | | | 1.6M | 180.1k | 12.0M | 126.8k | | 529.2k | 1h 12m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 254 | 4712.8 | 316.1 | 64.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 109 | 78366.6 | 1832.3 | 583.0 |
| **Total** | **363** | 32986.1 | 1457.8 | 496.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 107 | 23.6k | 977.0k | 82.9k | 17m 19s |
| MiniMax-M2.7-highspeed | 3 | 1.6M | 21.8k | 1.7M | 110.6k | 7m 35s |