### PR TITLE
ci: api-simulator cache diagnostics (issue #2135)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,17 @@
+# GitHub Actions CI — Agent Instructions
+
+## `setup-uv@v7` Cache Behavior
+
+- **Parameter name**: Use `version:` not `uv-version:` — the old name is silently ignored.
+- **Cache key**: Exact hash of `uv.lock` + `pyproject.toml` + `*requirements*.txt` + arch/OS/Python. No `restore-keys` fallback — any `uv.lock` change is a total miss.
+- **Cache save rule**: GitHub Actions skips save when the key already exists. If job A saves a cache and job B restores it with the same key, job B's changes are never persisted. The first job to complete with a given key "wins."
+- **`prune-cache: true` (default)**: Runs `uv cache prune --ci` before save. Source-built wheels survive pruning; pre-built PyPI wheels do not.
+- **Implication for source-built deps**: If a job that only validates (e.g. `uv lock --check`) saves the cache before a job that installs (e.g. `uv sync`), the compiled wheel never enters the persisted cache. Either disable caching on the validation job or use a separate `actions/cache` step with a different key.
+
+## `dtolnay/rust-toolchain`
+
+Only needed in jobs that run `uv sync`/`uv pip install` with Rust/PyO3 source deps. Not needed for `uv lock --check` (lockfile validation doesn't build packages).
+
+## `api-simulator` Dependency
+
+Private Rust/PyO3 crate at `TalonT-Org/api-simulator`, built via maturin. Requires `dtolnay/rust-toolchain@stable` and git auth (`GH_USER`/`GH_PAT` secrets via URL rewrite). Gated to `sys_platform == 'linux'` — not built on macOS CI targets.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
+        id: setup-uv
         uses: astral-sh/setup-uv@v7
         with:
           uv-version: "0.9.21"
@@ -81,8 +82,42 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Check api-simulator cache status (diagnostic - issue 2135)
+        run: |
+          echo "=== uv cache-hit output ==="
+          echo "Cache hit: ${{ steps.setup-uv.outputs.cache-hit }}"
+          echo ""
+          echo "=== uv cache dir ==="
+          uv cache dir
+          echo ""
+          echo "=== Looking for api-simulator in uv cache ==="
+          find "$(uv cache dir)" -path "*simulator*" -type f 2>/dev/null || echo "api-simulator NOT found in uv cache (will need Rust compilation)"
+          echo ""
+          echo "=== uv cache size ==="
+          du -sh "$(uv cache dir)" 2>/dev/null || echo "cache dir not found"
+
       - name: Install dependencies
-        run: uv sync --locked --extra dev
+        run: |
+          echo "=== Starting uv sync (timestamp: $(date -u +%H:%M:%S)) ==="
+          uv sync --locked --extra dev -v 2>&1 | tee /tmp/uv-sync.log
+          echo "=== Finished uv sync (timestamp: $(date -u +%H:%M:%S)) ==="
+          echo ""
+          echo "=== Rust/maturin compilation evidence ==="
+          grep -i "building\|compiling\|maturin\|cargo\|rustc\|Built api" /tmp/uv-sync.log || echo "No Rust compilation detected"
+          echo ""
+          echo "=== Cache/wheel reuse evidence ==="
+          grep -i "cached\|using cached\|found cached\|Installed.*api.simulator" /tmp/uv-sync.log || echo "No cache hit detected for api-simulator"
+
+      - name: Post-install api-simulator cache status (diagnostic - issue 2135)
+        run: |
+          echo "=== api-simulator in uv cache AFTER install ==="
+          find "$(uv cache dir)" -path "*simulator*" -type f 2>/dev/null | head -20
+          echo ""
+          echo "=== uv cache size AFTER install ==="
+          du -sh "$(uv cache dir)" 2>/dev/null || echo "cache dir not found"
+          echo ""
+          echo "=== Wheel file details ==="
+          find "$(uv cache dir)" -path "*simulator*" -name "*.whl" -exec ls -lh {} \; 2>/dev/null || echo "No wheel found"
 
       - name: Generate recipe diagrams
         run: uv run autoskillit recipes render


### PR DESCRIPTION
## Summary
- Adds diagnostic CI steps to verify whether the api-simulator Rust/PyO3 wheel is being cached or recompiled on every run
- Captures pre-install cache state, verbose `uv sync` output with compilation/cache pattern matching, and post-install cache contents
- This is a diagnostic-only PR for investigation — not intended to be merged as-is

## Context
Investigation for #2135. The hypothesis (supported by log analysis of recent runs) is that the wheel is recompiled every time because `uv.lock` changes frequently (version bumps), invalidating the entire `setup-uv` cache key.

## What the diagnostic steps check
1. **Pre-install**: Whether api-simulator wheel exists in the uv cache before `uv sync`
2. **During install**: Verbose `uv sync` output filtered for Rust compilation vs cache-hit patterns
3. **Post-install**: What's in the uv cache after install completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)