### PR TITLE
perf: lazy-import igraph inside build_recipe_graph

### DIFF
--- a/src/autoskillit/recipe/_analysis_graph.py
+++ b/src/autoskillit/recipe/_analysis_graph.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import igraph
 
 from autoskillit.core import get_logger
 from autoskillit.recipe.schema import _TERMINAL_TARGETS, Recipe, RecipeStep

--- a/src/autoskillit/recipe/_analysis_graph.py
+++ b/src/autoskillit/recipe/_analysis_graph.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import dataclasses
 
-import igraph
-
 from autoskillit.core import get_logger
 from autoskillit.recipe.schema import _TERMINAL_TARGETS, Recipe, RecipeStep
 
@@ -70,6 +68,8 @@ def build_recipe_graph(recipe: Recipe) -> igraph.Graph:
     Returns:
         A directed ``igraph.Graph`` with vertex and edge attributes as described.
     """
+    import igraph  # noqa: PLC0415
+
     step_names = list(recipe.steps.keys())
     name_to_id: dict[str, int] = {name: i for i, name in enumerate(step_names)}
 

--- a/tests/recipe/test_api_split.py
+++ b/tests/recipe/test_api_split.py
@@ -63,6 +63,10 @@ def test_analysis_graph_no_toplevel_igraph_import():
 
     src_file = Path(_analysis_graph_mod.__file__)
     tree = ast.parse(src_file.read_text())
+    # iter_child_nodes only visits direct children of the module node — it does not
+    # recurse into nested try/except or if-blocks. A top-level try/except ImportError
+    # wrapping igraph would be missed, but that edge case would also defeat the lazy-import
+    # purpose (module-load overhead at import time), so the coverage is intentionally scoped.
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:

--- a/tests/recipe/test_api_split.py
+++ b/tests/recipe/test_api_split.py
@@ -53,3 +53,29 @@ def test_recipe_init_surface_unchanged():
     )
 
     assert callable(make_validation_context)
+
+
+def test_analysis_graph_no_toplevel_igraph_import():
+    import ast
+    from pathlib import Path
+
+    src_file = (
+        Path(__file__).parent.parent.parent
+        / "src"
+        / "autoskillit"
+        / "recipe"
+        / "_analysis_graph.py"
+    )
+    tree = ast.parse(src_file.read_text())
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "igraph", (
+                    f"Top-level 'import igraph' found at line {node.lineno}; "
+                    "must be a function-level import inside build_recipe_graph()"
+                )
+        if isinstance(node, ast.ImportFrom) and (node.module or "").split(".")[0] == "igraph":
+            assert False, (
+                f"Top-level 'from {node.module} import ...' found at line {node.lineno}; "
+                "igraph must only be imported inside build_recipe_graph()"
+            )

--- a/tests/recipe/test_api_split.py
+++ b/tests/recipe/test_api_split.py
@@ -59,13 +59,9 @@ def test_analysis_graph_no_toplevel_igraph_import():
     import ast
     from pathlib import Path
 
-    src_file = (
-        Path(__file__).parent.parent.parent
-        / "src"
-        / "autoskillit"
-        / "recipe"
-        / "_analysis_graph.py"
-    )
+    import autoskillit.recipe._analysis_graph as _analysis_graph_mod
+
+    src_file = Path(_analysis_graph_mod.__file__)
     tree = ast.parse(src_file.read_text())
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.Import):


### PR DESCRIPTION
## Summary

Move the top-level `import igraph` in `src/autoskillit/recipe/_analysis_graph.py` to a function-level import inside `build_recipe_graph()`. This eliminates 59ms of import latency from every xdist worker that touches the `recipe` package for validation — igraph is only needed for diagram rendering, not for the pure-Python step graph, routing edge extraction, or infrastructure step classification that validation uses.

The file already has `from __future__ import annotations` (line 3), so the return type annotation `-> igraph.Graph` on `build_recipe_graph` remains valid without runtime evaluation of the `igraph` name at module load.

Closes #2139

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-2139-20260507-075812-798702/.autoskillit/temp/make-plan/perf_lazy_import_igraph_plan_2026-05-07_080300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 70 | 6.2k | 585.6k | 53.0k | 63 | 43.2k | 5m 13s |
| verify | claude-opus-4-6 | 1 | 41 | 7.5k | 571.3k | 56.5k | 68 | 70.7k | 6m 4s |
| implement* | MiniMax-M2.7-highspeed | 1 | 242.1k | 5.0k | 508.3k | 35.1k | 43 | 26.1k | 6m 4s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 66.7k | 3.1k | 235.2k | 29.8k | 21 | 15.3k | 1m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 36.7k | 1.5k | 175.7k | 29.8k | 13 | 15.1k | 48s |
| review_pr | claude-sonnet-4-6 | 1 | 187 | 9.3k | 290.1k | 41.3k | 26 | 31.0k | 2m 16s |
| resolve_review | claude-sonnet-4-6 | 1 | 223 | 13.1k | 1.3M | 63.3k | 65 | 87.8k | 5m 34s |
| **Total** | | | 346.1k | 45.7k | 3.6M | 63.3k | | 289.1k | 27m 23s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 30 | 16941.9 | 870.5 | 166.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 18 | 70675.0 | 4876.1 | 728.9 |
| **Total** | **48** | 75796.7 | 6022.0 | 952.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 111 | 13.8k | 1.2M | 113.8k | 11m 18s |
| MiniMax-M2.7-highspeed | 3 | 345.6k | 9.6k | 919.1k | 56.4k | 8m 14s |