### PR TITLE
Document the tag-visibility vs application-gate split for MCP tools

### DIFF
--- a/src/autoskillit/server/CLAUDE.md
+++ b/src/autoskillit/server/CLAUDE.md
@@ -33,3 +33,65 @@ This has regressed three times. Defense-in-depth:
 
 If you believe a tool genuinely needs `readOnlyHint: False`, you are wrong. All pipelines
 use independent branches. There is no shared mutable state between concurrent tool calls.
+
+## Tool Gating Architecture
+
+Tools are controlled by two independent mechanisms. A tool may be affected by one, both, or neither.
+
+### Tag-Visibility (FastMCP layer)
+
+Controls whether the tool appears in `tools/list` (whether the agent can see it):
+
+- `mcp.disable(tags={"kitchen"})` at startup hides all `kitchen`-tagged tools
+- `_apply_session_type_visibility()` selectively reveals tags per session type:
+  - **FLEET** sessions: `fleet`-tagged tools revealed; `fleet-dispatch` revealed only in dispatch mode
+  - **ORCHESTRATOR + HEADLESS**: `kitchen` (or `kitchen-core` + pack tags) revealed
+  - **SKILL + HEADLESS**: `headless`-tagged tools revealed (`test_check`)
+  - **Interactive** (no HEADLESS): nothing pre-revealed; `open_kitchen` reveals `kitchen` tag
+- Tags not disabled at startup (`kitchen-core`, `fleet-dispatch`, `fleet`, `headless`) remain
+  visible unless a session-type or feature-gate transform explicitly disables them
+- `ALL_VISIBILITY_TAGS` in `core/types/_type_constants.py` is the canonical set:
+  `{"kitchen", "headless", "fleet", "fleet-dispatch", "kitchen-core"}`
+
+### Application-Gate (Python layer)
+
+Controls whether the tool succeeds when called (independent of visibility):
+
+- Most kitchen tools call `_require_enabled()` as their first statement, which checks `ctx.gate.enabled`
+- Returns a `gate_error` JSON envelope if the kitchen hasn't been opened
+- `_require_enabled()` is defined in `server/_guards.py`; the error envelope is defined in `pipeline/gate.py`
+- Enforcement is validated by `test_gated_tools_call_require_enabled_first` in `tests/arch/test_layer_enforcement.py`
+
+### The Anomalies
+
+1. **Fleet-dispatch tools are tag-visible but application-gated.** `fetch_github_issue`, `get_issue_title`,
+   `list_recipes`, and `load_recipe` carry the `fleet-dispatch` tag (not `kitchen`), so they are
+   NOT hidden by `mcp.disable(tags={"kitchen"})`. In interactive sessions they appear in `tools/list`
+   without `open_kitchen`. But they call `_require_enabled()` internally — an agent that sees them
+   and calls them gets an unexpected gate error.
+
+2. **`test_check` is tag-hidden but NOT application-gated.** It carries the `kitchen` + `headless`
+   tags (hidden at startup), but does NOT call `_require_enabled()`. Headless skill sessions need
+   `test_check` without opening the kitchen — the `headless` tag provides visibility in SKILL sessions,
+   and skipping `_require_enabled()` lets the call succeed without a gate open.
+
+### Tool Gating Matrix
+
+| Category | Tag(s) | Hidden at startup? | Application-gated? | Example tools |
+|----------|--------|-------------------|--------------------|--------------|
+| Standard kitchen | `kitchen` | Yes | Yes (`_require_enabled`) | `run_cmd`, `run_skill`, `report_bug` |
+| Fleet tool | `fleet`, `kitchen-core` | No (no `kitchen` tag) | Yes (`_require_fleet` or `_require_enabled`) | `dispatch_food_truck`, `record_gate_dispatch` |
+| Fleet-dispatch tool | `fleet-dispatch` (± `kitchen-core`) | No (no `kitchen` tag) | Yes (`_require_enabled`) | `fetch_github_issue`, `list_recipes` |
+| Headless-exempt | `kitchen`, `headless` | Yes | No | `test_check` |
+| Free-range | _(none of the above)_ | No | No | `open_kitchen`, `close_kitchen` |
+
+### Registry Constants
+
+The canonical tool sets are in `core/types/_type_constants.py`:
+
+- `GATED_TOOLS` — all tools that call `_require_enabled()` (validated by arch test)
+- `UNGATED_TOOLS` = `FREE_RANGE_TOOLS` — tools with no gating at all
+- `HEADLESS_TOOLS` — `{"test_check"}` — kitchen-tagged but not application-gated
+- `FLEET_TOOLS` — fleet-session-only tools
+- `FLEET_DISPATCH_TOOLS` — fleet-dispatch-mode tools (always tag-visible, application-gated)
+- `ALL_VISIBILITY_TAGS` — `{"kitchen", "headless", "fleet", "fleet-dispatch", "kitchen-core"}`

--- a/src/autoskillit/server/CLAUDE.md
+++ b/src/autoskillit/server/CLAUDE.md
@@ -70,8 +70,8 @@ Controls whether the tool succeeds when called (independent of visibility):
    without `open_kitchen`. But they call `_require_enabled()` internally — an agent that sees them
    and calls them gets an unexpected gate error.
 
-2. **`test_check` is tag-hidden but NOT application-gated.** It carries the `kitchen` + `headless`
-   tags (hidden at startup), but does NOT call `_require_enabled()`. Headless skill sessions need
+2. **`test_check` is tag-hidden but NOT application-gated.** It carries the `kitchen`, `kitchen-core`,
+   `headless`, and `autoskillit` tags (hidden at startup), but does NOT call `_require_enabled()`. Headless skill sessions need
    `test_check` without opening the kitchen — the `headless` tag provides visibility in SKILL sessions,
    and skipping `_require_enabled()` lets the call succeed without a gate open.
 

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -1,18 +1,22 @@
 """MCP server for orchestrating automated skill-driven workflows.
 
-Kitchen tools (48 kitchen-tagged: 47 gated + 1 headless-tagged) are hidden at startup
-via FastMCP v3 mcp.disable(tags={'kitchen'}) applied once after all tool modules are
-imported. Each new session sees only the 4 free-range tools (open_kitchen, close_kitchen,
-disable_quota_guard, and reload_session).
+Tool gating uses two independent layers — see server/CLAUDE.md "Tool Gating
+Architecture" section for the full matrix.
+
+Tag-Visibility (FastMCP): kitchen-tagged tools are hidden at startup via
+mcp.disable(tags={'kitchen'}). Session-type dispatch (_apply_session_type_visibility)
+selectively reveals tags per session type. open_kitchen reveals all kitchen-tagged
+tools for interactive sessions.
+
+Application-Gate (Python): most tools call _require_enabled() internally, which
+checks ctx.gate.enabled and returns a gate_error envelope if the kitchen is closed.
+See GATED_TOOLS and UNGATED_TOOLS in core/types/_type_constants.py.
 
 Startup tag visibility is determined by AUTOSKILLIT_SESSION_TYPE (3-branch dispatch):
   FLEET — fleet-tagged tools pre-revealed
   ORCHESTRATOR + HEADLESS=1 — all kitchen-tagged tools pre-revealed
   SKILL + HEADLESS=1 — headless-tagged tools (test_check) pre-revealed
   ORCHESTRATOR/SKILL (interactive) — no pre-reveal; open_kitchen unlocks
-
-Calling the open_kitchen tool reveals all kitchen-tagged tools for that session
-via ctx.enable_components(tags={'kitchen'}).
 
 Transport: stdio (default for FastMCP).
 """

--- a/src/autoskillit/server/tools/tools_workspace.py
+++ b/src/autoskillit/server/tools/tools_workspace.py
@@ -23,6 +23,8 @@ logger = get_logger(__name__)
 @mcp.tool(
     tags={"autoskillit", "kitchen", "kitchen-core", "headless"}, annotations={"readOnlyHint": True}
 )
+# No _require_enabled() — headless skill sessions need test_check without opening kitchen.
+# The kitchen tag governs visibility only; the headless tag provides access in SKILL sessions.
 @track_response_size("test_check")
 async def test_check(
     worktree_path: str,

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1023,27 +1023,15 @@ def test_tool_subset_tags_match_decorators() -> None:
     )
 
 
-def test_server_docstring_counts_accurate() -> None:
-    """server/__init__.py docstring numeric claims match actual frozenset sizes."""
-    from autoskillit.core.types import FREE_RANGE_TOOLS, GATED_TOOLS, HEADLESS_TOOLS
+def test_server_docstring_references_registry_constants() -> None:
+    """server/__init__.py docstring references registry constants, not hardcoded counts."""
+    import re
 
     docstring = (SRC_ROOT / "server" / "__init__.py").read_text()
-    expected_substrings: dict[str, str] = {
-        "gated": f"{len(GATED_TOOLS)} gated",
-        "headless-tagged": f"{len(HEADLESS_TOOLS)} headless-tagged",
-        "free-range": f"{len(FREE_RANGE_TOOLS)} free-range",
-        "kitchen-tagged": f"{len(GATED_TOOLS) + len(HEADLESS_TOOLS)} kitchen-tagged",
-    }
-
-    mismatches = [
-        f"'{label}': expected '{claim}' in docstring"
-        for label, claim in expected_substrings.items()
-        if claim not in docstring
-    ]
-
-    assert not mismatches, (
-        "server/__init__.py docstring count claims do not match frozenset sizes:\n"
-        + "\n".join(f"  {m}" for m in mismatches)
+    assert "GATED_TOOLS" in docstring, "docstring should reference GATED_TOOLS"
+    assert "UNGATED_TOOLS" in docstring, "docstring should reference UNGATED_TOOLS"
+    assert not re.search(r"\d+ kitchen-tagged", docstring), (
+        "docstring must not contain hardcoded tool counts — they rot as tools are added"
     )
 
 

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1027,9 +1027,9 @@ def test_tool_subset_tags_match_decorators() -> None:
 def test_server_docstring_references_registry_constants() -> None:
     """server/__init__.py docstring references registry constants, not hardcoded counts."""
     src = (SRC_ROOT / "server" / "__init__.py").read_text()
-    match = re.match(r'^"""(.*?)"""', src, re.DOTALL)
-    assert match, "server/__init__.py should start with a module docstring"
-    docstring = match.group(1)
+    tree = ast.parse(src)
+    docstring = ast.get_docstring(tree)
+    assert docstring, "server/__init__.py should have a module docstring"
     assert "GATED_TOOLS" in docstring, "docstring should reference GATED_TOOLS"
     assert "UNGATED_TOOLS" in docstring, "docstring should reference UNGATED_TOOLS"
     assert not re.search(r"\d+ kitchen-tagged", docstring), (

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -12,6 +12,7 @@ Tests:
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 import pytest
@@ -1025,9 +1026,10 @@ def test_tool_subset_tags_match_decorators() -> None:
 
 def test_server_docstring_references_registry_constants() -> None:
     """server/__init__.py docstring references registry constants, not hardcoded counts."""
-    import re
-
-    docstring = (SRC_ROOT / "server" / "__init__.py").read_text()
+    src = (SRC_ROOT / "server" / "__init__.py").read_text()
+    match = re.match(r'^"""(.*?)"""', src, re.DOTALL)
+    assert match, "server/__init__.py should start with a module docstring"
+    docstring = match.group(1)
     assert "GATED_TOOLS" in docstring, "docstring should reference GATED_TOOLS"
     assert "UNGATED_TOOLS" in docstring, "docstring should reference UNGATED_TOOLS"
     assert not re.search(r"\d+ kitchen-tagged", docstring), (

--- a/tests/docs/test_claude_md_structure.py
+++ b/tests/docs/test_claude_md_structure.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 
 CLAUDE_MD = Path(__file__).resolve().parents[2] / "CLAUDE.md"
+_SERVER_DIR = CLAUDE_MD.parent / "src" / "autoskillit" / "server"
 
 
 def test_claude_md_architecture_tree_has_subpackages() -> None:
@@ -87,8 +88,7 @@ def test_claude_md_defines_channel_b() -> None:
 
 def test_server_claude_md_has_tool_gating_section() -> None:
     """server/CLAUDE.md documents the two-layer tool gating architecture."""
-    server_claude = CLAUDE_MD.parent / "src" / "autoskillit" / "server" / "CLAUDE.md"
-    text = server_claude.read_text()
+    text = (_SERVER_DIR / "CLAUDE.md").read_text()
     assert "## Tool Gating Architecture" in text
     assert "### Tag-Visibility" in text
     assert "### Application-Gate" in text
@@ -96,8 +96,7 @@ def test_server_claude_md_has_tool_gating_section() -> None:
 
 def test_server_claude_md_gating_matrix_covers_categories() -> None:
     """server/CLAUDE.md gating matrix includes all five tool categories."""
-    server_claude = CLAUDE_MD.parent / "src" / "autoskillit" / "server" / "CLAUDE.md"
-    text = server_claude.read_text()
+    text = (_SERVER_DIR / "CLAUDE.md").read_text()
     for category in [
         "Standard kitchen",
         "Fleet tool",
@@ -110,7 +109,7 @@ def test_server_claude_md_gating_matrix_covers_categories() -> None:
 
 def test_server_init_docstring_no_stale_tool_count() -> None:
     """server/__init__.py docstring must not contain hardcoded tool counts."""
-    init_file = CLAUDE_MD.parent / "src" / "autoskillit" / "server" / "__init__.py"
+    init_file = _SERVER_DIR / "__init__.py"
     # Read only the module docstring (first triple-quoted block)
     src = init_file.read_text()
     docstring_match = re.match(r'^"""(.*?)"""', src, re.DOTALL)
@@ -124,14 +123,14 @@ def test_server_init_docstring_no_stale_tool_count() -> None:
 
 def test_test_check_has_require_enabled_exception_comment() -> None:
     """test_check has an inline comment explaining why it skips _require_enabled()."""
-    ws_file = CLAUDE_MD.parent / "src" / "autoskillit" / "server" / "tools" / "tools_workspace.py"
+    ws_file = _SERVER_DIR / "tools" / "tools_workspace.py"
     src = ws_file.read_text()
     lines = src.splitlines()
-    # Find the line defining test_check and scan backwards to its decorator block
     for i, line in enumerate(lines):
         if "async def test_check(" in line:
-            decorator_region = "\n".join(lines[max(0, i - 10) : i])
-            assert "_require_enabled" in decorator_region, (
+            region = lines[max(0, i - 10) : i]
+            comment_lines = [ln for ln in region if ln.lstrip().startswith("#")]
+            assert any("_require_enabled" in c for c in comment_lines), (
                 "test_check decorator region should contain a comment about _require_enabled"
             )
             return

--- a/tests/docs/test_claude_md_structure.py
+++ b/tests/docs/test_claude_md_structure.py
@@ -83,3 +83,56 @@ def test_claude_md_defines_channel_b() -> None:
     assert re.search(r"Channel B[^.]*JSONL", content), (
         "CLAUDE.md references 'Channel B' without an inline definition mentioning JSONL"
     )
+
+
+def test_server_claude_md_has_tool_gating_section() -> None:
+    """server/CLAUDE.md documents the two-layer tool gating architecture."""
+    server_claude = CLAUDE_MD.parent / "src" / "autoskillit" / "server" / "CLAUDE.md"
+    text = server_claude.read_text()
+    assert "## Tool Gating Architecture" in text
+    assert "### Tag-Visibility" in text
+    assert "### Application-Gate" in text
+
+
+def test_server_claude_md_gating_matrix_covers_categories() -> None:
+    """server/CLAUDE.md gating matrix includes all five tool categories."""
+    server_claude = CLAUDE_MD.parent / "src" / "autoskillit" / "server" / "CLAUDE.md"
+    text = server_claude.read_text()
+    for category in [
+        "Standard kitchen",
+        "Fleet tool",
+        "Fleet-dispatch tool",
+        "Headless-exempt",
+        "Free-range",
+    ]:
+        assert category in text, f"Missing tool category {category!r} in gating matrix"
+
+
+def test_server_init_docstring_no_stale_tool_count() -> None:
+    """server/__init__.py docstring must not contain hardcoded tool counts."""
+    init_file = CLAUDE_MD.parent / "src" / "autoskillit" / "server" / "__init__.py"
+    # Read only the module docstring (first triple-quoted block)
+    src = init_file.read_text()
+    docstring_match = re.match(r'^"""(.*?)"""', src, re.DOTALL)
+    assert docstring_match, "server/__init__.py should start with a module docstring"
+    docstring = docstring_match.group(1)
+    assert not re.search(r"\d+ kitchen-tagged", docstring), (
+        "Stale tool count in server/__init__.py docstring — "
+        "remove hardcoded counts, they rot as tools are added"
+    )
+
+
+def test_test_check_has_require_enabled_exception_comment() -> None:
+    """test_check has an inline comment explaining why it skips _require_enabled()."""
+    ws_file = CLAUDE_MD.parent / "src" / "autoskillit" / "server" / "tools" / "tools_workspace.py"
+    src = ws_file.read_text()
+    lines = src.splitlines()
+    # Find the line defining test_check and scan backwards to its decorator block
+    for i, line in enumerate(lines):
+        if "async def test_check(" in line:
+            decorator_region = "\n".join(lines[max(0, i - 10) : i])
+            assert "_require_enabled" in decorator_region, (
+                "test_check decorator region should contain a comment about _require_enabled"
+            )
+            return
+    raise AssertionError("async def test_check not found in tools_workspace.py")

--- a/tests/docs/test_claude_md_structure.py
+++ b/tests/docs/test_claude_md_structure.py
@@ -107,20 +107,6 @@ def test_server_claude_md_gating_matrix_covers_categories() -> None:
         assert category in text, f"Missing tool category {category!r} in gating matrix"
 
 
-def test_server_init_docstring_no_stale_tool_count() -> None:
-    """server/__init__.py docstring must not contain hardcoded tool counts."""
-    init_file = _SERVER_DIR / "__init__.py"
-    # Read only the module docstring (first triple-quoted block)
-    src = init_file.read_text()
-    docstring_match = re.match(r'^"""(.*?)"""', src, re.DOTALL)
-    assert docstring_match, "server/__init__.py should start with a module docstring"
-    docstring = docstring_match.group(1)
-    assert not re.search(r"\d+ kitchen-tagged", docstring), (
-        "Stale tool count in server/__init__.py docstring — "
-        "remove hardcoded counts, they rot as tools are added"
-    )
-
-
 def test_test_check_has_require_enabled_exception_comment() -> None:
     """test_check has an inline comment explaining why it skips _require_enabled()."""
     ws_file = _SERVER_DIR / "tools" / "tools_workspace.py"


### PR DESCRIPTION
## Summary

Documents the two independent enforcement mechanisms for MCP tool gating in the server package:
1. Tag-visibility layer (FastMCP): tools with `kitchen` tag are hidden at startup, revealed by `open_kitchen`
2. Application-gate layer (Python): tools call `_require_enabled()` internally, which checks `ctx.gate.enabled`

The changes add a "Tool Gating Architecture" section to `src/autoskillit/server/CLAUDE.md` with a matrix explaining the different tool categories, update the `server/__init__.py` docstring, and add an inline comment on `test_check` explaining why it skips `_require_enabled()`.

## Requirements

- `server/CLAUDE.md` contains the gating architecture section with the matrix
- `server/__init__.py` docstring no longer contains stale tool counts
- `test_check` has an inline comment explaining why it skips `_require_enabled()`
- An agent asked "which tools require the kitchen to be open?" can answer correctly from CLAUDE.md alone without reading every tool implementation

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

(None)

Closes #2049

## Implementation Plan

Plan file: `(plan file not available at expected path)`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 85 | 18.4k | 1.8M | 89.4k | 120 | 76.2k | 9m 41s |
| verify | claude-sonnet-4-6 | 1 | 39 | 7.1k | 487.5k | 59.0k | 95 | 45.5k | 5m 29s |
| implement* | MiniMax-M2.7-highspeed | 1 | 245.7k | 5.1k | 413.8k | 29.8k | 37 | 16.2k | 1m 50s |
| fix | claude-opus-4-6 | 1 | 46 | 4.8k | 719.7k | 53.2k | 33 | 40.2k | 4m 20s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 153.0k | 4.7k | 502.9k | 29.7k | 43 | 27.2k | 1m 52s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 35.5k | 1.1k | 175.6k | 29.7k | 13 | 14.8k | 35s |
| **Total** | | | 434.4k | 41.0k | 4.1M | 89.4k | | 220.1k | 23m 50s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 135 | 3064.9 | 119.7 | 37.4 |
| fix | 26 | 27680.2 | 1545.4 | 183.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **161** | 25483.8 | 1366.9 | 254.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 131 | 23.1k | 2.5M | 116.4k | 14m 2s |
| claude-sonnet-4-6 | 1 | 39 | 7.1k | 487.5k | 45.5k | 5m 29s |
| MiniMax-M2.7-highspeed | 3 | 434.2k | 10.8k | 1.1M | 58.2k | 4m 18s |