### PR TITLE
Recipe completeness guard in _parse_recipe

### DIFF
--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -272,6 +272,47 @@ if _PARSE_STEP_HANDLED_FIELDS != frozenset(RecipeStep.__dataclass_fields__):
         f"{_PARSE_STEP_HANDLED_FIELDS - frozenset(RecipeStep.__dataclass_fields__)}"
     )
 
+_PARSE_RECIPE_HANDLED_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "description",
+        "summary",
+        "ingredients",
+        "steps",
+        "kitchen_rules",
+        "version",
+        "recipe_version",
+        "experimental",
+        "requires_packs",
+        "kind",
+        "dispatches",
+        "categories",
+        "requires_recipe_packs",
+        "allowed_recipes",
+        "continue_on_failure",
+        "requires_features",
+    }
+)
+
+_RECIPE_COMPUTED_FIELDS: frozenset[str] = frozenset(
+    {
+        "content_hash",
+        "composite_hash",
+        "blocks",
+    }
+)
+
+if _PARSE_RECIPE_HANDLED_FIELDS | _RECIPE_COMPUTED_FIELDS != frozenset(
+    Recipe.__dataclass_fields__
+):
+    _expected = frozenset(Recipe.__dataclass_fields__)
+    _combined = _PARSE_RECIPE_HANDLED_FIELDS | _RECIPE_COMPUTED_FIELDS
+    raise RuntimeError(
+        "_parse_recipe field list is out of sync with Recipe schema.\n"
+        f"  Missing from handled+computed: {_expected - _combined}\n"
+        f"  Extra in handled+computed:     {_combined - _expected}"
+    )
+
 
 def _parse_recipe(data: dict[str, Any]) -> Recipe:
     name = data.get("name", "")

--- a/tests/recipe/test_io_parsing.py
+++ b/tests/recipe/test_io_parsing.py
@@ -600,6 +600,27 @@ def test_parse_step_handles_all_recipe_step_fields() -> None:
     )
 
 
+def test_parse_recipe_handles_all_recipe_fields() -> None:
+    """Combined handled+computed fields must equal Recipe.__dataclass_fields__."""
+    from autoskillit.recipe.io import _PARSE_RECIPE_HANDLED_FIELDS, _RECIPE_COMPUTED_FIELDS
+
+    schema_fields = frozenset(Recipe.__dataclass_fields__)
+    combined = _PARSE_RECIPE_HANDLED_FIELDS | _RECIPE_COMPUTED_FIELDS
+    assert combined == schema_fields, (
+        f"_parse_recipe field list is out of sync.\n"
+        f"  Missing from handled+computed: {schema_fields - combined}\n"
+        f"  Extra in handled+computed:     {combined - schema_fields}"
+    )
+
+
+def test_parse_recipe_handled_and_computed_are_disjoint() -> None:
+    """Parsed and computed field sets must not overlap."""
+    from autoskillit.recipe.io import _PARSE_RECIPE_HANDLED_FIELDS, _RECIPE_COMPUTED_FIELDS
+
+    overlap = _PARSE_RECIPE_HANDLED_FIELDS & _RECIPE_COMPUTED_FIELDS
+    assert not overlap, f"Fields in both handled and computed: {overlap}"
+
+
 def test_step_provider_field_parses_correctly() -> None:
     step = _parse_step({"tool": "run_skill", "provider": "minimax"})
     assert step.provider == "minimax"


### PR DESCRIPTION
## Summary

Add a `_PARSE_RECIPE_HANDLED_FIELDS` frozenset and import-time assertion to `src/autoskillit/recipe/io.py`, mirroring the existing `_PARSE_STEP_HANDLED_FIELDS` guard pattern. This ensures that any field added to the `Recipe` dataclass without a corresponding mapping in `_parse_recipe()` triggers an immediate `RuntimeError` at import time, preventing silent-default bugs like the one that occurred with `requires_features` (commit `f3ef62bb4`).

Three `Recipe` fields are computed post-load (`content_hash`, `composite_hash`, `blocks`) and are not mapped in `_parse_recipe()`. A separate `_RECIPE_COMPUTED_FIELDS` frozenset accounts for these so the assertion checks `_PARSE_RECIPE_HANDLED_FIELDS | _RECIPE_COMPUTED_FIELDS == frozenset(Recipe.__dataclass_fields__)`.

Closes #2063

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-024534-284532/.autoskillit/temp/make-plan/recipe_completeness_guard_plan_2026-05-07_025300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 68 | 6.0k | 496.3k | 53.3k | 50 | 42.6k | 3m 20s |
| verify | claude-opus-4-6 | 1 | 1.3k | 5.1k | 528.9k | 48.8k | 50 | 35.9k | 2m 56s |
| implement* | MiniMax-M2.7-highspeed | 1 | 301.7k | 4.9k | 592.2k | 29.8k | 44 | 16.1k | 1m 53s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 57.5k | 2.9k | 178.5k | 29.8k | 18 | 42.1k | 1m 13s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 43.9k | 1.1k | 178.5k | 29.8k | 14 | 41.9k | 36s |
| review_pr | claude-sonnet-4-6 | 1 | 84 | 13.1k | 345.4k | 47.6k | 32 | 36.4k | 2m 56s |
| resolve_review | claude-sonnet-4-6 | 1 | 253 | 12.9k | 1.3M | 62.9k | 71 | 50.3k | 4m 57s |
| **Total** | | | 404.8k | 46.1k | 3.6M | 62.9k | | 265.4k | 17m 53s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 62 | 9552.1 | 260.3 | 79.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **62** | 58784.9 | 4280.6 | 743.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 1.4k | 11.1k | 1.0M | 78.6k | 6m 16s |
| MiniMax-M2.7-highspeed | 3 | 403.1k | 8.9k | 949.3k | 100.2k | 3m 42s |