### PR TITLE
Sweep stale documentation: counts, retired names, constraint scopes

### DIFF
--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 48 MCP tools and 132 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 52 MCP tools and 132 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 
@@ -23,12 +23,12 @@ AutoSkillit uses a three-tier tool visibility model:
 
 - **Free-range (4 tools)**: Always visible — `open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`
 - **Headless tools (1 tool)**: Revealed in headless sessions via `mcp.enable({'headless'})` — `test_check`
-- **Kitchen-tagged tools (44 tools total)**: Gated behind `open_kitchen` — `run_skill`,
+- **Kitchen-tagged tools (37 tools total)**: Gated behind `open_kitchen` — `run_skill`,
   `run_cmd`, `run_python`, `merge_worktree`, `clone_repo`, `push_to_remote`, and 31 more.
   One kitchen tool (`test_check`) also carries the `headless` tag and is additionally
   pre-enabled in headless sessions.
 
-When you call `open_kitchen` (automatically done by `order`), all 44 kitchen-tagged tools become
+When you call `open_kitchen` (automatically done by `order`), all 37 kitchen-tagged tools become
 available for that session. This keeps normal Claude Code sessions clean — no pipeline tools
 cluttering the tool list.
 
@@ -60,7 +60,7 @@ AutoSkillit supports four session modes with different tool and skill visibility
 
 - **`$ claude` (plugin, no kitchen)**: Regular Claude Code session with the AutoSkillit plugin
   loaded. Sees 4 Free Range MCP tools (`open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`) and Tier 1 skills only
-  (`open-kitchen`, `close-kitchen`). After calling `/open-kitchen`, all 44 kitchen-tagged MCP
+  (`open-kitchen`, `close-kitchen`). After calling `/open-kitchen`, all 37 kitchen-tagged MCP
   tools become available.
 
 - **`$ autoskillit cook`**: Interactive development session. Sees all three skill tiers

--- a/docs/execution/orchestration.md
+++ b/docs/execution/orchestration.md
@@ -21,7 +21,7 @@ pipeline primarily connects the L2 orchestrator and L1 workers:
   tool). Cannot call `run_skill`, `run_cmd`, or `run_python`.
 
 The boundary is enforced three ways: FastMCP visibility, the
-`leaf_orchestration_guard.py` PreToolUse hook, and the
+`skill_orchestration_guard.py` PreToolUse hook, and the
 `_require_orchestrator_or_higher()` runtime guard inside `tools_execution.py`. All
 three must independently agree before any orchestration tool can fire.
 

--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -42,7 +42,7 @@ remain hidden even after `open_kitchen`.
 | Tag | Meaning |
 |-----|---------|
 | `autoskillit` | Identifies the tool as belonging to AutoSkillit. Present on every tool. |
-| `kitchen` | Tool is hidden at startup via `mcp.disable(tags={'kitchen'})`. 42 tools carry this tag. |
+| `kitchen` | Tool is hidden at startup via `mcp.disable(tags={'kitchen'})`. 37 tools carry this tag. |
 | `headless` | Tool is revealed in headless sessions via `mcp.enable(tags={'headless'})`. Additive — also carries `kitchen`. |
 | `github` | Functional category: GitHub-interacting tools. Can be disabled as a subset. |
 | `ci` | Functional category: CI/merge-queue polling tools. Can be disabled as a subset. |
@@ -55,7 +55,7 @@ Server startup sequence:
 
 ```
 1. mcp.disable(tags={"kitchen"})
-   → hides 42 kitchen-tagged tools (including the 1 headless-tagged tool)
+   → hides 37 kitchen-tagged tools (including the 1 headless-tagged tool)
 
 2. mcp.disable(tags={subset}) for each entry in config.subsets.disabled
    → e.g. hides all github-tagged tools if "github" is disabled

--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -77,7 +77,7 @@ Three independent layers prevent headless sessions from calling orchestration to
 | Layer | Mechanism | What It Blocks |
 |-------|-----------|----------------|
 | 1. FastMCP | Kitchen tools remain hidden (`mcp.enable(headless)` does not reveal kitchen-only tools) | `run_skill`, `run_cmd`, `run_python`, `merge_worktree`, and all other kitchen-only tools |
-| 2. Hook | `leaf_orchestration_guard.py` PreToolUse hook | `run_skill`, `run_cmd`, `run_python` |
+| 2. Hook | `skill_orchestration_guard.py` PreToolUse hook | `run_skill`, `run_cmd`, `run_python` |
 | 3. Code | `_require_orchestrator_or_higher()` guard in `tools_execution.py` | `run_skill`, `run_cmd`, `run_python` |
 
 All three layers must independently agree before any orchestration tool can execute.
@@ -215,7 +215,7 @@ GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`, FL = `fleet`
 
 ---
 
-**Total: 48 tools** — 4 Free Range + 44 Kitchen-tagged (of which 1, `test_check`, additionally carries the `headless` tag and is revealed inside headless sessions)
+**Total: 52 tools** — 4 Free Range + 11 Fleet + 37 Kitchen-tagged (of which 1, `test_check`, additionally carries the `headless` tag and is revealed inside headless sessions)
 
 For subset configuration that can hide functional-category tools, see
 [Subset Categories](../skills/subsets.md).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -96,8 +96,8 @@ UUID). Recorded in pipeline telemetry.
 
 Leaf subagent. Terminal node in the orchestration hierarchy. Cannot launch
 sub-agents or headless sessions. Cannot call `run_skill`, `run_cmd`, or
-`run_python` (enforced by `skill_orchestration_guard.py`). Spawned by an L1
-via Claude Code's Agent/Task tool. See `docs/orchestration-levels.md`.
+`run_python`. Spawned by an L1 via Claude Code's Agent/Task tool. See
+`docs/orchestration-levels.md`.
 
 ### L1
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -13,8 +13,11 @@ Common mistake: `Arch Lens` or `arch lens`.
 
 ### bundled recipes
 
-The 5 YAML recipes shipped under `src/autoskillit/recipes/`: `implementation`,
-`implementation-groups`, `merge-prs`, `remediation`, and `research`.
+The 14 YAML recipes shipped under `src/autoskillit/recipes/`: `bem-wrapper`,
+`full-audit`, `implement-findings`, `implementation`, `implementation-groups`,
+`merge-prs`, `planner`, `promote-to-main-wrapper`, `remediation`,
+`research`, `research-archive`, `research-design`, `research-implement`,
+and `research-review`.
 Distinguished from project-local recipes that live under
 `.autoskillit/recipes/`. Common mistake: "the built-in recipes".
 
@@ -76,13 +79,13 @@ need to run outside the local machine.
 
 ### kitchen
 
-The collection of 44 kitchen-tagged MCP tools that the orchestrator must
+The collection of 37 kitchen-tagged MCP tools that the orchestrator must
 explicitly reveal via `open_kitchen` before they can be called. Hidden at
 server startup via `mcp.disable(tags={'kitchen'})`.
 
 ### kitchen tools
 
-Synonym for the 44 kitchen-tagged MCP tools. Two words, no hyphen.
+Synonym for the 37 kitchen-tagged MCP tools. Two words, no hyphen.
 
 ### kitchen_id
 
@@ -93,7 +96,7 @@ UUID). Recorded in pipeline telemetry.
 
 Leaf subagent. Terminal node in the orchestration hierarchy. Cannot launch
 sub-agents or headless sessions. Cannot call `run_skill`, `run_cmd`, or
-`run_python` (enforced by `leaf_orchestration_guard.py`). Spawned by an L1
+`run_python` (enforced by `skill_orchestration_guard.py`). Spawned by an L1
 via Claude Code's Agent/Task tool. See `docs/orchestration-levels.md`.
 
 ### L1
@@ -197,7 +200,7 @@ that runs many sibling implementations in parallel waves rather than serially.
 ### worker
 
 A headless Claude session spawned by the orchestrator via `run_skill`. L1
-boundary — workers cannot call `run_skill`, `run_cmd`, or `run_python`.
+boundary — headless workers cannot call `run_skill`, `run_cmd`, or `run_python`.
 
 ### worktree
 

--- a/docs/orchestration-levels.md
+++ b/docs/orchestration-levels.md
@@ -31,8 +31,8 @@ Key properties:
 - Headless variant: `run_skill` worker
 - SessionType: `SKILL` (both interactive and headless)
 - Can spawn L0 subagents via Agent/Task tool
-- Cannot call `run_skill` (enforced by `skill_orchestration_guard.py` and
-  `skill_cmd_guard.py`)
+- Headless variant cannot call `run_skill` (enforced by `skill_orchestration_guard.py`
+  and `skill_cmd_guard.py`); interactive L1 sessions bypass this constraint
 
 ```
 L1 (interactive cook)
@@ -55,7 +55,7 @@ Key properties:
 - Interactive variant: `autoskillit order` (SessionType `ORCHESTRATOR`)
 - Headless variant: food truck (dispatched by L3, SessionType `ORCHESTRATOR`)
 - Spawns L1 workers via `run_skill`
-- Has full kitchen access (44 kitchen-tagged MCP tools)
+- Has full kitchen access (37 kitchen-tagged MCP tools)
 
 ```
 L2 (interactive order)
@@ -97,7 +97,7 @@ L3 (interactive fleet)
 
 ## Key Rules
 
-- **L1 workers cannot call `run_skill`.** The boundary is enforced three ways:
+- **Headless L1 workers cannot call `run_skill`.** The boundary is enforced three ways:
   FastMCP visibility tags, the `skill_orchestration_guard.py` PreToolUse hook,
   and the `_require_orchestrator_or_higher()` runtime guard in
   `tools_execution.py`. All three must independently agree.

--- a/docs/safety/hooks.md
+++ b/docs/safety/hooks.md
@@ -53,11 +53,11 @@ marker exists (TTL: 24 hours). Prevents leaf workers from attempting
 interactive user prompts that can never be answered. Fails open on parse
 errors or missing session ID. Session scope: headless only.
 
-### `leaf_orchestration_guard.py`
+### `skill_orchestration_guard.py`
 **Guarded tools:** `run_skill`, `run_cmd`, `run_python`
-Blocks orchestration tools from leaf-tier sessions. Enforces the tier
+Blocks orchestration tools from skill-tier sessions. Enforces the tier
 invariant: orchestrator and fleet sessions may call orchestration tools;
-leaf workers use native Claude Code tools only.
+skill workers use native Claude Code tools only.
 
 ### `unsafe_install_guard.py`
 **Guarded tool:** `run_cmd`

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -25,18 +25,18 @@ tiers. See [Subset Categories](subsets.md) for subset configuration.
 - **Default members** (101 total):
   `investigate`, `make-plan`, `implement-worktree`, `rectify`,
   `dry-walkthrough`, `make-groups`, `review-approach`, `mermaid`, `make-arch-diag`,
-  `make-experiment-diag`, `build-execution-map`, `plan-visualization`,
+  `make-experiment-diag`, `plan-visualization`,
   all 13 `arch-lens-*` skills, all 18 `exp-lens-*` skills, all 12 `vis-lens-*` skills,
-  all 12 `planner-*` skills,
+  all 14 `planner-*` skills,
   `audit-arch`, `audit-cohesion`, `audit-tests`,
   `audit-defense-standards`, `audit-bugs`, `audit-friction`, `validate-audit`,
-  `audit-claims`, `audit-docs`, `audit-feature-gates`,
+  `audit-docs`, `audit-feature-gates`, `audit-review-decisions`,
   `make-req`, `elaborate-phase`, `write-recipe`, `migrate-recipes`, `setup-project`,
   `design-guards`, `triage-issues`, `collapse-issues`,
   `issue-splitter`, `enrich-issues`, `prepare-issue`, `process-issues`, `make-campaign`,
   `scope`, `plan-experiment`, `implement-experiment`, `run-experiment`,
-  `generate-report`, `troubleshoot-experiment`,
-  `review-design`, `stage-data`, `setup-environment`, `bundle-local-report`, `reload-session`
+  `generate-report`, `validate-test-audit`,
+  `stage-data`, `setup-environment`, `bundle-local-report`, `reload-session`
 - **Visible in**: cook and headless sessions
 - **Mechanism**: copied to an ephemeral session directory (cook) or exposed via
   `--add-dir` (headless sessions launched by `run_skill`)
@@ -44,13 +44,15 @@ tiers. See [Subset Categories](subsets.md) for subset configuration.
 ### Tier 3 — Pipeline-Only (Automation Skills)
 
 - **Location**: `src/autoskillit/skills_extended/` (same directory as Tier 2)
-- **Default members** (23 total):
+- **Default members** (28 total):
   `prepare-pr`, `compose-pr`, `open-integration-pr`, `merge-pr`, `analyze-prs`,
   `review-pr`, `resolve-review`, `implement-worktree-no-merge`, `resolve-failures`,
   `retry-worktree`, `resolve-merge-conflicts`, `audit-impl`, `smoke-task`,
   `report-bug`, `pipeline-summary`, `diagnose-ci`, `verify-diag`,
   `compose-research-pr`, `prepare-research-pr`, `resolve-claims-review`,
-  `resolve-design-review`, `resolve-research-review`, `review-research-pr`
+  `resolve-design-review`, `resolve-research-review`, `review-research-pr`,
+  `audit-claims`, `build-execution-map`, `promote-to-main`,
+  `review-design`, `troubleshoot-experiment`
 - **Visible in**: cook and headless sessions
 - **Distinction from Tier 2**: semantic only — both tiers live in `skills_extended/` and
   are available in the same session modes. The tier distinction lets users reclassify

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -299,8 +299,8 @@ def _assert_doc_states_number(doc: Path, label: str, expected: int) -> None:
         DOCS_DIR / "execution" / "tool-access.md",
     ],
 )
-def test_docs_state_48_mcp_tools(doc_path: Path) -> None:
-    _assert_doc_states_number(doc_path, "MCP tools", 48)
+def test_docs_state_52_mcp_tools(doc_path: Path) -> None:
+    _assert_doc_states_number(doc_path, "MCP tools", 52)
 
 
 @pytest.mark.parametrize(
@@ -310,8 +310,8 @@ def test_docs_state_48_mcp_tools(doc_path: Path) -> None:
         DOCS_DIR / "execution" / "tool-access.md",
     ],
 )
-def test_docs_state_44_kitchen_tools(doc_path: Path) -> None:
-    _assert_doc_states_number(doc_path, "kitchen tools", 44)
+def test_docs_state_37_kitchen_tools(doc_path: Path) -> None:
+    _assert_doc_states_number(doc_path, "kitchen tools", 37)
 
 
 def test_skill_visibility_states_132_skills() -> None:


### PR DESCRIPTION
## Summary

Five categories of stale documentation cause agents to waste 10+ tool calls reconciling docs against reality. This plan corrects all stale references across 10 documentation files and 0 source files. The fixes are: (1) rename `leaf_orchestration_guard.py` → `skill_orchestration_guard.py` in 4 doc sites, (2) fix kitchen-tagged tool counts from 44→37 across 7 sites and total tool counts from 48→52 across 2 sites (architecture.md, tool-access.md), (3) update bundled recipe count from 5→14, (4) correct skill tier membership lists and subtotals, (5) add "headless" qualifier to 3 L1 `run_skill` prohibition statements.

## Requirements

- All 5 stale reference sites for `leaf_orchestration_guard.py` updated
- Tool/recipe/skill counts either updated to correct values or replaced with non-numeric language
- L1 prohibition statements include headless qualifier
- No new stale references introduced (do not add new hardcoded counts unless necessary)
- All existing tests pass

Closes #2044

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-131900-509289/.autoskillit/temp/make-plan/sweep_stale_documentation_plan_2026-05-07_131900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 78 | 10.0k | 555.8k | 49.1k | 132 | 41.0k | 5m 10s |
| verify | claude-opus-4-6 | 1 | 53 | 28.0k | 1.5M | 80.0k | 118 | 67.6k | 9m 6s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 9.2k | 1.2M | 29.8k | 82 | 43.2k | 7m 0s |
| fix | claude-sonnet-4-6 | 1 | 144 | 4.8k | 612.1k | 46.0k | 39 | 35.9k | 2m 27s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 73.5k | 3.0k | 178.6k | 29.8k | 20 | 42.2k | 1m 1s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 63.8k | 2.7k | 235.3k | 29.8k | 22 | 15.1k | 58s |
| **Total** | | | 1.3M | 57.8k | 4.3M | 80.0k | | 245.1k | 25m 44s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 59 | 19676.5 | 731.4 | 156.2 |
| fix | 8 | 76508.1 | 4489.0 | 600.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **67** | 63768.2 | 3657.6 | 862.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 222 | 14.8k | 1.2M | 76.9k | 7m 37s |
| claude-opus-4-6 | 1 | 53 | 28.0k | 1.5M | 67.6k | 9m 6s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 14.9k | 1.6M | 100.5k | 8m 59s |