### PR TITLE
[FIX] Rectify: _merge_group() Deliverable Bounds — Field Merge Policy

### DIFF
--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -99,6 +99,11 @@ def _merge_group(
     ]
 
     for policy in _LIST_MERGE_POLICIES:
+        if policy.overflow_target is not None:
+            assert policy.overflow_target in merged, (
+                f"overflow_target {policy.overflow_target!r} for field {policy.field!r} "
+                "must appear before it in _LIST_MERGE_POLICIES"
+            )
         seen: set[str] = set()
         raw = [
             x

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -6,11 +6,11 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from autoskillit.core import atomic_write, write_versioned_json
 from autoskillit.planner._sort_utils import _natural_sort_key
-from autoskillit.planner.schema import validate_wp_result
+from autoskillit.planner.schema import DELIVERABLE_BOUNDS, validate_wp_result
 
 _ASSIGNMENT_RE = re.compile(r"^(P\d+-A\d+)-")
 _FALLBACK_MIN_WPS = 5
@@ -24,6 +24,22 @@ class _ConsolidationGroup:
     merge_order: list[str]
     name: str | None
     goal: str | None
+
+
+class _FieldMergePolicy(NamedTuple):
+    field: str
+    cap: int | None
+    overflow_target: str | None
+
+
+# files_touched must come before deliverables so overflow demotion works correctly
+_LIST_MERGE_POLICIES: tuple[_FieldMergePolicy, ...] = (
+    _FieldMergePolicy("files_touched", cap=None, overflow_target=None),
+    _FieldMergePolicy("deliverables", cap=DELIVERABLE_BOUNDS[1], overflow_target="files_touched"),
+    _FieldMergePolicy("acceptance_criteria", cap=None, overflow_target=None),
+    _FieldMergePolicy("apis_defined", cap=None, overflow_target=None),
+    _FieldMergePolicy("apis_consumed", cap=None, overflow_target=None),
+)
 
 
 def _load_manifests(consolidation_dir: Path) -> list[dict[str, Any]]:
@@ -82,20 +98,25 @@ def _merge_group(
         s for wp in sources_in_order for s in wp.get("technical_steps", [])
     ]
 
-    for field in (
-        "deliverables",
-        "acceptance_criteria",
-        "files_touched",
-        "apis_defined",
-        "apis_consumed",
-    ):
+    for policy in _LIST_MERGE_POLICIES:
         seen: set[str] = set()
-        merged[field] = [
+        raw = [
             x
             for wp in sources_in_order
-            for x in wp.get(field, [])
+            for x in wp.get(policy.field, [])
             if not (x in seen or seen.add(x))  # type: ignore[func-returns-value]
         ]
+        if policy.cap is not None:
+            overflow = raw[policy.cap :]
+            merged[policy.field] = raw[: policy.cap]
+            if overflow and policy.overflow_target is not None:
+                existing: set[str] = set(merged.get(policy.overflow_target, []))
+                for entry in overflow:
+                    if entry not in existing:
+                        merged.setdefault(policy.overflow_target, []).append(entry)
+                        existing.add(entry)
+        else:
+            merged[policy.field] = raw
 
     # Collect all external deps; intra-group removal done in rewrite pass
     all_source_ids = set(group.source_wp_ids)

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -449,7 +449,7 @@
       "with": {
         "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "generate_report"
+        "step_name": "generate_report_inconclusive"
       },
       "capture": {
         "report_path": "${{ result.report_path }}"

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -130,13 +130,10 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }} ${{ context.experiment_type }}",
+        "skill_command": "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_visualization"
       },
-      "optional_context_refs": [
-        "experiment_type"
-      ],
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
         "report_plan_path": "${{ result.report_plan_path }}",
@@ -438,10 +435,6 @@
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
-      "optional_context_refs": [
-        "experiment_type",
-        "methodology_tradition"
-      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },
@@ -458,10 +451,6 @@
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
-      "optional_context_refs": [
-        "experiment_type",
-        "methodology_tradition"
-      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },
@@ -758,10 +747,6 @@
         "cwd": "${{ context.worktree_path }}",
         "step_name": "re_generate_report"
       },
-      "optional_context_refs": [
-        "experiment_type",
-        "methodology_tradition"
-      ],
       "capture": {
         "report_path": "${{ result.report_path }}"
       },

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -161,7 +161,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 358),
     ("src/autoskillit/smoke_utils.py", 406),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
-    ("src/autoskillit/planner/consolidation.py", 307),
+    ("src/autoskillit/planner/consolidation.py", 328),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 255),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)

--- a/tests/planner/conftest.py
+++ b/tests/planner/conftest.py
@@ -42,13 +42,19 @@ def make_assignment_result(
     return validate_assignment_result(data)
 
 
-def make_wp_result(wp_id: str, *, allow_stub: bool = False, **overrides: Any) -> dict[str, Any]:
+def make_wp_result(
+    wp_id: str, *, allow_stub: bool = False, n_deliverables: int = 1, **overrides: Any
+) -> dict[str, Any]:
+    if n_deliverables == 1:
+        deliverables = [f"src/mod_{wp_id}.py"]
+    else:
+        deliverables = [f"src/mod_{wp_id}_{i}.py" for i in range(n_deliverables)]
     data: dict[str, Any] = {
         "id": wp_id,
         "name": f"WP {wp_id}",
         "summary": "summary",
         "goal": "goal",
-        "deliverables": [f"src/mod_{wp_id}.py"],
+        "deliverables": deliverables,
         "technical_steps": ["step 1"],
         "acceptance_criteria": ["criterion 1"],
         "depends_on": [],

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -815,7 +815,7 @@ def test_consolidate_wps_wp_index_in_work_packages(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_merge_group_overflows_deliverable_bound_raises(tmp_path: Path) -> None:
+def test_merge_group_overflows_deliverable_bound_caps_at_bound(tmp_path: Path) -> None:
     """3 WPs × 2 distinct deliverables = 6 unique; merge must not raise ValueError."""
     wps = [
         make_wp_result("P1-A1-WP1", n_deliverables=2),
@@ -838,7 +838,6 @@ def test_merge_group_overflows_deliverable_bound_raises(tmp_path: Path) -> None:
         ],
     )
 
-    # Before the fix: ValueError about deliverables count. After the fix: succeeds.
     result = consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
     consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
     assert len(consolidated["work_packages"]) == 1

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -937,6 +937,13 @@ def test_fallback_groups_overflow_caps_deliverables(tmp_path: Path) -> None:
     assert "P1-A1-WP4" in output_ids
     merged_a = next(wp for wp in consolidated["work_packages"] if wp["id"] == "P1-A1-WP1")
     assert len(merged_a["deliverables"]) == DELIVERABLE_BOUNDS[1]
+    shared_wps_ordered = sorted(
+        [wp for wp in wps if "src/shared.py" in wp["files_touched"]],
+        key=lambda w: w["id"],
+    )
+    all_deliverables = [d for wp in shared_wps_ordered for d in wp["deliverables"]]
+    expected_overflow = set(all_deliverables[DELIVERABLE_BOUNDS[1] :])
+    assert expected_overflow <= set(merged_a["files_touched"])
 
 
 def test_merge_policy_covers_all_wp_list_fields() -> None:

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -807,3 +807,143 @@ def test_consolidate_wps_wp_index_in_work_packages(tmp_path: Path) -> None:
 
     assert (tmp_path / "work_packages" / "wp_index.json").exists()
     assert not (tmp_path / "wp_index.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Deliverable bound overflow — merge policy tests
+# ---------------------------------------------------------------------------
+
+
+def test_merge_group_overflows_deliverable_bound_raises(tmp_path: Path) -> None:
+    """3 WPs × 2 distinct deliverables = 6 unique; merge must not raise ValueError."""
+    wps = [
+        make_wp_result("P1-A1-WP1", n_deliverables=2),
+        make_wp_result("P1-A1-WP2", n_deliverables=2),
+        make_wp_result("P1-A1-WP3", n_deliverables=2),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+    consolidation_dir = tmp_path / "work_packages" / "consolidation"
+    _make_manifest(
+        consolidation_dir,
+        "P1",
+        [
+            {
+                "merged_id": "P1-A1-WP1",
+                "source_wp_ids": ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+                "merge_order": ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+                "name": None,
+                "goal": None,
+            }
+        ],
+    )
+
+    # Before the fix: ValueError about deliverables count. After the fix: succeeds.
+    result = consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    assert len(consolidated["work_packages"]) == 1
+    merged = consolidated["work_packages"][0]
+    assert len(merged["deliverables"]) == 5
+    assert result["merged_count"] == "1"
+
+
+def test_merge_group_caps_deliverables_at_bound_and_demotes_overflow(tmp_path: Path) -> None:
+    """3 WPs × 2 distinct deliverables; 6th unique deliverable must appear in files_touched."""
+    wps = [
+        make_wp_result("P1-A1-WP1", n_deliverables=2),
+        make_wp_result("P1-A1-WP2", n_deliverables=2),
+        make_wp_result("P1-A1-WP3", n_deliverables=2),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+    consolidation_dir = tmp_path / "work_packages" / "consolidation"
+    _make_manifest(
+        consolidation_dir,
+        "P1",
+        [
+            {
+                "merged_id": "P1-A1-WP1",
+                "source_wp_ids": ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+                "merge_order": ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+                "name": None,
+                "goal": None,
+            }
+        ],
+    )
+
+    consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    merged = consolidated["work_packages"][0]
+    # Exactly 5 deliverables (cap)
+    assert len(merged["deliverables"]) == 5
+    # The 6th unique deliverable was demoted to files_touched
+    assert "src/mod_P1-A1-WP3_1.py" in merged["files_touched"]
+
+
+def test_merge_group_exactly_at_bound_passes(tmp_path: Path) -> None:
+    """Union of 3 WPs with 1+2+2=5 unique deliverables must pass with exactly 5."""
+    wp1 = make_wp_result("P1-A1-WP1", n_deliverables=1)
+    wp2 = make_wp_result("P1-A1-WP2", n_deliverables=2)
+    wp3 = make_wp_result("P1-A1-WP3", n_deliverables=2)
+    refined_path = _make_refined_wps(tmp_path, [wp1, wp2, wp3])
+    consolidation_dir = tmp_path / "work_packages" / "consolidation"
+    _make_manifest(
+        consolidation_dir,
+        "P1",
+        [
+            {
+                "merged_id": "P1-A1-WP1",
+                "source_wp_ids": ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+                "merge_order": ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+                "name": None,
+                "goal": None,
+            }
+        ],
+    )
+
+    consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    merged = consolidated["work_packages"][0]
+    assert len(merged["deliverables"]) == 5
+
+
+def test_fallback_groups_overflow_caps_deliverables(tmp_path: Path) -> None:
+    """3 WPs sharing a file, each with 2 deliverables → fallback caps at 5, demotes overflow."""
+    wps = [
+        make_wp_result("P1-A1-WP1", files_touched=["src/shared.py"], n_deliverables=2),
+        make_wp_result("P1-A1-WP2", files_touched=["src/shared.py"], n_deliverables=2),
+        make_wp_result("P1-A1-WP3", files_touched=["src/shared.py"], n_deliverables=2),
+        make_wp_result("P1-A1-WP4", files_touched=["src/other.py"]),
+        make_wp_result("P1-A1-WP5", files_touched=["src/other.py"]),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+
+    consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    output_ids = {wp["id"] for wp in consolidated["work_packages"]}
+    assert "P1-A1-WP1" in output_ids
+    assert "P1-A1-WP4" in output_ids
+    merged_a = next(wp for wp in consolidated["work_packages"] if wp["id"] == "P1-A1-WP1")
+    assert len(merged_a["deliverables"]) == 5
+
+
+def test_merge_policy_covers_all_wp_list_fields(tmp_path: Path) -> None:
+    """Every list field in WPResult must have a corresponding _LIST_MERGE_POLICIES entry."""
+    from autoskillit.planner.consolidation import _LIST_MERGE_POLICIES
+    from autoskillit.planner.schema import WPResult
+
+    # All WPResult fields that are list-typed and merged (not technical_steps/depends_on)
+    wp_result_fields = set(WPResult.__annotations__.keys())
+    merged_fields = wp_result_fields - {
+        "id",
+        "name",
+        "summary",
+        "goal",
+        "technical_steps",
+        "depends_on",
+    }
+    policy_fields = {p.field for p in _LIST_MERGE_POLICIES}
+    assert merged_fields == policy_fields, (
+        f"WPResult merged fields {merged_fields} != policy fields {policy_fields}"
+    )

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -10,6 +10,7 @@ import pytest
 
 from autoskillit.planner.compiler import compile_plan
 from autoskillit.planner.consolidation import consolidate_wps
+from autoskillit.planner.schema import DELIVERABLE_BOUNDS
 from autoskillit.planner.validation import validate_plan
 from tests.planner.conftest import (
     make_assignment_result,
@@ -842,7 +843,7 @@ def test_merge_group_overflows_deliverable_bound_raises(tmp_path: Path) -> None:
     consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
     assert len(consolidated["work_packages"]) == 1
     merged = consolidated["work_packages"][0]
-    assert len(merged["deliverables"]) == 5
+    assert len(merged["deliverables"]) == DELIVERABLE_BOUNDS[1]
     assert result["merged_count"] == "1"
 
 
@@ -873,9 +874,7 @@ def test_merge_group_caps_deliverables_at_bound_and_demotes_overflow(tmp_path: P
 
     consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
     merged = consolidated["work_packages"][0]
-    # Exactly 5 deliverables (cap)
-    assert len(merged["deliverables"]) == 5
-    # The 6th unique deliverable was demoted to files_touched
+    assert len(merged["deliverables"]) == DELIVERABLE_BOUNDS[1]
     assert "src/mod_P1-A1-WP3_1.py" in merged["files_touched"]
 
 
@@ -904,7 +903,7 @@ def test_merge_group_exactly_at_bound_passes(tmp_path: Path) -> None:
 
     consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
     merged = consolidated["work_packages"][0]
-    assert len(merged["deliverables"]) == 5
+    assert len(merged["deliverables"]) == DELIVERABLE_BOUNDS[1]
 
 
 def test_fallback_groups_overflow_caps_deliverables(tmp_path: Path) -> None:
@@ -925,7 +924,7 @@ def test_fallback_groups_overflow_caps_deliverables(tmp_path: Path) -> None:
     assert "P1-A1-WP1" in output_ids
     assert "P1-A1-WP4" in output_ids
     merged_a = next(wp for wp in consolidated["work_packages"] if wp["id"] == "P1-A1-WP1")
-    assert len(merged_a["deliverables"]) == 5
+    assert len(merged_a["deliverables"]) == DELIVERABLE_BOUNDS[1]
 
 
 def test_merge_policy_covers_all_wp_list_fields(tmp_path: Path) -> None:

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, get_type_hints
 
 import pytest
 
@@ -874,7 +874,20 @@ def test_merge_group_caps_deliverables_at_bound_and_demotes_overflow(tmp_path: P
     consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
     merged = consolidated["work_packages"][0]
     assert len(merged["deliverables"]) == DELIVERABLE_BOUNDS[1]
-    assert "src/mod_P1-A1-WP3_1.py" in merged["files_touched"]
+    all_union: list[str] = []
+    seen_union: set[str] = set()
+    for wp in wps:
+        for d in wp["deliverables"]:
+            if d not in seen_union:
+                all_union.append(d)
+                seen_union.add(d)
+    expected_overflow = set(all_union[DELIVERABLE_BOUNDS[1] :])
+    assert not (expected_overflow & set(merged["deliverables"])), (
+        "overflow items must not appear in deliverables"
+    )
+    assert expected_overflow <= set(merged["files_touched"]), (
+        "overflow items must appear in files_touched"
+    )
 
 
 def test_merge_group_exactly_at_bound_passes(tmp_path: Path) -> None:
@@ -926,13 +939,12 @@ def test_fallback_groups_overflow_caps_deliverables(tmp_path: Path) -> None:
     assert len(merged_a["deliverables"]) == DELIVERABLE_BOUNDS[1]
 
 
-def test_merge_policy_covers_all_wp_list_fields(tmp_path: Path) -> None:
+def test_merge_policy_covers_all_wp_list_fields() -> None:
     """Every list field in WPResult must have a corresponding _LIST_MERGE_POLICIES entry."""
     from autoskillit.planner.consolidation import _LIST_MERGE_POLICIES
     from autoskillit.planner.schema import WPResult
 
-    # All WPResult fields that are list-typed and merged (not technical_steps/depends_on)
-    wp_result_fields = set(WPResult.__annotations__.keys())
+    wp_result_fields = set(get_type_hints(WPResult).keys())
     merged_fields = wp_result_fields - {
         "id",
         "name",


### PR DESCRIPTION
## Summary

`_merge_group()` in `consolidation.py` unions all WP list fields via unbounded dedup logic, then passes the result straight to `validate_wp_result()` which enforces `DELIVERABLE_BOUNDS = (1, 5)`. When two source WPs each carry 3+ distinct deliverables, the merged result exceeds the hard limit and the consolidation pass aborts with `ValueError`. The fix introduces a per-field `_FieldMergePolicy` registry inside `consolidation.py` that encodes cap and overflow behavior at the point of mutation, giving `_merge_group()` structural immunity.

## Requirements

(Review GitHub issue #2058 for full requirements)

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_merge_group_deliverable_bounds_2026-05-07_120000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 166.7k | 4.9k | 357.3k | 29.8k | 29 | 42.2k | 1m 52s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 95.1k | 1.5k | 265.1k | 29.8k | 18 | 15.1k | 46s |
| **Total** | | | 261.7k | 6.4k | 622.4k | 29.8k | | 57.3k | 2m 38s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| MiniMax-M2.7-highspeed | 2 | 261.7k | 6.4k | 622.4k | 57.3k | 2m 38s |