### PR TITLE
Disambiguate IL-N Import Layers from L-N Orchestration Levels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,13 @@ generic_automation_mcp/
 
 **CRITICAL**: When using subagents, invoke with `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=120000` to ensure subagents exit when finished.
 
-**Import layer vs. orchestration level:** Module docstrings and import-linter
-contracts use IL-N labels (IL-001–IL-009 in `pyproject.toml`) for the import
-dependency hierarchy — these are separate from the L0–L3 orchestration levels
-defined in `docs/orchestration-levels.md`.
+**Import layer vs. orchestration level — disambiguation table:**
+
+| Notation | System | Example | Meaning |
+|----------|--------|---------|---------|
+| IL-N (single digit) | Import layer level | IL-0, IL-2 | Module's position in the import DAG |
+| IL-NNN (three-digit) | Import-linter contract ID | IL-001, IL-009 | Specific pyproject.toml contract |
+| L-N | Orchestration level | L0, L3 | Runtime session spawning tier (see `docs/orchestration-levels.md`) |
 
 ## 7. Session Diagnostics
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,10 @@ root_packages = ["autoskillit"]
 # inside TYPE_CHECKING blocks to avoid circular imports at runtime.
 exclude_type_checking_imports = true
 
+# Contract IDs below use IL-NNN (three-digit serial numbers, e.g. IL-001).
+# These are NOT import layer levels (IL-0 through IL-3).
+# IL-002 = config's contract; IL-2 = the recipe/migration/fleet import layer.
+
 # IL-001 | Lens: module-dependency | DS-001
 # Rationale: IL-0 (core) is the foundation layer; it must have zero upward imports to
 # remain independently testable and importable outside the autoskillit package.

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -120,7 +120,11 @@
       "outputs": [
         {
           "name": "merged",
-          "type": "string"
+          "type": "string",
+          "allowed_values": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "needs_plan",

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T10:12:39.088966+00:00",
+  "generated_at": "2026-05-07T16:23:58.667262+00:00",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {
@@ -80,6 +80,10 @@
         {
           "name": "revision_guidance",
           "type": "file_path"
+        },
+        {
+          "name": "classification_timestamp",
+          "type": "string"
         }
       ],
       "expected_output_patterns": [
@@ -113,7 +117,13 @@
         },
         {
           "name": "scope_report_path",
-          "type": "file_path",
+          "type": "string",
+          "required": false,
+          "recommended": false
+        },
+        {
+          "name": "experiment_type",
+          "type": "string",
           "required": false,
           "recommended": false
         }
@@ -126,14 +136,32 @@
         {
           "name": "report_plan_path",
           "type": "file_path"
+        },
+        {
+          "name": "disambiguation_rule_applied",
+          "type": "string"
+        },
+        {
+          "name": "tier_c_lens",
+          "type": "string"
+        },
+        {
+          "name": "methodology_tradition",
+          "type": "string"
+        },
+        {
+          "name": "visualization_plan_trace_path",
+          "type": "file_path"
         }
       ],
       "expected_output_patterns": [
         "visualization_plan_path\\s*=\\s*/.+",
-        "report_plan_path\\s*=\\s*/.+"
+        "report_plan_path\\s*=\\s*/.+",
+        "methodology_tradition\\s*=\\s*\\S+"
       ],
       "pattern_examples": [
-        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\n%%ORDER_UP%%"
+        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\nmethodology_tradition = controlled_intervention\n%%ORDER_UP%%",
+        "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\nmethodology_tradition = null\n%%ORDER_UP%%"
       ],
       "write_behavior": "always"
     },
@@ -331,7 +359,7 @@
       "inputs": [
         {
           "name": "worktree_path",
-          "type": "directory_path",
+          "type": "string",
           "required": true,
           "recommended": false
         },
@@ -399,6 +427,18 @@
           "name": "results_path",
           "type": "file_path",
           "required": true,
+          "recommended": false
+        },
+        {
+          "name": "experiment_type",
+          "type": "string",
+          "required": false,
+          "recommended": false
+        },
+        {
+          "name": "methodology_tradition",
+          "type": "string",
+          "required": false,
           "recommended": false
         }
       ],
@@ -498,7 +538,7 @@
         },
         {
           "name": "lens_context_paths",
-          "type": "file_path_list"
+          "type": "string"
         }
       ],
       "expected_output_patterns": [
@@ -521,7 +561,7 @@
         },
         {
           "name": "all_diagram_paths",
-          "type": "file_path_list",
+          "type": "string",
           "required": true,
           "recommended": false
         },
@@ -593,8 +633,7 @@
         "verdict = approved\n%%ORDER_UP%%",
         "verdict = changes_requested\n%%ORDER_UP%%",
         "verdict = needs_human\n%%ORDER_UP%%"
-      ],
-      "write_behavior": "always"
+      ]
     },
     "audit-claims": {
       "inputs": [
@@ -630,8 +669,7 @@
         "verdict = approved\n%%ORDER_UP%%",
         "verdict = changes_requested\n%%ORDER_UP%%",
         "verdict = needs_human\n%%ORDER_UP%%"
-      ],
-      "write_behavior": "always"
+      ]
     },
     "resolve-research-review": {
       "inputs": [
@@ -663,13 +701,13 @@
         }
       ],
       "expected_output_patterns": [
-        "needs_rerun\\s*=\\s*(true|false)",
-        "verdict\\s*=\\s*(real_fix|already_green)",
-        "fixes_applied\\s*=\\s*\\d+"
+        "needs_rerun\\s*=\\s*(true|false)"
       ],
       "pattern_examples": [
         "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%",
-        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
+        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = true\nverdict = flake_suspected\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
       ],
       "write_behavior": "conditional",
       "write_expected_when": [
@@ -706,13 +744,13 @@
         }
       ],
       "expected_output_patterns": [
-        "needs_rerun\\s*=\\s*(true|false)",
-        "verdict\\s*=\\s*(real_fix|already_green)",
-        "fixes_applied\\s*=\\s*\\d+"
+        "needs_rerun\\s*=\\s*(true|false)"
       ],
       "pattern_examples": [
         "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%",
-        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
+        "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = true\nverdict = flake_suspected\nfixes_applied = 0\n%%ORDER_UP%%",
+        "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
       ],
       "write_behavior": "conditional",
       "write_expected_when": [
@@ -823,7 +861,8 @@
         "verdict",
         "experiment_type",
         "evaluation_dashboard",
-        "revision_guidance"
+        "revision_guidance",
+        "classification_timestamp"
       ]
     },
     {
@@ -831,6 +870,7 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
@@ -849,7 +889,11 @@
       ],
       "produced": [
         "visualization_plan_path",
-        "report_plan_path"
+        "report_plan_path",
+        "disambiguation_rule_applied",
+        "tier_c_lens",
+        "methodology_tradition",
+        "visualization_plan_trace_path"
       ]
     },
     {
@@ -857,10 +901,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -869,8 +916,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": []
@@ -880,10 +929,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -892,8 +944,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": [
@@ -905,10 +959,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -917,8 +974,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": []
@@ -928,10 +987,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "review_design",
@@ -940,8 +1002,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
-        "visualization_plan_path"
+        "visualization_plan_path",
+        "visualization_plan_trace_path"
       ],
       "required": [],
       "produced": [
@@ -954,10 +1018,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -967,8 +1034,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -982,10 +1051,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -996,8 +1068,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1010,10 +1084,13 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -1024,8 +1101,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1040,11 +1119,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "report_plan_path",
         "research_dir",
@@ -1055,8 +1137,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1071,11 +1155,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1087,8 +1174,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1103,11 +1192,14 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1119,8 +1211,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1134,12 +1228,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1151,8 +1248,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1163,12 +1262,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1180,8 +1282,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1192,12 +1296,15 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_type",
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1209,8 +1316,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1223,6 +1332,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1230,6 +1341,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1241,8 +1353,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1256,6 +1370,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1263,6 +1379,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1275,8 +1392,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1287,6 +1406,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1294,6 +1415,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1306,8 +1428,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1321,6 +1445,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1328,6 +1454,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1340,8 +1467,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1354,6 +1483,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1361,6 +1492,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_plan_path",
@@ -1373,21 +1505,25 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 2
+      "positional_args": 14
     },
     {
       "step": "generate_report_inconclusive",
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1395,6 +1531,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1408,21 +1545,25 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 3
+      "positional_args": 15
     },
     {
       "step": "test",
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1430,6 +1571,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1443,8 +1585,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1455,6 +1599,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1462,6 +1608,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1475,8 +1622,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1492,6 +1641,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1500,6 +1651,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1513,8 +1665,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1525,6 +1679,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1533,6 +1689,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1546,8 +1703,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1558,6 +1717,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1566,6 +1727,7 @@
         "group_files",
         "is_fixable",
         "issue_url",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "report_path",
@@ -1579,8 +1741,10 @@
         "scope_report",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -1597,6 +1761,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1606,6 +1772,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1621,8 +1788,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1633,6 +1802,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1642,6 +1813,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1657,8 +1829,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1669,6 +1843,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1678,6 +1854,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1693,8 +1870,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1705,6 +1884,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1714,6 +1895,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "prep_path",
@@ -1729,8 +1911,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1744,6 +1928,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1753,6 +1939,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1769,8 +1956,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1781,6 +1970,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1790,6 +1981,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1806,8 +1998,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1820,6 +2014,8 @@
       "available": [
         "audit_claims",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1829,6 +2025,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1846,8 +2043,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1861,6 +2060,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1870,6 +2071,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1887,8 +2089,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1900,6 +2104,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1909,6 +2115,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1926,8 +2133,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1941,6 +2150,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1950,6 +2161,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -1968,8 +2180,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -1981,6 +2195,8 @@
         "audit_claims",
         "audit_verdict",
         "base_branch",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -1990,6 +2206,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2008,8 +2225,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2024,6 +2243,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2033,6 +2254,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2051,8 +2273,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2065,6 +2289,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2074,6 +2300,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2092,8 +2319,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2109,6 +2338,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2118,6 +2349,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2136,15 +2368,17 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
       "produced": [
         "report_path"
       ],
-      "positional_args": 2
+      "positional_args": 14
     },
     {
       "step": "re_stage_bundle",
@@ -2153,6 +2387,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2162,6 +2398,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2180,8 +2417,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2194,6 +2433,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2203,6 +2444,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2221,8 +2463,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2235,6 +2479,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2244,6 +2490,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2262,8 +2509,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2276,6 +2525,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2285,6 +2536,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2303,8 +2555,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2319,6 +2573,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2328,6 +2584,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2347,8 +2604,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [
@@ -2365,6 +2624,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2375,6 +2636,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2394,8 +2656,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2408,6 +2672,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2418,6 +2684,7 @@
         "is_fixable",
         "issue_url",
         "lens_context_paths",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2437,8 +2704,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2453,6 +2722,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2464,6 +2735,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2483,8 +2755,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2497,6 +2771,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_plan",
         "experiment_results",
@@ -2508,6 +2784,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2527,8 +2804,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2543,6 +2822,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2555,6 +2836,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2574,8 +2856,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2591,6 +2875,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2603,6 +2889,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2622,8 +2909,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2640,6 +2929,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2652,6 +2943,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2671,8 +2963,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2690,6 +2984,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2702,6 +2998,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2721,8 +3018,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2738,6 +3037,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2750,6 +3051,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2769,8 +3071,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2786,6 +3090,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2798,6 +3104,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2817,8 +3124,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],
@@ -2834,6 +3143,8 @@
         "audit_verdict",
         "base_branch",
         "claims_needs_rerun",
+        "classification_timestamp",
+        "disambiguation_rule_applied",
         "evaluation_dashboard",
         "experiment_branch",
         "experiment_plan",
@@ -2846,6 +3157,7 @@
         "issue_url",
         "lens_context_paths",
         "local_bundle_path",
+        "methodology_tradition",
         "output_mode",
         "phase_plan_path",
         "pr_url",
@@ -2865,8 +3177,10 @@
         "selected_lenses",
         "source_dir",
         "task",
+        "tier_c_lens",
         "verdict",
         "visualization_plan_path",
+        "visualization_plan_trace_path",
         "worktree_path"
       ],
       "required": [],

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -53,7 +53,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",
@@ -317,7 +318,7 @@
         },
         {
           "when": "result.failed_step == 'rebase'",
-          "route": "fix"
+          "route": "rebase_conflict_fix"
         },
         {
           "when": "result.error",
@@ -377,6 +378,31 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "test",
       "note": "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
+    },
+    "rebase_conflict_fix": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "rebase_conflict_fix"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "test"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "next_or_done": {
       "action": "route",
@@ -720,7 +746,7 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "ci_watch"
+          "route": "check_ci_timed_out_loop"
         },
         {
           "route": "detect_ci_conflict"
@@ -729,7 +755,32 @@
       "on_failure": "detect_ci_conflict",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → self (re-watch), failure → detect_ci_conflict.\n"
+      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → check_ci_timed_out_loop (iteration guard), failure → detect_ci_conflict.\n"
+    },
+    "check_ci_timed_out_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_timed_out_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ci_timed_out_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "detect_ci_conflict"
+        },
+        {
+          "route": "ci_watch"
+        }
+      ],
+      "on_failure": "detect_ci_conflict",
+      "optional_context_refs": [
+        "ci_timed_out_loop_count"
+      ],
+      "note": "Caps the ci_watch re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to detect_ci_conflict instead of spinning indefinitely.\n"
     },
     "handle_no_ci_runs": {
       "tool": "check_repo_merge_state",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -53,7 +53,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",
@@ -312,7 +313,7 @@
         },
         {
           "when": "result.failed_step == 'rebase'",
-          "route": "fix"
+          "route": "rebase_conflict_fix"
         },
         {
           "when": "result.error",
@@ -369,6 +370,31 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "test",
       "note": "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
+    },
+    "rebase_conflict_fix": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "rebase_conflict_fix"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "test"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "next_or_done": {
       "action": "route",
@@ -723,7 +749,7 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "ci_watch"
+          "route": "check_ci_timed_out_loop"
         },
         {
           "route": "detect_ci_conflict"
@@ -732,7 +758,32 @@
       "on_failure": "detect_ci_conflict",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → self (re-watch), failure → detect_ci_conflict.\n"
+      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → check_ci_timed_out_loop (iteration guard), failure → detect_ci_conflict.\n"
+    },
+    "check_ci_timed_out_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_timed_out_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ci_timed_out_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "detect_ci_conflict"
+        },
+        {
+          "route": "ci_watch"
+        }
+      ],
+      "on_failure": "detect_ci_conflict",
+      "optional_context_refs": [
+        "ci_timed_out_loop_count"
+      ],
+      "note": "Caps the ci_watch re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to detect_ci_conflict instead of spinning indefinitely.\n"
     },
     "handle_no_ci_runs": {
       "tool": "check_repo_merge_state",

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -672,7 +672,8 @@
         "escalation_required": "${{ result.escalation_required }}",
         "escalation_reason": "${{ result.escalation_reason }}",
         "task": "${{ result.conflict_report_path }}",
-        "current_pr_number": "${{ result.pr_number }}"
+        "current_pr_number": "${{ result.pr_number }}",
+        "merged": "${{ result.merged }}"
       },
       "on_result": [
         {
@@ -684,6 +685,10 @@
           "route": "plan"
         },
         {
+          "when": "${{ result.merged }} == false",
+          "route": "register_clone_failure"
+        },
+        {
           "route": "next_part_or_next_pr"
         }
       ],
@@ -691,7 +696,7 @@
       "retries": 5,
       "on_exhausted": "register_clone_failure",
       "on_context_limit": "register_clone_failure",
-      "note": "The agent reads context.pr_order_file at context.current_pr_number to get the current PR's complexity. Appends number and complexity to skill_command:\n  /autoskillit:merge-pr {pr_number} {complexity}\nescalation_required=true → ambiguous conflict, human intervention needed → escalate_stop. needs_plan=true → conflict_report_path set as context.task → plan. needs_plan=false (fallthrough) → PR merged directly → next_part_or_next_pr.\n"
+      "note": "The agent reads context.pr_order_file at context.current_pr_number to get the current PR's complexity. Appends number and complexity to skill_command:\n  /autoskillit:merge-pr {pr_number} {complexity}\nescalation_required=true → ambiguous conflict, human intervention needed → escalate_stop. needs_plan=true → conflict_report_path set as context.task → plan. merged=false (timeout/conflict) → register_clone_failure. merged=true + fallthrough → PR merged directly → next_part_or_next_pr.\n"
     },
     "plan": {
       "tool": "run_skill",
@@ -804,7 +809,8 @@
         "branch": "${{ context.worktree_branch_name }}",
         "event": "${{ context.ci_event }}",
         "timeout_seconds": 600,
-        "cwd": "${{ context.work_dir }}"
+        "cwd": "${{ context.work_dir }}",
+        "auto_trigger": "true"
       },
       "on_result": [
         {
@@ -813,14 +819,39 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "wait_for_conflict_ci"
+          "route": "check_conflict_ci_loop"
         },
         {
           "route": "register_clone_failure"
         }
       ],
       "on_failure": "register_clone_failure",
-      "note": "Waits for CI to pass on the worktree branch before merging. 600 second timeout matches the merge-pr skill poll timeout. Routes on result.conclusion: success → merge_conflict_pr, timed_out → self (re-watch), no_runs/failure → register_clone_failure.\n"
+      "note": "Waits for CI to pass on the worktree branch before merging. 600 second timeout matches the merge-pr skill poll timeout. Routes on result.conclusion: success → merge_conflict_pr, timed_out → check_conflict_ci_loop (iteration guard), no_runs/failure → register_clone_failure.\n"
+    },
+    "check_conflict_ci_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.conflict_ci_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "conflict_ci_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "register_clone_failure"
+        },
+        {
+          "route": "wait_for_conflict_ci"
+        }
+      ],
+      "on_failure": "register_clone_failure",
+      "optional_context_refs": [
+        "conflict_ci_loop_count"
+      ],
+      "note": "Caps the wait_for_conflict_ci re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to register_clone_failure instead of spinning indefinitely.\n"
     },
     "merge_conflict_pr": {
       "tool": "run_cmd",
@@ -1076,7 +1107,8 @@
         "callable": "autoskillit.smoke_utils.annotate_pr_diff",
         "pr_number": "${{ context.review_pr_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr",
+        "local_review_rounds": "0"
       },
       "capture": {
         "annotated_diff_path": "${{ result.annotated_diff_path }}",
@@ -1172,7 +1204,8 @@
         "event": "${{ context.ci_event }}",
         "timeout_seconds": 600,
         "cwd": "${{ context.work_dir }}",
-        "pr_url": "${{ context.pr_url }}"
+        "pr_url": "${{ context.pr_url }}",
+        "auto_trigger": "true"
       },
       "on_result": [
         {
@@ -1181,14 +1214,39 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "ci_watch_pr"
+          "route": "check_ci_watch_pr_loop"
         },
         {
           "route": "register_clone_failure"
         }
       ],
       "on_failure": "diagnose_ci",
-      "note": "Waits for the GitHub Actions CI run on context.batch_branch to complete using the wait_for_ci MCP tool (timeout: 300 s). Routes on result.conclusion: success → register_clone_success, timed_out → self (re-watch), no_runs/failure → register_clone_failure. Tool-level failure routes to diagnose_ci for log capture.\n"
+      "note": "Waits for the GitHub Actions CI run on context.batch_branch to complete using the wait_for_ci MCP tool (timeout: 300 s). Routes on result.conclusion: success → patch_token_summary, timed_out → check_ci_watch_pr_loop (iteration guard), no_runs/failure → register_clone_failure. Tool-level failure routes to diagnose_ci for log capture.\n"
+    },
+    "check_ci_watch_pr_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_watch_pr_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ci_watch_pr_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "register_clone_failure"
+        },
+        {
+          "route": "ci_watch_pr"
+        }
+      ],
+      "on_failure": "register_clone_failure",
+      "optional_context_refs": [
+        "ci_watch_pr_loop_count"
+      ],
+      "note": "Caps the ci_watch_pr re-poll loop at 2 iterations.\n"
     },
     "diagnose_ci": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -61,7 +61,8 @@
     },
     "local_review_rounds": {
       "description": "Number of review-resolve cycles to run locally before switching to GitHub-backed review. 0 disables local mode entirely.",
-      "default": ""
+      "type": "integer",
+      "default": "3"
     },
     "issue_url": {
       "description": "GitHub issue to close on merge",
@@ -333,6 +334,31 @@
       "on_failure": "release_issue_failure",
       "on_exhausted": "release_issue_failure"
     },
+    "rebase_conflict_fix": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "rebase_conflict_fix"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "test"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
+    },
     "audit_impl": {
       "tool": "run_skill",
       "model": "",
@@ -423,7 +449,7 @@
         },
         {
           "when": "result.failed_step == 'rebase'",
-          "route": "assess"
+          "route": "rebase_conflict_fix"
         },
         {
           "when": "result.error",
@@ -750,7 +776,7 @@
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
-          "route": "ci_watch"
+          "route": "check_ci_timed_out_loop"
         },
         {
           "route": "detect_ci_conflict"
@@ -759,7 +785,32 @@
       "on_failure": "detect_ci_conflict",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → self (re-watch), failure → detect_ci_conflict.\n"
+      "note": "Waits for the GitHub Actions CI run on context.merge_target to complete using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false — no remote feature branch is opened in that mode. Routes on result.conclusion: success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached only when push fails), timed_out → check_ci_timed_out_loop (iteration guard), failure → detect_ci_conflict.\n"
+    },
+    "check_ci_timed_out_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_timed_out_loop_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ci_timed_out_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "detect_ci_conflict"
+        },
+        {
+          "route": "ci_watch"
+        }
+      ],
+      "on_failure": "detect_ci_conflict",
+      "optional_context_refs": [
+        "ci_timed_out_loop_count"
+      ],
+      "note": "Caps the ci_watch re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to detect_ci_conflict instead of spinning indefinitely.\n"
     },
     "handle_no_ci_runs": {
       "tool": "check_repo_merge_state",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -100,7 +100,8 @@
         "verdict": "${{ result.verdict }}",
         "experiment_type": "${{ result.experiment_type }}",
         "evaluation_dashboard": "${{ result.evaluation_dashboard }}",
-        "revision_guidance": "${{ result.revision_guidance }}"
+        "revision_guidance": "${{ result.revision_guidance }}",
+        "classification_timestamp": "${{ result.classification_timestamp }}"
       },
       "skip_when_false": "inputs.review_design",
       "retries": 2,
@@ -129,17 +130,17 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }} ${{ context.experiment_type }}",
+        "skill_command": "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_visualization"
       },
-      "optional_context_refs": [
-        "experiment_type"
-      ],
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
         "report_plan_path": "${{ result.report_plan_path }}",
-        "methodology_tradition": "${{ result.methodology_tradition }}"
+        "disambiguation_rule_applied": "${{ result.disambiguation_rule_applied }}",
+        "tier_c_lens": "${{ result.tier_c_lens }}",
+        "methodology_tradition": "${{ result.methodology_tradition }}",
+        "visualization_plan_trace_path": "${{ result.visualization_plan_trace_path }}"
       },
       "on_success": "create_worktree",
       "on_failure": "escalate_stop",
@@ -194,7 +195,7 @@
     "create_worktree": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}'",
+        "cmd": "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}' '${{ context.visualization_plan_trace_path }}'",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "create_worktree"
       },
@@ -430,14 +431,10 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
-      "optional_context_refs": [
-        "experiment_type",
-        "methodology_tradition"
-      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },
@@ -450,14 +447,10 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
-      "optional_context_refs": [
-        "experiment_type",
-        "methodology_tradition"
-      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },
@@ -750,14 +743,10 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type ${{ context.experiment_type }} --methodology-tradition ${{ context.methodology_tradition }}",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "re_generate_report"
       },
-      "optional_context_refs": [
-        "experiment_type",
-        "methodology_tradition"
-      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -435,6 +435,14 @@
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
+      "optional_context_refs": [
+        "experiment_type",
+        "methodology_tradition",
+        "verdict",
+        "disambiguation_rule_applied",
+        "tier_c_lens",
+        "classification_timestamp"
+      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },
@@ -451,6 +459,14 @@
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
+      "optional_context_refs": [
+        "experiment_type",
+        "methodology_tradition",
+        "verdict",
+        "disambiguation_rule_applied",
+        "tier_c_lens",
+        "classification_timestamp"
+      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },
@@ -747,6 +763,14 @@
         "cwd": "${{ context.worktree_path }}",
         "step_name": "re_generate_report"
       },
+      "optional_context_refs": [
+        "experiment_type",
+        "methodology_tradition",
+        "verdict",
+        "disambiguation_rule_applied",
+        "tier_c_lens",
+        "classification_timestamp"
+      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },

--- a/tests/arch/test_cli_decomposition.py
+++ b/tests/arch/test_cli_decomposition.py
@@ -41,7 +41,7 @@ def _body_is_only_sys_exit(node: ast.ExceptHandler) -> bool:
 
 
 # CD1
-# cli/app.py is L3 and can import from every internal layer (L0–L2), which makes
+# cli/app.py is IL-3 and can import from every internal layer (IL-0–IL-2), which makes
 # it the single easiest place for AI to dump new logic — it bypasses all layer
 # restrictions that guard other modules.  This limit exists to keep that file
 # decomposed.  Only a human may raise it beyond 750.

--- a/tests/arch/test_gfm_rendering_guard.py
+++ b/tests/arch/test_gfm_rendering_guard.py
@@ -19,11 +19,11 @@ def test_format_ingredients_table_delegates_to_render_gfm_table():
     src = inspect.getsource(format_ingredients_table)
     assert "_render_gfm_table" in src, (
         "format_ingredients_table must delegate to _render_gfm_table. "
-        "Reverting to inline width math is prohibited — it bypasses the L0 cap contract."
+        "Reverting to inline width math is prohibited — it bypasses the IL-0 cap contract."
     )
     assert "max(len(" not in src, (
         "format_ingredients_table must not contain ad-hoc max(len(...)) width computation. "
-        "Width capping belongs in _render_gfm_table at L0."
+        "Width capping belongs in _render_gfm_table at IL-0."
     )
 
 

--- a/tests/arch/test_import_layer_labels.py
+++ b/tests/arch/test_import_layer_labels.py
@@ -199,3 +199,30 @@ def test_precautionary_skip_paths_do_not_contain_matching_files() -> None:
             f"Precautionary skip {skip_path!r} now contains import-layer label patterns: "
             f"{violations!r}. Move it to _LOAD_BEARING_SKIP_PATHS."
         )
+
+
+def test_no_bare_import_layer_labels_in_arch_tests() -> None:
+    """Arch test files must use IL-N, not bare L-N, for import-layer references.
+
+    test_import_layer_labels.py is exempt because its regex patterns
+    necessarily contain L-number literals as detection targets.
+    """
+    arch_dir = Path(__file__).parent
+    pattern = re.compile(r"(?<!orchestration-)(?<!IL-)\bL[0-3]\b")
+    exempt = {"test_import_layer_labels.py"}
+
+    violations: dict[str, list[str]] = {}
+    for py_file in sorted(arch_dir.glob("test_*.py")):
+        if py_file.name in exempt:
+            continue
+        for lineno, line in enumerate(py_file.read_text(encoding="utf-8").splitlines(), 1):
+            if pattern.search(line):
+                violations.setdefault(py_file.name, []).append(f"{lineno}: {line.strip()!r}")
+
+    assert not violations, (
+        "Found bare L-number import-layer labels in arch tests — use IL-N:\n"
+        + "\n".join(
+            f"  {name}:\n" + "\n".join(f"    {v}" for v in lines)
+            for name, lines in sorted(violations.items())
+        )
+    )

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -3,7 +3,7 @@
 Tests:
   - MCP tool registry completeness (bidirectional equality with _gate registry)
   - Import layer contract (each module only imports from same or lower layer)
-  - L1 package runtime isolation
+  - IL-1 package runtime isolation
   - Cross-package submodule import restrictions
   - server/tools/tools_*.py import constraints
   - Notification and convention guards
@@ -29,19 +29,19 @@ from tests.arch._rules import RuleDescriptor
 
 # ── Sub-package layer registry ────────────────────────────────────────────────
 SUBPACKAGE_LAYERS: dict[str, int] = {
-    # Layer 0: core/ — zero autoskillit internal imports
+    # IL-0: core/ — zero autoskillit internal imports
     "core": 0,
-    # Layer 1: domain primitives — may import only from L0
+    # IL-1: domain primitives — may import only from IL-0
     "config": 1,
     "pipeline": 1,
     "execution": 1,
     "workspace": 1,
     "planner": 1,
-    # Layer 2: domain services — may import from L0 and L1
+    # IL-2: domain services — may import from IL-0 and IL-1
     "recipe": 2,
     "migration": 2,
     "fleet": 2,
-    # Layer 3: application layer — may import from L0–L2
+    # IL-3: application layer — may import from IL-0–IL-2
     "server": 3,
     "cli": 3,
 }
@@ -61,7 +61,7 @@ LAYER_RULES: dict[str, RuleDescriptor] = {
         lens="module-dependency",
         description=(
             "Each autoskillit sub-package may only import from packages at the same or lower "
-            "layer (L0 \u2264 L1 \u2264 L2 \u2264 L3). Upward imports introduce coupling that "
+            "layer (IL-0 \u2264 IL-1 \u2264 IL-2 \u2264 IL-3). Upward imports introduce coupling that "
             "hinders independent testing and layering guarantees."
         ),
         rationale=(
@@ -75,15 +75,15 @@ LAYER_RULES: dict[str, RuleDescriptor] = {
     ),
     "REQ-ARCH-003": RuleDescriptor(
         rule_id="REQ-ARCH-003",
-        name="l1-packages-no-runtime-l2-l3-imports",
+        name="il1-packages-no-runtime-il2-il3-imports",
         lens="module-dependency",
         description=(
-            "L1 sub-packages (config, pipeline, execution, workspace) must not import from "
-            "L2 or L3 packages at runtime. TYPE_CHECKING-guarded imports are permitted."
+            "IL-1 sub-packages (config, pipeline, execution, workspace) must not import from "
+            "IL-2 or IL-3 packages at runtime. TYPE_CHECKING-guarded imports are permitted."
         ),
         rationale=(
-            "Runtime L1\u2192L2 imports would introduce cyclic dependency risk because L2 "
-            "packages (recipe, migration) are permitted to import from L1."
+            "Runtime IL-1\u2192IL-2 imports would introduce cyclic dependency risk because IL-2 "
+            "packages (recipe, migration) are permitted to import from IL-1."
         ),
         exemptions=frozenset(),
         severity="high",
@@ -349,8 +349,8 @@ def test_import_layer_enforcement(pkg_name: str, layer: int) -> None:
             imported_layer = SUBPACKAGE_LAYERS[imported_stem]
             if imported_layer > layer:
                 violations.append(
-                    f"  {_rel(py_file)}:{lineno}: {pkg_name} (L{layer}) imports "
-                    f"{imported_stem} (L{imported_layer}) — upward import"
+                    f"  {_rel(py_file)}:{lineno}: {pkg_name} (IL-{layer}) imports "
+                    f"{imported_stem} (IL-{imported_layer}) — upward import"
                 )
 
     assert not violations, f"Layer violations in {pkg_name}/:\n" + "\n".join(violations)
@@ -360,14 +360,14 @@ def test_import_layer_enforcement(pkg_name: str, layer: int) -> None:
     "pkg_name",
     [pkg for pkg, layer in SUBPACKAGE_LAYERS.items() if layer in {1, 2}],
 )
-def test_l2_no_deferred_upward_imports(pkg_name: str) -> None:
-    """L1/L2 sub-packages must not use deferred imports that violate layer contracts.
+def test_il2_no_deferred_upward_imports(pkg_name: str) -> None:
+    """IL-1/IL-2 sub-packages must not use deferred imports that violate layer contracts.
 
     Extends test_import_layer_enforcement to cover function-body (deferred) imports
     via ast.walk, not just tree.body scans. Mirrors the upward-only rule applied at
-    module level: L1 packages (config, pipeline, execution, workspace) may not
-    deferred-import an L2+ package; L2 packages (recipe, migration) may not
-    deferred-import an L3 package (server, cli) — always forbidden.
+    module level: IL-1 packages (config, pipeline, execution, workspace) may not
+    deferred-import an IL-2+ package; IL-2 packages (recipe, migration) may not
+    deferred-import an IL-3 package (server, cli) — always forbidden.
     """
     pkg_dir = SRC_ROOT / pkg_name
     if not pkg_dir.exists():
@@ -399,8 +399,8 @@ def test_l2_no_deferred_upward_imports(pkg_name: str) -> None:
                 imported_layer = SUBPACKAGE_LAYERS[imported_stem]
                 if imported_layer > pkg_layer:
                     violations.append(
-                        f"  {_rel(py_file)}:{node.lineno}: {pkg_name} (L{pkg_layer}) "
-                        f"deferred-imports {imported_stem} (L{imported_layer})"
+                        f"  {_rel(py_file)}:{node.lineno}: {pkg_name} (IL-{pkg_layer}) "
+                        f"deferred-imports {imported_stem} (IL-{imported_layer})"
                         f" — upward deferred import"
                     )
 
@@ -426,7 +426,7 @@ def test_workspace_deferred_import_has_comment() -> None:
 
 
 def test_layer_enforcement_detects_upward_import(tmp_path: Path) -> None:
-    """A L1 module importing a L3 module triggers a violation."""
+    """An IL-1 module importing an IL-3 module triggers a violation."""
     f = tmp_path / "fake_l1.py"
     f.write_text("from autoskillit.server import mcp\n")
     violations: list[str] = []
@@ -436,14 +436,14 @@ def test_layer_enforcement_detects_upward_import(tmp_path: Path) -> None:
             parts = node.module.split(".")
             if parts[0] == "autoskillit" and len(parts) > 1:
                 imported = parts[1]
-                # synthetic module is L1; upward = strictly greater
+                # synthetic module is IL-1; upward = strictly greater
                 if SUBPACKAGE_LAYERS.get(imported, 0) > 1:
                     violations.append(imported)
     assert violations  # must detect the upward import
 
 
-def test_l0_no_dynamic_internal_imports() -> None:
-    """L0 code must not dynamically import autoskillit subpackages."""
+def test_il0_no_dynamic_internal_imports() -> None:
+    """IL-0 code must not dynamically import autoskillit subpackages."""
     violations = []
     for src_file in sorted(_CORE_SRC.rglob("*.py")):
         tree = ast.parse(src_file.read_text(), filename=str(src_file))
@@ -463,11 +463,12 @@ def test_l0_no_dynamic_internal_imports() -> None:
                         f"{src_file.name}:{node.lineno}: importlib.import_module({arg.value!r})"
                     )
     assert not violations, (
-        "L0 (core/) must not dynamically import autoskillit subpackages:\n" + "\n".join(violations)
+        "IL-0 (core/) must not dynamically import autoskillit subpackages:\n"
+        + "\n".join(violations)
     )
 
 
-# ── L1 Package Runtime Isolation Tests ────────────────────────────────────────
+# ── IL-1 Package Runtime Isolation Tests ────────────────────────────────────────
 
 
 def test_execution_imports_only_core() -> None:
@@ -664,7 +665,7 @@ def test_server_tools_import_only_allowed_packages() -> None:
 
 def test_server_non_tools_no_cli_imports() -> None:
     """REQ-ARCH-003b: server/*.py (non-tools_*) files must not import from
-    autoskillit.cli — cross-L3 peer dependency. TYPE_CHECKING exempt.
+    autoskillit.cli — cross-IL-3 peer dependency. TYPE_CHECKING exempt.
     """
     DENIED = {"cli"}
     non_tools_files = [
@@ -681,11 +682,11 @@ def test_server_non_tools_no_cli_imports() -> None:
                 if parts[1] in DENIED:
                     violations.append(
                         f"{path.name}:{node.lineno} imports from "
-                        f"autoskillit.{parts[1]} (cross-L3 peer, not allowed)"
+                        f"autoskillit.{parts[1]} (cross-IL-3 peer, not allowed)"
                     )
 
     assert not violations, (
-        "server/*.py (non-tools_*) files import from peer-L3 autoskillit sub-packages:\n"
+        "server/*.py (non-tools_*) files import from peer-IL-3 autoskillit sub-packages:\n"
         + "\n".join(violations)
     )
 
@@ -944,7 +945,7 @@ def test_display_categories_sync() -> None:
 
 
 def test_tool_categories_not_in_core() -> None:
-    """TOOL_CATEGORIES must not be exported from the L0 core layer."""
+    """TOOL_CATEGORIES must not be exported from the IL-0 core layer."""
     import autoskillit.core
     import autoskillit.core.types._type_constants
 
@@ -1125,7 +1126,7 @@ def test_default_classes_only_instantiated_inside_factory_or_allowlist() -> None
 _TESTS_ROOT = Path(__file__).parent.parent  # = tests/
 
 # Allowed autoskillit top-level packages per test layer directory.
-# L3 dirs (server, cli) use wildcard "autoskillit" meaning any sub-package is allowed.
+# IL-3 dirs (server, cli) use wildcard "autoskillit" meaning any sub-package is allowed.
 _TEST_LAYER_ALLOWED: dict[str, frozenset[str]] = {
     "tests/core": frozenset({"autoskillit.core"}),
     "tests/config": frozenset({"autoskillit.core", "autoskillit.config"}),
@@ -1185,7 +1186,7 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     # workspace tests
     "tests/workspace/test_clone_ci_contract.py": frozenset({"autoskillit.execution"}),
     "tests/workspace/test_skills.py": frozenset({"autoskillit.config"}),
-    # recipe tests — recipe layer is L2 and may use workspace (L1 sibling)
+    # recipe tests — recipe layer is IL-2 and may use workspace (IL-1 sibling)
     "tests/recipe/test_contracts.py": frozenset({"autoskillit.workspace"}),
     "tests/recipe/test_rules_skill_content.py": frozenset({"autoskillit.workspace"}),
     # review loop routing integration imports root-level smoke_utils
@@ -1253,7 +1254,7 @@ def test_test_files_respect_layer_boundaries(
 ) -> None:
     """Each test_*.py in a layered directory may only import from its allowed autoskillit packages.
 
-    L3 test dirs (server/, cli/) use a wildcard and may import from any autoskillit sub-package.
+    IL-3 test dirs (server/, cli/) use a wildcard and may import from any autoskillit sub-package.
     Known intentional cross-refs are listed in _TEST_LAYER_ALLOWLIST with rationale.
     conftest.py files are exempt (only test_*.py is scanned).
     """

--- a/tests/arch/test_python_no_hardcoded_temp.py
+++ b/tests/arch/test_python_no_hardcoded_temp.py
@@ -48,12 +48,12 @@ _TEMP_PATH_WHITELIST: dict[str, str] = {
     "execution/testing.py": "sidecar path for worktree base branch detection",
     # Justification: reads fleet dispatch state files from the canonical temp dir
     # (<project_root>/.autoskillit/temp/dispatches/) to determine which campaign IDs
-    # have active dispatches; owned by the fleet layer after the L1→L2 refactor.
+    # have active dispatches; owned by the fleet layer after the IL-1→IL-2 refactor.
     "fleet/state.py": "reads fleet dispatch state from canonical temp dir",
-    # Justification: stdlib-only L0 module (no autoskillit imports allowed); uses the
+    # Justification: stdlib-only IL-0 module (no autoskillit imports allowed); uses the
     # canonical .autoskillit/temp path to locate session_registry.json, mirroring the
     # same path construction used by kitchen_state.py and _hook_settings.py.
-    "core/runtime/session_registry.py": "stdlib-only L0 registry; cannot use resolve_temp_dir()",
+    "core/runtime/session_registry.py": "stdlib-only IL-0 registry; cannot use resolve_temp_dir()",
     # Justification: docstring for _write_hook_config() references the canonical
     # hook config path so callers know where the file is written.
     "server/tools/tools_kitchen.py": "docstring example",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -437,7 +437,7 @@ def test_server_uses_recipe_io_not_recipe_loader_for_discovery() -> None:
     assert "from autoskillit.recipe.loader import load_recipe" not in combined_src
 
 
-# ── New L2 sub-package tests (T1–T7 from groupC plan) ─────────────────────────
+# ── New IL-2 sub-package tests (T1–T7 from groupC plan) ─────────────────────────
 
 
 def test_recipe_subpackage_importable() -> None:
@@ -520,7 +520,7 @@ def test_old_flat_migration_modules_removed() -> None:
         )
 
 
-# ── New L3 package tests (groupD plan) ────────────────────────────────────────
+# ── New IL-3 package tests (groupD plan) ────────────────────────────────────────
 
 
 def test_server_is_package() -> None:
@@ -724,9 +724,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         (_type_enums, _type_protocols_logging, _type_protocols_execution,
         _type_protocols_github, _type_protocols_workspace, _type_protocols_recipe,
         _type_protocols_infra, _type_results, _type_subprocess, etc.) to
-        prevent circular imports while keeping L0 types co-located. Also houses
-        _terminal_table.py as the L0 shared terminal rendering primitive so that
-        both cli/ (L3) and pipeline/ (L1) can import it without layer violations.
+        prevent circular imports while keeping IL-0 types co-located. Also houses
+        _terminal_table.py as the IL-0 shared terminal rendering primitive so that
+        both cli/ (IL-3) and pipeline/ (IL-1) can import it without layer violations.
         _claude_env.py adds the canonical IDE-scrubbing env builder for all
         claude subprocess launches. kitchen_state.py adds the stdlib-only
         kitchen-open session marker reader for hook subprocesses.
@@ -735,13 +735,13 @@ def test_no_subpackage_exceeds_10_files() -> None:
         _plugin_cache.py adds the plugin cache lifecycle: retiring cache sweep,
         install locking, and kitchen registry (accessible from server/ without
         cli/ import).
-        feature_flags.py adds the L0 is_feature_enabled() primitive — must live
+        feature_flags.py adds the IL-0 is_feature_enabled() primitive — must live
         in core/ to be importable by all layers without cross-layer violations.
         session_registry.py adds the stdlib-only session registry mapping
         autoskillit launch IDs to Claude Code session UUIDs for the scoped
         resume picker.
         tool_sequence_analysis.py adds the stdlib-only cross-session tool call
-        sequence DFG analysis (L0; must live in core/ to be importable by server/).
+        sequence DFG analysis (IL-0; must live in core/ to be importable by server/).
         Monolithic protocol module split into 6 domain-grouped shard files (net +5 files).
         _install_detect.py adds the is_dev_install() predicate for config resolution
         to auto-detect whether the install is editable when experimental_enabled is absent,
@@ -767,7 +767,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         _doctor_mcp.py, _doctor_hooks.py, _doctor_install.py, _doctor_config.py,
         _doctor_runtime.py, _doctor_env.py, _doctor_features.py, _doctor_fleet.py.
         _prompts.py (819 lines) was decomposed into three domain-focused submodules:
-        _prompts_campaign.py (L3 campaign dispatcher), _prompts_orchestrator.py
+        _prompts_campaign.py (IL-3 campaign dispatcher), _prompts_orchestrator.py
         (IL-1/IL-2 cook session), and _prompts_kitchen.py (open-kitchen + fleet-dispatch),
         with _prompts.py reduced to a shared-helpers + re-export hub (~50 lines).
         Exempt at 20 files.
@@ -839,7 +839,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
 def test_data_directories_are_not_python_packages() -> None:
     """REQ-ARCH-005: data-only directories under src/autoskillit/ must not
     contain __init__.py — that turns them into phantom Python packages
-    distinct from the real L2 module of similar name."""
+    distinct from the real IL-2 module of similar name."""
     src = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
     data_dirs = {"migrations", "recipes", "skills", "skills_extended"}
     offenders: list[str] = []
@@ -880,7 +880,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "recovery + IDLE_STALL routing + contract nudge resume tier "
         "+ DIR_MISSING late-bind recovery arm + RecordingSubprocessRunner "
         "step-name auto-derivation gate + recipe identity threading "
-        "+ _execute_claude_headless extraction + dispatch_food_truck L2 path "
+        "+ _execute_claude_headless extraction + dispatch_food_truck orchestration-L2 path "
         "+ campaign_id/dispatch_id propagation kwargs "
         "+ fs-level write detection (pre/post temp-dir snapshot + _resolve_skill_temp_dir); "
         "splitting would fragment the adjudication pipeline across modules",

--- a/tests/docs/test_orchestration_levels.py
+++ b/tests/docs/test_orchestration_levels.py
@@ -64,9 +64,11 @@ def test_orchestration_doc_cross_references_levels():
 def test_claude_md_has_il_disambiguation():
     claude_md = REPO_ROOT / "CLAUDE.md"
     text = claude_md.read_text()
-    assert "| IL-N" in text and "| IL-NNN" in text and "| L-N" in text, (
-        "CLAUDE.md must contain the three-row IL-N/IL-NNN/L-N disambiguation table"
+    assert "| IL-N" in text, "CLAUDE.md must contain the '| IL-N' row in the disambiguation table"
+    assert "| IL-NNN" in text, (
+        "CLAUDE.md must contain the '| IL-NNN' row in the disambiguation table"
     )
+    assert "| L-N" in text, "CLAUDE.md must contain the '| L-N' row in the disambiguation table"
     assert "Import layer level" in text, (
         "Disambiguation table must explain IL-N as 'Import layer level'"
     )

--- a/tests/docs/test_orchestration_levels.py
+++ b/tests/docs/test_orchestration_levels.py
@@ -64,7 +64,15 @@ def test_orchestration_doc_cross_references_levels():
 def test_claude_md_has_il_disambiguation():
     claude_md = REPO_ROOT / "CLAUDE.md"
     text = claude_md.read_text()
-    paragraphs = text.split("\n\n")
-    assert any("IL-" in p and "import" in p.lower() for p in paragraphs), (
-        "CLAUDE.md Section 6 must contain a paragraph with both IL-N notation and 'import'"
+    assert "| IL-N" in text and "| IL-NNN" in text and "| L-N" in text, (
+        "CLAUDE.md must contain the three-row IL-N/IL-NNN/L-N disambiguation table"
+    )
+    assert "Import layer level" in text, (
+        "Disambiguation table must explain IL-N as 'Import layer level'"
+    )
+    assert "Import-linter contract ID" in text, (
+        "Disambiguation table must explain IL-NNN as 'Import-linter contract ID'"
+    )
+    assert "Orchestration level" in text or "orchestration level" in text, (
+        "Disambiguation table must explain L-N as orchestration level"
     )


### PR DESCRIPTION
## Summary

Rename all bare `L0`/`L1`/`L2`/`L3` references in `tests/arch/` files to use the `IL-N` prefix when they refer to import layers (not orchestration levels). Update CLAUDE.md with a three-row disambiguation table. Add a header comment to pyproject.toml's `[tool.importlinter]` section clarifying that IL-NNN are contract serial numbers. Add a regression guard test to prevent future bare L-number import-layer labels from appearing in arch tests.

Seven files are modified; no new files are created except for test additions within existing files.

Closes #2043

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-111319-470360/.autoskillit/temp/make-plan/disambiguate_il_n_from_l_n_plan_2026-05-07_111900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 78 | 16.4k | 1.3M | 77.0k | 78 | 69.3k | 7m 4s |
| verify | claude-opus-4-6 | 1 | 48 | 14.0k | 1.6M | 70.8k | 116 | 58.0k | 7m 50s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.7M | 18.7k | 2.4M | 29.8k | 200 | 192.2k | 17m 34s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 74.0k | 3.9k | 178.6k | 29.8k | 19 | 42.2k | 1m 17s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 107.4k | 2.0k | 294.7k | 29.8k | 22 | 15.1k | 58s |
| **Total** | | | 3.9M | 54.9k | 5.7M | 77.0k | | 376.9k | 34m 45s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 817 | 2947.8 | 235.3 | 22.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **817** | 7016.1 | 461.3 | 67.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 126 | 30.3k | 2.9M | 127.3k | 14m 54s |
| MiniMax-M2.7-highspeed | 3 | 3.9M | 24.6k | 2.9M | 249.6k | 19m 50s |