### PR TITLE
Activity-Aware Fleet Dispatch Timeout + Quota Sleep Resumable Exit

### DIFF
--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -315,7 +315,8 @@ NEVER retry the same dispatch_name on non-quota failures in v1.
 
 ## QUOTA RETRY
 
-Trigger: a dispatch returns reason=quota_exhausted with a wait_seconds field.
+Trigger: a dispatch returns reason=quota_exhausted OR
+  reason=fleet_quota_exhausted with a wait_seconds field.
 
 Action:
 1. Sleep min(wait_seconds, {max_quota_wait_sec}) seconds.

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -303,6 +303,9 @@ class FleetConfig:
     default_timeout_sec: int = 3600
     max_concurrent_dispatches: int = _MAX_CONCURRENT_DISPATCHES
     max_total_issues: int = 12
+    enable_deadline_extension: bool = True
+    max_extension_seconds: int = 7200
+    idle_output_timeout: int = 1800
 
     def validate(self, feature_enabled: bool) -> None:
         """Validate only when the feature is active."""
@@ -323,6 +326,10 @@ class FleetConfig:
             )
         if self.max_total_issues < 1:
             raise ValueError(f"max_total_issues must be >= 1, got {self.max_total_issues}")
+        if self.max_extension_seconds <= 0:
+            raise ValueError(
+                f"max_extension_seconds must be positive, got {self.max_extension_seconds}"
+            )
 
 
 @dataclass

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -304,8 +304,8 @@ class FleetConfig:
     max_concurrent_dispatches: int = _MAX_CONCURRENT_DISPATCHES
     max_total_issues: int = 12
     enable_deadline_extension: bool = True
-    max_extension_seconds: int = 7200
-    idle_output_timeout: int = 1800
+    max_extension_seconds: float = 7200
+    idle_output_timeout: float = 1800
 
     def validate(self, feature_enabled: bool) -> None:
         """Validate only when the feature is active."""

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -330,6 +330,10 @@ class FleetConfig:
             raise ValueError(
                 f"max_extension_seconds must be positive, got {self.max_extension_seconds}"
             )
+        if self.idle_output_timeout < 0:
+            raise ValueError(
+                f"idle_output_timeout must be non-negative, got {self.idle_output_timeout}"
+            )
 
 
 @dataclass

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -282,6 +282,9 @@ fleet:
   default_timeout_sec: 3600
   max_concurrent_dispatches: 3
   max_total_issues: 12
+  enable_deadline_extension: true
+  max_extension_seconds: 7200
+  idle_output_timeout: 1800
 
 providers:
   default_provider: null

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -503,10 +503,10 @@ class AutomationConfig:
                 enable_deadline_extension=bool(
                     val(fr, "enable_deadline_extension", _fr["enable_deadline_extension"])
                 ),
-                max_extension_seconds=int(
+                max_extension_seconds=float(
                     val(fr, "max_extension_seconds", _fr["max_extension_seconds"])
                 ),
-                idle_output_timeout=int(
+                idle_output_timeout=float(
                     val(fr, "idle_output_timeout", _fr["idle_output_timeout"])
                 ),
             ),

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -500,6 +500,15 @@ class AutomationConfig:
                     val(fr, "max_concurrent_dispatches", _fr["max_concurrent_dispatches"])
                 ),
                 max_total_issues=int(val(fr, "max_total_issues", _fr["max_total_issues"])),
+                enable_deadline_extension=bool(
+                    val(fr, "enable_deadline_extension", _fr["enable_deadline_extension"])
+                ),
+                max_extension_seconds=int(
+                    val(fr, "max_extension_seconds", _fr["max_extension_seconds"])
+                ),
+                idle_output_timeout=int(
+                    val(fr, "idle_output_timeout", _fr["idle_output_timeout"])
+                ),
             ),
             providers=ProvidersConfig(
                 default_provider=val(pvd, "default_provider", _pvd["default_provider"]),

--- a/src/autoskillit/core/types/_type_subprocess.py
+++ b/src/autoskillit/core/types/_type_subprocess.py
@@ -144,4 +144,6 @@ class SubprocessRunner(Protocol):
         idle_output_timeout: float | None = None,
         max_suppression_seconds: float | None = None,
         on_pid_resolved: Callable[[int, int], None] | None = None,
+        enable_deadline_extension: bool = False,
+        max_extension_seconds: float = 7200,
     ) -> Awaitable[SubprocessResult]: ...

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -227,6 +227,8 @@ async def _execute_claude_headless(
     provider_fallback_env: dict[str, str] | None = None,
     provider_fallback_name: str = "",
     provider_extras: Mapping[str, str] | None = None,
+    enable_deadline_extension: bool = False,
+    max_extension_seconds: float = 7200,
 ) -> SkillResult:
     """Shared subprocess execution for headless Claude sessions.
 
@@ -314,6 +316,8 @@ async def _execute_claude_headless(
                 idle_output_timeout=effective_idle,
                 max_suppression_seconds=cfg.max_suppression_seconds,
                 on_pid_resolved=on_spawn,
+                enable_deadline_extension=enable_deadline_extension,
+                max_extension_seconds=max_extension_seconds,
             )
         except Exception as exc:
             logger.error("headless_runner_crashed", exc_info=True)
@@ -826,12 +830,6 @@ class DefaultHeadlessExecutor:
                 )
             merged_extras["AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS"] = ",".join(sorted(requires_packs))
 
-        idle_cfg_val = cfg.run_skill.idle_output_timeout
-        if idle_output_timeout is not None:
-            merged_extras["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] = str(idle_output_timeout)
-        elif idle_cfg_val > 0:
-            merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(idle_cfg_val))
-
         spec = build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,
             plugin_source=self._ctx.plugin_source,
@@ -852,6 +850,26 @@ class DefaultHeadlessExecutor:
         effective_stale = (
             stale_threshold if stale_threshold is not None else cfg.run_skill.stale_threshold
         )
+        effective_deadline_ext = fleet_cfg.enable_deadline_extension
+        effective_max_ext = float(fleet_cfg.max_extension_seconds)
+
+        fleet_idle = fleet_cfg.idle_output_timeout
+        if idle_output_timeout is not None:
+            merged_extras["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] = str(idle_output_timeout)
+        elif fleet_idle > 0:
+            merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(fleet_idle))
+        else:
+            idle_cfg_val = cfg.run_skill.idle_output_timeout
+            if idle_cfg_val > 0:
+                merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(idle_cfg_val))
+
+        effective_idle_out: float | None = (
+            idle_output_timeout
+            if idle_output_timeout is not None
+            else float(fleet_idle)
+            if fleet_idle > 0
+            else None
+        )
 
         return await _execute_claude_headless(
             spec,
@@ -867,11 +885,13 @@ class DefaultHeadlessExecutor:
             project_dir=project_dir,
             timeout=float(effective_timeout),
             stale_threshold=float(effective_stale),
-            idle_output_timeout=idle_output_timeout,
+            idle_output_timeout=effective_idle_out,
             completion_marker=completion_marker,
             on_spawn=on_spawn,
             skip_clone_guard=True,
             provider_name=provider_name,
             provider_fallback_env=provider_fallback_env,
             provider_fallback_name=provider_fallback_name,
+            enable_deadline_extension=effective_deadline_ext,
+            max_extension_seconds=effective_max_ext,
         )

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -830,6 +830,16 @@ class DefaultHeadlessExecutor:
                 )
             merged_extras["AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS"] = ",".join(sorted(requires_packs))
 
+        fleet_idle = fleet_cfg.idle_output_timeout
+        if idle_output_timeout is not None:
+            merged_extras["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] = str(idle_output_timeout)
+        elif fleet_idle > 0:
+            merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(fleet_idle))
+        else:
+            idle_cfg_val = cfg.run_skill.idle_output_timeout
+            if idle_cfg_val > 0:
+                merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(idle_cfg_val))
+
         spec = build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,
             plugin_source=self._ctx.plugin_source,
@@ -852,16 +862,6 @@ class DefaultHeadlessExecutor:
         )
         effective_deadline_ext = fleet_cfg.enable_deadline_extension
         effective_max_ext = float(fleet_cfg.max_extension_seconds)
-
-        fleet_idle = fleet_cfg.idle_output_timeout
-        if idle_output_timeout is not None:
-            merged_extras["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] = str(idle_output_timeout)
-        elif fleet_idle > 0:
-            merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(fleet_idle))
-        else:
-            idle_cfg_val = cfg.run_skill.idle_output_timeout
-            if idle_cfg_val > 0:
-                merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(idle_cfg_val))
 
         effective_idle_out: float | None = (
             idle_output_timeout

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -52,6 +52,7 @@ from autoskillit.execution.process._process_race import (
     RaceAccumulator,
     RaceSignals,
     _extract_stdout_session_id,
+    _watch_child_activity,
     _watch_heartbeat,
     _watch_process,
     _watch_session_log,
@@ -197,6 +198,8 @@ async def run_managed_async(
     idle_output_timeout: float | None = None,
     max_suppression_seconds: float | None = None,
     on_pid_resolved: Callable[[int, int], None] | None = None,
+    enable_deadline_extension: bool = False,
+    max_extension_seconds: float = 7200,
     _phase1_poll: float = 1.0,
     _phase2_poll: float = 2.0,
     _heartbeat_poll: float = 0.5,
@@ -296,7 +299,7 @@ async def run_managed_async(
             trigger = anyio.Event()
             channel_b_ready = anyio.Event()
             stdout_session_id_ready = anyio.Event()
-            timeout_scope = None  # bound inside task group body; initialized for safety
+            timeout_scope_ref: list[anyio.CancelScope | None] = [None]
 
             async with anyio.create_task_group() as tg:
                 tg.start_soon(_watch_process, proc, acc, trigger)
@@ -352,8 +355,19 @@ async def run_managed_async(
                         config=linux_tracing_config,
                         tg=tg,
                     )
-                with anyio.move_on_after(timeout) as timeout_scope:
+                if enable_deadline_extension and _observed_pid is not None:
+                    tg.start_soon(
+                        _watch_child_activity,
+                        _observed_pid,
+                        timeout_scope_ref,
+                        max_extension_seconds,
+                        trigger,
+                    )
+                timeout_scope: anyio.CancelScope | None
+                with anyio.move_on_after(timeout) as _ts:
+                    timeout_scope_ref[0] = _ts
                     await trigger.wait()
+                timeout_scope = timeout_scope_ref[0]
                 # Symmetric drain: if the process exited before Channel B deposited,
                 # give the session monitor a bounded window to complete its current
                 # poll cycle and deposit its signal.
@@ -556,6 +570,8 @@ class DefaultSubprocessRunner:
         idle_output_timeout: float | None = None,
         max_suppression_seconds: float | None = None,
         on_pid_resolved: Callable[[int, int], None] | None = None,
+        enable_deadline_extension: bool = False,
+        max_extension_seconds: float = 7200,
     ) -> SubprocessResult:
         return await run_managed_async(
             cmd,
@@ -572,4 +588,6 @@ class DefaultSubprocessRunner:
             idle_output_timeout=idle_output_timeout,
             max_suppression_seconds=max_suppression_seconds,
             on_pid_resolved=on_pid_resolved,
+            enable_deadline_extension=enable_deadline_extension,
+            max_extension_seconds=max_extension_seconds,
         )

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -11,7 +11,12 @@ import anyio.abc
 
 from autoskillit.core import ChannelBStatus, ChannelConfirmation, TerminationReason, get_logger
 from autoskillit.core import fast_loads as _fast_loads
-from autoskillit.execution.process._process_monitor import _heartbeat, _session_log_monitor
+from autoskillit.execution.process._process_monitor import (
+    _has_active_api_connection,
+    _has_active_child_processes,
+    _heartbeat,
+    _session_log_monitor,
+)
 
 logger = get_logger(__name__)
 
@@ -170,6 +175,57 @@ async def _watch_stdout_idle(
             )
             acc.idle_stall = True
             trigger.set()
+            return
+
+
+async def _watch_child_activity(
+    pid: int,
+    timeout_scope_ref: list[anyio.CancelScope | None],
+    max_extension_seconds: float,
+    trigger: anyio.Event,
+    _poll_interval: float = 30.0,
+) -> None:
+    """Extend the wall-clock CancelScope.deadline when child processes are active.
+
+    Polls _has_active_child_processes and _has_active_api_connection every
+    _poll_interval seconds. When either returns True, pushes
+    timeout_scope.deadline forward (up to max_extension_seconds beyond the
+    original deadline).
+
+    Terminates when trigger fires (session completed normally). Crash is
+    fail-closed — anyio propagates exceptions in the task group, cancelling
+    siblings.
+    """
+    original_deadline: float | None = None
+
+    while not trigger.is_set():
+        await anyio.sleep(_poll_interval)
+        if trigger.is_set():
+            return
+
+        scope = timeout_scope_ref[0]
+        if scope is None:
+            continue
+
+        if original_deadline is None:
+            original_deadline = scope.deadline
+
+        active = _has_active_child_processes(pid) or _has_active_api_connection(pid)
+        if not active:
+            continue
+
+        cap = original_deadline + max_extension_seconds
+        desired = original_deadline + _poll_interval * 2
+        new_deadline = min(desired, cap)
+        if new_deadline > scope.deadline:
+            logger.debug(
+                "deadline_extended",
+                extension=new_deadline - scope.deadline,
+                new_deadline=new_deadline,
+                cap=cap,
+            )
+            scope.deadline = new_deadline
+        if trigger.is_set():
             return
 
 

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -196,7 +196,7 @@ async def _watch_child_activity(
     fail-closed — anyio propagates exceptions in the task group, cancelling
     siblings.
     """
-    original_deadline: float | None = None
+    _first_observed_deadline: float | None = None
 
     while not trigger.is_set():
         await anyio.sleep(_poll_interval)
@@ -207,15 +207,15 @@ async def _watch_child_activity(
         if scope is None:
             continue
 
-        if original_deadline is None:
-            original_deadline = scope.deadline
+        if _first_observed_deadline is None:
+            _first_observed_deadline = scope.deadline
 
         active = _has_active_child_processes(pid) or _has_active_api_connection(pid)
         if not active:
             continue
 
-        cap = original_deadline + max_extension_seconds
-        desired = original_deadline + _poll_interval * 2
+        cap = _first_observed_deadline + max_extension_seconds
+        desired = _first_observed_deadline + _poll_interval * 2
         new_deadline = min(desired, cap)
         if new_deadline > scope.deadline:
             logger.debug(

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -215,7 +215,7 @@ async def _watch_child_activity(
             continue
 
         cap = _first_observed_deadline + max_extension_seconds
-        desired = _first_observed_deadline + _poll_interval * 2
+        desired = anyio.current_time() + _poll_interval * 2
         new_deadline = min(desired, cap)
         if new_deadline > scope.deadline:
             logger.debug(

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import tempfile
 from collections import deque
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -101,7 +101,9 @@ class RecordingSubprocessRunner(SubprocessRunner):
         linux_tracing_config: Any | None = None,
         idle_output_timeout: float | None = None,
         max_suppression_seconds: float | None = None,
-        on_pid_resolved: Any | None = None,
+        on_pid_resolved: Callable[[int, int], None] | None = None,
+        enable_deadline_extension: bool = False,
+        max_extension_seconds: float = 7200,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 
@@ -128,6 +130,8 @@ class RecordingSubprocessRunner(SubprocessRunner):
             idle_output_timeout=idle_output_timeout,
             max_suppression_seconds=max_suppression_seconds,
             on_pid_resolved=on_pid_resolved,
+            enable_deadline_extension=enable_deadline_extension,
+            max_extension_seconds=max_extension_seconds,
         )
 
         if step_name:
@@ -242,7 +246,9 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         linux_tracing_config: Any | None = None,
         idle_output_timeout: float | None = None,
         max_suppression_seconds: float | None = None,
-        on_pid_resolved: Any | None = None,
+        on_pid_resolved: Callable[[int, int], None] | None = None,
+        enable_deadline_extension: bool = False,
+        max_extension_seconds: float = 7200,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -430,7 +430,7 @@ async def _run_dispatch(
                 started_at
                 + (
                     float(timeout_sec)
-                    if timeout_sec
+                    if timeout_sec is not None
                     else float(tool_ctx.config.fleet.default_timeout_sec)
                 )
             ),

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -427,7 +427,12 @@ async def _run_dispatch(
             "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
             "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
             "AUTOSKILLIT_SESSION_DEADLINE": str(
-                started_at + (float(timeout_sec) if timeout_sec else 3600.0)
+                started_at
+                + (
+                    float(timeout_sec)
+                    if timeout_sec
+                    else float(tool_ctx.config.fleet.default_timeout_sec)
+                )
             ),
         },
         requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -426,6 +426,9 @@ async def _run_dispatch(
             "AUTOSKILLIT_PROJECT_DIR": str(tool_ctx.project_dir),
             "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
             "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
+            "AUTOSKILLIT_SESSION_DEADLINE": str(
+                started_at + (float(timeout_sec) if timeout_sec else 3600.0)
+            ),
         },
         requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
         on_spawn=_on_spawn,

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -12,7 +12,11 @@ import json
 import regex as re
 
 from autoskillit.core import ADMIRAL_DISPATCH_SECTIONS, get_logger, pkg_root
-from autoskillit.hooks import QUOTA_GUARD_DENY_TRIGGER, QUOTA_POST_WARNING_TRIGGER
+from autoskillit.hooks import (
+    QUOTA_BUDGET_EXCEEDED_TRIGGER,
+    QUOTA_GUARD_DENY_TRIGGER,
+    QUOTA_POST_WARNING_TRIGGER,
+)
 
 logger = get_logger(__name__)
 
@@ -187,6 +191,12 @@ QUOTA DENIAL ROUTING — run_skill only (check BEFORE on_failure):
   - The deny message contains a run_cmd sleep command. Execute it immediately.
   - After the sleep completes, retry the EXACT same run_skill call (same arguments).
   - NEVER treat a quota denial as a permanent failure or pipeline-stopping error.
+- When a PreToolUse hook DENIES run_skill with "{QUOTA_BUDGET_EXCEEDED_TRIGGER}":
+  - The required quota sleep EXCEEDS the session's remaining wall-clock budget.
+  - Do NOT sleep. Instead, emit the sentinel block immediately with the fields
+    specified in the deny message (success=false, reason=fleet_quota_exhausted,
+    wait_seconds, summary).
+  - Then STOP — do not call any more tools after emitting the sentinel.
 - When run_skill output contains "{QUOTA_POST_WARNING_TRIGGER}":
   - A post-execution quota check detected high utilization.
   - The warning contains a run_cmd sleep command. Execute it BEFORE the next run_skill call.

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -176,6 +176,7 @@ def _validate_transition(current: str, new: str, dispatch_name: str) -> None:
 _INFRASTRUCTURE_FAILURE_REASONS: frozenset[str] = frozenset(
     {
         FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK,
+        FleetErrorCode.FLEET_QUOTA_EXHAUSTED,
     }
 )
 

--- a/src/autoskillit/hooks/__init__.py
+++ b/src/autoskillit/hooks/__init__.py
@@ -7,7 +7,10 @@ from autoskillit.hook_registry import (
 )
 from autoskillit.hooks.formatters._fmt_primitives import _HOOK_CONFIG_PATH_COMPONENTS
 from autoskillit.hooks.guards.branch_protection_guard import BRANCH_PROTECTION_DENY_TRIGGER
-from autoskillit.hooks.guards.quota_guard import QUOTA_GUARD_DENY_TRIGGER
+from autoskillit.hooks.guards.quota_guard import (
+    QUOTA_BUDGET_EXCEEDED_TRIGGER,
+    QUOTA_GUARD_DENY_TRIGGER,
+)
 from autoskillit.hooks.guards.review_loop_gate import REVIEW_LOOP_DENY_TRIGGER
 from autoskillit.hooks.guards.skill_orchestration_guard import SKILL_ORCHESTRATION_DENY_TRIGGER
 from autoskillit.hooks.quota_post_hook import QUOTA_POST_WARNING_TRIGGER
@@ -18,6 +21,7 @@ __all__ = [
     "BRANCH_PROTECTION_DENY_TRIGGER",
     "SKILL_ORCHESTRATION_DENY_TRIGGER",
     "QUOTA_GUARD_DENY_TRIGGER",
+    "QUOTA_BUDGET_EXCEEDED_TRIGGER",
     "QUOTA_POST_WARNING_TRIGGER",
     "REVIEW_LOOP_DENY_TRIGGER",
     "_HOOK_CONFIG_PATH_COMPONENTS",

--- a/src/autoskillit/hooks/guards/quota_guard.py
+++ b/src/autoskillit/hooks/guards/quota_guard.py
@@ -15,6 +15,7 @@ requiring the autoskillit package to be importable.
 import json
 import os
 import sys
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -34,6 +35,10 @@ _AUTOSKILLIT_LOG_DIR_ENV = "AUTOSKILLIT_LOG_DIR"
 # Emitted in deny messages; also referenced by orchestrator prompt QUOTA DENIAL ROUTING.
 # Changing this value requires updating _prompts.py and sous-chef/SKILL.md in the same commit.
 QUOTA_GUARD_DENY_TRIGGER: str = "QUOTA WAIT REQUIRED"
+
+# Emitted when required sleep exceeds remaining session wall-clock budget.
+# Instructs the session to emit a clean sentinel and exit, rather than sleep-and-retry.
+QUOTA_BUDGET_EXCEEDED_TRIGGER: str = "QUOTA BUDGET EXCEEDED"
 
 
 def _read_quota_cache(cache_path_str: str, max_age: int) -> dict | None:
@@ -170,39 +175,76 @@ def main(*, cache_path_override: str | None = None) -> None:
         else:
             n = settings.buffer_seconds
 
+        session_deadline_str = os.environ.get("AUTOSKILLIT_SESSION_DEADLINE")
+        budget_exceeded = False
+        if session_deadline_str:
+            try:
+                session_deadline = float(session_deadline_str)
+                remaining_budget = max(0, session_deadline - time.time())
+                if n > remaining_budget:
+                    budget_exceeded = True
+            except (ValueError, TypeError):
+                pass  # malformed deadline — fall through to normal deny
+
         _write_quota_log_event(
             {
                 "ts": ts,
-                "event": "blocked",
+                "event": "blocked_budget_exceeded" if budget_exceeded else "blocked",
                 "effective_threshold": effective_threshold,
                 "window_name": window_name,
                 "utilization": utilization,
                 "sleep_seconds": n,
                 "resets_at": resets_at_str,
+                "budget_exceeded": budget_exceeded,
             },
             log_dir,
         )
-        print(
-            json.dumps(
-                {
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "deny",
-                        "permissionDecisionReason": (
-                            f"{QUOTA_GUARD_DENY_TRIGGER} (temporary — NOT a permanent error). "
-                            f"Utilization: {utilization:.0f}% on window '{window_name}' "
-                            f"(threshold: {effective_threshold:.0f}%). "
-                            f"MANDATORY ACTION: Call run_cmd with: "
-                            f'python3 -c "import time; time.sleep({n})" timeout={n + 30} — '
-                            f"then retry the SAME run_skill call with identical arguments. "
-                            f"Before executing, state aloud: "
-                            f"'Quota exceeded at {utilization:.0f}%. "
-                            f"Sleeping {n}s, then retrying.'"
-                        ),
+
+        if budget_exceeded:
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": (
+                                f"{QUOTA_BUDGET_EXCEEDED_TRIGGER} — "
+                                f"Quota sleep ({n}s) exceeds session budget "
+                                f"({remaining_budget:.0f}s remaining). "
+                                f"MANDATORY ACTION: Emit your result block with "
+                                f'"success": false, '
+                                f'"reason": "fleet_quota_exhausted", '
+                                f'"wait_seconds": {n}, '
+                                f'"summary": "Quota exceeded; session budget insufficient '
+                                f'for sleep. Resume after window resets." '
+                                f"Then STOP — do not call any more tools."
+                            ),
+                        }
                     }
-                }
+                )
             )
-        )
+        else:
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": (
+                                f"{QUOTA_GUARD_DENY_TRIGGER} (temporary — NOT a permanent error). "
+                                f"Utilization: {utilization:.0f}% on window '{window_name}' "
+                                f"(threshold: {effective_threshold:.0f}%). "
+                                f"MANDATORY ACTION: Call run_cmd with: "
+                                f'python3 -c "import time; time.sleep({n})" timeout={n + 30} — '
+                                f"then retry the SAME run_skill call with identical arguments. "
+                                f"Before executing, state aloud: "
+                                f"'Quota exceeded at {utilization:.0f}%. "
+                                f"Sleeping {n}s, then retrying.'"
+                            ),
+                        }
+                    }
+                )
+            )
     else:
         _write_quota_log_event(
             {

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -568,6 +568,21 @@ When `run_skill` output contains `--- QUOTA WARNING ---`:
 3. After sleeping, proceed normally with the next step.
 4. Before executing, state aloud: "Quota warning. Sleeping N seconds before next step."
 
+### Budget-Exceeded Denial (quota sleep exceeds session wall-clock budget)
+
+When a `run_skill` call is DENIED with "QUOTA BUDGET EXCEEDED":
+
+1. The required quota sleep exceeds the session's remaining wall-clock budget.
+2. **MANDATORY**: Do NOT execute the sleep command.
+3. Instead, emit your result block immediately with:
+   - `"success": false`
+   - `"reason": "fleet_quota_exhausted"`
+   - `"wait_seconds": <seconds_until_reset>`
+   - `"summary": "Quota exceeded; session budget insufficient for sleep. Resume after window resets."`
+4. Then STOP — do not call any more tools.
+5. Do NOT follow `on_failure`. Do NOT report to the user.
+6. The fleet dispatcher will handle retry scheduling.
+
 ### Key Rules
 
 - Quota denials are **always temporary**. The API enforces multiple rate-limit windows (e.g. one-minute, one-hour, five-hour, one-day). The guard waits for the most constrained window — the one that resets latest among all windows above the threshold — to reset before retrying.

--- a/tests/config/test_fleet_config.py
+++ b/tests/config/test_fleet_config.py
@@ -177,6 +177,38 @@ class TestFleetConfig:
         cfg = load_config(tmp_path)
         assert cfg.fleet.max_concurrent_dispatches == 3
 
+    def test_fleet_config_enable_deadline_extension_defaults_true(self) -> None:
+        """FleetConfig.enable_deadline_extension defaults to True."""
+        from autoskillit.config.settings import FleetConfig
+
+        assert FleetConfig().enable_deadline_extension is True
+
+    def test_fleet_config_max_extension_seconds_defaults_7200(self) -> None:
+        """FleetConfig.max_extension_seconds defaults to 7200."""
+        from autoskillit.config.settings import FleetConfig
+
+        assert FleetConfig().max_extension_seconds == 7200
+
+    def test_fleet_config_idle_output_timeout_defaults_1800(self) -> None:
+        """FleetConfig.idle_output_timeout defaults to 1800."""
+        from autoskillit.config.settings import FleetConfig
+
+        assert FleetConfig().idle_output_timeout == 1800
+
+    def test_fleet_config_rejects_zero_max_extension_seconds(self) -> None:
+        """FleetConfig raises ValueError when max_extension_seconds is zero."""
+        from autoskillit.config.settings import FleetConfig
+
+        with pytest.raises(ValueError, match="max_extension_seconds must be positive"):
+            FleetConfig(max_extension_seconds=0).validate(feature_enabled=True)
+
+    def test_fleet_config_rejects_negative_max_extension_seconds(self) -> None:
+        """FleetConfig raises ValueError when max_extension_seconds is negative."""
+        from autoskillit.config.settings import FleetConfig
+
+        with pytest.raises(ValueError, match="max_extension_seconds must be positive"):
+            FleetConfig(max_extension_seconds=-1).validate(feature_enabled=True)
+
 
 def test_config_resolution_fleet_enabled_via_experimental(tmp_path) -> None:
     """Full config resolution enables fleet when experimental_enabled=True in project config."""

--- a/tests/config/test_fleet_config.py
+++ b/tests/config/test_fleet_config.py
@@ -209,6 +209,13 @@ class TestFleetConfig:
         with pytest.raises(ValueError, match="max_extension_seconds must be positive"):
             FleetConfig(max_extension_seconds=-1).validate(feature_enabled=True)
 
+    def test_fleet_config_rejects_negative_idle_output_timeout(self) -> None:
+        """FleetConfig raises ValueError when idle_output_timeout is negative."""
+        from autoskillit.config.settings import FleetConfig
+
+        with pytest.raises(ValueError, match="idle_output_timeout must be non-negative"):
+            FleetConfig(idle_output_timeout=-1).validate(feature_enabled=True)
+
 
 def test_config_resolution_fleet_enabled_via_experimental(tmp_path) -> None:
     """Full config resolution enables fleet when experimental_enabled=True in project config."""

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -340,6 +340,8 @@ class TestGroupDApiContractPreservation:
             "idle_output_timeout",
             "max_suppression_seconds",
             "on_pid_resolved",
+            "enable_deadline_extension",
+            "max_extension_seconds",
         }
         assert expected == public_params, (
             f"run_managed_async public params changed.\n"
@@ -402,6 +404,8 @@ class TestGroupDApiContractPreservation:
             "idle_output_timeout",
             "max_suppression_seconds",
             "on_pid_resolved",
+            "enable_deadline_extension",
+            "max_extension_seconds",
         }
         assert expected == actual, (
             f"DefaultSubprocessRunner.__call__ params changed.\n"

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -51,6 +51,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_pr_analysis.py` | Tests for execution/pr_analysis.py |
 | `test_process_channel_b.py` | Integration tests for Channel B drain-race and COMPLETED pipeline adjudication |
 | `test_process_debug_logging.py` | Tests for debug logging instrumentation in process.py |
+| `test_process_deadline_extension.py` | Tests for _watch_child_activity coroutine and deadline extension behavior |
 | `test_process_heartbeat.py` | Unit tests for _heartbeat, _has_active_api_connection, _has_active_child_processes, orphaned tool result detection |
 | `test_process_idle_watchdog.py` | Tests for the stdout idle watchdog coroutine (_watch_stdout_idle) |
 | `test_process_jsonl.py` | Tests for JSONL marker detection utilities |

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -161,11 +161,11 @@ class TestDispatchFoodTruckIdleEnvInjection:
         self, minimal_ctx, tmp_path: Path, monkeypatch
     ) -> None:
         """dispatch_food_truck adds AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT to env_extras
-        based on cfg.run_skill.idle_output_timeout when it is > 0."""
+        based on fleet config idle_output_timeout (priority: caller > fleet > run_skill)."""
         from autoskillit.core.types import SkillResult as _SkillResult
         from autoskillit.execution.headless import DefaultHeadlessExecutor
 
-        minimal_ctx.config.run_skill.idle_output_timeout = 120
+        minimal_ctx.config.fleet.idle_output_timeout = 120
 
         captured_env_extras: list[dict[str, str] | None] = []
 

--- a/tests/execution/test_process_deadline_extension.py
+++ b/tests/execution/test_process_deadline_extension.py
@@ -1,0 +1,168 @@
+"""Tests for _watch_child_activity coroutine and deadline extension behavior."""
+
+from __future__ import annotations
+
+import anyio
+import pytest
+
+from autoskillit.execution.process._process_race import _watch_child_activity
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
+
+
+@pytest.mark.anyio
+async def test_extends_deadline_when_children_active(monkeypatch) -> None:
+    """Deadline is extended when _has_active_child_processes returns True."""
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_child_processes",
+        lambda pid: True,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_api_connection",
+        lambda pid: False,
+    )
+    trigger = anyio.Event()
+    scope_ref: list[anyio.CancelScope | None] = [None]
+    original_deadline_ref: list[float] = []
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_watch_child_activity, 1, scope_ref, 7200.0, trigger, 0.05)
+        with anyio.move_on_after(2.0) as scope:
+            scope_ref[0] = scope
+            original_deadline_ref.append(scope.deadline)
+            await anyio.sleep(0.3)
+            trigger.set()
+        tg.cancel_scope.cancel()
+
+    assert scope_ref[0] is not None
+    assert scope_ref[0].deadline > original_deadline_ref[0]
+
+
+@pytest.mark.anyio
+async def test_no_extension_when_inactive(monkeypatch) -> None:
+    """Deadline is NOT extended when both probes return False."""
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_child_processes",
+        lambda pid: False,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_api_connection",
+        lambda pid: False,
+    )
+    trigger = anyio.Event()
+    scope_ref: list[anyio.CancelScope | None] = [None]
+    original_deadline_ref: list[float] = []
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_watch_child_activity, 1, scope_ref, 7200.0, trigger, 0.05)
+        with anyio.move_on_after(2.0) as scope:
+            scope_ref[0] = scope
+            original_deadline_ref.append(scope.deadline)
+            await anyio.sleep(0.5)
+            trigger.set()
+        tg.cancel_scope.cancel()
+
+    assert scope_ref[0] is not None
+    assert scope_ref[0].deadline == original_deadline_ref[0]
+
+
+@pytest.mark.anyio
+async def test_max_extension_cap_enforced(monkeypatch) -> None:
+    """Extension is capped at max_extension_seconds beyond original deadline."""
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_child_processes",
+        lambda pid: True,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_api_connection",
+        lambda pid: False,
+    )
+    trigger = anyio.Event()
+    scope_ref: list[anyio.CancelScope | None] = [None]
+    original_deadline_ref: list[float] = []
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_watch_child_activity, 1, scope_ref, 0.2, trigger, 0.05)
+        with anyio.move_on_after(2.0) as scope:
+            scope_ref[0] = scope
+            original_deadline_ref.append(scope.deadline)
+            await anyio.sleep(0.8)
+            trigger.set()
+        tg.cancel_scope.cancel()
+
+    assert scope_ref[0] is not None
+    # Cap is original_deadline + 0.2 (max_extension_seconds)
+    assert scope_ref[0].deadline <= original_deadline_ref[0] + 0.2 + 0.05
+
+
+@pytest.mark.anyio
+async def test_terminates_on_trigger(monkeypatch) -> None:
+    """Watcher exits cleanly when trigger fires immediately."""
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_child_processes",
+        lambda pid: True,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_api_connection",
+        lambda pid: True,
+    )
+    trigger = anyio.Event()
+    scope_ref: list[anyio.CancelScope | None] = [None]
+
+    trigger.set()
+
+    with anyio.fail_after(2.0):
+        await _watch_child_activity(1, scope_ref, 7200.0, trigger, 0.05)
+
+
+@pytest.mark.anyio
+async def test_api_connection_also_extends(monkeypatch) -> None:
+    """Deadline is extended when _has_active_api_connection returns True (children inactive)."""
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_child_processes",
+        lambda pid: False,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_api_connection",
+        lambda pid: True,
+    )
+    trigger = anyio.Event()
+    scope_ref: list[anyio.CancelScope | None] = [None]
+    original_deadline_ref: list[float] = []
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_watch_child_activity, 1, scope_ref, 7200.0, trigger, 0.05)
+        with anyio.move_on_after(2.0) as scope:
+            scope_ref[0] = scope
+            original_deadline_ref.append(scope.deadline)
+            await anyio.sleep(0.3)
+            trigger.set()
+        tg.cancel_scope.cancel()
+
+    assert scope_ref[0] is not None
+    assert scope_ref[0].deadline > original_deadline_ref[0]
+
+
+@pytest.mark.anyio
+async def test_scope_ref_none_polling(monkeypatch) -> None:
+    """Watcher polls harmlessly when scope_ref is None (before scope binding)."""
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_child_processes",
+        lambda pid: True,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_api_connection",
+        lambda pid: True,
+    )
+    trigger = anyio.Event()
+    scope_ref: list[anyio.CancelScope | None] = [None]  # intentionally empty
+
+    with anyio.fail_after(2.0):
+        # Run watcher with empty scope_ref for 3 poll cycles, then set scope and trigger
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_watch_child_activity, 1, scope_ref, 7200.0, trigger, 0.05)
+            await anyio.sleep(0.2)
+            with anyio.move_on_after(1.0) as scope:
+                scope_ref[0] = scope
+            trigger.set()
+            tg.cancel_scope.cancel()

--- a/tests/execution/test_process_deadline_extension.py
+++ b/tests/execution/test_process_deadline_extension.py
@@ -27,7 +27,7 @@ async def test_extends_deadline_when_children_active(monkeypatch) -> None:
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(_watch_child_activity, 1, scope_ref, 7200.0, trigger, 0.05)
-        with anyio.move_on_after(2.0) as scope:
+        with anyio.move_on_after(0.1) as scope:
             scope_ref[0] = scope
             original_deadline_ref.append(scope.deadline)
             await anyio.sleep(0.3)
@@ -83,7 +83,7 @@ async def test_max_extension_cap_enforced(monkeypatch) -> None:
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(_watch_child_activity, 1, scope_ref, 0.2, trigger, 0.05)
-        with anyio.move_on_after(2.0) as scope:
+        with anyio.move_on_after(0.1) as scope:
             scope_ref[0] = scope
             original_deadline_ref.append(scope.deadline)
             await anyio.sleep(0.8)
@@ -91,8 +91,7 @@ async def test_max_extension_cap_enforced(monkeypatch) -> None:
         tg.cancel_scope.cancel()
 
     assert scope_ref[0] is not None
-    # Cap is original_deadline + 0.2 (max_extension_seconds)
-    assert scope_ref[0].deadline <= original_deadline_ref[0] + 0.2 + 0.05
+    assert scope_ref[0].deadline <= original_deadline_ref[0] + 0.2
 
 
 @pytest.mark.anyio
@@ -132,7 +131,7 @@ async def test_api_connection_also_extends(monkeypatch) -> None:
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(_watch_child_activity, 1, scope_ref, 7200.0, trigger, 0.05)
-        with anyio.move_on_after(2.0) as scope:
+        with anyio.move_on_after(0.1) as scope:
             scope_ref[0] = scope
             original_deadline_ref.append(scope.deadline)
             await anyio.sleep(0.3)

--- a/tests/fleet/test_dispatch_outcome_classifier.py
+++ b/tests/fleet/test_dispatch_outcome_classifier.py
@@ -107,7 +107,7 @@ class TestInfrastructureFailureReasons:
     def test_has_failed_dispatch_returns_false_for_quota_exhaustion(self, tmp_path):
         """Quota exhaustion is infrastructure failure — does not halt campaign."""
         from autoskillit.core import FleetErrorCode as FEC
-        from autoskillit.fleet.state import write_state
+        from autoskillit.fleet.state import _write_state as write_state
         from autoskillit.fleet.state_recovery import has_failed_dispatch
         from autoskillit.fleet.state_types import CampaignState, DispatchRecord
 

--- a/tests/fleet/test_dispatch_outcome_classifier.py
+++ b/tests/fleet/test_dispatch_outcome_classifier.py
@@ -87,6 +87,49 @@ class TestClassifyDispatchOutcomeCompletedClean:
         assert reason == "my-error"
 
 
+class TestQuotaExhaustedOutcome:
+    def test_quota_exhausted_is_failure(self):
+        """completed_clean + success=false + reason=fleet_quota_exhausted → FAILURE."""
+        parsed = L3ParseResult(
+            outcome="completed_clean",
+            payload={"success": False, "reason": FleetErrorCode.FLEET_QUOTA_EXHAUSTED},
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        )
+        skill_result = dataclasses.replace(_DEFAULT_SKILL_RESULT)
+        status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=False)
+        assert status == DispatchStatus.FAILURE
+        assert reason == FleetErrorCode.FLEET_QUOTA_EXHAUSTED
+
+
+class TestInfrastructureFailureReasons:
+    def test_has_failed_dispatch_returns_false_for_quota_exhaustion(self, tmp_path):
+        """Quota exhaustion is infrastructure failure — does not halt campaign."""
+        from autoskillit.core import FleetErrorCode as FEC
+        from autoskillit.fleet.state import write_state
+        from autoskillit.fleet.state_recovery import has_failed_dispatch
+        from autoskillit.fleet.state_types import CampaignState, DispatchRecord
+
+        dispatches = [
+            DispatchRecord(
+                name="step_1",
+                status=DispatchStatus.FAILURE,
+                reason=FEC.FLEET_QUOTA_EXHAUSTED,
+            ),
+        ]
+        state = CampaignState(
+            schema_version=4,
+            campaign_id="test-id",
+            campaign_name="test",
+            manifest_path="manifest.yaml",
+            started_at=0.0,
+            dispatches=dispatches,
+        )
+        write_state(tmp_path / "state.json", state)
+        assert not has_failed_dispatch(tmp_path / "state.json")
+
+
 class TestClassifyDispatchOutcomeCompletedDirty:
     def test_completed_dirty_is_failure(self):
         parsed = L3ParseResult(

--- a/tests/fleet/test_food_truck_prompt.py
+++ b/tests/fleet/test_food_truck_prompt.py
@@ -37,3 +37,18 @@ def test_food_truck_prompt_contains_hook_denial_compliance():
         l3_timeout_sec=300,
     )
     assert "HOOK DENIAL" in prompt.upper()
+
+
+def test_fleet_prompt_contains_budget_exceeded_routing():
+    """L3 food truck prompt must contain QUOTA WAIT REQUIRED and QUOTA BUDGET EXCEEDED routing."""
+    prompt = _build_food_truck_prompt(
+        recipe="test-recipe",
+        task="Test task",
+        ingredients={},
+        mcp_prefix=DIRECT_PREFIX,
+        dispatch_id="test-dispatch",
+        campaign_id="test-campaign",
+        l3_timeout_sec=300,
+    )
+    assert "QUOTA WAIT REQUIRED" in prompt
+    assert "QUOTA BUDGET EXCEEDED" in prompt

--- a/tests/hooks/test_hook_config_bridge.py
+++ b/tests/hooks/test_hook_config_bridge.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import io
 import json
+import time
 from contextlib import redirect_stdout
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -230,3 +231,97 @@ def test_write_hook_config_round_trip_via_resolve_quota_settings(tmp_path, monke
     assert settings.buffer_seconds == 42
     assert settings.cache_path == "/round/trip.json"
     assert settings.disabled is False  # enabled=True → disabled=False
+
+
+# T-BUDGET-1
+def test_quota_guard_budget_exceeded_exit(tmp_path, monkeypatch):
+    """When sleep exceeds remaining budget, deny message instructs clean exit."""
+    cache = tmp_path / "quota_cache.json"
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_DEADLINE", str(time.time() + 60))
+    _write_blocking_cache(
+        cache,
+        fetched_at=datetime.now(UTC).isoformat(),
+    )
+    _write_hook_config(
+        tmp_path,
+        {
+            "cache_path": str(cache),
+            "cache_max_age": 300,
+            "buffer_seconds": 3600,
+            "disabled": False,
+        },
+    )
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+
+    out, _ = _run_hook(event={"tool_name": "run_skill"})
+
+    assert out != "", "hook failed-open unexpectedly (empty output)"
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "QUOTA BUDGET EXCEEDED" in reason
+    assert "fleet_quota_exhausted" in reason
+    assert "run_cmd" not in reason  # no sleep command
+
+
+# T-BUDGET-2
+def test_quota_guard_normal_deny_when_budget_sufficient(tmp_path, monkeypatch):
+    """Normal deny when deadline is far in the future (sleep fits in budget)."""
+    cache = tmp_path / "quota_cache.json"
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_DEADLINE", str(time.time() + 7200))
+    _write_blocking_cache(
+        cache,
+        fetched_at=datetime.now(UTC).isoformat(),
+    )
+    _write_hook_config(
+        tmp_path,
+        {
+            "cache_path": str(cache),
+            "cache_max_age": 300,
+            "buffer_seconds": 300,
+            "disabled": False,
+        },
+    )
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+
+    out, _ = _run_hook(event={"tool_name": "run_skill"})
+
+    assert out != "", "hook failed-open unexpectedly (empty output)"
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "QUOTA WAIT REQUIRED" in reason
+    assert "run_cmd" in reason or "time.sleep" in reason  # contains sleep command
+
+
+# T-BUDGET-3
+def test_quota_guard_normal_deny_when_no_deadline(tmp_path, monkeypatch):
+    """Normal deny when AUTOSKILLIT_SESSION_DEADLINE is not set (backward compatible)."""
+    cache = tmp_path / "quota_cache.json"
+    _write_blocking_cache(
+        cache,
+        fetched_at=datetime.now(UTC).isoformat(),
+    )
+    _write_hook_config(
+        tmp_path,
+        {
+            "cache_path": str(cache),
+            "cache_max_age": 300,
+            "buffer_seconds": 300,
+            "disabled": False,
+        },
+    )
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
+
+    out, _ = _run_hook(event={"tool_name": "run_skill"})
+
+    assert out != "", "hook failed-open unexpectedly (empty output)"
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "QUOTA WAIT REQUIRED" in reason
+    assert "run_cmd" in reason or "time.sleep" in reason

--- a/tests/hooks/test_hook_sync.py
+++ b/tests/hooks/test_hook_sync.py
@@ -40,3 +40,14 @@ def test_hook_config_path_single_source_of_truth():
     assert (*HOOK_DIR_COMPONENTS, HOOK_CONFIG_FILENAME) == _HOOK_CONFIG_PATH_COMPONENTS, (
         "_hook_settings path constants must match _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS"
     )
+
+
+def test_quota_budget_exceeded_trigger_consistency():
+    """QUOTA_BUDGET_EXCEEDED_TRIGGER must be identical in quota_guard and autoskillit.hooks."""
+    from autoskillit.hooks import QUOTA_BUDGET_EXCEEDED_TRIGGER
+    from autoskillit.hooks.guards.quota_guard import QUOTA_BUDGET_EXCEEDED_TRIGGER as _DIRECT
+
+    assert QUOTA_BUDGET_EXCEEDED_TRIGGER == _DIRECT, (
+        f"QUOTA_BUDGET_EXCEEDED_TRIGGER mismatch: "
+        f"quota_guard={_DIRECT!r} vs hooks re-export={QUOTA_BUDGET_EXCEEDED_TRIGGER!r}"
+    )


### PR DESCRIPTION
## Summary

Adds two coordinated improvements to fleet dispatch reliability: (1) an activity-aware deadline extension watcher that extends wall-clock timeouts when child processes are actively running, preventing useful work (review cycles, CI watches, merge queue waits) from being killed by unconditional timeouts; and (2) a budget-aware quota guard that detects when required sleep exceeds the remaining session budget and emits a clean sentinel exit instead of sleeping into a timeout, with quota exhaustion classified as a retryable infrastructure failure rather than a halting logic failure.

## Requirements

n/a

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

n/a

## Architecture Impact

n/a

## Implementation Plan

Plan files:
- `.autoskillit/temp/make-plan/activity_aware_fleet_dispatch_timeout_quota_sleep_resumable_exit_plan_2026-05-07_170500_part_a.md`
- `.autoskillit/temp/make-plan/activity_aware_fleet_dispatch_timeout_quota_sleep_resumable_exit_plan_2026-05-07_170500_part_b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 101 | 37.5k | 2.0M | 110.6k | 175 | 110.9k | 16m 48s |
| verify | claude-opus-4-6 | 2 | 2.8k | 37.2k | 2.8M | 77.7k | 191 | 117.3k | 18m 11s |
| implement* | MiniMax-M2.7 | 2 | 232.8k | 73.8k | 14.7M | 21.0k | 415 | 0 | 35m 22s |
| prepare_pr* | MiniMax-M2.7 | 1 | 51.5k | 4.9k | 302.9k | 0 | 25 | 0 | 2m 22s |
| compose_pr* | MiniMax-M2.7 | 1 | 48.8k | 1.8k | 311.3k | 0 | 21 | 0 | 1m 2s |
| review_pr | claude-opus-4-6 | 3 | 106 | 129.4k | 2.1M | 108.8k | 107 | 262.0k | 34m 8s |
| resolve_review | claude-opus-4-6 | 3 | 2.4k | 62.2k | 4.9M | 100.8k | 201 | 209.0k | 34m 20s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 38 | 5.8k | 929.5k | 67.9k | 40 | 55.0k | 2m 28s |
| **Total** | | | 338.5k | 352.7k | 28.1M | 110.6k | | 754.2k | 2h 24m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 638 | 22962.5 | 0.0 | 115.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 49 | 100528.5 | 4266.0 | 1268.4 |
| ci_conflict_fix | 1411 | 658.8 | 39.0 | 4.1 |
| **Total** | **2098** | 13372.3 | 359.5 | 168.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 3.0k | 85.7k | 6.4M | 318.9k | 56m 39s |
| MiniMax-M2.7 | 3 | 333.0k | 80.6k | 15.3M | 0 | 38m 47s |