### PR TITLE
Implementation Plan: Perf — Add CDumper for YAML Writes + Hoist re.compile() to Module Level

### DIFF
--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -24,6 +24,11 @@ try:
 except ImportError:
     _Loader = yaml.SafeLoader  # type: ignore[misc,assignment]
 
+try:
+    from yaml import CDumper as _Dumper
+except ImportError:
+    from yaml import Dumper as _Dumper  # type: ignore[misc,assignment]
+
 __all__ = [
     "YAMLError",
     "atomic_write",
@@ -203,4 +208,4 @@ def dump_yaml_str(data: Any, **kwargs: Any) -> str:
     ``default_flow_style=False``). Distinct from the removed ``dump_yaml`` which wrote
     to disk.
     """
-    return yaml.dump(data, **kwargs)
+    return yaml.dump(data, Dumper=_Dumper, **kwargs)

--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -208,4 +208,5 @@ def dump_yaml_str(data: Any, **kwargs: Any) -> str:
     ``default_flow_style=False``). Distinct from the removed ``dump_yaml`` which wrote
     to disk.
     """
+    kwargs.pop("Dumper", None)
     return yaml.dump(data, Dumper=_Dumper, **kwargs)

--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -8,6 +8,9 @@ from autoskillit.core import PRState, Severity
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
+_NO_RUNS_RE = re.compile(r"""==\s*['"]?no_runs['"]?""")
+_TIMED_OUT_RE = re.compile(r"""==\s*['"]?timed_out['"]?""")
+
 
 @semantic_rule(
     name="ci-polling-inline-shell",
@@ -154,7 +157,6 @@ def _check_ci_failure_conflict_gate(ctx: ValidationContext) -> list[RuleFinding]
     severity=Severity.ERROR,
 )
 def _check_ci_no_runs_unguarded(ctx: ValidationContext) -> list[RuleFinding]:
-    no_runs_re = re.compile(r"""==\s*['"]?no_runs['"]?""")
     findings: list[RuleFinding] = []
     for name, step in ctx.recipe.steps.items():
         if step.tool != "wait_for_ci":
@@ -162,7 +164,7 @@ def _check_ci_no_runs_unguarded(ctx: ValidationContext) -> list[RuleFinding]:
         has_no_runs_guard = False
         if step.on_result and step.on_result.conditions:
             has_explicit_no_runs = any(
-                c.when and no_runs_re.search(c.when) for c in step.on_result.conditions
+                c.when and _NO_RUNS_RE.search(c.when) for c in step.on_result.conditions
             )
             has_catch_all = any(not c.when for c in step.on_result.conditions)
             has_no_runs_guard = has_explicit_no_runs or has_catch_all
@@ -196,7 +198,6 @@ def _check_ci_no_runs_unguarded(ctx: ValidationContext) -> list[RuleFinding]:
     severity=Severity.ERROR,
 )
 def _check_ci_timed_out_unguarded(ctx: ValidationContext) -> list[RuleFinding]:
-    timed_out_re = re.compile(r"""==\s*['"]?timed_out['"]?""")
     findings: list[RuleFinding] = []
     for name, step in ctx.recipe.steps.items():
         if step.tool != "wait_for_ci":
@@ -206,7 +207,7 @@ def _check_ci_timed_out_unguarded(ctx: ValidationContext) -> list[RuleFinding]:
         has_explicit_timed_out = False
         if step.on_result and step.on_result.conditions:
             has_explicit_timed_out = any(
-                c.when and timed_out_re.search(c.when) for c in step.on_result.conditions
+                c.when and _TIMED_OUT_RE.search(c.when) for c in step.on_result.conditions
             )
         if has_explicit_timed_out:
             continue

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -119,6 +119,34 @@ class TestDumpYamlStr:
         # Block style: items on separate lines, no inline [...] for lists
         assert "[1, 2, 3]" not in result
 
+    def test_dumper_is_cdumper_or_dumper(self):
+        import yaml as _yaml
+
+        from autoskillit.core.io import _Dumper
+
+        if getattr(_yaml, "__with_libyaml__", False):
+            assert _Dumper is _yaml.CDumper
+        else:
+            assert _Dumper is _yaml.Dumper
+
+    def test_dump_yaml_str_uses_c_dumper_when_available(self, monkeypatch):
+        import yaml as _yaml
+
+        from autoskillit.core.io import dump_yaml_str
+
+        if not getattr(_yaml, "__with_libyaml__", False):
+            pytest.skip("LibYAML not available")
+        captured: dict[str, object] = {}
+        original_dump = _yaml.dump
+
+        def spy(data, **kw):
+            captured["Dumper"] = kw.get("Dumper")
+            return original_dump(data, **kw)
+
+        monkeypatch.setattr("autoskillit.core.io.yaml.dump", spy)
+        dump_yaml_str({"x": 1})
+        assert captured["Dumper"] is _yaml.CDumper
+
 
 class TestYamlConsolidationArchitecture:
     def test_only_yaml_imports_yaml_directly(self):

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -109,7 +109,7 @@ def _is_yaml_dump(node: ast.expr) -> bool:
 # Any new site that writes a dict payload SHOULD use write_versioned_json.
 _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
-    ("src/autoskillit/core/io.py", 123),
+    ("src/autoskillit/core/io.py", 128),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
     ("src/autoskillit/execution/session_log.py", 305),

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -948,11 +948,6 @@ def test_ci_watch_post_queue_fix_has_auto_trigger() -> None:
             )
 
 
-# ---------------------------------------------------------------------------
-# Module-level regex constants
-# ---------------------------------------------------------------------------
-
-
 def test_no_runs_re_is_module_level_constant():
     import re
 
@@ -960,6 +955,7 @@ def test_no_runs_re_is_module_level_constant():
 
     assert hasattr(rules_ci, "_NO_RUNS_RE")
     assert isinstance(rules_ci._NO_RUNS_RE, re.Pattern)
+    assert rules_ci._NO_RUNS_RE.pattern == r"""==\s*['"]?no_runs['"]?"""
 
 
 def test_timed_out_re_is_module_level_constant():
@@ -969,3 +965,4 @@ def test_timed_out_re_is_module_level_constant():
 
     assert hasattr(rules_ci, "_TIMED_OUT_RE")
     assert isinstance(rules_ci._TIMED_OUT_RE, re.Pattern)
+    assert rules_ci._TIMED_OUT_RE.pattern == r"""==\s*['"]?timed_out['"]?"""

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -946,3 +946,26 @@ def test_ci_watch_post_queue_fix_has_auto_trigger() -> None:
             assert step.with_args.get("auto_trigger") in ("true", True), (
                 f"{name}: {step_name} missing auto_trigger: true"
             )
+
+
+# ---------------------------------------------------------------------------
+# Module-level regex constants
+# ---------------------------------------------------------------------------
+
+
+def test_no_runs_re_is_module_level_constant():
+    import re
+
+    import autoskillit.recipe.rules.rules_ci as rules_ci
+
+    assert hasattr(rules_ci, "_NO_RUNS_RE")
+    assert isinstance(rules_ci._NO_RUNS_RE, re.Pattern)
+
+
+def test_timed_out_re_is_module_level_constant():
+    import re
+
+    import autoskillit.recipe.rules.rules_ci as rules_ci
+
+    assert hasattr(rules_ci, "_TIMED_OUT_RE")
+    assert isinstance(rules_ci._TIMED_OUT_RE, re.Pattern)


### PR DESCRIPTION
## Summary

Two independent micro-performance fixes: (A) use the C-extension CDumper for YAML writes in `dump_yaml_str()` instead of the pure-Python dumper (~5× speedup), mirroring the existing CSafeLoader pattern for reads; and (B) hoist two `re.compile()` calls from inside `@semantic_rule` function bodies to module-level constants in `rules_ci.py`, since the patterns are static and those rules run on every `validate_recipe()` call (131 rules total).

## Requirements

**Labels**: `recipe:implementation`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-150035-838422/.autoskillit/temp/make-plan/perf_add_cdumper_yaml_hoist_re_compile_plan_2026-05-07_150500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 125 | 7.8k | 497.3k | 55.9k | 46 | 46.9k | 2m 54s |
| verify | claude-sonnet-4-6 | 1 | 84 | 7.8k | 422.2k | 61.8k | 29 | 49.0k | 2m 26s |
| implement* | MiniMax-M2.7-highspeed | 1 | 384.5k | 5.8k | 645.0k | 70.6k | 52 | 51.9k | 2m 18s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 101.7k | 5.2k | 329.9k | 35.1k | 25 | 22.7k | 1m 58s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 66.7k | 1.4k | 265.1k | 29.8k | 18 | 15.1k | 47s |
| review_pr | claude-sonnet-4-6 | 1 | 84 | 31.7k | 371.4k | 66.0k | 32 | 56.1k | 6m 16s |
| resolve_review | claude-sonnet-4-6 | 1 | 217 | 9.9k | 1.2M | 60.8k | 61 | 47.8k | 6m 51s |
| **Total** | | | 553.5k | 69.6k | 3.7M | 70.6k | | 289.5k | 23m 31s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 67 | 9626.8 | 774.1 | 86.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 151703.5 | 5979.9 | 1241.1 |
| **Total** | **75** | 49926.3 | 3860.1 | 928.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 359 | 21.2k | 1.6M | 133.4k | 14m 5s |
| MiniMax-M2.7-highspeed | 3 | 553.0k | 12.3k | 1.2M | 89.7k | 5m 3s |