### PR TITLE
[FIX] Fix batch_create_issues Validation Summary Append

### DIFF
--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -652,8 +652,8 @@ def batch_create_issues(
     parsed: list[tuple[str, str, str]] = []
     for f in ticket_bodies:
         raw = f.read_text()
-        m = re.match(r"ticket_body_(\w+)_\d+_(.+)\.md", f.name)
-        ts = m.group(2) if m else ""
+        m = re.match(r"ticket_body_\w+_\d+_(.+)\.md", f.name)
+        ts = m.group(1) if m else ""
         title = _extract_title(raw)
         body = _strip_ticket_body(raw)
         parsed.append((title, body, ts))

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -653,13 +653,9 @@ def batch_create_issues(
     for f in ticket_bodies:
         raw = f.read_text()
         m = re.match(r"ticket_body_(\w+)_\d+_(.+)\.md", f.name)
-        source = m.group(1) if m else "unknown"
         ts = m.group(2) if m else ""
         title = _extract_title(raw)
         body = _strip_ticket_body(raw)
-        summary_path = temp_dir / f"validation_summary_{source}_{ts}.md"
-        if summary_path.exists():
-            body += "\n\n---\n\n" + summary_path.read_text()
         parsed.append((title, body, ts))
 
     owner, repo_name, repo_id = _resolve_repo_identity(workspace)

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -120,7 +120,11 @@
       "outputs": [
         {
           "name": "merged",
-          "type": "string"
+          "type": "string",
+          "allowed_values": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "needs_plan",

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T10:12:39.088966+00:00",
+  "generated_at": "2026-05-07T16:23:58.667262+00:00",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {
@@ -80,6 +80,10 @@
         {
           "name": "revision_guidance",
           "type": "file_path"
+        },
+        {
+          "name": "classification_timestamp",
+          "type": "string"
         }
       ],
       "expected_output_patterns": [
@@ -113,7 +117,13 @@
         },
         {
           "name": "scope_report_path",
-          "type": "file_path",
+          "type": "string",
+          "required": false,
+          "recommended": false
+        },
+        {
+          "name": "experiment_type",
+          "type": "string",
           "required": false,
           "recommended": false
         }
@@ -126,14 +136,32 @@
         {
           "name": "report_plan_path",
           "type": "file_path"
+        },
+        {
+          "name": "disambiguation_rule_applied",
+          "type": "string"
+        },
+        {
+          "name": "tier_c_lens",
+          "type": "string"
+        },
+        {
+          "name": "methodology_tradition",
+          "type": "string"
+        },
+        {
+          "name": "visualization_plan_trace_path",
+          "type": "file_path"
         }
       ],
       "expected_output_patterns": [
         "visualization_plan_path\\s*=\\s*/.+",
-        "report_plan_path\\s*=\\s*/.+"
+        "report_plan_path\\s*=\\s*/.+",
+        "methodology_tradition\\s*=\\s*\\S+"
       ],
       "pattern_examples": [
-        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\n%%ORDER_UP%%"
+        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\nmethodology_tradition = controlled_intervention\n%%ORDER_UP%%",
+        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\nmethodology_tradition = null\n%%ORDER_UP%%"
       ],
       "write_behavior": "always"
     },
@@ -331,7 +359,7 @@
       "inputs": [
         {
           "name": "worktree_path",
-          "type": "directory_path",
+          "type": "string",
           "required": true,
           "recommended": false
         },
@@ -399,6 +427,18 @@
           "name": "results_path",
           "type": "file_path",
           "required": true,
+          "recommended": false
+        },
+        {
+          "name": "experiment_type",
+          "type": "string",
+          "required": false,
+          "recommended": false
+        },
+        {
+          "name": "methodology_tradition",
+          "type": "string",
+          "required": false,
           "recommended": false
         }
       ],
@@ -498,7 +538,7 @@
         },
         {
           "name": "lens_context_paths",
-          "type": "file_path_list"
+          "type": "string"
         }
       ],
       "expected_output_patterns": [
@@ -521,7 +561,7 @@
         },
         {
           "name": "all_diagram_paths",
-          "type": "file_path_list",
+          "type": "string",
           "required": true,
           "recommended": false
         },
@@ -593,8 +633,7 @@
         "verdict = approved\n%%ORDER_UP%%",
         "verdict = changes_requested\n%%ORDER_UP%%",
         "verdict = needs_human\n%%ORDER_UP%%"
-      ],
-      "write_behavior": "always"
+      ]
     },
     "audit-claims": {
       "inputs": [
@@ -630,8 +669,7 @@
         "verdict = approved\n%%ORDER_UP%%",
         "verdict = changes_requested\n%%ORDER_UP%%",
         "verdict = needs_human\n%%ORDER_UP%%"
-      ],
-      "write_behavior": "always"
+      ]
     },
     "resolve-research-review": {
       "inputs": [
@@ -663,13 +701,13 @@
         }
       ],
       "expected_output_patterns": [
-        "needs_rerun\\s*=\\s*(true|false)",
-        "verdict\\s*=\\s*(real_fix|already_green)",
-        "fixes_applied\\s*=\\s*\\d+"
+        "needs_rerun\\s*=\\s*(true|false)"
       ],
       "pattern_examples": [
         "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%",
-        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
+        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = true\nverdict = flake_suspected\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
       ],
       "write_behavior": "conditional",
       "write_expected_when": [
@@ -706,13 +744,13 @@
         }
       ],
       "expected_output_patterns": [
-        "needs_rerun\\s*=\\s*(true|false)",
-        "verdict\\s*=\\s*(real_fix|already_green)",
-        "fixes_applied\\s*=\\s*\\d+"
+        "needs_rerun\\s*=\\s*(true|false)"
       ],
       "pattern_examples": [
         "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%",
-        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
+        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = true\nverdict = flake_suspected\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
       ],
       "write_behavior": "conditional",
       "write_expected_when": [
@@ -823,7 +861,8 @@
         "verdict",
         "experiment_type",
         "evaluation_dashboard",
-        "revision_guidance"
+        "revision_guidance",
+        "classification_timestamp"
       ]
     },
     {
@@ -831,6 +870,7 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
@@ -849,7 +889,11 @@
       ],
       "produced": [
         "visualization_plan_path",
-        "report_plan_path"
+        "report_plan_path",
+        "disambiguation_rule_applied",
+        "tier_c_lens",
+        "methodology_tradition",
+        "visualization_plan_trace_path"
       ]
     },
     {
@@ -857,10 +901,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -869,8 +916,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": []
@@ -880,10 +929,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -892,8 +944,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": [
@@ -905,10 +959,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -917,8 +974,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": []
@@ -928,10 +987,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -940,8 +1002,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": [
@@ -954,10 +1018,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -967,8 +1034,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -982,10 +1051,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -996,8 +1068,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1010,10 +1084,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -1024,8 +1101,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1040,11 +1119,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -1055,8 +1137,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1071,11 +1155,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1087,8 +1174,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1103,11 +1192,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1119,8 +1211,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1134,12 +1228,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1151,8 +1248,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1163,12 +1262,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1180,8 +1282,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1192,12 +1296,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1209,8 +1316,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1223,6 +1332,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1230,6 +1341,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1241,8 +1353,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1256,6 +1370,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1263,6 +1379,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1275,8 +1392,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1287,6 +1406,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1294,6 +1415,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1306,8 +1428,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1321,6 +1445,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1328,6 +1454,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1340,8 +1467,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1354,6 +1483,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1361,6 +1492,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1373,21 +1505,25 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 2
+      "positional_args": 14
     },
     {
       "step": "generate_report_inconclusive",
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1395,6 +1531,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1408,21 +1545,25 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 3
+      "positional_args": 15
     },
     {
       "step": "test",
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1430,6 +1571,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1443,8 +1585,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1455,6 +1599,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1462,6 +1608,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1475,8 +1622,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1492,6 +1641,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1500,6 +1651,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1513,8 +1665,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1525,6 +1679,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1533,6 +1689,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1546,8 +1703,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1558,6 +1717,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1566,6 +1727,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1579,8 +1741,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1597,6 +1761,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1606,6 +1772,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1621,8 +1788,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1633,6 +1802,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1642,6 +1813,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1657,8 +1829,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1669,6 +1843,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1678,6 +1854,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1693,8 +1870,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1705,6 +1884,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1714,6 +1895,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1729,8 +1911,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1744,6 +1928,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1753,6 +1939,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1769,8 +1956,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1781,6 +1970,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1790,6 +1981,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1806,8 +1998,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1820,6 +2014,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1829,6 +2025,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1846,8 +2043,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1861,6 +2060,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1870,6 +2071,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1887,8 +2089,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1900,6 +2104,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1909,6 +2115,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1926,8 +2133,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1941,6 +2150,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1950,6 +2161,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1968,8 +2180,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1981,6 +2195,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1990,6 +2206,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2008,8 +2225,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2024,6 +2243,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2033,6 +2254,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2051,8 +2273,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2065,6 +2289,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2074,6 +2300,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2092,8 +2319,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2109,6 +2338,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2118,6 +2349,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2136,15 +2368,17 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 2
+      "positional_args": 14
     },
     {
       "step": "re_stage_bundle",
@@ -2153,6 +2387,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2162,6 +2398,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2180,8 +2417,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2194,6 +2433,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2203,6 +2444,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2221,8 +2463,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2235,6 +2479,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2244,6 +2490,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2262,8 +2509,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2276,6 +2525,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2285,6 +2536,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2303,8 +2555,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2319,6 +2573,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2328,6 +2584,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2347,8 +2604,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -2365,6 +2624,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2375,6 +2636,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2394,8 +2656,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2408,6 +2672,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2418,6 +2684,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2437,8 +2704,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2453,6 +2722,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2464,6 +2735,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2483,8 +2755,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2497,6 +2771,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2508,6 +2784,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2527,8 +2804,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2543,6 +2822,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2555,6 +2836,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2574,8 +2856,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2591,6 +2875,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2603,6 +2889,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2622,8 +2909,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2640,6 +2929,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2652,6 +2943,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2671,8 +2963,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2690,6 +2984,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2702,6 +2998,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2721,8 +3018,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2738,6 +3037,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2750,6 +3051,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2769,8 +3071,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2786,6 +3090,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2798,6 +3104,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2817,8 +3124,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2834,6 +3143,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2846,6 +3157,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2865,8 +3177,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -53,7 +53,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",
@@ -317,7 +318,7 @@
         },
         {
           "when": "result.failed_step == 'rebase'",
-          "route": "fix"
+          "route": "rebase_conflict_fix"
         },
         {
           "when": "result.error",
@@ -377,6 +378,31 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "test",
       "note": "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
+    },
+    "rebase_conflict_fix": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "rebase_conflict_fix"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "test"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "next_or_done": {
       "action": "route",
@@ -720,7 +746,7 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "ci_watch"
+          "route": "check_ci_timed_out_loop"
         },
         {
           "route": "detect_ci_conflict"
@@ -729,7 +755,32 @@
       "on_failure": "detect_ci_conflict",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → self (re-watch), failure → detect_ci_conflict.\n"
+      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → check_ci_timed_out_loop (iteration guard), failure → detect_ci_conflict.\n"
+    },
+    "check_ci_timed_out_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_timed_out_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ci_timed_out_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "detect_ci_conflict"
+        },
+        {
+          "route": "ci_watch"
+        }
+      ],
+      "on_failure": "detect_ci_conflict",
+      "optional_context_refs": [
+        "ci_timed_out_loop_count"
+      ],
+      "note": "Caps the ci_watch re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to detect_ci_conflict instead of spinning indefinitely.\n"
     },
     "handle_no_ci_runs": {
       "tool": "check_repo_merge_state",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -53,7 +53,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",
@@ -312,7 +313,7 @@
         },
         {
           "when": "result.failed_step == 'rebase'",
-          "route": "fix"
+          "route": "rebase_conflict_fix"
         },
         {
           "when": "result.error",
@@ -369,6 +370,31 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "test",
       "note": "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
+    },
+    "rebase_conflict_fix": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "rebase_conflict_fix"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "test"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "next_or_done": {
       "action": "route",
@@ -723,7 +749,7 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "ci_watch"
+          "route": "check_ci_timed_out_loop"
         },
         {
           "route": "detect_ci_conflict"
@@ -732,7 +758,32 @@
       "on_failure": "detect_ci_conflict",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → self (re-watch), failure → detect_ci_conflict.\n"
+      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → check_ci_timed_out_loop (iteration guard), failure → detect_ci_conflict.\n"
+    },
+    "check_ci_timed_out_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_timed_out_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ci_timed_out_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "detect_ci_conflict"
+        },
+        {
+          "route": "ci_watch"
+        }
+      ],
+      "on_failure": "detect_ci_conflict",
+      "optional_context_refs": [
+        "ci_timed_out_loop_count"
+      ],
+      "note": "Caps the ci_watch re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to detect_ci_conflict instead of spinning indefinitely.\n"
     },
     "handle_no_ci_runs": {
       "tool": "check_repo_merge_state",

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -672,7 +672,8 @@
         "escalation_required": "${{ result.escalation_required }}",
         "escalation_reason": "${{ result.escalation_reason }}",
         "task": "${{ result.conflict_report_path }}",
-        "current_pr_number": "${{ result.pr_number }}"
+        "current_pr_number": "${{ result.pr_number }}",
+        "merged": "${{ result.merged }}"
       },
       "on_result": [
         {
@@ -684,6 +685,10 @@
           "route": "plan"
         },
         {
+          "when": "${{ result.merged }} == false",
+          "route": "register_clone_failure"
+        },
+        {
           "route": "next_part_or_next_pr"
         }
       ],
@@ -691,7 +696,7 @@
       "retries": 5,
       "on_exhausted": "register_clone_failure",
       "on_context_limit": "register_clone_failure",
-      "note": "The agent reads context.pr_order_file at context.current_pr_number to get the current PR's complexity. Appends number and complexity to skill_command:\n  /autoskillit:merge-pr {pr_number} {complexity}\nescalation_required=true → ambiguous conflict, human intervention needed → escalate_stop. needs_plan=true → conflict_report_path set as context.task → plan. needs_plan=false (fallthrough) → PR merged directly → next_part_or_next_pr.\n"
+      "note": "The agent reads context.pr_order_file at context.current_pr_number to get the current PR's complexity. Appends number and complexity to skill_command:\n  /autoskillit:merge-pr {pr_number} {complexity}\nescalation_required=true → ambiguous conflict, human intervention needed → escalate_stop. needs_plan=true → conflict_report_path set as context.task → plan. merged=false (timeout/conflict) → register_clone_failure. merged=true + fallthrough → PR merged directly → next_part_or_next_pr.\n"
     },
     "plan": {
       "tool": "run_skill",
@@ -804,7 +809,8 @@
         "branch": "${{ context.worktree_branch_name }}",
         "event": "${{ context.ci_event }}",
         "timeout_seconds": 600,
-        "cwd": "${{ context.work_dir }}"
+        "cwd": "${{ context.work_dir }}",
+        "auto_trigger": "true"
       },
       "on_result": [
         {
@@ -813,14 +819,39 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "wait_for_conflict_ci"
+          "route": "check_conflict_ci_loop"
         },
         {
           "route": "register_clone_failure"
         }
       ],
       "on_failure": "register_clone_failure",
-      "note": "Waits for CI to pass on the worktree branch before merging. 600 second timeout matches the merge-pr skill poll timeout. Routes on result.conclusion: success → merge_conflict_pr, timed_out → self (re-watch), no_runs/failure → register_clone_failure.\n"
+      "note": "Waits for CI to pass on the worktree branch before merging. 600 second timeout matches the merge-pr skill poll timeout. Routes on result.conclusion: success → merge_conflict_pr, timed_out → check_conflict_ci_loop (iteration guard), no_runs/failure → register_clone_failure.\n"
+    },
+    "check_conflict_ci_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.conflict_ci_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "conflict_ci_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "register_clone_failure"
+        },
+        {
+          "route": "wait_for_conflict_ci"
+        }
+      ],
+      "on_failure": "register_clone_failure",
+      "optional_context_refs": [
+        "conflict_ci_loop_count"
+      ],
+      "note": "Caps the wait_for_conflict_ci re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to register_clone_failure instead of spinning indefinitely.\n"
     },
     "merge_conflict_pr": {
       "tool": "run_cmd",
@@ -1076,7 +1107,8 @@
         "callable": "autoskillit.smoke_utils.annotate_pr_diff",
         "pr_number": "${{ context.review_pr_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr",
+        "local_review_rounds": "0"
       },
       "capture": {
         "annotated_diff_path": "${{ result.annotated_diff_path }}",
@@ -1172,7 +1204,8 @@
         "event": "${{ context.ci_event }}",
         "timeout_seconds": 600,
         "cwd": "${{ context.work_dir }}",
-        "pr_url": "${{ context.pr_url }}"
+        "pr_url": "${{ context.pr_url }}",
+        "auto_trigger": "true"
       },
       "on_result": [
         {
@@ -1181,14 +1214,39 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "ci_watch_pr"
+          "route": "check_ci_watch_pr_loop"
         },
         {
           "route": "register_clone_failure"
         }
       ],
       "on_failure": "diagnose_ci",
-      "note": "Waits for the GitHub Actions CI run on context.batch_branch to complete using the wait_for_ci MCP tool (timeout: 300 s). Routes on result.conclusion: success → register_clone_success, timed_out → self (re-watch), no_runs/failure → register_clone_failure. Tool-level failure routes to diagnose_ci for log capture.\n"
+      "note": "Waits for the GitHub Actions CI run on context.batch_branch to complete using the wait_for_ci MCP tool (timeout: 300 s). Routes on result.conclusion: success → patch_token_summary, timed_out → check_ci_watch_pr_loop (iteration guard), no_runs/failure → register_clone_failure. Tool-level failure routes to diagnose_ci for log capture.\n"
+    },
+    "check_ci_watch_pr_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_watch_pr_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ci_watch_pr_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "register_clone_failure"
+        },
+        {
+          "route": "ci_watch_pr"
+        }
+      ],
+      "on_failure": "register_clone_failure",
+      "optional_context_refs": [
+        "ci_watch_pr_loop_count"
+      ],
+      "note": "Caps the ci_watch_pr re-poll loop at 2 iterations.\n"
     },
     "diagnose_ci": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -61,7 +61,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",
@@ -333,6 +334,31 @@
       "on_failure": "release_issue_failure",
       "on_exhausted": "release_issue_failure"
     },
+    "rebase_conflict_fix": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "rebase_conflict_fix"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "test"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
+    },
     "audit_impl": {
       "tool": "run_skill",
       "model": "",
@@ -423,7 +449,7 @@
         },
         {
           "when": "result.failed_step == 'rebase'",
-          "route": "assess"
+          "route": "rebase_conflict_fix"
         },
         {
           "when": "result.error",
@@ -750,7 +776,7 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "ci_watch"
+          "route": "check_ci_timed_out_loop"
         },
         {
           "route": "detect_ci_conflict"
@@ -759,7 +785,32 @@
       "on_failure": "detect_ci_conflict",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → self (re-watch), failure → detect_ci_conflict.\n"
+      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → check_ci_timed_out_loop (iteration guard), failure → detect_ci_conflict.\n"
+    },
+    "check_ci_timed_out_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_timed_out_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ci_timed_out_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "detect_ci_conflict"
+        },
+        {
+          "route": "ci_watch"
+        }
+      ],
+      "on_failure": "detect_ci_conflict",
+      "optional_context_refs": [
+        "ci_timed_out_loop_count"
+      ],
+      "note": "Caps the ci_watch re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to detect_ci_conflict instead of spinning indefinitely.\n"
     },
     "handle_no_ci_runs": {
       "tool": "check_repo_merge_state",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -100,7 +100,8 @@
         "verdict": "${{ result.verdict }}",
         "experiment_type": "${{ result.experiment_type }}",
         "evaluation_dashboard": "${{ result.evaluation_dashboard }}",
-        "revision_guidance": "${{ result.revision_guidance }}"
+        "revision_guidance": "${{ result.revision_guidance }}",
+        "classification_timestamp": "${{ result.classification_timestamp }}"
       },
       "skip_when_false": "inputs.review_design",
       "retries": 2,
@@ -139,7 +140,10 @@
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
         "report_plan_path": "${{ result.report_plan_path }}",
-        "methodology_tradition": "${{ result.methodology_tradition }}"
+        "disambiguation_rule_applied": "${{ result.disambiguation_rule_applied }}",
+        "tier_c_lens": "${{ result.tier_c_lens }}",
+        "methodology_tradition": "${{ result.methodology_tradition }}",
+        "visualization_plan_trace_path": "${{ result.visualization_plan_trace_path }}"
       },
       "on_success": "create_worktree",
       "on_failure": "escalate_stop",
@@ -194,7 +198,7 @@
     "create_worktree": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}'",
+        "cmd": "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}' '${{ context.visualization_plan_trace_path }}'",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "create_worktree"
       },
@@ -430,7 +434,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
@@ -450,7 +454,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
@@ -750,7 +754,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "re_generate_report"
       },

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -434,7 +434,7 @@ def test_batch_create_issues_ignores_validation_summary_file(tmp_path):
     """batch_create_issues must not append validation_summary content to issue bodies.
 
     The validation_summary file is a bulk audit artifact covering all findings
-    for a source. SKILL.md line 300-301 states it is NOT part of the issue body.
+    for a source. SKILL.md § Issue Body Construction states it is NOT part of the issue body.
     """
     va_dir = tmp_path / ".autoskillit" / "temp" / "validate-audit"
     va_dir.mkdir(parents=True)

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -430,11 +430,16 @@ def test_batch_create_issues_chunks_large_batches(tmp_path):
     assert result["issue_count"] == "25"
 
 
-def test_batch_create_issues_appends_validation_summary(tmp_path):
+def test_batch_create_issues_ignores_validation_summary_file(tmp_path):
+    """batch_create_issues must not append validation_summary content to issue bodies.
+
+    The validation_summary file is a bulk audit artifact covering all findings
+    for a source. SKILL.md line 300-301 states it is NOT part of the issue body.
+    """
     va_dir = tmp_path / ".autoskillit" / "temp" / "validate-audit"
     va_dir.mkdir(parents=True)
     (va_dir / "ticket_body_tests_1_2026-01-01_120000.md").write_text(
-        "# Audit Finding\n\nSome finding."
+        "validated: true\n\n# Audit Finding\n\nSome finding."
     )
     (va_dir / "validation_summary_tests_2026-01-01_120000.md").write_text(
         "## Validation Summary\nAll clear."
@@ -445,17 +450,19 @@ def test_batch_create_issues_appends_validation_summary(tmp_path):
     ):
         mock_run.side_effect = _make_side_effect()
         batch_create_issues(workspace=str(tmp_path))
-    found = False
     for call in mock_run.call_args_list:
         kwargs = call[1]
         if kwargs.get("input"):
             mutation_call = json.loads(kwargs["input"])
             body = mutation_call["variables"]["i0"]["body"]
-            assert "## Validation Summary" in body
-            assert "All clear." in body
-            found = True
-            break
-    assert found, "no createIssue mutation call found in mock_run calls"
+            assert "## Validation Summary" not in body, (
+                "validation_summary content must not be appended to issue bodies"
+            )
+            assert "All clear." not in body, (
+                "validation_summary content must not be appended to issue bodies"
+            )
+            return
+    pytest.fail("no createIssue mutation call found in mock_run calls")
 
 
 def test_batch_create_issues_handles_no_tickets(tmp_path):


### PR DESCRIPTION
## Summary

`batch_create_issues` in `src/autoskillit/recipe/_cmd_rpc.py` (lines 660–662) incorrectly appends the full `validation_summary_{source}_{ts}.md` — a bulk audit artifact covering ALL findings — to the body of EVERY ticket created from that source/timestamp pair. For a run with N tickets from the same audit source, the same 14K summary is embedded in N GitHub issues.

The root cause is a three-line block that violates the `validate-audit` skill's own specification: SKILL.md line 300–301 explicitly states the validation summary "is NOT part of the issue body — it is posted as a comment after issue creation." In headless mode (the mode used by the full-audit recipe pipeline), the SKILL.md says the summary path is printed to terminal only; no automatic issue edit occurs. The append logic in `batch_create_issues` contradicts both of these constraints.

The fix is to remove lines 660–662 and update the covering test.

Closes #2097

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-2097-20260507-110349-089032/.autoskillit/temp/make-plan/fix_batch_create_issues_validation_summary_plan_2026-05-07_110500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 105 | 11.9k | 438.1k | 62.7k | 72 | 44.2k | 9m 28s |
| verify | claude-sonnet-4-6 | 1 | 333 | 7.1k | 348.9k | 46.3k | 31 | 33.5k | 2m 38s |
| implement* | MiniMax-M2.7-highspeed | 1 | 308.3k | 4.8k | 565.6k | 29.8k | 53 | 43.1k | 5m 24s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 88.7k | 4.2k | 265.0k | 29.8k | 24 | 15.3k | 1m 29s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 72.1k | 2.1k | 235.3k | 29.8k | 19 | 15.1k | 52s |
| review_pr | claude-sonnet-4-6 | 1 | 94 | 22.1k | 479.5k | 80.3k | 38 | 76.1k | 5m 45s |
| resolve_review | claude-sonnet-4-6 | 1 | 257 | 18.0k | 1.7M | 72.1k | 109 | 59.3k | 9m 51s |
| **Total** | | | 469.9k | 70.2k | 4.0M | 80.3k | | 286.6k | 35m 30s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 672 | 841.6 | 64.1 | 7.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 280361.0 | 9875.7 | 2993.3 |
| **Total** | **678** | 5921.1 | 422.6 | 103.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 438 | 19.0k | 787.0k | 77.7k | 12m 7s |
| MiniMax-M2.7-highspeed | 3 | 469.1k | 11.1k | 1.1M | 73.5k | 7m 46s |