### PR TITLE
Skill-Rename Migration Note

### DIFF
--- a/src/autoskillit/migrations/0.9.526-to-0.9.527.yaml
+++ b/src/autoskillit/migrations/0.9.526-to-0.9.527.yaml
@@ -1,0 +1,30 @@
+from_version: "0.9.526"
+to_version: "0.9.527"
+description: >
+  Skill rename: vis-lens-domain-norms → vis-lens-methodology-norms.
+changes:
+  - id: vis-lens-methodology-norms-rename
+    description: "Skill renamed: vis-lens-domain-norms → vis-lens-methodology-norms"
+    instruction: |
+      If your .autoskillit/recipes/*.yaml files or custom Taskfile invoke
+      vis-lens-domain-norms explicitly:
+
+      1. Replace '/autoskillit:vis-lens-domain-norms' with
+         '/autoskillit:vis-lens-methodology-norms' in every skill_command step.
+      2. Update any downstream captures, routing references, or log greps that
+         hardcoded the old skill name.
+
+      The skill's input/output contract is unchanged; only the slug is different.
+      Most users with only bundled-recipe workflows will see no disruption — the
+      rename is transparent inside the bundled research.yaml.
+    detect:
+      tool: run_skill
+      skill_pattern: "vis-lens-domain-norms"
+    example_before: |
+      - tool: run_skill
+        with:
+          skill_command: "/autoskillit:vis-lens-domain-norms ${{ context.experiment_plan }}"
+    example_after: |
+      - tool: run_skill
+        with:
+          skill_command: "/autoskillit:vis-lens-methodology-norms ${{ context.experiment_plan }}"

--- a/tests/migration/CLAUDE.md
+++ b/tests/migration/CLAUDE.md
@@ -11,5 +11,6 @@ Migration engine, store, and loader tests.
 | `test_api_integration.py` | Integration tests for migration/_api.py — no mocking of recipe lookup or engine |
 | `test_engine.py` | Tests for migration_engine.py — ME1 through ME21 |
 | `test_fleet_migration_note.py` | Fleet migration note tests |
+| `test_vis_lens_rename_migration_note.py` | Vis-lens skill rename migration note tests |
 | `test_loader.py` | Tests for migration note discovery and version chaining |
 | `test_store.py` | Tests for failure_store.py — FS1 through FS11 and FS-IM1 through FS-IM4 |

--- a/tests/migration/test_vis_lens_rename_migration_note.py
+++ b/tests/migration/test_vis_lens_rename_migration_note.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.layer("migration"), pytest.mark.small]
+
+MIGRATIONS_DIR = Path(__file__).parents[2] / "src" / "autoskillit" / "migrations"
+
+
+def test_vis_lens_rename_migration_note_exists():
+    """A migration note must cover the vis-lens-domain-norms → vis-lens-methodology-norms rename."""
+    notes = list(MIGRATIONS_DIR.glob("*.yaml"))
+    matches = []
+    for note_path in notes:
+        try:
+            data = yaml.safe_load(note_path.read_text())
+        except yaml.YAMLError as exc:
+            pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
+        for change in data.get("changes", []):
+            detect = change.get("detect", {})
+            if detect.get("skill_pattern") == "vis-lens-domain-norms":
+                matches.append(note_path.name)
+    assert matches, (
+        "No migration note found with detect.skill_pattern == 'vis-lens-domain-norms'. "
+        "Create src/autoskillit/migrations/<from>-to-<to>.yaml with a "
+        "vis-lens-methodology-norms-rename change entry."
+    )
+
+
+def test_vis_lens_rename_migration_note_is_valid():
+    """Migration note for vis-lens rename must have instruction and examples."""
+    notes = list(MIGRATIONS_DIR.glob("*.yaml"))
+    for note_path in notes:
+        try:
+            data = yaml.safe_load(note_path.read_text())
+        except yaml.YAMLError as exc:
+            pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
+        for change in data.get("changes", []):
+            if change.get("detect", {}).get("skill_pattern") == "vis-lens-domain-norms":
+                assert "instruction" in change, "Migration note missing 'instruction'"
+                assert change["instruction"].strip(), "Migration note 'instruction' is empty"
+                assert "example_before" in change, "Migration note missing 'example_before'"
+                assert change["example_before"].strip(), "Migration note 'example_before' is empty"
+                assert "example_after" in change, "Migration note missing 'example_after'"
+                assert change["example_after"].strip(), "Migration note 'example_after' is empty"
+                return
+    pytest.fail(
+        "No matching migration change found with detect.skill_pattern == 'vis-lens-domain-norms'"
+    )


### PR DESCRIPTION
## Summary

Create a migration note YAML at `src/autoskillit/migrations/0.9.526-to-0.9.527.yaml` documenting the `vis-lens-domain-norms` → `vis-lens-methodology-norms` skill rename. The rename itself has already landed (the new skill directory exists, the old one is removed, and `RETIRED_SKILL_NAMES` already includes `vis-lens-domain-norms`). This task adds the migration note so users with custom recipes referencing the old slug get clear upgrade guidance. A companion test file validates the note's existence and schema compliance.

## Requirements

Part of **Unit 8 — Deprecation & Release Plumbing (P1)** from the auto-research master plan. **New Unit from gap analysis (§11.5.2).**

## Changed Files

### New
- `src/autoskillit/migrations/0.9.526-to-0.9.527.yaml` — migration note documenting the vis-lens-domain-norms → vis-lens-methodology-norms rename
- `tests/migration/test_vis_lens_rename_migration_note.py` — existence and schema-compliance tests

### Modified
- `tests/migration/CLAUDE.md` — added new test file to the file table

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-065934-141826/.autoskillit/temp/make-plan/skill-rename-migration-note_plan_2026-05-07_070200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 72 | 7.8k | 717.8k | 57.4k | 79 | 61.9k | 4m 57s |
| verify | claude-sonnet-4-6 | 1 | 37 | 5.2k | 330.3k | 42.7k | 78 | 29.5k | 4m 38s |
| implement* | MiniMax-M2.7-highspeed | 1 | 316.6k | 4.1k | 654.7k | 29.8k | 55 | 58.0k | 5m 27s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 82.6k | 2.4k | 265.1k | 29.8k | 20 | 15.2k | 1m 3s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.0k | 1.6k | 175.7k | 29.8k | 14 | 15.0k | 43s |
| review_pr | claude-opus-4-6 | 1 | 26 | 8.7k | 260.6k | 44.2k | 24 | 32.1k | 2m 32s |
| **Total** | | | 446.3k | 29.8k | 2.4M | 57.4k | | 211.8k | 19m 22s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 81 | 8082.4 | 716.4 | 51.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **81** | 29680.7 | 2615.0 | 368.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 72 | 7.8k | 717.8k | 61.9k | 4m 57s |
| claude-sonnet-4-6 | 1 | 37 | 5.2k | 330.3k | 29.5k | 4m 38s |
| MiniMax-M2.7-highspeed | 3 | 446.2k | 8.1k | 1.1M | 88.3k | 7m 14s |