### PR TITLE
Rectify: Food Truck Resume Gate Boot

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -109,6 +109,7 @@ from .types import FLEET_DISPATCH_TOOLS as FLEET_DISPATCH_TOOLS
 from .types import FLEET_ERROR_CODES as FLEET_ERROR_CODES
 from .types import FLEET_MENU_TOOLS as FLEET_MENU_TOOLS
 from .types import FLEET_MODE_ENV_VAR as FLEET_MODE_ENV_VAR
+from .types import FOOD_TRUCK_TOOL_TAGS_ENV_VAR as FOOD_TRUCK_TOOL_TAGS_ENV_VAR
 from .types import FLEET_TOOLS as FLEET_TOOLS
 from .types import FREE_RANGE_TOOLS as FREE_RANGE_TOOLS
 from .types import GATED_TOOLS as GATED_TOOLS

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -48,6 +48,7 @@ __all__ = [
     "DISPATCH_ID_ENV_VAR",
     "KITCHEN_SESSION_ID_ENV_VAR",
     "LAUNCH_ID_ENV_VAR",
+    "FOOD_TRUCK_TOOL_TAGS_ENV_VAR",
     "FLEET_DISPATCH_TOOLS",
     "FLEET_ERROR_CODES",
     "FeatureDef",
@@ -77,6 +78,7 @@ FLEET_DISPATCH_MODE: str = "dispatch"
 DISPATCH_ID_ENV_VAR: str = "AUTOSKILLIT_DISPATCH_ID"
 KITCHEN_SESSION_ID_ENV_VAR: str = "AUTOSKILLIT_KITCHEN_SESSION_ID"
 LAUNCH_ID_ENV_VAR: str = "AUTOSKILLIT_LAUNCH_ID"
+FOOD_TRUCK_TOOL_TAGS_ENV_VAR: str = "AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS"
 
 # Env vars that control MCP server-level behavior and must not leak into
 # user-code subprocesses (pytest runs, shell commands, etc.).
@@ -96,7 +98,7 @@ AUTOSKILLIT_PRIVATE_ENV_VARS: frozenset[str] = frozenset(
         "AUTOSKILLIT_KITCHEN_SESSION_ID",
         "AUTOSKILLIT_CAMPAIGN_STATE_PATH",
         "AUTOSKILLIT_PROJECT_DIR",
-        "AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS",
+        FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
         "AUTOSKILLIT_LAUNCH_ID",
         "AUTOSKILLIT_SKILL_NAME",
         # Provider-routing vars — must not leak into user-code subprocesses

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -25,6 +25,7 @@ import structlog
 from autoskillit.core import (
     CAMPAIGN_ID_ENV_VAR,
     DISPATCH_ID_ENV_VAR,
+    FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
     KillReason,
     ProviderOutcome,
     RecipeIdentity,
@@ -819,12 +820,12 @@ class DefaultHeadlessExecutor:
 
         merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}
         if requires_packs:
-            if "AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS" in merged_extras:
+            if FOOD_TRUCK_TOOL_TAGS_ENV_VAR in merged_extras:
                 raise ValueError(
                     "dispatch_food_truck: requires_packs and env_extras both specify "
                     "AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS — use requires_packs exclusively"
                 )
-            merged_extras["AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS"] = ",".join(sorted(requires_packs))
+            merged_extras[FOOD_TRUCK_TOOL_TAGS_ENV_VAR] = ",".join(sorted(requires_packs))
 
         idle_cfg_val = cfg.run_skill.idle_output_timeout
         if idle_output_timeout is not None:

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -822,8 +822,8 @@ class DefaultHeadlessExecutor:
         if requires_packs:
             if FOOD_TRUCK_TOOL_TAGS_ENV_VAR in merged_extras:
                 raise ValueError(
-                    "dispatch_food_truck: requires_packs and env_extras both specify "
-                    "AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS — use requires_packs exclusively"
+                    f"dispatch_food_truck: requires_packs and env_extras both specify "
+                    f"{FOOD_TRUCK_TOOL_TAGS_ENV_VAR} — use requires_packs exclusively"
                 )
             merged_extras[FOOD_TRUCK_TOOL_TAGS_ENV_VAR] = ",".join(sorted(requires_packs))
 

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -216,7 +216,6 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
     AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS is set. No-ops for interactive
     ORCHESTRATOR sessions (open_kitchen handles the gate there).
     """
-    import os as _os
     from pathlib import Path
     from uuid import uuid4
 
@@ -233,14 +232,14 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
     )
     from autoskillit.server.tools.tools_kitchen import _write_hook_config
 
-    if _os.environ.get(HEADLESS_ENV_VAR) != "1":
+    if os.environ.get(HEADLESS_ENV_VAR) != "1":
         return
-    _raw_tags = _os.environ.get(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "")
+    _raw_tags = os.environ.get(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "")
     if not _raw_tags:
         return
 
     _packs = frozenset(p.strip() for p in _raw_tags.split(",") if p.strip())
-    ctx.kitchen_id = _os.environ.get(CAMPAIGN_ID_ENV_VAR) or str(uuid4())
+    ctx.kitchen_id = os.environ.get(CAMPAIGN_ID_ENV_VAR) or str(uuid4())
     ctx.active_recipe_packs = _packs
     ctx.active_recipe_features = frozenset()
 
@@ -278,15 +277,16 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         logger.warning("food_truck_auto_gate_boot_quota_cache_failed", exc_info=True)
 
     try:
-        ctx.quota_refresh_task = create_background_task(
-            _quota_refresh_loop(ctx.config.quota_guard),
-            label="quota_refresh_loop",
-        )
+        if ctx.config is not None:
+            ctx.quota_refresh_task = create_background_task(
+                _quota_refresh_loop(ctx.config.quota_guard),
+                label="quota_refresh_loop",
+            )
     except Exception:
         logger.warning("food_truck_auto_gate_boot_refresh_loop_failed", exc_info=True)
 
     try:
-        register_active_kitchen(ctx.kitchen_id, _os.getpid(), str(Path.cwd()))
+        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(Path.cwd()))
     except Exception:
         logger.warning("food_truck_auto_gate_boot_registry_failed", exc_info=True)
 

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -18,10 +18,16 @@ from __future__ import annotations
 
 import asyncio as _asyncio
 import os
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
-from autoskillit.core import cleanup_readiness_sentinel, get_logger, write_readiness_sentinel
+from autoskillit.core import (
+    SessionType,
+    cleanup_readiness_sentinel,
+    get_logger,
+    write_readiness_sentinel,
+)
 from autoskillit.execution import RecordingSubprocessRunner
 from autoskillit.server._state import _get_ctx_or_none, deferred_initialize
 
@@ -203,6 +209,95 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
         logger.warning("fleet_auto_gate_boot_registry_failed", exc_info=True)
 
 
+async def _food_truck_auto_gate_boot(ctx: Any) -> None:
+    """Auto-open gate for headless food truck (ORCHESTRATOR) sessions.
+
+    Runs at lifespan startup when AUTOSKILLIT_HEADLESS=1 and
+    AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS is set. No-ops for interactive
+    ORCHESTRATOR sessions (open_kitchen handles the gate there).
+    """
+    import os as _os
+    from pathlib import Path
+    from uuid import uuid4
+
+    from autoskillit.core import (
+        CAMPAIGN_ID_ENV_VAR,
+        FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
+        HEADLESS_ENV_VAR,
+        register_active_kitchen,
+    )
+    from autoskillit.pipeline import create_background_task
+    from autoskillit.server._misc import (
+        _prime_quota_cache,
+        _quota_refresh_loop,
+    )
+    from autoskillit.server.tools.tools_kitchen import _write_hook_config
+
+    if _os.environ.get(HEADLESS_ENV_VAR) != "1":
+        return
+    _raw_tags = _os.environ.get(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "")
+    if not _raw_tags:
+        return
+
+    _packs = frozenset(p.strip() for p in _raw_tags.split(",") if p.strip())
+    ctx.kitchen_id = _os.environ.get(CAMPAIGN_ID_ENV_VAR) or str(uuid4())
+    ctx.active_recipe_packs = _packs
+    ctx.active_recipe_features = frozenset()
+
+    if ctx.gate is None:
+        logger.warning("food_truck_auto_gate_boot_no_gate")
+        return
+
+    ctx.gate.enable()
+    logger.info(
+        "food_truck_auto_gate_boot",
+        gate_state="open",
+        kitchen_id=ctx.kitchen_id,
+        packs=sorted(_packs),
+    )
+
+    try:
+        from autoskillit.core import _collect_disabled_feature_tags
+        from autoskillit.server import mcp as _mcp
+
+        _features = ctx.config.features if ctx.config is not None else {}
+        _exp_enabled = ctx.config.experimental_enabled if ctx.config is not None else False
+        for _tag in _collect_disabled_feature_tags(_features, experimental_enabled=_exp_enabled):
+            _mcp.disable(tags={_tag})
+    except Exception:
+        logger.warning("food_truck_auto_gate_boot_feature_suppression_failed", exc_info=True)
+
+    try:
+        _write_hook_config()
+    except Exception:
+        logger.warning("food_truck_auto_gate_boot_hook_config_failed", exc_info=True)
+
+    try:
+        await _prime_quota_cache()
+    except Exception:
+        logger.warning("food_truck_auto_gate_boot_quota_cache_failed", exc_info=True)
+
+    try:
+        ctx.quota_refresh_task = create_background_task(
+            _quota_refresh_loop(ctx.config.quota_guard),
+            label="quota_refresh_loop",
+        )
+    except Exception:
+        logger.warning("food_truck_auto_gate_boot_refresh_loop_failed", exc_info=True)
+
+    try:
+        register_active_kitchen(ctx.kitchen_id, _os.getpid(), str(Path.cwd()))
+    except Exception:
+        logger.warning("food_truck_auto_gate_boot_registry_failed", exc_info=True)
+
+
+_LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | None] = {
+    SessionType.FLEET: _fleet_auto_gate_boot,
+    SessionType.ORCHESTRATOR: _food_truck_auto_gate_boot,
+    SessionType.SKILL: None,
+}
+
+
 @asynccontextmanager
 async def _autoskillit_lifespan(server: Any) -> Any:
     """Server lifecycle: write readiness sentinel, yield, then finalize recording.
@@ -239,13 +334,13 @@ async def _autoskillit_lifespan(server: Any) -> Any:
             create_background_task(_run_hook_health_check_async(), label="hook_health")
         )
         bg_tasks.append(create_background_task(_run_deferred_init(event), label="deferred_init"))
-        from autoskillit.core import SessionType
         from autoskillit.core import session_type as _resolve_session_type
 
-        if _resolve_session_type() is SessionType.FLEET:
-            _fleet_ctx = _get_ctx_or_none()
-            if _fleet_ctx is not None:
-                await _fleet_auto_gate_boot(_fleet_ctx)
+        _boot_fn = _LIFESPAN_BOOT_REGISTRY.get(_resolve_session_type())
+        if _boot_fn is not None:
+            _boot_ctx = _get_ctx_or_none()
+            if _boot_ctx is not None:
+                await _boot_fn(_boot_ctx)
         yield
     finally:
         for task in bg_tasks:

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -13,6 +13,7 @@ from autoskillit.core import (
     FEATURE_REGISTRY,
     FLEET_DISPATCH_MODE,
     FLEET_MODE_ENV_VAR,
+    FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
     HEADLESS_ENV_VAR,
     SessionType,
     get_logger,
@@ -46,7 +47,7 @@ def _apply_session_type_visibility() -> None:
         if os.environ.get(FLEET_MODE_ENV_VAR) == FLEET_DISPATCH_MODE:
             mcp.enable(tags={"fleet-dispatch"})
     elif _session is SessionType.ORCHESTRATOR and _headless:
-        tool_tags = os.environ.get("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "")
+        tool_tags = os.environ.get(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "")
         if tool_tags:
             mcp.enable(tags={"kitchen-core"})
             for pack in tool_tags.split(","):

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -26,15 +26,15 @@ Never rely on inverse method calls for cleanup.
   `make_context()` — a full-stack L3 fixture that imports all production layers. Use for
   server integration tests that need executor, tester, recipes, or other service fields.
   It monkeypatches `server._ctx` so all server tool handler calls use the test context
-  without global state leakage.
+  without global state leakage. Gate starts closed (matching production) — use
+  `tool_ctx_kitchen_open` when a test needs the gate open.
 - The `minimal_ctx` fixture (conftest.py) provides a lightweight `ToolContext` using only
   L0+L1 imports (core, pipeline, config). Use for tests that only need gate, audit,
   token_log, timing_log, or config — no server factory, no L2/L3 service wiring. Does NOT
-  monkeypatch `server._state._ctx`. Guard tests in `test_conftest.py` enforce the import
-  boundary via AST analysis.
-- To test with the kitchen closed, set `ctx.gate = DefaultGateState(enabled=False)` at
-  the start of the test or in a class-level autouse fixture (see `_close_kitchen` in
-  `test_instruction_surface.py` for an example).
+  monkeypatch `server._state._ctx`. Gate starts closed (matching production). Guard tests
+  in `test_conftest.py` enforce the import boundary via AST analysis.
+- Both `tool_ctx` and `minimal_ctx` start with gate closed to match production behavior.
+  Use `tool_ctx_kitchen_open` or `build_ctx_open` for tests that need an open gate.
 - Never use bare assignment or `try/finally` to restore server state — use `monkeypatch` or
   rely on the fixture's teardown.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,7 +274,7 @@ def minimal_ctx(tmp_path):
         audit=DefaultAuditLog(),
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
-        gate=DefaultGateState(enabled=True),
+        gate=DefaultGateState(enabled=False),
         plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
         temp_dir=tmp_path / ".autoskillit" / "temp",
@@ -292,15 +292,14 @@ def tool_ctx(monkeypatch, tmp_path):
     test only needs gate, audit, token_log, timing_log, or config fields.
 
     Monkeypatches server._ctx so all server tool calls use this context.
-    Gate is enabled (open kitchen) by default — tests that need a closed
-    gate should do: tool_ctx.gate = DefaultGateState(enabled=False) locally.
+    Gate starts closed (matching production) — use tool_ctx_kitchen_open
+    when a test needs the gate open.
 
     All service fields (executor, tester, db_reader, workspace_mgr, recipes,
     migrations) are wired via make_context() so routing tests work correctly.
     """
     from autoskillit.config import AutomationConfig
     from autoskillit.core.types._type_plugin_source import DirectInstall
-    from autoskillit.pipeline.gate import DefaultGateState
     from autoskillit.server import _state
     from autoskillit.server._factory import make_context
     from tests.fakes import MockSubprocessRunner
@@ -311,7 +310,6 @@ def tool_ctx(monkeypatch, tmp_path):
         runner=mock_runner,
         plugin_source=DirectInstall(plugin_dir=tmp_path),
     )
-    ctx.gate = DefaultGateState(enabled=True)
     ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
     ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
     # Anchor temp_dir to tmp_path so server tools that read from ctx.temp_dir
@@ -342,13 +340,27 @@ def tool_ctx_marketplace(monkeypatch, tmp_path):
         runner=mock_runner,
         plugin_source=MarketplaceInstall(cache_path=fake_cache),
     )
-    ctx.gate = DefaultGateState(enabled=True)
+    ctx.gate = DefaultGateState(enabled=False)
     ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
     ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
     ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
     monkeypatch.setattr(_state, "_ctx", ctx)
     monkeypatch.setattr(_state, "_startup_ready", None)
     return ctx
+
+
+@pytest.fixture
+def tool_ctx_kitchen_open(tool_ctx):
+    """tool_ctx variant with gate explicitly opened.
+
+    Use when the test requires a tool that calls _require_enabled() and
+    the test is not testing gate-boot behavior itself. This fixture
+    mirrors the post-lifespan-boot state for interactive sessions.
+    """
+    from autoskillit.pipeline.gate import DefaultGateState
+
+    tool_ctx.gate = DefaultGateState(enabled=True)
+    return tool_ctx
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -41,7 +41,9 @@ class TestRecordGateDispatch:
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
 
     @pytest.mark.anyio
-    async def test_record_gate_dispatch_writes_success(self, tool_ctx, monkeypatch, tmp_path):
+    async def test_record_gate_dispatch_writes_success(
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
+    ):
         sp = _init_state(tmp_path, "gate-check", "phase-one")
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(sp))
 
@@ -60,7 +62,9 @@ class TestRecordGateDispatch:
         assert phase.status == DispatchStatus.PENDING
 
     @pytest.mark.anyio
-    async def test_record_gate_dispatch_writes_failure(self, tool_ctx, monkeypatch, tmp_path):
+    async def test_record_gate_dispatch_writes_failure(
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
+    ):
         sp = _init_state(tmp_path, "gate-check", "phase-one")
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(sp))
 
@@ -78,7 +82,7 @@ class TestRecordGateDispatch:
 
     @pytest.mark.anyio
     async def test_record_gate_dispatch_rejects_unknown_dispatch(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         sp = _init_state(tmp_path, "full-audit", "review-gate")
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(sp))
@@ -91,7 +95,9 @@ class TestRecordGateDispatch:
         assert result["error"] == "fleet_gate_unknown_dispatch"
 
     @pytest.mark.anyio
-    async def test_record_gate_dispatch_rejects_non_pending(self, tool_ctx, monkeypatch, tmp_path):
+    async def test_record_gate_dispatch_rejects_non_pending(
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
+    ):
         from autoskillit.fleet.state import append_dispatch_record
 
         sp = _init_state(tmp_path, "gate-check", "phase-one")
@@ -111,7 +117,9 @@ class TestRecordGateDispatch:
         assert result["error"] == "fleet_gate_already_recorded"
 
     @pytest.mark.anyio
-    async def test_record_gate_dispatch_requires_campaign_state_path(self, tool_ctx, monkeypatch):
+    async def test_record_gate_dispatch_requires_campaign_state_path(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", raising=False)
 
         from autoskillit.server.tools.tools_fleet_dispatch import record_gate_dispatch
@@ -134,7 +142,7 @@ class TestDispatchFoodTruckCampaignState:
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_updates_campaign_state_on_success(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         sp = _init_state(tmp_path, "full-audit")
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(sp))
@@ -169,7 +177,7 @@ class TestDispatchFoodTruckCampaignState:
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_updates_campaign_state_on_failure(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         sp = _init_state(tmp_path, "full-audit")
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(sp))
@@ -204,7 +212,7 @@ class TestDispatchFoodTruckCampaignState:
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_skips_campaign_state_without_env(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", raising=False)
         monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
@@ -236,7 +244,7 @@ class TestDispatchFoodTruckCampaignState:
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_skips_campaign_state_without_dispatch_name(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         sp = _init_state(tmp_path, "full-audit")
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(sp))

--- a/tests/infra/test_pretty_output_integration.py
+++ b/tests/infra/test_pretty_output_integration.py
@@ -41,7 +41,7 @@ class TestFormatterSchemaConsistency:
             )
 
     @pytest.mark.anyio
-    async def test_kitchen_status_tool_output_through_hook(self, tool_ctx):
+    async def test_kitchen_status_tool_output_through_hook(self, tool_ctx_kitchen_open):
         """PHK-E2: kitchen_status real output contains all key fields through hook."""
         from autoskillit.hooks.formatters.pretty_output_hook import _format_response
         from autoskillit.server.tools.tools_status import kitchen_status

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,7 +127,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # background.py — payload dict
     ("src/autoskillit/pipeline/background.py", 132),
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
-    ("src/autoskillit/server/_lifespan.py", 56),
+    ("src/autoskillit/server/_lifespan.py", 62),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools/tools_kitchen.py", 112),
     ("src/autoskillit/server/tools/tools_kitchen.py", 552),

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -142,7 +142,7 @@ def build_ctx(tmp_path):
             audit=DefaultAuditLog(),
             token_log=DefaultTokenLog(),
             timing_log=DefaultTimingLog(),
-            gate=DefaultGateState(enabled=True),
+            gate=DefaultGateState(enabled=False),
             plugin_source=DirectInstall(plugin_dir=tmp_path),
             runner=None,
             temp_dir=tmp_path / ".autoskillit" / "temp",
@@ -153,3 +153,13 @@ def build_ctx(tmp_path):
         return ctx
 
     return _factory
+
+
+@pytest.fixture
+def build_ctx_open(build_ctx):
+    """build_ctx variant with gate open."""
+    from autoskillit.pipeline.gate import DefaultGateState
+
+    ctx = build_ctx()
+    ctx.gate = DefaultGateState(enabled=True)
+    return ctx

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -157,9 +157,12 @@ def build_ctx(tmp_path):
 
 @pytest.fixture
 def build_ctx_open(build_ctx):
-    """build_ctx variant with gate open."""
+    """build_ctx variant with gate open — returns a factory callable like build_ctx."""
     from autoskillit.pipeline.gate import DefaultGateState
 
-    ctx = build_ctx()
-    ctx.gate = DefaultGateState(enabled=True)
-    return ctx
+    def _factory(**overrides):
+        ctx = build_ctx(**overrides)
+        ctx.gate = DefaultGateState(enabled=True)
+        return ctx
+
+    return _factory

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -574,3 +574,26 @@ def test_make_context_no_env_profile_preserves_config_default(monkeypatch):
     config.providers.profiles = {}
     ctx = make_context(config, runner=_runner())
     assert ctx.config.providers.default_provider == "openai"
+
+
+# ---------------------------------------------------------------------------
+# Fixture gate-default verification tests
+# ---------------------------------------------------------------------------
+
+
+def test_tool_ctx_fixture_gate_starts_closed(tool_ctx) -> None:
+    """tool_ctx must start with gate closed to match production."""
+    assert tool_ctx.gate.enabled is False, (
+        "tool_ctx must start with gate closed to match production. "
+        "Use tool_ctx_kitchen_open for tests that need an open gate."
+    )
+
+
+def test_minimal_ctx_fixture_gate_starts_closed(minimal_ctx) -> None:
+    """minimal_ctx must start with gate closed to match production."""
+    assert minimal_ctx.gate.enabled is False
+
+
+def test_tool_ctx_kitchen_open_fixture_gate_starts_open(tool_ctx_kitchen_open) -> None:
+    """tool_ctx_kitchen_open must start with gate open."""
+    assert tool_ctx_kitchen_open.gate.enabled is True

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -231,7 +231,9 @@ def test_build_replay_runner_scans_skill_snapshots(tmp_path, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_run_skill_replay_uses_snapshot_over_init_session(tool_ctx, tmp_path, monkeypatch):
+async def test_run_skill_replay_uses_snapshot_over_init_session(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+):
     """With a skill snapshot for the step, run_skill skips init_session."""
     from unittest.mock import MagicMock
 
@@ -245,17 +247,17 @@ async def test_run_skill_replay_uses_snapshot_over_init_session(tool_ctx, tmp_pa
     skill_md.write_text("# investigate\n", encoding="utf-8")
 
     replay_runner = ReplayingSubprocessRunner({}, {}, skill_snapshots={"investigate": snap_dir})
-    tool_ctx.runner = replay_runner
+    tool_ctx_kitchen_open.runner = replay_runner
 
     mock_ssm = MagicMock()
-    tool_ctx.session_skill_manager = mock_ssm
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
+    tool_ctx_kitchen_open.executor = executor
 
     ephemeral_root = tmp_path / "sessions"
-    tool_ctx.ephemeral_root = ephemeral_root
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.ephemeral_root = ephemeral_root
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/investigate foo", str(tmp_path), step_name="investigate")
 
@@ -269,7 +271,9 @@ async def test_run_skill_replay_uses_snapshot_over_init_session(tool_ctx, tmp_pa
 
 
 @pytest.mark.anyio
-async def test_run_skill_replay_fallback_to_init_session(tool_ctx, tmp_path, monkeypatch):
+async def test_run_skill_replay_fallback_to_init_session(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+):
     """With no snapshot for the step, run_skill falls back to init_session."""
     from unittest.mock import MagicMock
 
@@ -279,17 +283,17 @@ async def test_run_skill_replay_fallback_to_init_session(tool_ctx, tmp_path, mon
     from tests.fakes import InMemoryHeadlessExecutor
 
     replay_runner = ReplayingSubprocessRunner({}, {}, skill_snapshots={})
-    tool_ctx.runner = replay_runner
+    tool_ctx_kitchen_open.runner = replay_runner
 
     fake_validated = ValidatedAddDir(path="/fake/session")
     mock_ssm = MagicMock()
     mock_ssm.init_session.return_value = fake_validated
-    tool_ctx.session_skill_manager = mock_ssm
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
+    tool_ctx_kitchen_open.executor = executor
 
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/investigate foo", str(tmp_path), step_name="investigate")
 

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -192,3 +192,15 @@ def test_serve_startup_regenerates_on_hash_mismatch(tmp_path: Path, monkeypatch)
 
     updated = _json.loads((hooks_dir / "hooks.json").read_text())
     assert updated.get("_autoskillit_registry_hash") == HOOK_REGISTRY_HASH
+
+
+def test_lifespan_boot_registry_covers_all_session_types() -> None:
+    """_LIFESPAN_BOOT_REGISTRY must have an entry for every SessionType value."""
+    from autoskillit.core import SessionType
+    from autoskillit.server._lifespan import _LIFESPAN_BOOT_REGISTRY
+
+    missing = set(SessionType) - set(_LIFESPAN_BOOT_REGISTRY)
+    assert not missing, (
+        f"SessionType values not in _LIFESPAN_BOOT_REGISTRY: {missing}. "
+        "Every SessionType must declare a boot function or None."
+    )

--- a/tests/server/test_release_issue_fail_label.py
+++ b/tests/server/test_release_issue_fail_label.py
@@ -14,12 +14,12 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 class TestReleaseIssueFailLabel:
     @pytest.mark.anyio
-    async def test_release_issue_fail_label_swap(self, tool_ctx, monkeypatch):
+    async def test_release_issue_fail_label_swap(self, tool_ctx_kitchen_open, monkeypatch):
         """fail_label swaps in-progress for fail label."""
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["fail"]}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         result = json.loads(
             await release_issue(
@@ -41,12 +41,14 @@ class TestReleaseIssueFailLabel:
         )
 
     @pytest.mark.anyio
-    async def test_release_issue_success_removes_fail_label(self, tool_ctx, monkeypatch):
+    async def test_release_issue_success_removes_fail_label(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """Staging path includes fail label in remove_labels for cleanup."""
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["staged"]}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         result = json.loads(
             await release_issue(
@@ -63,11 +65,13 @@ class TestReleaseIssueFailLabel:
         assert "staged" in swap_call.kwargs["add_labels"]
 
     @pytest.mark.anyio
-    async def test_release_issue_simple_remove_cleans_fail_label(self, tool_ctx, monkeypatch):
+    async def test_release_issue_simple_remove_cleans_fail_label(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """Simple release (no staging, no fail_label) also removes fail label."""
         mock_client = AsyncMock()
         mock_client.swap_labels.return_value = {"success": True, "labels": []}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         result = json.loads(
             await release_issue(
@@ -83,7 +87,9 @@ class TestReleaseIssueFailLabel:
 
 class TestClaimIssueFailLabelCleanup:
     @pytest.mark.anyio
-    async def test_claim_issue_removes_fail_label_on_claim(self, tool_ctx, monkeypatch):
+    async def test_claim_issue_removes_fail_label_on_claim(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """claim_issue uses swap_labels to remove fail label while adding in-progress."""
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {
@@ -95,7 +101,7 @@ class TestClaimIssueFailLabelCleanup:
             "success": True,
             "labels": ["in-progress"],
         }
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         result = json.loads(
             await claim_issue(

--- a/tests/server/test_run_skill_add_dirs.py
+++ b/tests/server/test_run_skill_add_dirs.py
@@ -10,13 +10,13 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.anyio
-async def test_raw_skills_extended_excluded_from_run_skill_add_dirs(tool_ctx):
+async def test_raw_skills_extended_excluded_from_run_skill_add_dirs(tool_ctx_kitchen_open):
     """T-OVR-014: run_skill passes ephemeral session dir (not raw skills_extended/) as add_dirs."""
     from autoskillit.server.tools.tools_execution import run_skill
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
+    tool_ctx_kitchen_open.executor = executor
 
     await run_skill("/autoskillit:investigate foo", "/some/cwd")
 

--- a/tests/server/test_run_skill_resume.py
+++ b/tests/server/test_run_skill_resume.py
@@ -12,13 +12,13 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.anyio
-async def test_resume_session_id_threaded_to_executor(tool_ctx, monkeypatch) -> None:
+async def test_resume_session_id_threaded_to_executor(tool_ctx_kitchen_open, monkeypatch) -> None:
     """resume_session_id flows from run_skill → executor.run()."""
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/implement foo", "/tmp", resume_session_id="sess-123")
 
@@ -27,13 +27,13 @@ async def test_resume_session_id_threaded_to_executor(tool_ctx, monkeypatch) -> 
 
 
 @pytest.mark.anyio
-async def test_resume_skips_skill_command_validation(tool_ctx, monkeypatch) -> None:
+async def test_resume_skips_skill_command_validation(tool_ctx_kitchen_open, monkeypatch) -> None:
     """When resume_session_id is set, non-slash skill_command is allowed."""
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     result = await run_skill(
         "Continue from where you left off",
@@ -45,9 +45,9 @@ async def test_resume_skips_skill_command_validation(tool_ctx, monkeypatch) -> N
 
 
 @pytest.mark.anyio
-async def test_no_resume_still_validates_skill_command(tool_ctx, monkeypatch) -> None:
+async def test_no_resume_still_validates_skill_command(tool_ctx_kitchen_open, monkeypatch) -> None:
     """Without resume_session_id, non-slash skill_command is still rejected."""
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     result = await run_skill("Continue from where you left off", "/tmp")
     data = json.loads(result)

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -622,7 +622,7 @@ class TestFoodTruckAutoGateBoot:
 
     @pytest.mark.anyio
     async def test_run_skill_gate_error_when_food_truck_gate_closed(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx, monkeypatch
     ) -> None:
         import json
 
@@ -631,13 +631,13 @@ class TestFoodTruckAutoGateBoot:
 
         tool_ctx.gate = DefaultGateState(enabled=False)
 
-        result = json.loads(await run_skill("/some-skill", str(tmp_path)))
+        result = json.loads(await run_skill("/some-skill", "/tmp"))
         assert result["subtype"] == "gate_error"
         assert result["success"] is False
 
     @pytest.mark.anyio
     async def test_run_skill_succeeds_after_food_truck_auto_gate_boot(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx, monkeypatch
     ) -> None:
         import json
         from unittest.mock import AsyncMock, MagicMock, patch
@@ -662,7 +662,7 @@ class TestFoodTruckAutoGateBoot:
                     with patch("autoskillit.core.register_active_kitchen"):
                         await _food_truck_auto_gate_boot(tool_ctx)
 
-        result = json.loads(await run_skill("/some-skill", str(tmp_path)))
+        result = json.loads(await run_skill("/some-skill", "/tmp"))
         assert result.get("success") is True
 
 

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -652,6 +652,7 @@ class TestFoodTruckAutoGateBoot:
         tool_ctx.executor = InMemoryHeadlessExecutor()
         tool_ctx.quota_refresh_task = None
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
         monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core")
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -529,6 +529,139 @@ class TestFleetAutoGateBoot:
 
 
 @pytest.mark.feature("fleet")
+class TestFoodTruckAutoGateBoot:
+    """Food truck lifespan auto-gate: _food_truck_auto_gate_boot opens gate."""
+
+    @pytest.mark.anyio
+    async def test_food_truck_headless_lifespan_auto_opens_gate(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _food_truck_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core,rectify")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task", return_value=MagicMock()
+                ):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        await _food_truck_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is True
+
+    @pytest.mark.anyio
+    async def test_food_truck_auto_gate_boot_sets_active_recipe_packs(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _food_truck_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core,rectify")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task", return_value=MagicMock()
+                ):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        await _food_truck_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.active_recipe_packs == frozenset({"kitchen-core", "rectify"})
+        assert tool_ctx.active_recipe_features == frozenset()
+
+    @pytest.mark.anyio
+    async def test_food_truck_auto_gate_boot_skips_non_headless_orchestrator(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _food_truck_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core")
+
+        await _food_truck_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is False
+
+    @pytest.mark.anyio
+    async def test_food_truck_auto_gate_boot_skips_when_no_tool_tags(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _food_truck_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.delenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", raising=False)
+
+        await _food_truck_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is False
+
+    def test_food_truck_tool_tags_env_var_constant_value(self) -> None:
+        from autoskillit.core import FOOD_TRUCK_TOOL_TAGS_ENV_VAR
+
+        assert FOOD_TRUCK_TOOL_TAGS_ENV_VAR == "AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS"
+
+    @pytest.mark.anyio
+    async def test_run_skill_gate_error_when_food_truck_gate_closed(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        import json
+
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server.tools.tools_execution import run_skill
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+
+        result = json.loads(await run_skill("/some-skill", "/tmp"))
+        assert result["subtype"] == "gate_error"
+        assert result["success"] is False
+
+    @pytest.mark.anyio
+    async def test_run_skill_succeeds_after_food_truck_auto_gate_boot(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        import json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _food_truck_auto_gate_boot
+        from autoskillit.server.tools.tools_execution import run_skill
+        from tests.fakes import InMemoryHeadlessExecutor
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.executor = InMemoryHeadlessExecutor()
+        tool_ctx.quota_refresh_task = None
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task", return_value=MagicMock()
+                ):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        await _food_truck_auto_gate_boot(tool_ctx)
+
+        result = json.loads(await run_skill("/some-skill", "/tmp"))
+        assert result.get("subtype") != "gate_error"
+
+
+@pytest.mark.feature("fleet")
 class TestFeatureGateVisibility:
     """Session-type dispatch in _apply_session_type_visibility (phase 1 only)."""
 

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -622,7 +622,7 @@ class TestFoodTruckAutoGateBoot:
 
     @pytest.mark.anyio
     async def test_run_skill_gate_error_when_food_truck_gate_closed(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx, monkeypatch, tmp_path
     ) -> None:
         import json
 
@@ -631,13 +631,13 @@ class TestFoodTruckAutoGateBoot:
 
         tool_ctx.gate = DefaultGateState(enabled=False)
 
-        result = json.loads(await run_skill("/some-skill", "/tmp"))
+        result = json.loads(await run_skill("/some-skill", str(tmp_path)))
         assert result["subtype"] == "gate_error"
         assert result["success"] is False
 
     @pytest.mark.anyio
     async def test_run_skill_succeeds_after_food_truck_auto_gate_boot(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx, monkeypatch, tmp_path
     ) -> None:
         import json
         from unittest.mock import AsyncMock, MagicMock, patch
@@ -662,7 +662,7 @@ class TestFoodTruckAutoGateBoot:
                     with patch("autoskillit.core.register_active_kitchen"):
                         await _food_truck_auto_gate_boot(tool_ctx)
 
-        result = json.loads(await run_skill("/some-skill", "/tmp"))
+        result = json.loads(await run_skill("/some-skill", str(tmp_path)))
         assert result.get("success") is True
 
 

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -528,7 +528,7 @@ class TestFleetAutoGateBoot:
         )
 
 
-@pytest.mark.feature("fleet")
+@pytest.mark.feature("orchestrator")
 class TestFoodTruckAutoGateBoot:
     """Food truck lifespan auto-gate: _food_truck_auto_gate_boot opens gate."""
 
@@ -538,13 +538,14 @@ class TestFoodTruckAutoGateBoot:
     ) -> None:
         from unittest.mock import AsyncMock, MagicMock, patch
 
+        from autoskillit.core import FOOD_TRUCK_TOOL_TAGS_ENV_VAR
         from autoskillit.pipeline.gate import DefaultGateState
         from autoskillit.server._lifespan import _food_truck_auto_gate_boot
 
         tool_ctx.gate = DefaultGateState(enabled=False)
         tool_ctx.quota_refresh_task = None
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
-        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core,rectify")
+        monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core,rectify")
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
@@ -562,13 +563,14 @@ class TestFoodTruckAutoGateBoot:
     ) -> None:
         from unittest.mock import AsyncMock, MagicMock, patch
 
+        from autoskillit.core import FOOD_TRUCK_TOOL_TAGS_ENV_VAR
         from autoskillit.pipeline.gate import DefaultGateState
         from autoskillit.server._lifespan import _food_truck_auto_gate_boot
 
         tool_ctx.gate = DefaultGateState(enabled=False)
         tool_ctx.quota_refresh_task = None
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
-        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core,rectify")
+        monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core,rectify")
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
@@ -585,12 +587,13 @@ class TestFoodTruckAutoGateBoot:
     async def test_food_truck_auto_gate_boot_skips_non_headless_orchestrator(
         self, tool_ctx, monkeypatch
     ) -> None:
+        from autoskillit.core import FOOD_TRUCK_TOOL_TAGS_ENV_VAR
         from autoskillit.pipeline.gate import DefaultGateState
         from autoskillit.server._lifespan import _food_truck_auto_gate_boot
 
         tool_ctx.gate = DefaultGateState(enabled=False)
         monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
-        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core")
+        monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core")
 
         await _food_truck_auto_gate_boot(tool_ctx)
 
@@ -600,12 +603,13 @@ class TestFoodTruckAutoGateBoot:
     async def test_food_truck_auto_gate_boot_skips_when_no_tool_tags(
         self, tool_ctx, monkeypatch
     ) -> None:
+        from autoskillit.core import FOOD_TRUCK_TOOL_TAGS_ENV_VAR
         from autoskillit.pipeline.gate import DefaultGateState
         from autoskillit.server._lifespan import _food_truck_auto_gate_boot
 
         tool_ctx.gate = DefaultGateState(enabled=False)
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
-        monkeypatch.delenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", raising=False)
+        monkeypatch.delenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, raising=False)
 
         await _food_truck_auto_gate_boot(tool_ctx)
 
@@ -638,6 +642,7 @@ class TestFoodTruckAutoGateBoot:
         import json
         from unittest.mock import AsyncMock, MagicMock, patch
 
+        from autoskillit.core import FOOD_TRUCK_TOOL_TAGS_ENV_VAR
         from autoskillit.pipeline.gate import DefaultGateState
         from autoskillit.server._lifespan import _food_truck_auto_gate_boot
         from autoskillit.server.tools.tools_execution import run_skill
@@ -647,7 +652,7 @@ class TestFoodTruckAutoGateBoot:
         tool_ctx.executor = InMemoryHeadlessExecutor()
         tool_ctx.quota_refresh_task = None
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
-        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core")
+        monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core")
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
@@ -658,7 +663,7 @@ class TestFoodTruckAutoGateBoot:
                         await _food_truck_auto_gate_boot(tool_ctx)
 
         result = json.loads(await run_skill("/some-skill", "/tmp"))
-        assert result.get("subtype") != "gate_error"
+        assert result.get("success") is True
 
 
 @pytest.mark.feature("fleet")

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -266,68 +266,76 @@ class TestConfigDrivenBehavior:
         assert tool_ctx.runner.call_args_list[0][2] == pytest.approx(300.0, abs=1.0)
 
     @pytest.mark.anyio
-    async def test_classify_fix_uses_config_prefixes(self, tool_ctx, tmp_path):
+    async def test_classify_fix_uses_config_prefixes(self, tool_ctx_kitchen_open, tmp_path):
         """S2: classify_fix uses config.classify_fix.path_prefixes."""
         from autoskillit.config import ClassifyFixConfig
         from autoskillit.core.types import RestartScope
         from autoskillit.server.tools.tools_git import classify_fix
         from tests.conftest import _make_result
 
-        tool_ctx.config = AutomationConfig(
+        tool_ctx_kitchen_open.config = AutomationConfig(
             classify_fix=ClassifyFixConfig(path_prefixes=["src/custom/"])
         )
 
         changed = "src/custom/handler.py\nsrc/other/util.py\n"
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch succeeds
-        tool_ctx.runner.push(_make_result(0, changed, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, changed, ""))
         result = json.loads(await classify_fix(worktree_path=str(tmp_path), base_branch="main"))
 
         assert result["restart_scope"] == RestartScope.FULL_RESTART
         assert "src/custom/handler.py" in result["critical_files"]
 
     @pytest.mark.anyio
-    async def test_classify_fix_empty_prefixes_always_partial(self, tool_ctx, tmp_path):
+    async def test_classify_fix_empty_prefixes_always_partial(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """S3: Empty prefix list -> always returns partial_restart."""
         from autoskillit.config import ClassifyFixConfig
         from autoskillit.core.types import RestartScope
         from autoskillit.server.tools.tools_git import classify_fix
         from tests.conftest import _make_result
 
-        tool_ctx.config = AutomationConfig(classify_fix=ClassifyFixConfig(path_prefixes=[]))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            classify_fix=ClassifyFixConfig(path_prefixes=[])
+        )
 
         changed = "src/core/handler.py\n"
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch succeeds
-        tool_ctx.runner.push(_make_result(0, changed, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, changed, ""))
         result = json.loads(await classify_fix(worktree_path=str(tmp_path), base_branch="main"))
 
         assert result["restart_scope"] == RestartScope.PARTIAL_RESTART
 
     @pytest.mark.anyio
-    async def test_reset_workspace_uses_config_command(self, tool_ctx, tmp_path):
+    async def test_reset_workspace_uses_config_command(self, tool_ctx_kitchen_open, tmp_path):
         """S4: reset_workspace runs config.reset_workspace.command."""
         from autoskillit.config import ResetWorkspaceConfig
         from autoskillit.server.tools.tools_workspace import reset_workspace
         from tests.conftest import _make_result
 
-        tool_ctx.config = AutomationConfig(
+        tool_ctx_kitchen_open.config = AutomationConfig(
             reset_workspace=ResetWorkspaceConfig(command=["make", "reset"])
         )
 
         workspace = tmp_path / "workspace"
         workspace.mkdir(parents=True)
         (workspace / ".autoskillit-workspace").write_text("# marker\n")
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
         await reset_workspace(test_dir=str(workspace))
-        assert tool_ctx.runner.call_args_list[0][0] == ["make", "reset"]
+        assert tool_ctx_kitchen_open.runner.call_args_list[0][0] == ["make", "reset"]
 
     @pytest.mark.anyio
-    async def test_reset_workspace_not_configured_returns_error(self, tool_ctx, tmp_path):
+    async def test_reset_workspace_not_configured_returns_error(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """S5: command=None -> returns not-configured error."""
         from autoskillit.config import ResetWorkspaceConfig
         from autoskillit.server.tools.tools_workspace import reset_workspace
 
-        tool_ctx.config = AutomationConfig(reset_workspace=ResetWorkspaceConfig(command=None))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            reset_workspace=ResetWorkspaceConfig(command=None)
+        )
 
         workspace = tmp_path / "workspace"
         workspace.mkdir(parents=True)
@@ -337,13 +345,15 @@ class TestConfigDrivenBehavior:
         assert result["error"] == "reset_workspace not configured for this project"
 
     @pytest.mark.anyio
-    async def test_reset_workspace_uses_config_preserve_dirs(self, tool_ctx, tmp_path):
+    async def test_reset_workspace_uses_config_preserve_dirs(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """S6: Preserves config.reset_workspace.preserve_dirs."""
         from autoskillit.config import ResetWorkspaceConfig
         from autoskillit.server.tools.tools_workspace import reset_workspace
         from tests.conftest import _make_result
 
-        tool_ctx.config = AutomationConfig(
+        tool_ctx_kitchen_open.config = AutomationConfig(
             reset_workspace=ResetWorkspaceConfig(
                 command=["true"],
                 preserve_dirs={"keep_me"},
@@ -355,7 +365,7 @@ class TestConfigDrivenBehavior:
         (workspace / ".autoskillit-workspace").write_text("# marker\n")
         (workspace / "keep_me").mkdir()
         (workspace / "delete_me").touch()
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
         result = json.loads(await reset_workspace(test_dir=str(workspace)))
 
@@ -401,7 +411,7 @@ class TestConfigDrivenBehavior:
         assert result is None  # /autoskillit:implement-worktree is NOT gated (not in skill_names)
 
     @pytest.mark.anyio
-    async def test_merge_worktree_uses_config_test_command(self, tool_ctx, tmp_path):
+    async def test_merge_worktree_uses_config_test_command(self, tool_ctx_kitchen_open, tmp_path):
         """S9: Merge's test gate runs config.test_check.command."""
         from autoskillit.config import TestCheckConfig
         from autoskillit.core.types import MergeFailedStep
@@ -409,26 +419,34 @@ class TestConfigDrivenBehavior:
         from autoskillit.server.tools.tools_git import merge_worktree
         from tests.conftest import _make_result
 
-        tool_ctx.config = AutomationConfig(
+        tool_ctx_kitchen_open.config = AutomationConfig(
             test_check=TestCheckConfig(command=["make", "test"], timeout=120)
         )
         # Re-create tester with updated config so it reads the new command
-        tool_ctx.tester = DefaultTestRunner(config=tool_ctx.config, runner=tool_ctx.runner)
+        tool_ctx_kitchen_open.tester = DefaultTestRunner(
+            config=tool_ctx_kitchen_open.config, runner=tool_ctx_kitchen_open.runner
+        )
 
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(1, "FAIL", ""))  # test gate fails
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(1, "FAIL", ""))  # test gate fails
         result = json.loads(await merge_worktree(str(wt), "dev"))
         assert result["failed_step"] == MergeFailedStep.TEST_GATE
 
         # Verify the test command was ["make", "test"] (5th call, after ls-files + porcelain)
-        test_call = tool_ctx.runner.call_args_list[4]
+        test_call = tool_ctx_kitchen_open.runner.call_args_list[4]
         assert test_call[0] == ["make", "test"]
 
     @pytest.mark.anyio
@@ -447,7 +465,7 @@ class TestSafetyConfigWiring:
     """Safety config fields are read at the point of enforcement."""
 
     @pytest.mark.anyio
-    async def test_reset_test_dir_allows_with_marker(self, tool_ctx, tmp_path):
+    async def test_reset_test_dir_allows_with_marker(self, tool_ctx_kitchen_open, tmp_path):
         """2a: Directory with marker passes the reset guard."""
         from autoskillit.server.tools.tools_workspace import reset_test_dir
 
@@ -460,7 +478,9 @@ class TestSafetyConfigWiring:
         assert result["success"] is True
 
     @pytest.mark.anyio
-    async def test_reset_test_dir_enforces_marker_when_missing(self, tool_ctx, tmp_path):
+    async def test_reset_test_dir_enforces_marker_when_missing(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """2b: Missing marker blocks reset_test_dir."""
         from autoskillit.server.tools.tools_workspace import reset_test_dir
 
@@ -471,12 +491,14 @@ class TestSafetyConfigWiring:
         assert "marker" in result["error"].lower()
 
     @pytest.mark.anyio
-    async def test_reset_workspace_enforces_marker(self, tool_ctx, tmp_path):
+    async def test_reset_workspace_enforces_marker(self, tool_ctx_kitchen_open, tmp_path):
         """2c: reset_workspace requires marker, then checks command config."""
         from autoskillit.config import ResetWorkspaceConfig
         from autoskillit.server.tools.tools_workspace import reset_workspace
 
-        tool_ctx.config = AutomationConfig(reset_workspace=ResetWorkspaceConfig(command=None))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            reset_workspace=ResetWorkspaceConfig(command=None)
+        )
 
         target = tmp_path / "my_project"
         target.mkdir()
@@ -487,58 +509,76 @@ class TestSafetyConfigWiring:
         assert result["error"] == "reset_workspace not configured for this project"
 
     @pytest.mark.anyio
-    async def test_merge_worktree_skips_test_gate_when_disabled(self, tool_ctx, tmp_path):
+    async def test_merge_worktree_skips_test_gate_when_disabled(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """2d: test_gate_on_merge=False skips test execution."""
         from autoskillit.server.tools.tools_git import merge_worktree
         from tests.conftest import _make_result
 
-        tool_ctx.config = AutomationConfig(safety=SafetyConfig(test_gate_on_merge=False))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            safety=SafetyConfig(test_gate_on_merge=False)
+        )
 
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
         # NO test-check call — skipped
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "", "")
         )  # git log --merges (step 5.6 — no merge commits)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git rebase
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git rebase
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n",
                 "",
             )
         )  # worktree list
-        tool_ctx.runner.push(_make_result(0, "dev\n", ""))  # git branch --show-current (step 7.5)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git merge
-        tool_ctx.runner.push(_make_result(0, "", ""))  # worktree remove
-        tool_ctx.runner.push(_make_result(0, "", ""))  # branch -D
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "dev\n", "")
+        )  # git branch --show-current (step 7.5)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git merge
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # worktree remove
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D
         result = json.loads(await merge_worktree(str(wt), "dev"))
         assert result["merge_succeeded"] is True
 
         # Verify no test command was called — the 5th call should be git fetch, not test
-        fifth_call_cmd = tool_ctx.runner.call_args_list[4][0]
+        fifth_call_cmd = tool_ctx_kitchen_open.runner.call_args_list[4][0]
         assert fifth_call_cmd == ["git", "fetch", "origin"]
 
     @pytest.mark.anyio
-    async def test_run_skill_2e_skips_dry_walkthrough_when_disabled(self, tool_ctx, tmp_path):
+    async def test_run_skill_2e_skips_dry_walkthrough_when_disabled(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """2e: require_dry_walkthrough=False bypasses dry-walkthrough gate (using run_skill)."""
         from autoskillit.server.tools.tools_execution import run_skill
         from tests.conftest import _make_result
 
-        tool_ctx.config = AutomationConfig(safety=SafetyConfig(require_dry_walkthrough=False))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            safety=SafetyConfig(require_dry_walkthrough=False)
+        )
 
         plan = tmp_path / "plan.md"
         plan.write_text("# No marker plan")
 
-        tool_ctx.runner.push(_make_result(0, '{"result": "done"}', ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, '{"result": "done"}', ""))
         result = json.loads(
             await run_skill(f"/autoskillit:implement-worktree {plan}", str(tmp_path))
         )
@@ -546,7 +586,9 @@ class TestSafetyConfigWiring:
         assert result["exit_code"] == 0
 
     @pytest.mark.anyio
-    async def test_run_skill_enforces_dry_walkthrough_when_enabled(self, tool_ctx, tmp_path):
+    async def test_run_skill_enforces_dry_walkthrough_when_enabled(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """2f: run_skill enforces dry-walkthrough gate when enabled (default)."""
         from autoskillit.server.tools.tools_execution import run_skill
 

--- a/tests/server/test_set_commit_status.py
+++ b/tests/server/test_set_commit_status.py
@@ -57,13 +57,13 @@ async def test_set_commit_status_gate_check(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_posts_pending(tool_ctx, monkeypatch):
+async def test_set_commit_status_posts_pending(tool_ctx_kitchen_open, monkeypatch):
     """Tool posts gh api with state=pending to the correct endpoint."""
     monkeypatch.setattr(
         "autoskillit.server.tools.tools_ci.resolve_repo_from_remote",
         lambda cwd, hint=None: _async_return("owner/repo"),
     )
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
     raw = await set_commit_status(
         sha="deadbeef",
@@ -80,7 +80,7 @@ async def test_set_commit_status_posts_pending(tool_ctx, monkeypatch):
     assert result["context"] == "autoskillit/ai-review"
 
     # Verify the POST call went to the right endpoint
-    cmd, *_ = tool_ctx.runner.call_args_list[0]
+    cmd, *_ = tool_ctx_kitchen_open.runner.call_args_list[0]
     cmd_str = " ".join(cmd)
     assert "/repos/owner/repo/statuses/deadbeef" in cmd_str
     assert "pending" in cmd_str
@@ -92,13 +92,13 @@ async def test_set_commit_status_posts_pending(tool_ctx, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_posts_success(tool_ctx, monkeypatch):
+async def test_set_commit_status_posts_success(tool_ctx_kitchen_open, monkeypatch):
     """Tool posts gh api with state=success and context preserved."""
     monkeypatch.setattr(
         "autoskillit.server.tools.tools_ci.resolve_repo_from_remote",
         lambda cwd, hint=None: _async_return("myorg/myrepo"),
     )
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
     raw = await set_commit_status(
         sha="cafebabe",
@@ -112,7 +112,7 @@ async def test_set_commit_status_posts_success(tool_ctx, monkeypatch):
     assert result["state"] == "success"
     assert result["context"] == "autoskillit/ai-review"
 
-    post_cmd = " ".join(tool_ctx.runner.call_args_list[0][0])
+    post_cmd = " ".join(tool_ctx_kitchen_open.runner.call_args_list[0][0])
     assert "success" in post_cmd
 
 
@@ -122,13 +122,13 @@ async def test_set_commit_status_posts_success(tool_ctx, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_posts_failure(tool_ctx, monkeypatch):
+async def test_set_commit_status_posts_failure(tool_ctx_kitchen_open, monkeypatch):
     """Tool posts gh api with state=failure."""
     monkeypatch.setattr(
         "autoskillit.server.tools.tools_ci.resolve_repo_from_remote",
         lambda cwd, hint=None: _async_return("owner/repo"),
     )
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
     raw = await set_commit_status(
         sha="feedface",
@@ -141,7 +141,7 @@ async def test_set_commit_status_posts_failure(tool_ctx, monkeypatch):
     assert result["success"] is True
     assert result["state"] == "failure"
 
-    post_cmd = " ".join(tool_ctx.runner.call_args_list[0][0])
+    post_cmd = " ".join(tool_ctx_kitchen_open.runner.call_args_list[0][0])
     assert "failure" in post_cmd
 
 
@@ -151,7 +151,7 @@ async def test_set_commit_status_posts_failure(tool_ctx, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_infers_repo_from_cwd(tool_ctx, monkeypatch):
+async def test_set_commit_status_infers_repo_from_cwd(tool_ctx_kitchen_open, monkeypatch):
     """Tool infers owner/repo via resolve_repo_from_remote when repo param is absent."""
     infer_calls: list[str] = []
 
@@ -160,7 +160,7 @@ async def test_set_commit_status_infers_repo_from_cwd(tool_ctx, monkeypatch):
         return "inferred/repo"
 
     monkeypatch.setattr("autoskillit.server.tools.tools_ci.resolve_repo_from_remote", fake_infer)
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
     raw = await set_commit_status(
         sha="abc001",
@@ -175,12 +175,14 @@ async def test_set_commit_status_infers_repo_from_cwd(tool_ctx, monkeypatch):
     assert infer_calls, "resolve_repo_from_remote was not called"
 
     # POST must use the inferred repo
-    post_cmd = tool_ctx.runner.call_args_list[0][0]
+    post_cmd = tool_ctx_kitchen_open.runner.call_args_list[0][0]
     assert "inferred/repo" in " ".join(post_cmd)
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_falls_back_to_plugin_dir_when_no_cwd(tool_ctx, monkeypatch):
+async def test_set_commit_status_falls_back_to_plugin_dir_when_no_cwd(
+    tool_ctx_kitchen_open, monkeypatch
+):
     """When neither repo nor cwd is provided, tool falls back to plugin_source for inference."""
     infer_calls: list[str] = []
 
@@ -189,25 +191,27 @@ async def test_set_commit_status_falls_back_to_plugin_dir_when_no_cwd(tool_ctx, 
         return "fallback/repo"
 
     monkeypatch.setattr("autoskillit.server.tools.tools_ci.resolve_repo_from_remote", fake_infer)
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
     raw = await set_commit_status(
         sha="abc003",
         state="pending",
         context="autoskillit/ai-review",
-        # neither repo nor cwd — falls back to tool_ctx.plugin_source
+        # neither repo nor cwd — falls back to tool_ctx_kitchen_open.plugin_source
     )
     result = json.loads(raw)
 
     assert result["success"] is True
     assert infer_calls, "resolve_repo_from_remote was not called for fallback"
     # POST must reference the fallback repo
-    post_cmd, *_ = tool_ctx.runner.call_args_list[0]
+    post_cmd, *_ = tool_ctx_kitchen_open.runner.call_args_list[0]
     assert "fallback/repo" in " ".join(post_cmd)
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_uses_explicit_repo_without_inference(tool_ctx, monkeypatch):
+async def test_set_commit_status_uses_explicit_repo_without_inference(
+    tool_ctx_kitchen_open, monkeypatch
+):
     """When repo is provided explicitly, resolve_repo_from_remote is not called."""
     infer_calls: list[str] = []
 
@@ -216,7 +220,7 @@ async def test_set_commit_status_uses_explicit_repo_without_inference(tool_ctx, 
         return "should-not-be-used/repo"
 
     monkeypatch.setattr("autoskillit.server.tools.tools_ci.resolve_repo_from_remote", fake_infer)
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
     raw = await set_commit_status(
         sha="abc002",
@@ -229,7 +233,7 @@ async def test_set_commit_status_uses_explicit_repo_without_inference(tool_ctx, 
 
     assert result["success"] is True
     assert not infer_calls, "resolve_repo_from_remote should not be called when repo is explicit"
-    post_cmd = tool_ctx.runner.call_args_list[0][0]
+    post_cmd = tool_ctx_kitchen_open.runner.call_args_list[0][0]
     assert "explicit/repo" in " ".join(post_cmd)
 
 
@@ -239,13 +243,15 @@ async def test_set_commit_status_uses_explicit_repo_without_inference(tool_ctx, 
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_on_gh_failure_returns_error_dict(tool_ctx, monkeypatch):
+async def test_set_commit_status_on_gh_failure_returns_error_dict(
+    tool_ctx_kitchen_open, monkeypatch
+):
     """When gh api returns non-zero, tool returns success=false, never raises."""
     monkeypatch.setattr(
         "autoskillit.server.tools.tools_ci.resolve_repo_from_remote",
         lambda cwd, hint=None: _async_return("owner/repo"),
     )
-    tool_ctx.runner.push(_make_result(1, "", "API rate limit exceeded"))
+    tool_ctx_kitchen_open.runner.push(_make_result(1, "", "API rate limit exceeded"))
 
     raw = await set_commit_status(
         sha="baadf00d",
@@ -260,7 +266,9 @@ async def test_set_commit_status_on_gh_failure_returns_error_dict(tool_ctx, monk
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_repo_inference_failure_returns_error(tool_ctx, monkeypatch):
+async def test_set_commit_status_repo_inference_failure_returns_error(
+    tool_ctx_kitchen_open, monkeypatch
+):
     """When repo inference returns empty string, tool returns success=false."""
     monkeypatch.setattr(
         "autoskillit.server.tools.tools_ci.resolve_repo_from_remote",
@@ -308,7 +316,7 @@ async def test_set_commit_status_validation_errors_return_str(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_success_returns_str(tool_ctx, monkeypatch):
+async def test_set_commit_status_success_returns_str(tool_ctx_kitchen_open, monkeypatch):
     """Success path returns str."""
     import json
 
@@ -318,7 +326,7 @@ async def test_set_commit_status_success_returns_str(tool_ctx, monkeypatch):
         return "owner/repo"
 
     monkeypatch.setattr("autoskillit.server.tools.tools_ci.resolve_repo_from_remote", fake_infer)
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
     result = await set_commit_status(sha="abc123", state="success", context="ci", cwd="/tmp")
     assert isinstance(result, str)
     parsed = json.loads(result)
@@ -326,7 +334,9 @@ async def test_set_commit_status_success_returns_str(tool_ctx, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_set_commit_status_uses_infer_repo_not_gh_subprocess(tool_ctx, monkeypatch):
+async def test_set_commit_status_uses_infer_repo_not_gh_subprocess(
+    tool_ctx_kitchen_open, monkeypatch
+):
     """Must call resolve_repo_from_remote, not launch gh repo view subprocess."""
     from tests.conftest import _make_result
 
@@ -338,11 +348,11 @@ async def test_set_commit_status_uses_infer_repo_not_gh_subprocess(tool_ctx, mon
 
     monkeypatch.setattr("autoskillit.server.tools.tools_ci.resolve_repo_from_remote", fake_infer)
     # Only one runner push needed (the POST call, repo already resolved)
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
     await set_commit_status(sha="abc", state="success", context="ci", cwd="/tmp")
     assert calls, "resolve_repo_from_remote was never called"
     # gh repo view must NOT have been invoked as a subprocess
-    for cmd_args, *_ in tool_ctx.runner.call_args_list:
+    for cmd_args, *_ in tool_ctx_kitchen_open.runner.call_args_list:
         assert not ("repo" in cmd_args and "view" in cmd_args), (
             "gh repo view subprocess was invoked; resolve_repo_from_remote should be used instead"
         )

--- a/tests/server/test_smoke_pipeline.py
+++ b/tests/server/test_smoke_pipeline.py
@@ -74,8 +74,8 @@ class TestSmokeScriptValidation:
     """Validate the smoke-test pipeline YAML structure."""
 
     @pytest.fixture(autouse=True)
-    def _setup_ctx(self, tool_ctx):
-        """Pull tool_ctx into scope to trigger its monkeypatch side-effect.
+    def _setup_ctx(self, tool_ctx_kitchen_open):
+        """Pull tool_ctx_kitchen_open into scope to trigger its monkeypatch side-effect.
 
         The server module's _ctx is set by the tool_ctx fixture. Tests in this
         class call server tools (e.g. validate_recipe) that read _ctx. Without

--- a/tests/server/test_tools_bootstrap.py
+++ b/tests/server/test_tools_bootstrap.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 class TestBootstrapClone:
     @pytest.mark.anyio
-    async def test_bootstrap_clone_success(self, tool_ctx, tmp_path):
+    async def test_bootstrap_clone_success(self, tool_ctx_kitchen_open, tmp_path):
         """bootstrap_clone returns work_dir, remote_url, base_sha, merge_target."""
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {
@@ -27,8 +27,8 @@ class TestBootstrapClone:
             "source_dir": "/src",
             "remote_url": "https://github.com/o/r.git",
         }
-        tool_ctx.clone_mgr = mock_mgr
-        tool_ctx.runner.push(_make_result(0, "abc123def\n", ""))
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "abc123def\n", ""))
         result = json.loads(
             await bootstrap_clone(source_dir="/src", run_name="impl", base_branch="main")
         )
@@ -46,10 +46,10 @@ class TestBootstrapClone:
         assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
-    async def test_bootstrap_clone_clone_failure(self, tool_ctx):
+    async def test_bootstrap_clone_clone_failure(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.side_effect = RuntimeError("disk full")
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await bootstrap_clone(source_dir="/src", run_name="impl", base_branch="main")
         )
@@ -57,15 +57,15 @@ class TestBootstrapClone:
         assert "disk full" in result["error"]
 
     @pytest.mark.anyio
-    async def test_bootstrap_clone_revparse_failure(self, tool_ctx, tmp_path):
+    async def test_bootstrap_clone_revparse_failure(self, tool_ctx_kitchen_open, tmp_path):
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {
             "clone_path": str(tmp_path),
             "source_dir": "/src",
             "remote_url": "url",
         }
-        tool_ctx.clone_mgr = mock_mgr
-        tool_ctx.runner.push(_make_result(128, "", "fatal: not a git repo\n"))
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.runner.push(_make_result(128, "", "fatal: not a git repo\n"))
         result = json.loads(
             await bootstrap_clone(source_dir="/src", run_name="impl", base_branch="main")
         )
@@ -73,30 +73,30 @@ class TestBootstrapClone:
         assert "rev-parse" in result["error"]
 
     @pytest.mark.anyio
-    async def test_bootstrap_clone_timing(self, tool_ctx, tmp_path):
+    async def test_bootstrap_clone_timing(self, tool_ctx_kitchen_open, tmp_path):
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {
             "clone_path": str(tmp_path),
             "source_dir": "/src",
             "remote_url": "url",
         }
-        tool_ctx.clone_mgr = mock_mgr
-        tool_ctx.runner.push(_make_result(0, "sha\n", ""))
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "sha\n", ""))
         await bootstrap_clone(
             source_dir="/src", run_name="impl", base_branch="main", step_name="bootstrap"
         )
-        assert_step_timed(tool_ctx.timing_log, "bootstrap")
+        assert_step_timed(tool_ctx_kitchen_open.timing_log, "bootstrap")
 
     @pytest.mark.anyio
-    async def test_bootstrap_clone_sub_timings(self, tool_ctx, tmp_path):
+    async def test_bootstrap_clone_sub_timings(self, tool_ctx_kitchen_open, tmp_path):
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {
             "clone_path": str(tmp_path),
             "source_dir": "/src",
             "remote_url": "url",
         }
-        tool_ctx.clone_mgr = mock_mgr
-        tool_ctx.runner.push(_make_result(0, "sha\n", ""))
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "sha\n", ""))
         result = json.loads(
             await bootstrap_clone(source_dir="/src", run_name="impl", base_branch="main")
         )
@@ -107,16 +107,18 @@ class TestBootstrapClone:
 
 class TestClaimAndResolveIssue:
     @pytest.mark.anyio
-    async def test_claim_and_resolve_issue_claimed(self, tool_ctx):
-        tool_ctx.github_client = AsyncMock()
-        tool_ctx.github_client.fetch_title = AsyncMock(
+    async def test_claim_and_resolve_issue_claimed(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
             return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
         )
-        tool_ctx.github_client.fetch_issue = AsyncMock(
+        tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
             return_value={"success": True, "labels": []}
         )
-        tool_ctx.github_client.ensure_label = AsyncMock(return_value={"success": True})
-        tool_ctx.github_client.swap_labels = AsyncMock(return_value={"success": True})
+        tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(
+            return_value={"success": True}
+        )
+        tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
         result = json.loads(await claim_and_resolve_issue(issue_url="owner/repo#42"))
         assert result["claimed"] is True
         assert result["issue_number"] == 42
@@ -124,12 +126,12 @@ class TestClaimAndResolveIssue:
         assert result["issue_slug"] == "fix-bug"
 
     @pytest.mark.anyio
-    async def test_claim_and_resolve_issue_already_claimed(self, tool_ctx):
-        tool_ctx.github_client = AsyncMock()
-        tool_ctx.github_client.fetch_title = AsyncMock(
+    async def test_claim_and_resolve_issue_already_claimed(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
             return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
         )
-        tool_ctx.github_client.fetch_issue = AsyncMock(
+        tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
             return_value={
                 "success": True,
                 "labels": [{"name": "in-progress"}],
@@ -142,12 +144,12 @@ class TestClaimAndResolveIssue:
         assert result["issue_slug"] == "fix-bug"
 
     @pytest.mark.anyio
-    async def test_claim_and_resolve_issue_reentry(self, tool_ctx):
-        tool_ctx.github_client = AsyncMock()
-        tool_ctx.github_client.fetch_title = AsyncMock(
+    async def test_claim_and_resolve_issue_reentry(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
             return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
         )
-        tool_ctx.github_client.fetch_issue = AsyncMock(
+        tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
             return_value={
                 "success": True,
                 "labels": [{"name": "in-progress"}],
@@ -160,9 +162,9 @@ class TestClaimAndResolveIssue:
         assert result["reentry"] is True
 
     @pytest.mark.anyio
-    async def test_claim_and_resolve_issue_title_failure(self, tool_ctx):
-        tool_ctx.github_client = AsyncMock()
-        tool_ctx.github_client.fetch_title = AsyncMock(
+    async def test_claim_and_resolve_issue_title_failure(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
             return_value={"success": False, "error": "not found"}
         )
         result = json.loads(await claim_and_resolve_issue(issue_url="owner/repo#42"))
@@ -176,16 +178,18 @@ class TestClaimAndResolveIssue:
         assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
-    async def test_claim_and_resolve_issue_timings(self, tool_ctx):
-        tool_ctx.github_client = AsyncMock()
-        tool_ctx.github_client.fetch_title = AsyncMock(
+    async def test_claim_and_resolve_issue_timings(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
             return_value={"success": True, "number": 42, "title": "X", "slug": "x"}
         )
-        tool_ctx.github_client.fetch_issue = AsyncMock(
+        tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
             return_value={"success": True, "labels": []}
         )
-        tool_ctx.github_client.ensure_label = AsyncMock(return_value={"success": True})
-        tool_ctx.github_client.swap_labels = AsyncMock(return_value={"success": True})
+        tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(
+            return_value={"success": True}
+        )
+        tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
         result = json.loads(await claim_and_resolve_issue(issue_url="owner/repo#42"))
         assert "timings" in result
         assert "fetch_title_ms" in result["timings"]
@@ -194,16 +198,16 @@ class TestClaimAndResolveIssue:
 
 class TestCreateAndPublishBranch:
     @pytest.mark.anyio
-    async def test_create_and_publish_branch_success(self, tool_ctx, tmp_path):
+    async def test_create_and_publish_branch_success(self, tool_ctx_kitchen_open, tmp_path):
         # ls-remote: empty (branch available)
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         # branch --show-current
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))
         # git checkout -b
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": True, "stderr": ""}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await create_and_publish_branch(
                 issue_slug="fix-bug",
@@ -216,18 +220,18 @@ class TestCreateAndPublishBranch:
         assert result["merge_target"] == "fix-bug/42"
 
     @pytest.mark.anyio
-    async def test_create_and_publish_branch_collision(self, tool_ctx, tmp_path):
+    async def test_create_and_publish_branch_collision(self, tool_ctx_kitchen_open, tmp_path):
         # ls-remote: branch exists
-        tool_ctx.runner.push(_make_result(0, "abc123\trefs/heads/fix-bug/42\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "abc123\trefs/heads/fix-bug/42\n", ""))
         # ls-remote: suffix -2 is free
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         # branch --show-current
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))
         # git checkout -b
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": True, "stderr": ""}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await create_and_publish_branch(
                 issue_slug="fix-bug",
@@ -240,17 +244,17 @@ class TestCreateAndPublishBranch:
         assert result["merge_target"] == "fix-bug/42-2"
 
     @pytest.mark.anyio
-    async def test_create_and_publish_branch_push_failure(self, tool_ctx, tmp_path):
-        tool_ctx.runner.push(_make_result(0, "", ""))
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))
+    async def test_create_and_publish_branch_push_failure(self, tool_ctx_kitchen_open, tmp_path):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {
             "success": False,
             "stderr": "rejected",
             "error_type": "",
         }
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await create_and_publish_branch(
                 issue_slug="fix-bug",
@@ -277,13 +281,13 @@ class TestCreateAndPublishBranch:
         assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
-    async def test_create_and_publish_branch_no_issue(self, tool_ctx, tmp_path):
-        tool_ctx.runner.push(_make_result(0, "", ""))
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))
+    async def test_create_and_publish_branch_no_issue(self, tool_ctx_kitchen_open, tmp_path):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": True, "stderr": ""}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await create_and_publish_branch(
                 issue_slug="",
@@ -297,13 +301,13 @@ class TestCreateAndPublishBranch:
         assert result["merge_target"].startswith("impl/")
 
     @pytest.mark.anyio
-    async def test_create_and_publish_branch_timings(self, tool_ctx, tmp_path):
-        tool_ctx.runner.push(_make_result(0, "", ""))
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))
+    async def test_create_and_publish_branch_timings(self, tool_ctx_kitchen_open, tmp_path):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": True, "stderr": ""}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await create_and_publish_branch(
                 issue_slug="x",

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -50,12 +50,12 @@ async def test_wait_for_ci_gate_check(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_success_response(tool_ctx):
+async def test_wait_for_ci_success_response(tool_ctx_kitchen_open):
     watcher = InMemoryCIWatcher(
         wait_result={"run_id": 12345, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = watcher
-    tool_ctx.runner.push(
+    tool_ctx_kitchen_open.ci_watcher = watcher
+    tool_ctx_kitchen_open.runner.push(
         SubprocessResult(
             returncode=0,
             stdout="abc123\n",
@@ -73,7 +73,7 @@ async def test_wait_for_ci_success_response(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_failure_response(tool_ctx):
+async def test_wait_for_ci_failure_response(tool_ctx_kitchen_open):
     watcher = InMemoryCIWatcher(
         wait_result={
             "run_id": 12345,
@@ -81,8 +81,8 @@ async def test_wait_for_ci_failure_response(tool_ctx):
             "failed_jobs": ["test", "lint"],
         }
     )
-    tool_ctx.ci_watcher = watcher
-    tool_ctx.runner.push(
+    tool_ctx_kitchen_open.ci_watcher = watcher
+    tool_ctx_kitchen_open.runner.push(
         SubprocessResult(
             returncode=0,
             stdout="abc123\n",
@@ -104,13 +104,13 @@ async def test_wait_for_ci_failure_response(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_infers_head_sha(tool_ctx):
+async def test_wait_for_ci_infers_head_sha(tool_ctx_kitchen_open):
     """When head_sha is not provided, it's inferred via git rev-parse HEAD."""
     watcher = InMemoryCIWatcher(
         wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = watcher
-    tool_ctx.runner.push(
+    tool_ctx_kitchen_open.ci_watcher = watcher
+    tool_ctx_kitchen_open.runner.push(
         SubprocessResult(
             returncode=0,
             stdout="abc123\n",
@@ -127,15 +127,15 @@ async def test_wait_for_ci_infers_head_sha(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_head_sha_uses_runner(tool_ctx):
+async def test_wait_for_ci_head_sha_uses_runner(tool_ctx_kitchen_open):
     """git rev-parse HEAD must flow through MockSubprocessRunner, not raw asyncio."""
     watcher = InMemoryCIWatcher(
         wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
 
     # Pre-configure runner to return a valid SHA when git rev-parse is called
-    tool_ctx.runner.push(
+    tool_ctx_kitchen_open.runner.push(
         SubprocessResult(
             returncode=0,
             stdout="deadbeef\n",
@@ -148,8 +148,8 @@ async def test_wait_for_ci_head_sha_uses_runner(tool_ctx):
     await wait_for_ci("main", cwd="/some/repo")
 
     # Runner must have been called with the git command
-    assert tool_ctx.runner.call_args_list, "runner was never called"
-    cmd = tool_ctx.runner.call_args_list[0][0]
+    assert tool_ctx_kitchen_open.runner.call_args_list, "runner was never called"
+    cmd = tool_ctx_kitchen_open.runner.call_args_list[0][0]
     assert cmd == ["git", "rev-parse", "HEAD"], f"Unexpected runner call: {cmd}"
 
     # SHA extracted from runner output must have been passed to the CI watcher
@@ -162,8 +162,8 @@ async def test_wait_for_ci_head_sha_uses_runner(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_no_watcher(tool_ctx):
-    tool_ctx.ci_watcher = None
+async def test_wait_for_ci_no_watcher(tool_ctx_kitchen_open):
+    tool_ctx_kitchen_open.ci_watcher = None
     result = json.loads(await wait_for_ci("main"))
     assert result["conclusion"] == "error"
     assert "not configured" in result["error"]
@@ -183,9 +183,9 @@ async def test_get_ci_status_gate_check(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_get_ci_status_missing_branch_and_run_id(tool_ctx):
+async def test_get_ci_status_missing_branch_and_run_id(tool_ctx_kitchen_open):
     watcher = InMemoryCIWatcher()
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
 
     result = json.loads(await get_ci_status())
     assert result["runs"] == []
@@ -193,8 +193,8 @@ async def test_get_ci_status_missing_branch_and_run_id(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_get_ci_status_no_watcher(tool_ctx):
-    tool_ctx.ci_watcher = None
+async def test_get_ci_status_no_watcher(tool_ctx_kitchen_open):
+    tool_ctx_kitchen_open.ci_watcher = None
     result = json.loads(await get_ci_status(branch="main"))
     assert result["runs"] == []
     assert "not configured" in result["error"]
@@ -206,12 +206,12 @@ async def test_get_ci_status_no_watcher(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_passes_event_to_scope(tool_ctx):
+async def test_wait_for_ci_passes_event_to_scope(tool_ctx_kitchen_open):
     """wait_for_ci must propagate event param into CIRunScope."""
     watcher = InMemoryCIWatcher(
         wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
     await wait_for_ci(branch="main", event="push", cwd="/tmp")
     assert len(watcher.wait_calls) == 1
     assert watcher.wait_calls[-1]["scope"].event == "push"
@@ -223,23 +223,23 @@ async def test_wait_for_ci_passes_event_to_scope(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_forwards_lookback_seconds(tool_ctx):
+async def test_wait_for_ci_forwards_lookback_seconds(tool_ctx_kitchen_open):
     """wait_for_ci must propagate lookback_seconds to ci_watcher.wait()."""
     watcher = InMemoryCIWatcher(
         wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
     await wait_for_ci(branch="main", lookback_seconds=7200, cwd="/tmp")
     assert watcher.wait_calls[-1]["lookback_seconds"] == 7200
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_lookback_defaults_to_3600(tool_ctx):
+async def test_wait_for_ci_lookback_defaults_to_3600(tool_ctx_kitchen_open):
     """wait_for_ci default lookback_seconds is 3600 (1 hour)."""
     watcher = InMemoryCIWatcher(
         wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
     await wait_for_ci(branch="main", cwd="/tmp")
     assert watcher.wait_calls[-1]["lookback_seconds"] == 3600
 
@@ -263,11 +263,11 @@ async def test_gate_closed_returns_gate_error(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_delegates_to_merge_queue_watcher(tool_ctx):
+async def test_delegates_to_merge_queue_watcher(tool_ctx_kitchen_open):
     watcher = InMemoryMergeQueueWatcher(
         wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
     )
-    tool_ctx.merge_queue_watcher = watcher
+    tool_ctx_kitchen_open.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -291,11 +291,11 @@ async def test_delegates_to_merge_queue_watcher(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_infers_repo_from_git_remote_when_repo_empty(tool_ctx):
+async def test_infers_repo_from_git_remote_when_repo_empty(tool_ctx_kitchen_open):
     watcher = InMemoryMergeQueueWatcher(
         wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
     )
-    tool_ctx.merge_queue_watcher = watcher
+    tool_ctx_kitchen_open.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -314,11 +314,11 @@ async def test_infers_repo_from_git_remote_when_repo_empty(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_explicit_repo_skips_subprocess(tool_ctx):
+async def test_explicit_repo_skips_subprocess(tool_ctx_kitchen_open):
     watcher = InMemoryMergeQueueWatcher(
         wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
     )
-    tool_ctx.merge_queue_watcher = watcher
+    tool_ctx_kitchen_open.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -336,8 +336,8 @@ async def test_explicit_repo_skips_subprocess(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_watcher_none_returns_error(tool_ctx):
-    tool_ctx.merge_queue_watcher = None
+async def test_watcher_none_returns_error(tool_ctx_kitchen_open):
+    tool_ctx_kitchen_open.merge_queue_watcher = None
     result = json.loads(await wait_for_merge_queue(pr_number=42, target_branch="main", cwd="."))
     assert result["success"] is False
     assert "pr_state" in result
@@ -350,7 +350,7 @@ async def test_watcher_none_returns_error(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_parses_remote_url_to_resolve_repo(tool_ctx):
+async def test_wait_for_ci_parses_remote_url_to_resolve_repo(tool_ctx_kitchen_open):
     """When remote_url is provided, wait_for_ci must parse it to owner/repo
     and pass that to the watcher without calling any subprocess."""
     watcher = InMemoryCIWatcher(
@@ -361,7 +361,7 @@ async def test_wait_for_ci_parses_remote_url_to_resolve_repo(tool_ctx):
             "head_sha": "abc123",
         }
     )
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
 
     result = json.loads(
         await wait_for_ci(
@@ -375,7 +375,7 @@ async def test_wait_for_ci_parses_remote_url_to_resolve_repo(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_remote_url_wins_over_empty_repo(tool_ctx):
+async def test_wait_for_ci_remote_url_wins_over_empty_repo(tool_ctx_kitchen_open):
     """remote_url= supersedes repo='' — hint priority in resolve_remote_repo."""
     watcher = InMemoryCIWatcher(
         wait_result={
@@ -385,7 +385,7 @@ async def test_wait_for_ci_remote_url_wins_over_empty_repo(tool_ctx):
             "head_sha": "abc",
         }
     )
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
     await wait_for_ci(
         branch="main",
         remote_url="https://github.com/owner/repo.git",
@@ -401,13 +401,13 @@ async def test_wait_for_ci_remote_url_wins_over_empty_repo(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_merge_queue_parses_remote_url_to_resolve_repo(tool_ctx):
+async def test_wait_for_merge_queue_parses_remote_url_to_resolve_repo(tool_ctx_kitchen_open):
     """When remote_url is provided, wait_for_merge_queue parses it to owner/repo
     without calling any subprocess."""
     watcher = InMemoryMergeQueueWatcher(
         wait_result={"success": True, "pr_state": "merged", "pr_number": 42}
     )
-    tool_ctx.merge_queue_watcher = watcher
+    tool_ctx_kitchen_open.merge_queue_watcher = watcher
 
     result = json.loads(
         await wait_for_merge_queue(
@@ -425,13 +425,13 @@ class TestWaitForCiTiming:
     """wait_for_ci records wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_wait_for_ci_step_name_records_timing(self, tool_ctx):
+    async def test_wait_for_ci_step_name_records_timing(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(
             wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
         )
-        tool_ctx.ci_watcher = watcher
+        tool_ctx_kitchen_open.ci_watcher = watcher
         await wait_for_ci("main", step_name="ci_wait")
-        assert_step_timed(tool_ctx.timing_log, "ci_wait")
+        assert_step_timed(tool_ctx_kitchen_open.timing_log, "ci_wait")
 
     @pytest.mark.anyio
     async def test_wait_for_ci_empty_step_name_skips_timing(self, tool_ctx):
@@ -447,11 +447,11 @@ class TestWaitForMergeQueueTiming:
     """wait_for_merge_queue records wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_wait_for_merge_queue_step_name_records_timing(self, tool_ctx):
+    async def test_wait_for_merge_queue_step_name_records_timing(self, tool_ctx_kitchen_open):
         watcher = InMemoryMergeQueueWatcher(
             wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
         )
-        tool_ctx.merge_queue_watcher = watcher
+        tool_ctx_kitchen_open.merge_queue_watcher = watcher
         with patch(
             "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
@@ -465,7 +465,7 @@ class TestWaitForMergeQueueTiming:
             await wait_for_merge_queue(
                 pr_number=1, target_branch="main", cwd=".", step_name="mq_wait"
             )
-        assert_step_timed(tool_ctx.timing_log, "mq_wait")
+        assert_step_timed(tool_ctx_kitchen_open.timing_log, "mq_wait")
 
     @pytest.mark.anyio
     async def test_wait_for_merge_queue_empty_step_name_skips_timing(self, tool_ctx):
@@ -489,7 +489,7 @@ class TestWaitForMergeQueueTiming:
 
 @pytest.mark.anyio
 async def test_wait_for_merge_queue_invalid_remote_url_falls_through_to_inference(
-    tool_ctx, tmp_path
+    tool_ctx_kitchen_open, tmp_path
 ):
     """
     remote_url that parses to None (e.g. file://) does NOT short-circuit;
@@ -502,7 +502,7 @@ async def test_wait_for_merge_queue_invalid_remote_url_falls_through_to_inferenc
             "reason": "Invalid repo format: None",
         }
     )
-    tool_ctx.merge_queue_watcher = watcher
+    tool_ctx_kitchen_open.merge_queue_watcher = watcher
 
     # provide a file:// remote_url — should fall through, eventually fail gracefully
     result = json.loads(
@@ -524,12 +524,12 @@ async def test_wait_for_merge_queue_invalid_remote_url_falls_through_to_inferenc
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_handler_passes_workflow(tool_ctx):
+async def test_wait_for_ci_handler_passes_workflow(tool_ctx_kitchen_open):
     """wait_for_ci MCP handler must forward workflow to watcher via scope."""
     watcher = InMemoryCIWatcher(
         wait_result={"conclusion": "success", "failed_jobs": [], "run_id": 1}
     )
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
 
     # cwd="" → head_sha inference skipped (empty string is falsy)
     json.loads(await wait_for_ci(branch="main", workflow="tests.yml", cwd=""))
@@ -539,10 +539,10 @@ async def test_wait_for_ci_handler_passes_workflow(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_get_ci_status_handler_passes_workflow(tool_ctx):
+async def test_get_ci_status_handler_passes_workflow(tool_ctx_kitchen_open):
     """get_ci_status MCP handler must forward workflow to watcher via scope."""
     watcher = InMemoryCIWatcher(status_result={"runs": []})
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
 
     await get_ci_status(branch="main", workflow="tests.yml")
 
@@ -555,7 +555,7 @@ async def test_get_ci_status_handler_passes_workflow(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_watcher_exception_returns_structured_json(tool_ctx):
+async def test_wait_for_ci_watcher_exception_returns_structured_json(tool_ctx_kitchen_open):
     """wait_for_ci returns structured JSON with conclusion='error' when watcher.wait() raises.
 
     BEFORE fix: bare raise propagates to track_response_size which adds
@@ -563,7 +563,7 @@ async def test_wait_for_ci_watcher_exception_returns_structured_json(tool_ctx):
     """
     watcher = InMemoryCIWatcher()
     watcher.wait_side_effect = RuntimeError("network timeout")
-    tool_ctx.ci_watcher = watcher
+    tool_ctx_kitchen_open.ci_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -583,7 +583,9 @@ async def test_wait_for_ci_watcher_exception_returns_structured_json(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_merge_queue_watcher_exception_returns_structured_json(tool_ctx):
+async def test_wait_for_merge_queue_watcher_exception_returns_structured_json(
+    tool_ctx_kitchen_open,
+):
     """wait_for_merge_queue returns {success: false, error: ...} when watcher.wait() raises.
 
     BEFORE fix: bare raise propagates to track_response_size decorator.
@@ -591,7 +593,7 @@ async def test_wait_for_merge_queue_watcher_exception_returns_structured_json(to
     """
     watcher = InMemoryMergeQueueWatcher()
     watcher.wait_side_effect = RuntimeError("connection refused")
-    tool_ctx.merge_queue_watcher = watcher
+    tool_ctx_kitchen_open.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -617,13 +619,13 @@ async def test_wait_for_merge_queue_watcher_exception_returns_structured_json(to
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_includes_head_sha_in_result(tool_ctx):
+async def test_wait_for_ci_includes_head_sha_in_result(tool_ctx_kitchen_open):
     """wait_for_ci result includes head_sha when git rev-parse HEAD succeeds."""
     watcher = InMemoryCIWatcher(
         wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = watcher
-    tool_ctx.runner.push(
+    tool_ctx_kitchen_open.ci_watcher = watcher
+    tool_ctx_kitchen_open.runner.push(
         SubprocessResult(
             returncode=0,
             stdout="deadbeef1234\n",
@@ -639,13 +641,13 @@ async def test_wait_for_ci_includes_head_sha_in_result(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_omits_head_sha_when_git_fails(tool_ctx):
+async def test_wait_for_ci_omits_head_sha_when_git_fails(tool_ctx_kitchen_open):
     """wait_for_ci result omits head_sha when git rev-parse fails."""
     watcher = InMemoryCIWatcher(
         wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = watcher
-    tool_ctx.runner.push(
+    tool_ctx_kitchen_open.ci_watcher = watcher
+    tool_ctx_kitchen_open.runner.push(
         SubprocessResult(
             returncode=128,
             stdout="",
@@ -668,7 +670,7 @@ async def test_wait_for_ci_omits_head_sha_when_git_fails(tool_ctx):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("pr_state", list(PRState))
-async def test_wait_for_merge_queue_serializes_every_pr_state(pr_state, tool_ctx):
+async def test_wait_for_merge_queue_serializes_every_pr_state(pr_state, tool_ctx_kitchen_open):
     """Every PRState value round-trips faithfully through the MCP handler.
 
     Adding a new PRState member without a handler test fails this parametrized suite.
@@ -680,7 +682,7 @@ async def test_wait_for_merge_queue_serializes_every_pr_state(pr_state, tool_ctx
             "reason": f"test reason for {pr_state.value}",
         }
     )
-    tool_ctx.merge_queue_watcher = watcher
+    tool_ctx_kitchen_open.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -724,13 +726,13 @@ def test_pr_state_docstring_documents_all_members():
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_exception_returns_conclusion_key(tool_ctx, monkeypatch):
+async def test_wait_for_ci_exception_returns_conclusion_key(tool_ctx_kitchen_open, monkeypatch):
     """Inner exception path must return conclusion='error' for recipe on_result routing."""
 
     async def _exploding_wait(*a, **kw):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(tool_ctx.ci_watcher, "wait", _exploding_wait)
+    monkeypatch.setattr(tool_ctx_kitchen_open.ci_watcher, "wait", _exploding_wait)
     raw = await wait_for_ci(branch="main", cwd="/tmp")
     result = json.loads(raw)
     assert "conclusion" in result, "Exception path must include conclusion key"

--- a/tests/server/test_tools_ci_enqueue.py
+++ b/tests/server/test_tools_ci_enqueue.py
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.anyio
-async def test_enqueue_pr_delegates_to_watcher_enqueue(tool_ctx):
+async def test_enqueue_pr_delegates_to_watcher_enqueue(tool_ctx_kitchen_open):
     """enqueue_pr tool passes auto_merge_available to watcher.enqueue()."""
     watcher = InMemoryMergeQueueWatcher(
         enqueue_result={
@@ -22,7 +22,7 @@ async def test_enqueue_pr_delegates_to_watcher_enqueue(tool_ctx):
             "enrollment_method": "direct_enqueue",
         },
     )
-    tool_ctx.merge_queue_watcher = watcher
+    tool_ctx_kitchen_open.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.server.tools.tools_ci_merge_queue.resolve_repo_from_remote",
@@ -46,9 +46,9 @@ async def test_enqueue_pr_delegates_to_watcher_enqueue(tool_ctx):
 
 
 @pytest.mark.anyio
-async def test_enqueue_pr_returns_structured_error_when_watcher_none(tool_ctx):
+async def test_enqueue_pr_returns_structured_error_when_watcher_none(tool_ctx_kitchen_open):
     """enqueue_pr returns {"success": false} when merge_queue_watcher is None."""
-    tool_ctx.merge_queue_watcher = None
+    tool_ctx_kitchen_open.merge_queue_watcher = None
 
     from autoskillit.server.tools.tools_ci_merge_queue import enqueue_pr
 

--- a/tests/server/test_tools_ci_merge_state.py
+++ b/tests/server/test_tools_ci_merge_state.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.anyio
-async def test_check_repo_merge_state_uses_token_factory(tool_ctx, monkeypatch):
+async def test_check_repo_merge_state_uses_token_factory(tool_ctx_kitchen_open, monkeypatch):
     """check_repo_merge_state calls token_factory() when set, not config.github.token."""
     resolved_calls = []
 
@@ -27,8 +27,8 @@ async def test_check_repo_merge_state_uses_token_factory(tool_ctx, monkeypatch):
         resolved_calls.append(1)
         return "factory-token"
 
-    tool_ctx.token_factory = factory
-    tool_ctx.config.github.token = "config-token"
+    tool_ctx_kitchen_open.token_factory = factory
+    tool_ctx_kitchen_open.config.github.token = "config-token"
 
     captured_tokens = []
 
@@ -54,11 +54,11 @@ async def test_check_repo_merge_state_uses_token_factory(tool_ctx, monkeypatch):
 
 @pytest.mark.anyio
 async def test_check_repo_merge_state_falls_back_to_config_token_when_no_factory(
-    tool_ctx, monkeypatch
+    tool_ctx_kitchen_open, monkeypatch
 ):
     """When token_factory is None, config.github.token is used."""
-    tool_ctx.token_factory = None
-    tool_ctx.config.github.token = "config-token"
+    tool_ctx_kitchen_open.token_factory = None
+    tool_ctx_kitchen_open.config.github.token = "config-token"
 
     captured_tokens = []
 
@@ -82,7 +82,9 @@ async def test_check_repo_merge_state_falls_back_to_config_token_when_no_factory
 
 
 @pytest.mark.anyio
-async def test_check_repo_merge_state_error_includes_http_status(tool_ctx, monkeypatch):
+async def test_check_repo_merge_state_error_includes_http_status(
+    tool_ctx_kitchen_open, monkeypatch
+):
     """HTTP error response envelope contains http_status field."""
 
     async def fake_fetch(owner, repo, branch, token):

--- a/tests/server/test_tools_ci_watch.py
+++ b/tests/server/test_tools_ci_watch.py
@@ -14,16 +14,16 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_rejects_invalid_event(tool_ctx) -> None:
-    tool_ctx.ci_watcher = InMemoryCIWatcher()
+async def test_wait_for_ci_rejects_invalid_event(tool_ctx_kitchen_open) -> None:
+    tool_ctx_kitchen_open.ci_watcher = InMemoryCIWatcher()
     result = json.loads(await wait_for_ci("main", event="made_up_event"))
     assert result["conclusion"] == "error"
     assert "event" in result.get("error", "").lower()
 
 
 @pytest.mark.anyio
-async def test_wait_for_ci_coerces_string_none_to_null(tool_ctx) -> None:
-    tool_ctx.ci_watcher = InMemoryCIWatcher(
+async def test_wait_for_ci_coerces_string_none_to_null(tool_ctx_kitchen_open) -> None:
+    tool_ctx_kitchen_open.ci_watcher = InMemoryCIWatcher(
         wait_result={"run_id": 42, "conclusion": "success", "failed_jobs": []}
     )
     result = json.loads(await wait_for_ci("main", event="None"))
@@ -56,34 +56,34 @@ class TestWaitForCiAutoTrigger:
     """wait_for_ci auto_trigger=True: active webhook recovery."""
 
     @pytest.mark.anyio
-    async def test_auto_trigger_default_false_does_not_fire(self, tool_ctx):
+    async def test_auto_trigger_default_false_does_not_fire(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
-        tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(_sub(0, "abc123\n"))
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo"))
 
         assert len(watcher.wait_calls) == 1
-        assert len(tool_ctx.runner.call_args_list) == 1
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 1
         assert result["conclusion"] == "no_runs"
         assert "triggered" not in result
 
     @pytest.mark.anyio
-    async def test_auto_trigger_fires_on_no_runs(self, tool_ctx):
+    async def test_auto_trigger_fires_on_no_runs(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
-        tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(
             _sub(0, "abc123\n")
         )  # git rev-parse HEAD — wait_for_ci initial HEAD inference
-        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
-        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx_kitchen_open.runner.push(
             _sub(0, "def456\n")
         )  # git rev-parse HEAD — new HEAD after empty commit
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
             _sub(0, "https://github.com/org/repo\n")
         )  # git remote get-url upstream
-        tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git push --force-with-lease
 
         result = json.loads(await wait_for_ci("feature-branch", cwd="/repo", auto_trigger=True))
 
@@ -94,11 +94,11 @@ class TestWaitForCiAutoTrigger:
         assert result["head_sha"] == "def456"
 
     @pytest.mark.anyio
-    async def test_auto_trigger_skips_on_conflicting_pr(self, tool_ctx):
+    async def test_auto_trigger_skips_on_conflicting_pr(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
-        tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx.runner.push(_sub(0, '{"mergeable":"CONFLICTING"}\n'))  # gh pr view
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"CONFLICTING"}\n'))  # gh pr view
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
 
@@ -109,11 +109,11 @@ class TestWaitForCiAutoTrigger:
         assert result["failed_jobs"] == []
 
     @pytest.mark.anyio
-    async def test_auto_trigger_returns_gh_view_failed_on_gh_failure(self, tool_ctx):
+    async def test_auto_trigger_returns_gh_view_failed_on_gh_failure(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
-        tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD (initial)
-        tool_ctx.runner.push(_sub(1))  # gh pr view — CLI failure (no PR)
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD (initial)
+        tool_ctx_kitchen_open.runner.push(_sub(1))  # gh pr view — CLI failure (no PR)
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
 
@@ -122,12 +122,12 @@ class TestWaitForCiAutoTrigger:
         assert result["triggered"] is False
 
     @pytest.mark.anyio
-    async def test_auto_trigger_commit_failure_returns_no_runs(self, tool_ctx):
+    async def test_auto_trigger_commit_failure_returns_no_runs(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
-        tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx_kitchen_open.runner.push(
             _sub(128, stderr="error: pre-commit hook rejected commit")
         )  # git commit fails
 
@@ -138,22 +138,24 @@ class TestWaitForCiAutoTrigger:
         assert "triggered" not in result
 
     @pytest.mark.anyio
-    async def test_auto_trigger_push_failure_returns_no_runs(self, tool_ctx):
+    async def test_auto_trigger_push_failure_returns_no_runs(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
-        tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
-        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
-        tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx_kitchen_open.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
+        tool_ctx_kitchen_open.runner.push(
             _sub(0, "https://github.com/org/repo\n")
         )  # git remote get-url upstream
-        tool_ctx.runner.push(_sub(1, stderr="error: remote rejected"))  # git push fails
-        tool_ctx.runner.push(_sub(0))  # git reset --soft HEAD~1 (cleanup)
+        tool_ctx_kitchen_open.runner.push(
+            _sub(1, stderr="error: remote rejected")
+        )  # git push fails
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git reset --soft HEAD~1 (cleanup)
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
 
-        reset_cmd = tool_ctx.runner.call_args_list[-1][0]
+        reset_cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         assert reset_cmd == ["git", "reset", "--soft", "HEAD~1"], (
             f"Expected reset, got: {reset_cmd}"
         )
@@ -162,7 +164,9 @@ class TestWaitForCiAutoTrigger:
         assert "triggered" not in result
 
     @pytest.mark.anyio
-    async def test_auto_trigger_ci_poll_exception_returns_auto_trigger_failed(self, tool_ctx):
+    async def test_auto_trigger_ci_poll_exception_returns_auto_trigger_failed(
+        self, tool_ctx_kitchen_open
+    ):
         call_count_holder = [0]
 
         def poll_raises_on_second_call() -> dict:
@@ -173,19 +177,19 @@ class TestWaitForCiAutoTrigger:
 
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         watcher.wait_side_effect = poll_raises_on_second_call
-        tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(
             _sub(0, "abc123\n")
         )  # git rev-parse HEAD — wait_for_ci initial HEAD inference
-        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
-        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx_kitchen_open.runner.push(
             _sub(0, "def456\n")
         )  # git rev-parse HEAD — new HEAD after empty commit
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
             _sub(0, "https://github.com/org/repo\n")
         )  # git remote get-url upstream
-        tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git push --force-with-lease
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
 
@@ -194,18 +198,18 @@ class TestWaitForCiAutoTrigger:
         assert result["triggered"] is False
 
     @pytest.mark.anyio
-    async def test_auto_trigger_ci_forwards_lookback_seconds(self, tool_ctx):
+    async def test_auto_trigger_ci_forwards_lookback_seconds(self, tool_ctx_kitchen_open):
         """The second wait() call in _auto_trigger_ci must forward lookback_seconds."""
         watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
-        tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
-        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
-        tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD — new HEAD
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx_kitchen_open.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD — new HEAD
+        tool_ctx_kitchen_open.runner.push(
             _sub(0, "https://github.com/org/repo\n")
         )  # git remote get-url upstream
-        tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git push --force-with-lease
 
         await wait_for_ci("branch", cwd="/repo", auto_trigger=True, lookback_seconds=7200)
 

--- a/tests/server/test_tools_clone.py
+++ b/tests/server/test_tools_clone.py
@@ -28,51 +28,51 @@ class TestCloneRepoTool:
         assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
-    async def test_delegates_to_workspace_clone(self, tool_ctx):
+    async def test_delegates_to_workspace_clone(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {"clone_path": "/clone/path", "source_dir": "/src"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(await clone_repo(source_dir="/src", run_name="myrun"))
         assert result["clone_path"] == "/clone/path"
         assert result["source_dir"] == "/src"
 
     @pytest.mark.anyio
-    async def test_returns_error_on_value_error(self, tool_ctx):
+    async def test_returns_error_on_value_error(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.side_effect = ValueError("resolved to nonexistent")
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(await clone_repo(source_dir="/bad/path", run_name="run"))
         assert "error" in result
         assert "resolved to" in result["error"]
 
     @pytest.mark.anyio
-    async def test_returns_error_on_runtime_error(self, tool_ctx):
+    async def test_returns_error_on_runtime_error(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.side_effect = RuntimeError("git clone failed")
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(await clone_repo(source_dir="/src", run_name="run"))
         assert "error" in result
 
     @pytest.mark.anyio
-    async def test_cb17_forwards_branch_to_clone_manager(self, tool_ctx):
+    async def test_cb17_forwards_branch_to_clone_manager(self, tool_ctx_kitchen_open):
         """T_CB17: branch param is forwarded to the underlying clone_repo call."""
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {"clone_path": "/clone/path", "source_dir": "/src"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         await clone_repo(source_dir="/src", run_name="r", branch="dev")
         mock_mgr.clone_repo.assert_called_once_with("/src", "r", "dev", "", "")
 
     @pytest.mark.anyio
-    async def test_cb18_forwards_strategy_to_clone_manager(self, tool_ctx):
+    async def test_cb18_forwards_strategy_to_clone_manager(self, tool_ctx_kitchen_open):
         """T_CB18: strategy param is forwarded to the underlying clone_repo call."""
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {"clone_path": "/clone/path", "source_dir": "/src"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         await clone_repo(source_dir="/src", run_name="r", strategy="proceed")
         mock_mgr.clone_repo.assert_called_once_with("/src", "r", "", "proceed", "")
 
     @pytest.mark.anyio
-    async def test_ru3_forwards_remote_url_to_clone_manager(self, tool_ctx):
+    async def test_ru3_forwards_remote_url_to_clone_manager(self, tool_ctx_kitchen_open):
         """T_RU3: remote_url param is forwarded to the underlying clone_repo call."""
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {
@@ -80,7 +80,7 @@ class TestCloneRepoTool:
             "source_dir": "/src",
             "remote_url": "https://github.com/example/repo.git",
         }
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await clone_repo(
                 source_dir="/src",
@@ -94,7 +94,7 @@ class TestCloneRepoTool:
         assert result["remote_url"] == "https://github.com/example/repo.git"
 
     @pytest.mark.anyio
-    async def test_cb19_returns_uncommitted_changes_result_as_json(self, tool_ctx):
+    async def test_cb19_returns_uncommitted_changes_result_as_json(self, tool_ctx_kitchen_open):
         """T_CB19: uncommitted_changes warning dict passes through without 'error' key."""
         uncommitted_result = {
             "uncommitted_changes": "true",
@@ -105,7 +105,7 @@ class TestCloneRepoTool:
         }
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = uncommitted_result
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(await clone_repo(source_dir="/src", run_name="r"))
         assert result["uncommitted_changes"] == "true"
         assert "error" not in result
@@ -119,18 +119,18 @@ class TestRemoveCloneTool:
         assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
-    async def test_delegates_to_workspace_clone(self, tool_ctx):
+    async def test_delegates_to_workspace_clone(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(await remove_clone(clone_path="/clone/path", keep="false"))
         assert result["removed"] == "true"
 
     @pytest.mark.anyio
-    async def test_keep_true_passes_through(self, tool_ctx):
+    async def test_keep_true_passes_through(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "false", "reason": "keep=true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(await remove_clone(clone_path="/clone/path", keep="true"))
         assert result["removed"] == "false"
 
@@ -151,10 +151,10 @@ class TestPushToRemoteTool:
         assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
-    async def test_delegates_to_workspace_clone_on_success(self, tool_ctx):
+    async def test_delegates_to_workspace_clone_on_success(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": "true", "stderr": ""}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await push_to_remote(clone_path="/clone", source_dir="/src", branch="main")
         )
@@ -162,10 +162,10 @@ class TestPushToRemoteTool:
         assert "error" not in result
 
     @pytest.mark.anyio
-    async def test_returns_error_key_when_push_fails(self, tool_ctx):
+    async def test_returns_error_key_when_push_fails(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": False, "stderr": "remote rejected"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await push_to_remote(clone_path="/clone", source_dir="/src", branch="main")
         )
@@ -173,7 +173,9 @@ class TestPushToRemoteTool:
         assert "remote rejected" in result["stderr"]
 
     @pytest.mark.anyio
-    async def test_push_to_remote_failure_response_includes_success_false(self, tool_ctx):
+    async def test_push_to_remote_failure_response_includes_success_false(
+        self, tool_ctx_kitchen_open
+    ):
         """REQ-C9-01: failure payload must include success=False for on_failure routing."""
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {
@@ -181,7 +183,7 @@ class TestPushToRemoteTool:
             "stderr": "remote rejected",
             "error_type": "push_rejected",
         }
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         result = json.loads(
             await push_to_remote(clone_path="/clone", source_dir="/src", branch="main")
         )
@@ -189,21 +191,23 @@ class TestPushToRemoteTool:
         assert "error" in result
 
     @pytest.mark.anyio
-    async def test_push_to_remote_mcp_handler_passes_force_true_to_clone_mgr(self, tool_ctx):
+    async def test_push_to_remote_mcp_handler_passes_force_true_to_clone_mgr(
+        self, tool_ctx_kitchen_open
+    ):
         """T3: push_to_remote MCP handler converts force='true' to bool True for clone_mgr."""
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": True, "stderr": ""}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         await push_to_remote(clone_path="/clone", source_dir="/src", branch="main", force="true")
         _args, kwargs = mock_mgr.push_to_remote.call_args
         assert kwargs.get("force") is True
 
     @pytest.mark.anyio
-    async def test_push_to_remote_mcp_handler_default_force_false(self, tool_ctx):
+    async def test_push_to_remote_mcp_handler_default_force_false(self, tool_ctx_kitchen_open):
         """T4: push_to_remote MCP handler defaults to force=False when not supplied."""
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": True, "stderr": ""}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         await push_to_remote(clone_path="/clone", source_dir="/src", branch="main")
         _args, kwargs = mock_mgr.push_to_remote.call_args
         assert kwargs.get("force") is False
@@ -213,12 +217,12 @@ class TestCloneRepoTiming:
     """clone_repo records wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_clone_repo_step_name_records_timing(self, tool_ctx):
+    async def test_clone_repo_step_name_records_timing(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.clone_repo.return_value = {"clone_path": "/clone", "source_dir": "/src"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         await clone_repo(source_dir="/src", run_name="test", step_name="clone")
-        report = tool_ctx.timing_log.get_report()
+        report = tool_ctx_kitchen_open.timing_log.get_report()
         assert any(e["step_name"] == "clone" for e in report)
 
     @pytest.mark.anyio
@@ -234,12 +238,12 @@ class TestRemoveCloneTiming:
     """remove_clone records wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_remove_clone_step_name_records_timing(self, tool_ctx):
+    async def test_remove_clone_step_name_records_timing(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         await remove_clone(clone_path="/clone", step_name="cleanup")
-        report = tool_ctx.timing_log.get_report()
+        report = tool_ctx_kitchen_open.timing_log.get_report()
         assert any(e["step_name"] == "cleanup" for e in report)
 
     @pytest.mark.anyio
@@ -255,12 +259,12 @@ class TestPushToRemoteTiming:
     """push_to_remote records wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_push_to_remote_step_name_records_timing(self, tool_ctx):
+    async def test_push_to_remote_step_name_records_timing(self, tool_ctx_kitchen_open):
         mock_mgr = MagicMock()
         mock_mgr.push_to_remote.return_value = {"success": "true", "stderr": ""}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
         await push_to_remote(clone_path="/clone", branch="main", step_name="push")
-        report = tool_ctx.timing_log.get_report()
+        report = tool_ctx_kitchen_open.timing_log.get_report()
         assert any(e["step_name"] == "push" for e in report)
 
     @pytest.mark.anyio
@@ -274,9 +278,9 @@ class TestPushToRemoteTiming:
 
 class TestRegisterCloneStatusTool:
     @pytest.mark.anyio
-    async def test_register_clone_status_success(self, tool_ctx, tmp_path):
+    async def test_register_clone_status_success(self, tool_ctx_kitchen_open, tmp_path):
         """register_clone_status status='success' writes registry and returns registered=true."""
-        tool_ctx.kitchen_id = "kit-test"
+        tool_ctx_kitchen_open.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         result = json.loads(
             await register_clone_status(
@@ -289,9 +293,9 @@ class TestRegisterCloneStatusTool:
         assert "registry_path" in result
 
     @pytest.mark.anyio
-    async def test_register_clone_status_error(self, tool_ctx, tmp_path):
+    async def test_register_clone_status_error(self, tool_ctx_kitchen_open, tmp_path):
         """register_clone_status status='error' writes registry and returns registered=true."""
-        tool_ctx.kitchen_id = "kit-test"
+        tool_ctx_kitchen_open.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         result = json.loads(
             await register_clone_status(
@@ -304,7 +308,7 @@ class TestRegisterCloneStatusTool:
         assert "registry_path" in result
 
     @pytest.mark.anyio
-    async def test_register_clone_status_invalid_status(self, tool_ctx, tmp_path):
+    async def test_register_clone_status_invalid_status(self, tool_ctx_kitchen_open, tmp_path):
         """register_clone_status with status='invalid' returns error without writing."""
         registry_path = str(tmp_path / "registry.json")
         result = json.loads(
@@ -320,9 +324,11 @@ class TestRegisterCloneStatusTool:
         assert not (tmp_path / "registry.json").exists()
 
     @pytest.mark.anyio
-    async def test_register_clone_status_unconfirmed_accepted(self, tool_ctx, tmp_path):
+    async def test_register_clone_status_unconfirmed_accepted(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """status='unconfirmed' is accepted: writes registry entry, returns registered=true."""
-        tool_ctx.kitchen_id = "kit-test"
+        tool_ctx_kitchen_open.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         result = json.loads(
             await register_clone_status(
@@ -340,9 +346,11 @@ class TestRegisterCloneStatusTool:
 
 class TestBatchCleanupClonesTool:
     @pytest.mark.anyio
-    async def test_batch_cleanup_clones_deletes_success_preserves_error(self, tool_ctx, tmp_path):
+    async def test_batch_cleanup_clones_deletes_success_preserves_error(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """batch_cleanup_clones removes success clones, skips error clones."""
-        tool_ctx.kitchen_id = "kit-test"
+        tool_ctx_kitchen_open.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         success_path = str(tmp_path / "success_clone")
         error_path = str(tmp_path / "error_clone")
@@ -354,7 +362,7 @@ class TestBatchCleanupClonesTool:
         # Mock clone_mgr so remove_clone reports success for the success clone
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=registry_path))
 
@@ -364,17 +372,19 @@ class TestBatchCleanupClonesTool:
         mock_mgr.remove_clone.assert_called_once_with(success_path, "false")
 
     @pytest.mark.anyio
-    async def test_batch_cleanup_clones_empty_registry(self, tool_ctx, tmp_path):
+    async def test_batch_cleanup_clones_empty_registry(self, tool_ctx_kitchen_open, tmp_path):
         """batch_cleanup_clones with missing registry returns deleted=[], preserved=[]."""
-        tool_ctx.kitchen_id = "kit-test"
+        tool_ctx_kitchen_open.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "nonexistent.json")
         result = json.loads(await batch_cleanup_clones(registry_path=registry_path))
         assert result == {"deleted": [], "delete_failures": [], "preserved": []}
 
     @pytest.mark.anyio
-    async def test_batch_cleanup_clones_nonexistent_path_does_not_raise(self, tool_ctx, tmp_path):
+    async def test_batch_cleanup_clones_nonexistent_path_does_not_raise(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """batch_cleanup_clones reports failure gracefully when a success clone path is gone."""
-        tool_ctx.kitchen_id = "kit-test"
+        tool_ctx_kitchen_open.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         missing_path = str(tmp_path / "gone_clone")
 
@@ -384,7 +394,7 @@ class TestBatchCleanupClonesTool:
         # Mock clone_mgr to report removal failure (path not found)
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "false", "reason": "not found"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=registry_path))
 
@@ -403,9 +413,11 @@ class TestRegisterCloneStatusOwner:
     """T12–T13: register_clone_status propagates kitchen_id as owner."""
 
     @pytest.mark.anyio
-    async def test_register_clone_status_propagates_kitchen_id_as_owner(self, tool_ctx, tmp_path):
+    async def test_register_clone_status_propagates_kitchen_id_as_owner(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """T12 — register_clone_status writes entry with owner == kitchen_id."""
-        tool_ctx.kitchen_id = "kit-xyz"
+        tool_ctx_kitchen_open.kitchen_id = "kit-xyz"
         reg = str(tmp_path / "registry.json")
         result = json.loads(
             await register_clone_status(clone_path="/c", status="success", registry_path=reg)
@@ -417,9 +429,11 @@ class TestRegisterCloneStatusOwner:
         assert data["clones"][0]["owner"] == "kit-xyz"
 
     @pytest.mark.anyio
-    async def test_register_clone_status_rejects_when_kitchen_id_empty(self, tool_ctx, tmp_path):
+    async def test_register_clone_status_rejects_when_kitchen_id_empty(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """T13 — register_clone_status returns registered=false when kitchen_id is empty."""
-        tool_ctx.kitchen_id = ""
+        tool_ctx_kitchen_open.kitchen_id = ""
         reg = str(tmp_path / "registry.json")
         result = json.loads(
             await register_clone_status(clone_path="/c", status="success", registry_path=reg)
@@ -434,17 +448,17 @@ class TestBatchCleanupClonesOwner:
 
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_default_scopes_to_current_kitchen_id(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """T14 — default call only removes current kitchen's clones."""
         reg = str(tmp_path / "registry.json")
         clone_registry.register_clone("/clone-A", "success", "kit-A", reg)
         clone_registry.register_clone("/clone-B", "success", "kit-B", reg)
 
-        tool_ctx.kitchen_id = "kit-A"
+        tool_ctx_kitchen_open.kitchen_id = "kit-A"
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=reg))
 
@@ -454,17 +468,17 @@ class TestBatchCleanupClonesOwner:
 
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_all_owners_true_removes_every_success(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """T15 — all_owners='true' escape hatch removes all success entries."""
         reg = str(tmp_path / "registry.json")
         clone_registry.register_clone("/clone-A", "success", "kit-A", reg)
         clone_registry.register_clone("/clone-B", "success", "kit-B", reg)
 
-        tool_ctx.kitchen_id = "kit-A"
+        tool_ctx_kitchen_open.kitchen_id = "kit-A"
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=reg, all_owners="true"))
 
@@ -474,13 +488,13 @@ class TestBatchCleanupClonesOwner:
 
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_empty_kitchen_id_and_all_owners_false_returns_error(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """T16 — empty kitchen_id with default all_owners='false' returns error."""
-        tool_ctx.kitchen_id = ""
+        tool_ctx_kitchen_open.kitchen_id = ""
         reg = str(tmp_path / "registry.json")
         mock_mgr = MagicMock()
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=reg))
 
@@ -490,17 +504,17 @@ class TestBatchCleanupClonesOwner:
 
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_empty_kitchen_id_with_all_owners_true_succeeds(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """T17 — escape hatch works even when kitchen_id is empty (legacy recovery)."""
 
         reg_path = tmp_path / "registry.json"
         reg_path.write_text(json.dumps({"clones": [{"path": "/legacy", "status": "success"}]}))
 
-        tool_ctx.kitchen_id = ""
+        tool_ctx_kitchen_open.kitchen_id = ""
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(
             await batch_cleanup_clones(registry_path=str(reg_path), all_owners="true")
@@ -511,17 +525,17 @@ class TestBatchCleanupClonesOwner:
 
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_invalid_all_owners_literal_treated_as_false(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """T18 — all_owners='yes' is not the escape hatch; scoped behaviour applies."""
         reg = str(tmp_path / "registry.json")
         clone_registry.register_clone("/clone-A", "success", "kit-A", reg)
         clone_registry.register_clone("/clone-B", "success", "kit-B", reg)
 
-        tool_ctx.kitchen_id = "kit-A"
+        tool_ctx_kitchen_open.kitchen_id = "kit-A"
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=reg, all_owners="yes"))
 
@@ -529,7 +543,9 @@ class TestBatchCleanupClonesOwner:
         assert "/clone-B" not in result["deleted"]
 
     @pytest.mark.anyio
-    async def test_two_kitchens_register_and_cleanup_isolated(self, tool_ctx, tmp_path):
+    async def test_two_kitchens_register_and_cleanup_isolated(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """T19 — kitchen A's cleanup does not touch kitchen B's registry entry."""
         reg = str(tmp_path / "registry.json")
 
@@ -539,10 +555,10 @@ class TestBatchCleanupClonesOwner:
         clone_registry.register_clone("/clone-2", "success", "kit-2", reg)
 
         # Session 1 cleans up via the MCP tool
-        tool_ctx.kitchen_id = "kit-1"
+        tool_ctx_kitchen_open.kitchen_id = "kit-1"
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=reg))
 
@@ -563,11 +579,11 @@ class TestRegisterCloneStatusCampaignPreference:
 
     @pytest.mark.anyio
     async def test_register_clone_status_prefers_campaign_id_over_kitchen_id(
-        self, tool_ctx, tmp_path, monkeypatch: pytest.MonkeyPatch
+        self, tool_ctx_kitchen_open, tmp_path, monkeypatch: pytest.MonkeyPatch
     ):
-        """T26 — CAMPAIGN_ID env var takes precedence over tool_ctx.kitchen_id."""
+        """T26 — CAMPAIGN_ID env var takes precedence over tool_ctx_kitchen_open.kitchen_id."""
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_ID", "camp-x")
-        tool_ctx.kitchen_id = "kit-y"
+        tool_ctx_kitchen_open.kitchen_id = "kit-y"
         reg = str(tmp_path / "registry.json")
 
         result = json.loads(
@@ -580,11 +596,11 @@ class TestRegisterCloneStatusCampaignPreference:
 
     @pytest.mark.anyio
     async def test_register_clone_status_falls_back_to_kitchen_id_without_campaign_id(
-        self, tool_ctx, tmp_path, monkeypatch: pytest.MonkeyPatch
+        self, tool_ctx_kitchen_open, tmp_path, monkeypatch: pytest.MonkeyPatch
     ):
-        """T27 — Falls back to tool_ctx.kitchen_id when CAMPAIGN_ID is not set."""
+        """T27 — Falls back to tool_ctx_kitchen_open.kitchen_id when CAMPAIGN_ID is not set."""
         monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
-        tool_ctx.kitchen_id = "kit-fallback"
+        tool_ctx_kitchen_open.kitchen_id = "kit-fallback"
         reg = str(tmp_path / "registry.json")
 
         result = json.loads(
@@ -601,17 +617,17 @@ class TestBatchCleanupClonesOwnerFilter:
 
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_owner_filter_scopes_to_specified_owner(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """T28 — owner_filter='camp-A' removes only camp-A's clones regardless of kitchen_id."""
         reg = str(tmp_path / "registry.json")
         clone_registry.register_clone("/clone-a", "success", "camp-A", reg)
         clone_registry.register_clone("/clone-b", "success", "camp-B", reg)
 
-        tool_ctx.kitchen_id = "kit-x"
+        tool_ctx_kitchen_open.kitchen_id = "kit-x"
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=reg, owner_filter="camp-A"))
 
@@ -621,17 +637,17 @@ class TestBatchCleanupClonesOwnerFilter:
 
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_owner_filter_empty_falls_back_to_kitchen_id(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """T29 — owner_filter='' falls back to kitchen_id (backward compatible)."""
         reg = str(tmp_path / "registry.json")
         clone_registry.register_clone("/clone-a", "success", "kit-x", reg)
         clone_registry.register_clone("/clone-b", "success", "kit-y", reg)
 
-        tool_ctx.kitchen_id = "kit-x"
+        tool_ctx_kitchen_open.kitchen_id = "kit-x"
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(await batch_cleanup_clones(registry_path=reg, owner_filter=""))
 
@@ -640,17 +656,17 @@ class TestBatchCleanupClonesOwnerFilter:
 
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_owner_filter_with_all_owners_true_ignores_filter(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """T30 — owner_filter='camp-A' + all_owners='true' → all_owners takes precedence."""
         reg = str(tmp_path / "registry.json")
         clone_registry.register_clone("/clone-a", "success", "camp-A", reg)
         clone_registry.register_clone("/clone-b", "success", "camp-B", reg)
 
-        tool_ctx.kitchen_id = "kit-x"
+        tool_ctx_kitchen_open.kitchen_id = "kit-x"
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
-        tool_ctx.clone_mgr = mock_mgr
+        tool_ctx_kitchen_open.clone_mgr = mock_mgr
 
         result = json.loads(
             await batch_cleanup_clones(registry_path=reg, owner_filter="camp-A", all_owners="true")

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -47,7 +47,9 @@ async def _noop_quota_refresher(config, **kwargs) -> None:
 
 class TestDispatchFoodTruckGates:
     @pytest.mark.anyio
-    async def test_dispatch_food_truck_hard_refusal_headless(self, tool_ctx, monkeypatch):
+    async def test_dispatch_food_truck_hard_refusal_headless(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """AUTOSKILLIT_HEADLESS=1 → fleet_hard_refusal_headless, regardless of SESSION_TYPE."""
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
@@ -57,7 +59,9 @@ class TestDispatchFoodTruckGates:
         assert result["subtype"] == "headless_error"
 
     @pytest.mark.anyio
-    async def test_dispatch_food_truck_requires_fleet_session_type(self, tool_ctx, monkeypatch):
+    async def test_dispatch_food_truck_requires_fleet_session_type(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """Non-fleet session type → headless_error, even for interactive callers."""
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
         monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
@@ -107,7 +111,7 @@ class TestDispatchFoodTruckGates:
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_refuses_when_fleet_feature_disabled(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ):
         """features.fleet: false in config → fleet_feature_disabled, regardless of gate state."""
         import dataclasses
@@ -118,7 +122,9 @@ class TestDispatchFoodTruckGates:
         # Gate is open (fleet session already booted), env var absent
         # Only config file has fleet disabled
         monkeypatch.delenv("AUTOSKILLIT_FEATURES__FLEET", raising=False)
-        tool_ctx.config = dataclasses.replace(tool_ctx.config, features={"fleet": False})
+        tool_ctx_kitchen_open.config = dataclasses.replace(
+            tool_ctx_kitchen_open.config, features={"fleet": False}
+        )
 
         result = json.loads(await dispatch_food_truck(recipe="r", task="t"))
         assert result["success"] is False
@@ -724,20 +730,20 @@ class TestDispatchFoodTruckExecution:
 
 @pytest.mark.anyio
 async def test_dispatch_food_truck_tool_passes_resume_session_id_to_executor(
-    tool_ctx, monkeypatch
+    tool_ctx_kitchen_open, monkeypatch
 ):
     """dispatch_food_truck MCP tool forwards resume_session_id all the way to the executor."""
     from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-    tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+    tool_ctx_kitchen_open.fleet_lock = FleetSemaphore(max_concurrent=1)
     repo = InMemoryRecipeRepository()
     recipe_info = _make_recipe_info("test-recipe")
     repo.add_recipe("test-recipe", recipe_info)
     repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe"))
-    tool_ctx.recipes = repo
+    tool_ctx_kitchen_open.recipes = repo
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
+    tool_ctx_kitchen_open.executor = executor
 
     await dispatch_food_truck(
         recipe="test-recipe",
@@ -812,12 +818,12 @@ class TestDispatchFoodTruckIdleTimeout:
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_passes_idle_output_timeout_to_executor(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ):
         """dispatch_food_truck MCP tool forwards idle_output_timeout to executor."""
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
-        self._setup_dispatch(tool_ctx)
+        self._setup_dispatch(tool_ctx_kitchen_open)
 
         await dispatch_food_truck(
             recipe="test-recipe",
@@ -825,38 +831,38 @@ class TestDispatchFoodTruckIdleTimeout:
             idle_output_timeout=0,
         )
 
-        executor = tool_ctx.executor
+        executor = tool_ctx_kitchen_open.executor
         assert executor.dispatch_calls, "dispatch_food_truck executor was never called"
         assert executor.dispatch_calls[0].idle_output_timeout == 0.0
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_idle_timeout_none_when_not_specified(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ):
         """When idle_output_timeout is not specified, executor receives None."""
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
-        self._setup_dispatch(tool_ctx)
+        self._setup_dispatch(tool_ctx_kitchen_open)
 
         await dispatch_food_truck(
             recipe="test-recipe",
             task="do-work",
         )
 
-        executor = tool_ctx.executor
+        executor = tool_ctx_kitchen_open.executor
         assert executor.dispatch_calls, "dispatch_food_truck executor was never called"
         assert executor.dispatch_calls[0].idle_output_timeout is None
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_idle_timeout_overrides_config_default(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ):
         """Explicit idle_output_timeout=0 overrides the config default of 1000."""
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
-        self._setup_dispatch(tool_ctx)
+        self._setup_dispatch(tool_ctx_kitchen_open)
         # Config idle_output_timeout is 1000 (default from RunSkillConfig)
-        assert tool_ctx.config.run_skill.idle_output_timeout == 1000
+        assert tool_ctx_kitchen_open.config.run_skill.idle_output_timeout == 1000
 
         await dispatch_food_truck(
             recipe="test-recipe",
@@ -864,7 +870,7 @@ class TestDispatchFoodTruckIdleTimeout:
             idle_output_timeout=0,
         )
 
-        executor = tool_ctx.executor
+        executor = tool_ctx_kitchen_open.executor
         assert executor.dispatch_calls, "dispatch_food_truck executor was never called"
         # Executor receives 0.0, overriding the config default
         assert executor.dispatch_calls[0].idle_output_timeout == 0.0

--- a/tests/server/test_tools_dispatch_halt.py
+++ b/tests/server/test_tools_dispatch_halt.py
@@ -41,7 +41,7 @@ class TestDispatchFoodTruckHaltEnforcement:
 
     @pytest.mark.anyio
     async def test_dispatch_refuses_after_failure_when_halt_enabled(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """Prior FAILURE + continue_on_failure=false → FLEET_CAMPAIGN_HALTED."""
         state_path = tmp_path / "state.json"
@@ -57,7 +57,7 @@ class TestDispatchFoodTruckHaltEnforcement:
 
     @pytest.mark.anyio
     async def test_dispatch_proceeds_after_failure_when_continue_enabled(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """dispatch_food_truck proceeds when continue_on_failure=true even with prior failure."""
         state_path = tmp_path / "state.json"
@@ -65,18 +65,20 @@ class TestDispatchFoodTruckHaltEnforcement:
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(state_path))
         monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "true")
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
         assert "dispatch_id" in result
 
     @pytest.mark.anyio
-    async def test_dispatch_proceeds_when_no_campaign_state_path(self, tool_ctx, monkeypatch):
+    async def test_dispatch_proceeds_when_no_campaign_state_path(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """Without AUTOSKILLIT_CAMPAIGN_STATE_PATH, halt check is skipped."""
         monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", raising=False)
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
@@ -84,7 +86,7 @@ class TestDispatchFoodTruckHaltEnforcement:
 
     @pytest.mark.anyio
     async def test_dispatch_proceeds_when_no_failures_in_state(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """dispatch_food_truck proceeds when all prior dispatches are SUCCESS."""
         state_path = tmp_path / "state.json"
@@ -92,7 +94,7 @@ class TestDispatchFoodTruckHaltEnforcement:
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(state_path))
         monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
@@ -100,13 +102,13 @@ class TestDispatchFoodTruckHaltEnforcement:
 
     @pytest.mark.anyio
     async def test_dispatch_proceeds_when_state_file_missing(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """If state file doesn't exist, halt check is skipped (fail-open)."""
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(tmp_path / "nonexistent.json"))
         monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
@@ -114,7 +116,7 @@ class TestDispatchFoodTruckHaltEnforcement:
 
     @pytest.mark.anyio
     async def test_campaign_state_write_uses_envelope_dispatch_status(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """Campaign-state write reads dispatch_status from envelope, not success flag.
 
@@ -151,7 +153,7 @@ class TestDispatchFoodTruckHaltEnforcement:
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         await dispatch_food_truck(recipe="test-recipe", task="t", dispatch_name="d1")
 
         state = read_state(state_path)
@@ -167,7 +169,7 @@ class TestDispatchFoodTruckHaltEnforcement:
 
     @pytest.mark.anyio
     async def test_no_result_block_failure_does_not_halt_campaign(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """dispatch_food_truck proceeds when prior FAILURE has fleet_l3_no_result_block reason."""
         state_path = tmp_path / "state.json"
@@ -178,7 +180,7 @@ class TestDispatchFoodTruckHaltEnforcement:
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(state_path))
         monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
@@ -202,7 +204,7 @@ class TestDispatchFoodTruckRetryOnFailure:
 
     @pytest.mark.anyio
     async def test_dispatch_resets_and_proceeds_when_retrying_failed_dispatch(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """dispatch_name matches failed dispatch → reset to PENDING, proceed."""
         state_path = tmp_path / "state.json"
@@ -212,7 +214,7 @@ class TestDispatchFoodTruckRetryOnFailure:
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(state_path))
         monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
         result = json.loads(
@@ -222,7 +224,7 @@ class TestDispatchFoodTruckRetryOnFailure:
 
     @pytest.mark.anyio
     async def test_dispatch_halts_when_different_dispatch_has_failure(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """dispatch_name does NOT match failed dispatch → still halts."""
         state_path = tmp_path / "state.json"
@@ -232,7 +234,7 @@ class TestDispatchFoodTruckRetryOnFailure:
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(state_path))
         monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
         result = json.loads(
@@ -243,7 +245,7 @@ class TestDispatchFoodTruckRetryOnFailure:
 
     @pytest.mark.anyio
     async def test_dispatch_halts_when_no_dispatch_name_provided(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
         """No dispatch_name + prior failure → halts (current behavior)."""
         state_path = tmp_path / "state.json"
@@ -253,7 +255,7 @@ class TestDispatchFoodTruckRetryOnFailure:
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(state_path))
         monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
 
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -23,10 +23,10 @@ class TestRunSkillPluginDir:
     """T2: run_skill passes --plugin-dir to the claude command."""
 
     @pytest.mark.anyio
-    async def test_run_skill_passes_plugin_dir(self, tool_ctx):
-        """run_skill includes --plugin-dir and the plugin_dir from tool_ctx in the command."""
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(
+    async def test_run_skill_passes_plugin_dir(self, tool_ctx_kitchen_open):
+        """run_skill includes --plugin-dir and the plugin_dir from tool_ctx_kitchen_open in the command."""
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 '{"type": "result", "subtype": "success", "is_error": false,'
@@ -36,16 +36,16 @@ class TestRunSkillPluginDir:
         )
         await run_skill("/investigate some-error", "/tmp")
 
-        cmd = tool_ctx.runner.call_args_list[-1][0]
+        cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         assert "--plugin-dir" in cmd
         plugin_dir_idx = cmd.index("--plugin-dir")
         from autoskillit.core.types._type_plugin_source import DirectInstall
 
-        assert isinstance(tool_ctx.plugin_source, DirectInstall)
-        assert cmd[plugin_dir_idx + 1] == str(tool_ctx.plugin_source.plugin_dir)
+        assert isinstance(tool_ctx_kitchen_open.plugin_source, DirectInstall)
+        assert cmd[plugin_dir_idx + 1] == str(tool_ctx_kitchen_open.plugin_source.plugin_dir)
         assert "--output-format" in cmd
         assert cmd[cmd.index("--output-format") + 1] == "stream-json"
-        actual_cwd = tool_ctx.runner.call_args_list[-1][1]
+        actual_cwd = tool_ctx_kitchen_open.runner.call_args_list[-1][1]
         assert actual_cwd == Path("/tmp"), f"Subprocess cwd mismatch: {actual_cwd} != /tmp"
 
 
@@ -53,15 +53,15 @@ class TestRunSkillTimeoutFromConfig:
     """run_skill uses configurable timeouts."""
 
     @pytest.mark.anyio
-    async def test_run_skill_timeout_from_config(self, tool_ctx):
+    async def test_run_skill_timeout_from_config(self, tool_ctx_kitchen_open):
         """run_skill uses _config.run_skill.timeout instead of hardcoded value."""
         cfg = AutomationConfig()
         cfg.run_skill = RunSkillConfig(timeout=120)
         cfg.safety.require_dry_walkthrough = False
-        tool_ctx.config = cfg
+        tool_ctx_kitchen_open.config = cfg
 
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 '{"type": "result", "subtype": "success", "is_error": false,'
@@ -71,21 +71,21 @@ class TestRunSkillTimeoutFromConfig:
         )
         await run_skill("/investigate foo", "/tmp")
 
-        assert tool_ctx.runner.call_args_list[-1][2] == 120.0
+        assert tool_ctx_kitchen_open.runner.call_args_list[-1][2] == 120.0
 
 
 class TestRunSkillInjectsCompletionDirective:
     """run_skill injects completion directive into the skill command."""
 
     @pytest.mark.anyio
-    async def test_run_skill_injects_completion_directive(self, tool_ctx):
+    async def test_run_skill_injects_completion_directive(self, tool_ctx_kitchen_open):
         """Skill command passed to claude -p contains the completion marker instruction."""
         cfg = AutomationConfig()
         cfg.safety.require_dry_walkthrough = False
-        tool_ctx.config = cfg
+        tool_ctx_kitchen_open.config = cfg
 
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 '{"type": "result", "subtype": "success", "is_error": false,'
@@ -95,7 +95,7 @@ class TestRunSkillInjectsCompletionDirective:
         )
         await run_skill("/investigate foo", "/tmp")
 
-        cmd = tool_ctx.runner.call_args_list[-1][0]
+        cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         prompt_idx = cmd.index("--print") + 1 if "--print" in cmd else cmd.index("-p") + 1
         skill_arg = cmd[prompt_idx]
         assert "%%ORDER_UP::" in skill_arg
@@ -120,43 +120,43 @@ class TestRunSkillEnvPrefix:
     """run_skill always injects AUTOSKILLIT_HEADLESS=1 and optionally CLAUDE_CODE_EXIT_AFTER_STOP_DELAY via the env kwarg."""  # noqa: E501
 
     @pytest.mark.anyio
-    async def test_default_delay_populates_env(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(0, _SUCCESS_JSON, ""))
+    async def test_default_delay_populates_env(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(0, _SUCCESS_JSON, ""))
         await run_skill("/investigate something", "/tmp")
-        cmd, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[-1]
+        cmd, _cwd, _timeout, kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1]
         assert cmd[0] == "claude"
         env = kwargs["env"]
         assert env["AUTOSKILLIT_HEADLESS"] == "1"
         assert env["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] == "2000"
 
     @pytest.mark.anyio
-    async def test_zero_delay_omits_delay_env_var(self, tool_ctx):
+    async def test_zero_delay_omits_delay_env_var(self, tool_ctx_kitchen_open):
         cfg = AutomationConfig()
         cfg.run_skill = RunSkillConfig(exit_after_stop_delay_ms=0)
         cfg.safety.require_dry_walkthrough = False
-        tool_ctx.config = cfg
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(0, _SUCCESS_JSON, ""))
+        tool_ctx_kitchen_open.config = cfg
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(0, _SUCCESS_JSON, ""))
         await run_skill("/investigate something", "/tmp")
-        cmd, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[-1]
+        cmd, _cwd, _timeout, kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1]
         assert cmd[0] == "claude"
         env = kwargs["env"]
         assert env["AUTOSKILLIT_HEADLESS"] == "1"
         assert "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" not in env
 
     @pytest.mark.anyio
-    async def test_custom_delay_value_in_env(self, tool_ctx):
+    async def test_custom_delay_value_in_env(self, tool_ctx_kitchen_open):
         cfg = AutomationConfig()
         cfg.run_skill = RunSkillConfig(
             exit_after_stop_delay_ms=60000, natural_exit_grace_seconds=61.0
         )
         cfg.safety.require_dry_walkthrough = False
-        tool_ctx.config = cfg
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(0, _SUCCESS_JSON, ""))
+        tool_ctx_kitchen_open.config = cfg
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(0, _SUCCESS_JSON, ""))
         await run_skill("/investigate something", "/tmp")
-        cmd, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[-1]
+        cmd, _cwd, _timeout, kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1]
         assert cmd[0] == "claude"
         env = kwargs["env"]
         assert env["AUTOSKILLIT_HEADLESS"] == "1"
@@ -167,14 +167,14 @@ class TestRunSkillPassesSessionLogDir:
     """run_skill passes session_log_dir derived from cwd."""
 
     @pytest.mark.anyio
-    async def test_run_skill_passes_session_log_dir(self, tool_ctx):
+    async def test_run_skill_passes_session_log_dir(self, tool_ctx_kitchen_open):
         """runner receives session_log_dir derived from cwd."""
         cfg = AutomationConfig()
         cfg.safety.require_dry_walkthrough = False
-        tool_ctx.config = cfg
+        tool_ctx_kitchen_open.config = cfg
 
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 '{"type": "result", "subtype": "success", "is_error": false,'
@@ -184,7 +184,7 @@ class TestRunSkillPassesSessionLogDir:
         )
         await run_skill("/investigate foo", "/some/project")
 
-        call_kwargs = tool_ctx.runner.call_args_list[-1][3]
+        call_kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1][3]
         expected_dir = _session_log_dir("/some/project")
         assert call_kwargs["session_log_dir"] == expected_dir
         assert "-some-project" in str(expected_dir)
@@ -200,22 +200,22 @@ class TestRunSkillModel:
 
     # MOD_S1
     @pytest.mark.anyio
-    async def test_run_skill_passes_model_flag(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(0, self._MOCK_STDOUT, ""))
+    async def test_run_skill_passes_model_flag(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(0, self._MOCK_STDOUT, ""))
         await run_skill("/investigate error", "/tmp", model="sonnet")
-        cmd = tool_ctx.runner.call_args_list[-1][0]
+        cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         assert "--model" in cmd
         assert cmd[cmd.index("--model") + 1] == "sonnet"
 
     # MOD_S3
     @pytest.mark.anyio
-    async def test_run_skill_no_model_flag_when_empty(self, tool_ctx):
-        tool_ctx.config.model.default = ""  # ← add this line
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(0, self._MOCK_STDOUT, ""))
+    async def test_run_skill_no_model_flag_when_empty(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.config.model.default = ""  # ← add this line
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(0, self._MOCK_STDOUT, ""))
         await run_skill("/investigate error", "/tmp", model="")
-        cmd = tool_ctx.runner.call_args_list[-1][0]
+        cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         assert "--model" not in cmd
 
 
@@ -223,21 +223,25 @@ class TestRunSkillPerInvocationMarker:
     """Per-invocation completion markers are unique across run_skill calls."""
 
     @pytest.mark.anyio
-    async def test_run_skill_markers_are_unique_per_invocation(self, tool_ctx):
+    async def test_run_skill_markers_are_unique_per_invocation(self, tool_ctx_kitchen_open):
         """Two run_skill calls must generate different completion_marker values."""
         success_json = (
             '{"type": "result", "subtype": "success", "is_error": false,'
             ' "result": "done", "session_id": "s1"}'
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot call 1
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot call 2
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=1)
+        )  # clone guard snapshot call 1
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=success_json))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=1)
+        )  # clone guard snapshot call 2
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=success_json))
 
         await run_skill("/investigate a", cwd="/tmp")
         await run_skill("/investigate b", cwd="/tmp")
 
-        calls = tool_ctx.runner.call_args_list
+        calls = tool_ctx_kitchen_open.runner.call_args_list
         claude_calls = [c for c in calls if c[0][0] == "claude"]
         assert len(claude_calls) >= 2
         marker1 = claude_calls[0][3]["completion_marker"]

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -123,11 +123,11 @@ class TestRunSkillPrefix:
     """run_skill passes prefixed command to subprocess."""
 
     @pytest.mark.anyio
-    async def test_run_skill_prefixes_skill_command(self, tool_ctx):
+    async def test_run_skill_prefixes_skill_command(self, tool_ctx_kitchen_open):
         from tests.conftest import _make_result
 
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 '{"type": "result", "subtype": "success", "is_error": false, '
@@ -136,10 +136,10 @@ class TestRunSkillPrefix:
             )
         )
         await run_skill("/investigate error", "/tmp")
-        cmd = tool_ctx.runner.call_args_list[-1][0]
+        cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         prompt_idx = cmd.index("--print") + 1 if "--print" in cmd else cmd.index("-p") + 1
         assert cmd[prompt_idx].startswith("Use the /investigate skill error")
-        actual_cwd = tool_ctx.runner.call_args_list[-1][1]
+        actual_cwd = tool_ctx_kitchen_open.runner.call_args_list[-1][1]
         assert actual_cwd == Path("/tmp"), f"Subprocess cwd mismatch: {actual_cwd} != /tmp"
 
     @pytest.mark.anyio
@@ -171,7 +171,7 @@ class TestRunSkillPrefix:
         assert tool_ctx.runner.call_args_list == []
 
     @pytest.mark.anyio
-    async def test_run_skill_format_error_includes_slash_examples(self, tool_ctx):
+    async def test_run_skill_format_error_includes_slash_examples(self, tool_ctx_kitchen_open):
         """FRICT-6-1: error message for invalid format includes concrete slash-command examples."""
         result = json.loads(await run_skill("investigate this bug", "/tmp"))
         assert result["success"] is False
@@ -179,11 +179,11 @@ class TestRunSkillPrefix:
         assert "/" in result["result"]
 
     @pytest.mark.anyio
-    async def test_run_skill_includes_completion_directive(self, tool_ctx):
+    async def test_run_skill_includes_completion_directive(self, tool_ctx_kitchen_open):
         from tests.conftest import _make_result
 
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 '{"type": "result", "subtype": "success", "is_error": false, '
@@ -192,12 +192,12 @@ class TestRunSkillPrefix:
             )
         )
         await run_skill("/investigate error", "/tmp")
-        cmd = tool_ctx.runner.call_args_list[-1][0]
+        cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         prompt_idx = cmd.index("--print") + 1 if "--print" in cmd else cmd.index("-p") + 1
         assert "%%ORDER_UP::" in cmd[prompt_idx]
         from pathlib import Path
 
-        actual_cwd = tool_ctx.runner.call_args_list[-1][1]
+        actual_cwd = tool_ctx_kitchen_open.runner.call_args_list[-1][1]
         assert actual_cwd == Path("/tmp"), f"Subprocess cwd mismatch: {actual_cwd} != /tmp"
 
 
@@ -243,7 +243,7 @@ class TestDryWalkthroughGateWithPrefix:
     """Dry-walkthrough gate still receives raw command before prefix is applied."""
 
     @pytest.mark.anyio
-    async def test_gate_still_fires_for_implement_skill(self, tool_ctx, tmp_path):
+    async def test_gate_still_fires_for_implement_skill(self, tool_ctx_kitchen_open, tmp_path):
         plan = tmp_path / "plan.md"
         plan.write_text("# No marker plan")
         result = json.loads(await run_skill(f"/implement-worktree {plan}", str(tmp_path)))
@@ -256,7 +256,7 @@ class TestRunSkillCwdValidation:
     """run_skill rejects non-empty relative cwd at the boundary."""
 
     @pytest.mark.anyio
-    async def test_run_skill_rejects_relative_cwd(self, tool_ctx):
+    async def test_run_skill_rejects_relative_cwd(self, tool_ctx_kitchen_open):
         """Non-empty relative cwd is rejected immediately with a clear diagnostic."""
         result = json.loads(
             await run_skill(
@@ -267,10 +267,10 @@ class TestRunSkillCwdValidation:
         assert result["success"] is False
         assert "cwd must be an absolute path" in result["error"]
         assert "../worktrees/impl-fix-20260316" in result["error"]
-        assert tool_ctx.runner.call_args_list == []
+        assert tool_ctx_kitchen_open.runner.call_args_list == []
 
     @pytest.mark.anyio
-    async def test_run_skill_accepts_empty_cwd(self, tool_ctx, monkeypatch):
+    async def test_run_skill_accepts_empty_cwd(self, tool_ctx_kitchen_open, monkeypatch):
         """Empty cwd is accepted (some skills have no specific cwd requirement)."""
         from tests.conftest import _make_result
 
@@ -280,13 +280,13 @@ class TestRunSkillCwdValidation:
             '{"type": "result", "subtype": "success", "is_error": false,'
             f' "result": "done {marker}", "session_id": "s1"}}'
         )
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=success_json))
         result = json.loads(await run_skill("/investigate foo", cwd=""))
         assert "cwd must be an absolute path" not in result.get("error", "")
         assert result.get("subtype") != "gate_error"
 
     @pytest.mark.anyio
-    async def test_run_skill_accepts_absolute_cwd(self, tool_ctx, monkeypatch):
+    async def test_run_skill_accepts_absolute_cwd(self, tool_ctx_kitchen_open, monkeypatch):
         """Absolute cwd passes the boundary check and proceeds normally."""
         from tests.conftest import _make_result
 
@@ -296,8 +296,8 @@ class TestRunSkillCwdValidation:
             '{"type": "result", "subtype": "success", "is_error": false,'
             f' "result": "done {marker}", "session_id": "s1"}}'
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=success_json))
         result = json.loads(await run_skill("/investigate foo", cwd="/tmp"))
         assert "cwd must be an absolute path" not in result.get("error", "")
         assert result.get("subtype") != "gate_error"

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -11,13 +11,13 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 @pytest.mark.anyio
 async def test_run_skill_provider_extras_none_when_feature_disabled(
-    tool_ctx, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
 
     captured: dict = {}
@@ -37,13 +37,13 @@ async def test_run_skill_provider_extras_none_when_feature_disabled(
 
 @pytest.mark.anyio
 async def test_run_skill_provider_extras_none_for_anthropic_sentinel(
-    tool_ctx, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
@@ -67,13 +67,13 @@ async def test_run_skill_provider_extras_none_for_anthropic_sentinel(
 
 @pytest.mark.anyio
 async def test_run_skill_provider_extras_forwarded_for_non_anthropic(
-    tool_ctx, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
@@ -97,13 +97,13 @@ async def test_run_skill_provider_extras_forwarded_for_non_anthropic(
 
 @pytest.mark.anyio
 async def test_run_skill_model_as_profile_resolves_provider(
-    tool_ctx, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
@@ -132,13 +132,13 @@ async def test_run_skill_model_as_profile_resolves_provider(
 
 @pytest.mark.anyio
 async def test_run_skill_step_overrides_win_over_model_as_profile(
-    tool_ctx, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
@@ -168,13 +168,13 @@ async def test_run_skill_step_overrides_win_over_model_as_profile(
 
 @pytest.mark.anyio
 async def test_run_skill_model_as_profile_disabled_when_feature_off(
-    tool_ctx, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
 
     captured: dict = {}
@@ -194,13 +194,13 @@ async def test_run_skill_model_as_profile_disabled_when_feature_off(
 
 @pytest.mark.anyio
 async def test_run_skill_model_as_profile_no_anthropic_model_falls_through(
-    tool_ctx, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -56,7 +56,7 @@ class TestRunSkillFailurePaths:
     """run_skill surfaces session outcome on failure."""
 
     @pytest.mark.anyio
-    async def test_returns_subtype_on_incomplete_session(self, tool_ctx):
+    async def test_returns_subtype_on_incomplete_session(self, tool_ctx_kitchen_open):
         """run_skill includes subtype when session didn't finish."""
         stdout = json.dumps(
             {
@@ -66,14 +66,14 @@ class TestRunSkillFailurePaths:
                 "session_id": "s1",
             }
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(1, stdout, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(1, stdout, ""))
         result = json.loads(await run_skill("/investigate error", "/tmp"))
         assert result["session_id"] == "s1"
         assert result["subtype"] == "error_max_turns"
 
     @pytest.mark.anyio
-    async def test_returns_is_error_on_context_limit(self, tool_ctx):
+    async def test_returns_is_error_on_context_limit(self, tool_ctx_kitchen_open):
         """run_skill includes is_error when context limit is hit."""
         stdout = json.dumps(
             {
@@ -84,18 +84,18 @@ class TestRunSkillFailurePaths:
                 "session_id": "s1",
             }
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(1, stdout, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(1, stdout, ""))
         result = json.loads(await run_skill("/investigate error", "/tmp"))
         assert result["is_error"] is True
         assert result["subtype"] == "context_exhausted"
         assert result["cli_subtype"] == "success"
 
     @pytest.mark.anyio
-    async def test_handles_empty_stdout(self, tool_ctx):
+    async def test_handles_empty_stdout(self, tool_ctx_kitchen_open):
         """run_skill returns error result when stdout is empty."""
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
             _make_result(1, "", "segfault", channel_confirmation=ChannelConfirmation.UNMONITORED)
         )
         result = json.loads(await run_skill("/investigate error", "/tmp"))
@@ -105,10 +105,10 @@ class TestRunSkillFailurePaths:
         assert result["success"] is False
 
     @pytest.mark.anyio
-    async def test_empty_stdout_exit_zero_is_retriable(self, tool_ctx):
+    async def test_empty_stdout_exit_zero_is_retriable(self, tool_ctx_kitchen_open):
         """Infrastructure failure (empty stdout, exit 0) is retriable with stderr."""
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0, "", "session dropped", channel_confirmation=ChannelConfirmation.UNMONITORED
             )
@@ -143,35 +143,43 @@ class TestRunSkillStepName:
         return result_rec
 
     @pytest.mark.anyio
-    async def test_step_name_records_token_usage(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot (not a git repo)
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
+    async def test_step_name_records_token_usage(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=1)
+        )  # clone guard snapshot (not a git repo)
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
         await run_skill(
             skill_command="/autoskillit:investigate topic", cwd="/tmp", step_name="plan"
         )
-        report = tool_ctx.token_log.get_report()
+        report = tool_ctx_kitchen_open.token_log.get_report()
         assert len(report) == 1
         assert report[0]["step_name"] == "plan"
         assert report[0]["input_tokens"] == 200
 
     @pytest.mark.anyio
-    async def test_no_step_name_records_with_ad_hoc_label(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot (not a git repo)
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
+    async def test_no_step_name_records_with_ad_hoc_label(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=1)
+        )  # clone guard snapshot (not a git repo)
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
         await run_skill(skill_command="/autoskillit:investigate topic", cwd="/tmp", step_name="")
-        report = tool_ctx.token_log.get_report()
+        report = tool_ctx_kitchen_open.token_log.get_report()
         assert len(report) == 1
         assert report[0]["step_name"] == "(ad-hoc)"
         assert report[0]["input_tokens"] == 200
 
     @pytest.mark.anyio
-    async def test_dispatch_id_env_records_with_dispatch_label(self, tool_ctx, monkeypatch):
+    async def test_dispatch_id_env_records_with_dispatch_label(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """step_name='' with AUTOSKILLIT_DISPATCH_ID set records under dispatch:{id} label."""
         monkeypatch.setenv("AUTOSKILLIT_DISPATCH_ID", "abc-123")
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot (not a git repo)
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=1)
+        )  # clone guard snapshot (not a git repo)
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
         await run_skill(skill_command="/autoskillit:investigate topic", cwd="/tmp", step_name="")
-        report = tool_ctx.token_log.get_report()
+        report = tool_ctx_kitchen_open.token_log.get_report()
         assert len(report) == 1
         assert report[0]["step_name"] == "dispatch:abc-123"
         assert report[0]["input_tokens"] == 200
@@ -196,16 +204,18 @@ class TestRunSkillStepName:
         assert tool_ctx.token_log.get_report() == []
 
     @pytest.mark.anyio
-    async def test_step_name_run_skill_long_running(self, tool_ctx):
+    async def test_step_name_run_skill_long_running(self, tool_ctx_kitchen_open):
         """run_skill accumulates token usage by step_name (run_skill_retry test replacement)."""
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot (not a git repo)
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=1)
+        )  # clone guard snapshot (not a git repo)
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
         await run_skill(
             skill_command="/autoskillit:investigate the test failures",
             cwd="/tmp",
             step_name="implement",
         )
-        report = tool_ctx.token_log.get_report()
+        report = tool_ctx_kitchen_open.token_log.get_report()
         assert len(report) == 1
         assert report[0]["step_name"] == "implement"
         assert report[0]["input_tokens"] == 200
@@ -223,9 +233,11 @@ class TestGatedToolObservability:
         return ctx
 
     @pytest.mark.anyio
-    async def test_run_skill_binds_tool_contextvar_and_calls_ctx_info(self, tool_ctx, mock_ctx):
+    async def test_run_skill_binds_tool_contextvar_and_calls_ctx_info(
+        self, tool_ctx_kitchen_open, mock_ctx
+    ):
         """run_skill binds tool='run_skill' contextvar and calls ctx.info on success."""
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 '{"type": "result", "subtype": "success", "is_error": false,'
@@ -401,12 +413,16 @@ class TestTierAwareGateEnforcement:
     """T_TAGE: tier-aware guard permits orchestrator, denies skill and fleet as appropriate."""
 
     @pytest.mark.anyio
-    async def test_run_skill_permitted_for_orchestrator_tier(self, tool_ctx, monkeypatch):
+    async def test_run_skill_permitted_for_orchestrator_tier(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """run_skill does NOT return headless_error for orchestrator-tier headless sessions."""
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot (not a git repo)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=1)
+        )  # clone guard snapshot (not a git repo)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 returncode=0,
                 stdout=json.dumps({"type": "result", "subtype": "success", "is_error": False}),
@@ -486,10 +502,10 @@ class TestRunSkillTiming:
     """run_skill accumulates wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_run_skill_records_timing_via_step_name(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, _SUCCESS_JSON, ""))
+    async def test_run_skill_records_timing_via_step_name(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, _SUCCESS_JSON, ""))
         await run_skill("/investigate foo", "/tmp", step_name="implement")
-        assert_step_timed(tool_ctx.timing_log, "implement")
+        assert_step_timed(tool_ctx_kitchen_open.timing_log, "implement")
 
     @pytest.mark.anyio
     async def test_run_skill_empty_step_name_skips_timing(self, tool_ctx):
@@ -534,7 +550,7 @@ class TestRunHeadlessCoreFlushTelemetry:
         return asst + "\n" + result
 
     @pytest.mark.anyio
-    async def test_passes_step_telemetry_to_flush(self, tool_ctx, monkeypatch):
+    async def test_passes_step_telemetry_to_flush(self, tool_ctx_kitchen_open, monkeypatch):
         """flush_session_log is called with step_name, token_usage, and timing_seconds."""
         import autoskillit.execution.session_log as sl_mod
 
@@ -544,8 +560,10 @@ class TestRunHeadlessCoreFlushTelemetry:
             calls.append(kwargs)
 
         monkeypatch.setattr(sl_mod, "flush_session_log", mock_flush)
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson_with_usage()))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=0, stdout=self._make_ndjson_with_usage())
+        )
         await run_skill("/investigate foo", "/tmp", step_name="implement")
         assert len(calls) == 1
         assert calls[0]["step_name"] == "implement"
@@ -554,7 +572,7 @@ class TestRunHeadlessCoreFlushTelemetry:
 
     @pytest.mark.anyio
     async def test_flush_session_log_session_id_matches_returned_skill_result(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ):
         """flush_session_log receives the same session_id as the returned SkillResult."""
         import autoskillit.execution.session_log as sl_mod
@@ -566,7 +584,7 @@ class TestRunHeadlessCoreFlushTelemetry:
             calls.append(kwargs)
 
         monkeypatch.setattr(sl_mod, "flush_session_log", mock_flush)
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
         # Stale result with session_id resolved from Channel B
         stale_result = SubprocessResult(
             returncode=-1,
@@ -576,7 +594,7 @@ class TestRunHeadlessCoreFlushTelemetry:
             pid=12345,
             session_id="test-uuid-coherence-check",
         )
-        tool_ctx.runner.push(stale_result)
+        tool_ctx_kitchen_open.runner.push(stale_result)
         result_json = json.loads(
             await run_skill("/investigate foo", "/tmp", step_name="implement")
         )
@@ -586,7 +604,7 @@ class TestRunHeadlessCoreFlushTelemetry:
         assert result_json["session_id"] != ""
 
     @pytest.mark.anyio
-    async def test_flushes_on_success_when_step_name_set(self, tool_ctx, monkeypatch):
+    async def test_flushes_on_success_when_step_name_set(self, tool_ctx_kitchen_open, monkeypatch):
         """Successful sessions without proc_snapshots still flush when step_name is provided."""
         import autoskillit.execution.session_log as sl_mod
 
@@ -596,22 +614,22 @@ class TestRunHeadlessCoreFlushTelemetry:
             calls.append(kwargs)
 
         monkeypatch.setattr(sl_mod, "flush_session_log", mock_flush)
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=_SUCCESS_JSON))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=_SUCCESS_JSON))
         await run_skill("/investigate foo", "/tmp", step_name="plan")
         assert len(calls) == 1
 
     @pytest.mark.anyio
-    async def test_records_timing_in_timing_log(self, tool_ctx):
+    async def test_records_timing_in_timing_log(self, tool_ctx_kitchen_open):
         """ctx.timing_log.record() is called with step_name and computed timing_seconds."""
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=_SUCCESS_JSON))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=0, stdout=_SUCCESS_JSON))
         await run_skill("/investigate foo", "/tmp", step_name="plan")
-        report = tool_ctx.timing_log.get_report()
+        report = tool_ctx_kitchen_open.timing_log.get_report()
         assert len(report) == 1
         assert report[0]["step_name"] == "plan"
         assert report[0]["total_seconds"] >= 0.0
 
     @pytest.mark.anyio
-    async def test_passes_github_api_log_to_flush(self, tool_ctx, monkeypatch):
+    async def test_passes_github_api_log_to_flush(self, tool_ctx_kitchen_open, monkeypatch):
         """headless.py drains github_api_log into telemetry.github_api_usage."""
         import autoskillit.execution.session_log as sl_mod
         from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
@@ -623,7 +641,7 @@ class TestRunHeadlessCoreFlushTelemetry:
             latency_ms=50.0,
             timestamp="2026-05-02T10:00:00Z",
         )
-        tool_ctx.github_api_log = log
+        tool_ctx_kitchen_open.github_api_log = log
 
         calls = []
 
@@ -631,14 +649,16 @@ class TestRunHeadlessCoreFlushTelemetry:
             calls.append(kwargs)
 
         monkeypatch.setattr(sl_mod, "flush_session_log", mock_flush)
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson_with_usage()))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=0, stdout=self._make_ndjson_with_usage())
+        )
         await run_skill("/investigate foo", "/tmp", step_name="implement")
         assert len(calls) == 1
         assert calls[0]["telemetry"].github_api_usage is not None
         assert calls[0]["telemetry"].github_api_requests > 0
 
     @pytest.mark.anyio
-    async def test_flush_telemetry_kwargs_exhaustive(self, tool_ctx, monkeypatch):
+    async def test_flush_telemetry_kwargs_exhaustive(self, tool_ctx_kitchen_open, monkeypatch):
         """headless.py passes a SessionTelemetry bundle covering all telemetry fields."""
         import autoskillit.execution.session_log as sl_mod
         from autoskillit.core.types._type_results_execution import SessionTelemetry
@@ -649,7 +669,9 @@ class TestRunHeadlessCoreFlushTelemetry:
             calls.append(kwargs)
 
         monkeypatch.setattr(sl_mod, "flush_session_log", mock_flush)
-        tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson_with_usage()))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(returncode=0, stdout=self._make_ndjson_with_usage())
+        )
         await run_skill("/investigate foo", "/tmp", step_name="implement")
         assert len(calls) == 1
         assert "telemetry" in calls[0], "flush_session_log must receive telemetry= kwarg"
@@ -660,7 +682,7 @@ class TestRunHeadlessCoreFlushTelemetry:
 
 @pytest.mark.anyio
 async def test_run_skill_returns_structured_error_when_executor_raises(
-    tool_ctx, monkeypatch, tmp_path
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
 ) -> None:
     """run_skill returns SkillResult-shaped JSON even if executor.run() raises unexpectedly."""
     from autoskillit.core import SkillResult
@@ -669,8 +691,8 @@ async def test_run_skill_returns_structured_error_when_executor_raises(
         async def run(self, *args, **kwargs) -> SkillResult:
             raise RuntimeError("unexpected executor failure")
 
-    tool_ctx.executor = ExplodingExecutor()
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = ExplodingExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     from autoskillit.server.tools.tools_execution import run_skill
 

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -10,13 +10,13 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.anyio
-async def test_tools_execution_routes_through_executor(tool_ctx, monkeypatch) -> None:
+async def test_tools_execution_routes_through_executor(tool_ctx_kitchen_open, monkeypatch) -> None:
     """run_skill routes through ctx.executor.run(), not run_headless_core directly."""
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/test skill", "/tmp")
     assert len(executor.calls) == 1
@@ -25,14 +25,14 @@ async def test_tools_execution_routes_through_executor(tool_ctx, monkeypatch) ->
 
 
 @pytest.mark.anyio
-async def test_run_skill_passes_validated_add_dirs(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_passes_validated_add_dirs(tool_ctx_kitchen_open, monkeypatch) -> None:
     """run_skill passes ValidatedAddDir instances (not raw strings) as add_dirs."""
     from autoskillit.core import ValidatedAddDir
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/test skill", "/tmp")
     # All add_dirs must be ValidatedAddDir instances
@@ -47,7 +47,9 @@ async def test_run_skill_passes_validated_add_dirs(tool_ctx, monkeypatch) -> Non
 
 
 @pytest.mark.anyio
-async def test_run_skill_calls_session_skill_manager_init_session(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_calls_session_skill_manager_init_session(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
     """run_skill routes through session_skill_manager.init_session() for add_dirs."""
     from unittest.mock import MagicMock
 
@@ -57,13 +59,13 @@ async def test_run_skill_calls_session_skill_manager_init_session(tool_ctx, monk
     fake_validated = ValidatedAddDir(path="/fake/session/dir")
     mock_ssm = MagicMock()
     mock_ssm.init_session.return_value = fake_validated
-    tool_ctx.session_skill_manager = mock_ssm
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
 
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/test skill", "/tmp")
 
@@ -77,7 +79,9 @@ async def test_run_skill_calls_session_skill_manager_init_session(tool_ctx, monk
 
 
 @pytest.mark.anyio
-async def test_run_skill_activates_deps_for_tier3_target(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_activates_deps_for_tier3_target(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
     """run_skill calls activate_skill_deps even when target is tier3 (not in tier2 list)."""
     from unittest.mock import MagicMock
 
@@ -86,17 +90,17 @@ async def test_run_skill_activates_deps_for_tier3_target(tool_ctx, monkeypatch) 
     fake_validated = ValidatedAddDir(path="/fake/session/dir")
     mock_ssm = MagicMock()
     mock_ssm.init_session.return_value = fake_validated
-    tool_ctx.session_skill_manager = mock_ssm
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
 
     # Set up skill_resolver to produce a resolved name
     mock_resolver = MagicMock()
     mock_resolver.resolve.return_value = MagicMock(source=MagicMock(value="bundled_extended"))
-    tool_ctx.skill_resolver = mock_resolver
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
 
     from tests.fakes import InMemoryHeadlessExecutor
 
-    tool_ctx.executor = InMemoryHeadlessExecutor()
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     # Use a tier3 skill name
     await run_skill("/open-pr", "/tmp")
@@ -106,14 +110,16 @@ async def test_run_skill_activates_deps_for_tier3_target(tool_ctx, monkeypatch) 
 
 
 @pytest.mark.anyio
-async def test_run_skill_result_includes_order_id_when_passed(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_result_includes_order_id_when_passed(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
     """run_skill injects order_id into the result JSON when order_id is non-empty."""
     import json as _json
 
     from tests.fakes import InMemoryHeadlessExecutor
 
-    tool_ctx.executor = InMemoryHeadlessExecutor()
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     result_json = await run_skill("/test skill", "/tmp", order_id="issue-185")
     data = _json.loads(result_json)
@@ -122,15 +128,15 @@ async def test_run_skill_result_includes_order_id_when_passed(tool_ctx, monkeypa
 
 @pytest.mark.anyio
 async def test_run_skill_result_order_id_empty_string_when_not_passed(
-    tool_ctx, monkeypatch
+    tool_ctx_kitchen_open, monkeypatch
 ) -> None:
     """run_skill emits order_id as empty string in result JSON when none provided."""
     import json as _json
 
     from tests.fakes import InMemoryHeadlessExecutor
 
-    tool_ctx.executor = InMemoryHeadlessExecutor()
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     result_json = await run_skill("/test skill", "/tmp")  # no order_id
     data = _json.loads(result_json)
@@ -138,7 +144,9 @@ async def test_run_skill_result_order_id_empty_string_when_not_passed(
 
 
 @pytest.mark.anyio
-async def test_run_skill_passes_allow_only_to_init_session(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_passes_allow_only_to_init_session(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
     """run_skill computes the closure for the resolved target and forwards it as allow_only."""
     from unittest.mock import MagicMock
 
@@ -151,14 +159,14 @@ async def test_run_skill_passes_allow_only_to_init_session(tool_ctx, monkeypatch
     mock_ssm = MagicMock()
     mock_ssm.init_session.return_value = fake_validated
     mock_ssm.compute_skill_closure.return_value = expected_closure
-    tool_ctx.session_skill_manager = mock_ssm
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
 
     mock_resolver = MagicMock()
     mock_resolver.resolve.return_value = MagicMock(source=MagicMock(value="bundled_extended"))
-    tool_ctx.skill_resolver = mock_resolver
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
 
-    tool_ctx.executor = InMemoryHeadlessExecutor()
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/autoskillit:investigate the bug", "/tmp")
 
@@ -168,7 +176,9 @@ async def test_run_skill_passes_allow_only_to_init_session(tool_ctx, monkeypatch
 
 
 @pytest.mark.anyio
-async def test_run_skill_no_target_skill_passes_none_allow_only(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_no_target_skill_passes_none_allow_only(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
     """When skill_resolver is unset, target_name is None and allow_only stays None."""
     from unittest.mock import MagicMock
 
@@ -178,11 +188,11 @@ async def test_run_skill_no_target_skill_passes_none_allow_only(tool_ctx, monkey
     fake_validated = ValidatedAddDir(path="/fake/session/dir")
     mock_ssm = MagicMock()
     mock_ssm.init_session.return_value = fake_validated
-    tool_ctx.session_skill_manager = mock_ssm
-    tool_ctx.skill_resolver = None  # disables resolve_target_skill
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+    tool_ctx_kitchen_open.skill_resolver = None  # disables resolve_target_skill
 
-    tool_ctx.executor = InMemoryHeadlessExecutor()
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/test skill", "/tmp")
 
@@ -192,7 +202,9 @@ async def test_run_skill_no_target_skill_passes_none_allow_only(tool_ctx, monkey
 
 
 @pytest.mark.anyio
-async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_make_plan_closure_includes_arch_lens_pack(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
     """End-to-end: /make-plan resolves a closure containing the entire arch-lens pack."""
     from unittest.mock import MagicMock
 
@@ -204,7 +216,9 @@ async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, mon
     from tests.fakes import InMemoryHeadlessExecutor
 
     real_provider = SkillsDirectoryProvider()
-    real_mgr = DefaultSessionSkillManager(provider=real_provider, ephemeral_root=tool_ctx.temp_dir)
+    real_mgr = DefaultSessionSkillManager(
+        provider=real_provider, ephemeral_root=tool_ctx_kitchen_open.temp_dir
+    )
 
     captured: dict = {}
 
@@ -225,14 +239,14 @@ async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, mon
         def cleanup_stale(self, max_age_seconds=86400):
             return 0
 
-    tool_ctx.session_skill_manager = _RecordingManager(real_mgr)
+    tool_ctx_kitchen_open.session_skill_manager = _RecordingManager(real_mgr)
 
     mock_resolver = MagicMock()
     mock_resolver.resolve.return_value = MagicMock(source=MagicMock(value="bundled_extended"))
-    tool_ctx.skill_resolver = mock_resolver
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
 
-    tool_ctx.executor = InMemoryHeadlessExecutor()
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/autoskillit:make-plan refactor", "/tmp")
 
@@ -245,26 +259,28 @@ async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, mon
 
 
 @pytest.mark.anyio
-async def test_run_skill_passes_idle_output_timeout(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_passes_idle_output_timeout(tool_ctx_kitchen_open, monkeypatch) -> None:
     """run_skill passes idle_output_timeout (as float) to executor.run()."""
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/test skill", "/tmp", idle_output_timeout=120)
     assert executor.calls[0].idle_output_timeout == 120.0  # int→float conversion
 
 
 @pytest.mark.anyio
-async def test_run_skill_idle_output_timeout_defaults_to_none(tool_ctx, monkeypatch) -> None:
+async def test_run_skill_idle_output_timeout_defaults_to_none(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
     """run_skill passes None to executor.run() when idle_output_timeout is not set."""
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill("/test skill", "/tmp")
     assert executor.calls[0].idle_output_timeout is None
@@ -284,7 +300,7 @@ class TestOutputDirParameter:
 
     @pytest.mark.anyio
     async def test_run_skill_forwards_output_dir_to_write_watch_dirs(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ) -> None:
         """output_dir is resolved and forwarded to executor.run() as write_watch_dirs."""
         from pathlib import Path
@@ -292,8 +308,8 @@ class TestOutputDirParameter:
         from tests.fakes import InMemoryHeadlessExecutor
 
         executor = InMemoryHeadlessExecutor()
-        tool_ctx.executor = executor
-        monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+        tool_ctx_kitchen_open.executor = executor
+        monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
         output_dir = str(tmp_path / "output")
         await run_skill("/test skill", str(tmp_path), output_dir=output_dir)
@@ -304,14 +320,14 @@ class TestOutputDirParameter:
 
 @pytest.mark.anyio
 async def test_run_skill_injects_provider_extras_when_feature_enabled(
-    tool_ctx, monkeypatch, tmp_path
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
 ) -> None:
     """run_skill records provider_extras and profile_name when feature is enabled."""
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
@@ -326,14 +342,14 @@ async def test_run_skill_injects_provider_extras_when_feature_enabled(
 
 @pytest.mark.anyio
 async def test_run_skill_provider_extras_none_when_feature_disabled(
-    tool_ctx, monkeypatch, tmp_path
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
 ) -> None:
     """run_skill records None provider_extras and empty profile_name when feature is disabled."""
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
 
     await run_skill("/autoskillit:probe", str(tmp_path))
@@ -344,14 +360,14 @@ async def test_run_skill_provider_extras_none_when_feature_disabled(
 
 @pytest.mark.anyio
 async def test_run_skill_provider_extras_none_when_default_profile(
-    tool_ctx, monkeypatch, tmp_path
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
 ) -> None:
     """run_skill records None provider_extras when profile resolves to default anthropic."""
     from tests.fakes import InMemoryHeadlessExecutor
 
     executor = InMemoryHeadlessExecutor()
-    tool_ctx.executor = executor
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",

--- a/tests/server/test_tools_git.py
+++ b/tests/server/test_tools_git.py
@@ -41,10 +41,10 @@ class TestClassifyFix:
         )
 
     @pytest.mark.anyio
-    async def test_critical_files_return_full_restart(self, tool_ctx, tmp_path):
+    async def test_critical_files_return_full_restart(self, tool_ctx_kitchen_open, tmp_path):
         changed = "src/core/handler.py\nlib/utils/helpers.py\n"
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch succeeds
-        tool_ctx.runner.push(_make_result(0, changed, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, changed, ""))
 
         result = json.loads(await classify_fix(worktree_path=str(tmp_path), base_branch="main"))
 
@@ -54,10 +54,10 @@ class TestClassifyFix:
         assert len(result["all_changed_files"]) == 2
 
     @pytest.mark.anyio
-    async def test_non_critical_returns_partial_restart(self, tool_ctx, tmp_path):
+    async def test_non_critical_returns_partial_restart(self, tool_ctx_kitchen_open, tmp_path):
         changed = "src/workers/runner.py\nlib/utils/helpers.py\n"
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch succeeds
-        tool_ctx.runner.push(_make_result(0, changed, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, changed, ""))
 
         result = json.loads(await classify_fix(worktree_path=str(tmp_path), base_branch="main"))
 
@@ -66,9 +66,9 @@ class TestClassifyFix:
         assert len(result["all_changed_files"]) == 2
 
     @pytest.mark.anyio
-    async def test_git_diff_failure(self, tool_ctx, tmp_path):
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch succeeds
-        tool_ctx.runner.push(_make_result(128, "", "fatal: bad revision"))
+    async def test_git_diff_failure(self, tool_ctx_kitchen_open, tmp_path):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(128, "", "fatal: bad revision"))
 
         result = json.loads(await classify_fix(worktree_path=str(tmp_path), base_branch="main"))
 
@@ -76,34 +76,49 @@ class TestClassifyFix:
         assert "Cannot diff" in result["reason"]
 
     @pytest.mark.anyio
-    async def test_critical_path_in_diff_triggers_full_restart(self, tool_ctx, tmp_path):
+    async def test_critical_path_in_diff_triggers_full_restart(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         changed = "src/api/routes.py\n"
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch succeeds
-        tool_ctx.runner.push(_make_result(0, changed, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, changed, ""))
 
         result = json.loads(await classify_fix(worktree_path=str(tmp_path), base_branch="main"))
 
         assert result["restart_scope"] == RestartScope.FULL_RESTART
 
     @pytest.mark.anyio
-    async def test_classify_fix_nonexistent_worktree_path_returns_clear_error(self, tool_ctx):
+    async def test_classify_fix_nonexistent_worktree_path_returns_clear_error(
+        self, tool_ctx_kitchen_open
+    ):
         """[FAILS NOW] nonexistent path returns a distinct path-not-found error."""
         result = json.loads(await classify_fix("/no/such/path", "main"))
         assert result["restart_scope"] == RestartScope.FULL_RESTART
         assert "does not exist" in result["reason"].lower()
 
     @pytest.mark.anyio
-    async def test_classify_fix_git_fetch_called_before_diff(self, tool_ctx, tmp_path):
+    async def test_classify_fix_git_fetch_called_before_diff(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """git fetch must be issued before git diff."""
-        tool_ctx.runner.push(_make_result(0, "", ""))  # fetch succeeds
-        tool_ctx.runner.push(_make_result(0, "src/foo.py\n", ""))  # diff succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "src/foo.py\n", ""))  # diff succeeds
         with patch(
             "autoskillit.server._misc.resolve_remote_name",
             new=AsyncMock(return_value="origin"),
         ):
             await classify_fix(str(tmp_path), "main")
-        assert tool_ctx.runner.call_args_list[0][0] == ["git", "fetch", "origin", "main"]
-        assert tool_ctx.runner.call_args_list[1][0][0:3] == ["git", "diff", "--name-only"]
+        assert tool_ctx_kitchen_open.runner.call_args_list[0][0] == [
+            "git",
+            "fetch",
+            "origin",
+            "main",
+        ]
+        assert tool_ctx_kitchen_open.runner.call_args_list[1][0][0:3] == [
+            "git",
+            "diff",
+            "--name-only",
+        ]
 
     @pytest.mark.anyio
     async def test_classify_fix_gate_closed_returns_gate_error(
@@ -118,11 +133,11 @@ class TestClassifyFix:
 
     @pytest.mark.anyio
     async def test_classify_fix_empty_diff_returns_partial_restart_with_no_files(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """[NEW COVERAGE] empty diff is a valid state returning partial_restart with no files."""
-        tool_ctx.runner.push(_make_result(0, "", ""))  # fetch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # diff (empty)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # fetch
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # diff (empty)
         result = json.loads(await classify_fix(str(tmp_path), "main"))
         assert result["restart_scope"] == RestartScope.PARTIAL_RESTART
         assert result["all_changed_files"] == []
@@ -133,19 +148,27 @@ class TestMergeWorktree:
     """merge_worktree enforces test gate, rebases, and merges."""
 
     @pytest.mark.anyio
-    async def test_merge_worktree_blocks_on_failing_tests(self, tool_ctx, tmp_path):
+    async def test_merge_worktree_blocks_on_failing_tests(self, tool_ctx_kitchen_open, tmp_path):
         """merge_worktree returns error with failed_step when test-check fails."""
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "/repo/.git/worktrees/wt\n", "")
         )  # rev-parse --git-dir
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(1, "FAIL\n= 3 failed, 97 passed =", ""))  # test-check
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "impl-branch\n", "")
+        )  # branch --show-current
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(1, "FAIL\n= 3 failed, 97 passed =", "")
+        )  # test-check
         result = json.loads(await merge_worktree(str(wt), "dev"))
         assert "error" in result
         assert result["failed_step"] == MergeFailedStep.TEST_GATE
@@ -153,25 +176,37 @@ class TestMergeWorktree:
         assert "test_summary" not in result
 
     @pytest.mark.anyio
-    async def test_merge_worktree_merges_on_green(self, tool_ctx, tmp_path):
+    async def test_merge_worktree_merges_on_green(self, tool_ctx_kitchen_open, tmp_path):
         """merge_worktree performs rebase+merge when tests pass."""
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # pre-rebase test-check
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # pre-rebase test-check
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "", "")
         )  # git log --merges (no merge commits — step 5.6)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git rebase
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # post-rebase test-check
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git rebase
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # post-rebase test-check
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 "worktree /repo\nHEAD abc123\nbranch refs/heads/dev\n\n"
@@ -179,11 +214,15 @@ class TestMergeWorktree:
                 "",
             )
         )  # worktree list --porcelain
-        tool_ctx.runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git merge
-        tool_ctx.runner.push(_make_result(0, "", ""))  # worktree remove
-        tool_ctx.runner.push(_make_result(0, "", ""))  # branch -D
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "dev\n", "")
+        )  # step 7.5: branch --show-current
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # step 7.6: git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git merge
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # worktree remove
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D
         result = json.loads(await merge_worktree(str(wt), "dev"))
         assert result["merge_succeeded"] is True
         assert result["into_branch"] == "dev"
@@ -193,30 +232,42 @@ class TestMergeWorktree:
         # Verify merge command cwd is the main_repo (/repo)
         merge_call = next(
             args
-            for args in tool_ctx.runner.call_args_list
+            for args in tool_ctx_kitchen_open.runner.call_args_list
             if len(args[0]) > 1 and args[0][1] == "merge"
         )
         assert merge_call[1] == Path("/repo")
 
     @pytest.mark.anyio
-    async def test_merge_worktree_aborts_on_rebase_failure(self, tool_ctx, tmp_path):
+    async def test_merge_worktree_aborts_on_rebase_failure(self, tool_ctx_kitchen_open, tmp_path):
         """merge_worktree runs rebase --abort and returns step-specific error."""
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # test-check
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # test-check
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "", "")
         )  # git log --merges (no merge commits — step 5.6)
-        tool_ctx.runner.push(_make_result(1, "", "CONFLICT (content): ..."))  # git rebase FAILS
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git rebase --abort
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(1, "", "CONFLICT (content): ...")
+        )  # git rebase FAILS
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git rebase --abort
         result = json.loads(await merge_worktree(str(wt), "dev"))
         assert "error" in result
         assert result["failed_step"] == MergeFailedStep.REBASE
@@ -228,13 +279,13 @@ class TestMergeWorktree:
         assert "CONFLICT" in result["stderr"]
 
     @pytest.mark.anyio
-    async def test_merge_worktree_rejects_nonexistent_path(self, tool_ctx):
+    async def test_merge_worktree_rejects_nonexistent_path(self, tool_ctx_kitchen_open):
         """merge_worktree rejects non-existent paths."""
         result = json.loads(await merge_worktree("/nonexistent/path", "dev"))
         assert "error" in result
 
     @pytest.mark.anyio
-    async def test_merge_worktree_rejects_non_worktree(self, tool_ctx, tmp_path):
+    async def test_merge_worktree_rejects_non_worktree(self, tool_ctx_kitchen_open, tmp_path):
         """merge_worktree rejects paths that aren't git worktrees."""
         result = json.loads(await merge_worktree(str(tmp_path), "dev"))
         assert "error" in result
@@ -252,17 +303,23 @@ class TestMergeWorktreeNoBypass:
         assert "skip_test_gate" in result["error"]
 
     @pytest.mark.anyio
-    async def test_internal_gate_cross_validates_output(self, tool_ctx, tmp_path):
+    async def test_internal_gate_cross_validates_output(self, tool_ctx_kitchen_open, tmp_path):
         """merge_worktree's internal gate catches rc=0 with failure text."""
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "= 3 failed, 97 passed =", "")
         )  # test-check: rc=0 but failed text
         result = json.loads(await merge_worktree(str(wt), "dev"))
@@ -270,16 +327,22 @@ class TestMergeWorktreeNoBypass:
         assert result["failed_step"] == MergeFailedStep.TEST_GATE
 
     @pytest.mark.anyio
-    async def test_gate_failure_does_not_expose_summary(self, tool_ctx, tmp_path):
+    async def test_gate_failure_does_not_expose_summary(self, tool_ctx_kitchen_open, tmp_path):
         """When gate blocks, response contains no test output details."""
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(1, "= 3 failed, 97 passed =", ""))  # test-check
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(1, "= 3 failed, 97 passed =", "")
+        )  # test-check
         result = json.loads(await merge_worktree(str(wt), "dev"))
         assert "error" in result
         assert "test_summary" not in result
@@ -289,35 +352,51 @@ class TestMergeWorktreeCleanupReporting:
     """merge_worktree reports accurate cleanup results."""
 
     @pytest.mark.anyio
-    async def test_reports_worktree_remove_failure(self, tool_ctx, tmp_path):
+    async def test_reports_worktree_remove_failure(self, tool_ctx_kitchen_open, tmp_path):
         """3a: worktree_removed reflects actual worktree removal result."""
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # pre-rebase test-check
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # pre-rebase test-check
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "", "")
         )  # git log --merges (no merge commits — step 5.6)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git rebase
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # post-rebase test-check
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git rebase
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # post-rebase test-check
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n",
                 "",
             )
         )  # worktree list
-        tool_ctx.runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git merge
-        tool_ctx.runner.push(_make_result(0, "", ""))  # branch -D
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "dev\n", "")
+        )  # step 7.5: branch --show-current
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # step 7.6: git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git merge
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D
         with patch(
             "autoskillit.server.git.remove_git_worktree",
             new=AsyncMock(
@@ -330,36 +409,54 @@ class TestMergeWorktreeCleanupReporting:
         assert result["worktree_removed"] is False
 
     @pytest.mark.anyio
-    async def test_reports_branch_delete_failure(self, tool_ctx, tmp_path):
+    async def test_reports_branch_delete_failure(self, tool_ctx_kitchen_open, tmp_path):
         """3b: branch_deleted reflects actual git branch -D result."""
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # pre-rebase test-check
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # pre-rebase test-check
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "", "")
         )  # git log --merges (no merge commits — step 5.6)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git rebase
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # post-rebase test-check
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git rebase
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # post-rebase test-check
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n",
                 "",
             )
         )  # worktree list
-        tool_ctx.runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git merge
-        tool_ctx.runner.push(_make_result(0, "", ""))  # worktree remove
-        tool_ctx.runner.push(_make_result(1, "", "error: branch not found"))  # branch -D FAILS
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "dev\n", "")
+        )  # step 7.5: branch --show-current
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # step 7.6: git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git merge
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # worktree remove
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(1, "", "error: branch not found")
+        )  # branch -D FAILS
         result = json.loads(await merge_worktree(str(wt), "dev"))
         assert result["merge_succeeded"] is True
         assert result["cleanup_succeeded"] is False
@@ -367,18 +464,26 @@ class TestMergeWorktreeCleanupReporting:
         assert result["branch_deleted"] is False
 
     @pytest.mark.anyio
-    async def test_checks_fetch_result(self, tool_ctx, tmp_path):
+    async def test_checks_fetch_result(self, tool_ctx_kitchen_open, tmp_path):
         """3c: git fetch failure returns error before rebase attempt."""
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # test-check
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # test-check
+        tool_ctx_kitchen_open.runner.push(
             _make_result(1, "", "fatal: could not connect to remote")
         )  # git fetch FAILS
         result = json.loads(await merge_worktree(str(wt), "dev"))
@@ -390,30 +495,44 @@ class TestMergeWorktreeCleanupWarnings:
     """merge_worktree emits logger.warning when cleanup steps fail post-merge."""
 
     @pytest.mark.anyio
-    async def test_warns_on_worktree_remove_failure(self, tool_ctx, tmp_path):
+    async def test_warns_on_worktree_remove_failure(self, tool_ctx_kitchen_open, tmp_path):
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # pre-rebase test-check
-        tool_ctx.runner.push(_make_result(0, "", ""))  # fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # pre-rebase test-check
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "", "")
         )  # git log --merges (no merge commits — step 5.6)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # rebase
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # post-rebase test-check
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # rebase
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # post-rebase test-check
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n", "")
         )
-        tool_ctx.runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # merge
-        tool_ctx.runner.push(_make_result(0, "", ""))  # branch -D
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "dev\n", "")
+        )  # step 7.5: branch --show-current
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # step 7.6: git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # merge
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D
 
         with (
             patch(
@@ -433,31 +552,47 @@ class TestMergeWorktreeCleanupWarnings:
         assert any(entry.get("operation") == "worktree_remove" for entry in warning_entries)
 
     @pytest.mark.anyio
-    async def test_warns_on_branch_delete_failure(self, tool_ctx, tmp_path):
+    async def test_warns_on_branch_delete_failure(self, tool_ctx_kitchen_open, tmp_path):
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # pre-rebase test-check
-        tool_ctx.runner.push(_make_result(0, "", ""))  # fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # pre-rebase test-check
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "", "")
         )  # git log --merges (no merge commits — step 5.6)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # rebase
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # post-rebase test-check
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # rebase
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # post-rebase test-check
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n", "")
         )
-        tool_ctx.runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # merge
-        tool_ctx.runner.push(_make_result(0, "", ""))  # worktree remove
-        tool_ctx.runner.push(_make_result(1, "", "error: branch not found"))  # branch -D FAILS
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "dev\n", "")
+        )  # step 7.5: branch --show-current
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # step 7.6: git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # merge
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # worktree remove
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(1, "", "error: branch not found")
+        )  # branch -D FAILS
 
         with structlog.testing.capture_logs() as logs:
             result = json.loads(await merge_worktree(str(wt), "dev"))
@@ -469,31 +604,45 @@ class TestMergeWorktreeCleanupWarnings:
         assert any(entry.get("operation") == "branch_delete" for entry in warning_entries)
 
     @pytest.mark.anyio
-    async def test_no_warning_on_clean_cleanup(self, tool_ctx, tmp_path):
+    async def test_no_warning_on_clean_cleanup(self, tool_ctx_kitchen_open, tmp_path):
         wt = tmp_path / "worktree"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # pre-rebase test-check
-        tool_ctx.runner.push(_make_result(0, "", ""))  # fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # pre-rebase test-check
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "", "")
         )  # git log --merges (no merge commits — step 5.6)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # rebase
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # post-rebase test-check
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # rebase
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # post-rebase test-check
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n", "")
         )
-        tool_ctx.runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # merge
-        tool_ctx.runner.push(_make_result(0, "", ""))  # worktree remove — success
-        tool_ctx.runner.push(_make_result(0, "", ""))  # branch -D — success
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "dev\n", "")
+        )  # step 7.5: branch --show-current
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # step 7.6: git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # merge
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # worktree remove — success
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D — success
 
         with structlog.testing.capture_logs() as logs:
             result = json.loads(await merge_worktree(str(wt), "dev"))
@@ -513,21 +662,27 @@ class TestMergeWorktreeRemoteTrackingGuard:
 
     @pytest.mark.anyio
     async def test_merge_worktree_diagnoses_unpublished_base_branch(
-        self, tool_ctx: object, tmp_path: Path
+        self, tool_ctx_kitchen_open: object, tmp_path: Path
     ) -> None:
         """merge_worktree returns BASE_NOT_PUBLISHED error when ref is absent after fetch."""
         wt = tmp_path / "wt"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(stdout="/repo/.git/worktrees/wt"))  # rev-parse
-        tool_ctx.runner.push(_make_result(stdout="impl/task-01"))  # branch --show-current
-        tool_ctx.runner.push(_make_result())  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result())  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(stdout="PASS\n= 100 passed ="))  # test check
-        tool_ctx.runner.push(_make_result())  # git fetch origin
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(stdout="/repo/.git/worktrees/wt")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(stdout="impl/task-01")
+        )  # branch --show-current
+        tool_ctx_kitchen_open.runner.push(_make_result())  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(_make_result())  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(stdout="PASS\n= 100 passed =")
+        )  # test check
+        tool_ctx_kitchen_open.runner.push(_make_result())  # git fetch origin
         # Step 5.5: ref check fails — branch not on remote
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
             _make_result(returncode=128, stderr="fatal: Needed a single revision")
         )
 
@@ -541,20 +696,22 @@ class TestMergeWorktreeRemoteTrackingGuard:
 
     @pytest.mark.anyio
     async def test_merge_worktree_unpublished_base_reports_pre_rebase_check_step(
-        self, tool_ctx: object, tmp_path: Path
+        self, tool_ctx_kitchen_open: object, tmp_path: Path
     ) -> None:
         """Step 5.5 failure must report failed_step=PRE_REBASE_CHECK, not REBASE."""
         wt = tmp_path / "wt"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(stdout="/repo/.git/worktrees/wt"))  # rev-parse
-        tool_ctx.runner.push(_make_result(stdout="feat/x"))  # branch
-        tool_ctx.runner.push(_make_result())  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result())  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(stdout="PASS\n= 5 passed ="))  # test-check
-        tool_ctx.runner.push(_make_result())  # fetch
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(stdout="/repo/.git/worktrees/wt")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="feat/x"))  # branch
+        tool_ctx_kitchen_open.runner.push(_make_result())  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(_make_result())  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="PASS\n= 5 passed ="))  # test-check
+        tool_ctx_kitchen_open.runner.push(_make_result())  # fetch
+        tool_ctx_kitchen_open.runner.push(
             _make_result(returncode=128, stderr="fatal: Needed a single revision")
         )  # step 5.5
 
@@ -565,28 +722,30 @@ class TestMergeWorktreeRemoteTrackingGuard:
 
     @pytest.mark.anyio
     async def test_merge_worktree_fatal_invalid_upstream_produces_rebase_aborted(
-        self, tool_ctx: object, tmp_path: Path
+        self, tool_ctx_kitchen_open: object, tmp_path: Path
     ) -> None:
         """Regression: git rebase fatal: invalid upstream is caught as rebase failure."""
         wt = tmp_path / "wt"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(stdout="/repo/.git/worktrees/wt"))
-        tool_ctx.runner.push(_make_result(stdout="impl/task-01"))
-        tool_ctx.runner.push(_make_result())  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result())  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(stdout="PASS\n= 100 passed ="))  # test gate
-        tool_ctx.runner.push(_make_result())  # fetch
-        tool_ctx.runner.push(_make_result())  # ref check passes
-        tool_ctx.runner.push(_make_result())  # git log --merges (no merge commits — step 5.6)
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="/repo/.git/worktrees/wt"))
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="impl/task-01"))
+        tool_ctx_kitchen_open.runner.push(_make_result())  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(_make_result())  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="PASS\n= 100 passed ="))  # test gate
+        tool_ctx_kitchen_open.runner.push(_make_result())  # fetch
+        tool_ctx_kitchen_open.runner.push(_make_result())  # ref check passes
+        tool_ctx_kitchen_open.runner.push(
+            _make_result()
+        )  # git log --merges (no merge commits — step 5.6)
         # Rebase fails with fatal: invalid upstream (bypassed guard scenario)
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 returncode=128, stderr="fatal: invalid upstream 'origin/feature/local-only'"
             )
         )
-        tool_ctx.runner.push(_make_result())  # rebase --abort
+        tool_ctx_kitchen_open.runner.push(_make_result())  # rebase --abort
 
         result = json.loads(await merge_worktree(str(wt), "feature/local-only"))
 
@@ -599,22 +758,22 @@ class TestMergeWorktreeTiming:
     """merge_worktree records wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_merge_worktree_step_name_records_timing(self, tool_ctx, tmp_path):
+    async def test_merge_worktree_step_name_records_timing(self, tool_ctx_kitchen_open, tmp_path):
         wt = tmp_path / "wt"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
-        tool_ctx.runner.push(_make_result(stdout="/repo/.git/worktrees/wt"))
-        tool_ctx.runner.push(_make_result(stdout="impl/task-01"))
-        tool_ctx.runner.push(_make_result())
-        tool_ctx.runner.push(_make_result(stdout="PASS\n= 100 passed ="))
-        tool_ctx.runner.push(_make_result())
-        tool_ctx.runner.push(_make_result())
-        tool_ctx.runner.push(_make_result())  # git log --merges (step 5.6)
-        tool_ctx.runner.push(_make_result())
-        tool_ctx.runner.push(_make_result())
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="/repo/.git/worktrees/wt"))
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="impl/task-01"))
+        tool_ctx_kitchen_open.runner.push(_make_result())
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="PASS\n= 100 passed ="))
+        tool_ctx_kitchen_open.runner.push(_make_result())
+        tool_ctx_kitchen_open.runner.push(_make_result())
+        tool_ctx_kitchen_open.runner.push(_make_result())  # git log --merges (step 5.6)
+        tool_ctx_kitchen_open.runner.push(_make_result())
+        tool_ctx_kitchen_open.runner.push(_make_result())
 
         await merge_worktree(str(wt), "dev", step_name="merge")
-        assert_step_timed(tool_ctx.timing_log, "merge")
+        assert_step_timed(tool_ctx_kitchen_open.timing_log, "merge")
 
     @pytest.mark.anyio
     async def test_merge_worktree_empty_step_name_skips_timing(self, tool_ctx, tmp_path):
@@ -639,10 +798,10 @@ class TestClassifyFixTiming:
     """classify_fix records wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_classify_fix_step_name_records_timing(self, tool_ctx, tmp_path):
-        tool_ctx.runner.push(_make_result(stdout="src/other/file.py\n"))
+    async def test_classify_fix_step_name_records_timing(self, tool_ctx_kitchen_open, tmp_path):
+        tool_ctx_kitchen_open.runner.push(_make_result(stdout="src/other/file.py\n"))
         await classify_fix(str(tmp_path), "main", step_name="classify")
-        assert_step_timed(tool_ctx.timing_log, "classify")
+        assert_step_timed(tool_ctx_kitchen_open.timing_log, "classify")
 
     @pytest.mark.anyio
     async def test_classify_fix_empty_step_name_skips_timing(self, tool_ctx, tmp_path):
@@ -655,21 +814,31 @@ class TestMergeWorktreeMergeCommitDetection:
     """merge_worktree detects merge commits before rebase and returns actionable error."""
 
     @pytest.mark.anyio
-    async def test_detects_merge_commits_before_rebase(self, tool_ctx, tmp_path):
+    async def test_detects_merge_commits_before_rebase(self, tool_ctx_kitchen_open, tmp_path):
         """Step 5.6: merge commits in worktree history abort before rebase with specific error."""
         wt = tmp_path / "wt"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))  # rev-parse
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))  # test-check
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git fetch
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))  # rev-parse --verify (step 5.5)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "/repo/.git/worktrees/wt\n", "")
+        )  # rev-parse
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))  # branch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "PASS\n= 100 passed =", "")
+        )  # test-check
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git fetch
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\n", "")
+        )  # rev-parse --verify (step 5.5)
         # Step 5.6: git log --merges finds merge commits
-        tool_ctx.runner.push(_make_result(0, "bb481aa Merge PR branch\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "bb481aa Merge PR branch\n", ""))
 
         result = json.loads(await merge_worktree(str(wt), "dev"))
 
@@ -679,20 +848,24 @@ class TestMergeWorktreeMergeCommitDetection:
         assert result["merge_commits"] == ["bb481aa Merge PR branch"]
 
     @pytest.mark.anyio
-    async def test_merge_commit_error_message_is_actionable(self, tool_ctx, tmp_path):
+    async def test_merge_commit_error_message_is_actionable(self, tool_ctx_kitchen_open, tmp_path):
         """Step 5.6: error message names cherry-pick, checkout, and forbids run_cmd bypass."""
         wt = tmp_path / "wt"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))
-        tool_ctx.runner.push(_make_result(0, "bb481aa Merge PR branch\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "abc123\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "bb481aa Merge PR branch\n", ""))
 
         result = json.loads(await merge_worktree(str(wt), "dev"))
 
@@ -702,22 +875,30 @@ class TestMergeWorktreeMergeCommitDetection:
         assert "run_cmd" in result["error"]
 
     @pytest.mark.anyio
-    async def test_linear_history_passes_merge_commit_check(self, tool_ctx, tmp_path):
+    async def test_linear_history_passes_merge_commit_check(self, tool_ctx_kitchen_open, tmp_path):
         """Step 5.6: empty git log --merges output allows pipeline to continue to rebase."""
         wt = tmp_path / "wt"
         wt.mkdir()
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/wt")
 
-        tool_ctx.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
-        tool_ctx.runner.push(_make_result(0, "impl-branch\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git ls-files (pre-dirty-tree check)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
-        tool_ctx.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))
-        tool_ctx.runner.push(_make_result(0, "abc123\n", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git log --merges returns empty (step 5.6)
-        tool_ctx.runner.push(_make_result(1, "", "CONFLICT (content): ..."))  # rebase fails
-        tool_ctx.runner.push(_make_result(0, "", ""))  # rebase --abort
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "/repo/.git/worktrees/wt\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "impl-branch\n", ""))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git ls-files (pre-dirty-tree check)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git status --porcelain (clean)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "PASS\n= 100 passed =", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "abc123\n", ""))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # git log --merges returns empty (step 5.6)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(1, "", "CONFLICT (content): ...")
+        )  # rebase fails
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # rebase --abort
 
         result = json.loads(await merge_worktree(str(wt), "dev"))
 
@@ -728,38 +909,48 @@ class TestMergeWorktreeMergeCommitDetection:
 
 class TestCreateUniqueBranch:
     @pytest.mark.anyio
-    async def test_creates_branch_when_unique(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "", ""))  # ls-remote: empty = absent
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))  # branch --show-current (HEAD state)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git checkout -b
+    async def test_creates_branch_when_unique(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # ls-remote: empty = absent
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "main\n", "")
+        )  # branch --show-current (HEAD state)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git checkout -b
         result = json.loads(await create_unique_branch("feat-foo", 42, "origin", "."))
         assert result["branch_name"] == "feat-foo-42"
         assert result["was_unique"] is True
 
     @pytest.mark.anyio
-    async def test_appends_suffix_when_branch_exists_on_remote(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "abc123\trefs/heads/feat-foo-42\n", ""))  # exists
-        tool_ctx.runner.push(_make_result(0, "", ""))  # -2 not found
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))  # branch --show-current (HEAD state)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # checkout -b feat-foo-42-2
+    async def test_appends_suffix_when_branch_exists_on_remote(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "abc123\trefs/heads/feat-foo-42\n", "")
+        )  # exists
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # -2 not found
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "main\n", "")
+        )  # branch --show-current (HEAD state)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # checkout -b feat-foo-42-2
         result = json.loads(await create_unique_branch("feat-foo", 42, "origin", "."))
         assert result["branch_name"] == "feat-foo-42-2"
         assert result["was_unique"] is False
 
     @pytest.mark.anyio
-    async def test_ls_remote_auth_failure_falls_back_gracefully(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(128, "", "fatal: Authentication failed"))
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))  # branch --show-current (HEAD state)
-        tool_ctx.runner.push(_make_result(0, "", ""))  # checkout proceeds with base name
+    async def test_ls_remote_auth_failure_falls_back_gracefully(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(128, "", "fatal: Authentication failed"))
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "main\n", "")
+        )  # branch --show-current (HEAD state)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # checkout proceeds with base name
         result = json.loads(await create_unique_branch("feat-foo", 42, "origin", "."))
         assert result["branch_name"] == "feat-foo-42"
         assert result["was_unique"] is True
 
     @pytest.mark.anyio
-    async def test_no_issue_uses_slug_only(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "", ""))  # ls-remote
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))  # branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # checkout -b
+    async def test_no_issue_uses_slug_only(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # ls-remote
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))  # branch --show-current
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # checkout -b
         result = json.loads(await create_unique_branch("feat-bar", None, "origin", "."))
         assert result["branch_name"] == "feat-bar"
 
@@ -771,46 +962,58 @@ class TestCreateUniqueBranch:
         assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
-    async def test_timing_recorded_when_step_name_provided(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "", ""))  # ls-remote
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))  # branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # checkout -b
+    async def test_timing_recorded_when_step_name_provided(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # ls-remote
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))  # branch --show-current
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # checkout -b
         await create_unique_branch("feat-x", 1, "origin", ".", step_name="branch_step")
-        assert any(e["step_name"] == "branch_step" for e in tool_ctx.timing_log.get_report())
+        assert any(
+            e["step_name"] == "branch_step" for e in tool_ctx_kitchen_open.timing_log.get_report()
+        )
 
     @pytest.mark.anyio
-    async def test_create_unique_branch_uses_base_branch_name_when_provided(self, tool_ctx):
+    async def test_create_unique_branch_uses_base_branch_name_when_provided(
+        self, tool_ctx_kitchen_open
+    ):
         """AP3: when base_branch_name is provided, use it directly as the base."""
-        tool_ctx.runner.push(_make_result(0, "", ""))  # ls-remote: empty = absent
-        tool_ctx.runner.push(_make_result(0, "main\n", ""))  # branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git checkout -b
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # ls-remote: empty = absent
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))  # branch --show-current
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git checkout -b
         result = json.loads(await create_unique_branch(base_branch_name="impl/238", cwd="."))
         assert result["branch_name"] == "impl/238"
         # ls-remote must check the exact base_branch_name, not slug-issue composition
         ls_remote_cmd = next(
-            (args[0] for args in tool_ctx.runner.call_args_list if "ls-remote" in args[0]),
+            (
+                args[0]
+                for args in tool_ctx_kitchen_open.runner.call_args_list
+                if "ls-remote" in args[0]
+            ),
             None,
         )
         assert ls_remote_cmd is not None, "No ls-remote subprocess call found"
         assert any("impl/238" in arg for arg in ls_remote_cmd)
 
     @pytest.mark.anyio
-    async def test_reports_base_ref_in_return_value(self, tool_ctx):
+    async def test_reports_base_ref_in_return_value(self, tool_ctx_kitchen_open):
         """Test 1.6: create_unique_branch reports base_ref (the branch HEAD was on)."""
-        tool_ctx.runner.push(_make_result(0, "", ""))  # ls-remote: empty = absent
-        tool_ctx.runner.push(_make_result(0, "feature-branch\n", ""))  # branch --show-current
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git checkout -b
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # ls-remote: empty = absent
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "feature-branch\n", "")
+        )  # branch --show-current
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git checkout -b
         result = json.loads(await create_unique_branch("feat-foo", 42, "origin", "."))
         assert result["branch_name"] == "feat-foo-42"
         assert result["was_unique"] is True
         assert result["base_ref"] == "feature-branch"
 
     @pytest.mark.anyio
-    async def test_reports_detached_head_as_base_ref(self, tool_ctx):
+    async def test_reports_detached_head_as_base_ref(self, tool_ctx_kitchen_open):
         """create_unique_branch reports DETACHED_HEAD when HEAD is detached."""
-        tool_ctx.runner.push(_make_result(0, "", ""))  # ls-remote: empty = absent
-        tool_ctx.runner.push(_make_result(0, "", ""))  # branch --show-current returns empty
-        tool_ctx.runner.push(_make_result(0, "", ""))  # git checkout -b
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # ls-remote: empty = absent
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # branch --show-current returns empty
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git checkout -b
         result = json.loads(await create_unique_branch("feat-foo", 42, "origin", "."))
         assert result["branch_name"] == "feat-foo-42"
         assert result["base_ref"] == "DETACHED_HEAD"
@@ -818,8 +1021,8 @@ class TestCreateUniqueBranch:
 
 class TestCheckPrMergeable:
     @pytest.mark.anyio
-    async def test_mergeable_pr(self, tool_ctx):
-        tool_ctx.runner.push(
+    async def test_mergeable_pr(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0, json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}), ""
             )
@@ -830,8 +1033,8 @@ class TestCheckPrMergeable:
         assert result["mergeable_status"] == "MERGEABLE"
 
     @pytest.mark.anyio
-    async def test_conflicting_pr_is_not_mergeable(self, tool_ctx):
-        tool_ctx.runner.push(
+    async def test_conflicting_pr_is_not_mergeable(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0, json.dumps({"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"}), ""
             )
@@ -842,8 +1045,8 @@ class TestCheckPrMergeable:
         assert result["mergeable_status"] == "CONFLICTING"
 
     @pytest.mark.anyio
-    async def test_unknown_mergeable_status_returned_raw(self, tool_ctx):
-        tool_ctx.runner.push(
+    async def test_unknown_mergeable_status_returned_raw(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0, json.dumps({"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"}), ""
             )
@@ -866,14 +1069,14 @@ class TestCheckPrMergeable:
         assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
-    async def test_repo_flag_passed_to_gh(self, tool_ctx):
-        tool_ctx.runner.push(
+    async def test_repo_flag_passed_to_gh(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0, json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}), ""
             )
         )
         result = json.loads(await check_pr_mergeable(42, ".", repo="owner/myrepo"))
-        call_cmd = tool_ctx.runner.call_args_list[-1][0]
+        call_cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         assert "-R" in call_cmd
         assert result["mergeable"] is True
 
@@ -882,10 +1085,12 @@ class TestClassifyFixRemoteResolution:
     """T3: classify_fix resolves the remote via resolve_remote_name internally."""
 
     @pytest.mark.anyio
-    async def test_classify_fix_uses_upstream_when_available(self, tool_ctx, tmp_path):
+    async def test_classify_fix_uses_upstream_when_available(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """When resolve_remote_name returns 'upstream', fetch and diff use 'upstream'."""
-        tool_ctx.runner.push(_make_result(0, "", ""))  # fetch succeeds
-        tool_ctx.runner.push(_make_result(0, "src/foo.py\n", ""))  # diff succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "src/foo.py\n", ""))  # diff succeeds
 
         with patch(
             "autoskillit.server._misc.resolve_remote_name",
@@ -893,16 +1098,16 @@ class TestClassifyFixRemoteResolution:
         ):
             await classify_fix(str(tmp_path), "main")
 
-        fetch_cmd = tool_ctx.runner.call_args_list[0][0]
+        fetch_cmd = tool_ctx_kitchen_open.runner.call_args_list[0][0]
         assert fetch_cmd == ["git", "fetch", "upstream", "main"]
-        diff_cmd = tool_ctx.runner.call_args_list[1][0]
+        diff_cmd = tool_ctx_kitchen_open.runner.call_args_list[1][0]
         assert "upstream/main...HEAD" in diff_cmd[-1]
 
     @pytest.mark.anyio
-    async def test_classify_fix_falls_back_to_origin(self, tool_ctx, tmp_path):
+    async def test_classify_fix_falls_back_to_origin(self, tool_ctx_kitchen_open, tmp_path):
         """When resolve_remote_name returns 'origin', fetch and diff use 'origin'."""
-        tool_ctx.runner.push(_make_result(0, "", ""))  # fetch succeeds
-        tool_ctx.runner.push(_make_result(0, "src/bar.py\n", ""))  # diff succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # fetch succeeds
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "src/bar.py\n", ""))  # diff succeeds
 
         with patch(
             "autoskillit.server._misc.resolve_remote_name",
@@ -910,7 +1115,7 @@ class TestClassifyFixRemoteResolution:
         ):
             await classify_fix(str(tmp_path), "main")
 
-        fetch_cmd = tool_ctx.runner.call_args_list[0][0]
+        fetch_cmd = tool_ctx_kitchen_open.runner.call_args_list[0][0]
         assert fetch_cmd == ["git", "fetch", "origin", "main"]
-        diff_cmd = tool_ctx.runner.call_args_list[1][0]
+        diff_cmd = tool_ctx_kitchen_open.runner.call_args_list[1][0]
         assert "origin/main...HEAD" in diff_cmd[-1]

--- a/tests/server/test_tools_github.py
+++ b/tests/server/test_tools_github.py
@@ -30,16 +30,16 @@ async def test_fetch_github_issue_gate_closed(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_fetch_github_issue_no_client(tool_ctx) -> None:
+async def test_fetch_github_issue_no_client(tool_ctx_kitchen_open) -> None:
     """github_client=None → {"success": False, "error": "GitHub client not configured"}."""
-    tool_ctx.github_client = None
+    tool_ctx_kitchen_open.github_client = None
     result = json.loads(await fetch_github_issue("owner/repo#42"))
     assert result["success"] is False
     assert "GitHub client not configured" in result["error"]
 
 
 @pytest.mark.anyio
-async def test_fetch_github_issue_success(tool_ctx) -> None:
+async def test_fetch_github_issue_success(tool_ctx_kitchen_open) -> None:
     """client.fetch_issue returns data → JSON with that data."""
     issue_data = {
         "success": True,
@@ -50,8 +50,8 @@ async def test_fetch_github_issue_success(tool_ctx) -> None:
         "labels": [],
         "content": "## Body\nSome content.",
     }
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.github_client.fetch_issue = AsyncMock(return_value=issue_data)
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(return_value=issue_data)
 
     result = json.loads(await fetch_github_issue("https://github.com/owner/repo/issues/42"))
     assert result["success"] is True
@@ -59,10 +59,10 @@ async def test_fetch_github_issue_success(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_fetch_github_issue_bare_number_no_default_repo(tool_ctx) -> None:
+async def test_fetch_github_issue_bare_number_no_default_repo(tool_ctx_kitchen_open) -> None:
     """issue_url='42', no default_repo → error response."""
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.config.github.default_repo = ""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.config.github.default_repo = ""
 
     result = json.loads(await fetch_github_issue("42"))
     assert result["success"] is False
@@ -71,10 +71,10 @@ async def test_fetch_github_issue_bare_number_no_default_repo(tool_ctx) -> None:
 
 @pytest.mark.anyio
 async def test_fetch_github_issue_bare_number_with_default_repo(
-    tool_ctx,
+    tool_ctx_kitchen_open,
 ) -> None:
     """issue_url='42', default_repo='owner/repo' → resolves to 'owner/repo#42'."""
-    tool_ctx.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
     issue_data = {
         "success": True,
         "issue_number": 42,
@@ -84,18 +84,18 @@ async def test_fetch_github_issue_bare_number_with_default_repo(
         "labels": [],
         "content": "content",
     }
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.github_client.fetch_issue = AsyncMock(return_value=issue_data)
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(return_value=issue_data)
 
     result = json.loads(await fetch_github_issue("42"))
     assert result["success"] is True
     # Verify fetch_issue was called with the resolved ref
-    call_args = tool_ctx.github_client.fetch_issue.call_args
+    call_args = tool_ctx_kitchen_open.github_client.fetch_issue.call_args
     assert "owner/repo#42" in call_args.args[0]
 
 
 @pytest.mark.anyio
-async def test_fetch_github_issue_delegates_to_client(tool_ctx):
+async def test_fetch_github_issue_delegates_to_client(tool_ctx_kitchen_open):
     mock_client = AsyncMock()
     mock_client.fetch_issue.return_value = {
         "success": True,
@@ -106,7 +106,7 @@ async def test_fetch_github_issue_delegates_to_client(tool_ctx):
         "labels": [],
         "content": "# T",
     }
-    tool_ctx.github_client = mock_client
+    tool_ctx_kitchen_open.github_client = mock_client
     result = json.loads(await fetch_github_issue("owner/repo#1"))
     assert result["success"] is True
     mock_client.fetch_issue.assert_called_once_with("owner/repo#1", include_comments=True)
@@ -170,7 +170,7 @@ async def test_get_issue_title_no_client(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_get_issue_title_success(tool_ctx) -> None:
+async def test_get_issue_title_success(tool_ctx_kitchen_open) -> None:
     """client.fetch_title returns data → JSON with title and slug."""
     title_data = {
         "success": True,
@@ -178,8 +178,8 @@ async def test_get_issue_title_success(tool_ctx) -> None:
         "title": "Fix the bug",
         "slug": "fix-the-bug",
     }
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.github_client.fetch_title = AsyncMock(return_value=title_data)
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(return_value=title_data)
 
     result = json.loads(await get_issue_title("owner/repo#42"))
     assert result["success"] is True
@@ -188,7 +188,7 @@ async def test_get_issue_title_success(tool_ctx) -> None:
 
 class TestGetIssueTitleTool:
     @pytest.mark.anyio
-    async def test_get_issue_title_success(self, tool_ctx):
+    async def test_get_issue_title_success(self, tool_ctx_kitchen_open):
         """Delegates to github_client.fetch_title; returns JSON result."""
         mock_client = AsyncMock()
         mock_client.fetch_title.return_value = {
@@ -197,7 +197,7 @@ class TestGetIssueTitleTool:
             "title": "Fix merge conflict triage",
             "slug": "fix-merge-conflict-triage",
         }
-        tool_ctx.github_client = mock_client
+        tool_ctx_kitchen_open.github_client = mock_client
         result = json.loads(await get_issue_title("https://github.com/owner/repo/issues/42"))
         assert result["success"] is True
         assert result["number"] == 42

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -34,39 +34,39 @@ class TestClaimIssueTool:
         assert "claim_issue" in GATED_TOOLS
 
     @pytest.mark.anyio
-    async def test_claim_issue_returns_error_without_github_client(self, tool_ctx):
-        tool_ctx.github_client = None
+    async def test_claim_issue_returns_error_without_github_client(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.github_client = None
         result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
         assert result["success"] is False
         assert "error" in result
 
     @pytest.mark.anyio
-    async def test_claim_issue_success(self, tool_ctx):
+    async def test_claim_issue_success(self, tool_ctx_kitchen_open):
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {"success": True, "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.add_labels.return_value = {"success": True, "labels": ["in-progress"]}
-        tool_ctx.github_client = mock_client
+        tool_ctx_kitchen_open.github_client = mock_client
         result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
         assert result["success"] is True
         assert result["claimed"] is True
         assert result["issue_number"] == 42
 
     @pytest.mark.anyio
-    async def test_claim_issue_already_claimed(self, tool_ctx):
+    async def test_claim_issue_already_claimed(self, tool_ctx_kitchen_open):
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {
             "success": True,
             "labels": [{"name": "in-progress"}],
         }
-        tool_ctx.github_client = mock_client
+        tool_ctx_kitchen_open.github_client = mock_client
         result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
         assert result["success"] is True
         assert result["claimed"] is False
 
     # P5F4-T1
     @pytest.mark.anyio
-    async def test_claim_issue_binds_structlog_context(self, tool_ctx, monkeypatch):
+    async def test_claim_issue_binds_structlog_context(self, tool_ctx_kitchen_open, monkeypatch):
         """claim_issue must bind structlog context vars via bind_contextvars."""
         import structlog
 
@@ -78,7 +78,7 @@ class TestClaimIssueTool:
         monkeypatch.setattr(structlog.contextvars, "bind_contextvars", fake_bind_contextvars)
         monkeypatch.setattr(structlog.contextvars, "clear_contextvars", lambda: None)
 
-        tool_ctx.github_client = None  # triggers early return after bind
+        tool_ctx_kitchen_open.github_client = None  # triggers early return after bind
 
         await claim_issue(issue_url="https://github.com/owner/repo/issues/1")
         assert captured == {
@@ -88,7 +88,7 @@ class TestClaimIssueTool:
 
     @pytest.mark.anyio
     async def test_claim_issue_allow_reentry_true_returns_claimed_true_when_already_labeled(
-        self, tool_ctx
+        self, tool_ctx_kitchen_open
     ):
         """allow_reentry=True with label present: returns claimed=True and reentry=True."""
         mock_client = AsyncMock()
@@ -96,7 +96,7 @@ class TestClaimIssueTool:
             "success": True,
             "labels": [{"name": "in-progress"}],
         }
-        tool_ctx.github_client = mock_client
+        tool_ctx_kitchen_open.github_client = mock_client
         result = json.loads(
             await claim_issue("https://github.com/owner/repo/issues/42", allow_reentry=True)
         )
@@ -107,7 +107,7 @@ class TestClaimIssueTool:
 
     @pytest.mark.anyio
     async def test_claim_issue_allow_reentry_false_returns_claimed_false_when_already_labeled(
-        self, tool_ctx
+        self, tool_ctx_kitchen_open
     ):
         """Default allow_reentry=False: claimed=False when label already present."""
         mock_client = AsyncMock()
@@ -115,20 +115,22 @@ class TestClaimIssueTool:
             "success": True,
             "labels": [{"name": "in-progress"}],
         }
-        tool_ctx.github_client = mock_client
+        tool_ctx_kitchen_open.github_client = mock_client
         result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
         assert result["success"] is True
         assert result["claimed"] is False
         assert "reentry" not in result
 
     @pytest.mark.anyio
-    async def test_claim_issue_allow_reentry_true_still_claims_when_label_absent(self, tool_ctx):
+    async def test_claim_issue_allow_reentry_true_still_claims_when_label_absent(
+        self, tool_ctx_kitchen_open
+    ):
         """allow_reentry=True with no pre-existing label performs normal claim."""
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {"success": True, "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["in-progress"]}
-        tool_ctx.github_client = mock_client
+        tool_ctx_kitchen_open.github_client = mock_client
         result = json.loads(
             await claim_issue("https://github.com/owner/repo/issues/42", allow_reentry=True)
         )
@@ -147,24 +149,24 @@ class TestReleaseIssueTool:
         assert "release_issue" in GATED_TOOLS
 
     @pytest.mark.anyio
-    async def test_release_issue_returns_error_without_github_client(self, tool_ctx):
-        tool_ctx.github_client = None
+    async def test_release_issue_returns_error_without_github_client(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.github_client = None
         result = json.loads(await release_issue("https://github.com/owner/repo/issues/42"))
         assert result["success"] is False
         assert "error" in result
 
     @pytest.mark.anyio
-    async def test_release_issue_success(self, tool_ctx):
+    async def test_release_issue_success(self, tool_ctx_kitchen_open):
         mock_client = AsyncMock()
         mock_client.remove_label.return_value = {"success": True}
-        tool_ctx.github_client = mock_client
+        tool_ctx_kitchen_open.github_client = mock_client
         result = json.loads(await release_issue("https://github.com/owner/repo/issues/42"))
         assert result["success"] is True
         assert result["issue_number"] == 42
 
     # P5F4-T2
     @pytest.mark.anyio
-    async def test_release_issue_binds_structlog_context(self, tool_ctx, monkeypatch):
+    async def test_release_issue_binds_structlog_context(self, tool_ctx_kitchen_open, monkeypatch):
         """release_issue must bind structlog context vars via bind_contextvars."""
         import structlog
 
@@ -176,7 +178,7 @@ class TestReleaseIssueTool:
         monkeypatch.setattr(structlog.contextvars, "bind_contextvars", fake_bind_contextvars)
         monkeypatch.setattr(structlog.contextvars, "clear_contextvars", lambda: None)
 
-        tool_ctx.github_client = None  # triggers early return after bind
+        tool_ctx_kitchen_open.github_client = None  # triggers early return after bind
 
         await release_issue(issue_url="https://github.com/owner/repo/issues/1")
         assert captured == {
@@ -192,7 +194,7 @@ class TestPrepareIssueTool:
         assert "prepare_issue" in GATED_TOOLS
 
     @pytest.mark.anyio
-    async def test_prepare_issue_success_with_result_block(self, tool_ctx):
+    async def test_prepare_issue_success_with_result_block(self, tool_ctx_kitchen_open):
         """Happy path: executor returns success=True with a valid result block."""
         result_text = (
             f"{_PREPARE_RESULT_START}\n"
@@ -214,7 +216,7 @@ class TestPrepareIssueTool:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(await prepare_issue("Test title", "Test body"))
 
@@ -224,7 +226,9 @@ class TestPrepareIssueTool:
         assert "error" not in result
 
     @pytest.mark.anyio
-    async def test_prepare_issue_success_empty_result_channel_b_drain_race(self, tool_ctx):
+    async def test_prepare_issue_success_empty_result_channel_b_drain_race(
+        self, tool_ctx_kitchen_open
+    ):
         """Channel B drain race: executor returns success=True but result is empty.
         Response must be success=False with diagnostics — THE KEY CONTRADICTION TEST.
         """
@@ -240,7 +244,7 @@ class TestPrepareIssueTool:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(await prepare_issue("Test title", "Test body"))
 
@@ -251,7 +255,7 @@ class TestPrepareIssueTool:
         assert result["status"] != "complete"  # contradiction must be impossible
 
     @pytest.mark.anyio
-    async def test_prepare_issue_failure_with_diagnostics(self, tool_ctx):
+    async def test_prepare_issue_failure_with_diagnostics(self, tool_ctx_kitchen_open):
         """Executor failure: response must surface session_id, stderr, subtype, exit_code."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -265,7 +269,7 @@ class TestPrepareIssueTool:
             retry_reason=RetryReason.NONE,
             stderr="Claude exited unexpectedly",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(await prepare_issue("Test title", "Test body"))
 
@@ -276,7 +280,9 @@ class TestPrepareIssueTool:
         assert result["exit_code"] == 1
 
     @pytest.mark.anyio
-    async def test_prepare_issue_passes_expected_output_patterns_to_executor(self, tool_ctx):
+    async def test_prepare_issue_passes_expected_output_patterns_to_executor(
+        self, tool_ctx_kitchen_open
+    ):
         """output_pattern_resolver is consulted and patterns are passed to executor.run()."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -290,8 +296,8 @@ class TestPrepareIssueTool:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
-        tool_ctx.output_pattern_resolver = lambda cmd: ["---prepare-issue-result---"]
+        tool_ctx_kitchen_open.executor = mock_executor
+        tool_ctx_kitchen_open.output_pattern_resolver = lambda cmd: ["---prepare-issue-result---"]
 
         await prepare_issue("Title", "Body")
 
@@ -300,7 +306,7 @@ class TestPrepareIssueTool:
 
     @pytest.mark.anyio
     async def test_prepare_issue_response_success_field_never_overwritten_by_parsed_spread(
-        self, tool_ctx
+        self, tool_ctx_kitchen_open
     ):
         """When parsed block contains 'success': false, the outer success=True is preserved."""
         result_text = (
@@ -320,7 +326,7 @@ class TestPrepareIssueTool:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(await prepare_issue("Title", "Body"))
 
@@ -336,7 +342,7 @@ class TestPrepareIssueTool:
         ],
     )
     async def test_prepare_issue_contradictory_state_is_impossible(
-        self, tool_ctx, skill_success, skill_result_text
+        self, tool_ctx_kitchen_open, skill_success, skill_result_text
     ):
         """status=complete and success=False must never co-exist in any response."""
         mock_executor = AsyncMock()
@@ -351,7 +357,7 @@ class TestPrepareIssueTool:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(await prepare_issue("Title", "Body"))
 
@@ -359,7 +365,7 @@ class TestPrepareIssueTool:
         assert result["status"] == "failed"
 
     @pytest.mark.anyio
-    async def test_prepare_issue_no_result_block_includes_stderr(self, tool_ctx):
+    async def test_prepare_issue_no_result_block_includes_stderr(self, tool_ctx_kitchen_open):
         """success=True + non-empty result + no delimiters → stderr surfaced."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -373,7 +379,7 @@ class TestPrepareIssueTool:
             needs_retry=False,
             retry_reason=RetryReason.NONE,
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
         response = json.loads(await prepare_issue("Test Issue", ""))
         assert response["success"] is False
         assert response["error"] == "no result block found"
@@ -382,7 +388,7 @@ class TestPrepareIssueTool:
         assert response["session_id"] == "abc-123"
 
     @pytest.mark.anyio
-    async def test_prepare_issue_empty_output_includes_stderr(self, tool_ctx):
+    async def test_prepare_issue_empty_output_includes_stderr(self, tool_ctx_kitchen_open):
         """success=True + empty result (drain race) → stderr surfaced."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -396,7 +402,7 @@ class TestPrepareIssueTool:
             needs_retry=False,
             retry_reason=RetryReason.NONE,
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
         response = json.loads(await prepare_issue("Test Issue", ""))
         assert response["success"] is False
         assert "drain race" in response["error"]
@@ -405,7 +411,9 @@ class TestPrepareIssueTool:
         assert response["session_id"] == "abc-456"
 
     @pytest.mark.anyio
-    async def test_prepare_issue_session_failure_uses_subtype_not_block_sentinel(self, tool_ctx):
+    async def test_prepare_issue_session_failure_uses_subtype_not_block_sentinel(
+        self, tool_ctx_kitchen_open
+    ):
         """success=False must NOT call _parse_prepare_result.
         The error must reflect actual failure reason, not 'no result block found'.
         """
@@ -421,7 +429,7 @@ class TestPrepareIssueTool:
             needs_retry=True,
             retry_reason=RetryReason.RESUME,
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
         response = json.loads(await prepare_issue("Test Issue", ""))
         assert response["success"] is False
         assert response["error"] != "no result block found", (
@@ -437,7 +445,9 @@ class TestEnrichIssuesTool:
         assert "enrich_issues" in GATED_TOOLS
 
     @pytest.mark.anyio
-    async def test_enrich_issues_success_empty_result_includes_diagnostics(self, tool_ctx):
+    async def test_enrich_issues_success_empty_result_includes_diagnostics(
+        self, tool_ctx_kitchen_open
+    ):
         """Drain race for enrich_issues: success=True with empty result must yield failure."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -451,7 +461,7 @@ class TestEnrichIssuesTool:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(await enrich_issues())
 
@@ -459,7 +469,9 @@ class TestEnrichIssuesTool:
         assert result["session_id"] == "sid789"
 
     @pytest.mark.anyio
-    async def test_enrich_issues_failure_includes_session_id_and_stderr(self, tool_ctx):
+    async def test_enrich_issues_failure_includes_session_id_and_stderr(
+        self, tool_ctx_kitchen_open
+    ):
         """Executor failure: response includes session_id and stderr for diagnosis."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -473,7 +485,7 @@ class TestEnrichIssuesTool:
             retry_reason=RetryReason.NONE,
             stderr="Session timed out",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(await enrich_issues())
 
@@ -482,7 +494,9 @@ class TestEnrichIssuesTool:
         assert result["stderr"] == "Session timed out"
 
     @pytest.mark.anyio
-    async def test_enrich_issues_passes_expected_output_patterns_to_executor(self, tool_ctx):
+    async def test_enrich_issues_passes_expected_output_patterns_to_executor(
+        self, tool_ctx_kitchen_open
+    ):
         """output_pattern_resolver is consulted and patterns are passed to executor.run()."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -496,8 +510,8 @@ class TestEnrichIssuesTool:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
-        tool_ctx.output_pattern_resolver = lambda cmd: ["---enrich-issues-result---"]
+        tool_ctx_kitchen_open.executor = mock_executor
+        tool_ctx_kitchen_open.output_pattern_resolver = lambda cmd: ["---enrich-issues-result---"]
 
         await enrich_issues()
 
@@ -505,7 +519,7 @@ class TestEnrichIssuesTool:
         assert call_kwargs.get("expected_output_patterns") == ["---enrich-issues-result---"]
 
     @pytest.mark.anyio
-    async def test_enrich_issues_no_result_block_includes_stderr(self, tool_ctx):
+    async def test_enrich_issues_no_result_block_includes_stderr(self, tool_ctx_kitchen_open):
         """success=True + non-empty result + no delimiters → stderr surfaced."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -519,7 +533,7 @@ class TestEnrichIssuesTool:
             needs_retry=False,
             retry_reason=RetryReason.NONE,
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
         response = json.loads(await enrich_issues())
         assert response["success"] is False
         assert response["error"] == "no result block found"
@@ -632,7 +646,7 @@ _HEADLESS_FAILURE_SCENARIOS = [
 @pytest.mark.anyio
 @pytest.mark.parametrize("tool_name,skill_result_kwargs", _HEADLESS_FAILURE_SCENARIOS)
 async def test_headless_tool_failure_paths_include_all_diagnostic_fields(
-    tool_name, skill_result_kwargs, tool_ctx
+    tool_name, skill_result_kwargs, tool_ctx_kitchen_open
 ):
     """Contract test: every failure path of every headless session tool
     must surface the full diagnostic set: success, error, session_id,
@@ -641,7 +655,7 @@ async def test_headless_tool_failure_paths_include_all_diagnostic_fields(
     tool_fn = {"prepare_issue": prepare_issue, "enrich_issues": enrich_issues}[tool_name]
     mock_executor = AsyncMock()
     mock_executor.run.return_value = SkillResult(**skill_result_kwargs)
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     kwargs: dict = {}
     if tool_name == "prepare_issue":
@@ -657,8 +671,8 @@ async def test_headless_tool_failure_paths_include_all_diagnostic_fields(
 
 class TestGetPrReviews:
     @pytest.mark.anyio
-    async def test_returns_structured_reviews(self, tool_ctx):
-        tool_ctx.runner.push(
+    async def test_returns_structured_reviews(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 json.dumps(
@@ -679,8 +693,8 @@ class TestGetPrReviews:
         assert result["reviews"][0] == {"author": "reviewer1", "state": "APPROVED", "body": "LGTM"}
 
     @pytest.mark.anyio
-    async def test_empty_reviews(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, json.dumps([]), ""))
+    async def test_empty_reviews(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, json.dumps([]), ""))
         result = json.loads(await get_pr_reviews(42, ".", repo="owner/repo"))
         assert result["reviews"] == []
 
@@ -691,8 +705,8 @@ class TestGetPrReviews:
         assert result["success"] is False
 
     @pytest.mark.anyio
-    async def test_without_repo_uses_pr_view(self, tool_ctx):
-        tool_ctx.runner.push(
+    async def test_without_repo_uses_pr_view(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(
             _make_result(
                 0,
                 json.dumps(
@@ -725,34 +739,34 @@ class TestBulkCloseIssues:
         )
 
     @pytest.mark.anyio
-    async def test_closes_all_issues_successfully(self, tool_ctx):
+    async def test_closes_all_issues_successfully(self, tool_ctx_kitchen_open):
         for _ in range(3):
-            tool_ctx.runner.push(_make_result(0, "", ""))
+            tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         result = json.loads(await bulk_close_issues([1, 2, 3], "", "."))
         assert result["closed"] == [1, 2, 3]
         assert result["failed"] == []
 
     @pytest.mark.anyio
-    async def test_partial_failure_tracked_per_issue(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "", ""))
-        tool_ctx.runner.push(_make_result(1, "", "not found"))
-        tool_ctx.runner.push(_make_result(0, "", ""))
+    async def test_partial_failure_tracked_per_issue(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(1, "", "not found"))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         result = json.loads(await bulk_close_issues([1, 2, 3], "", "."))
         assert result["closed"] == [1, 3]
         assert result["failed"] == [2]
 
     @pytest.mark.anyio
-    async def test_empty_numbers_list(self, tool_ctx):
+    async def test_empty_numbers_list(self, tool_ctx_kitchen_open):
         result = json.loads(await bulk_close_issues([], "", "."))
         assert result == {"closed": [], "failed": []}
 
     @pytest.mark.anyio
-    async def test_comment_appended_to_body_when_provided(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "existing body", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))
-        tool_ctx.runner.push(_make_result(0, "", ""))
+    async def test_comment_appended_to_body_when_provided(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "existing body", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         result = json.loads(await bulk_close_issues([7], "Closed by pipeline.", "."))
-        all_cmds = [call[0] for call in tool_ctx.runner.call_args_list]
+        all_cmds = [call[0] for call in tool_ctx_kitchen_open.runner.call_args_list]
         edit_calls = [cmd for cmd in all_cmds if "edit" in cmd]
         assert any("--body-file" in cmd for cmd in edit_calls), (
             "Expected gh issue edit --body-file call"

--- a/tests/server/test_tools_integrations_release.py
+++ b/tests/server/test_tools_integrations_release.py
@@ -14,12 +14,14 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 class TestReleaseIssueStagedLifecycle:
     @pytest.mark.anyio
-    async def test_release_issue_non_default_branch_applies_staged(self, tool_ctx, monkeypatch):
+    async def test_release_issue_non_default_branch_applies_staged(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """Non-default target_branch: swap_labels atomically removes in-progress, adds staged."""
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["bug", "staged"]}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -41,11 +43,13 @@ class TestReleaseIssueStagedLifecycle:
         mock_client.swap_labels.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_release_issue_default_branch_no_staged(self, tool_ctx, monkeypatch):
+    async def test_release_issue_default_branch_no_staged(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """release_issue with target_branch='main' uses swap_labels to remove in-progress."""
         mock_client = AsyncMock()
         mock_client.swap_labels.return_value = {"success": True, "labels": []}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -60,11 +64,13 @@ class TestReleaseIssueStagedLifecycle:
         mock_client.swap_labels.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_release_issue_no_target_branch_no_staged(self, tool_ctx, monkeypatch):
+    async def test_release_issue_no_target_branch_no_staged(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """release_issue without target_branch: uses swap_labels, no staged label."""
         mock_client = AsyncMock()
         mock_client.swap_labels.return_value = {"success": True, "labels": []}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -74,12 +80,12 @@ class TestReleaseIssueStagedLifecycle:
         assert result.get("staged") is False
 
     @pytest.mark.anyio
-    async def test_release_issue_staged_label_idempotent(self, tool_ctx, monkeypatch):
+    async def test_release_issue_staged_label_idempotent(self, tool_ctx_kitchen_open, monkeypatch):
         """ensure_label treats 422 (already exists) as success — applies it without error."""
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": True, "created": False}  # 422 path
         mock_client.swap_labels.return_value = {"success": True, "labels": ["staged"]}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -90,7 +96,7 @@ class TestReleaseIssueStagedLifecycle:
         assert result["staged"] is True
 
     @pytest.mark.anyio
-    async def test_release_issue_custom_staged_label(self, tool_ctx, monkeypatch):
+    async def test_release_issue_custom_staged_label(self, tool_ctx_kitchen_open, monkeypatch):
         """staged_label parameter overrides the default 'staged' label name."""
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": True, "created": True}
@@ -98,7 +104,7 @@ class TestReleaseIssueStagedLifecycle:
             "success": True,
             "labels": ["awaiting-promotion"],
         }
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -118,11 +124,13 @@ class TestReleaseIssueStagedLifecycle:
         )
 
     @pytest.mark.anyio
-    async def test_release_issue_ensure_label_failure_returns_error(self, tool_ctx, monkeypatch):
+    async def test_release_issue_ensure_label_failure_returns_error(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """When ensure_label fails, release_issue returns an error without applying the label."""
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": False, "error": "API error"}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -134,12 +142,14 @@ class TestReleaseIssueStagedLifecycle:
         mock_client.swap_labels.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_release_issue_add_labels_failure_returns_error(self, tool_ctx, monkeypatch):
+    async def test_release_issue_add_labels_failure_returns_error(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """When swap_labels fails after ensure_label, release_issue returns an error."""
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": False, "error": "Labels limit"}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -150,11 +160,13 @@ class TestReleaseIssueStagedLifecycle:
         assert "staged label" in result["error"]
 
     @pytest.mark.anyio
-    async def test_release_issue_staged_null_when_not_staged(self, tool_ctx, monkeypatch):
+    async def test_release_issue_staged_null_when_not_staged(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """staged_label field is None in response when staging was not applied."""
         mock_client = AsyncMock()
         mock_client.swap_labels.return_value = {"success": True, "labels": []}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -180,7 +192,7 @@ class TestReleaseIssueStagedLifecycle:
     )
     async def test_release_issue_staging_uses_promotion_target(
         self,
-        tool_ctx,
+        tool_ctx_kitchen_open,
         monkeypatch,
         default_base_branch,
         promotion_target,
@@ -194,15 +206,15 @@ class TestReleaseIssueStagedLifecycle:
         Conversely, no staged label when target_branch == promotion_target, regardless
         of default_base_branch.
         """
-        tool_ctx.config.branching.default_base_branch = default_base_branch
-        tool_ctx.config.branching.promotion_target = promotion_target
+        tool_ctx_kitchen_open.config.branching.default_base_branch = default_base_branch
+        tool_ctx_kitchen_open.config.branching.promotion_target = promotion_target
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": True, "created": False}
         mock_client.swap_labels.return_value = {
             "success": True,
-            "labels": [tool_ctx.config.github.staged_label],
+            "labels": [tool_ctx_kitchen_open.config.github.staged_label],
         }
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -226,12 +238,12 @@ class TestReleaseIssueStagedLifecycle:
             )
 
     @pytest.mark.anyio
-    async def test_release_issue_staged_uses_swap_labels(self, tool_ctx, monkeypatch):
+    async def test_release_issue_staged_uses_swap_labels(self, tool_ctx_kitchen_open, monkeypatch):
         """release_issue staged path: uses swap_labels; remove_label/add_labels not called."""
         mock_client = AsyncMock()
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["bug", "staged"]}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
@@ -245,11 +257,13 @@ class TestReleaseIssueStagedLifecycle:
         mock_client.add_labels.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_release_issue_no_stage_uses_swap_labels(self, tool_ctx, monkeypatch):
+    async def test_release_issue_no_stage_uses_swap_labels(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """release_issue without target_branch uses swap_labels; remove_label not called."""
         mock_client = AsyncMock()
         mock_client.swap_labels.return_value = {"success": True, "labels": ["bug"]}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -173,9 +173,9 @@ async def test_prepare_issue_gate_closed(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_prepare_issue_no_executor(tool_ctx) -> None:
+async def test_prepare_issue_no_executor(tool_ctx_kitchen_open) -> None:
     """executor=None → {"success": False, "error": "Executor not configured"}."""
-    tool_ctx.executor = None
+    tool_ctx_kitchen_open.executor = None
     result = json.loads(await prepare_issue("Title", "Body"))
     assert result["success"] is False
     assert "Executor not configured" in result["error"]
@@ -197,11 +197,11 @@ async def test_prepare_issue_session_failure(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_prepare_issue_empty_output(tool_ctx) -> None:
+async def test_prepare_issue_empty_output(tool_ctx_kitchen_open) -> None:
     """success=True but result="" → drain-race error."""
     skill_result = _make_skill_result(success=True, result="")
-    tool_ctx.executor = AsyncMock()
-    tool_ctx.executor.run = AsyncMock(return_value=skill_result)
+    tool_ctx_kitchen_open.executor = AsyncMock()
+    tool_ctx_kitchen_open.executor.run = AsyncMock(return_value=skill_result)
 
     result = json.loads(await prepare_issue("Title", "Body"))
     assert result["success"] is False
@@ -209,11 +209,11 @@ async def test_prepare_issue_empty_output(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_prepare_issue_block_parse_error(tool_ctx) -> None:
+async def test_prepare_issue_block_parse_error(tool_ctx_kitchen_open) -> None:
     """success=True, output present, but no delimiters → 'no result block found' error."""
     skill_result = _make_skill_result(success=True, result="some output without delimiters")
-    tool_ctx.executor = AsyncMock()
-    tool_ctx.executor.run = AsyncMock(return_value=skill_result)
+    tool_ctx_kitchen_open.executor = AsyncMock()
+    tool_ctx_kitchen_open.executor.run = AsyncMock(return_value=skill_result)
 
     result = json.loads(await prepare_issue("Title", "Body"))
     assert result["success"] is False
@@ -221,14 +221,14 @@ async def test_prepare_issue_block_parse_error(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_prepare_issue_success(tool_ctx) -> None:
+async def test_prepare_issue_success(tool_ctx_kitchen_open) -> None:
     """Complete success path → success=True, block fields merged without 'success' key conflict."""
     block_data = {"issue_url": "https://github.com/o/r/issues/1", "issue_number": 1}
     payload = json.dumps(block_data)
     output = f"---prepare-issue-result---\n{payload}\n---/prepare-issue-result---\n"
     skill_result = _make_skill_result(success=True, result=output)
-    tool_ctx.executor = AsyncMock()
-    tool_ctx.executor.run = AsyncMock(return_value=skill_result)
+    tool_ctx_kitchen_open.executor = AsyncMock()
+    tool_ctx_kitchen_open.executor.run = AsyncMock(return_value=skill_result)
 
     result = json.loads(await prepare_issue("Title", "Body"))
     assert result["success"] is True
@@ -246,14 +246,14 @@ async def test_enrich_issues_gate_closed(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_enrich_issues_success(tool_ctx) -> None:
+async def test_enrich_issues_success(tool_ctx_kitchen_open) -> None:
     """Successful enrich → success=True, enriched list in response."""
     block_data = {"enriched": [42], "skipped_already_enriched": []}
     payload = json.dumps(block_data)
     output = f"---enrich-issues-result---\n{payload}\n---/enrich-issues-result---\n"
     skill_result = _make_skill_result(success=True, result=output)
-    tool_ctx.executor = AsyncMock()
-    tool_ctx.executor.run = AsyncMock(return_value=skill_result)
+    tool_ctx_kitchen_open.executor = AsyncMock()
+    tool_ctx_kitchen_open.executor.run = AsyncMock(return_value=skill_result)
 
     result = json.loads(await enrich_issues())
     assert result["success"] is True
@@ -270,9 +270,9 @@ async def test_claim_issue_gate_closed(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_claim_issue_no_client(tool_ctx) -> None:
+async def test_claim_issue_no_client(tool_ctx_kitchen_open) -> None:
     """github_client=None → error response."""
-    tool_ctx.github_client = None
+    tool_ctx_kitchen_open.github_client = None
     result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
     assert result["success"] is False
     assert "token" in result["error"].lower() or "github" in result["error"].lower()
@@ -280,15 +280,15 @@ async def test_claim_issue_no_client(tool_ctx) -> None:
 
 @pytest.mark.anyio
 async def test_claim_issue_already_claimed_returns_not_claimed(
-    tool_ctx,
+    tool_ctx_kitchen_open,
 ) -> None:
     """Label already present, allow_reentry=False → claimed=False."""
     issue_data = {
         "success": True,
         "labels": [{"name": "autoskillit:in-progress"}],
     }
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.github_client.fetch_issue = AsyncMock(return_value=issue_data)
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(return_value=issue_data)
 
     result = json.loads(
         await claim_issue(
@@ -302,14 +302,14 @@ async def test_claim_issue_already_claimed_returns_not_claimed(
 
 
 @pytest.mark.anyio
-async def test_claim_issue_reentry_allowed(tool_ctx) -> None:
+async def test_claim_issue_reentry_allowed(tool_ctx_kitchen_open) -> None:
     """Label already present, allow_reentry=True → claimed=True, reentry=True."""
     issue_data = {
         "success": True,
         "labels": [{"name": "autoskillit:in-progress"}],
     }
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.github_client.fetch_issue = AsyncMock(return_value=issue_data)
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(return_value=issue_data)
 
     result = json.loads(
         await claim_issue(
@@ -324,13 +324,13 @@ async def test_claim_issue_reentry_allowed(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_claim_issue_success(tool_ctx) -> None:
+async def test_claim_issue_success(tool_ctx_kitchen_open) -> None:
     """Label not present → applies label, claimed=True."""
     issue_data = {"success": True, "labels": []}
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.github_client.fetch_issue = AsyncMock(return_value=issue_data)
-    tool_ctx.github_client.ensure_label = AsyncMock(return_value={"success": True})
-    tool_ctx.github_client.swap_labels = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(return_value=issue_data)
+    tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
 
     result = json.loads(
         await claim_issue(
@@ -354,12 +354,12 @@ async def test_release_issue_gate_closed(tool_ctx) -> None:
 
 @pytest.mark.anyio
 async def test_release_issue_no_staging_when_same_branch(
-    tool_ctx,
+    tool_ctx_kitchen_open,
 ) -> None:
     """target_branch == promotion_target → staged=False."""
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.github_client.remove_label = AsyncMock(return_value={"success": True})
-    promotion_target = tool_ctx.config.branching.promotion_target
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.remove_label = AsyncMock(return_value={"success": True})
+    promotion_target = tool_ctx_kitchen_open.config.branching.promotion_target
 
     result = json.loads(
         await release_issue(
@@ -374,13 +374,13 @@ async def test_release_issue_no_staging_when_same_branch(
 
 @pytest.mark.anyio
 async def test_release_issue_stages_when_different_branch(
-    tool_ctx,
+    tool_ctx_kitchen_open,
 ) -> None:
     """target_branch != promotion_target → staged=True, staged_label applied."""
-    tool_ctx.github_client = AsyncMock()
-    tool_ctx.github_client.remove_label = AsyncMock(return_value={"success": True})
-    tool_ctx.github_client.ensure_label = AsyncMock(return_value={"success": True})
-    tool_ctx.github_client.swap_labels = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.remove_label = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
 
     result = json.loads(
         await release_issue(

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -18,11 +18,11 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 class TestClaimIssueWhitelist:
     @pytest.mark.anyio
-    async def test_claim_issue_rejects_disallowed_label(self, tool_ctx, monkeypatch):
+    async def test_claim_issue_rejects_disallowed_label(self, tool_ctx_kitchen_open, monkeypatch):
         """claim_issue returns error when effective_label is not in whitelist."""
-        tool_ctx.config.github.allowed_labels = ["bug", "enhancement"]
+        tool_ctx_kitchen_open.config.github.allowed_labels = ["bug", "enhancement"]
         mock_client = AsyncMock()
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         result = json.loads(
             await claim_issue(
@@ -36,9 +36,9 @@ class TestClaimIssueWhitelist:
         mock_client.swap_labels.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_claim_issue_allows_whitelisted_label(self, tool_ctx, monkeypatch):
+    async def test_claim_issue_allows_whitelisted_label(self, tool_ctx_kitchen_open, monkeypatch):
         """claim_issue proceeds when effective_label is in whitelist."""
-        tool_ctx.config.github.allowed_labels = ["in-progress", "bug"]
+        tool_ctx_kitchen_open.config.github.allowed_labels = ["in-progress", "bug"]
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {
             "success": True,
@@ -46,7 +46,7 @@ class TestClaimIssueWhitelist:
         }
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["in-progress"]}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         result = json.loads(
             await claim_issue(
@@ -57,14 +57,16 @@ class TestClaimIssueWhitelist:
         assert result["success"] is True
 
     @pytest.mark.anyio
-    async def test_claim_issue_empty_whitelist_permits_any_label(self, tool_ctx, monkeypatch):
+    async def test_claim_issue_empty_whitelist_permits_any_label(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """claim_issue with empty allowed_labels proceeds without restriction."""
-        tool_ctx.config.github.allowed_labels = []
+        tool_ctx_kitchen_open.config.github.allowed_labels = []
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {"success": True, "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["any-label"]}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         result = json.loads(
             await claim_issue(
@@ -77,12 +79,14 @@ class TestClaimIssueWhitelist:
 
 class TestReleaseIssueWhitelist:
     @pytest.mark.anyio
-    async def test_release_issue_rejects_disallowed_staged_label(self, tool_ctx, monkeypatch):
+    async def test_release_issue_rejects_disallowed_staged_label(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """release_issue returns error when staged label is not in whitelist."""
-        tool_ctx.config.github.allowed_labels = ["in-progress", "bug"]
+        tool_ctx_kitchen_open.config.github.allowed_labels = ["in-progress", "bug"]
         mock_client = AsyncMock()
         mock_client.remove_label.return_value = {"success": True}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         result = json.loads(
             await release_issue(
@@ -96,12 +100,14 @@ class TestReleaseIssueWhitelist:
         mock_client.ensure_label.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_release_issue_no_staging_skips_validation(self, tool_ctx, monkeypatch):
+    async def test_release_issue_no_staging_skips_validation(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """release_issue without staging doesn't validate staged_label."""
-        tool_ctx.config.github.allowed_labels = ["in-progress"]
+        tool_ctx_kitchen_open.config.github.allowed_labels = ["in-progress"]
         mock_client = AsyncMock()
         mock_client.remove_label.return_value = {"success": True}
-        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
 
         # target_branch=main means no staging — staged label not validated
         result = json.loads(
@@ -115,11 +121,13 @@ class TestReleaseIssueWhitelist:
 
 class TestPrepareIssueWhitelist:
     @pytest.mark.anyio
-    async def test_prepare_issue_rejects_disallowed_explicit_label(self, tool_ctx, monkeypatch):
+    async def test_prepare_issue_rejects_disallowed_explicit_label(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """prepare_issue returns error when explicit labels contain a disallowed entry."""
-        tool_ctx.config.github.allowed_labels = ["bug", "enhancement"]
+        tool_ctx_kitchen_open.config.github.allowed_labels = ["bug", "enhancement"]
         mock_executor = AsyncMock()
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(
             await prepare_issue(
@@ -133,7 +141,9 @@ class TestPrepareIssueWhitelist:
         mock_executor.run.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_prepare_issue_allows_whitelisted_explicit_labels(self, tool_ctx, monkeypatch):
+    async def test_prepare_issue_allows_whitelisted_explicit_labels(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """prepare_issue proceeds when all explicit labels are whitelisted."""
         import json as _json
 
@@ -144,7 +154,7 @@ class TestPrepareIssueWhitelist:
             _PREPARE_RESULT_START,
         )
 
-        tool_ctx.config.github.allowed_labels = ["bug", "enhancement"]
+        tool_ctx_kitchen_open.config.github.allowed_labels = ["bug", "enhancement"]
         mock_executor = AsyncMock()
         payload = _json.dumps({"issue_url": "https://github.com/x/y/issues/1", "route": "impl"})
         mock_executor.run.return_value = SkillResult(
@@ -158,7 +168,7 @@ class TestPrepareIssueWhitelist:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(
             await prepare_issue(
@@ -171,7 +181,9 @@ class TestPrepareIssueWhitelist:
         mock_executor.run.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_prepare_issue_no_labels_skips_validation(self, tool_ctx, monkeypatch):
+    async def test_prepare_issue_no_labels_skips_validation(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """prepare_issue with labels=None skips whitelist validation entirely."""
         import json as _json
 
@@ -182,7 +194,7 @@ class TestPrepareIssueWhitelist:
             _PREPARE_RESULT_START,
         )
 
-        tool_ctx.config.github.allowed_labels = ["bug"]  # restrictive whitelist
+        tool_ctx_kitchen_open.config.github.allowed_labels = ["bug"]  # restrictive whitelist
         mock_executor = AsyncMock()
         payload = _json.dumps({"issue_url": "https://github.com/x/y/issues/1", "route": "impl"})
         mock_executor.run.return_value = SkillResult(
@@ -196,7 +208,7 @@ class TestPrepareIssueWhitelist:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(
             await prepare_issue(

--- a/tests/server/test_tools_list_recipes.py
+++ b/tests/server/test_tools_list_recipes.py
@@ -18,8 +18,8 @@ class TestListRecipeTools:
     """Tests for kitchen-gated list_recipes tool."""
 
     @pytest.fixture(autouse=True)
-    def _ensure_ctx(self, tool_ctx):
-        """Ensure server context is initialized (gate open by default)."""
+    def _ensure_ctx(self, tool_ctx_kitchen_open):
+        """Ensure server context is initialized with gate open."""
 
     # SS1
     @pytest.mark.anyio

--- a/tests/server/test_tools_list_recipes.py
+++ b/tests/server/test_tools_list_recipes.py
@@ -147,9 +147,9 @@ class TestListRecipeTools:
 
 # P5F2-T1
 @pytest.mark.anyio
-async def test_list_recipes_no_recipes_returns_empty(tool_ctx):
+async def test_list_recipes_no_recipes_returns_empty(tool_ctx_kitchen_open):
     """list_recipes returns error JSON when recipes is not configured."""
-    tool_ctx.recipes = None
+    tool_ctx_kitchen_open.recipes = None
     result = json.loads(await list_recipes())
     assert isinstance(result, dict) and "error" in result
 

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -61,8 +61,8 @@ class TestLoadRecipeTools:
     """Tests for kitchen-gated load_recipe tool."""
 
     @pytest.fixture(autouse=True)
-    def _ensure_ctx(self, tool_ctx):
-        """Ensure server context is initialized (gate open by default)."""
+    def _ensure_ctx(self, tool_ctx_kitchen_open):
+        """Ensure server context is initialized with gate open."""
 
     # SS2
     @pytest.mark.anyio
@@ -195,8 +195,8 @@ class TestLoadRecipeExceptionHandling:
     """CC-1: Outer except in load_recipe must catch anticipated exceptions only."""
 
     @pytest.fixture(autouse=True)
-    def _setup_ctx(self, tool_ctx):
-        """Initialize ToolContext so load_recipe can call _get_config()."""
+    def _setup_ctx(self, tool_ctx_kitchen_open):
+        """Initialize ToolContext with gate open so load_recipe can call _get_config()."""
 
     @pytest.mark.anyio
     async def test_yaml_error_surfaces_as_suggestion(
@@ -437,8 +437,8 @@ class TestLoadRecipeReadOnly:
     """P4: load_recipe is strictly read-only — no migration, no contract card generation."""
 
     @pytest.fixture(autouse=True)
-    def _ensure_ctx(self, tool_ctx):
-        """Ensure server context is initialized (gate open by default)."""
+    def _ensure_ctx(self, tool_ctx_kitchen_open):
+        """Ensure server context is initialized with gate open."""
 
     @pytest.mark.anyio
     async def test_load_recipe_does_not_call_migration_engine(self, tmp_path, monkeypatch):
@@ -525,8 +525,8 @@ class TestLoadRecipeIngredientsOnly:
     """load_recipe(ingredients_only=True) strips content, preserves metadata."""
 
     @pytest.fixture(autouse=True)
-    def _ensure_ctx(self, tool_ctx):
-        """Ensure server context is initialized (gate open by default)."""
+    def _ensure_ctx(self, tool_ctx_kitchen_open):
+        """Ensure server context is initialized with gate open."""
 
     @pytest.mark.anyio
     async def test_load_recipe_ingredients_only_strips_content(self, tmp_path, monkeypatch):

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -300,7 +300,7 @@ class TestMigrationSuppression:
     # SUP1
     @pytest.mark.anyio
     async def test_outdated_version_not_in_suggestions_when_suppressed(
-        self, tmp_path, monkeypatch, tool_ctx
+        self, tmp_path, monkeypatch, tool_ctx_kitchen_open
     ):
         """SUP1: outdated-recipe-version absent when recipe is suppressed; headless not called."""
         from autoskillit.config import MigrationConfig
@@ -309,7 +309,9 @@ class TestMigrationSuppression:
         scripts_dir = tmp_path / ".autoskillit" / "recipes"
         _write_minimal_script(scripts_dir, "test-script")
 
-        tool_ctx.config = AutomationConfig(migration=MigrationConfig(suppressed=["test-script"]))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            migration=MigrationConfig(suppressed=["test-script"])
+        )
 
         mock_headless = AsyncMock(
             return_value=SkillResult(
@@ -335,7 +337,7 @@ class TestMigrationSuppression:
     # SUP4
     @pytest.mark.anyio
     async def test_validate_always_includes_outdated_version_regardless_of_suppression(
-        self, tmp_path, tool_ctx
+        self, tmp_path, tool_ctx_kitchen_open
     ):
         """SUP4: validate_recipe includes outdated-script-version even when suppressed."""
         from autoskillit.config import MigrationConfig
@@ -345,7 +347,9 @@ class TestMigrationSuppression:
         script.write_text(_MINIMAL_SCRIPT_YAML + 'autoskillit_version: "0.0.1"\n')
 
         # Even with script suppressed in config, validate_recipe does not filter
-        tool_ctx.config = AutomationConfig(migration=MigrationConfig(suppressed=["test-script"]))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            migration=MigrationConfig(suppressed=["test-script"])
+        )
 
         result = json.loads(await validate_recipe(script_path=str(script)))
         assert "findings" in result
@@ -477,7 +481,9 @@ class TestLoadRecipeDiagram:
 
     # DG-12
     @pytest.mark.anyio
-    async def test_load_recipe_response_has_diagram_key(self, tmp_path, monkeypatch, tool_ctx):
+    async def test_load_recipe_response_has_diagram_key(
+        self, tmp_path, monkeypatch, tool_ctx_kitchen_open
+    ):
         """DG-12: load_recipe response always contains a 'diagram' key."""
         self._setup_project_recipe(tmp_path, monkeypatch)
         result = json.loads(await load_recipe(name="my-recipe"))
@@ -486,7 +492,7 @@ class TestLoadRecipeDiagram:
     # DG-13
     @pytest.mark.anyio
     async def test_load_recipe_diagram_none_when_not_generated(
-        self, tmp_path, monkeypatch, tool_ctx
+        self, tmp_path, monkeypatch, tool_ctx_kitchen_open
     ):
         """DG-13: diagram is None when no diagram file exists."""
         self._setup_project_recipe(tmp_path, monkeypatch)

--- a/tests/server/test_tools_pr_ops.py
+++ b/tests/server/test_tools_pr_ops.py
@@ -133,7 +133,9 @@ async def test_get_pr_reviews_gate_closed(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_get_pr_reviews_with_repo_success(tool_ctx, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_pr_reviews_with_repo_success(
+    tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """repo provided → gh api repos/{repo}/pulls/123/reviews path used."""
     api_response = json.dumps([{"user": {"login": "alice"}, "state": "APPROVED", "body": ""}])
     with patch(
@@ -148,7 +150,7 @@ async def test_get_pr_reviews_with_repo_success(tool_ctx, monkeypatch: pytest.Mo
 
 @pytest.mark.anyio
 async def test_get_pr_reviews_without_repo_success(
-    tool_ctx, monkeypatch: pytest.MonkeyPatch
+    tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """repo='' → gh pr view 123 --json reviews path used."""
     pr_view_response = json.dumps(
@@ -164,7 +166,9 @@ async def test_get_pr_reviews_without_repo_success(
 
 
 @pytest.mark.anyio
-async def test_get_pr_reviews_gh_failure(tool_ctx, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_pr_reviews_gh_failure(
+    tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """gh returns rc=1 → {"success": False, "error": ...}."""
     with patch(
         "autoskillit.server.tools.tools_pr_ops._run_subprocess",
@@ -186,7 +190,9 @@ async def test_bulk_close_issues_gate_closed(tool_ctx) -> None:
 
 
 @pytest.mark.anyio
-async def test_bulk_close_issues_all_closed(tool_ctx, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_bulk_close_issues_all_closed(
+    tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """All succeed → {"closed": [1, 2, 3], "failed": []}."""
     with patch(
         "autoskillit.server.tools.tools_pr_ops._run_subprocess",
@@ -204,7 +210,7 @@ async def test_bulk_close_issues_all_closed(tool_ctx, monkeypatch: pytest.Monkey
 
 @pytest.mark.anyio
 async def test_bulk_close_issues_partial_failure(
-    tool_ctx, monkeypatch: pytest.MonkeyPatch
+    tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Mixed outcomes → correct closed/failed split."""
     call_count = {"n": 0}

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -453,9 +453,9 @@ class TestLoadSkillScriptFailurePredicates:
 
 # P5F2-T3
 @pytest.mark.anyio
-async def test_validate_recipe_no_recipes_returns_error(tool_ctx, tmp_path):
+async def test_validate_recipe_no_recipes_returns_error(tool_ctx_kitchen_open, tmp_path):
     """validate_recipe returns invalid JSON when recipes is not configured."""
-    tool_ctx.recipes = None
+    tool_ctx_kitchen_open.recipes = None
     result = json.loads(await validate_recipe(script_path=str(tmp_path / "x.yaml")))
     assert result.get("valid") is False
 

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -99,8 +99,8 @@ class TestValidateRecipeTool:
     """Tests for kitchen-gated validate_recipe tool."""
 
     @pytest.fixture(autouse=True)
-    def _ensure_ctx(self, tool_ctx):
-        """Ensure server context is initialized (gate open by default)."""
+    def _ensure_ctx(self, tool_ctx_kitchen_open):
+        """Ensure server context is initialized with gate open."""
 
     # VS1
     @pytest.mark.anyio
@@ -252,8 +252,8 @@ class TestMigrationSuggestions:
     """MSUG2: validate_recipe surfaces migration warnings."""
 
     @pytest.fixture(autouse=True)
-    def _ensure_ctx(self, tool_ctx):
-        """Ensure server context is initialized (gate open by default)."""
+    def _ensure_ctx(self, tool_ctx_kitchen_open):
+        """Ensure server context is initialized with gate open."""
 
     # MSUG2
     @pytest.mark.anyio

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -96,10 +96,12 @@ def test_github_config_defaults():
 
 class TestReportBugTool:
     @pytest.mark.anyio
-    async def test_report_bug_failure_includes_session_id_and_stderr(self, tool_ctx, tmp_path):
+    async def test_report_bug_failure_includes_session_id_and_stderr(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
         """Blocking failure response must include session_id and stderr for diagnosis."""
-        tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-        tool_ctx.config.report_bug.github_filing = False
+        tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+        tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -113,7 +115,7 @@ class TestReportBugTool:
             retry_reason=RetryReason.NONE,
             stderr="Claude crashed",
         )
-        tool_ctx.executor = mock_executor
+        tool_ctx_kitchen_open.executor = mock_executor
 
         result = json.loads(await report_bug("some error", str(tmp_path), severity="blocking"))
 
@@ -123,11 +125,11 @@ class TestReportBugTool:
 
     @pytest.mark.anyio
     async def test_report_bug_passes_expected_output_patterns_to_executor(
-        self, tool_ctx, tmp_path
+        self, tool_ctx_kitchen_open, tmp_path
     ):
         """output_pattern_resolver is consulted and patterns are passed to executor.run()."""
-        tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-        tool_ctx.config.report_bug.github_filing = False
+        tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+        tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
@@ -141,8 +143,8 @@ class TestReportBugTool:
             retry_reason=RetryReason.NONE,
             stderr="",
         )
-        tool_ctx.executor = mock_executor
-        tool_ctx.output_pattern_resolver = lambda cmd: ["---bug-fingerprint---"]
+        tool_ctx_kitchen_open.executor = mock_executor
+        tool_ctx_kitchen_open.output_pattern_resolver = lambda cmd: ["---bug-fingerprint---"]
 
         await report_bug("error ctx", str(tmp_path), severity="blocking")
 
@@ -240,8 +242,8 @@ async def test_report_bug_gate_closed(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_no_executor(tool_ctx, tmp_path):
-    tool_ctx.executor = None
+async def test_report_bug_no_executor(tool_ctx_kitchen_open, tmp_path):
+    tool_ctx_kitchen_open.executor = None
     result = json.loads(await report_bug("error ctx", str(tmp_path)))
     assert result["success"] is False
     assert "executor" in result["error"].lower()
@@ -253,14 +255,14 @@ async def test_report_bug_no_executor(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_blocking_success(tool_ctx, tmp_path):
+async def test_report_bug_blocking_success(tool_ctx_kitchen_open, tmp_path):
     """Blocking mode awaits the session and returns status=complete."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok("## Report\nroot cause found")
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("KeyError in foo", str(tmp_path), severity="blocking"))
 
@@ -272,14 +274,14 @@ async def test_report_bug_blocking_success(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_blocking_failure_propagated(tool_ctx, tmp_path):
+async def test_report_bug_blocking_failure_propagated(tool_ctx_kitchen_open, tmp_path):
     """If the headless session fails, status=failed is returned."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_fail()
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("crash here", str(tmp_path), severity="blocking"))
 
@@ -288,15 +290,15 @@ async def test_report_bug_blocking_failure_propagated(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_blocking_writes_report_file(tool_ctx, tmp_path):
+async def test_report_bug_blocking_writes_report_file(tool_ctx_kitchen_open, tmp_path):
     """The report text must be written to the resolved report_path."""
     report_dir = tmp_path / "rpts"
-    tool_ctx.config.report_bug.report_dir = str(report_dir)
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(report_dir)
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok("# Bug Report\nfoo bar")
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("err", str(tmp_path), severity="blocking"))
 
@@ -311,10 +313,10 @@ async def test_report_bug_blocking_writes_report_file(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_non_blocking_returns_immediately(tool_ctx, tmp_path):
+async def test_report_bug_non_blocking_returns_immediately(tool_ctx_kitchen_open, tmp_path):
     """Non-blocking mode must return dispatched before the session completes."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     ready = anyio.Event()
 
@@ -324,7 +326,7 @@ async def test_report_bug_non_blocking_returns_immediately(tool_ctx, tmp_path):
 
     mock_executor = MagicMock()
     mock_executor.run = slow_run
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("error ctx", str(tmp_path), severity="non_blocking"))
 
@@ -338,14 +340,14 @@ async def test_report_bug_non_blocking_returns_immediately(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_non_blocking_default_severity(tool_ctx, tmp_path):
+async def test_report_bug_non_blocking_default_severity(tool_ctx_kitchen_open, tmp_path):
     """The default severity is non_blocking."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok()
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("err", str(tmp_path)))
     assert result["status"] == "dispatched"
@@ -357,14 +359,14 @@ async def test_report_bug_non_blocking_default_severity(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_non_blocking_outcome_writes_report_file(tool_ctx, tmp_path):
+async def test_report_bug_non_blocking_outcome_writes_report_file(tool_ctx_kitchen_open, tmp_path):
     """After the background task completes, report_path must exist with content."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok("# Bug Report\nroot cause: missing guard")
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(
         await report_bug("KeyError in foo", str(tmp_path), severity="non_blocking")
@@ -372,21 +374,23 @@ async def test_report_bug_non_blocking_outcome_writes_report_file(tool_ctx, tmp_
     assert result["status"] == "dispatched"
 
     report_path = Path(result["report_path"])
-    await tool_ctx.background.drain()
+    await tool_ctx_kitchen_open.background.drain()
 
     assert report_path.exists(), "report_path must exist after background task completes"
     assert "Bug Report" in report_path.read_text()
 
 
 @pytest.mark.anyio
-async def test_report_bug_non_blocking_writes_status_file_on_success(tool_ctx, tmp_path):
+async def test_report_bug_non_blocking_writes_status_file_on_success(
+    tool_ctx_kitchen_open, tmp_path
+):
     """A status.json file must be written with status='complete' after successful dispatch."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok("# Report\nfoo")
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("err", str(tmp_path), severity="non_blocking"))
     report_path = Path(result["report_path"])
@@ -398,7 +402,7 @@ async def test_report_bug_non_blocking_writes_status_file_on_success(tool_ctx, t
     assert pending["status"] == "pending"
 
     # After task completes: status should update to complete
-    await tool_ctx.background.drain()
+    await tool_ctx_kitchen_open.background.drain()
 
     data = json.loads(status_path.read_text())
     assert data["status"] == "complete"
@@ -406,19 +410,21 @@ async def test_report_bug_non_blocking_writes_status_file_on_success(tool_ctx, t
 
 
 @pytest.mark.anyio
-async def test_report_bug_non_blocking_writes_status_file_on_failure(tool_ctx, tmp_path):
+async def test_report_bug_non_blocking_writes_status_file_on_failure(
+    tool_ctx_kitchen_open, tmp_path
+):
     """When the headless session fails, status.json must reflect the failure."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_fail()
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("crash here", str(tmp_path), severity="non_blocking"))
     status_path = Path(result["report_path"]).with_suffix(".status.json")
 
-    await tool_ctx.background.drain()
+    await tool_ctx_kitchen_open.background.drain()
 
     data = json.loads(status_path.read_text())
     assert data["status"] == "failed"
@@ -426,20 +432,22 @@ async def test_report_bug_non_blocking_writes_status_file_on_failure(tool_ctx, t
 
 
 @pytest.mark.anyio
-async def test_report_bug_non_blocking_executor_raises_is_observed(tool_ctx, tmp_path):
+async def test_report_bug_non_blocking_executor_raises_is_observed(
+    tool_ctx_kitchen_open, tmp_path
+):
     """If executor.run() raises, the exception must be logged — not silently dropped."""
 
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     mock_executor = AsyncMock()
     mock_executor.run.side_effect = RuntimeError("executor exploded")
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("error ctx", str(tmp_path), severity="non_blocking"))
     assert result["status"] == "dispatched"
 
-    await tool_ctx.background.drain()
+    await tool_ctx_kitchen_open.background.drain()
 
     # The exception must be captured and logged — not silently dropped
     status_path = Path(result["report_path"]).with_suffix(".status.json")
@@ -472,11 +480,11 @@ async def test_report_bug_no_pending_tasks_after_completion(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_creates_github_issue_on_no_duplicate(tool_ctx, tmp_path):
+async def test_report_bug_creates_github_issue_on_no_duplicate(tool_ctx_kitchen_open, tmp_path):
     """When no matching issue is found, create_issue is called."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
 
     report_with_fp = (
         f"{_FINGERPRINT_START}\n"
@@ -486,7 +494,7 @@ async def test_report_bug_creates_github_issue_on_no_duplicate(tool_ctx, tmp_pat
     )
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok(report_with_fp)
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     mock_gh = AsyncMock()
     mock_gh.has_token = True
@@ -496,7 +504,7 @@ async def test_report_bug_creates_github_issue_on_no_duplicate(tool_ctx, tmp_pat
         "issue_number": 99,
         "url": "https://github.com/owner/repo/issues/99",
     }
-    tool_ctx.github_client = mock_gh
+    tool_ctx_kitchen_open.github_client = mock_gh
 
     result = json.loads(await report_bug("KeyError crash", str(tmp_path), severity="blocking"))
 
@@ -508,17 +516,17 @@ async def test_report_bug_creates_github_issue_on_no_duplicate(tool_ctx, tmp_pat
 
 
 @pytest.mark.anyio
-async def test_report_bug_updates_duplicate_issue_body(tool_ctx, tmp_path):
+async def test_report_bug_updates_duplicate_issue_body(tool_ctx_kitchen_open, tmp_path):
     """When a matching issue exists and error_context is new, update_issue_body is called."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok(
         "## Report\n" + _FINGERPRINT_START + "\nfp\n" + _FINGERPRINT_END
     )
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     mock_gh = AsyncMock()
     mock_gh.has_token = True
@@ -539,7 +547,7 @@ async def test_report_bug_updates_duplicate_issue_body(tool_ctx, tmp_path):
         "success": True,
         "issue_url": "https://github.com/owner/repo/issues/7",
     }
-    tool_ctx.github_client = mock_gh
+    tool_ctx_kitchen_open.github_client = mock_gh
 
     result = json.loads(
         await report_bug("brand new error text", str(tmp_path), severity="blocking")
@@ -552,16 +560,16 @@ async def test_report_bug_updates_duplicate_issue_body(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_skips_comment_if_already_present(tool_ctx, tmp_path):
+async def test_report_bug_skips_comment_if_already_present(tool_ctx_kitchen_open, tmp_path):
     """If error_context is already in the issue body, no comment is posted."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
 
     error_ctx = "exact error text already filed"
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok()
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     mock_gh = AsyncMock()
     mock_gh.has_token = True
@@ -578,7 +586,7 @@ async def test_report_bug_skips_comment_if_already_present(tool_ctx, tmp_path):
             }
         ],
     }
-    tool_ctx.github_client = mock_gh
+    tool_ctx_kitchen_open.github_client = mock_gh
 
     result = json.loads(await report_bug(error_ctx, str(tmp_path), severity="blocking"))
 
@@ -587,17 +595,17 @@ async def test_report_bug_skips_comment_if_already_present(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_skips_github_if_no_token(tool_ctx, tmp_path):
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
+async def test_report_bug_skips_github_if_no_token(tool_ctx_kitchen_open, tmp_path):
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok()
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     mock_gh = AsyncMock()
     mock_gh.has_token = False
-    tool_ctx.github_client = mock_gh
+    tool_ctx_kitchen_open.github_client = mock_gh
 
     result = json.loads(await report_bug("err", str(tmp_path), severity="blocking"))
 
@@ -608,18 +616,18 @@ async def test_report_bug_skips_github_if_no_token(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_skips_github_if_no_default_repo(tool_ctx, tmp_path):
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = None
+async def test_report_bug_skips_github_if_no_default_repo(tool_ctx_kitchen_open, tmp_path):
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = None
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok()
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     mock_gh = AsyncMock()
     mock_gh.has_token = True
-    tool_ctx.github_client = mock_gh
+    tool_ctx_kitchen_open.github_client = mock_gh
 
     result = json.loads(await report_bug("err", str(tmp_path), severity="blocking"))
 
@@ -628,19 +636,19 @@ async def test_report_bug_skips_github_if_no_default_repo(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_github_filing_disabled(tool_ctx, tmp_path):
+async def test_report_bug_github_filing_disabled(tool_ctx_kitchen_open, tmp_path):
     """github_filing=false must skip all GitHub calls."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
-    tool_ctx.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok()
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     mock_gh = AsyncMock()
     mock_gh.has_token = True
-    tool_ctx.github_client = mock_gh
+    tool_ctx_kitchen_open.github_client = mock_gh
 
     result = json.loads(await report_bug("err", str(tmp_path), severity="blocking"))
 
@@ -649,22 +657,24 @@ async def test_report_bug_github_filing_disabled(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_report_bug_blocking_github_client_raises_does_not_propagate(tool_ctx, tmp_path):
+async def test_report_bug_blocking_github_client_raises_does_not_propagate(
+    tool_ctx_kitchen_open, tmp_path
+):
     """If the GitHub client raises unexpectedly, the error must be captured in the github dict."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok(
         "# Report\n" + _FINGERPRINT_START + "\nfp1\n" + _FINGERPRINT_END
     )
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     mock_gh = MagicMock()
     mock_gh.has_token = True
     mock_gh.search_issues = AsyncMock(side_effect=RuntimeError("network failure"))
-    tool_ctx.github_client = mock_gh
+    tool_ctx_kitchen_open.github_client = mock_gh
 
     # Must not raise — exception is captured in github dict
     result = json.loads(await report_bug("err", str(tmp_path), severity="blocking"))
@@ -680,9 +690,11 @@ async def test_report_bug_blocking_github_client_raises_does_not_propagate(tool_
 
 
 @pytest.mark.anyio
-async def test_report_bug_model_as_profile_resolves_provider(tool_ctx, tmp_path, monkeypatch):
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+async def test_report_bug_model_as_profile_resolves_provider(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+):
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
@@ -696,7 +708,7 @@ async def test_report_bug_model_as_profile_resolves_provider(tool_ctx, tmp_path,
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok("report text")
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(
         await report_bug("error ctx", str(tmp_path), model="minimax", severity="blocking")
@@ -713,16 +725,16 @@ async def test_report_bug_model_as_profile_resolves_provider(tool_ctx, tmp_path,
 
 @pytest.mark.anyio
 async def test_report_bug_model_as_profile_disabled_when_feature_off(
-    tool_ctx, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
 ):
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok("report text")
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(
         await report_bug("error ctx", str(tmp_path), model="minimax", severity="blocking")
@@ -735,10 +747,10 @@ async def test_report_bug_model_as_profile_disabled_when_feature_off(
 
 
 @pytest.mark.anyio
-async def test_report_bug_config_model_as_profile(tool_ctx, tmp_path, monkeypatch):
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = False
-    tool_ctx.config.report_bug.model = "minimax"
+async def test_report_bug_config_model_as_profile(tool_ctx_kitchen_open, tmp_path, monkeypatch):
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
+    tool_ctx_kitchen_open.config.report_bug.model = "minimax"
 
     map_calls: list[str] = []
 
@@ -751,7 +763,7 @@ async def test_report_bug_config_model_as_profile(tool_ctx, tmp_path, monkeypatc
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok("report text")
-    tool_ctx.executor = mock_executor
+    tool_ctx_kitchen_open.executor = mock_executor
 
     result = json.loads(await report_bug("error ctx", str(tmp_path), severity="blocking"))
 

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -103,7 +103,7 @@ class TestProcessRunnerResult:
         assert "5" in stderr
 
 
-@pytest.mark.usefixtures("tool_ctx")
+@pytest.mark.usefixtures("tool_ctx_kitchen_open")
 class TestRunPython:
     """run_python tool: import, call, timeout, async support."""
 
@@ -261,7 +261,7 @@ class TestRunCmdSleepInterception:
 # ─── Type coercion tests (Step 1a) ───────────────────────────────────────────
 
 
-@pytest.mark.usefixtures("tool_ctx")
+@pytest.mark.usefixtures("tool_ctx_kitchen_open")
 class TestImportAndCallTypeCoercion:
     """Test _import_and_call annotation-aware type coercion."""
 

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -19,30 +19,30 @@ class TestRunCmd:
     """T1, T2: run_cmd executes commands and returns exit code semantics."""
 
     @pytest.mark.anyio
-    async def test_successful_command(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "hello\n", ""))
+    async def test_successful_command(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "hello\n", ""))
         result = json.loads(await run_cmd(cmd="echo hello", cwd="/tmp"))
 
         assert result["success"] is True
         assert result["exit_code"] == 0
         assert "hello" in result["stdout"]
-        assert len(tool_ctx.runner.call_args_list) == 1
-        assert tool_ctx.runner.call_args_list[0][0] == ["bash", "-c", "echo hello"]
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 1
+        assert tool_ctx_kitchen_open.runner.call_args_list[0][0] == ["bash", "-c", "echo hello"]
 
     @pytest.mark.anyio
-    async def test_failing_command(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(1, "", "error"))
+    async def test_failing_command(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(1, "", "error"))
         result = json.loads(await run_cmd(cmd="false", cwd="/tmp"))
 
         assert result["success"] is False
         assert result["exit_code"] == 1
 
     @pytest.mark.anyio
-    async def test_custom_timeout(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "", ""))
+    async def test_custom_timeout(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         await run_cmd(cmd="echo timeout_test", cwd="/tmp", timeout=30)
 
-        assert tool_ctx.runner.call_args_list[-1][2] == 30.0
+        assert tool_ctx_kitchen_open.runner.call_args_list[-1][2] == 30.0
 
 
 class TestRunSubprocessDelegatesToManaged:
@@ -207,53 +207,55 @@ class TestRunCmdSleepInterception:
     """Sleep commands are intercepted and converted to asyncio.sleep."""
 
     @pytest.mark.anyio
-    async def test_python_sleep_intercepted(self, tool_ctx):
+    async def test_python_sleep_intercepted(self, tool_ctx_kitchen_open):
         result = json.loads(
             await run_cmd(cmd='python3 -c "import time; time.sleep(0)"', cwd="/tmp")
         )
         assert result == {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
-        assert len(tool_ctx.runner.call_args_list) == 0
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 0
 
     @pytest.mark.anyio
-    async def test_bare_sleep_intercepted(self, tool_ctx):
+    async def test_bare_sleep_intercepted(self, tool_ctx_kitchen_open):
         result = json.loads(await run_cmd(cmd="sleep 0", cwd="/tmp"))
         assert result["success"] is True
-        assert len(tool_ctx.runner.call_args_list) == 0
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 0
 
     @pytest.mark.anyio
-    async def test_python3_single_quotes_intercepted(self, tool_ctx):
+    async def test_python3_single_quotes_intercepted(self, tool_ctx_kitchen_open):
         result = json.loads(
             await run_cmd(cmd="python3 -c 'import time; time.sleep(0)'", cwd="/tmp")
         )
         assert result["success"] is True
-        assert len(tool_ctx.runner.call_args_list) == 0
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 0
 
     @pytest.mark.anyio
-    async def test_non_sleep_uses_subprocess(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "hello", ""))
+    async def test_non_sleep_uses_subprocess(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "hello", ""))
         await run_cmd(cmd="echo hello", cwd="/tmp")
-        assert len(tool_ctx.runner.call_args_list) == 1
-        assert tool_ctx.runner.call_args_list[0][0] == ["bash", "-c", "echo hello"]
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 1
+        assert tool_ctx_kitchen_open.runner.call_args_list[0][0] == ["bash", "-c", "echo hello"]
 
     @pytest.mark.anyio
-    async def test_decimal_seconds_intercepted(self, tool_ctx):
+    async def test_decimal_seconds_intercepted(self, tool_ctx_kitchen_open):
         result = json.loads(
             await run_cmd(cmd='python3 -c "import time; time.sleep(0.0)"', cwd="/tmp")
         )
         assert result["success"] is True
-        assert len(tool_ctx.runner.call_args_list) == 0
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 0
 
     @pytest.mark.anyio
-    async def test_compound_sleep_not_intercepted(self, tool_ctx):
-        tool_ctx.runner.push(_make_result(0, "", ""))
+    async def test_compound_sleep_not_intercepted(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         await run_cmd(cmd="echo before && sleep 10 && echo after", cwd="/tmp")
-        assert len(tool_ctx.runner.call_args_list) == 1
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 1
 
     @pytest.mark.anyio
-    async def test_step_name_timing_recorded(self, tool_ctx):
+    async def test_step_name_timing_recorded(self, tool_ctx_kitchen_open):
         await run_cmd(cmd="sleep 0", cwd="/tmp", step_name="quota_wait")
-        assert len(tool_ctx.runner.call_args_list) == 0
-        assert any(e["step_name"] == "quota_wait" for e in tool_ctx.timing_log.get_report())
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 0
+        assert any(
+            e["step_name"] == "quota_wait" for e in tool_ctx_kitchen_open.timing_log.get_report()
+        )
 
 
 # ─── Type coercion tests (Step 1a) ───────────────────────────────────────────

--- a/tests/server/test_tools_run_cmd_unit.py
+++ b/tests/server/test_tools_run_cmd_unit.py
@@ -26,9 +26,11 @@ class TestRunCmdObservability:
         return ctx
 
     @pytest.mark.anyio
-    async def test_run_cmd_binds_tool_contextvar_and_calls_ctx_info(self, tool_ctx, mock_ctx):
+    async def test_run_cmd_binds_tool_contextvar_and_calls_ctx_info(
+        self, tool_ctx_kitchen_open, mock_ctx
+    ):
         """run_cmd binds tool='run_cmd' contextvar and calls ctx.info on success."""
-        tool_ctx.runner.push(_make_result(0, "ok\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "ok\n", ""))
         with structlog.testing.capture_logs(
             processors=[structlog.contextvars.merge_contextvars]
         ) as logs:
@@ -36,9 +38,11 @@ class TestRunCmdObservability:
         assert any(entry.get("tool") == "run_cmd" for entry in logs)
 
     @pytest.mark.anyio
-    async def test_run_cmd_returns_failure_result_on_nonzero_exit(self, tool_ctx, mock_ctx):
+    async def test_run_cmd_returns_failure_result_on_nonzero_exit(
+        self, tool_ctx_kitchen_open, mock_ctx
+    ):
         """run_cmd reports failure (success=false) when subprocess exits non-zero."""
-        tool_ctx.runner.push(_make_result(1, "", "err"))
+        tool_ctx_kitchen_open.runner.push(_make_result(1, "", "err"))
         result = json.loads(await run_cmd(cmd="false", cwd="/tmp", ctx=mock_ctx))
         assert result["success"] is False
         assert result["exit_code"] == 1
@@ -48,9 +52,9 @@ class TestRunCmdTiming:
     """run_cmd accumulates wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_run_cmd_step_name_records_timing(self, tool_ctx):
+    async def test_run_cmd_step_name_records_timing(self, tool_ctx_kitchen_open):
         await run_cmd(cmd="echo hi", cwd="/tmp", step_name="clone")
-        report = tool_ctx.timing_log.get_report()
+        report = tool_ctx_kitchen_open.timing_log.get_report()
         assert len(report) == 1
         assert report[0]["step_name"] == "clone"
         assert report[0]["total_seconds"] >= 0.0
@@ -66,25 +70,29 @@ class TestRunCmdRecording:
     """run_cmd threads SCENARIO_STEP_NAME into env kwarg for RecordingSubprocessRunner."""
 
     @pytest.mark.anyio
-    async def test_run_cmd_with_step_name_passes_scenario_step_name_to_runner(self, tool_ctx):
+    async def test_run_cmd_with_step_name_passes_scenario_step_name_to_runner(
+        self, tool_ctx_kitchen_open
+    ):
         """run_cmd with step_name passes SCENARIO_STEP_NAME in env kwarg to ctx.runner."""
         from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV
 
-        tool_ctx.runner.push(_make_result(0, "ok", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "ok", ""))
         await run_cmd(cmd="echo hi", cwd="/tmp", step_name="setup")
-        call_kwargs = tool_ctx.runner.call_args_list[-1][3]
+        call_kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1][3]
         assert call_kwargs.get("env", {}).get(SCENARIO_STEP_NAME_ENV) == "setup"
 
     @pytest.mark.anyio
-    async def test_run_cmd_with_step_name_preserves_parent_env(self, tool_ctx, monkeypatch):
+    async def test_run_cmd_with_step_name_preserves_parent_env(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """run_cmd with step_name must not strip PATH/HOME from the child env."""
         from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV
 
         monkeypatch.setenv("PATH", "/usr/bin:/usr/local/bin")
         monkeypatch.setenv("HOME", "/home/testuser")
-        tool_ctx.runner.push(_make_result(0, "ok", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "ok", ""))
         await run_cmd(cmd="echo hi", cwd="/tmp", step_name="setup")
-        call_kwargs = tool_ctx.runner.call_args_list[-1][3]
+        call_kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1][3]
         env = call_kwargs["env"]
         assert env is not None
         assert "PATH" in env, "run_cmd stripped PATH from child environment"
@@ -92,18 +100,20 @@ class TestRunCmdRecording:
         assert env[SCENARIO_STEP_NAME_ENV] == "setup"
 
     @pytest.mark.anyio
-    async def test_run_cmd_without_step_name_passes_no_env(self, tool_ctx):
+    async def test_run_cmd_without_step_name_passes_no_env(self, tool_ctx_kitchen_open):
         """run_cmd without step_name passes env=None (no SCENARIO_STEP_NAME in env)."""
         from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV
 
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         await run_cmd(cmd="echo hi", cwd="/tmp")
-        call_kwargs = tool_ctx.runner.call_args_list[-1][3]
+        call_kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1][3]
         env = call_kwargs.get("env")
         assert env is None or SCENARIO_STEP_NAME_ENV not in env
 
     @pytest.mark.anyio
-    async def test_run_cmd_with_step_name_records_non_session_step(self, tool_ctx, monkeypatch):
+    async def test_run_cmd_with_step_name_records_non_session_step(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """End-to-end: run_cmd step_name → RecordingSubprocessRunner.record_non_session_step()."""
         from unittest.mock import Mock
 
@@ -115,7 +125,7 @@ class TestRunCmdRecording:
         inner = MockSubprocessRunner()
         inner.push(_mr(0, "task output", ""))
         recording_runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
-        tool_ctx.runner = recording_runner
+        tool_ctx_kitchen_open.runner = recording_runner
 
         await run_cmd(cmd="task install-worktree", cwd="/tmp", step_name="setup")
 

--- a/tests/server/test_tools_run_python.py
+++ b/tests/server/test_tools_run_python.py
@@ -25,7 +25,9 @@ class TestRunPythonObservability:
         return ctx
 
     @pytest.mark.anyio
-    async def test_run_python_binds_tool_contextvar_and_calls_ctx_info(self, tool_ctx, mock_ctx):
+    async def test_run_python_binds_tool_contextvar_and_calls_ctx_info(
+        self, tool_ctx_kitchen_open, mock_ctx
+    ):
         """run_python binds tool='run_python' contextvar and calls ctx.info on success."""
         with structlog.testing.capture_logs(
             processors=[structlog.contextvars.merge_contextvars]

--- a/tests/server/test_tools_run_skill_retry.py
+++ b/tests/server/test_tools_run_skill_retry.py
@@ -43,7 +43,7 @@ class TestRunSkillSessionOutcome:
     """run_skill correctly classifies all Claude Code session outcomes."""
 
     @pytest.mark.anyio
-    async def test_detects_max_turns_via_subtype(self, tool_ctx):
+    async def test_detects_max_turns_via_subtype(self, tool_ctx_kitchen_open):
         """error_max_turns in JSON output -> needs_retry=True, retry_reason=RESUME."""
         stdout = json.dumps(
             {
@@ -54,14 +54,14 @@ class TestRunSkillSessionOutcome:
                 "errors": ["Max turns reached"],
             }
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(1, stdout, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(1, stdout, ""))
         result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["needs_retry"] is True
         assert result["retry_reason"] == RetryReason.RESUME
 
     @pytest.mark.anyio
-    async def test_detects_context_limit(self, tool_ctx):
+    async def test_detects_context_limit(self, tool_ctx_kitchen_open):
         """'Prompt is too long' -> needs_retry=True, retry_reason='resume'."""
         stdout = json.dumps(
             {
@@ -72,8 +72,8 @@ class TestRunSkillSessionOutcome:
                 "session_id": "s1",
             }
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(1, stdout, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(1, stdout, ""))
         result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["needs_retry"] is True
         assert result["retry_reason"] == RetryReason.RESUME
@@ -135,7 +135,7 @@ class TestRunSkillAgentResult:
     """run_skill result field contains actionable text."""
 
     @pytest.mark.anyio
-    async def test_context_limit_result_is_actionable(self, tool_ctx):
+    async def test_context_limit_result_is_actionable(self, tool_ctx_kitchen_open):
         """When context is exhausted, result text must NOT say 'Prompt is too long'."""
         stdout = json.dumps(
             {
@@ -146,14 +146,14 @@ class TestRunSkillAgentResult:
                 "session_id": "s1",
             }
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(1, stdout, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(1, stdout, ""))
         result = json.loads(await run_skill("/retry-worktree plan.md", "/tmp"))
         assert "prompt is too long" not in result["result"].lower()
         assert result["needs_retry"] is True
 
     @pytest.mark.anyio
-    async def test_normal_success_result_passes_through(self, tool_ctx):
+    async def test_normal_success_result_passes_through(self, tool_ctx_kitchen_open):
         """Normal success result text is preserved."""
         stdout = json.dumps(
             {
@@ -164,8 +164,8 @@ class TestRunSkillAgentResult:
                 "session_id": "s1",
             }
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(0, stdout, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(0, stdout, ""))
         result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["result"] == "Done."
 
@@ -174,7 +174,7 @@ class TestRunSkillPassesAddDir:
     """run_skill passes ValidatedAddDir instances to executor."""
 
     @pytest.mark.anyio
-    async def test_run_skill_passes_validated_add_dirs_to_executor(self, tool_ctx):
+    async def test_run_skill_passes_validated_add_dirs_to_executor(self, tool_ctx_kitchen_open):
         """add_dirs forwarded to ctx.executor.run() are ValidatedAddDir instances."""
         from unittest.mock import AsyncMock
 
@@ -192,7 +192,7 @@ class TestRunSkillPassesAddDir:
             stderr="",
         )
         mock_run = AsyncMock(return_value=mock_result)
-        tool_ctx.executor = type("MockExec", (), {"run": mock_run})()
+        tool_ctx_kitchen_open.executor = type("MockExec", (), {"run": mock_run})()
         await run_skill("/investigate something", "/tmp")
 
         add_dirs = mock_run.call_args.kwargs.get("add_dirs", ())
@@ -224,7 +224,7 @@ class TestRunSkillFields:
         assert result["retry_reason"] == RetryReason.NONE
 
     @pytest.mark.anyio
-    async def test_includes_needs_retry_true_on_context_limit(self, tool_ctx):
+    async def test_includes_needs_retry_true_on_context_limit(self, tool_ctx_kitchen_open):
         """run_skill response includes needs_retry=True when context is exhausted."""
         stdout = json.dumps(
             {
@@ -235,15 +235,17 @@ class TestRunSkillFields:
                 "session_id": "s1",
             }
         )
-        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot
-        tool_ctx.runner.push(_make_result(1, stdout, ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
+        tool_ctx_kitchen_open.runner.push(_make_result(1, stdout, ""))
         result = json.loads(await run_skill("/investigate error", "/tmp"))
         assert result["needs_retry"] is True
         assert result["retry_reason"] == RetryReason.RESUME
         assert "prompt is too long" not in result["result"].lower()
 
     @pytest.mark.anyio
-    async def test_includes_empty_output_reason_on_empty_natural_exit_session(self, tool_ctx):
+    async def test_includes_empty_output_reason_on_empty_natural_exit_session(
+        self, tool_ctx_kitchen_open
+    ):
         """run_skill returns retry_reason=empty_output for empty natural-exit sessions.
 
         NATURAL_EXIT + rc=0 + empty_output subtype: the session exited cleanly but
@@ -260,7 +262,7 @@ class TestRunSkillFields:
                 "session_id": "",
             }
         )
-        tool_ctx.runner.push(
+        tool_ctx_kitchen_open.runner.push(
             _make_result(0, stdout, "", termination_reason=TerminationReason.NATURAL_EXIT)
         )
         result = json.loads(await run_skill("/investigate error", "/tmp"))

--- a/tests/server/test_tools_session_diagnostics.py
+++ b/tests/server/test_tools_session_diagnostics.py
@@ -314,23 +314,23 @@ def _make_session_dir(
 
 
 @pytest.mark.anyio
-async def test_report_bug_includes_diagnostics_in_new_issue_body(tool_ctx, tmp_path):
+async def test_report_bug_includes_diagnostics_in_new_issue_body(tool_ctx_kitchen_open, tmp_path):
     """New issue body includes the Session Diagnostics section when diagnostics are available."""
     session_id = "diag-session-001"
     _make_session_dir(tmp_path, session_id)
 
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = "owner/repo"
-    tool_ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
 
-    tool_ctx.executor = _make_mock_executor(
+    tool_ctx_kitchen_open.executor = _make_mock_executor(
         success=True,
         result="---bug-fingerprint---\nfp-001\n---/bug-fingerprint---\nReport text.",
         session_id=session_id,
     )
     github_mock = _make_mock_github(search_total=0)
-    tool_ctx.github_client = github_mock
+    tool_ctx_kitchen_open.github_client = github_mock
 
     result = json.loads(
         await report_bug(error_context="Test error", cwd=str(tmp_path), severity="blocking")
@@ -344,7 +344,9 @@ async def test_report_bug_includes_diagnostics_in_new_issue_body(tool_ctx, tmp_p
 
 
 @pytest.mark.anyio
-async def test_report_bug_includes_condensed_diagnostics_in_duplicate_comment(tool_ctx, tmp_path):
+async def test_report_bug_includes_condensed_diagnostics_in_duplicate_comment(
+    tool_ctx_kitchen_open, tmp_path
+):
     """Duplicate comment includes condensed metrics but no <details> blocks."""
     session_id = "diag-session-002"
     _make_session_dir(
@@ -353,18 +355,18 @@ async def test_report_bug_includes_condensed_diagnostics_in_duplicate_comment(to
         anomalies=[{"kind": "oom_spike", "severity": "warning", "detail": {}}],
     )
 
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = "owner/repo"
-    tool_ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
 
-    tool_ctx.executor = _make_mock_executor(
+    tool_ctx_kitchen_open.executor = _make_mock_executor(
         success=True,
         result="---bug-fingerprint---\nfp-002\n---/bug-fingerprint---\nReport text.",
         session_id=session_id,
     )
     github_mock = _make_mock_github(search_total=1, existing_body="different error")
-    tool_ctx.github_client = github_mock
+    tool_ctx_kitchen_open.github_client = github_mock
 
     await report_bug(error_context="Test error", cwd=str(tmp_path), severity="blocking")
 
@@ -376,21 +378,21 @@ async def test_report_bug_includes_condensed_diagnostics_in_duplicate_comment(to
 
 @pytest.mark.anyio
 async def test_report_bug_proceeds_without_diagnostics_when_session_dir_missing(
-    tool_ctx, tmp_path
+    tool_ctx_kitchen_open, tmp_path
 ):
     """GitHub issue is still filed even when no session diagnostics directory exists."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = "owner/repo"
-    tool_ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
 
-    tool_ctx.executor = _make_mock_executor(
+    tool_ctx_kitchen_open.executor = _make_mock_executor(
         success=True,
         result="---bug-fingerprint---\nfp-003\n---/bug-fingerprint---\nReport text.",
         session_id="nonexistent-session-id",  # no directory on disk
     )
     github_mock = _make_mock_github(search_total=0)
-    tool_ctx.github_client = github_mock
+    tool_ctx_kitchen_open.github_client = github_mock
 
     result = json.loads(
         await report_bug(error_context="Test error", cwd=str(tmp_path), severity="blocking")
@@ -404,20 +406,22 @@ async def test_report_bug_proceeds_without_diagnostics_when_session_dir_missing(
 
 
 @pytest.mark.anyio
-async def test_report_bug_skips_diagnostics_for_fallback_session_id(tool_ctx, tmp_path):
+async def test_report_bug_skips_diagnostics_for_fallback_session_id(
+    tool_ctx_kitchen_open, tmp_path
+):
     """Fallback session IDs (no_session_*) never trigger diagnostics read."""
-    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
-    tool_ctx.config.report_bug.github_filing = True
-    tool_ctx.config.github.default_repo = "owner/repo"
-    tool_ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = True
+    tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
+    tool_ctx_kitchen_open.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
 
-    tool_ctx.executor = _make_mock_executor(
+    tool_ctx_kitchen_open.executor = _make_mock_executor(
         success=True,
         result="---bug-fingerprint---\nfp-004\n---/bug-fingerprint---\nReport.",
         session_id="no_session_2026-01-01T00-00-00",
     )
     github_mock = _make_mock_github(search_total=0)
-    tool_ctx.github_client = github_mock
+    tool_ctx_kitchen_open.github_client = github_mock
 
     result = json.loads(
         await report_bug(error_context="Test error", cwd=str(tmp_path), severity="blocking")

--- a/tests/server/test_tools_status_kitchen.py
+++ b/tests/server/test_tools_status_kitchen.py
@@ -55,7 +55,7 @@ class TestKitchenStatus:
     """kitchen_status tool returns version health info."""
 
     @pytest.fixture(autouse=True)
-    def _setup(self, tool_ctx, monkeypatch, tmp_path):
+    def _setup(self, tool_ctx_kitchen_open, monkeypatch, tmp_path):
         monkeypatch.chdir(tmp_path)
 
     @pytest.mark.anyio

--- a/tests/server/test_tools_status_kitchen.py
+++ b/tests/server/test_tools_status_kitchen.py
@@ -59,11 +59,13 @@ class TestKitchenStatus:
         monkeypatch.chdir(tmp_path)
 
     @pytest.mark.anyio
-    async def test_status_returns_version_info(self, tool_ctx):
+    async def test_status_returns_version_info(self, tool_ctx_kitchen_open):
         import autoskillit
         from autoskillit.core.types._type_plugin_source import DirectInstall
 
-        tool_ctx.plugin_source = DirectInstall(plugin_dir=Path(autoskillit.__file__).parent)
+        tool_ctx_kitchen_open.plugin_source = DirectInstall(
+            plugin_dir=Path(autoskillit.__file__).parent
+        )
         from autoskillit import __version__
 
         result = json.loads(await kitchen_status())
@@ -73,7 +75,7 @@ class TestKitchenStatus:
         assert "warning" not in result
 
     @pytest.mark.anyio
-    async def test_status_reports_mismatch(self, tmp_path, tool_ctx):
+    async def test_status_reports_mismatch(self, tmp_path, tool_ctx_kitchen_open):
         plugin_dir = tmp_path / ".claude-plugin"
         plugin_dir.mkdir()
         (plugin_dir / "plugin.json").write_text(
@@ -81,7 +83,7 @@ class TestKitchenStatus:
         )
         from autoskillit.core.types._type_plugin_source import DirectInstall
 
-        tool_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        tool_ctx_kitchen_open.plugin_source = DirectInstall(plugin_dir=tmp_path)
         result = json.loads(await kitchen_status())
         assert result["versions_match"] is False
         assert "warning" in result
@@ -95,44 +97,46 @@ class TestKitchenStatus:
         assert result["token_usage_verbosity"] == "summary"
 
     @pytest.mark.anyio
-    async def test_status_reflects_none_verbosity(self, tool_ctx):
+    async def test_status_reflects_none_verbosity(self, tool_ctx_kitchen_open):
         """TU_S2: kitchen_status reflects 'none' verbosity from config."""
         cfg = AutomationConfig()
         cfg.token_usage = TokenUsageConfig(verbosity="none")
-        tool_ctx.config = cfg
+        tool_ctx_kitchen_open.config = cfg
         result = json.loads(await kitchen_status())
         assert result["token_usage_verbosity"] == "none"
 
     @pytest.mark.anyio
-    async def test_kitchen_status_includes_github_config(self, tool_ctx):
-        tool_ctx.config.github.default_repo = "owner/repo"
+    async def test_kitchen_status_includes_github_config(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.config.github.default_repo = "owner/repo"
         status = json.loads(await kitchen_status())
         assert "github_default_repo" in status
         assert status["github_default_repo"] == "owner/repo"
         assert "github_token_configured" in status
 
     @pytest.mark.anyio
-    async def test_kitchen_status_github_token_configured_true_from_client(self, tool_ctx):
+    async def test_kitchen_status_github_token_configured_true_from_client(
+        self, tool_ctx_kitchen_open
+    ):
         """kitchen_status must read github_token_configured from ctx.github_client.has_token."""
-        tool_ctx.github_client = DefaultGitHubFetcher(token="my-token")
+        tool_ctx_kitchen_open.github_client = DefaultGitHubFetcher(token="my-token")
         status = json.loads(await kitchen_status())
         assert status["github_token_configured"] is True
 
     @pytest.mark.anyio
     async def test_kitchen_status_github_token_not_configured_from_client(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ):
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        tool_ctx.github_client = DefaultGitHubFetcher(token=None)
+        tool_ctx_kitchen_open.github_client = DefaultGitHubFetcher(token=None)
         status = json.loads(await kitchen_status())
         assert status["github_token_configured"] is False
 
     @pytest.mark.anyio
     async def test_kitchen_status_github_token_does_not_reflect_post_construction_env(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ):
         """kitchen_status must NOT re-read os.environ — reflects ctx.github_client.has_token."""
-        tool_ctx.github_client = DefaultGitHubFetcher(token=None)
+        tool_ctx_kitchen_open.github_client = DefaultGitHubFetcher(token=None)
         monkeypatch.setenv("GITHUB_TOKEN", "set-after-construction")
         status = json.loads(await kitchen_status())
         assert status["github_token_configured"] is False
@@ -166,7 +170,7 @@ class TestGetPipelineReport:
         assert result.get("subtype") == "gate_error"
 
     @pytest.mark.anyio
-    async def test_returns_empty_initially(self, tool_ctx):
+    async def test_returns_empty_initially(self, tool_ctx_kitchen_open):
         result = json.loads(await get_pipeline_report())
         assert result["total_failures"] == 0
         assert result["failures"] == []
@@ -188,15 +192,17 @@ class TestGetPipelineReport:
         assert result["failures"][0]["skill_command"].startswith("/autoskillit:test")
 
     @pytest.mark.anyio
-    async def test_clear_true_resets_after_returning(self, tool_ctx):
-        tool_ctx.audit.record_failure(_make_failure_record())
+    async def test_clear_true_resets_after_returning(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.audit.record_failure(_make_failure_record())
         result = json.loads(await get_pipeline_report(clear=True))
         assert result["total_failures"] == 1
         result2 = json.loads(await get_pipeline_report())
         assert result2["total_failures"] == 0
 
     @pytest.mark.anyio
-    async def test_get_pipeline_report_awaits_startup_ready(self, tool_ctx, monkeypatch):
+    async def test_get_pipeline_report_awaits_startup_ready(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
         """get_pipeline_report must await _startup_ready before accessing audit data."""
         import autoskillit.server._state as _state_mod
 
@@ -286,33 +292,33 @@ class TestTelemetryRecoveryData:
             f.write(json.dumps(idx) + "\n")
 
     @pytest.mark.anyio
-    async def test_token_summary_reflects_recovered_data(self, tool_ctx, tmp_path):
+    async def test_token_summary_reflects_recovered_data(self, tool_ctx_kitchen_open, tmp_path):
         """get_token_summary returns data loaded via load_from_log_dir."""
         log_root = tmp_path / "logs"
         self._write_token_session(log_root, "s001", "implement", 500)
-        tool_ctx.token_log.load_from_log_dir(log_root)
+        tool_ctx_kitchen_open.token_log.load_from_log_dir(log_root)
         result = json.loads(await get_token_summary())
         steps = {s["step_name"]: s for s in result["steps"]}
         assert "implement" in steps
         assert steps["implement"]["input_tokens"] == 500
 
     @pytest.mark.anyio
-    async def test_timing_summary_reflects_recovered_data(self, tool_ctx, tmp_path):
+    async def test_timing_summary_reflects_recovered_data(self, tool_ctx_kitchen_open, tmp_path):
         """get_timing_summary returns data loaded via load_from_log_dir."""
         log_root = tmp_path / "logs"
         self._write_timing_session(log_root, "s001", "plan", 99.0)
-        tool_ctx.timing_log.load_from_log_dir(log_root)
+        tool_ctx_kitchen_open.timing_log.load_from_log_dir(log_root)
         result = json.loads(await get_timing_summary())
         steps = {s["step_name"]: s for s in result["steps"]}
         assert "plan" in steps
         assert steps["plan"]["total_seconds"] == pytest.approx(99.0)
 
     @pytest.mark.anyio
-    async def test_pipeline_report_reflects_recovered_audit(self, tool_ctx, tmp_path):
+    async def test_pipeline_report_reflects_recovered_audit(self, tool_ctx_kitchen_open, tmp_path):
         """get_pipeline_report returns failures loaded via load_from_log_dir."""
         log_root = tmp_path / "logs"
         self._write_audit_session(log_root, "s001")
-        tool_ctx.audit.load_from_log_dir(log_root)
+        tool_ctx_kitchen_open.audit.load_from_log_dir(log_root)
         result = json.loads(await get_pipeline_report())
         assert result["total_failures"] == 1
         assert result["failures"][0]["skill_command"] == "/autoskillit:implement-worktree"

--- a/tests/server/test_tools_status_mcp_response.py
+++ b/tests/server/test_tools_status_mcp_response.py
@@ -14,9 +14,9 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 class TestGetTokenSummaryMcpResponses:
     @pytest.mark.anyio
-    async def test_includes_mcp_responses_section(self, tool_ctx):
+    async def test_includes_mcp_responses_section(self, tool_ctx_kitchen_open):
         """get_token_summary returns an mcp_responses key with per-tool data."""
-        tool_ctx.response_log.record("run_skill", "a" * 400)
+        tool_ctx_kitchen_open.response_log.record("run_skill", "a" * 400)
 
         result = json.loads(await get_token_summary())
         assert "mcp_responses" in result
@@ -25,9 +25,9 @@ class TestGetTokenSummaryMcpResponses:
         assert result["mcp_responses"]["steps"][0]["tool_name"] == "run_skill"
 
     @pytest.mark.anyio
-    async def test_mcp_responses_steps_contain_expected_fields(self, tool_ctx):
+    async def test_mcp_responses_steps_contain_expected_fields(self, tool_ctx_kitchen_open):
         """Each step in mcp_responses has the expected fields."""
-        tool_ctx.response_log.record("load_recipe", "x" * 800)
+        tool_ctx_kitchen_open.response_log.record("load_recipe", "x" * 800)
 
         result = json.loads(await get_token_summary())
         step = result["mcp_responses"]["steps"][0]
@@ -37,10 +37,10 @@ class TestGetTokenSummaryMcpResponses:
         assert step["invocation_count"] == 1
 
     @pytest.mark.anyio
-    async def test_mcp_responses_total_fields(self, tool_ctx):
+    async def test_mcp_responses_total_fields(self, tool_ctx_kitchen_open):
         """mcp_responses.total contains aggregated byte and token counts."""
-        tool_ctx.response_log.record("run_skill", "a" * 400)
-        tool_ctx.response_log.record("load_recipe", "b" * 800)
+        tool_ctx_kitchen_open.response_log.record("run_skill", "a" * 400)
+        tool_ctx_kitchen_open.response_log.record("load_recipe", "b" * 800)
 
         result = json.loads(await get_token_summary())
         total = result["mcp_responses"]["total"]
@@ -49,14 +49,14 @@ class TestGetTokenSummaryMcpResponses:
         assert total["total_invocations"] == 2
 
     @pytest.mark.anyio
-    async def test_mcp_responses_empty_when_no_responses_recorded(self, tool_ctx):
+    async def test_mcp_responses_empty_when_no_responses_recorded(self, tool_ctx_kitchen_open):
         """mcp_responses section returns empty steps when no responses recorded."""
         result = json.loads(await get_token_summary())
         assert result["mcp_responses"]["steps"] == []
         assert result["mcp_responses"]["total"]["total_invocations"] == 0
 
     @pytest.mark.anyio
-    async def test_clear_true_also_clears_response_log(self, tool_ctx):
+    async def test_clear_true_also_clears_response_log(self, tool_ctx_kitchen_open):
         """When clear=True, response_log is cleared alongside token_log.
 
         Note: @track_response_size records the get_token_summary response itself
@@ -64,7 +64,7 @@ class TestGetTokenSummaryMcpResponses:
         have a 'get_token_summary' entry from the decorator, but 'run_skill'
         (recorded before clear) must be absent.
         """
-        tool_ctx.response_log.record("run_skill", "data" * 100)
+        tool_ctx_kitchen_open.response_log.record("run_skill", "data" * 100)
 
         result = json.loads(await get_token_summary(clear=True))
         names_before = {s["tool_name"] for s in result["mcp_responses"]["steps"]}
@@ -77,9 +77,9 @@ class TestGetTokenSummaryMcpResponses:
 
 class TestWriteTelemetryFilesMcpResponse:
     @pytest.mark.anyio
-    async def test_writes_mcp_response_metrics_json(self, tool_ctx, tmp_path):
+    async def test_writes_mcp_response_metrics_json(self, tool_ctx_kitchen_open, tmp_path):
         """write_telemetry_files writes mcp_response_metrics.json alongside token_summary.md."""
-        tool_ctx.response_log.record("run_skill", "x" * 800)
+        tool_ctx_kitchen_open.response_log.record("run_skill", "x" * 800)
 
         result = json.loads(await write_telemetry_files(str(tmp_path)))
 
@@ -91,7 +91,7 @@ class TestWriteTelemetryFilesMcpResponse:
         assert data["steps"][0]["tool_name"] == "run_skill"
 
     @pytest.mark.anyio
-    async def test_mcp_response_metrics_path_key_in_result(self, tool_ctx, tmp_path):
+    async def test_mcp_response_metrics_path_key_in_result(self, tool_ctx_kitchen_open, tmp_path):
         """write_telemetry_files returns mcp_response_metrics_path alongside existing keys."""
         result = json.loads(await write_telemetry_files(str(tmp_path)))
         assert "token_summary_path" in result
@@ -99,10 +99,10 @@ class TestWriteTelemetryFilesMcpResponse:
         assert "mcp_response_metrics_path" in result
 
     @pytest.mark.anyio
-    async def test_mcp_response_metrics_json_structure(self, tool_ctx, tmp_path):
+    async def test_mcp_response_metrics_json_structure(self, tool_ctx_kitchen_open, tmp_path):
         """mcp_response_metrics.json has steps list and total dict."""
-        tool_ctx.response_log.record("run_skill", "a" * 400)
-        tool_ctx.response_log.record("load_recipe", "b" * 800)
+        tool_ctx_kitchen_open.response_log.record("run_skill", "a" * 400)
+        tool_ctx_kitchen_open.response_log.record("load_recipe", "b" * 800)
 
         result = json.loads(await write_telemetry_files(str(tmp_path)))
         metrics_path = Path(result["mcp_response_metrics_path"])
@@ -113,7 +113,7 @@ class TestWriteTelemetryFilesMcpResponse:
         assert data["total"]["total_response_bytes"] == 1200
 
     @pytest.mark.anyio
-    async def test_existing_keys_unchanged(self, tool_ctx, tmp_path):
+    async def test_existing_keys_unchanged(self, tool_ctx_kitchen_open, tmp_path):
         """token_summary_path and timing_summary_path keys remain correct in result."""
         result = json.loads(await write_telemetry_files(str(tmp_path)))
         assert Path(result["token_summary_path"]).name == "token_summary.md"

--- a/tests/server/test_tools_status_quota_and_db.py
+++ b/tests/server/test_tools_status_quota_and_db.py
@@ -151,7 +151,7 @@ class TestWriteTelemetryFiles:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.usefixtures("tool_ctx")
+@pytest.mark.usefixtures("tool_ctx_kitchen_open")
 class TestReadDb:
     """Integration tests for read_db tool with real SQLite databases."""
 

--- a/tests/server/test_tools_status_quota_and_db.py
+++ b/tests/server/test_tools_status_quota_and_db.py
@@ -20,7 +20,7 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 class TestGetQuotaEvents:
     @pytest.mark.anyio
-    async def test_returns_events_from_jsonl(self, tool_ctx, tmp_path, monkeypatch):
+    async def test_returns_events_from_jsonl(self, tool_ctx_kitchen_open, tmp_path, monkeypatch):
         events = [
             {
                 "ts": "2026-03-10T10:00:00+00:00",
@@ -40,13 +40,13 @@ class TestGetQuotaEvents:
         (log_dir / "quota_events.jsonl").write_text(
             "\n".join(json.dumps(e) for e in events) + "\n"
         )
-        monkeypatch.setattr(tool_ctx.config.linux_tracing, "log_dir", str(log_dir))
+        monkeypatch.setattr(tool_ctx_kitchen_open.config.linux_tracing, "log_dir", str(log_dir))
         result = json.loads(await get_quota_events())
         assert result["total_count"] == 2
         assert result["events"][0]["event"] == "blocked"  # most recent first
 
     @pytest.mark.anyio
-    async def test_limits_to_n_events(self, tool_ctx, tmp_path, monkeypatch):
+    async def test_limits_to_n_events(self, tool_ctx_kitchen_open, tmp_path, monkeypatch):
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
         lines = [
@@ -54,7 +54,7 @@ class TestGetQuotaEvents:
             for h in range(10)
         ]
         (log_dir / "quota_events.jsonl").write_text("\n".join(lines) + "\n")
-        monkeypatch.setattr(tool_ctx.config.linux_tracing, "log_dir", str(log_dir))
+        monkeypatch.setattr(tool_ctx_kitchen_open.config.linux_tracing, "log_dir", str(log_dir))
         result = json.loads(await get_quota_events(n=3))
         assert len(result["events"]) == 3
         assert result["total_count"] == 10
@@ -64,10 +64,12 @@ class TestGetQuotaEvents:
         assert result["events"][2]["ts"] == "2026-03-10T07:00:00+00:00"
 
     @pytest.mark.anyio
-    async def test_returns_empty_when_file_missing(self, tool_ctx, tmp_path, monkeypatch):
+    async def test_returns_empty_when_file_missing(
+        self, tool_ctx_kitchen_open, tmp_path, monkeypatch
+    ):
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
-        monkeypatch.setattr(tool_ctx.config.linux_tracing, "log_dir", str(log_dir))
+        monkeypatch.setattr(tool_ctx_kitchen_open.config.linux_tracing, "log_dir", str(log_dir))
         result = json.loads(await get_quota_events())
         assert result["events"] == []
         assert result["total_count"] == 0
@@ -75,8 +77,8 @@ class TestGetQuotaEvents:
 
 class TestWriteTelemetryFiles:
     @pytest.mark.anyio
-    async def test_writes_token_summary_markdown(self, tool_ctx, tmp_path):
-        tool_ctx.token_log.record(
+    async def test_writes_token_summary_markdown(self, tool_ctx_kitchen_open, tmp_path):
+        tool_ctx_kitchen_open.token_log.record(
             "step1",
             {
                 "input_tokens": 100,
@@ -97,8 +99,8 @@ class TestWriteTelemetryFiles:
         assert "# Token Summary" not in content
 
     @pytest.mark.anyio
-    async def test_writes_timing_summary_markdown(self, tool_ctx, tmp_path):
-        tool_ctx.timing_log.record("step1", 12.5)
+    async def test_writes_timing_summary_markdown(self, tool_ctx_kitchen_open, tmp_path):
+        tool_ctx_kitchen_open.timing_log.record("step1", 12.5)
         result = json.loads(await write_telemetry_files(str(tmp_path)))
         path = Path(result["timing_summary_path"])
         assert path.exists()
@@ -111,9 +113,9 @@ class TestWriteTelemetryFiles:
         assert "# Timing Summary" not in content
 
     @pytest.mark.anyio
-    async def test_token_file_uses_wall_clock_seconds(self, tool_ctx, tmp_path):
+    async def test_token_file_uses_wall_clock_seconds(self, tool_ctx_kitchen_open, tmp_path):
         """write_telemetry_files merges wall_clock_seconds from timing log."""
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log.record(
             "deploy",
             {
                 "input_tokens": 100,
@@ -123,14 +125,14 @@ class TestWriteTelemetryFiles:
             },
             elapsed_seconds=5.0,
         )
-        tool_ctx.timing_log.record("deploy", 120.0)
+        tool_ctx_kitchen_open.timing_log.record("deploy", 120.0)
         result = json.loads(await write_telemetry_files(str(tmp_path)))
         content = Path(result["token_summary_path"]).read_text()
         # Should show 2m 0s (wall_clock=120), not 5s (elapsed)
         assert "2m 0s" in content
 
     @pytest.mark.anyio
-    async def test_creates_output_dir_if_missing(self, tool_ctx, tmp_path):
+    async def test_creates_output_dir_if_missing(self, tool_ctx_kitchen_open, tmp_path):
         out = str(tmp_path / "nested" / "telemetry")
         result = json.loads(await write_telemetry_files(out))
         assert Path(result["token_summary_path"]).exists()
@@ -293,8 +295,8 @@ class TestReadDb:
         assert "not enabled" in result["result"].lower()
 
     @pytest.mark.anyio
-    async def test_max_rows_truncation(self, sample_db, tool_ctx):
-        tool_ctx.config = AutomationConfig(read_db=ReadDbConfig(max_rows=2))
+    async def test_max_rows_truncation(self, sample_db, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.config = AutomationConfig(read_db=ReadDbConfig(max_rows=2))
         result = json.loads(
             await read_db(
                 db_path=str(sample_db),
@@ -324,8 +326,8 @@ class TestReadDb:
         assert base64.b64decode(result["rows"][0]["content"]) == b"\x00\x01\x02\xff"
 
     @pytest.mark.anyio
-    async def test_query_timeout(self, sample_db, tool_ctx):
-        tool_ctx.config = AutomationConfig(read_db=ReadDbConfig(timeout=1))
+    async def test_query_timeout(self, sample_db, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.config = AutomationConfig(read_db=ReadDbConfig(timeout=1))
         # Cross join 3 rows^18 = ~387 million rows — guaranteed to exceed 1s timeout
         slow_query = "SELECT count(*) FROM " + ", ".join(f"users t{i}" for i in range(18))
         result = json.loads(
@@ -349,14 +351,14 @@ class TestReadDb:
 
 
 @pytest.mark.anyio
-async def test_tools_status_routes_through_db_reader(tool_ctx, tmp_path) -> None:
+async def test_tools_status_routes_through_db_reader(tool_ctx_kitchen_open, tmp_path) -> None:
     """read_db routes through ctx.db_reader.query()."""
     import sqlite3 as _sqlite3
 
     from tests.fakes import InMemoryDatabaseReader
 
     reader = InMemoryDatabaseReader(query_result={"rows": [], "count": 0})
-    tool_ctx.db_reader = reader
+    tool_ctx_kitchen_open.db_reader = reader
 
     db_path = str(tmp_path / "test.db")
     # Create an empty sqlite db so path-exists check passes
@@ -371,11 +373,11 @@ async def test_tools_status_routes_through_db_reader(tool_ctx, tmp_path) -> None
 
 
 @pytest.mark.anyio
-async def test_read_db_all_error_paths_include_success_false(tool_ctx, monkeypatch):
+async def test_read_db_all_error_paths_include_success_false(tool_ctx_kitchen_open, monkeypatch):
     """Every read_db error path must return success=False."""
     from autoskillit.server import _state
 
-    monkeypatch.setattr(_state, "_ctx", tool_ctx)
+    monkeypatch.setattr(_state, "_ctx", tool_ctx_kitchen_open)
 
     # Nonexistent db path — exercises the "does not exist" error branch
     result = json.loads(await read_db(db_path="/nonexistent/path/db.sqlite", query="SELECT 1"))

--- a/tests/server/test_tools_status_summaries.py
+++ b/tests/server/test_tools_status_summaries.py
@@ -30,7 +30,7 @@ class TestGetTokenSummary:
         assert result.get("subtype") == "gate_error"
 
     @pytest.mark.anyio
-    async def test_returns_empty_steps_initially(self, tool_ctx):
+    async def test_returns_empty_steps_initially(self, tool_ctx_kitchen_open):
         result = json.loads(await get_token_summary())
         assert result["steps"] == []
         assert result["total"]["input_tokens"] == 0
@@ -39,8 +39,8 @@ class TestGetTokenSummary:
         assert result["total"]["cache_read_input_tokens"] == 0
 
     @pytest.mark.anyio
-    async def test_returns_entry_per_step_name(self, tool_ctx):
-        tool_ctx.token_log.record(
+    async def test_returns_entry_per_step_name(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.token_log.record(
             "investigate",
             {
                 "input_tokens": 100,
@@ -49,7 +49,7 @@ class TestGetTokenSummary:
                 "cache_read_input_tokens": 5,
             },
         )
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log.record(
             "implement",
             {
                 "input_tokens": 200,
@@ -64,24 +64,24 @@ class TestGetTokenSummary:
         assert result["steps"][1]["step_name"] == "implement"
 
     @pytest.mark.anyio
-    async def test_multiple_invocations_same_step_are_summed(self, tool_ctx):
+    async def test_multiple_invocations_same_step_are_summed(self, tool_ctx_kitchen_open):
         usage = {
             "input_tokens": 100,
             "output_tokens": 50,
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
         }
-        tool_ctx.token_log.record("implement", usage)
-        tool_ctx.token_log.record("implement", usage)
-        tool_ctx.token_log.record("implement", usage)
+        tool_ctx_kitchen_open.token_log.record("implement", usage)
+        tool_ctx_kitchen_open.token_log.record("implement", usage)
+        tool_ctx_kitchen_open.token_log.record("implement", usage)
         result = json.loads(await get_token_summary())
         assert len(result["steps"]) == 1
         assert result["steps"][0]["input_tokens"] == 300
         assert result["steps"][0]["invocation_count"] == 3
 
     @pytest.mark.anyio
-    async def test_total_field_sums_all_steps(self, tool_ctx):
-        tool_ctx.token_log.record(
+    async def test_total_field_sums_all_steps(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.token_log.record(
             "plan",
             {
                 "input_tokens": 100,
@@ -90,7 +90,7 @@ class TestGetTokenSummary:
                 "cache_read_input_tokens": 5,
             },
         )
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log.record(
             "implement",
             {
                 "input_tokens": 200,
@@ -106,8 +106,8 @@ class TestGetTokenSummary:
         assert result["total"]["cache_read_input_tokens"] == 15
 
     @pytest.mark.anyio
-    async def test_clear_true_resets_after_returning(self, tool_ctx):
-        tool_ctx.token_log.record(
+    async def test_clear_true_resets_after_returning(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.token_log.record(
             "plan",
             {
                 "input_tokens": 100,
@@ -122,8 +122,8 @@ class TestGetTokenSummary:
         assert result2["steps"] == []
 
     @pytest.mark.anyio
-    async def test_response_shape(self, tool_ctx):
-        tool_ctx.token_log.record(
+    async def test_response_shape(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.token_log.record(
             "plan",
             {
                 "input_tokens": 10,
@@ -150,24 +150,26 @@ class TestGetTokenSummary:
         } <= total_keys
 
     @pytest.mark.anyio
-    async def test_step_includes_elapsed_seconds(self, tool_ctx):
+    async def test_step_includes_elapsed_seconds(self, tool_ctx_kitchen_open):
         """Each step dict in the response includes elapsed_seconds."""
         start = "2026-01-01T00:00:00+00:00"
         end = "2026-01-01T00:00:30+00:00"
-        tool_ctx.token_log.record("deploy", {"input_tokens": 200}, start_ts=start, end_ts=end)
+        tool_ctx_kitchen_open.token_log.record(
+            "deploy", {"input_tokens": 200}, start_ts=start, end_ts=end
+        )
         result = json.loads(await get_token_summary())
         assert result["steps"][0]["elapsed_seconds"] == pytest.approx(30.0)
 
     @pytest.mark.anyio
-    async def test_total_includes_total_elapsed_seconds(self, tool_ctx):
+    async def test_total_includes_total_elapsed_seconds(self, tool_ctx_kitchen_open):
         """Total dict includes total_elapsed_seconds summed across all steps."""
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log.record(
             "a",
             {"input_tokens": 10},
             start_ts="2026-01-01T00:00:00+00:00",
             end_ts="2026-01-01T00:00:05+00:00",
         )
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log.record(
             "b",
             {"input_tokens": 20},
             start_ts="2026-01-01T00:01:00+00:00",
@@ -190,48 +192,48 @@ class TestGetTimingSummary:
         assert result.get("subtype") == "gate_error"
 
     @pytest.mark.anyio
-    async def test_returns_empty_steps_initially(self, tool_ctx):
+    async def test_returns_empty_steps_initially(self, tool_ctx_kitchen_open):
         result = json.loads(await get_timing_summary())
         assert result["steps"] == []
         assert result["total"]["total_seconds"] == 0.0
 
     @pytest.mark.anyio
-    async def test_returns_entry_per_step_name(self, tool_ctx):
-        tool_ctx.timing_log.record("clone", 4.0)
-        tool_ctx.timing_log.record("test_check", 12.0)
+    async def test_returns_entry_per_step_name(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.timing_log.record("clone", 4.0)
+        tool_ctx_kitchen_open.timing_log.record("test_check", 12.0)
         result = json.loads(await get_timing_summary())
         assert len(result["steps"]) == 2
         step_names = {s["step_name"] for s in result["steps"]}
         assert step_names == {"clone", "test_check"}
 
     @pytest.mark.anyio
-    async def test_multiple_invocations_same_step_are_summed(self, tool_ctx):
-        tool_ctx.timing_log.record("impl", 10.0)
-        tool_ctx.timing_log.record("impl", 10.0)
-        tool_ctx.timing_log.record("impl", 10.0)
+    async def test_multiple_invocations_same_step_are_summed(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.timing_log.record("impl", 10.0)
+        tool_ctx_kitchen_open.timing_log.record("impl", 10.0)
+        tool_ctx_kitchen_open.timing_log.record("impl", 10.0)
         result = json.loads(await get_timing_summary())
         assert len(result["steps"]) == 1
         assert result["steps"][0]["total_seconds"] == 30.0
         assert result["steps"][0]["invocation_count"] == 3
 
     @pytest.mark.anyio
-    async def test_total_field_sums_all_steps(self, tool_ctx):
-        tool_ctx.timing_log.record("a", 5.0)
-        tool_ctx.timing_log.record("b", 8.0)
+    async def test_total_field_sums_all_steps(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.timing_log.record("a", 5.0)
+        tool_ctx_kitchen_open.timing_log.record("b", 8.0)
         result = json.loads(await get_timing_summary())
         assert result["total"]["total_seconds"] == 13.0
 
     @pytest.mark.anyio
-    async def test_clear_true_resets_after_returning(self, tool_ctx):
-        tool_ctx.timing_log.record("clone", 4.0)
+    async def test_clear_true_resets_after_returning(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.timing_log.record("clone", 4.0)
         result = json.loads(await get_timing_summary(clear=True))
         assert len(result["steps"]) == 1
         result2 = json.loads(await get_timing_summary())
         assert result2["steps"] == []
 
     @pytest.mark.anyio
-    async def test_response_shape(self, tool_ctx):
-        tool_ctx.timing_log.record("plan", 3.0)
+    async def test_response_shape(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.timing_log.record("plan", 3.0)
         result = json.loads(await get_timing_summary())
         assert "steps" in result
         assert "total" in result
@@ -243,9 +245,9 @@ class TestGetTokenSummaryFormat:
     """Tests for get_token_summary format parameter."""
 
     @pytest.mark.anyio
-    async def test_format_json_default(self, tool_ctx):
+    async def test_format_json_default(self, tool_ctx_kitchen_open):
         """format='json' (default) returns JSON dict."""
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log.record(
             "plan",
             {"input_tokens": 100, "output_tokens": 50},
         )
@@ -254,9 +256,9 @@ class TestGetTokenSummaryFormat:
         assert "total" in result
 
     @pytest.mark.anyio
-    async def test_format_table_returns_markdown(self, tool_ctx):
+    async def test_format_table_returns_markdown(self, tool_ctx_kitchen_open):
         """format='table' returns a markdown table string."""
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log.record(
             "plan",
             {"input_tokens": 100, "output_tokens": 50},
         )
@@ -270,9 +272,9 @@ class TestGetTokenSummaryFormat:
             json.loads(result)
 
     @pytest.mark.anyio
-    async def test_format_table_with_clear(self, tool_ctx):
+    async def test_format_table_with_clear(self, tool_ctx_kitchen_open):
         """format='table' + clear=True clears the log after returning."""
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log.record(
             "plan",
             {"input_tokens": 100, "output_tokens": 50},
         )
@@ -286,17 +288,17 @@ class TestGetTimingSummaryFormat:
     """Tests for get_timing_summary format parameter."""
 
     @pytest.mark.anyio
-    async def test_format_json_default(self, tool_ctx):
+    async def test_format_json_default(self, tool_ctx_kitchen_open):
         """format='json' (default) returns JSON dict."""
-        tool_ctx.timing_log.record("plan", 3.0)
+        tool_ctx_kitchen_open.timing_log.record("plan", 3.0)
         result = json.loads(await get_timing_summary())
         assert "steps" in result
         assert "total" in result
 
     @pytest.mark.anyio
-    async def test_format_table_returns_markdown(self, tool_ctx):
+    async def test_format_table_returns_markdown(self, tool_ctx_kitchen_open):
         """format='table' returns a markdown table string."""
-        tool_ctx.timing_log.record("plan", 3.0)
+        tool_ctx_kitchen_open.timing_log.record("plan", 3.0)
         result = await get_timing_summary(format="table")
         assert "| Step |" in result
         assert "|---" in result
@@ -308,13 +310,13 @@ class TestGetTimingSummaryFormat:
 
 class TestTokenSummaryWallClock:
     @pytest.mark.anyio
-    async def test_wall_clock_seconds_merged_from_timing_log(self, tool_ctx):
+    async def test_wall_clock_seconds_merged_from_timing_log(self, tool_ctx_kitchen_open):
         from autoskillit.pipeline.timings import DefaultTimingLog
         from autoskillit.pipeline.tokens import DefaultTokenLog
 
-        tool_ctx.token_log = DefaultTokenLog()
-        tool_ctx.timing_log = DefaultTimingLog()
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log = DefaultTokenLog()
+        tool_ctx_kitchen_open.timing_log = DefaultTimingLog()
+        tool_ctx_kitchen_open.token_log.record(
             "step-a",
             {
                 "input_tokens": 100,
@@ -324,7 +326,7 @@ class TestTokenSummaryWallClock:
             },
             elapsed_seconds=8.0,
         )
-        tool_ctx.timing_log.record("step-a", 12.5)
+        tool_ctx_kitchen_open.timing_log.record("step-a", 12.5)
 
         result = json.loads(await get_token_summary())
         step = next(s for s in result["steps"] if s["step_name"] == "step-a")
@@ -332,13 +334,13 @@ class TestTokenSummaryWallClock:
         assert step["elapsed_seconds"] == pytest.approx(8.0)
 
     @pytest.mark.anyio
-    async def test_wall_clock_falls_back_to_elapsed_when_no_timing(self, tool_ctx):
+    async def test_wall_clock_falls_back_to_elapsed_when_no_timing(self, tool_ctx_kitchen_open):
         from autoskillit.pipeline.timings import DefaultTimingLog
         from autoskillit.pipeline.tokens import DefaultTokenLog
 
-        tool_ctx.token_log = DefaultTokenLog()
-        tool_ctx.timing_log = DefaultTimingLog()
-        tool_ctx.token_log.record(
+        tool_ctx_kitchen_open.token_log = DefaultTokenLog()
+        tool_ctx_kitchen_open.timing_log = DefaultTimingLog()
+        tool_ctx_kitchen_open.token_log.record(
             "step-b",
             {
                 "input_tokens": 200,
@@ -350,14 +352,16 @@ class TestTokenSummaryWallClock:
         )
 
         # Verify no step-b entry was injected into timing_log (guards against parallel pollution)
-        assert not any(e["step_name"] == "step-b" for e in tool_ctx.timing_log.get_report())
+        assert not any(
+            e["step_name"] == "step-b" for e in tool_ctx_kitchen_open.timing_log.get_report()
+        )
         result = json.loads(await get_token_summary())
         step = next(s for s in result["steps"] if s["step_name"] == "step-b")
         # No timing_log entry → falls back to elapsed_seconds
         assert step["wall_clock_seconds"] == pytest.approx(5.0)
 
     @pytest.mark.anyio
-    async def test_merge_wall_clock_after_normalization(self, tool_ctx):
+    async def test_merge_wall_clock_after_normalization(self, tool_ctx_kitchen_open):
         """
         When token entries and timing entries are both normalized to canonical names,
         _merge_wall_clock_seconds must match them correctly.
@@ -365,8 +369,8 @@ class TestTokenSummaryWallClock:
         from autoskillit.pipeline.timings import DefaultTimingLog
         from autoskillit.pipeline.tokens import DefaultTokenLog
 
-        tool_ctx.token_log = DefaultTokenLog()
-        tool_ctx.timing_log = DefaultTimingLog()
+        tool_ctx_kitchen_open.token_log = DefaultTokenLog()
+        tool_ctx_kitchen_open.timing_log = DefaultTimingLog()
 
         # Record via suffixed names — both should normalize to "implement"
         usage = {
@@ -375,10 +379,10 @@ class TestTokenSummaryWallClock:
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
         }
-        tool_ctx.token_log.record("implement-30", usage)
-        tool_ctx.token_log.record("implement-31", usage)
-        tool_ctx.timing_log.record("implement-30", 60.0)
-        tool_ctx.timing_log.record("implement-31", 55.0)
+        tool_ctx_kitchen_open.token_log.record("implement-30", usage)
+        tool_ctx_kitchen_open.token_log.record("implement-31", usage)
+        tool_ctx_kitchen_open.timing_log.record("implement-30", 60.0)
+        tool_ctx_kitchen_open.timing_log.record("implement-31", 55.0)
 
         result = json.loads(await get_token_summary(clear=False, format="json"))
 
@@ -401,12 +405,14 @@ class TestClearMarkerWritten:
         ],
     )
     @pytest.mark.anyio
-    async def test_clear_writes_marker(self, tool_ctx, tmp_path, monkeypatch, fn, kwargs):
+    async def test_clear_writes_marker(
+        self, tool_ctx_kitchen_open, tmp_path, monkeypatch, fn, kwargs
+    ):
         from autoskillit.execution.session_log import read_telemetry_clear_marker
 
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
-        monkeypatch.setattr(tool_ctx.config.linux_tracing, "log_dir", str(log_dir))
+        monkeypatch.setattr(tool_ctx_kitchen_open.config.linux_tracing, "log_dir", str(log_dir))
         await fn(**kwargs)
         assert read_telemetry_clear_marker(log_dir) is not None
 
@@ -432,7 +438,7 @@ class TestGetLogRoot:
 
 @pytest.mark.anyio
 async def test_get_token_summary_not_contaminated_by_prior_pipeline(
-    tmp_path, tool_ctx, monkeypatch
+    tmp_path, tool_ctx_kitchen_open, monkeypatch
 ):
     """
     get_token_summary() must return only the current pipeline's data.
@@ -444,9 +450,9 @@ async def test_get_token_summary_not_contaminated_by_prior_pipeline(
     from autoskillit.server import _state
     from autoskillit.server._state import _initialize
 
-    # tool_ctx fixture sets log_dir to tmp_path/"session_logs" — write sessions there
+    # tool_ctx_kitchen_open fixture sets log_dir to tmp_path/"session_logs" — write sessions there
     # so _initialize reads from the same directory it is configured to use.
-    log_dir = Path(tool_ctx.config.linux_tracing.log_dir)
+    log_dir = Path(tool_ctx_kitchen_open.config.linux_tracing.log_dir)
     log_dir.mkdir(parents=True, exist_ok=True)
 
     prior_cwd = str(tmp_path / "prior-pipeline-clone")
@@ -475,13 +481,13 @@ async def test_get_token_summary_not_contaminated_by_prior_pipeline(
 
     # Simulate server startup with cross-pipeline sessions in the log dir
     with patch("autoskillit.execution.recover_crashed_sessions", return_value=0):
-        _initialize(tool_ctx)
+        _initialize(tool_ctx_kitchen_open)
     # Register the _ctx mutation via monkeypatch so teardown is deterministic
-    # rather than relying on coincidental identity with the tool_ctx fixture's patch.
-    monkeypatch.setattr(_state, "_ctx", tool_ctx)
+    # rather than relying on coincidental identity with the tool_ctx_kitchen_open fixture's patch.
+    monkeypatch.setattr(_state, "_ctx", tool_ctx_kitchen_open)
 
     # Now simulate the CURRENT pipeline recording its own step
-    tool_ctx.token_log.record(
+    tool_ctx_kitchen_open.token_log.record(
         "rectify",
         {
             "input_tokens": 100,
@@ -491,7 +497,7 @@ async def test_get_token_summary_not_contaminated_by_prior_pipeline(
         },
     )
 
-    # get_token_summary uses _get_ctx() internally — tool_ctx fixture wires _ctx correctly
+    # get_token_summary uses _get_ctx() internally — tool_ctx_kitchen_open fixture wires _ctx correctly
     result_json = await get_token_summary(clear=False, format="json")
     result = json.loads(result_json)
     step_names = [s["step_name"] for s in result["steps"]]
@@ -509,12 +515,12 @@ class TestOrderIdFilterOnSummaryTools:
 
     @pytest.mark.anyio
     async def test_get_token_summary_order_id_filter_isolates_issue(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ) -> None:
         """D-1: get_token_summary(order_id='issue-185') returns only that order's steps."""
         from autoskillit.server import _state
 
-        monkeypatch.setattr(_state, "_ctx", tool_ctx)
+        monkeypatch.setattr(_state, "_ctx", tool_ctx_kitchen_open)
 
         usage = {
             "input_tokens": 100,
@@ -522,8 +528,8 @@ class TestOrderIdFilterOnSummaryTools:
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
         }
-        tool_ctx.token_log.record("plan", usage, order_id="issue-185")
-        tool_ctx.token_log.record("implement", usage, order_id="issue-186")
+        tool_ctx_kitchen_open.token_log.record("plan", usage, order_id="issue-185")
+        tool_ctx_kitchen_open.token_log.record("implement", usage, order_id="issue-186")
 
         result = json.loads(await get_token_summary(order_id="issue-185"))
         step_names = [s["step_name"] for s in result["steps"]]
@@ -531,11 +537,13 @@ class TestOrderIdFilterOnSummaryTools:
         assert "implement" not in step_names
 
     @pytest.mark.anyio
-    async def test_get_token_summary_no_order_id_returns_all(self, tool_ctx, monkeypatch) -> None:
+    async def test_get_token_summary_no_order_id_returns_all(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ) -> None:
         """D-2: get_token_summary() without order_id returns aggregated data for all orders."""
         from autoskillit.server import _state
 
-        monkeypatch.setattr(_state, "_ctx", tool_ctx)
+        monkeypatch.setattr(_state, "_ctx", tool_ctx_kitchen_open)
 
         usage = {
             "input_tokens": 100,
@@ -543,8 +551,8 @@ class TestOrderIdFilterOnSummaryTools:
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
         }
-        tool_ctx.token_log.record("plan", usage, order_id="issue-185")
-        tool_ctx.token_log.record("implement", usage, order_id="issue-186")
+        tool_ctx_kitchen_open.token_log.record("plan", usage, order_id="issue-185")
+        tool_ctx_kitchen_open.token_log.record("implement", usage, order_id="issue-186")
 
         result = json.loads(await get_token_summary())
         step_names = [s["step_name"] for s in result["steps"]]
@@ -553,16 +561,16 @@ class TestOrderIdFilterOnSummaryTools:
 
     @pytest.mark.anyio
     async def test_get_timing_summary_order_id_filter_isolates_issue(
-        self, tool_ctx, monkeypatch
+        self, tool_ctx_kitchen_open, monkeypatch
     ) -> None:
         """D-3: get_timing_summary(order_id='issue-185') returns only that order's steps."""
         from autoskillit.server import _state
         from autoskillit.server.tools.tools_status import get_timing_summary
 
-        monkeypatch.setattr(_state, "_ctx", tool_ctx)
+        monkeypatch.setattr(_state, "_ctx", tool_ctx_kitchen_open)
 
-        tool_ctx.timing_log.record("plan", 10.0, order_id="issue-185")
-        tool_ctx.timing_log.record("implement", 20.0, order_id="issue-186")
+        tool_ctx_kitchen_open.timing_log.record("plan", 10.0, order_id="issue-185")
+        tool_ctx_kitchen_open.timing_log.record("implement", 20.0, order_id="issue-186")
 
         result = json.loads(await get_timing_summary(order_id="issue-185"))
         step_names = [s["step_name"] for s in result["steps"]]

--- a/tests/server/test_tools_workspace.py
+++ b/tests/server/test_tools_workspace.py
@@ -51,7 +51,7 @@ class TestResetWorkspace:
         assert "does not exist" in result["error"]
 
     @pytest.mark.anyio
-    async def test_preserves_configured_dirs(self, tool_ctx, tmp_path):
+    async def test_preserves_configured_dirs(self, tool_ctx_kitchen_open, tmp_path):
         workspace = tmp_path / "workspace"
         workspace.mkdir(parents=True)
         (workspace / ".autoskillit-workspace").write_text("# marker\n")
@@ -64,7 +64,7 @@ class TestResetWorkspace:
         (workspace / "temp_dir").mkdir()
         (workspace / "temp_dir" / "file.txt").touch()
 
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
         result = json.loads(await reset_workspace(test_dir=str(workspace)))
 
@@ -80,12 +80,12 @@ class TestResetWorkspace:
         assert not (workspace / "temp_dir").exists()
 
     @pytest.mark.anyio
-    async def test_reset_command_failure(self, tool_ctx, tmp_path):
+    async def test_reset_command_failure(self, tool_ctx_kitchen_open, tmp_path):
         workspace = tmp_path / "workspace"
         workspace.mkdir(parents=True)
         (workspace / ".autoskillit-workspace").write_text("# marker\n")
 
-        tool_ctx.runner.push(_make_result(1, "", "command not found"))
+        tool_ctx_kitchen_open.runner.push(_make_result(1, "", "command not found"))
 
         result = json.loads(await reset_workspace(test_dir=str(workspace)))
 
@@ -94,16 +94,16 @@ class TestResetWorkspace:
         assert result["exit_code"] == 1
 
     @pytest.mark.anyio
-    async def test_runs_correct_reset_command(self, tool_ctx, tmp_path):
+    async def test_runs_correct_reset_command(self, tool_ctx_kitchen_open, tmp_path):
         workspace = tmp_path / "workspace"
         workspace.mkdir(parents=True)
         (workspace / ".autoskillit-workspace").write_text("# marker\n")
 
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
         await reset_workspace(test_dir=str(workspace))
 
-        call_args = tool_ctx.runner.call_args_list[0][0]
+        call_args = tool_ctx_kitchen_open.runner.call_args_list[0][0]
         assert call_args == [
             "make",
             "clean",
@@ -341,7 +341,7 @@ class TestResetGuard:
     """Marker-file-based reset guard for destructive operations."""
 
     @pytest.mark.anyio
-    async def test_reset_test_dir_refuses_without_marker(self, tool_ctx, tmp_path):
+    async def test_reset_test_dir_refuses_without_marker(self, tool_ctx_kitchen_open, tmp_path):
         """Directory without marker file is refused."""
         target = tmp_path / "workspace"
         target.mkdir()
@@ -351,7 +351,7 @@ class TestResetGuard:
         assert "marker" in result["error"].lower() or "reset guard" in result["error"].lower()
 
     @pytest.mark.anyio
-    async def test_reset_test_dir_allows_with_marker(self, tool_ctx, tmp_path):
+    async def test_reset_test_dir_allows_with_marker(self, tool_ctx_kitchen_open, tmp_path):
         """Directory with marker file is cleared."""
         target = tmp_path / "workspace"
         target.mkdir()
@@ -362,7 +362,7 @@ class TestResetGuard:
         assert not (target / "some_file.txt").exists()
 
     @pytest.mark.anyio
-    async def test_reset_test_dir_preserves_marker(self, tool_ctx, tmp_path):
+    async def test_reset_test_dir_preserves_marker(self, tool_ctx_kitchen_open, tmp_path):
         """Reset preserves the marker file so the workspace is reusable."""
         target = tmp_path / "workspace"
         target.mkdir()
@@ -373,30 +373,36 @@ class TestResetGuard:
         assert (target / ".autoskillit-workspace").is_file()
 
     @pytest.mark.anyio
-    async def test_reset_workspace_refuses_without_marker(self, tool_ctx, tmp_path):
+    async def test_reset_workspace_refuses_without_marker(self, tool_ctx_kitchen_open, tmp_path):
         """reset_workspace also checks for marker."""
-        tool_ctx.config = AutomationConfig(reset_workspace=ResetWorkspaceConfig(command=["true"]))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            reset_workspace=ResetWorkspaceConfig(command=["true"])
+        )
         target = tmp_path / "workspace"
         target.mkdir()
         result = json.loads(await reset_workspace(test_dir=str(target)))
         assert "error" in result
 
     @pytest.mark.anyio
-    async def test_reset_workspace_allows_with_marker(self, tool_ctx, tmp_path):
+    async def test_reset_workspace_allows_with_marker(self, tool_ctx_kitchen_open, tmp_path):
         """reset_workspace clears when marker is present."""
-        tool_ctx.config = AutomationConfig(reset_workspace=ResetWorkspaceConfig(command=["true"]))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            reset_workspace=ResetWorkspaceConfig(command=["true"])
+        )
         target = tmp_path / "workspace"
         target.mkdir()
         (target / ".autoskillit-workspace").write_text("# autoskillit workspace\n")
         (target / "file.txt").touch()
-        tool_ctx.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
         result = json.loads(await reset_workspace(test_dir=str(target)))
         assert result["success"] is True
 
     @pytest.mark.anyio
-    async def test_custom_marker_name(self, tool_ctx, tmp_path):
+    async def test_custom_marker_name(self, tool_ctx_kitchen_open, tmp_path):
         """Config can override marker file name."""
-        tool_ctx.config = AutomationConfig(safety=SafetyConfig(reset_guard_marker=".my-workspace"))
+        tool_ctx_kitchen_open.config = AutomationConfig(
+            safety=SafetyConfig(reset_guard_marker=".my-workspace")
+        )
         target = tmp_path / "workspace"
         target.mkdir()
         (target / ".my-workspace").touch()
@@ -405,7 +411,7 @@ class TestResetGuard:
         assert result["success"] is True
 
     @pytest.mark.anyio
-    async def test_force_overrides_marker_check(self, tool_ctx, tmp_path):
+    async def test_force_overrides_marker_check(self, tool_ctx_kitchen_open, tmp_path):
         """force=True on reset_test_dir bypasses marker requirement."""
         target = tmp_path / "workspace"
         target.mkdir()
@@ -415,7 +421,7 @@ class TestResetGuard:
         assert result["success"] is True
 
     @pytest.mark.anyio
-    async def test_rejects_nonexistent(self, tool_ctx, tmp_path):
+    async def test_rejects_nonexistent(self, tool_ctx_kitchen_open, tmp_path):
         result = json.loads(await reset_test_dir(test_dir=str(tmp_path / "nope")))
         assert "does not exist" in result["error"]
 
@@ -442,7 +448,7 @@ class TestConfigDefaults:
 
 
 @pytest.mark.anyio
-async def test_reset_test_dir_returns_partial_failure_json(tool_ctx, tmp_path):
+async def test_reset_test_dir_returns_partial_failure_json(tool_ctx_kitchen_open, tmp_path):
     """reset_test_dir returns structured JSON on partial failure."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -454,7 +460,7 @@ async def test_reset_test_dir_returns_partial_failure_json(tool_ctx, tmp_path):
         failed=[("bad_dir", "PermissionError: denied")],
         skipped=[],
     )
-    tool_ctx.workspace_mgr = type(
+    tool_ctx_kitchen_open.workspace_mgr = type(
         "MockWM", (), {"delete_contents": lambda self, d, preserve=None: mock_result}
     )()
     result = json.loads(await reset_test_dir(test_dir=str(workspace), force=False))
@@ -465,22 +471,24 @@ async def test_reset_test_dir_returns_partial_failure_json(tool_ctx, tmp_path):
 
 
 @pytest.mark.anyio
-async def test_reset_workspace_returns_partial_failure_json(tool_ctx, tmp_path):
+async def test_reset_workspace_returns_partial_failure_json(tool_ctx_kitchen_open, tmp_path):
     """reset_workspace returns structured JSON on partial failure."""
-    tool_ctx.config = AutomationConfig(reset_workspace=ResetWorkspaceConfig(command=["true"]))
+    tool_ctx_kitchen_open.config = AutomationConfig(
+        reset_workspace=ResetWorkspaceConfig(command=["true"])
+    )
 
     workspace = tmp_path / "workspace"
     workspace.mkdir(parents=True)
     (workspace / ".autoskillit-workspace").write_text("# marker\n")
 
-    tool_ctx.runner.push(_make_result(0, "", ""))
+    tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
 
     mock_result = CleanupResult(
         deleted=["ok_file"],
         failed=[("bad_dir", "PermissionError: denied")],
         skipped=[".cache"],
     )
-    tool_ctx.workspace_mgr = type(
+    tool_ctx_kitchen_open.workspace_mgr = type(
         "MockWM", (), {"delete_contents": lambda self, d, preserve=None: mock_result}
     )()
     result = json.loads(await reset_workspace(test_dir=str(workspace)))
@@ -510,15 +518,15 @@ class TestResetTestDirTiming:
     """reset_test_dir records wall-clock timing when step_name is provided."""
 
     @pytest.mark.anyio
-    async def test_reset_test_dir_step_name_records_timing(self, tool_ctx, tmp_path):
+    async def test_reset_test_dir_step_name_records_timing(self, tool_ctx_kitchen_open, tmp_path):
         marker = tmp_path / ".autoskillit-workspace"
         marker.write_text("")
         mock_result = CleanupResult(deleted=[], failed=[], skipped=[])
-        tool_ctx.workspace_mgr = type(
+        tool_ctx_kitchen_open.workspace_mgr = type(
             "MockWM", (), {"delete_contents": lambda self, d, preserve=None: mock_result}
         )()
         await reset_test_dir(str(tmp_path), step_name="reset")
-        report = tool_ctx.timing_log.get_report()
+        report = tool_ctx_kitchen_open.timing_log.get_report()
         assert any(e["step_name"] == "reset" for e in report)
 
     @pytest.mark.anyio

--- a/tests/server/test_tools_workspace.py
+++ b/tests/server/test_tools_workspace.py
@@ -26,9 +26,9 @@ class TestResetWorkspace:
     """T6, T7: reset_workspace preserves configured dirs, requires marker."""
 
     @pytest.fixture(autouse=True)
-    def _set_reset_command(self, tool_ctx):
+    def _set_reset_command(self, tool_ctx_kitchen_open):
         """Configure reset_workspace with a command for these tests."""
-        tool_ctx.config = AutomationConfig(
+        tool_ctx_kitchen_open.config = AutomationConfig(
             reset_workspace=ResetWorkspaceConfig(
                 command=["make", "clean"],
                 preserve_dirs={".cache", "reports"},

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -6,11 +6,11 @@ from autoskillit.core.types import SubprocessResult, TerminationReason
 
 
 def test_tool_ctx_provides_isolated_gate(tool_ctx):
-    """tool_ctx fixture provides a ToolContext with gate enabled."""
+    """tool_ctx fixture provides a ToolContext with gate closed (matching production)."""
     from autoskillit.pipeline.gate import DefaultGateState
 
     assert isinstance(tool_ctx.gate, DefaultGateState)
-    assert tool_ctx.gate.enabled is True
+    assert tool_ctx.gate.enabled is False
 
 
 def test_tool_ctx_provides_isolated_audit(tool_ctx):
@@ -218,11 +218,11 @@ def test_clear_headless_env_no_server_import():
 
 
 def test_minimal_ctx_provides_isolated_gate(minimal_ctx):
-    """minimal_ctx fixture provides a ToolContext with gate enabled."""
+    """minimal_ctx fixture provides a ToolContext with gate closed (matching production)."""
     from autoskillit.pipeline.gate import DefaultGateState
 
     assert isinstance(minimal_ctx.gate, DefaultGateState)
-    assert minimal_ctx.gate.enabled is True
+    assert minimal_ctx.gate.enabled is False
 
 
 def test_is_test_feature_enabled_reads_project_config(monkeypatch):


### PR DESCRIPTION
## Summary

`_autoskillit_lifespan` dispatches a pre-yield gate-boot only for `SessionType.FLEET`. Food truck sessions (`SessionType.ORCHESTRATOR + AUTOSKILLIT_HEADLESS=1`) receive no auto-gate-boot — their gate stays closed (`gate.enabled=False`) in every fresh subprocess, including resumes. Initial food truck dispatches mask this because the full orchestrator prompt instructs Claude to call `open_kitchen`. Resumed dispatches receive a short "continue from where you left off" prompt; Claude reads history showing the kitchen is open, skips `open_kitchen`, and every `run_skill` call immediately fails with `gate_error`.

The structural weakness is that **the session-type-to-boot-behavior mapping is an ad-hoc `if/elif` conditional with no enforcement that all session types are accounted for**. The fix replaces this conditional with an explicit registry (`_LIFESPAN_BOOT_REGISTRY: dict[SessionType, BootFn | None]`) that structurally requires every `SessionType` value to declare its boot behavior. A companion named constant for `AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS` eliminates the typo/rename vulnerability created by its current use as a repeated hardcoded string across two packages.

## Architecture Impact

This change introduces a boot registry pattern in the lifespan layer and a shared constant for food truck tool tags. The module-dependency lens validates that the new registry does not create circular import dependencies.

## Requirements



## Conflict Resolution Decisions



## Changed Files

### Modified (●):
- `src/autoskillit/core/__init__.pyi`
- `src/autoskillit/core/types/_type_constants.py`
- `src/autoskillit/execution/headless/__init__.py`
- `src/autoskillit/server/_lifespan.py`
- `src/autoskillit/server/_session_type.py`
- `tests/CLAUDE.md`
- `tests/conftest.py`
- `tests/fleet/test_gate_state_persistence.py`
- `tests/infra/test_pretty_output_integration.py`
- `tests/infra/test_schema_version_convention.py`
- `tests/server/conftest.py`
- `tests/server/test_factory.py`
- `tests/server/test_factory_recording.py`
- `tests/server/test_lifespan.py`
- `tests/server/test_release_issue_fail_label.py`
- `tests/server/test_run_skill_add_dirs.py`
- `tests/server/test_run_skill_resume.py`
- `tests/server/test_server_init_session_visibility.py`
- `tests/server/test_server_tool_registration.py`
- `tests/server/test_set_commit_status.py`
- `tests/server/test_smoke_pipeline.py`
- `tests/server/test_tools_bootstrap.py`
- `tests/server/test_tools_ci.py`
- `tests/server/test_tools_ci_enqueue.py`
- `tests/server/test_tools_ci_merge_state.py`
- `tests/server/test_tools_ci_watch.py`
- `tests/server/test_tools_clone.py`
- `tests/server/test_tools_dispatch.py`
- `tests/server/test_tools_dispatch_halt.py`
- `tests/server/test_tools_execution_command.py`
- `tests/server/test_tools_execution_input_gates.py`
- `tests/server/test_tools_execution_provider.py`
- `tests/server/test_tools_execution_results.py`
- `tests/server/test_tools_execution_routing.py`
- `tests/server/test_tools_git.py`
- `tests/server/test_tools_github.py`
- `tests/server/test_tools_integrations.py`
- `tests/server/test_tools_integrations_release.py`
- `tests/server/test_tools_issue_lifecycle.py`
- `tests/server/test_tools_label_validation.py`
- `tests/server/test_tools_list_recipes.py`
- `tests/server/test_tools_load_recipe.py`
- `tests/server/test_tools_pr_ops.py`
- `tests/server/test_tools_recipe.py`
- `tests/server/test_tools_report_bug.py`
- `tests/server/test_tools_run_cmd.py`
- `tests/server/test_tools_run_cmd_unit.py`
- `tests/server/test_tools_run_python.py`
- `tests/server/test_tools_run_skill_retry.py`
- `tests/server/test_tools_session_diagnostics.py`
- `tests/server/test_tools_status_kitchen.py`
- `tests/server/test_tools_status_mcp_response.py`
- `tests/server/test_tools_status_quota_and_db.py`
- `tests/server/test_tools_status_summaries.py`
- `tests/server/test_tools_workspace.py`
- `tests/test_conftest.py`

Closes #2208

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260507-171956-000102/.autoskillit/temp/rectify/rectify_food_truck_resume_gate_boot_2026-05-07_180000_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 2.3k | 30.6k | 1.1M | 108.5k | 163 | 95.7k | 13m 2s |
| rectify | claude-sonnet-4-6 | 1 | 121 | 26.9k | 731.6k | 85.2k | 179 | 72.8k | 13m 52s |
| dry_walkthrough | claude-opus-4-6 | 2 | 1.3k | 30.5k | 3.1M | 87.8k | 237 | 126.9k | 16m 57s |
| implement* | MiniMax-M2.7-highspeed | 2 | 4.0M | 27.7k | 3.1M | 80.5k | 243 | 124.8k | 12m 32s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 178.4k | 4.9k | 327.9k | 29.8k | 25 | 42.3k | 1m 39s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 52.8k | 2.6k | 178.8k | 29.8k | 15 | 42.0k | 55s |
| review_pr | claude-sonnet-4-6 | 3 | 2.5k | 94.3k | 3.2M | 140.5k | 228 | 290.8k | 23m 40s |
| resolve_review | claude-sonnet-4-6 | 2 | 1.2k | 83.1k | 12.1M | 139.3k | 333 | 199.1k | 43m 37s |
| **Total** | | | 4.2M | 300.6k | 23.8M | 140.5k | | 994.4k | 2h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 336 | 9199.5 | 371.5 | 82.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 53 | 227828.3 | 3755.7 | 1568.5 |
| **Total** | **389** | 61277.3 | 2556.3 | 772.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 6 | 2.3k | 196.8k | 10.9M | 647.8k | 1h 11m |
| MiniMax-M2.7-highspeed | 3 | 5.5M | 32.0k | 4.6M | 244.7k | 15m 44s |