### PR TITLE
Cache DefaultSkillResolver Results and Share Across Rule Functions

### DIFF
--- a/src/autoskillit/recipe/_analysis.py
+++ b/src/autoskillit/recipe/_analysis.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from autoskillit.core import SkillResolver  # noqa: PLC0415
 
 from autoskillit.recipe._analysis_bfs import _bfs_with_facts, bfs_reachable
 from autoskillit.recipe._analysis_blocks import extract_blocks
@@ -74,6 +78,7 @@ class ValidationContext:
     provider_profiles: frozenset[str] = field(default_factory=frozenset)
     skill_category_map: dict[str, frozenset[str]] | None = None
     overridden_skills: frozenset[str] | None = None
+    skill_resolver: SkillResolver | None = None
     blocks: tuple[RecipeBlock, ...] = field(default_factory=tuple)
     predecessors: dict[str, set[str]] = field(default_factory=dict)
 
@@ -123,6 +128,7 @@ def make_validation_context(
     disabled_subsets: frozenset[str] = frozenset(),
     disabled_features: frozenset[str] = frozenset(),
     provider_profiles: frozenset[str] = frozenset(),
+    skill_resolver: SkillResolver | None = None,
 ) -> ValidationContext:
     """Build a ``ValidationContext`` from a recipe.
 
@@ -148,6 +154,7 @@ def make_validation_context(
         disabled_subsets=disabled_subsets,
         disabled_features=disabled_features,
         provider_profiles=provider_profiles,
+        skill_resolver=skill_resolver,
         blocks=extract_blocks(recipe, step_graph, predecessors=predecessors),
         predecessors=predecessors,
     )

--- a/src/autoskillit/recipe/_analysis.py
+++ b/src/autoskillit/recipe/_analysis.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from autoskillit.core import SkillResolver  # noqa: PLC0415
+    from autoskillit.core import SkillResolver
 
 from autoskillit.recipe._analysis_bfs import _bfs_with_facts, bfs_reachable
 from autoskillit.recipe._analysis_blocks import extract_blocks

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -220,10 +220,16 @@ def validate_from_path(
 
         lister = DefaultSkillResolver()
 
+    from autoskillit.core import SkillResolver as _SkillResolver  # noqa: PLC0415
+
+    _skill_resolver = lister if isinstance(lister, _SkillResolver) else None
+
     recipe = _parse_recipe(data)
     errors = validate_recipe(recipe)
     known_skills = frozenset(s.name for s in lister.list_all())
-    ctx = make_validation_context(recipe, available_skills=known_skills)
+    ctx = make_validation_context(
+        recipe, available_skills=known_skills, skill_resolver=_skill_resolver
+    )
     report = ctx.dataflow
     semantic_findings = run_semantic_rules(ctx)
 
@@ -439,6 +445,10 @@ def load_and_validate(
 
                 lister = DefaultSkillResolver()
 
+            from autoskillit.core import SkillResolver as _SkillResolver  # noqa: PLC0415
+
+            _skill_resolver = lister if isinstance(lister, _SkillResolver) else None
+
             known = frozenset(
                 r.name
                 for r in (_recipe_list if _recipe_list is not None else list_recipes(_pdir).items)
@@ -459,6 +469,7 @@ def load_and_validate(
                 available_skills=known_skills,
                 available_sub_recipes=known_sub_recipes,
                 project_dir=_pdir,
+                skill_resolver=_skill_resolver,
             )
             semantic_findings = run_semantic_rules(val_ctx)
             semantic_suggestions = findings_to_dicts(semantic_findings)

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -363,17 +363,17 @@ def _check_output_section_no_markdown_directive(ctx: ValidationContext) -> list[
         if not skill_data or not skill_data.get("expected_output_patterns"):
             continue  # Only check skills that have contracts with patterns
 
-        skill_md_path = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
-        if skill_md_path is None:
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
+        if skill_md is None:
             continue  # unknown-skill-command rule handles missing skills
 
         try:
-            skill_md = skill_md_path.read_text(encoding="utf-8")
+            content = skill_md.read_text(encoding="utf-8")
         except OSError:
             continue  # file deleted or unreadable between resolution and read
 
         output_section_match = re.search(
-            r"##\s+Output\b(.+?)(?:^##|\Z)", skill_md, re.DOTALL | re.MULTILINE
+            r"##\s+Output\b(.+?)(?:^##|\Z)", content, re.DOTALL | re.MULTILINE
         )
         if not output_section_match:
             continue  # No output section — other rules handle this
@@ -504,11 +504,11 @@ def _check_transition_boundary_anti_confirmation(ctx: ValidationContext) -> list
         skill_name = resolve_skill_name(skill_cmd)
         if skill_name is None:
             continue
-        skill_md_path = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
-        if skill_md_path is None:
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
+        if skill_md is None:
             continue
         try:
-            content = skill_md_path.read_text(encoding="utf-8")
+            content = skill_md.read_text(encoding="utf-8")
         except OSError:
             continue
         unprotected: list[tuple[str, str]] = []

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -95,7 +95,7 @@ def _check_undefined_bash_placeholder(ctx: ValidationContext) -> list[RuleFindin
         if skill_name is None:
             continue
 
-        skill_md = _resolve_skill_md(skill_name)
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
         if skill_md is None:
             continue  # unknown-skill-command rule handles missing skills
 
@@ -169,7 +169,7 @@ def _check_hardcoded_origin_remote(ctx: ValidationContext) -> list[RuleFinding]:
         skill_name = resolve_skill_name(skill_cmd)
         if skill_name is None:
             continue
-        skill_md = _resolve_skill_md(skill_name)
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
         if skill_md is None:
             continue  # unknown-skill-command rule handles missing skills
         try:
@@ -226,7 +226,7 @@ def _check_no_autoskillit_import(ctx: ValidationContext) -> list[RuleFinding]:
         skill_name = resolve_skill_name(skill_cmd)
         if skill_name is None:
             continue
-        skill_md = _resolve_skill_md(skill_name)
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
         if skill_md is None:
             continue
         try:
@@ -289,7 +289,7 @@ def _check_no_grep_bre_alternation(ctx: ValidationContext) -> list[RuleFinding]:
         skill_name = resolve_skill_name(skill_cmd)
         if skill_name is None:
             continue
-        skill_md = _resolve_skill_md(skill_name)
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
         if skill_md is None:
             continue  # unknown-skill-command rule handles missing skills
         try:
@@ -363,7 +363,7 @@ def _check_output_section_no_markdown_directive(ctx: ValidationContext) -> list[
         if not skill_data or not skill_data.get("expected_output_patterns"):
             continue  # Only check skills that have contracts with patterns
 
-        skill_md_path = _resolve_skill_md(skill_name)
+        skill_md_path = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
         if skill_md_path is None:
             continue  # unknown-skill-command rule handles missing skills
 
@@ -416,7 +416,7 @@ def _check_no_gh_issue_comment(ctx: ValidationContext) -> list[RuleFinding]:
         skill_name = resolve_skill_name(skill_cmd)
         if skill_name is None:
             continue
-        skill_md = _resolve_skill_md(skill_name)
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
         if skill_md is None:
             continue
         try:
@@ -504,7 +504,7 @@ def _check_transition_boundary_anti_confirmation(ctx: ValidationContext) -> list
         skill_name = resolve_skill_name(skill_cmd)
         if skill_name is None:
             continue
-        skill_md_path = _resolve_skill_md(skill_name)
+        skill_md_path = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
         if skill_md_path is None:
             continue
         try:

--- a/src/autoskillit/workspace/skills.py
+++ b/src/autoskillit/workspace/skills.py
@@ -129,7 +129,7 @@ class DefaultSkillResolver:
         global _LIST_ALL_CACHE, _LIST_ALL_CACHE_KEY
         key = (_dir_mtime(self._dir), _dir_mtime(self._extended_dir))
         if _LIST_ALL_CACHE is not None and _LIST_ALL_CACHE_KEY == key:
-            return _LIST_ALL_CACHE
+            return list(_LIST_ALL_CACHE)
         bundled = _scan_directory(SkillSource.BUNDLED, self._dir)
         extended = _scan_directory(SkillSource.BUNDLED_EXTENDED, self._extended_dir)
         combined = sorted(bundled + extended, key=lambda s: s.name)
@@ -142,7 +142,7 @@ class DefaultSkillResolver:
             )
         _LIST_ALL_CACHE = combined
         _LIST_ALL_CACHE_KEY = key
-        return combined
+        return list(combined)
 
 
 def bundled_skills_dir() -> Path:

--- a/src/autoskillit/workspace/skills.py
+++ b/src/autoskillit/workspace/skills.py
@@ -49,6 +49,17 @@ _INTERNAL_SKILLS: frozenset[str] = frozenset({"sous-chef"})
 
 _OVERRIDE_SEARCH_DIRS: tuple[str, ...] = (".claude/skills", ".autoskillit/skills")
 
+_LIST_ALL_CACHE: list[SkillInfo] | None = None
+_LIST_ALL_CACHE_KEY: tuple[float, float] = (0.0, 0.0)
+
+
+def _dir_mtime(path: Path) -> float:
+    """Return directory mtime, or 0.0 if the path is inaccessible."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
 
 def detect_project_local_overrides(project_dir: Path) -> frozenset[str]:
     """Return the set of bundled skill names overridden by project-local SKILL.md files.
@@ -95,20 +106,30 @@ class DefaultSkillResolver:
     def __init__(self) -> None:
         self._dir = bundled_skills_dir()
         self._extended_dir = bundled_skills_extended_dir()
+        self._resolve_cache: dict[str, SkillInfo | None] = {}
 
     def resolve(self, name: str) -> SkillInfo | None:
         """Resolve a skill name to its path. Checks skills/ before skills_extended/."""
+        if name in self._resolve_cache:
+            return self._resolve_cache[name]
         for directory, source in (
             (self._dir, SkillSource.BUNDLED),
             (self._extended_dir, SkillSource.BUNDLED_EXTENDED),
         ):
             skill_path = directory / name / "SKILL.md"
             if skill_path.is_file():
-                return _skill_info_from_frontmatter(name, source, skill_path)
+                info = _skill_info_from_frontmatter(name, source, skill_path)
+                self._resolve_cache[name] = info
+                return info
+        self._resolve_cache[name] = None
         return None
 
     def list_all(self) -> list[SkillInfo]:
         """List all public bundled skills from both directories."""
+        global _LIST_ALL_CACHE, _LIST_ALL_CACHE_KEY
+        key = (_dir_mtime(self._dir), _dir_mtime(self._extended_dir))
+        if _LIST_ALL_CACHE is not None and _LIST_ALL_CACHE_KEY == key:
+            return _LIST_ALL_CACHE
         bundled = _scan_directory(SkillSource.BUNDLED, self._dir)
         extended = _scan_directory(SkillSource.BUNDLED_EXTENDED, self._extended_dir)
         combined = sorted(bundled + extended, key=lambda s: s.name)
@@ -119,6 +140,8 @@ class DefaultSkillResolver:
             raise RuntimeError(
                 f"Skill name collision across skills/ and skills_extended/: {sorted(dupes)}"
             )
+        _LIST_ALL_CACHE = combined
+        _LIST_ALL_CACHE_KEY = key
         return combined
 
 

--- a/tests/recipe/test_analysis_public_api.py
+++ b/tests/recipe/test_analysis_public_api.py
@@ -64,11 +64,12 @@ def test_validation_context_skill_resolver_default() -> None:
 
 def test_make_validation_context_passes_skill_resolver() -> None:
     """make_validation_context sets skill_resolver on the returned context."""
+    from unittest.mock import Mock
+
     from autoskillit.recipe._analysis import make_validation_context
     from autoskillit.recipe.schema import Recipe
-    from autoskillit.workspace.skills import DefaultSkillResolver
 
     recipe = Recipe(name="t", description="t", steps={}, kitchen_rules=["t"])
-    resolver = DefaultSkillResolver()
+    resolver = Mock()
     ctx = make_validation_context(recipe, skill_resolver=resolver)
     assert ctx.skill_resolver is resolver

--- a/tests/recipe/test_analysis_public_api.py
+++ b/tests/recipe/test_analysis_public_api.py
@@ -41,3 +41,34 @@ def test_bfs_reachable_traverses_graph() -> None:
     assert bfs_reachable(graph, "a") == {"b", "c", "d"}
     assert bfs_reachable(graph, "b") == {"d"}
     assert bfs_reachable(graph, "d") == set()
+
+
+# ---------------------------------------------------------------------------
+# ValidationContext.skill_resolver tests
+# ---------------------------------------------------------------------------
+
+
+def test_validation_context_skill_resolver_default() -> None:
+    """ValidationContext.skill_resolver defaults to None."""
+    from autoskillit.recipe._analysis import ValidationContext
+    from autoskillit.recipe.schema import DataFlowReport, Recipe
+
+    recipe = Recipe(name="t", description="t", steps={}, kitchen_rules=["t"])
+    ctx = ValidationContext(
+        recipe=recipe,
+        step_graph={},
+        dataflow=DataFlowReport(warnings=[], summary=""),
+    )
+    assert ctx.skill_resolver is None
+
+
+def test_make_validation_context_passes_skill_resolver() -> None:
+    """make_validation_context sets skill_resolver on the returned context."""
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.schema import Recipe
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    recipe = Recipe(name="t", description="t", steps={}, kitchen_rules=["t"])
+    resolver = DefaultSkillResolver()
+    ctx = make_validation_context(recipe, skill_resolver=resolver)
+    assert ctx.skill_resolver is resolver

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -880,3 +880,6 @@ def test_rules_pass_ctx_skill_resolver_to_resolve_skill_md(tmp_path: Path) -> No
     assert len(non_none) > 0, (
         "Expected rule functions to pass ctx.skill_resolver to _resolve_skill_md"
     )
+    assert all(r is resolver for r in non_none), (
+        "Expected every non-None resolver to be the exact instance from ctx"
+    )

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -825,3 +825,58 @@ def test_transition_boundary_anti_confirmation_rule_passes(tmp_path: Path) -> No
     assert _BOUNDARY_RULE_ID not in rule_ids, (
         f"Rule must not fire when anti-confirmation instruction is present, got: {rule_ids}"
     )
+
+
+def test_rules_pass_ctx_skill_resolver_to_resolve_skill_md(tmp_path: Path) -> None:
+    """Rule functions thread ctx.skill_resolver through to _resolve_skill_md."""
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    # Build a minimal recipe with a run_skill step that triggers skill content rules
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# test-skill\n## Arguments\nNone.\n")
+
+    recipe_yaml = tmp_path / "recipe.yaml"
+    recipe_yaml.write_text(
+        textwrap.dedent(
+            """\
+        name: test-recipe
+        kitchen_rules:
+          - "Use run_skill only."
+        steps:
+          run_impl:
+            tool: run_skill
+            with:
+              skill_command: "/autoskillit:test-skill"
+            on_success: done
+          done:
+            action: stop
+            message: "Done."
+        """
+        )
+    )
+    recipe = load_recipe(recipe_yaml)
+
+    # Track whether _resolve_skill_md received a non-None resolver
+    received_resolvers: list[object] = []
+    original_fn = _rsc._resolve_skill_md
+
+    def tracking_fn(skill_name: str, *, resolver: object = None) -> object:
+        received_resolvers.append(resolver)
+        return original_fn(skill_name, resolver=resolver)
+
+    resolver = DefaultSkillResolver()
+    ctx = make_validation_context(recipe, skill_resolver=resolver)
+
+    with (
+        patch.object(_rsc, "_resolve_skill_md", tracking_fn),
+        patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]),
+    ):
+        run_semantic_rules(ctx)
+
+    # At least one call should have received the resolver from ctx
+    non_none = [r for r in received_resolvers if r is not None]
+    assert len(non_none) > 0, (
+        "Expected rule functions to pass ctx.skill_resolver to _resolve_skill_md"
+    )

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+import autoskillit.workspace.skills as _skills_mod
 from autoskillit.core.types import SkillSource
 from autoskillit.workspace.skills import (
     DefaultSkillResolver,
@@ -733,3 +734,81 @@ def test_audit_docs_skill_md_exists() -> None:
     info = resolver.resolve("audit-docs")
     assert info is not None
     assert info.path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Cache tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_all_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Second list_all() call returns cached result without re-scanning."""
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE", None)
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE_KEY", (0.0, 0.0))
+    resolver = DefaultSkillResolver()
+    result1 = resolver.list_all()
+    call_count = 0
+    original_scan = _skills_mod._scan_directory
+
+    def counting_scan(*args: object, **kwargs: object) -> list[object]:
+        nonlocal call_count
+        call_count += 1
+        return original_scan(*args, **kwargs)  # type: ignore[no-any-return]
+
+    monkeypatch.setattr(_skills_mod, "_scan_directory", counting_scan)
+    result2 = resolver.list_all()
+    assert result2 == result1
+    assert call_count == 0  # Cache hit — no re-scan
+
+
+def test_list_all_cache_invalidation_on_mtime_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_all() re-scans when directory mtime changes."""
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE", None)
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE_KEY", (0.0, 0.0))
+    resolver = DefaultSkillResolver()
+    result1 = resolver.list_all()
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE_KEY", (999.0, 999.0))
+    call_count = 0
+    original_scan = _skills_mod._scan_directory
+
+    def counting_scan(*args: object, **kwargs: object) -> list[object]:
+        nonlocal call_count
+        call_count += 1
+        return original_scan(*args, **kwargs)  # type: ignore[no-any-return]
+
+    monkeypatch.setattr(_skills_mod, "_scan_directory", counting_scan)
+    result2 = resolver.list_all()
+    assert result2 == result1  # Same content
+    assert call_count == 2  # Re-scanned both directories
+
+
+def test_resolve_instance_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Second resolve() for same name returns cached SkillInfo without disk I/O."""
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE", None)
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE_KEY", (0.0, 0.0))
+    resolver = DefaultSkillResolver()
+    result1 = resolver.resolve("make-plan")
+    assert result1 is not None
+    call_count = 0
+    original_fn = _skills_mod._skill_info_from_frontmatter
+
+    def counting_fn(*args: object, **kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        return original_fn(*args, **kwargs)
+
+    monkeypatch.setattr(_skills_mod, "_skill_info_from_frontmatter", counting_fn)
+    result2 = resolver.resolve("make-plan")
+    assert result2 is not None
+    assert result2.name == result1.name
+    assert call_count == 0  # Cache hit
+
+
+def test_resolve_instance_cache_caches_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """resolve() caches None for unknown skills to avoid repeated is_file() checks."""
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE", None)
+    monkeypatch.setattr(_skills_mod, "_LIST_ALL_CACHE_KEY", (0.0, 0.0))
+    resolver = DefaultSkillResolver()
+    result1 = resolver.resolve("nonexistent-skill-xyz")
+    assert result1 is None
+    assert "nonexistent-skill-xyz" in resolver._resolve_cache

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -812,3 +812,4 @@ def test_resolve_instance_cache_caches_none(monkeypatch: pytest.MonkeyPatch) -> 
     result1 = resolver.resolve("nonexistent-skill-xyz")
     assert result1 is None
     assert "nonexistent-skill-xyz" in resolver._resolve_cache
+    assert resolver._resolve_cache["nonexistent-skill-xyz"] is None


### PR DESCRIPTION
## Summary

Eliminate redundant I/O in the recipe validation pipeline by (A) adding an mtime-keyed module-level cache to `DefaultSkillResolver.list_all()` and an instance-level cache to `resolve()`, and (B) threading the resolver instance through `ValidationContext` so all 7 rules in `rules_skill_content.py` share a single resolver instead of each creating a fresh one per `run_skill` step.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.



## Changed Files

### Modified (●):
- `src/autoskillit/recipe/_analysis.py`
- `src/autoskillit/recipe/_api.py`
- `src/autoskillit/recipe/rules/rules_skill_content.py`
- `src/autoskillit/workspace/skills.py`

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START(["load_and_validate()"])

    subgraph Resolver ["Resolver Creation"]
        direction TB
        R1["DefaultSkillResolver()<br/>━━━━━━━━━━<br/>_api.py:437-440"]
        R2{"★ Module cache<br/>━━━━━━━━━━<br/>mtime match?"}
        R3["list_all()<br/>━━━━━━━━━━<br/>_scan_directory × 2"]
        R4["★ Return cached<br/>━━━━━━━━━━<br/>skip 132-file scan"]
    end

    subgraph Context ["★ Resolver Sharing via ValidationContext"]
        direction TB
        C1["make_validation_context()<br/>━━━━━━━━━━<br/>● skill_resolver param"]
        C2["★ ValidationContext<br/>━━━━━━━━━━<br/>● skill_resolver field"]
    end

    subgraph Rules ["Rule Execution (× 7 rules × N steps)"]
        direction TB
        F1["● _resolve_skill_md()<br/>━━━━━━━━━━<br/>receives resolver from ctx"]
        F2{"★ Instance cache<br/>━━━━━━━━━━<br/>name in cache?"}
        F3["resolve(name)<br/>━━━━━━━━━━<br/>is_file + frontmatter"]
        F4["★ Return cached<br/>━━━━━━━━━━<br/>skip disk I/O"]
    end

    END(["Return findings"])

    START --> R1
    R1 -->|"list_all()"| R2
    R2 -->|"miss"| R3
    R2 -->|"hit"| R4
    R3 --> C1
    R4 --> C1
    R1 -->|"★ passed as skill_resolver"| C1
    C1 --> C2
    C2 -->|"run_semantic_rules(ctx)"| F1
    F1 -->|"resolver.resolve(name)"| F2
    F2 -->|"miss"| F3
    F2 -->|"hit"| F4
    F3 --> END
    F4 --> END

    class START,END terminal;
    class R1,R3 handler;
    class R2,F2 newComponent;
    class R4,F4 newComponent;
    class C1 phase;
    class C2 newComponent;
    class F1 phase;
    class F3 handler;
```

**Color Legend:**

| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Entry and exit points |
| Green | New Component | New cache logic and ValidationContext field |
| Purple | Phase | Control flow — context building and resolve dispatch |
| Orange | Handler | Existing processing — directory scan, frontmatter read |

Closes #2137

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-041549-284194/.autoskillit/temp/make-plan/cache_defaultskillresolver_results_plan_2026-05-07_041549.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 76 | 15.0k | 896.1k | 67.8k | 72 | 55.7k | 8m 31s |
| verify | claude-opus-4-6 | 1 | 65 | 23.5k | 2.0M | 93.2k | 118 | 80.3k | 8m 53s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.8M | 18.8k | 2.7M | 76.1k | 184 | 201.9k | 7m 53s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 73.5k | 2.8k | 178.6k | 29.8k | 18 | 42.1k | 1m 4s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 94.8k | 2.1k | 265.0k | 29.8k | 19 | 15.0k | 53s |
| review_pr | claude-sonnet-4-6 | 2 | 4.4k | 66.1k | 1.0M | 78.1k | 96 | 132.0k | 14m 24s |
| resolve_review | claude-opus-4-6 | 2 | 129 | 46.0k | 4.4M | 104.0k | 183 | 162.1k | 18m 48s |
| **Total** | | | 2.9M | 174.3k | 11.4M | 104.0k | | 689.2k | 1h 0m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 224 | 12081.7 | 901.5 | 83.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 24 | 182246.9 | 6753.7 | 1916.7 |
| **Total** | **248** | 46123.4 | 2779.1 | 702.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 187 | 43.0k | 3.6M | 178.7k | 21m 13s |
| MiniMax-M2.7-highspeed | 3 | 2.9M | 23.7k | 3.1M | 259.1k | 9m 50s |