### PR TITLE
Display ingredient table in fleet campaign sessions

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -35,6 +35,17 @@ def _read_full_sous_chef() -> str:
         return ""
 
 
+def _ingredient_table_display_instruction(source: str) -> str:
+    """Return the display-verbatim instruction for an ingredient table."""
+    return (
+        f"Display the ingredient table from {source} verbatim in your response — "
+        "do not reformat or re-render it.\n"
+        "Then ask for the required fields (marked with *). If the recipe has both\n"
+        "a task and an issue_url ingredient, mention that a GitHub issue URL can be\n"
+        "provided as the task. Keep it to one or two short sentences."
+    )
+
+
 # ── Re-exports from domain submodules ───────────────────────────────────
 
 from autoskillit.cli._prompts_campaign import (  # noqa: E402
@@ -57,6 +68,7 @@ from autoskillit.cli._prompts_orchestrator import (  # noqa: E402
 __all__ = [
     "_MCP_RETRY_INSTRUCTION",
     "_read_full_sous_chef",
+    "_ingredient_table_display_instruction",
     "_build_fleet_campaign_prompt",
     "_has_dynamic_dispatch",
     "_build_dynamic_dispatch_section",

--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from autoskillit.cli._prompts import _read_full_sous_chef
+from autoskillit.cli._prompts import _ingredient_table_display_instruction, _read_full_sous_chef
 from autoskillit.core import RetryReason
 
 if TYPE_CHECKING:
@@ -203,6 +203,18 @@ Do NOT re-dispatch from the full original issue list.
             "via AskUserQuestion. Do not dispatch until all required values are confirmed.\n"
         )
 
+    _first_action_section = ""
+    if ingredients_table:
+        _display = _ingredient_table_display_instruction(
+            "the ## RECIPE INGREDIENTS section in this system prompt"
+        )
+        _first_action_section = (
+            "\nFIRST ACTION — before asking for any inputs:\n\n"
+            f"1. {_display}\n\n"
+            "2. Collect ingredient values via AskUserQuestion.\n\n"
+            "3. Proceed only after all required ingredient values are confirmed.\n"
+        )
+
     return f"""\
 You are a fleet campaign dispatcher. Execute campaign '{campaign_recipe.name}' autonomously.
 Campaign ID: {campaign_id}. Dispatches: {dispatch_count}.
@@ -215,6 +227,7 @@ Campaign ID: {campaign_id}. Dispatches: {dispatch_count}.
 - Dispatch count: {dispatch_count} dispatches
 - Continue on failure: {campaign_recipe.continue_on_failure}
 {_ing_section}
+{_first_action_section}
 ## DISPATCH MANIFEST
 
 The following manifest defines all dispatches for this campaign:

--- a/src/autoskillit/cli/_prompts_orchestrator.py
+++ b/src/autoskillit/cli/_prompts_orchestrator.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autoskillit.cli._prompts import _MCP_RETRY_INSTRUCTION, _read_full_sous_chef
+from autoskillit.cli._prompts import (
+    _MCP_RETRY_INSTRUCTION,
+    _ingredient_table_display_instruction,
+    _read_full_sous_chef,
+)
 from autoskillit.core import get_logger
 from autoskillit.hooks import QUOTA_GUARD_DENY_TRIGGER, QUOTA_POST_WARNING_TRIGGER
 
@@ -91,6 +95,11 @@ def _build_orchestrator_prompt(
             "- Passing ingredients to pipeline steps via `with:` arguments\n\n"
         )
 
+    _display_step = _ingredient_table_display_instruction(
+        "the open_kitchen response "
+        "(between --- INGREDIENTS TABLE --- and --- END TABLE --- markers)"
+    )
+
     return f"""\
 You are a pipeline orchestrator. Execute the recipe '{recipe_name}' step-by-step.
 
@@ -100,12 +109,7 @@ You are a pipeline orchestrator. Execute the recipe '{recipe_name}' step-by-step
    the ingredients table above (when present) is provided for reference only.
    DO NOT call AskUserQuestion or any other tool before open_kitchen.
    {_MCP_RETRY_INSTRUCTION.replace(chr(10), chr(10) + "   ")}
-2. The response contains a pre-formatted ingredients table
-   between --- INGREDIENTS TABLE --- and --- END TABLE --- markers.
-   Display it verbatim in your response — do not reformat or re-render it.
-   Then ask for the required fields (marked with *). If the recipe has both
-   a task and an issue_url ingredient, mention that a GitHub issue URL can
-   be provided as the task. Keep it to one or two short sentences.
+2. {_display_step}
 3. Collect ingredient values conversationally from the user's response.
 4. Execute the pipeline steps.
 

--- a/tests/cli/test_l3_orchestrator_prompt.py
+++ b/tests/cli/test_l3_orchestrator_prompt.py
@@ -492,6 +492,52 @@ class TestK15IngredientsTableInjection:
         assert overview_pos < ingredients_pos < manifest_pos
 
 
+class TestK16IngredientDisplayFirstAction:
+    """K-16: Campaign FIRST ACTION instructs Claude to display the ingredient table."""
+
+    _TABLE = "| Name | Description | Default |\n| task | What to fix | — |"
+
+    def test_first_action_block_present_when_ingredients_table_provided(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        assert "FIRST ACTION" in prompt
+
+    def test_first_action_instructs_display_verbatim(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        first_action_idx = prompt.index("FIRST ACTION")
+        dispatch_manifest_idx = prompt.index("DISPATCH MANIFEST")
+        section = prompt[first_action_idx:dispatch_manifest_idx]
+        assert "verbatim" in section
+
+    def test_first_action_references_recipe_ingredients_section(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        first_action_idx = prompt.index("FIRST ACTION")
+        dispatch_manifest_idx = prompt.index("DISPATCH MANIFEST")
+        section = prompt[first_action_idx:dispatch_manifest_idx]
+        assert "RECIPE INGREDIENTS" in section
+
+    def test_first_action_absent_when_no_ingredients_table(self) -> None:
+        prompt = _build(ingredients_table=None)
+        assert "FIRST ACTION" not in prompt
+
+    def test_first_action_does_not_call_open_kitchen(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        first_action_idx = prompt.index("FIRST ACTION")
+        dispatch_manifest_idx = prompt.index("DISPATCH MANIFEST")
+        section = prompt[first_action_idx:dispatch_manifest_idx]
+        assert "open_kitchen(" not in section
+
+    def test_first_action_appears_before_dispatch_manifest(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        assert prompt.index("FIRST ACTION") < prompt.index("DISPATCH MANIFEST")
+
+    def test_first_action_instructs_ask_user_question(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        first_action_idx = prompt.index("FIRST ACTION")
+        dispatch_manifest_idx = prompt.index("DISPATCH MANIFEST")
+        section = prompt[first_action_idx:dispatch_manifest_idx]
+        assert "AskUserQuestion" in section
+
+
 class TestResumeReasonInPrompt:
     def test_idle_stall_resume_includes_reenter_guidance(self) -> None:
         prompt = _build(


### PR DESCRIPTION
## Summary

When `autoskillit fleet campaign` launches a session, the ingredient table is injected into the system prompt but Claude is never instructed to display it to the user. The user sees no ingredient names, required flags, or defaults — Claude just asks questions into the void.

The fix adds a FIRST ACTION block to `_build_fleet_campaign_prompt` that instructs Claude to display the table verbatim before collecting values. A shared helper function in `_prompts.py` encapsulates the "display verbatim from [source]" instruction, used by both the campaign path (source = system prompt section) and the orchestrator path (source = `open_kitchen` response).

Two files change: `_prompts.py` (new helper + export) and `_prompts_campaign.py` (FIRST ACTION block using the helper). `_prompts_orchestrator.py` is refactored to use the helper's display instruction so the wording stays in sync.

## Requirements

## Problem

When `autoskillit order` launches a Claude Code session, the user sees the ingredient table in Claude's first response. This works via a two-step mechanism:

1. The system prompt (`_prompts_orchestrator.py:97-108`) mandates calling `open_kitchen(name=recipe)` as the FIRST ACTION
2. `open_kitchen` returns the ingredient table in its MCP response; the PostToolUse formatter (`_fmt_recipe.py:104-108`) wraps it with `--- INGREDIENTS TABLE ---` markers
3. The system prompt instructs: "Display it verbatim in your response — do not reformat or re-render it"
4. The user sees the formatted ingredient table in Claude's first assistant message

When `autoskillit fleet campaign` launches a Claude Code session, the user sees **nothing** about ingredients. Claude just starts asking questions without showing what's available. The ingredient table is injected into the system prompt (`_prompts_campaign.py:199-206`) but is invisible to the user — and `open_kitchen` is explicitly **forbidden** (`_prompts_campaign.py:247`) because campaigns operate at L3 and use `dispatch_food_truck` instead of kitchen tools.

There is no replacement mechanism for displaying the table to the user inside the session.

## Solution

The `order` and `fleet campaign` flows should share an abstraction layer for the in-session ingredient table display instruction. The campaign system prompt already contains the full ingredient table in `_ing_section` — it just needs a FIRST ACTION block (analogous to `_prompts_orchestrator.py:97-108`) that instructs Claude to:

1. Display the ingredient table from its system prompt context verbatim as its first response
2. Then ask for required fields (marked with `*`)
3. Collect values via AskUserQuestion before dispatching

The shared abstraction should generate this FIRST ACTION instruction block, differing only in the source of the table: `open_kitchen` response for `order`, system prompt content for `campaign`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-152551-548485/.autoskillit/temp/make-plan/fleet_campaign_ingredient_table_display_plan_2026-05-07_152551.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.1k | 25.3k | 713.6k | 77.7k | 69 | 65.9k | 13m 17s |
| verify | claude-sonnet-4-6 | 1 | 100 | 11.8k | 590.1k | 73.2k | 35 | 60.6k | 3m 5s |
| implement* | MiniMax-M2.7-highspeed | 1 | 821.0k | 10.4k | 1.1M | 54.1k | 86 | 36.7k | 4m 8s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 61.0k | 3.3k | 232.0k | 34.0k | 23 | 22.4k | 1m 12s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 39.7k | 2.0k | 169.3k | 28.7k | 15 | 15.1k | 40s |
| review_pr | claude-sonnet-4-6 | 1 | 84 | 13.8k | 374.4k | 52.6k | 31 | 41.0k | 3m 48s |
| **Total** | | | 925.0k | 66.6k | 3.1M | 77.7k | | 241.7k | 26m 13s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 91 | 11615.3 | 402.9 | 113.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **91** | 34466.0 | 2656.0 | 732.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 3.2k | 37.1k | 1.3M | 126.5k | 16m 23s |
| MiniMax-M2.7-highspeed | 3 | 921.7k | 15.7k | 1.5M | 74.2k | 6m 0s |