### PR TITLE
Implementation Plan: Fix API-Simulator Wheel Caching in CI

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,48 @@
+# CI Workflow Constraints
+
+Rules for maintaining `.github/workflows/` files. Enforced for both human and AI contributors.
+
+## setup-uv parameter names
+
+The correct input parameter for pinning the uv version is `version`, not `uv-version`.
+
+```yaml
+# CORRECT
+- uses: astral-sh/setup-uv@v7
+  with:
+    version: "0.9.21"
+
+# WRONG — silently ignored, installs latest uv instead of pinned version
+- uses: astral-sh/setup-uv@v7
+  with:
+    uv-version: "0.9.21"
+```
+
+`uv-version` is an *output* of the action (the resolved installed version), not an input.
+
+## Caching discipline
+
+Jobs that do not run `uv sync` MUST disable setup-uv caching to avoid poisoning the
+wheel cache consumed by downstream jobs:
+
+```yaml
+- uses: astral-sh/setup-uv@v7
+  with:
+    version: "0.9.21"
+    enable-cache: false   # required for jobs that skip uv sync
+```
+
+Jobs that run `uv sync --locked` may omit `enable-cache` (defaults to `auto`, enabled on
+GitHub-hosted runners).
+
+## Rust toolchain scope
+
+`dtolnay/rust-toolchain` is only needed in jobs that compile native Python extensions
+(i.e., jobs that run `uv sync`). Do not add it to preflight, lint, or other utility jobs
+that only run `uv lock --check` or similar commands.
+
+## Lockfile verification
+
+The `preflight` job exists to validate the lockfile early and cheaply. It must NOT install
+the full dependency tree — only `uv lock --check`. Adding `uv sync` to preflight defeats
+the purpose of the job separation.

--- a/.github/workflows/patch-bump-develop.yml
+++ b/.github/workflows/patch-bump-develop.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          uv-version: "0.9.21"
+          version: "0.9.21"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          uv-version: "0.9.21"
+          version: "0.9.21"
 
       - name: Compute new minor version
         id: version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          uv-version: "0.9.21"
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+          version: "0.9.21"
+          enable-cache: false
 
       - name: Verify lockfile is up to date
         run: uv lock --check
@@ -62,7 +60,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          uv-version: "0.9.21"
+          version: "0.9.21"
 
       - name: Install go-task
         uses: arduino/setup-task@v2

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          uv-version: "0.9.21"
+          version: "0.9.21"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -142,14 +142,16 @@ class TestCIWorkflow:
         )
 
     def test_setup_uv_action_has_version_pin(self):
-        """All setup-uv action usages must specify a uv-version pin.
+        """All setup-uv action usages must specify a version pin.
 
-        Without uv-version, astral-sh/setup-uv calls the GitHub API to resolve the
+        Without version, astral-sh/setup-uv calls the GitHub API to resolve the
         latest release on every cache miss. On macOS runners, cache misses are frequent
         (the cache key includes the Python version), causing network timeout failures
         before any uv command runs.
 
-        If this test fails, add 'uv-version: "X.Y.Z"' to all setup-uv steps in tests.yml.
+        If this test fails, add 'version: "X.Y.Z"' to all setup-uv steps in tests.yml.
+        Note: the correct input parameter is 'version', not 'uv-version' — 'uv-version'
+        is an output of the action and is silently ignored as an input.
         """
         workflow = yaml.safe_load(CI_WORKFLOW.read_text())
         for job_name, job in workflow.get("jobs", {}).items():
@@ -157,9 +159,9 @@ class TestCIWorkflow:
                 uses = step.get("uses", "")
                 if "setup-uv" in uses:
                     with_block = step.get("with", {}) or {}
-                    assert "uv-version" in with_block, (
-                        f"CI job '{job_name}' uses {uses!r} without a uv-version pin — "
-                        "add 'uv-version: \"X.Y.Z\"' to prevent GitHub API network failures"
+                    assert "version" in with_block, (
+                        f"CI job '{job_name}' uses {uses!r} without a version pin — "
+                        "add 'version: \"X.Y.Z\"' to prevent GitHub API network failures"
                         " on macOS runner cache misses"
                     )
 

--- a/tests/infra/test_release_workflows.py
+++ b/tests/infra/test_release_workflows.py
@@ -23,13 +23,13 @@ def _load(path: Path) -> dict:
 
 
 def _uv_version_pins(workflow: dict) -> list[str]:
-    """Return all uv-version values declared in setup-uv steps."""
+    """Return all version values declared in setup-uv steps."""
     pins = []
     for job in workflow.get("jobs", {}).values():
         for step in job.get("steps", []):
             uses = step.get("uses", "")
             if "setup-uv" in uses:
-                pins.append(step.get("with", {}).get("uv-version", ""))
+                pins.append(step.get("with", {}).get("version", ""))
     return pins
 
 


### PR DESCRIPTION
## Summary

Four targeted fixes to `.github/workflows/tests.yml` and a new `.github/CLAUDE.md` file:

1. **Cache poisoning elimination** — add `enable-cache: false` to the `setup-uv` step in the `preflight` job. The preflight job runs `uv lock --check` without a full `uv sync`, so its cache entry would be incomplete and poison the wheel cache consumed by the `test` job.
2. **Wrong parameter name** — replace `uv-version` with `version` in both the `preflight` and `test` jobs' `setup-uv@v7` steps. `uv-version` is silently ignored by setup-uv@v7 (it's an output, not an input), causing the action to install the latest uv rather than the pinned `0.9.21`.
3. **Unnecessary Rust toolchain in preflight** — remove `dtolnay/rust-toolchain@stable` from the `preflight` job. Preflight only runs `uv lock --check` and reports versions; it never compiles native extensions. Only the `test` job requires Rust.
4. **Guard rails document** — create `.github/CLAUDE.md` with CI workflow constraints to prevent these bugs from recurring.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
- `.github/CLAUDE.md`

### Modified (●):
- `.github/workflows/patch-bump-develop.yml`
- `.github/workflows/release.yml`
- `.github/workflows/tests.yml`
- `.github/workflows/version-bump.yml`
- `tests/infra/test_ci_dev_config.py`
- `tests/infra/test_release_workflows.py`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/ci-wheel-cache-2135-20260507-082327-879707/.autoskillit/temp/make-plan/ci_wheel_cache_fix_plan_2026-05-07_082600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 99 | 7.0k | 302.5k | 36.0k | 43 | 27.0k | 4m 47s |
| review | claude-sonnet-4-6 | 1 | 6.7k | 6.2k | 155.0k | 68.9k | 160 | 29.5k | 7m 12s |
| verify | claude-sonnet-4-6 | 1 | 92 | 6.6k | 336.2k | 38.0k | 28 | 25.1k | 1m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 127.7k | 3.2k | 297.5k | 29.8k | 31 | 43.1k | 1m 6s |
| fix | claude-sonnet-4-6 | 1 | 182 | 10.1k | 941.4k | 61.6k | 64 | 49.1k | 4m 11s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 49.9k | 2.4k | 175.7k | 29.8k | 15 | 15.3k | 50s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.3k | 1.5k | 175.7k | 29.8k | 14 | 15.1k | 42s |
| review_pr | claude-sonnet-4-6 | 1 | 94 | 21.3k | 389.9k | 53.8k | 34 | 45.0k | 4m 15s |
| **Total** | | | 222.2k | 58.3k | 2.8M | 68.9k | | 249.2k | 24m 59s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 56 | 5313.0 | 769.5 | 57.1 |
| fix | 24 | 39223.9 | 2045.1 | 420.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **80** | 34674.3 | 3115.4 | 728.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 7.1k | 29.8k | 1.7M | 130.8k | 18m 5s |
| MiniMax-M2.7-highspeed | 3 | 215.0k | 7.1k | 649.0k | 73.5k | 2m 38s |