### PR TITLE
Add BEM pre-step gate to fleet dispatcher for multi-issue parallel dispatch

### DIFF
--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -51,8 +51,9 @@ If the array is empty (`[]`) there are no issues to implement — skip to INTERR
 3. If `parallel` is `true`: issue ALL `{mcp_prefix}dispatch_food_truck` calls for this
    group **in a single response (parallel tool calls)** — do not wait for one to
    complete before issuing the next. The fleet semaphore gates actual concurrency;
-   calls queue when the semaphore is saturated. **This overrides the general
-   sequential discipline — parallel groups are an explicit exception.**
+   if `at_capacity()` returns FLEET_PARALLEL_REFUSED, wait for a running dispatch to
+   complete and retry — the semaphore is a fast-fail, not a queue. **This overrides the
+   general sequential discipline — parallel groups are an explicit exception.**
 4. If `parallel` is `false`: dispatch each batch and wait for it to complete before
    dispatching the next batch in this group.
 5. Wait for ALL food trucks in this group to complete before advancing to the next group.
@@ -226,9 +227,8 @@ The following manifest defines all dispatches for this campaign:
 ## CAMPAIGN DISCIPLINE
 
 Execute static manifest dispatches SEQUENTIALLY via {mcp_prefix}dispatch_food_truck.
-The fleet_lock semaphore uses max_concurrent=1 for static dispatches — do NOT issue
-static manifest calls in parallel. For dynamic dispatches (see the dynamic dispatch
-instructions section when present), `parallel: true` groups override this rule.
+Static manifest dispatches are SEQUENTIAL — do NOT issue static manifest calls in parallel,
+regardless of the fleet semaphore's max_concurrent_dispatches setting.
 
 Each dispatch is an independent L2 food truck session with its own kitchen context. There is NO
 cross-dispatch state sharing managed by you — the runtime handles it

--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -227,8 +227,8 @@ The following manifest defines all dispatches for this campaign:
 ## CAMPAIGN DISCIPLINE
 
 Execute static manifest dispatches SEQUENTIALLY via {mcp_prefix}dispatch_food_truck.
-Static manifest dispatches are SEQUENTIAL — do NOT issue static manifest calls in parallel,
-regardless of the fleet semaphore's max_concurrent_dispatches setting.
+Static manifest dispatches use the fleet_lock semaphore and are SEQUENTIAL — do NOT issue
+static manifest calls in parallel, regardless of the fleet semaphore's max_concurrent_dispatches setting.
 
 Each dispatch is an independent L2 food truck session with its own kitchen context. There is NO
 cross-dispatch state sharing managed by you — the runtime handles it

--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -116,8 +116,42 @@ issue context when the task involves a GitHub issue.
 
 - `task` parameter: provide a clear, actionable one-line description of the work for each dispatch.
 - `ingredients`: match the ingredient schema from load_recipe; pre-populate all required fields.
-- Serial execution: dispatch one food truck at a time. fleet_lock enforces this — \
-do NOT attempt parallel dispatches.
+- Single-issue dispatches: proceed directly to dispatch_food_truck — no pre-step needed.
+
+## MULTI-ISSUE DISPATCH — BEM PRE-STEP GATE
+
+When the user requests 2 or more issues dispatched:
+
+1. Count total issues across all targets. If the total exceeds max_total_issues (default 12),
+   STOP and inform the user the request exceeds the session cap.
+
+2. Dispatch bem-wrapper first as the conflict analysis pre-step:
+   {mcp_prefix}dispatch_food_truck(
+       recipe="bem-wrapper",
+       task="Build execution map for conflict analysis",
+       ingredients={{
+           "issue_urls": "<comma-separated issue URLs>",
+           "base_branch": "<target branch, e.g. main>",
+       }},
+       capture={{"execution_map": "${{{{ result.execution_map }}}}"}},
+       dispatch_name="bem-pre-step",
+   )
+
+3. Read dispatch_plan from l3_payload in the dispatch_food_truck response. It is a JSON
+   array: [{{"group": N, "parallel": bool, "issues": "url1,url2"}}, ...].
+   If dispatch_plan is empty or bem-wrapper failed, fall back to sequential dispatch
+   (one issue at a time, no parallelism).
+
+4. For each group in array order:
+   - parallel: true → issue ALL dispatch_food_truck calls for this group in a single
+     response (parallel tool calls). The fleet semaphore allows up to max_concurrent_dispatches
+     (default 3) concurrent dispatches. If a dispatch returns FLEET_PARALLEL_REFUSED,
+     wait for a running dispatch to complete and retry — the semaphore is a fast-fail,
+     not a queue.
+   - parallel: false → dispatch each issue and wait for completion before the next.
+   - Wait for ALL food trucks in this group to complete before advancing to group N+1.
+
+BEM already caps parallel group sizes via max_parallel (default 6 issues per group).
 
 ## DISPATCHER DISCIPLINE
 

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -298,7 +298,8 @@ class WorkspaceConfig:
 @dataclass
 class FleetConfig:
     default_timeout_sec: int = 3600
-    max_concurrent_dispatches: int = 1
+    max_concurrent_dispatches: int = 3
+    max_total_issues: int = 12
 
     def validate(self, feature_enabled: bool) -> None:
         """Validate only when the feature is active."""
@@ -312,6 +313,12 @@ class FleetConfig:
             raise ValueError(
                 f"max_concurrent_dispatches must be >= 1, got {self.max_concurrent_dispatches}"
             )
+        if self.max_concurrent_dispatches > 3:
+            raise ValueError(
+                f"max_concurrent_dispatches must be <= 3, got {self.max_concurrent_dispatches}"
+            )
+        if self.max_total_issues < 1:
+            raise ValueError(f"max_total_issues must be >= 1, got {self.max_total_issues}")
 
 
 @dataclass

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -295,10 +295,13 @@ class WorkspaceConfig:
     temp_dir: str | None = None  # null = canonical default (see resolve_temp_dir)
 
 
+_MAX_CONCURRENT_DISPATCHES = 3
+
+
 @dataclass
 class FleetConfig:
     default_timeout_sec: int = 3600
-    max_concurrent_dispatches: int = 3
+    max_concurrent_dispatches: int = _MAX_CONCURRENT_DISPATCHES
     max_total_issues: int = 12
 
     def validate(self, feature_enabled: bool) -> None:
@@ -313,9 +316,10 @@ class FleetConfig:
             raise ValueError(
                 f"max_concurrent_dispatches must be >= 1, got {self.max_concurrent_dispatches}"
             )
-        if self.max_concurrent_dispatches > 3:
+        if self.max_concurrent_dispatches > _MAX_CONCURRENT_DISPATCHES:
             raise ValueError(
-                f"max_concurrent_dispatches must be <= 3, got {self.max_concurrent_dispatches}"
+                f"max_concurrent_dispatches must be <= {_MAX_CONCURRENT_DISPATCHES},"
+                f" got {self.max_concurrent_dispatches}"
             )
         if self.max_total_issues < 1:
             raise ValueError(f"max_total_issues must be >= 1, got {self.max_total_issues}")

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -280,7 +280,8 @@ workspace:
 
 fleet:
   default_timeout_sec: 3600
-  max_concurrent_dispatches: 1
+  max_concurrent_dispatches: 3
+  max_total_issues: 12
 
 providers:
   default_provider: null

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -499,6 +499,7 @@ class AutomationConfig:
                 max_concurrent_dispatches=int(
                     val(fr, "max_concurrent_dispatches", _fr["max_concurrent_dispatches"])
                 ),
+                max_total_issues=int(val(fr, "max_total_issues", _fr["max_total_issues"])),
             ),
             providers=ProvidersConfig(
                 default_provider=val(pvd, "default_provider", _pvd["default_provider"]),

--- a/tests/config/test_fleet_config.py
+++ b/tests/config/test_fleet_config.py
@@ -114,11 +114,18 @@ class TestFleetConfig:
         with pytest.raises(ValueError, match="default_timeout_sec must be positive"):
             load_config(tmp_path)
 
-    def test_fleet_config_max_concurrent_dispatches_defaults_to_1(self) -> None:
-        """FleetConfig.max_concurrent_dispatches defaults to 1 (serial)."""
+    def test_fleet_config_max_concurrent_dispatches_defaults_to_3(self) -> None:
+        """FleetConfig.max_concurrent_dispatches defaults to 3 (BEM-gated parallel)."""
         from autoskillit.config.settings import FleetConfig
 
-        assert FleetConfig().max_concurrent_dispatches == 1
+        assert FleetConfig().max_concurrent_dispatches == 3
+
+    def test_fleet_config_max_concurrent_dispatches_rejects_above_3(self) -> None:
+        """FleetConfig.validate() rejects max_concurrent_dispatches > 3."""
+        from autoskillit.config.settings import FleetConfig
+
+        with pytest.raises(ValueError, match="max_concurrent_dispatches"):
+            FleetConfig(max_concurrent_dispatches=4).validate(feature_enabled=True)
 
     def test_fleet_config_max_concurrent_dispatches_validates_positive(self) -> None:
         """FleetConfig raises ValueError when max_concurrent_dispatches is 0."""
@@ -126,6 +133,40 @@ class TestFleetConfig:
 
         with pytest.raises(ValueError, match="max_concurrent_dispatches"):
             FleetConfig(max_concurrent_dispatches=0).validate(feature_enabled=True)
+
+    def test_fleet_config_max_total_issues_defaults_to_12(self) -> None:
+        """FleetConfig.max_total_issues defaults to 12."""
+        from autoskillit.config.settings import FleetConfig
+
+        assert FleetConfig().max_total_issues == 12
+
+    def test_fleet_config_max_total_issues_validates_positive(self) -> None:
+        """FleetConfig.validate() rejects max_total_issues < 1."""
+        from autoskillit.config.settings import FleetConfig
+
+        with pytest.raises(ValueError, match="max_total_issues"):
+            FleetConfig(max_total_issues=0).validate(feature_enabled=True)
+
+    def test_fleet_config_max_total_issues_matches_defaults_yaml(self) -> None:
+        """FleetConfig.max_total_issues matches defaults.yaml fleet.max_total_issues."""
+        from autoskillit.config.settings import FleetConfig
+        from autoskillit.core.io import load_yaml
+        from autoskillit.core.paths import pkg_root
+
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+        assert FleetConfig().max_total_issues == defaults["fleet"]["max_total_issues"]
+
+    def test_fleet_config_max_concurrent_dispatches_matches_defaults_yaml(self) -> None:
+        """FleetConfig.max_concurrent_dispatches matches defaults.yaml."""
+        from autoskillit.config.settings import FleetConfig
+        from autoskillit.core.io import load_yaml
+        from autoskillit.core.paths import pkg_root
+
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+        assert (
+            FleetConfig().max_concurrent_dispatches
+            == defaults["fleet"]["max_concurrent_dispatches"]
+        )
 
     def test_load_config_fleet_max_concurrent_override(self, tmp_path: Path) -> None:
         """User config can override max_concurrent_dispatches."""

--- a/tests/config/test_fleet_config.py
+++ b/tests/config/test_fleet_config.py
@@ -124,7 +124,7 @@ class TestFleetConfig:
         """FleetConfig.validate() rejects max_concurrent_dispatches > 3."""
         from autoskillit.config.settings import FleetConfig
 
-        with pytest.raises(ValueError, match="max_concurrent_dispatches"):
+        with pytest.raises(ValueError, match="must be <= 3"):
             FleetConfig(max_concurrent_dispatches=4).validate(feature_enabled=True)
 
     def test_fleet_config_max_concurrent_dispatches_validates_positive(self) -> None:

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -15,6 +15,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_claim_issue_contracts.py` | Contract tests for claim_issue and release_issue MCP tools |
 | `test_claude_code_interface_contracts.py` | Contract tests for Claude Code external interface conventions |
 | `test_collapse_issues_contracts.py` | Contract tests for the collapse-issues skill SKILL.md |
+| `test_campaign_prompt_accuracy.py` | Contract: campaign prompt does not contain inaccurate semaphore language |
 | `test_config_field_coverage.py` | REQ-CONFIG-001: every sub-config dataclass field must be referenced in from_dynaconf |
 | `test_core_public_api_surface.py` | Validates that every symbol in autoskillit.core.__all__ is importable via the public gateway |
 | `test_diagnose_ci_steps.py` | Contract tests for diagnose-ci SKILL.md step numbering and cross-reference integrity |
@@ -24,6 +25,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_execution_map_contracts.py` | Contract tests for the build-execution-map skill SKILL.md |
 | `test_exogenous_string_coupling.py` | Exogenous string coupling tests: orchestrator prompt triggers coupled to emitting module |
 | `test_filter_env_var_coverage.py` | Tests that retry-worktree and audit-impl skills set filter env vars for test runs |
+| `test_fleet_dispatch_bem_gate.py` | Contract: fleet dispatcher prompt contains BEM pre-step gate instructions |
 | `test_generate_report_contracts.py` | Contract tests for generate-report SKILL.md — data provenance lifecycle |
 | `test_github_ops.py` | Contract tests: GitHub operation semantics in SKILL.md files |
 | `test_hook_bridge_coverage.py` | REQ-BRIDGE-001: quota guard hook config bridge must produce exactly the keys that resolve_quota_settings() reads |

--- a/tests/contracts/test_campaign_prompt_accuracy.py
+++ b/tests/contracts/test_campaign_prompt_accuracy.py
@@ -1,0 +1,22 @@
+"""Contract: campaign prompt does not contain inaccurate semaphore language."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.cli._prompts_campaign import _build_dynamic_dispatch_section
+
+MCP_PREFIX = "autoskillit__"
+
+
+@pytest.fixture(scope="module")
+def dynamic_dispatch_text() -> str:
+    return _build_dynamic_dispatch_section(mcp_prefix=MCP_PREFIX)
+
+
+def test_campaign_prompt_does_not_claim_queuing(dynamic_dispatch_text: str) -> None:
+    """Campaign prompt must NOT claim dispatches queue when semaphore is saturated."""
+    assert "calls queue" not in dynamic_dispatch_text, (
+        "Campaign prompt must not claim 'calls queue when the semaphore is saturated' — "
+        "FLEET_PARALLEL_REFUSED is a fast-fail, not a queue. Dispatcher must wait and retry."
+    )

--- a/tests/contracts/test_fleet_dispatch_bem_gate.py
+++ b/tests/contracts/test_fleet_dispatch_bem_gate.py
@@ -1,0 +1,62 @@
+"""Contract: fleet dispatcher prompt contains BEM pre-step gate instructions."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.cli._prompts_kitchen import _build_fleet_dispatch_prompt
+
+MCP_PREFIX = "autoskillit__"
+
+
+@pytest.fixture(scope="module")
+def fleet_prompt() -> str:
+    return _build_fleet_dispatch_prompt(mcp_prefix=MCP_PREFIX)
+
+
+def test_fleet_prompt_contains_bem_wrapperReference(fleet_prompt: str) -> None:
+    """Fleet dispatcher prompt must reference bem-wrapper for conflict analysis."""
+    assert "bem-wrapper" in fleet_prompt, (
+        "Fleet dispatcher prompt must instruct the dispatcher to use bem-wrapper "
+        "as the BEM pre-step for multi-issue dispatches"
+    )
+
+
+def test_fleet_prompt_contains_dispatch_plan_reference(fleet_prompt: str) -> None:
+    """Fleet dispatcher prompt must reference dispatch_plan from l3_payload."""
+    assert "dispatch_plan" in fleet_prompt, (
+        "Fleet dispatcher prompt must instruct the dispatcher to read dispatch_plan "
+        "from the bem-wrapper dispatch_food_truck response"
+    )
+
+
+def test_fleet_prompt_contains_multi_issue_gate_language(fleet_prompt: str) -> None:
+    """Fleet dispatcher prompt must contain multi-issue gate language."""
+    lower = fleet_prompt.lower()
+    assert any(phrase in lower for phrase in ("multi-issue", "2 or more", "2+ issues")), (
+        "Fleet dispatcher prompt must describe the multi-issue BEM gate trigger condition"
+    )
+
+
+def test_fleet_prompt_does_not_contain_stale_serial_guidance(fleet_prompt: str) -> None:
+    """Fleet dispatcher prompt must NOT contain stale serial-only dispatch guidance."""
+    assert "dispatch one food truck at a time" not in fleet_prompt, (
+        "Stale 'Serial execution: dispatch one food truck at a time' text must be "
+        "replaced by BEM-gated parallel dispatch guidance (REQ-BEM-002)"
+    )
+
+
+def test_fleet_prompt_references_fallback_to_sequential(fleet_prompt: str) -> None:
+    """Fleet dispatcher prompt must describe sequential fallback when BEM fails."""
+    lower = fleet_prompt.lower()
+    assert "fallback" in lower or "fall back" in lower or "sequential" in lower, (
+        "Fleet dispatcher prompt must describe the sequential fallback path when "
+        "bem-wrapper fails or returns an empty dispatch_plan"
+    )
+
+
+def test_fleet_prompt_references_max_total_issues_cap(fleet_prompt: str) -> None:
+    """Fleet dispatcher prompt must describe the max_total_issues cap."""
+    assert "max_total_issues" in fleet_prompt or "12" in fleet_prompt, (
+        "Fleet dispatcher prompt must mention the total issues session cap"
+    )

--- a/tests/contracts/test_fleet_dispatch_bem_gate.py
+++ b/tests/contracts/test_fleet_dispatch_bem_gate.py
@@ -14,7 +14,7 @@ def fleet_prompt() -> str:
     return _build_fleet_dispatch_prompt(mcp_prefix=MCP_PREFIX)
 
 
-def test_fleet_prompt_contains_bem_wrapperReference(fleet_prompt: str) -> None:
+def test_fleet_prompt_contains_bem_wrapper_reference(fleet_prompt: str) -> None:
     """Fleet dispatcher prompt must reference bem-wrapper for conflict analysis."""
     assert "bem-wrapper" in fleet_prompt, (
         "Fleet dispatcher prompt must instruct the dispatcher to use bem-wrapper "
@@ -57,6 +57,6 @@ def test_fleet_prompt_references_fallback_to_sequential(fleet_prompt: str) -> No
 
 def test_fleet_prompt_references_max_total_issues_cap(fleet_prompt: str) -> None:
     """Fleet dispatcher prompt must describe the max_total_issues cap."""
-    assert "max_total_issues" in fleet_prompt or "12" in fleet_prompt, (
+    assert "max_total_issues" in fleet_prompt, (
         "Fleet dispatcher prompt must mention the total issues session cap"
     )

--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -927,6 +927,38 @@ async def test_third_concurrent_dispatch_refused_with_max2(
     assert results[2]["success"] is False
 
 
+@pytest.mark.anyio
+async def test_fourth_concurrent_dispatch_refused_with_max3(
+    fleet_runtime_factory,
+) -> None:
+    """FleetSemaphore(max=3) rejects a fourth concurrent dispatch immediately."""
+    rt = fleet_runtime_factory(max_concurrent_dispatches=3)
+    rt.add_recipe("slow-recipe")
+    results: list[dict | None] = [None, None, None, None]
+
+    async def _slow(idx: int) -> None:
+        results[idx] = await rt.dispatch(
+            "slow-recipe", shim_mode="sleep_then_exit", sleep_sec=3.0, timeout_sec=15
+        )
+
+    async def _fast() -> None:
+        await anyio.sleep(0.3)
+        results[3] = await rt.dispatch("slow-recipe", shim_mode="success")
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_slow, 0)
+        tg.start_soon(_slow, 1)
+        tg.start_soon(_slow, 2)
+        tg.start_soon(_fast)
+
+    assert results[0] is not None and results[0]["success"] is True
+    assert results[1] is not None and results[1]["success"] is True
+    assert results[2] is not None and results[2]["success"] is True
+    assert results[3] is not None
+    assert results[3]["error"] == "fleet_parallel_refused"
+    assert results[3]["success"] is False
+
+
 # ---------------------------------------------------------------------------
 # Test: resume_session_id threads through to the subprocess cmd
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a BEM (build-execution-map) conflict gate to the fleet dispatcher's multi-issue dispatch path, and raise the fleet semaphore's default concurrency to allow the gate to actually enable parallel execution. The work spans four areas: (1) replace stale serial-only guidance in the fleet dispatcher prompt with BEM gate instructions, (2) fix inaccurate semaphore language in the campaign prompt, (3) raise `max_concurrent_dispatches` default from 1 to 3 and add a `max_total_issues: 12` cap to `FleetConfig`, and (4) add contract and config tests that enforce these prompt and config invariants going forward.

All machinery already exists: `bem-wrapper` is a `food-truck` recipe, `dispatch_food_truck` returns `l3_payload.dispatch_plan` inline, and `FleetSemaphore` already supports N>1. The gap is entirely in prompts and config defaults.

## Requirements

### REQ-BEM-001: Multi-issue conflict gate section in fleet dispatcher prompt
Add a new prompt section to `_build_fleet_dispatch_prompt()` in `src/autoskillit/cli/_prompts_kitchen.py` that instructs the fleet dispatcher to:
1. Detect when the user requests 2+ issues dispatched (regardless of whether user says "parallel" — any multi-issue dispatch needs the gate)
2. Dispatch `bem-wrapper` first: `dispatch_food_truck(recipe="bem-wrapper", task="Build execution map for conflict analysis", ingredients={"issue_urls": "<comma-separated URLs>", "base_branch": "<target branch>"}, capture={"execution_map": "${{ result.execution_map }}"})`
3. Read `l3_payload.dispatch_plan` from the `dispatch_food_truck` response — this is a JSON array of `{"group": N, "parallel": bool, "issues": "..."}` objects
4. Sequence subsequent dispatches per the group plan:
   - `parallel: true` groups → dispatch all issues in the group simultaneously
   - `parallel: false` groups → dispatch sequentially within the group
   - Wait for all dispatches in group N to complete before starting group N+1
5. Fall back to sequential dispatch (one at a time) if `bem-wrapper` fails
6. Single-issue dispatches skip BEM entirely (no pre-step needed)

### REQ-BEM-002: Update stale serial dispatch guidance
Replace the stale text at `_prompts_kitchen.py:121-122`:
```
- Serial execution: dispatch one food truck at a time. fleet_lock enforces this —
do NOT attempt parallel dispatches.
```
With guidance describing BEM-gated parallel dispatch. The new text should describe: single-issue dispatches proceed directly; multi-issue dispatches require the BEM pre-step; group ordering and merge-wait between groups; max concurrent dispatches is 3. Reference the existing `max_parallel` cap that BEM already enforces on group sizes.

### REQ-BEM-003: Contract test for fleet dispatcher BEM gate
Add a contract test (in `tests/contracts/`) asserting that the fleet dispatcher prompt returned by `_build_fleet_dispatch_prompt()` contains multi-issue conflict gate instructions. Similar pattern to `test_sous_chef_routing.py:176` which asserts sous-chef contains BEM invocation instructions.

Suggested assertions:
- Prompt contains "bem-wrapper" reference
- Prompt contains "dispatch_plan" reference
- Prompt contains "multi-issue" or "conflict" gate language
- Prompt does NOT contain the stale "Serial execution: dispatch one food truck at a time" text

### REQ-BEM-004: Include `bem-wrapper` in fleet dispatcher recipe table
If `_food_truck_section` (the recipe table injected into the fleet dispatcher prompt) does not already include `bem-wrapper`, ensure it appears so the dispatcher knows it's available for dispatch without calling `list_recipes` first.

### REQ-SEM-001: Raise `max_concurrent_dispatches` default to 3
Update the default from 1 to 3 in both `src/autoskillit/config/_config_dataclasses.py` (`FleetConfig.max_concurrent_dispatches`) and `src/autoskillit/config/defaults.yaml` (`fleet.max_concurrent_dispatches`). This allows the semaphore to permit up to 3 food trucks running simultaneously, which BEM groups can utilize when `parallel: true`. Users can still override via `.autoskillit/config.yaml` or the `AUTOSKILLIT_FLEET__MAX_CONCURRENT_DISPATCHES` env var. Update `FleetConfig.validate()` to enforce `1 <= max_concurrent_dispatches <= 3` (hard cap to prevent runaway subprocess spawning).

Note: `FleetSemaphore` itself needs no changes — it already supports N>1 via `asyncio.BoundedSemaphore(max_concurrent)`.

### REQ-SEM-002: Add `max_total_issues` fleet config cap (default 12)
Add a new `max_total_issues: int = 12` field to `FleetConfig` in `_config_dataclasses.py` and `defaults.yaml`. This caps the total number of issues a single fleet dispatch session can process (across all food trucks and all groups). The fleet dispatcher prompt should instruct the dispatcher to count total issues before dispatching `bem-wrapper` and refuse (or warn) if over the cap. User-overridable via config/env var. Validation: `1 <= max_total_issues`.

Note: This is distinct from the existing `max_parallel` (default 6), which caps issues per BEM group, not total issues across the session. `max_parallel` is a BEM skill argument; `max_total_issues` is a fleet-level config field. Both are needed: `max_parallel` controls group sizing, `max_total_issues` controls session-level scope.

Rationale for 12: with `max_parallel=6` (issues per group) and `max_concurrent_dispatches=3`, 12 issues is ~2 fully-loaded parallel groups — the upper bound of what the system should handle in a single dispatch session.

### REQ-SEM-003: Fix inaccurate "calls queue" campaign prompt claim
Replace the inaccurate text at `_prompts_campaign.py:53`:
```
The fleet semaphore gates actual concurrency; calls queue when the semaphore is saturated.
```
With accurate language reflecting the actual `at_capacity()` → `FLEET_PARALLEL_REFUSED` fast-fail behavior. The dispatcher must wait for a running dispatch to complete before retrying, not assume queuing. Also update `_prompts_campaign.py:231` which says "max_concurrent=1 for static dispatches" — this will be inaccurate once REQ-SEM-001 raises the default.

### REQ-SEM-004: Update tests for new defaults
- Update any tests that hardcode `max_concurrent_dispatches=1` as the expected default (search for `max_concurrent_dispatches` and `max_concurrent=1` in tests/)
- Add validation test for the new `max_total_issues` field and the `max_concurrent_dispatches <= 3` upper bound
- Update `test_fleet_e2e.py` tests that assert `FLEET_PARALLEL_REFUSED` at max=1 to account for the new default of 3
- Add contract test asserting the campaign prompt does NOT contain "calls queue" language

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

(None provided)

Closes #2182

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-160445-669401/.autoskillit/temp/make-plan/fleet_dispatcher_bem_gate_plan_2026-05-07_160822.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 123 | 13.2k | 495.3k | 52.1k | 89 | 46.7k | 5m 41s |
| verify | claude-sonnet-4-6 | 1 | 236 | 14.8k | 1.5M | 68.7k | 83 | 56.0k | 4m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 15.0k | 1.3M | 74.0k | 121 | 119.9k | 5m 13s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 87.9k | 4.9k | 198.4k | 28.8k | 22 | 15.2k | 1m 27s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.4k | 2.9k | 169.6k | 28.8k | 14 | 15.1k | 55s |
| review_pr | claude-sonnet-4-6 | 1 | 124 | 36.3k | 755.8k | 79.4k | 45 | 67.4k | 7m 7s |
| resolve_review | claude-sonnet-4-6 | 1 | 237 | 14.4k | 1.4M | 65.2k | 70 | 52.9k | 7m 44s |
| **Total** | | | 1.3M | 101.5k | 5.9M | 79.4k | | 373.2k | 32m 17s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 223 | 5925.8 | 537.8 | 67.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 89758.8 | 3304.4 | 901.1 |
| **Total** | **239** | 24494.1 | 1561.4 | 424.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 605 | 40.2k | 3.2M | 196.0k | 21m 58s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 22.8k | 1.7M | 150.2k | 7m 35s |