### PR TITLE
No-Mandatory-Figures Path in vis-lens-methodology-norms

### DIFF
--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T10:12:39.088966+00:00",
+  "generated_at": "2026-05-07T16:23:58.667262+00:00",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {
@@ -80,6 +80,10 @@
         {
           "name": "revision_guidance",
           "type": "file_path"
+        },
+        {
+          "name": "classification_timestamp",
+          "type": "string"
         }
       ],
       "expected_output_patterns": [
@@ -113,7 +117,13 @@
         },
         {
           "name": "scope_report_path",
-          "type": "file_path",
+          "type": "string",
+          "required": false,
+          "recommended": false
+        },
+        {
+          "name": "experiment_type",
+          "type": "string",
           "required": false,
           "recommended": false
         }
@@ -126,14 +136,32 @@
         {
           "name": "report_plan_path",
           "type": "file_path"
+        },
+        {
+          "name": "disambiguation_rule_applied",
+          "type": "string"
+        },
+        {
+          "name": "tier_c_lens",
+          "type": "string"
+        },
+        {
+          "name": "methodology_tradition",
+          "type": "string"
+        },
+        {
+          "name": "visualization_plan_trace_path",
+          "type": "file_path"
         }
       ],
       "expected_output_patterns": [
         "visualization_plan_path\\s*=\\s*/.+",
-        "report_plan_path\\s*=\\s*/.+"
+        "report_plan_path\\s*=\\s*/.+",
+        "methodology_tradition\\s*=\\s*\\S+"
       ],
       "pattern_examples": [
-        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\n%%ORDER_UP%%"
+        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\nmethodology_tradition = controlled_intervention\n%%ORDER_UP%%",
+        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\nmethodology_tradition = null\n%%ORDER_UP%%"
       ],
       "write_behavior": "always"
     },
@@ -331,7 +359,7 @@
       "inputs": [
         {
           "name": "worktree_path",
-          "type": "directory_path",
+          "type": "string",
           "required": true,
           "recommended": false
         },
@@ -399,6 +427,18 @@
           "name": "results_path",
           "type": "file_path",
           "required": true,
+          "recommended": false
+        },
+        {
+          "name": "experiment_type",
+          "type": "string",
+          "required": false,
+          "recommended": false
+        },
+        {
+          "name": "methodology_tradition",
+          "type": "string",
+          "required": false,
           "recommended": false
         }
       ],
@@ -498,7 +538,7 @@
         },
         {
           "name": "lens_context_paths",
-          "type": "file_path_list"
+          "type": "string"
         }
       ],
       "expected_output_patterns": [
@@ -521,7 +561,7 @@
         },
         {
           "name": "all_diagram_paths",
-          "type": "file_path_list",
+          "type": "string",
           "required": true,
           "recommended": false
         },
@@ -593,8 +633,7 @@
         "verdict = approved\n%%ORDER_UP%%",
         "verdict = changes_requested\n%%ORDER_UP%%",
         "verdict = needs_human\n%%ORDER_UP%%"
-      ],
-      "write_behavior": "always"
+      ]
     },
     "audit-claims": {
       "inputs": [
@@ -630,8 +669,7 @@
         "verdict = approved\n%%ORDER_UP%%",
         "verdict = changes_requested\n%%ORDER_UP%%",
         "verdict = needs_human\n%%ORDER_UP%%"
-      ],
-      "write_behavior": "always"
+      ]
     },
     "resolve-research-review": {
       "inputs": [
@@ -663,13 +701,13 @@
         }
       ],
       "expected_output_patterns": [
-        "needs_rerun\\s*=\\s*(true|false)",
-        "verdict\\s*=\\s*(real_fix|already_green)",
-        "fixes_applied\\s*=\\s*\\d+"
+        "needs_rerun\\s*=\\s*(true|false)"
       ],
       "pattern_examples": [
         "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%",
-        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
+        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = true\nverdict = flake_suspected\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
       ],
       "write_behavior": "conditional",
       "write_expected_when": [
@@ -706,13 +744,13 @@
         }
       ],
       "expected_output_patterns": [
-        "needs_rerun\\s*=\\s*(true|false)",
-        "verdict\\s*=\\s*(real_fix|already_green)",
-        "fixes_applied\\s*=\\s*\\d+"
+        "needs_rerun\\s*=\\s*(true|false)"
       ],
       "pattern_examples": [
         "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%",
-        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
+        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = true\nverdict = flake_suspected\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
       ],
       "write_behavior": "conditional",
       "write_expected_when": [
@@ -823,7 +861,8 @@
         "verdict",
         "experiment_type",
         "evaluation_dashboard",
-        "revision_guidance"
+        "revision_guidance",
+        "classification_timestamp"
       ]
     },
     {
@@ -831,6 +870,7 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
@@ -849,7 +889,11 @@
       ],
       "produced": [
         "visualization_plan_path",
-        "report_plan_path"
+        "report_plan_path",
+        "disambiguation_rule_applied",
+        "tier_c_lens",
+        "methodology_tradition",
+        "visualization_plan_trace_path"
       ]
     },
     {
@@ -857,10 +901,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -869,8 +916,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": []
@@ -880,10 +929,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -892,8 +944,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": [
@@ -905,10 +959,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -917,8 +974,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": []
@@ -928,10 +987,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -940,8 +1002,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": [
@@ -954,10 +1018,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -967,8 +1034,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -982,10 +1051,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -996,8 +1068,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1010,10 +1084,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -1024,8 +1101,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1040,11 +1119,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -1055,8 +1137,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1071,11 +1155,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1087,8 +1174,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1103,11 +1192,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1119,8 +1211,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1134,12 +1228,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1151,8 +1248,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1163,12 +1262,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1180,8 +1282,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1192,12 +1296,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1209,8 +1316,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1223,6 +1332,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1230,6 +1341,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1241,8 +1353,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1256,6 +1370,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1263,6 +1379,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1275,8 +1392,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1287,6 +1406,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1294,6 +1415,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1306,8 +1428,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1321,6 +1445,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1328,6 +1454,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1340,8 +1467,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1354,6 +1483,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1361,6 +1492,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1373,21 +1505,25 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 2
+      "positional_args": 14
     },
     {
       "step": "generate_report_inconclusive",
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1395,6 +1531,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1408,21 +1545,25 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 3
+      "positional_args": 15
     },
     {
       "step": "test",
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1430,6 +1571,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1443,8 +1585,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1455,6 +1599,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1462,6 +1608,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1475,8 +1622,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1492,6 +1641,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1500,6 +1651,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1513,8 +1665,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1525,6 +1679,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1533,6 +1689,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1546,8 +1703,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1558,6 +1717,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1566,6 +1727,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1579,8 +1741,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1597,6 +1761,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1606,6 +1772,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1621,8 +1788,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1633,6 +1802,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1642,6 +1813,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1657,8 +1829,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1669,6 +1843,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1678,6 +1854,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1693,8 +1870,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1705,6 +1884,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1714,6 +1895,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1729,8 +1911,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1744,6 +1928,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1753,6 +1939,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1769,8 +1956,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1781,6 +1970,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1790,6 +1981,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1806,8 +1998,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1820,6 +2014,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1829,6 +2025,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1846,8 +2043,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1861,6 +2060,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1870,6 +2071,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1887,8 +2089,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1900,6 +2104,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1909,6 +2115,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1926,8 +2133,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1941,6 +2150,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1950,6 +2161,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1968,8 +2180,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1981,6 +2195,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1990,6 +2206,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2008,8 +2225,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2024,6 +2243,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2033,6 +2254,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2051,8 +2273,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2065,6 +2289,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2074,6 +2300,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2092,8 +2319,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2109,6 +2338,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2118,6 +2349,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2136,15 +2368,17 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 2
+      "positional_args": 14
     },
     {
       "step": "re_stage_bundle",
@@ -2153,6 +2387,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2162,6 +2398,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2180,8 +2417,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2194,6 +2433,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2203,6 +2444,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2221,8 +2463,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2235,6 +2479,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2244,6 +2490,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2262,8 +2509,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2276,6 +2525,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2285,6 +2536,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2303,8 +2555,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2319,6 +2573,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2328,6 +2584,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2347,8 +2604,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -2365,6 +2624,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2375,6 +2636,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2394,8 +2656,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2408,6 +2672,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2418,6 +2684,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2437,8 +2704,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2453,6 +2722,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2464,6 +2735,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2483,8 +2755,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2497,6 +2771,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2508,6 +2784,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2527,8 +2804,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2543,6 +2822,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2555,6 +2836,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2574,8 +2856,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2591,6 +2875,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2603,6 +2889,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2622,8 +2909,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2640,6 +2929,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2652,6 +2943,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2671,8 +2963,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2690,6 +2984,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2702,6 +2998,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2721,8 +3018,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2738,6 +3037,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2750,6 +3051,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2769,8 +3071,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2786,6 +3090,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2798,6 +3104,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2817,8 +3124,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2834,6 +3143,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2846,6 +3157,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2865,8 +3177,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -53,7 +53,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -53,7 +53,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -1076,7 +1076,8 @@
         "callable": "autoskillit.smoke_utils.annotate_pr_diff",
         "pr_number": "${{ context.review_pr_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr",
+        "local_review_rounds": "0"
       },
       "capture": {
         "annotated_diff_path": "${{ result.annotated_diff_path }}",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -61,7 +61,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -100,7 +100,8 @@
         "verdict": "${{ result.verdict }}",
         "experiment_type": "${{ result.experiment_type }}",
         "evaluation_dashboard": "${{ result.evaluation_dashboard }}",
-        "revision_guidance": "${{ result.revision_guidance }}"
+        "revision_guidance": "${{ result.revision_guidance }}",
+        "classification_timestamp": "${{ result.classification_timestamp }}"
       },
       "skip_when_false": "inputs.review_design",
       "retries": 2,
@@ -139,7 +140,10 @@
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
         "report_plan_path": "${{ result.report_plan_path }}",
-        "methodology_tradition": "${{ result.methodology_tradition }}"
+        "disambiguation_rule_applied": "${{ result.disambiguation_rule_applied }}",
+        "tier_c_lens": "${{ result.tier_c_lens }}",
+        "methodology_tradition": "${{ result.methodology_tradition }}",
+        "visualization_plan_trace_path": "${{ result.visualization_plan_trace_path }}"
       },
       "on_success": "create_worktree",
       "on_failure": "escalate_stop",
@@ -194,7 +198,7 @@
     "create_worktree": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}'",
+        "cmd": "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}' '${{ context.visualization_plan_trace_path }}'",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "create_worktree"
       },
@@ -430,7 +434,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
@@ -450,7 +454,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
@@ -750,7 +754,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "re_generate_report"
       },

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -29,6 +29,8 @@ results are valid findings, not failures.
 
 ```
 /autoskillit:generate-report {worktree_path} {results_path} [--inconclusive]
+[--output-mode {local|pr}] [--issue-url {url}]
+[--experiment-type {type}] [--methodology-traditions {tradition}]
 ```
 
 - `{worktree_path}` — Absolute path to the worktree (required). First path-like
@@ -225,6 +227,16 @@ research/YYYY-MM-DD-{slug}/
 
 The `{slug}` is a kebab-case summary of the research topic (max 40 chars).
 
+<<<<<<< HEAD
+=======
+Write a YAML frontmatter block (fenced with `---`) at the very top of report.md,
+before the title heading. Use the values from `--experiment-type` and
+`--methodology-traditions` flags. If a flag is absent or its value is the literal
+string `null`, write the key with value `null` (not omitted). Always include
+`generated_at`. If `--output-mode local` with `--issue-url`, the issue blockquote
+goes AFTER the frontmatter, before the title.
+
+>>>>>>> b64b32f7 (fix(review): align --methodology-tradition synopsis to plural form)
 The report structure:
 
 ```markdown

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -166,9 +166,9 @@ advisory_context:
   subject_name: <tradition.name>
   reasoning: "<tradition.display_name> traditions do not mandate statistical figures. Rigor lives in trustworthiness/transferability/dependability/confirmability."
   reference_framework: "<tradition.canonical_guideline.name>"
-  strongly_expected_figures:
-    - "<figure text from tradition.strongly_expected_figures[0].figure>"
-    - "<figure text from tradition.strongly_expected_figures[1].figure>"
+  strongly_expected_figures:  # map each entry in spec.strongly_expected_figures
+    - "<figure text from entry.figure> (<entry.source>)"
+    - "..."
 requires_decision: false
 ```
 

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -141,6 +141,57 @@ alternate.
 provided directly), but Stage B still runs against the loaded tradition's `venue_specific_appendices`
 to detect ML sub-area specific figure requirements.
 
+## Out-of-Scope Tradition Handling
+
+Some methodology traditions (e.g., `qualitative_interpretive_tradition`) have an empty
+`mandatory_figures` list. These traditions do not mandate specific figure types — rigor
+is assessed through trustworthiness, transferability, dependability, and confirmability
+rather than statistical figures.
+
+**Detection:** After loading the tradition in Step 0, call `is_out_of_scope_tradition(spec)`
+from `recipe/methodology_tradition_registry.py`. This returns `True` when
+`len(spec.mandatory_figures) == 0`.
+
+**When detected (BEFORE Steps 1-4):**
+
+1. **Skip** Steps 1 through 4 entirely (no mandatory-figure scanning, no coverage check,
+   no gap analysis, no figure-spec emission)
+2. **Emit** a GO verdict with the following structured advisory matching the canonical
+   silent-type convention (`docs/research/silent-type-convention.md`):
+
+```yaml
+verdict: GO
+advisory_context:
+  subject_kind: methodology_tradition
+  subject_name: <tradition.name>
+  reasoning: "<tradition.display_name> traditions do not mandate statistical figures. Rigor lives in trustworthiness/transferability/dependability/confirmability."
+  reference_framework: "<tradition.canonical_guideline.name>"
+  strongly_expected_figures:
+    - "<figure text from tradition.strongly_expected_figures[0].figure>"
+    - "<figure text from tradition.strongly_expected_figures[1].figure>"
+requires_decision: false
+```
+
+3. **Write** the advisory to `visualization-plan-trace.md` in the output directory
+   (`{{AUTOSKILLIT_TEMP}}/plan-visualization/visualization-plan-trace.md`), appended
+   after any existing Tier-C routing metadata
+4. **Also write** the advisory into the vis_spec output file
+   (`{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/vis_spec_methodology_norms_{timestamp}.md`)
+   under a `## Out-of-Scope Advisory` heading instead of the normal coverage/gap tables
+5. **Emit** the `diagram_path` structured output token as usual (pointing to the vis_spec file)
+
+**Populating the advisory fields:**
+- `subject_name`: Use `spec.name` (e.g., `qualitative_interpretive_tradition`)
+- `reasoning`: Compose from `spec.display_name` + the standard trustworthiness rationale
+- `reference_framework`: Use `spec.canonical_guideline["name"]` (e.g., `"COREQ/SRQR"`)
+- `strongly_expected_figures`: Map each entry in `spec.strongly_expected_figures` to its
+  `figure` value with the `source` in parentheses (e.g.,
+  `"Coding Tree or Thematic Map (COREQ item 28)"`)
+
+**ML sub-area fallback path:** If no `tradition_slug` is provided and the ML sub-area
+keyword detection path is taken, the out-of-scope gate does not apply — it only fires
+when a tradition is loaded (either via `tradition_slug` or via `classify_methodology`).
+
 ## Critical Constraints
 
 **NEVER:**
@@ -175,6 +226,8 @@ a `## Methodology Tradition` section containing `tradition_slug`. If present:
 - Use the tradition's `mandatory_figures`, `strongly_expected_figures`, and `anti_patterns`
   as the norm source (instead of the ML Sub-Area table above)
 - Skip ML sub-area keyword detection — the tradition replaces it
+- Check `is_out_of_scope_tradition(spec)`. If True, follow the Out-of-Scope Tradition
+  Handling section — skip Steps 1-4 and emit the GO advisory.
 
 If no `tradition_slug` is provided, fall back to ML sub-area keyword detection:
 

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -147,6 +147,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_schema.py` | Tests for Recipe, RecipeStep, and DataFlowWarning schema |
 | `test_skill_emit_consistency.py` | Tests for skill emit consistency in recipe steps |
 | `test_silent_type_convention.py` | Tests for silent-type-convention.md documentation |
+| `test_silent_type_flows.py` | Integration tests for silent-type convention flows (vis-lens out-of-scope path) |
 | `test_staleness_cache.py` | Tests for recipe staleness cache |
 | `test_sub_recipe_loading.py` | Tests for sub-recipe loading and composition |
 | `test_sub_recipe_schema.py` | Tests for sub-recipe schema structure |

--- a/tests/recipe/test_silent_type_flows.py
+++ b/tests/recipe/test_silent_type_flows.py
@@ -1,8 +1,7 @@
 """Integration tests for silent-type convention flows.
 
-Shared between Work Item 2.3 (review-design silent-type) and Work Item 4.7
-(vis-lens out-of-scope traditions). Tests verify that registry, convention
-doc, and SKILL.md files are aligned on advisory schema and behavior.
+Tests verify that registry, convention doc, and SKILL.md files are aligned
+on advisory schema and behavior.
 """
 
 from __future__ import annotations
@@ -25,7 +24,7 @@ _CONVENTION_PATH = _REPO_ROOT / "docs" / "research" / "silent-type-convention.md
 
 
 class TestVisLensOutOfScopeFlow:
-    """Work Item 4.7: vis-lens-methodology-norms out-of-scope tradition path."""
+    """vis-lens-methodology-norms out-of-scope tradition path."""
 
     def test_qualitative_tradition_is_out_of_scope(self) -> None:
         spec = get_methodology_tradition_by_name("qualitative_interpretive_tradition")
@@ -37,22 +36,28 @@ class TestVisLensOutOfScopeFlow:
         assert spec is not None
         assert len(spec.strongly_expected_figures) >= 1
         for entry in spec.strongly_expected_figures:
+            assert isinstance(entry, dict), f"Expected dict, got {type(entry)}"
             assert "figure" in entry
             assert "source" in entry
 
     def test_qualitative_tradition_has_reference_framework(self) -> None:
         spec = get_methodology_tradition_by_name("qualitative_interpretive_tradition")
         assert spec is not None
+        assert "name" in spec.canonical_guideline, "canonical_guideline missing 'name' key"
         assert spec.canonical_guideline["name"] == "COREQ/SRQR"
 
     def test_vis_lens_skill_documents_out_of_scope_advisory(self) -> None:
         skill_md = (_SKILLS_DIR / "vis-lens-methodology-norms" / "SKILL.md").read_text()
         for term in [
+            "Out-of-Scope Tradition Handling",
             "advisory_context",
             "subject_kind",
             "methodology_tradition",
             "strongly_expected_figures",
             "is_out_of_scope_tradition",
+            "verdict: GO",
+            "requires_decision: false",
+            "visualization-plan-trace.md",
         ]:
             assert term in skill_md, f"SKILL.md missing '{term}'"
 

--- a/tests/recipe/test_silent_type_flows.py
+++ b/tests/recipe/test_silent_type_flows.py
@@ -1,0 +1,81 @@
+"""Integration tests for silent-type convention flows.
+
+Shared between Work Item 2.3 (review-design silent-type) and Work Item 4.7
+(vis-lens out-of-scope traditions). Tests verify that registry, convention
+doc, and SKILL.md files are aligned on advisory schema and behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.recipe.methodology_tradition_registry import (
+    get_methodology_tradition_by_name,
+    is_out_of_scope_tradition,
+    load_all_methodology_traditions,
+)
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SKILLS_DIR = _REPO_ROOT / "src" / "autoskillit" / "skills_extended"
+_CONVENTION_PATH = _REPO_ROOT / "docs" / "research" / "silent-type-convention.md"
+
+
+class TestVisLensOutOfScopeFlow:
+    """Work Item 4.7: vis-lens-methodology-norms out-of-scope tradition path."""
+
+    def test_qualitative_tradition_is_out_of_scope(self) -> None:
+        spec = get_methodology_tradition_by_name("qualitative_interpretive_tradition")
+        assert spec is not None
+        assert is_out_of_scope_tradition(spec) is True
+
+    def test_qualitative_tradition_has_strongly_expected_figures(self) -> None:
+        spec = get_methodology_tradition_by_name("qualitative_interpretive_tradition")
+        assert spec is not None
+        assert len(spec.strongly_expected_figures) >= 1
+        for entry in spec.strongly_expected_figures:
+            assert "figure" in entry
+            assert "source" in entry
+
+    def test_qualitative_tradition_has_reference_framework(self) -> None:
+        spec = get_methodology_tradition_by_name("qualitative_interpretive_tradition")
+        assert spec is not None
+        assert spec.canonical_guideline["name"] == "COREQ/SRQR"
+
+    def test_vis_lens_skill_documents_out_of_scope_advisory(self) -> None:
+        skill_md = (_SKILLS_DIR / "vis-lens-methodology-norms" / "SKILL.md").read_text()
+        for term in [
+            "advisory_context",
+            "subject_kind",
+            "methodology_tradition",
+            "strongly_expected_figures",
+            "is_out_of_scope_tradition",
+        ]:
+            assert term in skill_md, f"SKILL.md missing '{term}'"
+
+    def test_convention_doc_and_skill_agree_on_write_target(self) -> None:
+        convention = _CONVENTION_PATH.read_text()
+        skill_md = (_SKILLS_DIR / "vis-lens-methodology-norms" / "SKILL.md").read_text()
+        target = "visualization-plan-trace.md"
+        assert target in convention, f"Convention doc missing '{target}'"
+        assert target in skill_md, f"SKILL.md missing '{target}'"
+
+    def test_all_out_of_scope_traditions_have_strongly_expected_figures(self) -> None:
+        traditions = load_all_methodology_traditions()
+        oos = [s for s in traditions if is_out_of_scope_tradition(s)]
+        assert len(oos) >= 1, "Expected at least one out-of-scope tradition"
+        for spec in oos:
+            assert len(spec.strongly_expected_figures) >= 1, (
+                f"{spec.name}: out-of-scope tradition must have strongly_expected_figures"
+            )
+
+    def test_no_in_scope_tradition_has_empty_mandatory_figures(self) -> None:
+        traditions = load_all_methodology_traditions()
+        for spec in traditions:
+            if not is_out_of_scope_tradition(spec):
+                assert len(spec.mandatory_figures) >= 1, (
+                    f"{spec.name}: in-scope tradition must have mandatory_figures"
+                )

--- a/tests/skills/test_vis_lens_structural.py
+++ b/tests/skills/test_vis_lens_structural.py
@@ -122,22 +122,3 @@ def test_methodology_norms_documents_two_stage_matching() -> None:
     assert "Stage A" in text or "stage A" in text
     assert "Stage B" in text or "stage B" in text
     assert "venue_specific_appendices" in text or "venue appendix" in text
-
-
-def test_methodology_norms_documents_out_of_scope_handling() -> None:
-    """vis-lens-methodology-norms must document out-of-scope tradition handling."""
-    text = _read("methodology-norms")
-    assert "Out-of-Scope Tradition Handling" in text
-    assert "is_out_of_scope_tradition" in text
-    assert "advisory_context" in text
-    assert "strongly_expected_figures" in text
-
-
-def test_methodology_norms_advisory_matches_convention() -> None:
-    """vis-lens-methodology-norms advisory must align with silent-type convention."""
-    text = _read("methodology-norms")
-    assert "subject_kind" in text
-    assert "methodology_tradition" in text
-    assert "verdict: GO" in text
-    assert "requires_decision: false" in text
-    assert "visualization-plan-trace.md" in text

--- a/tests/skills/test_vis_lens_structural.py
+++ b/tests/skills/test_vis_lens_structural.py
@@ -122,3 +122,22 @@ def test_methodology_norms_documents_two_stage_matching() -> None:
     assert "Stage A" in text or "stage A" in text
     assert "Stage B" in text or "stage B" in text
     assert "venue_specific_appendices" in text or "venue appendix" in text
+
+
+def test_methodology_norms_documents_out_of_scope_handling() -> None:
+    """vis-lens-methodology-norms must document out-of-scope tradition handling."""
+    text = _read("methodology-norms")
+    assert "Out-of-Scope Tradition Handling" in text
+    assert "is_out_of_scope_tradition" in text
+    assert "advisory_context" in text
+    assert "strongly_expected_figures" in text
+
+
+def test_methodology_norms_advisory_matches_convention() -> None:
+    """vis-lens-methodology-norms advisory must align with silent-type convention."""
+    text = _read("methodology-norms")
+    assert "subject_kind" in text
+    assert "methodology_tradition" in text
+    assert "verdict: GO" in text
+    assert "requires_decision: false" in text
+    assert "visualization-plan-trace.md" in text


### PR DESCRIPTION
## Summary

Add an early-exit path to the `vis-lens-methodology-norms` SKILL.md that detects out-of-scope traditions (those with empty `mandatory_figures`) before the mandatory-figure scanning step, emits a GO verdict with a structured advisory matching the canonical silent-type convention schema, and skips the coverage/gap analysis workflow. The `is_out_of_scope_tradition(spec)` helper and the `silent-type-convention.md` schema already exist from upstream dependencies (#842, #856). This issue wires them into the vis-lens SKILL.md behavioral contract and adds tests to enforce the wiring.

## Requirements

Part of **Unit 4 — Vis-lens methodology-norms generalization (P1)** from the auto-research master plan.

## Scope

Implement the no-mandatory-figures handler in `vis-lens-methodology-norms` per the shared silent-type convention (§11.5.4). When a tradition's `mandatory_figures` list is empty (prototype: `qualitative_interpretive_tradition`), emit a GO-level verdict with a structured advisory listing strongly-expected figures and referencing the canonical guideline (COREQ/SRQR for qualitative). Write advisory to the audit trail.

## Rationale

Qualitative-interpretive research does not mandate statistical figures — trustworthiness, transferability, and dependability are the rigor framework. Forcing the lens to flag "missing" mandatory figures is inappropriate. Parallel pattern to Work Item 2.3's silent-type handler on the review-design side.

## Acceptance criteria

- [ ] `is_out_of_scope_tradition(spec)` returns True when `len(spec.mandatory_figures) == 0`, False otherwise
- [ ] Lens detects out-of-scope traditions BEFORE the mandatory-figure scanning step
- [ ] Emits verdict GO with structured advisory matching the schema
- [ ] Advisory lists strongly-expected figures from the tradition's `strongly_expected_figures` field
- [ ] Advisory references the canonical guideline by name (COREQ/SRQR for qualitative)
- [ ] Integration test (shared with Work Item 2.3): qualitative-interpretive plan passes review_design → plan_visualization → generate_report with BOTH advisories (review-side silent-type + vis-lens-side out-of-scope) appearing with matching schema
- [ ] `task test-check` passes

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-101911-689595/.autoskillit/temp/make-plan/no_mandatory_figures_vis_lens_plan_2026-05-07_102600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 77 | 10.1k | 697.3k | 78.7k | 164 | 68.7k | 6m 47s |
| verify | claude-opus-4-6 | 1 | 33 | 6.6k | 618.0k | 52.0k | 78 | 44.8k | 4m 14s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.3M | 12.7k | 1.3M | 35.0k | 109 | 122.8k | 8m 38s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 113.4k | 4.5k | 265.0k | 29.8k | 26 | 15.1k | 1m 28s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.6k | 1.7k | 205.5k | 29.8k | 14 | 15.0k | 45s |
| review_pr | claude-sonnet-4-6 | 1 | 40 | 33.4k | 807.2k | 109.8k | 281 | 97.4k | 17m 34s |
| resolve_review | claude-opus-4-6 | 1 | 60 | 18.3k | 1.8M | 92.1k | 83 | 81.3k | 7m 57s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 34 | 4.7k | 542.3k | 41.2k | 29 | 28.2k | 1m 48s |
| **Total** | | | 1.5M | 92.0k | 6.2M | 109.8k | | 473.4k | 49m 14s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 154 | 8152.9 | 797.5 | 82.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 42 | 42954.9 | 1936.6 | 434.8 |
| ci_conflict_fix | 2372 | 228.6 | 11.9 | 2.0 |
| **Total** | **2568** | 2412.4 | 184.3 | 35.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 77 | 10.1k | 697.3k | 68.7k | 6m 47s |
| claude-opus-4-6 | 1 | 33 | 6.6k | 618.0k | 44.8k | 4m 14s |
| MiniMax-M2.7-highspeed | 3 | 1.5M | 18.9k | 1.7M | 153.0k | 10m 52s |