### PR TITLE
Perf: Add slots=True to ~57 Frozen Dataclasses

### DIFF
--- a/src/autoskillit/cli/_install_info.py
+++ b/src/autoskillit/cli/_install_info.py
@@ -34,7 +34,7 @@ class InstallTrack(StrEnum):
     LOCAL = "local"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class InstallInfo:
     install_type: InstallType
     commit_id: str | None

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from autoskillit.core import ResumeSpec
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _InfraExitSignal:
     session_id: str
     category: str

--- a/src/autoskillit/cli/update/_update_checks.py
+++ b/src/autoskillit/cli/update/_update_checks.py
@@ -48,7 +48,7 @@ logger = get_logger(__name__)
 _DISMISS_FILE = "update_check.json"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Signal:
     """A single firing update condition."""
 

--- a/src/autoskillit/core/runtime/kitchen_state.py
+++ b/src/autoskillit/core/runtime/kitchen_state.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class KitchenMarker:
     """Immutable record written when open_kitchen is called."""
 

--- a/src/autoskillit/core/runtime/session_provenance.py
+++ b/src/autoskillit/core/runtime/session_provenance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from .._json import fast_dumps as _fast_dumps
@@ -52,7 +52,7 @@ def write_provenance_record(record: ProvenanceRecord, project_dir: Path | None =
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fh:
-            fh.write(_fast_dumps(record.__dict__, sort_keys=True) + "\n")
+            fh.write(_fast_dumps(asdict(record), sort_keys=True) + "\n")
     except OSError:
         pass
 

--- a/src/autoskillit/core/runtime/session_provenance.py
+++ b/src/autoskillit/core/runtime/session_provenance.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from .._json import fast_dumps as _fast_dumps
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ProvenanceRecord:
     """Immutable ownership tuple written when a food truck session is dispatched."""
 

--- a/src/autoskillit/core/types/_type_checkpoint.py
+++ b/src/autoskillit/core/types/_type_checkpoint.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SessionCheckpoint:
     completed_items: list[str] = field(default_factory=list)
     step_name: str = ""

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -385,7 +385,7 @@ if not _non_category_tool_tags <= ALL_VISIBILITY_TAGS:
     )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class FeatureDef:
     """Definition of a named feature gate."""
 

--- a/src/autoskillit/core/types/_type_plugin_source.py
+++ b/src/autoskillit/core/types/_type_plugin_source.py
@@ -11,14 +11,14 @@ from pathlib import Path
 __all__ = ["DirectInstall", "MarketplaceInstall", "PluginSource"]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DirectInstall:
     """Plugin loaded via --plugin-dir. plugin_dir is the package root (pkg_root())."""
 
     plugin_dir: Path
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MarketplaceInstall:
     """Plugin loaded via Claude marketplace.
 

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -69,7 +69,7 @@ class LoadResult(Generic[T]):
     errors: list[LoadReport] = field(default_factory=list)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ValidatedAddDir:
     """An --add-dir path validated for Claude Code convention compliance.
 
@@ -103,7 +103,7 @@ class ValidatedAddDir:
         return list(Path(self.path).glob(pattern))
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class WriteBehaviorSpec:
     """Write-expectation metadata resolved from skill contracts.
 
@@ -141,7 +141,7 @@ class FailureRecord:
         return asdict(self)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ProviderOutcome:
     """Typed bundle of provider execution outcome fields.
 
@@ -158,7 +158,7 @@ class ProviderOutcome:
         return cls(provider_used="", fallback_activated=False)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class InfraOutcome:
     """Infrastructure exit classification bundle."""
 

--- a/src/autoskillit/core/types/_type_results_execution.py
+++ b/src/autoskillit/core/types/_type_results_execution.py
@@ -23,7 +23,7 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SessionTelemetry:
     """Typed bundle of all per-session telemetry fields passed to flush_session_log.
 
@@ -54,7 +54,7 @@ class SessionTelemetry:
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RecipeIdentity:
     """Typed bundle of recipe identification fields for session logging.
 
@@ -73,7 +73,7 @@ class RecipeIdentity:
         return cls(name="", content_hash="", composite_hash="", version="")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CIRunScope:
     """Immutable scope parameters that uniquely identify which CI workflow runs are relevant.
 

--- a/src/autoskillit/core/types/_type_resume.py
+++ b/src/autoskillit/core/types/_type_resume.py
@@ -19,17 +19,17 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class NoResume:
     """No resume: start a fresh session."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class BareResume:
     """Bare --resume: delegate session selection to Claude Code's picker."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class NamedResume:
     """--resume <id>: resume a specific named session."""
 

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -42,14 +42,14 @@ WORKTREE_SKILLS: frozenset[str] = frozenset(
 _GIT_TIMEOUT: float = 10.0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CloneSnapshot:
     """Pre-session state of the clone directory."""
 
     head_sha: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ContaminationReport:
     """Details of detected clone contamination."""
 

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -30,7 +30,7 @@ from autoskillit.core import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ClaudeInteractiveCmd:
     """Resolved argv + env for a claude interactive subprocess.
 
@@ -44,7 +44,7 @@ class ClaudeInteractiveCmd:
     env: Mapping[str, str] = field(default_factory=dict)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ClaudeHeadlessCmd:
     """Resolved argv + env for a claude headless subprocess.
 

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -176,7 +176,7 @@ def _recursive_snapshot(directory: Path) -> set[str]:
     }
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class PostSessionMetrics:
     loc_insertions: int
     loc_deletions: int

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -602,7 +602,7 @@ def start_linux_tracing(
                 handle._snapshots.append(snap)
                 if handle._trace_file is not None:
                     try:
-                        handle._trace_file.write(_fast_dumps(snap.__dict__) + "\n")
+                        handle._trace_file.write(_fast_dumps(dataclasses.asdict(snap)) + "\n")
                     except OSError:
                         # Close broken file; degrade to in-memory only
                         try:

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -23,7 +23,7 @@ import sys
 import tempfile
 import time
 from collections.abc import AsyncIterator
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
@@ -602,7 +602,7 @@ def start_linux_tracing(
                 handle._snapshots.append(snap)
                 if handle._trace_file is not None:
                     try:
-                        handle._trace_file.write(_fast_dumps(dataclasses.asdict(snap)) + "\n")
+                        handle._trace_file.write(_fast_dumps(asdict(snap)) + "\n")
                     except OSError:
                         # Close broken file; degrade to in-memory only
                         try:

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -69,7 +69,7 @@ class TraceTargetResolutionError(RuntimeError):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TraceTarget:
     """Workload process identity with provenance — the correct target for the tracer.
 
@@ -189,7 +189,7 @@ def trace_target_from_pid(pid: int) -> TraceTarget:
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TraceEnrollmentRecord:
     """Identity triple written atomically at trace-open time.
 
@@ -252,7 +252,7 @@ def read_enrollment(path: Path) -> TraceEnrollmentRecord | None:
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ProcSnapshot:
     """Point-in-time snapshot of process state.
 

--- a/src/autoskillit/execution/merge_queue/_merge_queue_classifier.py
+++ b/src/autoskillit/execution/merge_queue/_merge_queue_classifier.py
@@ -65,7 +65,7 @@ if set(_QUERY_FIELD_MAP) != _ALL_FETCH_STATE_KEYS:
     )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ClassificationResult:
     """Positive-signal classification outcome from _classify_pr_state."""
 

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import subprocess
 import time
 from collections.abc import Callable, Mapping
+from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, assert_never
 
@@ -399,7 +400,7 @@ async def run_managed_async(
             snapshots_data: list[dict[str, object]] | None = None
             if tracing_handle is not None:
                 accumulated = tracing_handle.stop()
-                snapshots_data = [s.__dict__ for s in accumulated]
+                snapshots_data = [asdict(s) for s in accumulated]
                 if signals.exit_snapshot is not None:
                     snapshots_data.append(signals.exit_snapshot)
             elif signals.exit_snapshot is not None:

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -21,7 +21,7 @@ from autoskillit.execution.process._process_monitor import (
 logger = get_logger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RaceSignals:
     """Accumulated signals produced by the anyio task group race in run_managed_async.
 

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import assert_never
 
@@ -110,7 +110,7 @@ async def _watch_process(
 
         snap = read_proc_snapshot(proc.pid)
         if snap is not None:
-            acc.exit_snapshot = {**snap.__dict__, "event": "exit_snapshot"}
+            acc.exit_snapshot = {**asdict(snap), "event": "exit_snapshot"}
     except Exception:
         logger.debug("exit_snapshot_failed", pid=proc.pid, exc_info=True)
     acc.process_exited = True

--- a/src/autoskillit/execution/session/_session_state.py
+++ b/src/autoskillit/execution/session/_session_state.py
@@ -23,7 +23,7 @@ _LOCK_FILENAME = "dispatch_session_state.lock"
 _FD_CLOSED = -1
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SessionState:
     session_id: str
     pid: int

--- a/src/autoskillit/fleet/sidecar.py
+++ b/src/autoskillit/fleet/sidecar.py
@@ -10,7 +10,7 @@ from autoskillit.core import ensure_project_temp, get_logger
 logger = get_logger()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class IssueSidecarEntry:
     issue_url: str
     status: Literal["completed", "failed"]

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -118,7 +118,7 @@ class CampaignState:
     captured_values: dict[str, str] = field(default_factory=dict)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ResumeDecision:
     """Result of the resume algorithm."""
 
@@ -181,7 +181,7 @@ _INFRASTRUCTURE_FAILURE_REASONS: frozenset[str] = frozenset(
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class GateRecordResult:
     """Result of a gate dispatch recording attempt."""
 

--- a/src/autoskillit/fleet/summary.py
+++ b/src/autoskillit/fleet/summary.py
@@ -32,7 +32,7 @@ class ParseFailureKind(StrEnum):
     FIELD_ERROR = "field_error"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ParseFailure:
     kind: ParseFailureKind
     message: str
@@ -42,7 +42,7 @@ class ParseFailure:
             raise ValueError("ParseFailure.message must not be empty")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DispatchTokenUsage:
     """Per-dispatch token usage — exactly 4 fields, no extras."""
 
@@ -52,7 +52,7 @@ class DispatchTokenUsage:
     cache_creation: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PerDispatchEntry:
     """One entry per dispatch in execution order."""
 
@@ -64,7 +64,7 @@ class PerDispatchEntry:
     dispatch_id: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SummaryErrorRecord:
     """One entry per failed dispatch."""
 
@@ -74,7 +74,7 @@ class SummaryErrorRecord:
     dispatched_session_id: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CampaignSummary:
     """Campaign summary schema v1 — top-level contract."""
 

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -16,7 +16,7 @@ from typing import Literal, NamedTuple
 from autoskillit.core import DIRECT_INSTALL_CACHE_SUBDIR, pkg_root
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HookDef:
     """A single hook group: event type, matcher pattern, and ordered script list."""
 

--- a/src/autoskillit/hooks/formatters/_fmt_primitives.py
+++ b/src/autoskillit/hooks/formatters/_fmt_primitives.py
@@ -16,12 +16,12 @@ from typing import Any
 _HOOK_CONFIG_PATH_COMPONENTS = (".autoskillit", "temp", ".hook_config.json")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _DictPayload:
     data: dict[str, Any]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _PlainTextPayload:
     text: str
 

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -18,7 +18,7 @@ _FALLBACK_MIN_WPS = 5
 _FALLBACK_MAX_GROUP_SIZE = 5
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _ConsolidationGroup:
     merged_id: str
     source_wp_ids: list[str]

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -56,7 +56,7 @@ class SkillOutput:
     type: str
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class ResultFieldSpec:
     name: str
     type: str
@@ -75,14 +75,14 @@ class SkillContract:
     result_fields: list[ResultFieldSpec] = dataclasses.field(default_factory=list)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class ToolOutputFieldSpec:
     allowed_values: tuple[str, ...]
     terminal_values: frozenset[str]
     recoverable_values: frozenset[str]
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class ToolOutputContractSpec:
     result_field: str
     fields: dict[str, ToolOutputFieldSpec]
@@ -104,7 +104,7 @@ class DataFlowEntry:
     produced: list[str]
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class BlockFingerprint:
     """Structural fingerprint for a named recipe block.
 

--- a/src/autoskillit/recipe/methodology_disambiguation.py
+++ b/src/autoskillit/recipe/methodology_disambiguation.py
@@ -11,13 +11,13 @@ from autoskillit.core import load_yaml, pkg_root
 BUNDLED_METHODOLOGY_TRADITIONS_DIR: Path = pkg_root() / "recipes" / "methodology-traditions"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DisambiguationExceptionDef:
     when_present: str
     add_union_rules: tuple[str, ...]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DisambiguationRuleDef:
     name: str
     order: int
@@ -30,7 +30,7 @@ class DisambiguationRuleDef:
     exceptions: tuple[DisambiguationExceptionDef, ...]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CrossTraditionOverlapDef:
     name: str
     order: int
@@ -41,7 +41,7 @@ class CrossTraditionOverlapDef:
     overrides_primary: bool = False
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DisambiguationResult:
     primary_tradition: str | None
     applied_union_rules: tuple[str, ...]

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 BUNDLED_METHODOLOGY_TRADITIONS_DIR: Path = pkg_root() / "recipes" / "methodology-traditions"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class VenueAppendixDef:
     """A venue-specific appendix entry for an ML sub-area within a tradition."""
 
@@ -23,7 +23,7 @@ class VenueAppendixDef:
     expectations: tuple[dict[str, str], ...]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MethodologyTraditionSpec:
     """Specification for a single methodology tradition."""
 

--- a/src/autoskillit/recipe/methodology_tradition_router.py
+++ b/src/autoskillit/recipe/methodology_tradition_router.py
@@ -14,7 +14,7 @@ from autoskillit.recipe.methodology_tradition_registry import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class UnionRuleDef:
     """Resolves multi-match ambiguity when candidate_set ⊆ member_traditions."""
 
@@ -31,7 +31,7 @@ class UnionRuleDef:
             )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TraditionRouterResult:
     """Result from two-stage methodology classification."""
 

--- a/src/autoskillit/recipe/methodology_venue_appendix.py
+++ b/src/autoskillit/recipe/methodology_venue_appendix.py
@@ -18,14 +18,14 @@ from autoskillit.recipe.methodology_tradition_registry import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class AlternateParentDef:
     parent: str
     trigger_keywords: tuple[str, ...]
     constraint: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MLSubAreaFoldingDef:
     sub_area: str
     display_name: str
@@ -33,7 +33,7 @@ class MLSubAreaFoldingDef:
     alternate_parents: tuple[AlternateParentDef, ...]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class VenueAppendixMatch:
     sub_area: str
     resolved_parent: str

--- a/src/autoskillit/recipe/registry.py
+++ b/src/autoskillit/recipe/registry.py
@@ -37,7 +37,7 @@ class RuleFinding:
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RuleDef:
     """Static definition of a registered semantic rule."""
 
@@ -50,7 +50,7 @@ class RuleDef:
 _RULE_REGISTRY: list[RuleDef] = []
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class BlockContext:
     """Per-block dispatch context for block-level semantic rules.
 
@@ -63,7 +63,7 @@ class BlockContext:
     parent: ValidationContext
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class BlockRuleDef:
     """Static definition of a registered block-level semantic rule."""
 

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -113,7 +113,7 @@ class RecipeStep:
     block: str | None = None  # Named block anchor this step belongs to (e.g. "pre_queue_gate")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RecipeBlock:
     """A named contiguous region of the step routing graph with budget constraints.
 

--- a/src/autoskillit/server/git.py
+++ b/src/autoskillit/server/git.py
@@ -74,7 +74,7 @@ async def _run_git(
     return _process_runner_result(result, timeout)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class GitMergeTarget:
     """Verified merge target — proof that main_repo's branch was checked."""
 

--- a/src/autoskillit/workspace/_clone_remote.py
+++ b/src/autoskillit/workspace/_clone_remote.py
@@ -104,7 +104,7 @@ def _ensure_origin_isolated(clone_path: Path, known_url: str) -> None:
         _add_or_set_upstream(clone_path, known_url)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CloneSourceResolution:
     """Result of probing a source directory for its clone-source remote URL.
 

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -18,6 +18,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_bundled_recipes_split.py` | Enforcement: test_bundled_recipes.py split structure guard |
 | `test_cascade_map_guard.py` | REQ-GUARD-001..003, 005: CI guard validating cascade maps against AST-derived reverse import graph |
 | `test_channel_b_timeout_guard.py` | AST guard: Channel B tests must use timeout >= TimeoutTier.CHANNEL_B |
+| `test_dataclass_slots.py` | Architectural invariant: every @dataclass(frozen=True) must also have slots=True |
 | `test_cli_decomposition.py` | AST-level tests enforcing CLI decomposition and hook security hardening |
 | `test_doctor_readonly.py` | AST guard: run_doctor() must not perform filesystem mutations (REQ-DOCTOR-READONLY) |
 | `test_execution_source_split.py` | Arch guards for execution layer source splits (P8-F1, F3, F4 audit fixes) |

--- a/tests/arch/test_dataclass_slots.py
+++ b/tests/arch/test_dataclass_slots.py
@@ -1,0 +1,56 @@
+# tests/arch/test_dataclass_slots.py
+import ast
+import pathlib
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_SRC = pathlib.Path(__file__).parent.parent.parent / "src" / "autoskillit"
+
+
+def _frozen_without_slots(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Return (lineno, class_name) for frozen=True dataclasses missing slots=True."""
+    tree = ast.parse(path.read_text())
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for dec in node.decorator_list:
+            if not isinstance(dec, ast.Call):
+                continue
+            func = dec.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if name != "dataclass":
+                continue
+            has_frozen = any(
+                isinstance(kw, ast.keyword)
+                and kw.arg == "frozen"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+                for kw in dec.keywords
+            )
+            has_slots = any(
+                isinstance(kw, ast.keyword)
+                and kw.arg == "slots"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+                for kw in dec.keywords
+            )
+            if has_frozen and not has_slots:
+                violations.append((node.lineno, node.name))
+    return violations
+
+
+def test_all_frozen_dataclasses_have_slots() -> None:
+    """Every @dataclass(frozen=True) in src/autoskillit/ must also have slots=True."""
+    all_violations: list[str] = []
+    for py_file in sorted(_SRC.rglob("*.py")):
+        for lineno, cls_name in _frozen_without_slots(py_file):
+            rel = py_file.relative_to(_SRC.parent.parent)
+            all_violations.append(f"  {rel}:{lineno}  {cls_name}")
+
+    assert not all_violations, (
+        f"Found {len(all_violations)} frozen dataclass(es) missing slots=True:\n"
+        + "\n".join(all_violations)
+    )

--- a/tests/arch/test_dataclass_slots.py
+++ b/tests/arch/test_dataclass_slots.py
@@ -1,4 +1,3 @@
-# tests/arch/test_dataclass_slots.py
 import ast
 import pathlib
 

--- a/tests/arch/test_dataclass_slots.py
+++ b/tests/arch/test_dataclass_slots.py
@@ -19,7 +19,16 @@ def _frozen_without_slots(path: pathlib.Path) -> list[tuple[int, str]]:
             if not isinstance(dec, ast.Call):
                 continue
             func = dec.func
-            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if isinstance(func, ast.Name):
+                name = func.id
+            elif (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "dataclasses"
+            ):
+                name = func.attr
+            else:
+                continue
             if name != "dataclass":
                 continue
             has_frozen = any(
@@ -43,6 +52,7 @@ def _frozen_without_slots(path: pathlib.Path) -> list[tuple[int, str]]:
 
 def test_all_frozen_dataclasses_have_slots() -> None:
     """Every @dataclass(frozen=True) in src/autoskillit/ must also have slots=True."""
+    assert _SRC.is_dir(), f"Source directory not found: {_SRC}"
     all_violations: list[str] = []
     for py_file in sorted(_SRC.rglob("*.py")):
         for lineno, cls_name in _frozen_without_slots(py_file):

--- a/tests/execution/test_session_log_integration.py
+++ b/tests/execution/test_session_log_integration.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import time
+from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 
 import anyio
@@ -46,7 +47,7 @@ async def test_full_tracing_pipeline_writes_distinct_timestamps(tmp_path):
     elapsed = time.monotonic() - start_mono
     end_ts = (datetime.fromisoformat(start_ts) + timedelta(seconds=elapsed)).isoformat()
     assert len(snaps) >= 2, "Need at least 2 snapshots for timestamp variance test"
-    snap_dicts = [s.__dict__ for s in snaps]
+    snap_dicts = [asdict(s) for s in snaps]
 
     flush_session_log(
         log_dir=str(tmp_path),


### PR DESCRIPTION
## Summary

Add `slots=True` to all 63 `@dataclass(frozen=True)` definitions (across 33 files in 11
packages) that currently lack it. Python `slots=True` on a frozen dataclass eliminates the
`__dict__` per-instance overhead and replaces it with typed slot descriptors, reducing memory
usage and improving attribute access speed. The project's `requires-python = ">=3.11"` means
`slots=True` on `@dataclass` (introduced in 3.10) is fully supported.

Two frozen dataclasses already have `slots=True` (`result_parser.py`, `_hook_settings.py`) and
serve as the established pattern for this change. Every affected dataclass was verified to be
safe: no inheritance chains between dataclasses, no manually defined `__slots__`, and no
non-dataclass parent that would conflict.

A new architecture compliance test is introduced first to establish the invariant and prevent
future regressions.

Closes #2192

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-215724-550140/.autoskillit/temp/make-plan/perf_add_slots_true_frozen_dataclasses_plan_2026-05-07_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 115 | 10.6k | 396.2k | 45.2k | 82 | 51.2k | 6m 58s |
| verify | claude-sonnet-4-6 | 1 | 204 | 21.8k | 1.2M | 59.7k | 66 | 48.2k | 5m 3s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 15.0k | 1.0M | 35.1k | 166 | 52.5k | 4m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 58.8k | 4.2k | 149.0k | 29.8k | 16 | 42.3k | 1m 26s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 49.7k | 1.5k | 175.9k | 29.8k | 15 | 15.0k | 50s |
| review_pr | claude-sonnet-4-6 | 3 | 841 | 93.1k | 1.7M | 84.7k | 120 | 241.8k | 21m 38s |
| resolve_review | claude-sonnet-4-6 | 2 | 384 | 19.9k | 2.1M | 59.2k | 115 | 85.9k | 14m 6s |
| **Total** | | | 1.3M | 166.0k | 6.7M | 84.7k | | 537.0k | 54m 48s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 183 | 5727.6 | 287.1 | 81.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 17 | 120749.8 | 5054.4 | 1169.3 |
| **Total** | **200** | 33381.3 | 2685.1 | 830.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 679 | 49.6k | 4.3M | 179.1k | 27m 59s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 20.6k | 1.4M | 109.9k | 7m 1s |