### PR TITLE
Perf — Replace dataclasses.asdict() with Manual Dicts on 4 Warm Paths

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -9,7 +9,7 @@ directories — a cross-import would undermine the cascade narrowing.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any, Generic, Literal, TypedDict, TypeVar
@@ -137,8 +137,16 @@ class FailureRecord:
     retry_reason: str  # RetryReason.value string
     stderr: str  # truncated to STDERR_MAX_LEN
 
-    def to_dict(self) -> dict:  # type: ignore[type-arg]
-        return asdict(self)
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "skill_command": self.skill_command,
+            "exit_code": self.exit_code,
+            "subtype": self.subtype,
+            "needs_retry": self.needs_retry,
+            "retry_reason": self.retry_reason,
+            "stderr": self.stderr,
+        }
 
 
 @dataclass(frozen=True)

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import threading
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
@@ -56,7 +56,25 @@ class DispatchRecord:
     sidecar_path: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return {
+            "name": self.name,
+            "status": self.status,
+            "dispatch_id": self.dispatch_id,
+            "campaign_id": self.campaign_id,
+            "caller_session_id": self.caller_session_id,
+            "dispatched_session_id": self.dispatched_session_id,
+            "dispatched_session_log_dir": self.dispatched_session_log_dir,
+            "dispatched_pid": self.dispatched_pid,
+            "dispatched_starttime_ticks": self.dispatched_starttime_ticks,
+            "dispatched_boot_id": self.dispatched_boot_id,
+            "reason": self.reason,
+            "kill_reason": self.kill_reason,
+            "infra_exit_category": self.infra_exit_category,
+            "token_usage": dict(self.token_usage),
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "sidecar_path": self.sidecar_path,
+        }
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> DispatchRecord:

--- a/src/autoskillit/pipeline/timings.py
+++ b/src/autoskillit/pipeline/timings.py
@@ -7,7 +7,7 @@ MCP tool retrieves the accumulated data grouped by step.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +27,11 @@ class TimingEntry:
     invocation_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return {
+            "step_name": self.step_name,
+            "total_seconds": self.total_seconds,
+            "invocation_count": self.invocation_count,
+        }
 
 
 __all__ = ["TimingEntry", "DefaultTimingLog"]

--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -10,7 +10,7 @@ with a defensive copy getter.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
@@ -81,7 +81,20 @@ class TokenEntry:
     turn_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return {
+            "step_name": self.step_name,
+            "model": self.model,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_creation_input_tokens": self.cache_creation_input_tokens,
+            "cache_read_input_tokens": self.cache_read_input_tokens,
+            "invocation_count": self.invocation_count,
+            "elapsed_seconds": self.elapsed_seconds,
+            "loc_insertions": self.loc_insertions,
+            "loc_deletions": self.loc_deletions,
+            "peak_context": self.peak_context,
+            "turn_count": self.turn_count,
+        }
 
 
 __all__ = ["TokenEntry", "DefaultTokenLog", "canonical_step_name"]

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -275,7 +275,7 @@ class TestNormalizeDispatchTokenUsage:
 
 class TestDispatchRecordToDict:
     def test_dispatch_record_to_dict_all_fields(self) -> None:
-        """DispatchRecord.to_dict() must return all 17 keys."""
+        """DispatchRecord.to_dict() must return all expected keys."""
         from autoskillit.fleet import DispatchRecord
 
         record = DispatchRecord(name="test-job")

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -273,6 +273,58 @@ class TestNormalizeDispatchTokenUsage:
         assert "normalize_dispatch_token_usage" in autoskillit.fleet.__all__
 
 
+class TestDispatchRecordToDict:
+    def test_dispatch_record_to_dict_all_fields(self) -> None:
+        """DispatchRecord.to_dict() must return all 17 keys."""
+        from autoskillit.fleet import DispatchRecord
+
+        record = DispatchRecord(name="test-job")
+        d = record.to_dict()
+        assert set(d.keys()) == {
+            "name",
+            "status",
+            "dispatch_id",
+            "campaign_id",
+            "caller_session_id",
+            "dispatched_session_id",
+            "dispatched_session_log_dir",
+            "dispatched_pid",
+            "dispatched_starttime_ticks",
+            "dispatched_boot_id",
+            "reason",
+            "kill_reason",
+            "infra_exit_category",
+            "token_usage",
+            "started_at",
+            "ended_at",
+            "sidecar_path",
+        }
+
+    def test_dispatch_record_to_dict_token_usage_is_shallow_copy(self) -> None:
+        """DispatchRecord.to_dict() token_usage is a shallow copy, not a deep copy."""
+        from autoskillit.fleet import DispatchRecord
+
+        inner = {"nested": "value"}
+        record = DispatchRecord(name="test-job", token_usage={"key": inner})
+        d = record.to_dict()
+        # Outer dict must be a new object (not the same reference)
+        assert d["token_usage"] is not record.token_usage
+        # Inner dict value must be the SAME reference (shallow, not deep copy)
+        assert d["token_usage"]["key"] is inner
+
+    def test_dispatch_record_to_dict_is_json_serializable(self) -> None:
+        """DispatchRecord.to_dict() output must be JSON-serializable."""
+        import json
+
+        from autoskillit.fleet import DispatchRecord
+
+        record = DispatchRecord(name="test-job", token_usage={"x": 1})
+        d = record.to_dict()
+        roundtripped = json.loads(json.dumps(d))
+        assert roundtripped["name"] == "test-job"
+        assert roundtripped["token_usage"] == {"x": 1}
+
+
 class TestDispatchRecordSchemaV3:
     def test_normalize_maps_cache_keys_to_canonical_names(self) -> None:
         result = normalize_dispatch_token_usage(

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -307,9 +307,7 @@ class TestDispatchRecordToDict:
         inner = {"nested": "value"}
         record = DispatchRecord(name="test-job", token_usage={"key": inner})
         d = record.to_dict()
-        # Outer dict must be a new object (not the same reference)
         assert d["token_usage"] is not record.token_usage
-        # Inner dict value must be the SAME reference (shallow, not deep copy)
         assert d["token_usage"]["key"] is inner
 
     def test_dispatch_record_to_dict_is_json_serializable(self) -> None:

--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -53,10 +53,27 @@ class TestFailureRecord:
         assert json.loads(json.dumps(d)) == d
 
     def test_to_dict_contains_all_fields(self):
-        record = _make_record(skill_command="/test:cmd", exit_code=42)
+        record = _make_record(
+            timestamp="2026-01-01T00:00:00",
+            skill_command="/foo",
+            exit_code=1,
+            subtype="timeout",
+            needs_retry=False,
+            retry_reason="",
+            stderr="err",
+        )
         d = record.to_dict()
-        assert d["skill_command"] == "/test:cmd"
-        assert d["exit_code"] == 42
+        assert set(d.keys()) == {
+            "timestamp",
+            "skill_command",
+            "exit_code",
+            "subtype",
+            "needs_retry",
+            "retry_reason",
+            "stderr",
+        }
+        assert d["skill_command"] == "/foo"
+        assert d["exit_code"] == 1
 
 
 class TestDefaultAuditLog:

--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -52,7 +52,7 @@ class TestFailureRecord:
         d = record.to_dict()
         assert json.loads(json.dumps(d)) == d
 
-    def test_to_dict_contains_all_fields(self):
+    def test_to_dict_contains_all_fields(self) -> None:
         record = _make_record(
             timestamp="2026-01-01T00:00:00",
             skill_command="/foo",


### PR DESCRIPTION
## Summary

Replace `return asdict(self)` with explicit field dicts in the `to_dict()` method of four hot-path dataclasses: `DispatchRecord`, `TokenEntry`, `TimingEntry`, and `FailureRecord`. For `DispatchRecord.token_usage` (the single non-primitive field across all four), use `dict(self.token_usage)` for a shallow copy that avoids the deep-copy overhead of `asdict` while preserving safety for current callers. Remove `asdict` from the `dataclasses` import in all four files once it is no longer used. The cold-path `AutomationConfig` serialization at `cli/app.py:302` is explicitly out of scope and must remain unchanged.

## Requirements

## Acceptance Criteria

- [ ] All 4 warm-path `to_dict()` methods use explicit field dicts
- [ ] `DispatchRecord.token_usage` uses shallow copy (`dict(self.token_usage)`)
- [ ] `AutomationConfig` at `cli/app.py:302` keeps `asdict()`
- [ ] All existing tests pass
- [ ] JSON output is identical (verified by round-trip tests)

## Changed Files

### New (★):
tests/fleet/test_state_schema.py
tests/pipeline/test_audit.py

### Modified (●):
src/autoskillit/core/types/_type_results.py
src/autoskillit/fleet/state_types.py
src/autoskillit/pipeline/timings.py
src/autoskillit/pipeline/tokens.py

Closes #2193

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-215724-984456/.autoskillit/temp/make-plan/perf_replace_asdict_plan_2026-05-07_220015.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 107 | 10.0k | 340.2k | 61.7k | 40 | 32.2k | 4m 19s |
| verify | claude-sonnet-4-6 | 1 | 68 | 8.6k | 256.7k | 46.2k | 42 | 33.3k | 4m 32s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 6.5k | 831.6k | 29.8k | 77 | 16.3k | 2m 48s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 73.3k | 3.7k | 205.7k | 29.8k | 20 | 15.3k | 1m 34s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 28.6k | 1.5k | 146.1k | 29.8k | 14 | 15.1k | 45s |
| review_pr | claude-sonnet-4-6 | 3 | 294 | 76.4k | 1.4M | 66.4k | 109 | 154.8k | 15m 14s |
| resolve_review | claude-sonnet-4-6 | 3 | 491 | 25.2k | 2.4M | 58.6k | 148 | 124.0k | 16m 15s |
| **Total** | | | 1.3M | 132.1k | 5.5M | 66.4k | | 391.0k | 45m 31s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 136 | 6114.4 | 119.6 | 48.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 399185.0 | 20664.0 | 4204.8 |
| **Total** | **142** | 38964.3 | 2753.4 | 930.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 175 | 18.7k | 596.9k | 65.5k | 8m 52s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 11.8k | 1.2M | 46.7k | 5m 8s |