### PR TITLE
Mock asyncio.sleep in TestBulkCloseIssues to eliminate rate-limit delays

### DIFF
--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -717,6 +717,13 @@ class TestGetPrReviews:
 
 
 class TestBulkCloseIssues:
+    @pytest.fixture(autouse=True)
+    def _mock_rate_limit_sleep(self, monkeypatch):
+        monkeypatch.setattr(
+            "autoskillit.server.tools.tools_pr_ops.asyncio.sleep",
+            AsyncMock(),
+        )
+
     @pytest.mark.anyio
     async def test_closes_all_issues_successfully(self, tool_ctx):
         for _ in range(3):


### PR DESCRIPTION
## Summary

Add a class-level autouse `monkeypatch` fixture to `TestBulkCloseIssues` in `tests/server/test_tools_integrations.py` that replaces `autoskillit.server.tools.tools_pr_ops.asyncio.sleep` with an `AsyncMock` for the duration of every test in the class. This eliminates 6-8 seconds of real wall-clock sleep from `_close_issues_sequentially`'s rate-limit delays, which are production-correct but unnecessary when the subprocess runner is a mock and no actual GitHub API calls are made.

**One file changes:** `tests/server/test_tools_integrations.py`
**No imports needed:** `AsyncMock` is already imported at the top of the file; `monkeypatch` is a standard pytest fixture.

## Requirements

**Problem:** `TestBulkCloseIssues` in `tests/server/test_tools_integrations.py` has real `asyncio.sleep(1)` calls from the production rate-limiting code in `server/tools/tools_pr_ops.py` (lines 57, 86). These are GitHub API rate-limit delays. Since the tests use `InMemorySubprocessRunner` (no real `gh` calls), the sleep is pure wall-clock waste.

**Impact:** 3-4 tests x 2s each = 6-8s of real sleep per full test run.

**Solution:** Add a class-level autouse fixture that monkeypatches `autoskillit.server.tools.tools_pr_ops.asyncio.sleep` to a no-op `AsyncMock`.

**Validation:**
- No test in `TestBulkCloseIssues` asserts on sleep call count or duration
- The class is already marked `pytest.mark.small`
- Same monkeypatch pattern already used in `test_merge_queue_polling.py`

Closes #2188

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-150035-255000/.autoskillit/temp/make-plan/mock_asyncio_sleep_testbulkcloseissues_plan_2026-05-07_150035.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 123 | 8.0k | 454.6k | 46.7k | 44 | 36.0k | 3m 32s |
| verify | claude-sonnet-4-6 | 1 | 84 | 4.9k | 311.4k | 41.0k | 25 | 28.1k | 1m 22s |
| implement* | MiniMax-M2.7-highspeed | 1 | 170.3k | 2.4k | 387.0k | 29.8k | 31 | 43.2k | 1m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 46.5k | 3.3k | 148.9k | 29.8k | 16 | 42.3k | 1m 10s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.3k | 1.6k | 205.6k | 29.8k | 14 | 15.1k | 39s |
| review_pr | claude-sonnet-4-6 | 1 | 84 | 6.5k | 319.7k | 39.2k | 30 | 26.9k | 1m 52s |
| **Total** | | | 264.5k | 26.7k | 1.8M | 46.7k | | 191.6k | 9m 53s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 7 | 55287.1 | 6165.9 | 338.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **7** | 261017.0 | 27377.1 | 3819.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 207 | 12.9k | 766.0k | 64.2k | 4m 54s |
| MiniMax-M2.7-highspeed | 3 | 264.2k | 7.4k | 741.5k | 100.6k | 3m 6s |