### PR TITLE
Rectify: Merge Failure Domain Routing — Rebase Misrouted to resolve-failures

### DIFF
--- a/src/autoskillit/recipe/rules/rules_merge.py
+++ b/src/autoskillit/recipe/rules/rules_merge.py
@@ -36,6 +36,18 @@ _RECOVERABLE_FAILED_STEPS: frozenset[str] = frozenset(
     }
 )
 
+_MERGE_FAILURE_DOMAINS: dict[str, str] = {
+    MergeFailedStep.DIRTY_TREE: "code",
+    MergeFailedStep.TEST_GATE: "code",
+    MergeFailedStep.POST_REBASE_TEST_GATE: "code",
+    MergeFailedStep.REBASE: "git_conflict",
+}
+
+_REQUIRED_SKILL_BY_DOMAIN: dict[str, str] = {
+    "code": "resolve-failures",
+    "git_conflict": "resolve-merge-conflicts",
+}
+
 _FAILED_STEP_PATTERN = re.compile(r"result\.failed_step\s*==\s*['\"](\w+)['\"]")
 
 
@@ -80,6 +92,68 @@ def _check_merge_routing_completeness(ctx: ValidationContext) -> list[RuleFindin
                     ),
                 )
             )
+    return findings
+
+
+_SKILL_CMD_PATTERN = re.compile(r"/(?:autoskillit:)?([\w-]+)")
+
+
+@semantic_rule(
+    name="merge-failure-skill-domain-mismatch",
+    description=(
+        "A merge_worktree on_result condition routes a recoverable failed_step to a "
+        "step whose skill does not match the failure domain. Git-conflict failures "
+        "(rebase) must route to resolve-merge-conflicts; code failures (dirty_tree, "
+        "test_gate, post_rebase_test_gate) must route to resolve-failures."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_merge_failure_skill_domain_mismatch(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "merge_worktree":
+            continue
+        if not step.on_result or not step.on_result.conditions:
+            continue
+
+        for condition in step.on_result.conditions:
+            if condition.when is None:
+                continue
+            m = _FAILED_STEP_PATTERN.search(condition.when)
+            if not m:
+                continue
+            failed_step_value = m.group(1)
+            domain = _MERGE_FAILURE_DOMAINS.get(failed_step_value)
+            if domain is None:
+                continue
+
+            target_step = ctx.recipe.steps.get(condition.route)
+            if target_step is None or target_step.tool != "run_skill":
+                continue
+
+            skill_cmd = target_step.with_args.get("skill_command", "")
+            skill_match = _SKILL_CMD_PATTERN.search(skill_cmd)
+            if not skill_match:
+                continue
+            actual_skill = skill_match.group(1)
+
+            required_skill = _REQUIRED_SKILL_BY_DOMAIN[domain]
+            if actual_skill != required_skill:
+                findings.append(
+                    RuleFinding(
+                        rule="merge-failure-skill-domain-mismatch",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"failed_step == '{failed_step_value}' (domain: {domain}) "
+                            f"routes to step '{condition.route}' which invokes "
+                            f"'{actual_skill}', but {domain} failures require "
+                            f"'{required_skill}'."
+                        ),
+                    )
+                )
     return findings
 
 

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -312,7 +312,7 @@ steps:
       - when: "result.failed_step == 'post_rebase_test_gate'"
         route: fix
       - when: "result.failed_step == 'rebase'"
-        route: fix
+        route: rebase_conflict_fix
       - when: "result.error"
         route: release_issue_failure
       - route: next_or_done
@@ -366,6 +366,24 @@ steps:
     on_failure: release_issue_failure
     on_context_limit: test
     note: "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
+
+  rebase_conflict_fix:
+    tool: run_skill
+    model: ""
+    with:
+      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: "rebase_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
+    on_result:
+      - when: "${{ result.escalation_required }} == true"
+        route: release_issue_failure
+      - route: test
+    on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
 
   next_or_done:
     action: route

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -312,7 +312,7 @@ steps:
       - when: "result.failed_step == 'post_rebase_test_gate'"
         route: fix
       - when: "result.failed_step == 'rebase'"
-        route: fix
+        route: rebase_conflict_fix
       - when: "result.error"
         route: release_issue_failure
       - route: next_or_done
@@ -362,6 +362,24 @@ steps:
     on_failure: release_issue_failure
     on_context_limit: test
     note: "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
+
+  rebase_conflict_fix:
+    tool: run_skill
+    model: ""
+    with:
+      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: "rebase_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
+    on_result:
+      - when: "${{ result.escalation_required }} == true"
+        route: release_issue_failure
+      - route: test
+    on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
 
   next_or_done:
     action: route

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -319,6 +319,24 @@ steps:
     on_failure: release_issue_failure
     on_exhausted: release_issue_failure
 
+  rebase_conflict_fix:
+    tool: run_skill
+    model: ""
+    with:
+      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: "rebase_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
+    on_result:
+      - when: "${{ result.escalation_required }} == true"
+        route: release_issue_failure
+      - route: test
+    on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
+
   audit_impl:
     tool: run_skill
     model: ""
@@ -389,7 +407,7 @@ steps:
       - when: "result.failed_step == 'post_rebase_test_gate'"
         route: assess
       - when: "result.failed_step == 'rebase'"
-        route: assess
+        route: rebase_conflict_fix
       - when: "result.error"
         route: release_issue_failure
       - route: next_or_done

--- a/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
@@ -43,9 +43,9 @@ hooks:
 
 - Called by queue-ejection, direct-merge, immediate-merge, and CI-conflict paths
   when `merge_worktree` fails with `failed_step=rebase` and `state=worktree_intact_rebase_aborted`
-- Called by the `rebase_conflict_fix` step in ``implementation.yaml``,
-  ``implementation-groups.yaml``, and ``remediation.yaml`` when ``merge_worktree`` returns
-  ``failed_step == 'rebase'``
+- Called by the `rebase_conflict_fix` step in `implementation.yaml`,
+  `implementation-groups.yaml`, and `remediation.yaml` when `merge_worktree` returns
+  `failed_step == 'rebase'`
 - The worktree must still be intact (rebase aborted cleanly, no partial state)
 
 ## Workflow

--- a/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
@@ -41,8 +41,11 @@ hooks:
 
 ## When to Use
 
-- Called by the `merge-prs` when `merge_worktree` fails with
-  `failed_step=rebase` and `state=worktree_intact_rebase_aborted`
+- Called by queue-ejection, direct-merge, immediate-merge, and CI-conflict paths
+  when `merge_worktree` fails with `failed_step=rebase` and `state=worktree_intact_rebase_aborted`
+- Called by the `rebase_conflict_fix` step in ``implementation.yaml``,
+  ``implementation-groups.yaml``, and ``remediation.yaml`` when ``merge_worktree`` returns
+  ``failed_step == 'rebase'``
 - The worktree must still be intact (rebase aborted cleanly, no partial state)
 
 ## Workflow

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -112,6 +112,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_merge_base_unpublished.py` | Tests for merge_base_unpublished semantic validation rule |
 | `test_rules_merge_queue_push.py` | Tests for merge_queue_push semantic validation rule |
 | `test_rules_merge_routing_incomplete.py` | Tests for merge_routing_incomplete semantic validation rule |
+| `test_rules_merge_failure_domain.py` | Tests for merge-failure-skill-domain-mismatch semantic validation rule |
 | `test_rules_multipart_iteration.py` | Tests for multipart_iteration semantic validation rule |
 | `test_rules_on_context_limit.py` | Tests for on_context_limit semantic validation rule |
 | `test_rules_on_result_failure_route.py` | Tests for on_result_failure_route semantic validation rule |

--- a/tests/recipe/test_rules_integration_predicate.py
+++ b/tests/recipe/test_rules_integration_predicate.py
@@ -38,7 +38,7 @@ class TestRecipeIntegrationPredicateRouting:
 
         cond3 = step.on_result.conditions[3]
         assert cond3.when == "result.failed_step == 'rebase'"
-        assert cond3.route == "assess"
+        assert cond3.route == "rebase_conflict_fix"
 
         cond4 = step.on_result.conditions[4]
         assert cond4.when == "result.error"
@@ -74,7 +74,7 @@ class TestRecipeIntegrationPredicateRouting:
 
         cond3 = step.on_result.conditions[3]
         assert cond3.when == "result.failed_step == 'rebase'"
-        assert cond3.route == "fix"
+        assert cond3.route == "rebase_conflict_fix"
 
         cond4 = step.on_result.conditions[4]
         assert cond4.when == "result.error"

--- a/tests/recipe/test_rules_merge_failure_domain.py
+++ b/tests/recipe/test_rules_merge_failure_domain.py
@@ -172,11 +172,14 @@ class TestBundledRecipesPassFailureDomainCheck:
         merge_step = recipe.steps[merge_step_name]
         if merge_step.on_result is None or not merge_step.on_result.conditions:
             pytest.skip("merge step has no on_result conditions")
+        found_rebase = False
         for cond in merge_step.on_result.conditions:
             if cond.when and "rebase" in cond.when and "post_rebase" not in cond.when:
+                found_rebase = True
                 target_step = recipe.steps[cond.route]
                 skill_cmd = target_step.with_args.get("skill_command", "")
                 assert "resolve-merge-conflicts" in skill_cmd, (
                     f"{recipe_name}: rebase routes to '{cond.route}' which invokes "
                     f"'{skill_cmd}', expected resolve-merge-conflicts"
                 )
+        assert found_rebase, f"{recipe_name}: no rebase condition found in merge step"

--- a/tests/recipe/test_rules_merge_failure_domain.py
+++ b/tests/recipe/test_rules_merge_failure_domain.py
@@ -143,10 +143,38 @@ class TestMergeFailureSkillDomainMismatch:
 class TestBundledRecipesPassFailureDomainCheck:
     """Integration tests: bundled recipes pass the new rule."""
 
-    def test_bundled_recipes_pass_failure_domain_skill_check(self):
+    @pytest.mark.parametrize(
+        "recipe_name",
+        ["implementation", "remediation", "implementation-groups"],
+    )
+    def test_bundled_recipes_pass_failure_domain_skill_check(self, recipe_name):
         """All three merge_worktree recipes route rebase to resolve-merge-conflicts."""
-        pytest.skip("Recipe YAML fixes are pending — run after step 2c/2d/2e")
+        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-    def test_rebase_routes_to_merge_conflict_skill(self):
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.rule == "merge-failure-skill-domain-mismatch"]
+        assert errors == [], f"{recipe_name}: {[e.message for e in errors]}"
+
+    @pytest.mark.parametrize(
+        "recipe_name,merge_step_name",
+        [
+            ("implementation", "merge"),
+            ("remediation", "merge"),
+            ("implementation-groups", "merge"),
+        ],
+    )
+    def test_rebase_routes_to_merge_conflict_skill(self, recipe_name, merge_step_name):
         """rebase condition in each recipe routes to a step invoking resolve-merge-conflicts."""
-        pytest.skip("Recipe YAML fixes are pending — run after step 2c/2d/2e")
+        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        merge_step = recipe.steps[merge_step_name]
+        for cond in merge_step.on_result.conditions:
+            if cond.when and "rebase" in cond.when and "post_rebase" not in cond.when:
+                target_step = recipe.steps[cond.route]
+                skill_cmd = target_step.with_args.get("skill_command", "")
+                assert "resolve-merge-conflicts" in skill_cmd, (
+                    f"{recipe_name}: rebase routes to '{cond.route}' which invokes "
+                    f"'{skill_cmd}', expected resolve-merge-conflicts"
+                )

--- a/tests/recipe/test_rules_merge_failure_domain.py
+++ b/tests/recipe/test_rules_merge_failure_domain.py
@@ -1,0 +1,152 @@
+import pytest
+
+from autoskillit.recipe.validator import run_semantic_rules
+from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestMergeFailureSkillDomainMismatch:
+    """Tests for the merge-failure-skill-domain-mismatch semantic rule."""
+
+    def test_rebase_routed_to_resolve_failures_fires(self):
+        """ERROR when failed_step == 'rebase' routes to resolve-failures."""
+        recipe = _make_workflow(
+            {
+                "merge": {
+                    "tool": "merge_worktree",
+                    "with": {"worktree_path": "/tmp/wt", "base_branch": "main"},
+                    "on_result": [
+                        {"when": "result.failed_step == 'dirty_tree'", "route": "fix"},
+                        {"when": "result.failed_step == 'test_gate'", "route": "fix"},
+                        {"when": "result.failed_step == 'post_rebase_test_gate'", "route": "fix"},
+                        {"when": "result.failed_step == 'rebase'", "route": "fix"},
+                        {"when": "result.error", "route": "escalate"},
+                        {"route": "done"},
+                    ],
+                },
+                "fix": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": "/autoskillit:resolve-failures /tmp/wt /tmp/plan main"
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+                "escalate": {"action": "stop", "message": "Escalate."},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.rule == "merge-failure-skill-domain-mismatch"]
+        assert len(errors) == 1
+        assert "rebase" in errors[0].message
+        assert "resolve-merge-conflicts" in errors[0].message
+
+    def test_rebase_routed_to_resolve_merge_conflicts_is_clean(self):
+        """No finding when rebase routes to resolve-merge-conflicts."""
+        recipe = _make_workflow(
+            {
+                "merge": {
+                    "tool": "merge_worktree",
+                    "with": {"worktree_path": "/tmp/wt", "base_branch": "main"},
+                    "on_result": [
+                        {"when": "result.failed_step == 'dirty_tree'", "route": "fix"},
+                        {"when": "result.failed_step == 'test_gate'", "route": "fix"},
+                        {"when": "result.failed_step == 'post_rebase_test_gate'", "route": "fix"},
+                        {"when": "result.failed_step == 'rebase'", "route": "rebase_fix"},
+                        {"when": "result.error", "route": "escalate"},
+                        {"route": "done"},
+                    ],
+                },
+                "fix": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": "/autoskillit:resolve-failures /tmp/wt /tmp/plan main"
+                    },
+                    "on_success": "done",
+                },
+                "rebase_fix": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": "/autoskillit:resolve-merge-conflicts /tmp/wt /tmp/plan main"
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+                "escalate": {"action": "stop", "message": "Escalate."},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.rule == "merge-failure-skill-domain-mismatch"]
+        assert errors == []
+
+    def test_code_failure_routed_to_resolve_merge_conflicts_fires(self):
+        """ERROR when dirty_tree routes to resolve-merge-conflicts."""
+        recipe = _make_workflow(
+            {
+                "merge": {
+                    "tool": "merge_worktree",
+                    "with": {"worktree_path": "/tmp/wt", "base_branch": "main"},
+                    "on_result": [
+                        {"when": "result.failed_step == 'dirty_tree'", "route": "conflict_fix"},
+                        {"when": "result.failed_step == 'test_gate'", "route": "fix"},
+                        {"when": "result.failed_step == 'post_rebase_test_gate'", "route": "fix"},
+                        {"when": "result.failed_step == 'rebase'", "route": "conflict_fix"},
+                        {"when": "result.error", "route": "escalate"},
+                        {"route": "done"},
+                    ],
+                },
+                "fix": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": "/autoskillit:resolve-failures /tmp/wt /tmp/plan main"
+                    },
+                    "on_success": "done",
+                },
+                "conflict_fix": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": "/autoskillit:resolve-merge-conflicts /tmp/wt /tmp/plan main"
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+                "escalate": {"action": "stop", "message": "Escalate."},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.rule == "merge-failure-skill-domain-mismatch"]
+        assert len(errors) == 1
+        assert "dirty_tree" in errors[0].message
+        assert "resolve-failures" in errors[0].message
+
+    def test_rule_does_not_fire_for_non_merge_worktree(self):
+        """Rule is scoped to merge_worktree steps only."""
+        recipe = _make_workflow(
+            {
+                "run": {
+                    "tool": "run_skill",
+                    "with": {"skill_command": "/autoskillit:implement-worktree /tmp/wt"},
+                    "on_result": [
+                        {"when": "result.error", "route": "done"},
+                        {"route": "done"},
+                    ],
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.rule == "merge-failure-skill-domain-mismatch"]
+        assert errors == []
+
+
+class TestBundledRecipesPassFailureDomainCheck:
+    """Integration tests: bundled recipes pass the new rule."""
+
+    def test_bundled_recipes_pass_failure_domain_skill_check(self):
+        """All three merge_worktree recipes route rebase to resolve-merge-conflicts."""
+        pytest.skip("Recipe YAML fixes are pending — run after step 2c/2d/2e")
+
+    def test_rebase_routes_to_merge_conflict_skill(self):
+        """rebase condition in each recipe routes to a step invoking resolve-merge-conflicts."""
+        pytest.skip("Recipe YAML fixes are pending — run after step 2c/2d/2e")

--- a/tests/recipe/test_rules_merge_failure_domain.py
+++ b/tests/recipe/test_rules_merge_failure_domain.py
@@ -68,7 +68,9 @@ class TestMergeFailureSkillDomainMismatch:
                 "rebase_fix": {
                     "tool": "run_skill",
                     "with": {
-                        "skill_command": "/autoskillit:resolve-merge-conflicts /tmp/wt /tmp/plan main"
+                        "skill_command": (
+                            "/autoskillit:resolve-merge-conflicts /tmp/wt /tmp/plan main"
+                        )
                     },
                     "on_success": "done",
                 },
@@ -106,7 +108,9 @@ class TestMergeFailureSkillDomainMismatch:
                 "conflict_fix": {
                     "tool": "run_skill",
                     "with": {
-                        "skill_command": "/autoskillit:resolve-merge-conflicts /tmp/wt /tmp/plan main"
+                        "skill_command": (
+                            "/autoskillit:resolve-merge-conflicts /tmp/wt /tmp/plan main"
+                        )
                     },
                     "on_success": "done",
                 },
@@ -140,6 +144,7 @@ class TestMergeFailureSkillDomainMismatch:
         assert errors == []
 
 
+@pytest.mark.medium
 class TestBundledRecipesPassFailureDomainCheck:
     """Integration tests: bundled recipes pass the new rule."""
 
@@ -177,7 +182,7 @@ class TestBundledRecipesPassFailureDomainCheck:
             if cond.when and "rebase" in cond.when and "post_rebase" not in cond.when:
                 found_rebase = True
                 target_step = recipe.steps[cond.route]
-                skill_cmd = target_step.with_args.get("skill_command", "")
+                skill_cmd = (target_step.with_args or {}).get("skill_command", "")
                 assert "resolve-merge-conflicts" in skill_cmd, (
                     f"{recipe_name}: rebase routes to '{cond.route}' which invokes "
                     f"'{skill_cmd}', expected resolve-merge-conflicts"

--- a/tests/recipe/test_rules_merge_failure_domain.py
+++ b/tests/recipe/test_rules_merge_failure_domain.py
@@ -170,6 +170,8 @@ class TestBundledRecipesPassFailureDomainCheck:
 
         recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
         merge_step = recipe.steps[merge_step_name]
+        if merge_step.on_result is None or not merge_step.on_result.conditions:
+            pytest.skip("merge step has no on_result conditions")
         for cond in merge_step.on_result.conditions:
             if cond.when and "rebase" in cond.when and "post_rebase" not in cond.when:
                 target_step = recipe.steps[cond.route]


### PR DESCRIPTION
## Summary

The recipe routing architecture treats all four recoverable `MergeFailedStep` values as a single undifferentiated class, routing them all to the same `fix`/`assess` step which invokes `resolve-failures`. But `failed_step == 'rebase'` is a git-conflict failure that requires `resolve-merge-conflicts` — a fundamentally different skill. The existing `merge-routing-incomplete` semantic rule enforces routing *completeness* (all four values have explicit routes) but not routing *correctness* (each value routes to a domain-appropriate skill). The architectural fix introduces failure domain classification and a new semantic rule that cross-validates the failure domain against the downstream skill, making this entire class of misrouting bug impossible.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
- tests/recipe/test_rules_merge_failure_domain.py

### Modified (●):
- src/autoskillit/recipe/rules/rules_merge.py
- src/autoskillit/recipes/implementation-groups.yaml
- src/autoskillit/recipes/implementation.yaml
- src/autoskillit/recipes/remediation.yaml
- src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
- tests/recipe/CLAUDE.md
- tests/recipe/test_rules_integration_predicate.py

Closes #2173

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260507-093144-301871/.autoskillit/temp/rectify/rectify_rebase_misrouting_2026-05-07_093500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 2.7k | 15.2k | 1.0M | 136.9k | 204 | 72.3k | 12m 7s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 2.8k | 9.5k | 769.0k | 56.4k | 112 | 46.3k | 7m 14s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.6M | 20.2k | 2.2M | 34.0k | 185 | 44.1k | 15m 48s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 163.1k | 4.0k | 312.8k | 28.7k | 29 | 15.3k | 1m 22s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 48.1k | 2.0k | 198.0k | 28.7k | 18 | 15.1k | 47s |
| review_pr | claude-sonnet-4-6 | 2 | 578 | 58.7k | 754.3k | 75.5k | 70 | 119.7k | 13m 27s |
| resolve_review | claude-opus-4-6 | 2 | 107 | 20.0k | 2.4M | 76.7k | 93 | 165.7k | 12m 9s |
| **Total** | | | 3.8M | 129.6k | 7.6M | 136.9k | | 478.5k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 20 | 121269.9 | 8285.6 | 1000.2 |
| **Total** | **20** | 380971.2 | 23925.5 | 6480.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 5.5k | 24.7k | 1.8M | 118.6k | 19m 22s |
| MiniMax-M2.7-highspeed | 3 | 3.8M | 26.1k | 2.7M | 74.4k | 17m 58s |