### PR TITLE
fix: exempt subagents via agent_id and fix flag path via ancestor walk

### DIFF
--- a/src/autoskillit/hooks/CLAUDE.md
+++ b/src/autoskillit/hooks/CLAUDE.md
@@ -16,6 +16,7 @@ Sub-packages: guards/ (see guards/CLAUDE.md), formatters/ (see formatters/CLAUDE
 | `token_summary_hook.py` | Appends Token Usage Summary to PR body |
 | `session_start_hook.py` | Injects open-kitchen reminder on resume |
 | `skill_load_post_hook.py` | `PostToolUse`: writes skill-loaded flag for non-Anthropic provider guard |
+| `_hook_utils.py` | Shared stdlib-only utilities for hook scripts (e.g., `find_project_root`) |
 
 ## Architecture Notes
 

--- a/src/autoskillit/hooks/_hook_utils.py
+++ b/src/autoskillit/hooks/_hook_utils.py
@@ -1,0 +1,18 @@
+"""Shared stdlib-only utilities for hook scripts.
+
+Imported by both PreToolUse guards (in guards/) and PostToolUse hooks
+via sys.path bootstrap.  Stdlib-only — no autoskillit imports.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def find_project_root() -> Path:
+    """Walk up from CWD to find nearest ancestor containing .autoskillit/."""
+    cwd = Path.cwd()
+    for ancestor in [cwd, *cwd.parents]:
+        if (ancestor / ".autoskillit").is_dir():
+            return ancestor
+    return cwd

--- a/src/autoskillit/hooks/guards/CLAUDE.md
+++ b/src/autoskillit/hooks/guards/CLAUDE.md
@@ -25,9 +25,24 @@ PreToolUse guard scripts — standalone Python processes enforcing tool-call pol
 | `skill_cmd_guard.py` | Validates `skill_command` path argument format |
 | `skill_command_guard.py` | Blocks `run_skill` with non-slash `skill_command` |
 | `unsafe_install_guard.py` | Blocks `pip install -e` targeting system Python |
-| `skill_load_guard.py` | Denies native tools until Skill tool is called in non-Anthropic headless skill sessions |
+| `skill_load_guard.py` | Denies native tools until Skill tool is called in non-Anthropic headless skill sessions; exempts subagents via `agent_id` |
 | `write_guard.py` | Blocks Write/Edit outside allowed prefix in read-only sessions |
 
 ## Architecture Notes
 
 Each guard is a standalone Python script executed as a subprocess (not imported as a module). Protocol: read PreToolUse JSON from stdin, write decision JSON to stdout, exit 0. Most are stdlib-only for fast startup. Guards fail-open for malformed input. `skill_command_guard.py` has split error handling: malformed JSON fails-open (approve), unexpected runtime errors fail-closed (deny).
+
+## Hook Payload Fields for Guard Development
+
+### `agent_id` — Subagent Detection
+
+Claude Code includes `agent_id` in the hook JSON payload (stdin) when the hook fires
+inside a subagent (L0). The field is absent in top-level sessions. This is the standard
+mechanism for detecting subagent context in hook scripts.
+
+- `agent_id` — present ONLY in subagent context; absent at top-level
+- `agent_type` — also present in subagent context (e.g., `"Explore"`, `"general-purpose"`)
+- Subagents cannot spawn nested subagents, so the check is binary: top-level vs. one-level-deep
+- Check: `if data.get("agent_id"): sys.exit(0)` for unconditional subagent exemption
+
+Used by: `skill_load_guard.py`, `skill_load_post_hook.py`

--- a/src/autoskillit/hooks/guards/skill_load_guard.py
+++ b/src/autoskillit/hooks/guards/skill_load_guard.py
@@ -24,17 +24,13 @@ import os
 import sys
 from pathlib import Path
 
+_HOOKS_DIR = str(Path(__file__).resolve().parent.parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+from _hook_utils import find_project_root  # type: ignore[import-not-found]  # noqa: E402
+
 SKILL_LOAD_DENY_TRIGGER: str = "SKILL LOADING REQUIRED"
-
-
-def _find_project_root() -> Path:
-    """Walk up from CWD to find nearest ancestor containing .autoskillit/."""
-    cwd = Path.cwd()
-    for ancestor in [cwd, *cwd.parents]:
-        if (ancestor / ".autoskillit").is_dir():
-            return ancestor
-    return cwd
-
 
 _DENY_MESSAGE: str = (
     "SKILL LOADING REQUIRED. You MUST call the Skill tool to load the skill "
@@ -69,7 +65,7 @@ def main() -> None:
     if not session_id:
         sys.exit(0)
 
-    flag_path = _find_project_root() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
+    flag_path = find_project_root() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
     if flag_path.exists():
         sys.exit(0)
 

--- a/src/autoskillit/hooks/guards/skill_load_guard.py
+++ b/src/autoskillit/hooks/guards/skill_load_guard.py
@@ -9,6 +9,11 @@ When gated, checks for ``.autoskillit/temp/skill_guard_{session_id}.flag``.
 If absent, denies with a directive message instructing the model to call
 the Skill tool first.
 
+Known limitation: when the model invokes Skill + native tools in a single
+parallel message, the native tools fire PreToolUse before the Skill PostToolUse
+writes the flag. This costs one wasted turn but self-resolves on the next turn.
+This is inherent to the PreToolUse/PostToolUse timing model.
+
 Stdlib-only — no autoskillit imports.
 """
 
@@ -20,6 +25,16 @@ import sys
 from pathlib import Path
 
 SKILL_LOAD_DENY_TRIGGER: str = "SKILL LOADING REQUIRED"
+
+
+def _find_project_root() -> Path:
+    """Walk up from CWD to find nearest ancestor containing .autoskillit/."""
+    cwd = Path.cwd()
+    for ancestor in [cwd, *cwd.parents]:
+        if (ancestor / ".autoskillit").is_dir():
+            return ancestor
+    return cwd
+
 
 _DENY_MESSAGE: str = (
     "SKILL LOADING REQUIRED. You MUST call the Skill tool to load the skill "
@@ -37,6 +52,9 @@ def main() -> None:
     except Exception:
         sys.exit(0)
 
+    if data.get("agent_id"):
+        sys.exit(0)
+
     profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE", "").strip()
     if not profile or profile.casefold() == "anthropic":
         sys.exit(0)
@@ -51,7 +69,7 @@ def main() -> None:
     if not session_id:
         sys.exit(0)
 
-    flag_path = Path.cwd() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
+    flag_path = _find_project_root() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
     if flag_path.exists():
         sys.exit(0)
 

--- a/src/autoskillit/hooks/skill_load_post_hook.py
+++ b/src/autoskillit/hooks/skill_load_post_hook.py
@@ -69,8 +69,8 @@ def main() -> None:
     flag_path = _find_project_root() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
     try:
         _atomic_write(flag_path, skill_name)
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"skill_load_post_hook: failed to write flag {flag_path}: {exc}", file=sys.stderr)
 
     marker = os.environ.get("AUTOSKILLIT_COMPLETION_MARKER", "").strip()
     if marker:

--- a/src/autoskillit/hooks/skill_load_post_hook.py
+++ b/src/autoskillit/hooks/skill_load_post_hook.py
@@ -17,14 +17,11 @@ import sys
 import tempfile
 from pathlib import Path
 
+_HOOKS_DIR = str(Path(__file__).resolve().parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
 
-def _find_project_root() -> Path:
-    """Walk up from CWD to find nearest ancestor containing .autoskillit/."""
-    cwd = Path.cwd()
-    for ancestor in [cwd, *cwd.parents]:
-        if (ancestor / ".autoskillit").is_dir():
-            return ancestor
-    return cwd
+from _hook_utils import find_project_root  # type: ignore[import-not-found]  # noqa: E402
 
 
 def _atomic_write(path: Path, content: str) -> None:
@@ -66,7 +63,7 @@ def main() -> None:
     if not session_id:
         sys.exit(0)
 
-    flag_path = _find_project_root() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
+    flag_path = find_project_root() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
     try:
         _atomic_write(flag_path, skill_name)
     except Exception as exc:

--- a/src/autoskillit/hooks/skill_load_post_hook.py
+++ b/src/autoskillit/hooks/skill_load_post_hook.py
@@ -18,6 +18,15 @@ import tempfile
 from pathlib import Path
 
 
+def _find_project_root() -> Path:
+    """Walk up from CWD to find nearest ancestor containing .autoskillit/."""
+    cwd = Path.cwd()
+    for ancestor in [cwd, *cwd.parents]:
+        if (ancestor / ".autoskillit").is_dir():
+            return ancestor
+    return cwd
+
+
 def _atomic_write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
@@ -41,6 +50,9 @@ def main() -> None:
     except Exception:
         sys.exit(0)
 
+    if data.get("agent_id"):
+        sys.exit(0)
+
     if not os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE", "").strip():
         sys.exit(0)
 
@@ -54,7 +66,7 @@ def main() -> None:
     if not session_id:
         sys.exit(0)
 
-    flag_path = Path.cwd() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
+    flag_path = _find_project_root() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
     try:
         _atomic_write(flag_path, skill_name)
     except Exception:

--- a/src/autoskillit/hooks/skill_load_post_hook.py
+++ b/src/autoskillit/hooks/skill_load_post_hook.py
@@ -67,7 +67,7 @@ def main() -> None:
     try:
         _atomic_write(flag_path, skill_name)
     except Exception as exc:
-        print(f"skill_load_post_hook: failed to write flag {flag_path}: {exc}", file=sys.stderr)
+        sys.stderr.write(f"skill_load_post_hook: failed to write flag {flag_path}: {exc}\n")
 
     marker = os.environ.get("AUTOSKILLIT_COMPLETION_MARKER", "").strip()
     if marker:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -783,6 +783,8 @@ def test_no_subpackage_exceeds_10_files() -> None:
         and review_loop_gate.py add the review gate enforcement hooks. recipe_write_advisor.py
         adds a non-blocking advisory hook for recipe YAML writes. write_guard.py
         blocks Write/Edit outside the allowed prefix in read-only skill sessions.
+        _hook_utils.py provides shared stdlib-only utilities (e.g., find_project_root)
+        for hook scripts that need common path resolution logic.
         Exempt at 28 files.
       pipeline/ — REQ-CNST-003-E7: pipeline/ added github_api_log.py for session-scoped
         GitHub API request tracking (DefaultGitHubApiLog accumulator + GitHubApiEntry).
@@ -802,7 +804,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "core": 20,
         "core/types": 16,
         "cli": 20,
-        "hooks": 9,
+        "hooks": 10,
         "pipeline": 12,
         "fleet": 15,
         "recipe/rules": 29,

--- a/tests/hooks/test_skill_load_post_hook.py
+++ b/tests/hooks/test_skill_load_post_hook.py
@@ -196,9 +196,8 @@ def test_skips_flag_write_when_agent_id_present(tmp_path: Path) -> None:
         provider_profile="minimax",
     )
     flag_dir = tmp_path / ".autoskillit" / "temp"
-    if flag_dir.exists():
-        flags = list(flag_dir.glob("skill_guard_*.flag"))
-        assert not flags, "No flag file should be created in subagent context"
+    flags = list(flag_dir.glob("skill_guard_*.flag"))
+    assert not flags, "No flag file should be created in subagent context"
 
 
 def test_writes_flag_to_project_root_via_ancestor_walk(tmp_path: Path) -> None:

--- a/tests/hooks/test_skill_load_post_hook.py
+++ b/tests/hooks/test_skill_load_post_hook.py
@@ -51,17 +51,23 @@ def _run_hook(
 
 
 def _make_skill_event(
-    session_id: str = "abc123", skill: str = "implement-worktree-no-merge"
+    session_id: str = "abc123",
+    skill: str = "implement-worktree-no-merge",
+    agent_id: str | None = None,
 ) -> dict:
-    return {
+    event = {
         "tool_name": "Skill",
         "tool_input": {"skill": skill},
         "session_id": session_id,
     }
+    if agent_id is not None:
+        event["agent_id"] = agent_id
+    return event
 
 
 def test_writes_flag_when_provider_profile_set(tmp_path: Path) -> None:
     """T1-1: Flag file written with skill name when provider profile is set."""
+    (tmp_path / ".autoskillit").mkdir(parents=True)
     _run_hook(
         stdin_data=_make_skill_event(),
         tmp_dir=tmp_path,
@@ -180,3 +186,32 @@ def test_emits_additional_context_when_completion_marker_set(tmp_path: Path) -> 
     payload = json.loads(stdout)
     assert "additionalContext" in payload
     assert marker in payload["additionalContext"]
+
+
+def test_skips_flag_write_when_agent_id_present(tmp_path: Path) -> None:
+    """T1-7: No flag written when agent_id is present (subagent context)."""
+    _run_hook(
+        stdin_data=_make_skill_event(agent_id="agent-uuid-123"),
+        tmp_dir=tmp_path,
+        provider_profile="minimax",
+    )
+    flag_dir = tmp_path / ".autoskillit" / "temp"
+    if flag_dir.exists():
+        flags = list(flag_dir.glob("skill_guard_*.flag"))
+        assert not flags, "No flag file should be created in subagent context"
+
+
+def test_writes_flag_to_project_root_via_ancestor_walk(tmp_path: Path) -> None:
+    """T1-8: Flag written to project root when CWD is a subdirectory."""
+    project = tmp_path / "project"
+    (project / ".autoskillit").mkdir(parents=True)
+
+    deep_cwd = project / "sub" / "deep"
+    _run_hook(
+        stdin_data=_make_skill_event(),
+        tmp_dir=deep_cwd,
+        provider_profile="minimax",
+    )
+    flag = project / ".autoskillit" / "temp" / "skill_guard_abc123.flag"
+    assert flag.exists(), "Flag must be written to project root, not CWD"
+    assert "implement-worktree-no-merge" in flag.read_text()

--- a/tests/infra/test_skill_load_guard.py
+++ b/tests/infra/test_skill_load_guard.py
@@ -64,12 +64,17 @@ def _run_guard(
         return buf.getvalue()
 
 
-def _make_event(tool_name: str = "Read", session_id: str = "abc123") -> dict:
-    return {
+def _make_event(
+    tool_name: str = "Read", session_id: str = "abc123", agent_id: str | None = None
+) -> dict:
+    event = {
         "tool_name": tool_name,
         "tool_input": {"file_path": "/foo"},
         "session_id": session_id,
     }
+    if agent_id is not None:
+        event["agent_id"] = agent_id
+    return event
 
 
 def _create_flag(
@@ -206,3 +211,60 @@ def test_allows_silently_for_anthropic_case_insensitive(tmp_path):
         session_type="skill",
     )
     assert not out.strip()
+
+
+def test_allows_when_agent_id_present(tmp_path):
+    """T2-11: Subagent exemption — allow when agent_id is in payload."""
+    out = _run_guard(
+        _make_event("Read", agent_id="agent-uuid-123"),
+        tmp_dir=tmp_path,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+    )
+    assert not out.strip()
+
+
+def test_denies_when_agent_id_is_empty_string(tmp_path):
+    """T2-12: Empty agent_id is falsy — guard proceeds normally."""
+    out = _run_guard(
+        _make_event("Read", agent_id=""),
+        tmp_dir=tmp_path,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+    )
+    response = json.loads(out)
+    assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_flag_found_via_ancestor_walk_when_cwd_is_subdirectory(tmp_path):
+    """T2-13: Flag at project root found when CWD is a subdirectory."""
+    project = tmp_path / "project"
+    flag_dir = project / ".autoskillit" / "temp"
+    flag_dir.mkdir(parents=True)
+    (flag_dir / "skill_guard_abc123.flag").write_text("make-plan")
+
+    deep_cwd = project / "sub" / "deep"
+    out = _run_guard(
+        _make_event("Read"),
+        tmp_dir=deep_cwd,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+    )
+    assert not out.strip()
+
+
+def test_denies_when_no_autoskillit_dir_in_ancestors(tmp_path):
+    """T2-14: Deny when no .autoskillit/ found in any ancestor (fallback to CWD)."""
+    bare_dir = tmp_path / "bare" / "dir"
+    out = _run_guard(
+        _make_event("Read"),
+        tmp_dir=bare_dir,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+    )
+    response = json.loads(out)
+    assert response["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/tests/recipe/test_io_json_precompile.py
+++ b/tests/recipe/test_io_json_precompile.py
@@ -216,5 +216,6 @@ def test_bundled_json_files_are_fresh():
         json_data = json.loads(json_path.read_text(encoding="utf-8"))
         assert json_data == yaml_data, f"JSON is stale for {yaml_path.name}"
         assert json_path.stat().st_mtime_ns > yaml_path.stat().st_mtime_ns, (
-            f"JSON mtime is older than YAML mtime for {yaml_path.name} — fast-path would be bypassed"
+            f"JSON mtime is older than YAML mtime for {yaml_path.name}"
+            " — fast-path would be bypassed"
         )


### PR DESCRIPTION
## Summary

The `skill_load_guard.py` PreToolUse hook permanently blocks L0 subagents because they inherit `SESSION_TYPE=skill` but get a new `session_id`, causing the flag file lookup to fail. Additionally, `Path.cwd()` as the flag path root breaks when sessions run with a non-standard working directory. Fix: add `agent_id` early-exit in both the guard and post hook, and replace `Path.cwd()` with a stdlib-only ancestor walk to find the nearest `.autoskillit/` directory. The parallel batch race (Skill + Read in same message) is documented as a known limitation inherent to the PreToolUse/PostToolUse timing model.

## Requirements

## Requirements

## Problem

`skill_load_guard.py` uses a flag file (`.autoskillit/temp/skill_guard_{session_id}.flag`) to track whether a skill has been loaded. The flag is written by the PostToolUse hook AFTER the Skill tool call completes. But parallel native tool calls (Read, Bash, Grep, Glob) fire their PreToolUse hooks BEFORE the PostToolUse flag-write completes, so they get denied in the gap.

This causes three distinct failure modes:

### 1. Parallel batch cancellation

When the AI invokes Skill + Read/Bash/Grep in the same parallel message, the native tools fire PreToolUse before the Skill PostToolUse writes the flag. All parallel native tools are denied and cancelled.

### 2. L0 subagents permanently blocked

L0 subagents inherit `SESSION_TYPE=skill` and `AUTOSKILLIT_HEADLESS=1` but never call the Skill tool. Their flag is never written. The guard fires on EVERY tool call in every L0 subagent.

### 3. CWD mismatch causes permanent flag lookup failure

The guard computes `flag_path = Path.cwd() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"`. If the session runs with a non-standard CWD, the flag is written to the project's `.autoskillit/temp/` but looked up in the wrong directory.

## Acceptance Criteria

- [ ] L0 subagents are never blocked by the skill-loading guard (via `agent_id` check)
- [ ] `agent_id` check added to both `skill_load_guard.py` and `skill_load_post_hook.py`
- [ ] Tests added for the `agent_id` exemption path in both hooks
- [ ] Flag path resolution uses project root instead of `Path.cwd()`
- [ ] Tests added for CWD mismatch scenario
- [ ] Documentation added about `agent_id` as the standard subagent detection mechanism for hook scripts
- [ ] Parallel batch race documented as known limitation (not a code fix)
- [ ] Existing tests pass

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-083107-175207/.autoskillit/temp/make-plan/skill_loading_guard_race_condition_plan_2026-05-07_083300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.9k | 16.2k | 787.7k | 71.7k | 83 | 58.5k | 6m 51s |
| verify | claude-opus-4-6 | 1 | 33 | 7.1k | 188.3k | 51.2k | 33 | 40.7k | 3m 10s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.4M | 33.9k | 1.9M | 29.7k | 165 | 67.6k | 15m 30s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 112.2k | 3.0k | 294.7k | 29.8k | 20 | 15.2k | 1m 15s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 114.7k | 2.3k | 294.7k | 29.8k | 23 | 15.0k | 1m 3s |
| review_pr | claude-sonnet-4-6 | 2 | 208 | 69.6k | 1.2M | 85.1k | 78 | 129.0k | 13m 33s |
| resolve_review | claude-opus-4-6 | 3 | 152 | 58.3k | 3.3M | 93.1k | 167 | 279.5k | 29m 18s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 155 | 6.2k | 666.7k | 46.0k | 44 | 33.0k | 2m 31s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 93.8k | 1.5k | 226.6k | 28.7k | 18 | 14.9k | 49s |
| resolve_ci | claude-opus-4-6 | 1 | 53 | 5.6k | 1.6M | 77.4k | 49 | 64.4k | 7m 3s |
| resolve_queue_merge_conflicts | claude-sonnet-4-6 | 1 | 203 | 8.8k | 990.4k | 52.0k | 52 | 39.2k | 2m 47s |
| **Total** | | | 2.7M | 212.5k | 11.5M | 93.1k | | 757.0k | 1h 23m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 156 | 12186.5 | 433.2 | 217.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 85 | 38808.1 | 3287.7 | 685.7 |
| ci_conflict_fix | 650 | 1025.7 | 50.8 | 9.5 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 6 | 266104.8 | 10733.3 | 941.2 |
| resolve_queue_merge_conflicts | 29602 | 33.5 | 1.3 | 0.3 |
| **Total** | **30499** | 376.2 | 24.8 | 7.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 3.2k | 18.0k | 666.7k | 50.6k | 7m 38s |
| claude-opus-4-6 | 1 | 1.3k | 10.3k | 1.5M | 56.4k | 6m 19s |