### PR TITLE
Adopt per-run subdirectory output pattern for validate-audit

### DIFF
--- a/.claude/skills/validate-audit/SKILL.md
+++ b/.claude/skills/validate-audit/SKILL.md
@@ -436,6 +436,7 @@ headless.
   Tickets:   {ticket_body_1_path}
              {ticket_body_2_path}  (one line per ticket group)
   Contested: {contested_findings_path}  (omit if N_contested == 0)
+  Report:    {validated_report_path}
 validated_report_path = {validated_report_path}
 verdict = validated
 ```

--- a/.claude/skills/validate-audit/SKILL.md
+++ b/.claude/skills/validate-audit/SKILL.md
@@ -40,7 +40,7 @@ signal downstream processing.
 
 **NEVER:**
 - Modify any source code files
-- Create files outside `{{AUTOSKILLIT_TEMP}}/validate-audit/`
+- Create files outside the per-run output directory (`{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/`)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 - Write output files before synthesizing ALL subagent results
 - Subagents must NOT create their own files — they return findings in response text only
@@ -196,10 +196,11 @@ After all agents return:
 
 ### Step 5 — Generate Output Files
 
-Ensure `{{AUTOSKILLIT_TEMP}}/validate-audit/` exists (`mkdir -p`).
+Generate a run timestamp: `{YYYY-MM-DD_HHMMSS}` (current UTC). Create the per-run directory:
+`mkdir -p {{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/`
 
 **File 1 — Validated report**
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/validated_report_{source}.md`
 
 Structure:
 
@@ -229,11 +230,11 @@ Format: original finding text, VALID verdict badge, severity adjustment note if 
 
 ---
 
-*{N_contested} finding(s) contested and excluded — see contested_findings_{source}_{ts}.md*
+*{N_contested} finding(s) contested and excluded — see contested_findings_{source}.md*
 ```
 
 **File 2 — Contested findings** (write only when `N_contested > 0`)
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/contested_findings_{source}.md`
 
 Structure:
 
@@ -255,7 +256,7 @@ Structure:
 Write the full audit trail to a separate file. This file is NOT part of the issue body —
 it is posted as a comment after issue creation.
 
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/validation_summary_{source}.md`
 
 Structure:
 
@@ -309,8 +310,8 @@ tool — they return findings as response text only.
 
 Receives paths to three files:
 1. Original audit report (`{audit_report_path}`)
-2. Validated report (`validated_report_{source}_{ts}.md`)
-3. Validation summary (`validation_summary_{source}_{ts}.md`)
+2. Validated report (`validated_report_{source}.md`)
+3. Validation summary (`validation_summary_{source}.md`)
 
 Instructions:
 > You are cross-validating three audit artifacts for consistency. Read all three files.
@@ -403,11 +404,11 @@ For each ticket group in the grouping manifest:
    - A subset Summary Table (only the rows for included finding IDs)
    - Only the `## Validated Findings` sub-sections for included finding IDs
    - A footer: `*Part of validated {source} audit — see full report for remaining tickets.*`
-3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit/ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md`
+3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/ticket_body_{source}_{N}.md`
    where `{N}` is 1-indexed from the grouping manifest.
 
 Also write the grouping manifest itself to:
-`{{AUTOSKILLIT_TEMP}}/validate-audit/grouping_manifest_{source}_{YYYY-MM-DD_HHMMSS}.md`
+`{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/grouping_manifest_{source}.md`
 
 The grouping manifest file is the structured text returned by the ticket grouper subagent,
 prefixed with:
@@ -430,12 +431,13 @@ headless.
 ```
 [validate-audit] Done.
   Valid: {N_valid} | Exceptions: {N_exception} | Contested: {N_contested}
-  Report:    {validated_report_path}
   Summary:   {validation_summary_path}
   Manifest:  {grouping_manifest_path}
   Tickets:   {ticket_body_1_path}
              {ticket_body_2_path}  (one line per ticket group)
   Contested: {contested_findings_path}  (omit if N_contested == 0)
+validated_report_path = {validated_report_path}
+verdict = validated
 ```
 
 **Interactive mode:** Display the validation status table (verdict counts), then ask:
@@ -457,15 +459,15 @@ rule and the validation summary content, write the combined text to a temp file,
 
 ## Output Location
 
-All output files are written relative to the current working directory under `{{AUTOSKILLIT_TEMP}}/validate-audit/`:
+All output files are written under `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/`:
 
 ```
-{{AUTOSKILLIT_TEMP}}/validate-audit/
-├── validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md      (always written; VALID findings only)
-├── contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md    (when N_contested > 0)
-├── validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md    (always written; audit trail)
-├── grouping_manifest_{source}_{YYYY-MM-DD_HHMMSS}.md     (always written; ticket grouping)
-└── ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md       (one per ticket group, N ≥ 1)
+{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/
+├── validated_report_{source}.md           (always written; VALID findings only)
+├── contested_findings_{source}.md         (when N_contested > 0)
+├── validation_summary_{source}.md         (always written; audit trail)
+├── grouping_manifest_{source}.md          (always written; ticket grouping)
+└── ticket_body_{source}_{N}.md            (one per ticket group, N ≥ 1)
 ```
 
 `{source}` is `arch`, `tests`, `cohesion`, or `feature_gates` based on the input report.

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2078,7 +2078,7 @@ skills:
       - "validated_report_path\\s*=\\s*\\S+"
       - "verdict\\s*=\\s*\\S+"
     pattern_examples:
-      - "validated_report_path = /tmp/autoskillit/validate-audit/validated_report_tests_2026-04-28_120000.md\nverdict = validated"
+      - "validated_report_path = /tmp/autoskillit/validate-audit-2026-04-28_120000/validated_report_tests.md\nverdict = validated"
     write_behavior: conditional
     write_expected_when:
       - "verdict\\s*=\\s*validated"
@@ -2096,7 +2096,7 @@ skills:
       - "validated_report_path\\s*=\\s*\\S+"
       - "verdict\\s*=\\s*\\S+"
     pattern_examples:
-      - "validated_report_path = /tmp/autoskillit/validate-audit/validated_report_tests_2026-05-05_140000.md\nverdict = validated"
+      - "validated_report_path = /tmp/autoskillit/validate-audit-2026-05-05_140000/validated_report_tests.md\nverdict = validated"
     write_behavior: conditional
     write_expected_when:
       - "verdict\\s*=\\s*validated"

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -484,6 +484,7 @@ headless.
   Tickets:   {ticket_body_1_path}
              {ticket_body_2_path}  (one line per ticket group)
   Contested: {contested_findings_path}  (omit if N_contested == 0)
+  Report:    {validated_report_path}
 validated_report_path = {validated_report_path}
 verdict = validated
 ```
@@ -509,7 +510,7 @@ rule and the validation summary content, write the combined text to a temp file,
 
 All output files are written under `$AUDIT_BASE_DIR/` where `AUDIT_BASE_DIR` is determined as follows:
 - If `AUTOSKILLIT_AUDIT_RUN_DIR` is set (by the recipe's `init_audit_run` step): `$AUDIT_BASE_DIR = $AUTOSKILLIT_AUDIT_RUN_DIR`
-- Otherwise: `$AUDIT_BASE_DIR = {{AUTOSKILLIT_TEMP}}/validate-audit-$(date -u +%Y-%m-%d_%H%M%S)` (a newly created per-run directory):
+- Otherwise: `$AUDIT_BASE_DIR = {{AUTOSKILLIT_TEMP}}/validate-audit-$(date -u +%Y-%m-%d_%H%M%S)`:
 
 ```
 $AUDIT_BASE_DIR/

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -50,7 +50,7 @@ validated report carries a `validated: true` marker to signal downstream process
 
 **NEVER:**
 - Modify any source code files
-- Create files outside `$AUTOSKILLIT_AUDIT_RUN_DIR/validate-audit/` (when set) or `{{AUTOSKILLIT_TEMP}}/validate-audit/` (fallback)
+- Create files outside `$AUDIT_BASE_DIR/` (the per-run directory set in Step 5)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 - Write output files before synthesizing ALL subagent results
 - Subagents must NOT create their own files — they return findings in response text only
@@ -239,12 +239,16 @@ recipe's `init_audit_run` step), files are written to the per-run directory to
 prevent cross-run accumulation:
 
 ```bash
-AUDIT_BASE_DIR="${AUTOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}/validate-audit}"
+if [ -n "$AUTOSKILLIT_AUDIT_RUN_DIR" ]; then
+    AUDIT_BASE_DIR="$AUTOSKILLIT_AUDIT_RUN_DIR"
+else
+    AUDIT_BASE_DIR="{{AUTOSKILLIT_TEMP}}/validate-audit-$(date -u +%Y-%m-%d_%H%M%S)"
+fi
 mkdir -p "$AUDIT_BASE_DIR"
 ```
 
 **File 1 — Validated report**
-Path: `$AUDIT_BASE_DIR/validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `$AUDIT_BASE_DIR/validated_report_{source}.md`
 
 Structure:
 
@@ -274,11 +278,11 @@ Format: original finding text, VALID verdict badge, severity adjustment note if 
 
 ---
 
-*{N_contested} finding(s) contested and excluded — see contested_findings_{source}_{ts}.md*
+*{N_contested} finding(s) contested and excluded — see contested_findings_{source}.md*
 ```
 
 **File 2 — Contested findings** (write only when `N_contested > 0`)
-Path: `$AUDIT_BASE_DIR/contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `$AUDIT_BASE_DIR/contested_findings_{source}.md`
 
 Structure:
 
@@ -300,7 +304,7 @@ Structure:
 Write the full audit trail to a separate file. This file is NOT part of the issue body —
 it is posted as a comment after issue creation.
 
-Path: `$AUDIT_BASE_DIR/validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md`
+Path: `$AUDIT_BASE_DIR/validation_summary_{source}.md`
 
 Structure:
 
@@ -448,11 +452,11 @@ For each ticket group in the grouping manifest:
    - A subset Summary Table (only the rows for included finding IDs)
    - Only the `## Validated Findings` sub-sections for included finding IDs
    - A footer: `*Part of validated {source} audit — see full report for remaining tickets.*`
-3. Write to: `$AUDIT_BASE_DIR/ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md`
+3. Write to: `$AUDIT_BASE_DIR/ticket_body_{source}_{N}.md`
    where `{N}` is 1-indexed from the grouping manifest.
 
 Also write the grouping manifest itself to:
-`$AUDIT_BASE_DIR/grouping_manifest_{source}_{YYYY-MM-DD_HHMMSS}.md`
+`$AUDIT_BASE_DIR/grouping_manifest_{source}.md`
 
 The grouping manifest file is the structured text returned by the ticket grouper subagent,
 prefixed with:
@@ -503,16 +507,17 @@ rule and the validation summary content, write the combined text to a temp file,
 
 ## Output Location
 
-All output files are written under `$AUDIT_BASE_DIR/` where
-`AUDIT_BASE_DIR="${AUTOSKILLIT_AUDIT_RUN_DIR:-{{AUTOSKILLIT_TEMP}}/validate-audit}"`:
+All output files are written under `$AUDIT_BASE_DIR/` where `AUDIT_BASE_DIR` is determined as follows:
+- If `AUTOSKILLIT_AUDIT_RUN_DIR` is set (by the recipe's `init_audit_run` step): `$AUDIT_BASE_DIR = $AUTOSKILLIT_AUDIT_RUN_DIR`
+- Otherwise: `$AUDIT_BASE_DIR = {{AUTOSKILLIT_TEMP}}/validate-audit-$(date -u +%Y-%m-%d_%H%M%S)` (a newly created per-run directory):
 
 ```
 $AUDIT_BASE_DIR/
-├── validated_report_{source}_{YYYY-MM-DD_HHMMSS}.md      (always written; VALID findings only)
-├── contested_findings_{source}_{YYYY-MM-DD_HHMMSS}.md    (when N_contested > 0)
-├── validation_summary_{source}_{YYYY-MM-DD_HHMMSS}.md    (always written; audit trail)
-├── grouping_manifest_{source}_{YYYY-MM-DD_HHMMSS}.md     (always written; ticket grouping)
-└── ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md       (one per ticket group, N ≥ 1)
+├── validated_report_{source}.md           (always written; VALID findings only)
+├── contested_findings_{source}.md         (when N_contested > 0)
+├── validation_summary_{source}.md         (always written; audit trail)
+├── grouping_manifest_{source}.md          (always written; ticket grouping)
+└── ticket_body_{source}_{N}.md            (one per ticket group, N ≥ 1)
 ```
 
 `{source}` is `arch`, `tests`, `cohesion`, `feature_gates`, `docs`, or `review_decisions` based on the input report.

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -454,7 +454,7 @@ For each ticket group in the grouping manifest:
    - A subset Summary Table (only the rows for included finding IDs)
    - Only the `## Validated Findings` sub-sections for included finding IDs
    - A footer: `*Part of validated tests audit — see full report for remaining tickets.*`
-3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/ticket_body_tests_{N}.md` (relative to the current working directory)
+3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/ticket_body_tests_{N}.md`
    where `{N}` is 1-indexed from the grouping manifest.
 
 Also write the grouping manifest itself to:

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -43,7 +43,7 @@ signal downstream processing.
 
 **NEVER:**
 - Modify any source code files
-- Create files outside `{{AUTOSKILLIT_TEMP}}/validate-audit/`
+- Create files outside the per-run output directory (`{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/`)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 - Write output files before synthesizing ALL subagent results
 - Subagents must NOT create their own files — they return findings in response text only
@@ -246,10 +246,11 @@ After all agents return:
 
 ### Step 5 — Generate Output Files
 
-Ensure `{{AUTOSKILLIT_TEMP}}/validate-audit/` exists (`mkdir -p`).
+Generate a run timestamp: `{YYYY-MM-DD_HHMMSS}` (current UTC). Create the per-run directory:
+`mkdir -p {{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/`
 
 **File 1 — Validated report**
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/validated_report_tests_{YYYY-MM-DD_HHMMSS}.md`
+Path: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/validated_report_tests.md`
 
 Structure:
 
@@ -279,11 +280,11 @@ Format: original finding text, VALID verdict badge, severity adjustment note if 
 
 ---
 
-*{N_contested} finding(s) contested and excluded — see contested_findings_tests_{ts}.md*
+*{N_contested} finding(s) contested and excluded — see contested_findings_tests.md*
 ```
 
 **File 2 — Contested findings** (write only when `N_contested > 0`)
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/contested_findings_tests_{YYYY-MM-DD_HHMMSS}.md`
+Path: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/contested_findings_tests.md`
 
 Structure:
 
@@ -305,7 +306,7 @@ Structure:
 Write the full audit trail to a separate file. This file is NOT part of the issue body —
 it is posted as a comment after issue creation.
 
-Path: `{{AUTOSKILLIT_TEMP}}/validate-audit/validation_summary_tests_{YYYY-MM-DD_HHMMSS}.md`
+Path: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/validation_summary_tests.md`
 
 Structure:
 
@@ -359,8 +360,8 @@ tool — they return findings as response text only.
 
 Receives paths to three files:
 1. Original audit report (`{audit_report_path}`)
-2. Validated report (`validated_report_tests_{ts}.md`)
-3. Validation summary (`validation_summary_tests_{ts}.md`)
+2. Validated report (`validated_report_tests.md`)
+3. Validation summary (`validation_summary_tests.md`)
 
 Instructions:
 > You are cross-validating three audit artifacts for consistency. Read all three files.
@@ -453,11 +454,11 @@ For each ticket group in the grouping manifest:
    - A subset Summary Table (only the rows for included finding IDs)
    - Only the `## Validated Findings` sub-sections for included finding IDs
    - A footer: `*Part of validated tests audit — see full report for remaining tickets.*`
-3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit/ticket_body_tests_{N}_{YYYY-MM-DD_HHMMSS}.md`
+3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/ticket_body_tests_{N}.md`
    where `{N}` is 1-indexed from the grouping manifest.
 
 Also write the grouping manifest itself to:
-`{{AUTOSKILLIT_TEMP}}/validate-audit/grouping_manifest_tests_{YYYY-MM-DD_HHMMSS}.md`
+`{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/grouping_manifest_tests.md`
 
 The grouping manifest file is the structured text returned by the ticket grouper subagent,
 prefixed with:
@@ -508,15 +509,15 @@ rule and the validation summary content, write the combined text to a temp file,
 
 ## Output Location
 
-All output files are written relative to the current working directory under `{{AUTOSKILLIT_TEMP}}/validate-audit/`:
+All output files are written under `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/`:
 
 ```
-{{AUTOSKILLIT_TEMP}}/validate-audit/
-├── validated_report_tests_{YYYY-MM-DD_HHMMSS}.md      (always written; VALID findings only)
-├── contested_findings_tests_{YYYY-MM-DD_HHMMSS}.md       (when N_contested > 0)
-├── validation_summary_tests_{YYYY-MM-DD_HHMMSS}.md       (always written; audit trail)
-├── grouping_manifest_tests_{YYYY-MM-DD_HHMMSS}.md        (always written; ticket grouping)
-└── ticket_body_tests_{N}_{YYYY-MM-DD_HHMMSS}.md          (one per ticket group, N ≥ 1)
+{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/
+├── validated_report_tests.md      (always written; VALID findings only)
+├── contested_findings_tests.md       (when N_contested > 0)
+├── validation_summary_tests.md       (always written; audit trail)
+├── grouping_manifest_tests.md        (always written; ticket grouping)
+└── ticket_body_tests_{N}.md          (one per ticket group, N ≥ 1)
 ```
 
 ## Related Skills

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -454,7 +454,7 @@ For each ticket group in the grouping manifest:
    - A subset Summary Table (only the rows for included finding IDs)
    - Only the `## Validated Findings` sub-sections for included finding IDs
    - A footer: `*Part of validated tests audit — see full report for remaining tickets.*`
-3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/ticket_body_tests_{N}.md`
+3. Write to: `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/ticket_body_tests_{N}.md` (relative to the current working directory)
    where `{N}` is 1-indexed from the grouping manifest.
 
 Also write the grouping manifest itself to:

--- a/tests/skills/test_project_local_audit_skill_content.py
+++ b/tests/skills/test_project_local_audit_skill_content.py
@@ -249,6 +249,35 @@ def test_validate_audit_uses_autoskillit_temp_placeholder() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Test 11a: Per-run directory pattern in project-local validate-audit
+# ---------------------------------------------------------------------------
+
+
+def test_validate_audit_uses_per_run_subdirectory_pattern() -> None:
+    """Project-local validate-audit must use per-run subdirectory pattern."""
+    path = SKILLS_DIR / "validate-audit" / "SKILL.md"
+    content = path.read_text(encoding="utf-8")
+    assert "validate-audit-{YYYY-MM-DD_HHMMSS}/" in content, (
+        "validate-audit/SKILL.md missing per-run subdirectory pattern "
+        "'validate-audit-{YYYY-MM-DD_HHMMSS}/'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 11b: Timestamp-free filenames in project-local validate-audit
+# ---------------------------------------------------------------------------
+
+
+def test_validate_audit_filenames_have_no_timestamp_suffix() -> None:
+    """Individual filenames must not carry timestamp suffixes (the run dir has the timestamp)."""
+    path = SKILLS_DIR / "validate-audit" / "SKILL.md"
+    content = path.read_text(encoding="utf-8")
+    assert "validated_report_{source}.md" in content, (
+        "validate-audit/SKILL.md should use 'validated_report_{source}.md' (no timestamp suffix)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test 12: C11 heading exists in project-local SKILL.md
 # ---------------------------------------------------------------------------
 

--- a/tests/skills/test_validate_audit_contracts.py
+++ b/tests/skills/test_validate_audit_contracts.py
@@ -70,7 +70,7 @@ class TestValidateAuditContent:
 
     # T-VAL-014
     def test_output_dir(self) -> None:
-        assert "{{AUTOSKILLIT_TEMP}}/validate-audit-" in _skill_text()
+        assert "validate-audit-{YYYY-MM-DD_HHMMSS}/" in _skill_text()
 
     # T-VAL-015
     def test_history_research_agent(self) -> None:

--- a/tests/skills/test_validate_audit_contracts.py
+++ b/tests/skills/test_validate_audit_contracts.py
@@ -70,7 +70,7 @@ class TestValidateAuditContent:
 
     # T-VAL-014
     def test_output_dir(self) -> None:
-        assert "{{AUTOSKILLIT_TEMP}}/validate-audit/" in _skill_text()
+        assert "{{AUTOSKILLIT_TEMP}}/validate-audit-" in _skill_text()
 
     # T-VAL-015
     def test_history_research_agent(self) -> None:
@@ -165,3 +165,12 @@ class TestValidateAuditReviewDecisions:
         assert "Cohesion Audit" in text
         assert "Feature Gate Audit" in text
         assert "Documentation Audit" in text
+
+    # T-VAL-026
+    def test_validate_audit_extended_filenames_have_no_timestamp_suffix(self) -> None:
+        """Extended validate-audit filenames must not carry timestamp suffixes."""
+        text = _skill_text()
+        assert "validated_report_{source}.md" in text, (
+            "Extended validate-audit/SKILL.md should use 'validated_report_{source}.md' "
+            "(no timestamp suffix)"
+        )

--- a/tests/skills/test_validate_audit_contracts.py
+++ b/tests/skills/test_validate_audit_contracts.py
@@ -76,6 +76,15 @@ class TestValidateAuditContent:
     def test_history_research_agent(self) -> None:
         assert "history research agent" in _skill_text().lower()
 
+    # T-VAL-026
+    def test_validate_audit_extended_filenames_have_no_timestamp_suffix(self) -> None:
+        """Extended validate-audit filenames must not carry timestamp suffixes."""
+        text = _skill_text()
+        assert "validated_report_{source}.md" in text, (
+            "Extended validate-audit/SKILL.md should use 'validated_report_{source}.md' "
+            "(no timestamp suffix)"
+        )
+
 
 class TestValidateAuditNewSteps:
     # T-VAL-016
@@ -165,12 +174,3 @@ class TestValidateAuditReviewDecisions:
         assert "Cohesion Audit" in text
         assert "Feature Gate Audit" in text
         assert "Documentation Audit" in text
-
-    # T-VAL-026
-    def test_validate_audit_extended_filenames_have_no_timestamp_suffix(self) -> None:
-        """Extended validate-audit filenames must not carry timestamp suffixes."""
-        text = _skill_text()
-        assert "validated_report_{source}.md" in text, (
-            "Extended validate-audit/SKILL.md should use 'validated_report_{source}.md' "
-            "(no timestamp suffix)"
-        )

--- a/tests/skills/test_validate_audit_contracts.py
+++ b/tests/skills/test_validate_audit_contracts.py
@@ -70,7 +70,7 @@ class TestValidateAuditContent:
 
     # T-VAL-014
     def test_output_dir(self) -> None:
-        assert "validate-audit-{YYYY-MM-DD_HHMMSS}/" in _skill_text()
+        assert "{{AUTOSKILLIT_TEMP}}/validate-audit-" in _skill_text()
 
     # T-VAL-015
     def test_history_research_agent(self) -> None:

--- a/tests/skills/test_validate_test_audit_contracts.py
+++ b/tests/skills/test_validate_test_audit_contracts.py
@@ -63,7 +63,7 @@ class TestValidateTestAuditContent:
 
     # T-VTA-008
     def test_output_dir_matches_validate_audit(self) -> None:
-        assert "{{AUTOSKILLIT_TEMP}}/validate-audit-" in _skill_text()
+        assert "{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/" in _skill_text()
 
     # T-VTA-009
     def test_history_research_agent(self) -> None:

--- a/tests/skills/test_validate_test_audit_contracts.py
+++ b/tests/skills/test_validate_test_audit_contracts.py
@@ -63,7 +63,7 @@ class TestValidateTestAuditContent:
 
     # T-VTA-008
     def test_output_dir_matches_validate_audit(self) -> None:
-        assert "{{AUTOSKILLIT_TEMP}}/validate-audit/" in _skill_text()
+        assert "{{AUTOSKILLIT_TEMP}}/validate-audit-" in _skill_text()
 
     # T-VTA-009
     def test_history_research_agent(self) -> None:
@@ -96,6 +96,14 @@ class TestValidateTestAuditContent:
     # T-VTA-014
     def test_interactive_headless_distinction(self) -> None:
         assert "Interactive vs Headless" in _skill_text()
+
+    # T-VTA-027
+    def test_validate_test_audit_uses_per_run_subdirectory_pattern(self) -> None:
+        """validate-test-audit must use per-run subdirectory pattern."""
+        text = _skill_text()
+        assert "validate-audit-{YYYY-MM-DD_HHMMSS}/" in text, (
+            "validate-test-audit/SKILL.md missing per-run subdirectory pattern"
+        )
 
 
 class TestValidateTestAuditSemanticRules:


### PR DESCRIPTION
## Summary

Change validate-audit (project-local), validate-test-audit, and the extended validate-audit SKILL.md files from writing flat timestamped files into a shared `validate-audit/` directory to creating a per-run timestamped subdirectory (`validate-audit-{YYYY-MM-DD_HHMMSS}/`) with timestamp-free filenames inside. This matches the established pattern used by `validate-team`. Update downstream path references in `skill_contracts.yaml` and all affected tests.

Closes #1960

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260507-225440-809232/.autoskillit/temp/make-plan/validate-audit_adopt_per-run_subdirectory_output_pattern_plan_2026-05-07_225500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 79 | 19.2k | 755.8k | 79.2k | 57 | 85.7k | 7m 20s |
| verify | claude-sonnet-4-6 | 1 | 29 | 15.7k | 447.8k | 54.6k | 77 | 41.5k | 7m 44s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.8M | 20.0k | 2.3M | 29.8k | 178 | 72.2k | 7m 30s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 89.7k | 4.2k | 208.5k | 29.8k | 20 | 42.2k | 1m 32s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 68.6k | 1.8k | 172.3k | 28.7k | 16 | 41.0k | 55s |
| review_pr | claude-sonnet-4-6 | 3 | 334 | 127.7k | 1.9M | 91.5k | 138 | 223.8k | 29m 1s |
| resolve_review | claude-sonnet-4-6 | 3 | 2.3k | 73.3k | 5.5M | 92.8k | 274 | 200.8k | 36m 37s |
| **Total** | | | 3.9M | 261.8k | 11.2M | 92.8k | | 707.2k | 1h 30m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 162 | 13957.0 | 446.0 | 123.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 24 | 229304.4 | 8366.3 | 3053.9 |
| **Total** | **186** | 60407.9 | 3802.2 | 1407.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 295 | 38.6k | 1.9M | 131.6k | 20m 35s |
| claude-opus-4-6 | 1 | 79 | 19.2k | 755.8k | 85.7k | 7m 20s |
| MiniMax-M2.7-highspeed | 3 | 3.9M | 25.9k | 2.6M | 155.4k | 9m 57s |