### PR TITLE
Rectify: Undeclared Pack Requirement Validation Gap

### DIFF
--- a/src/autoskillit/recipe/rules/rules_packs.py
+++ b/src/autoskillit/recipe/rules/rules_packs.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-from autoskillit.core import PACK_REGISTRY, Severity
+from autoskillit.core import PACK_REGISTRY, SKILL_TOOLS, Severity
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._skill_helpers import _get_skill_category_map
+from autoskillit.recipe.contracts import resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 
 @semantic_rule(
     name="unknown-required-pack",
     description="Pack name in requires_packs is not in PACK_REGISTRY",
-    severity=Severity.WARNING,
+    severity=Severity.ERROR,
 )
 def _check_unknown_required_pack(ctx: ValidationContext) -> list[RuleFinding]:
     findings = []
@@ -21,7 +23,7 @@ def _check_unknown_required_pack(ctx: ValidationContext) -> list[RuleFinding]:
             findings.append(
                 RuleFinding(
                     rule="unknown-required-pack",
-                    severity=Severity.WARNING,
+                    severity=Severity.ERROR,
                     step_name="(top-level)",
                     message=(
                         f"Pack {pack_name!r} in requires_packs is not in PACK_REGISTRY. "
@@ -29,4 +31,56 @@ def _check_unknown_required_pack(ctx: ValidationContext) -> list[RuleFinding]:
                     ),
                 )
             )
+    return findings
+
+
+@semantic_rule(
+    name="undeclared-pack-requirement",
+    description=(
+        "Recipes dispatching skills in default-disabled pack categories "
+        "must declare those packs in requires_packs"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_undeclared_pack_requirement(ctx: ValidationContext) -> list[RuleFinding]:
+    """Flag recipes that dispatch skills in default-disabled pack categories without
+    declaring the corresponding requires_packs entry.
+
+    Mirrors the pattern of check_requires_features_declared in rules_features.py.
+    PACK_REGISTRY keys directly equal CATEGORY_TAGS, so no intermediate mapping
+    (like FeatureDef.skill_categories) is needed — a category that appears in
+    PACK_REGISTRY with default_enabled=False is exactly a pack that must be declared.
+    """
+    category_map = (
+        ctx.skill_category_map if ctx.skill_category_map is not None else _get_skill_category_map()
+    )
+    declared_packs = frozenset(ctx.recipe.requires_packs)
+    default_disabled = frozenset(
+        name for name, pdef in PACK_REGISTRY.items() if not pdef.default_enabled
+    )
+
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool not in SKILL_TOOLS:
+            continue
+        skill_cmd = (step.with_args or {}).get("skill_command") or ""
+        skill_name = resolve_skill_name(skill_cmd)
+        if skill_name is None:
+            continue
+        categories = category_map.get(skill_name, frozenset())
+        for cat in sorted(categories & default_disabled):
+            if cat not in declared_packs:
+                findings.append(
+                    RuleFinding(
+                        rule="undeclared-pack-requirement",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"step '{step_name}': skill_command '{skill_cmd}' references "
+                            f"skill '{skill_name}' which belongs to default-disabled pack "
+                            f"'{cat}'. Add '{cat}' to this recipe's requires_packs so "
+                            f"init_session can enable the pack gate."
+                        ),
+                    )
+                )
     return findings

--- a/src/autoskillit/recipe/rules/rules_skills.py
+++ b/src/autoskillit/recipe/rules/rules_skills.py
@@ -79,6 +79,12 @@ def _check_unknown_skill_command(ctx: ValidationContext) -> list[RuleFinding]:
     severity=Severity.WARNING,
 )
 def _check_subset_disabled_skill(ctx: ValidationContext) -> list[RuleFinding]:
+    """Flag steps that reference skills disabled by the user's subsets.disabled config.
+
+    Note: This rule checks USER CONFIG vs RECIPE compatibility.
+    For RECIPE DECLARATION completeness (requires_packs vs skill categories),
+    see 'undeclared-pack-requirement' in rules_packs.py.
+    """
     if not ctx.disabled_subsets:
         return []
     category_map = (

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -5,7 +5,8 @@
     "research-family"
   ],
   "requires_packs": [
-    "research"
+    "research",
+    "vis-lens"
   ],
   "description": "Design-phase sub-recipe extracted from research.yaml. Scopes a research question, plans an experiment, optionally reviews the design (bounded by check_design_review_loop, max 3 iterations), plans visualizations, then terminates with a cross-dispatch handoff sentinel containing the design artifacts. Dispatched as a food truck by campaign recipes that separate design from execution.\n",
   "summary": "scope > plan > [review?] > visualize > design_complete",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -1,7 +1,7 @@
 name: research-design
 recipe_version: "1.0.0"
 categories: [research-family]
-requires_packs: [research]
+requires_packs: [research, vis-lens]
 description: >
   Design-phase sub-recipe extracted from research.yaml. Scopes a research
   question, plans an experiment, optionally reviews the design (bounded by

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -9,7 +9,7 @@ import structlog.testing
 
 from autoskillit.core import SKILL_TOOLS
 from autoskillit.recipe._analysis import build_recipe_graph
-from autoskillit.recipe.contracts import load_bundled_manifest
+from autoskillit.recipe.contracts import load_bundled_manifest, resolve_skill_name
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.rules.rules_merge import _is_commit_guard
 from autoskillit.recipe.validator import run_semantic_rules
@@ -579,7 +579,6 @@ def test_resolve_failures_steps_have_on_context_limit() -> None:
     Without on_context_limit, context exhaustion mid-fix falls through to
     on_failure, discarding all uncommitted edits and losing partial progress.
     """
-    from autoskillit.recipe.contracts import resolve_skill_name
 
     for yaml_path in sorted(builtin_recipes_dir().glob("*.yaml")):
         recipe = load_recipe(yaml_path)
@@ -682,3 +681,30 @@ def test_reenroll_stalled_pr_has_loop_guard(recipe_name: str) -> None:
     assert reenroll.on_success == "check_stall_loop", (
         f"reenroll_stalled_pr must route to check_stall_loop, got: {reenroll.on_success!r}"
     )
+
+
+def test_requires_packs_covers_all_default_disabled_skill_categories() -> None:
+    """Every recipe's requires_packs must cover all default-disabled pack categories
+    needed by its run_skill steps. This is a structural defense-in-depth guard
+    complementary to the undeclared-pack-requirement semantic rule."""
+    category_map = _get_skill_category_map()
+    default_disabled = frozenset(
+        name for name, pdef in PACK_REGISTRY.items() if not pdef.default_enabled
+    )
+    for path in sorted(builtin_recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(path)
+        needed_packs: set[str] = set()
+        for step_name, step in recipe.steps.items():
+            if step.tool not in SKILL_TOOLS:
+                continue
+            skill_cmd = (step.with_args or {}).get("skill_command") or ""
+            skill_name = resolve_skill_name(skill_cmd)
+            if skill_name is None:
+                continue
+            categories = category_map.get(skill_name, frozenset())
+            needed_packs.update(categories & default_disabled)
+        missing = needed_packs - set(recipe.requires_packs)
+        assert not missing, (
+            f"{path.name}: run_skill steps reference default-disabled packs {sorted(missing)} "
+            f"but requires_packs={recipe.requires_packs!r} is missing them"
+        )

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -693,7 +693,10 @@ def test_requires_packs_covers_all_default_disabled_skill_categories() -> None:
         name for name, pdef in PACK_REGISTRY.items() if not pdef.default_enabled
     )
     for path in sorted(builtin_recipes_dir().glob("*.yaml")):
-        recipe = load_recipe(path)
+        try:
+            recipe = load_recipe(path)
+        except Exception as exc:
+            pytest.fail(f"{path.name}: {exc}")
         needed_packs: set[str] = set()
         for step_name, step in recipe.steps.items():
             if step.tool not in SKILL_TOOLS:

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import pytest
 import structlog.testing
 
-from autoskillit.core import SKILL_TOOLS
+from autoskillit.core import PACK_REGISTRY, SKILL_TOOLS
 from autoskillit.recipe._analysis import build_recipe_graph
+from autoskillit.recipe._skill_helpers import _get_skill_category_map
 from autoskillit.recipe.contracts import load_bundled_manifest, resolve_skill_name
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.rules.rules_merge import _is_commit_guard

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -30,7 +30,7 @@ class TestResearchDesignRecipeStructure:
         assert recipe.categories == ["research-family"]
 
     def test_requires_packs(self, recipe) -> None:
-        assert recipe.requires_packs == ["research"]
+        assert recipe.requires_packs == ["research", "vis-lens"]
 
     def test_ingredient_count(self, recipe) -> None:
         assert len(recipe.ingredients) == 5

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -144,6 +144,11 @@ class TestUndeclaredPackRequirement:
 
     def test_skill_needing_only_enabled_packs_passes(self):
         """A recipe that uses only default-enabled pack skills emits no finding."""
+        from autoskillit.core import PACK_REGISTRY
+
+        assert PACK_REGISTRY["github"].default_enabled, (
+            "precondition: github must be default-enabled"
+        )
         recipe = _make_recipe_with_run_skill(
             requires_packs=["github"],
             skill_command="/autoskillit:github-issue",

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -44,7 +44,7 @@ def _make_recipe_with_run_skill(
 
 
 # ----------------------------------------------------------------------
-# unknown-required-pack tests (severity upgraded to ERROR in Step 2c)
+# unknown-required-pack tests
 # ----------------------------------------------------------------------
 
 
@@ -98,7 +98,7 @@ def test_all_builtin_packs_pass():
 
 
 # ----------------------------------------------------------------------
-# undeclared-pack-requirement tests (Step 1a)
+# undeclared-pack-requirement tests
 # ----------------------------------------------------------------------
 
 

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from autoskillit.core import Severity
@@ -124,7 +126,8 @@ class TestUndeclaredPackRequirement:
             requires_packs=["research"],  # missing vis-lens
             skill_command="/autoskillit:plan-visualization",
         )
-        findings = self._run_rule(recipe)
+        mock_map = {"plan-visualization": frozenset({"vis-lens"})}
+        findings = self._run_rule(recipe, skill_category_map=mock_map)
         assert len(findings) == 1
         assert findings[0].severity == Severity.ERROR
         assert "vis-lens" in findings[0].message
@@ -135,7 +138,8 @@ class TestUndeclaredPackRequirement:
             requires_packs=["research", "vis-lens"],
             skill_command="/autoskillit:plan-visualization",
         )
-        findings = self._run_rule(recipe)
+        mock_map = {"plan-visualization": frozenset({"vis-lens"})}
+        findings = self._run_rule(recipe, skill_category_map=mock_map)
         assert not findings
 
     def test_skill_needing_only_enabled_packs_passes(self):
@@ -144,7 +148,8 @@ class TestUndeclaredPackRequirement:
             requires_packs=["github"],
             skill_command="/autoskillit:github-issue",
         )
-        findings = self._run_rule(recipe)
+        mock_map = {"github-issue": frozenset({"github"})}
+        findings = self._run_rule(recipe, skill_category_map=mock_map)
         assert not findings
 
     def test_multiple_missing_packs_emits_multiple_errors(self):
@@ -189,17 +194,12 @@ class TestUndeclaredPackRequirement:
         """research-design.yaml with only [research] triggers vis-lens ERROR."""
         import autoskillit.recipe  # noqa: F401 -- triggers rule registration
 
-        recipe = load_recipe(builtin_recipes_dir() / "research-design.yaml")
-        # Simulate the broken state before the YAML fix
-        original_packs = recipe.requires_packs
-        recipe.requires_packs = ["research"]
-        try:
-            findings = [
-                f for f in run_semantic_rules(recipe) if f.rule == "undeclared-pack-requirement"
-            ]
-            assert len(findings) >= 1, "Expected vis-lens to be flagged as missing"
-            vis_lens_findings = [f for f in findings if "vis-lens" in f.message]
-            assert len(vis_lens_findings) == 1
-            assert vis_lens_findings[0].severity == Severity.ERROR
-        finally:
-            recipe.requires_packs = original_packs
+        base_recipe = load_recipe(builtin_recipes_dir() / "research-design.yaml")
+        recipe = replace(base_recipe, requires_packs=["research"])
+        findings = [
+            f for f in run_semantic_rules(recipe) if f.rule == "undeclared-pack-requirement"
+        ]
+        assert len(findings) >= 1, "Expected vis-lens to be flagged as missing"
+        vis_lens_findings = [f for f in findings if "vis-lens" in f.message]
+        assert len(vis_lens_findings) == 1
+        assert vis_lens_findings[0].severity == Severity.ERROR

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -1,8 +1,11 @@
-"""Tests for the unknown-required-pack semantic rule."""
+"""Tests for the unknown-required-pack and undeclared-pack-requirement semantic rules."""
+
+from __future__ import annotations
 
 import pytest
 
 from autoskillit.core import Severity
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
@@ -19,14 +22,38 @@ def _make_recipe(requires_packs: list[str]) -> Recipe:
     )
 
 
-def test_unknown_pack_produces_warning():
-    """Pack name not in PACK_REGISTRY produces a WARNING finding."""
+def _make_recipe_with_run_skill(
+    requires_packs: list[str],
+    skill_command: str,
+    step_name: str = "run_it",
+) -> Recipe:
+    return Recipe(
+        name="test",
+        description="test recipe",
+        version="0.7.2",
+        requires_packs=requires_packs,
+        steps={
+            step_name: RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": skill_command},
+            )
+        },
+    )
+
+
+# ----------------------------------------------------------------------
+# unknown-required-pack tests (severity upgraded to ERROR in Step 2c)
+# ----------------------------------------------------------------------
+
+
+def test_unknown_pack_produces_error():
+    """Pack name not in PACK_REGISTRY produces an ERROR finding."""
     import autoskillit.recipe  # noqa: F401 -- triggers rule registration
 
     recipe = _make_recipe(["nonexistent-pack"])
     findings = [f for f in run_semantic_rules(recipe) if f.rule == "unknown-required-pack"]
     assert findings
-    assert findings[0].severity == Severity.WARNING
+    assert findings[0].severity == Severity.ERROR
     assert "nonexistent-pack" in findings[0].message
 
 
@@ -66,3 +93,102 @@ def test_all_builtin_packs_pass():
     recipe = _make_recipe(list(PACK_REGISTRY.keys()))
     findings = [f for f in run_semantic_rules(recipe) if f.rule == "unknown-required-pack"]
     assert not findings, f"Built-in packs must not trigger unknown-required-pack: {findings}"
+
+
+# ----------------------------------------------------------------------
+# undeclared-pack-requirement tests (Step 1a)
+# ----------------------------------------------------------------------
+
+
+class TestUndeclaredPackRequirement:
+    """Tests for the undeclared-pack-requirement semantic rule."""
+
+    def _run_rule(self, recipe: Recipe) -> list:
+        import autoskillit.recipe  # noqa: F401 -- triggers rule registration
+
+        return [f for f in run_semantic_rules(recipe) if f.rule == "undeclared-pack-requirement"]
+
+    def test_skill_needing_disabled_pack_without_declaration_is_error(self):
+        """A recipe that uses a vis-lens skill without declaring vis-lens emits ERROR."""
+        recipe = _make_recipe_with_run_skill(
+            requires_packs=["research"],  # missing vis-lens
+            skill_command="/autoskillit:plan-visualization",
+        )
+        findings = self._run_rule(recipe)
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.ERROR
+        assert "vis-lens" in findings[0].message
+
+    def test_skill_needing_disabled_pack_with_declaration_passes(self):
+        """A recipe that uses a vis-lens skill AND declares vis-lens emits no finding."""
+        recipe = _make_recipe_with_run_skill(
+            requires_packs=["research", "vis-lens"],
+            skill_command="/autoskillit:plan-visualization",
+        )
+        findings = self._run_rule(recipe)
+        assert not findings
+
+    def test_skill_needing_only_enabled_packs_passes(self):
+        """A recipe that uses only default-enabled pack skills emits no finding."""
+        recipe = _make_recipe_with_run_skill(
+            requires_packs=["github"],
+            skill_command="/autoskillit:github-issue",
+        )
+        findings = self._run_rule(recipe)
+        assert not findings
+
+    def test_multiple_missing_packs_emits_multiple_errors(self):
+        """A recipe missing both exp-lens and vis-lens emits two findings."""
+        recipe = _make_recipe_with_run_skill(
+            requires_packs=["research"],  # missing both exp-lens and vis-lens
+            skill_command="/autoskillit:experiment-compare",
+        )
+        findings = self._run_rule(recipe)
+        assert len(findings) == 2
+        assert all(f.severity == Severity.ERROR for f in findings)
+        pack_names = {p for f in findings for p in ["exp-lens", "vis-lens"] if p in f.message}
+        assert pack_names == {"exp-lens", "vis-lens"}
+
+    def test_dynamic_skill_name_is_skipped(self):
+        """A skill_command using a template expression emits no finding (graceful skip)."""
+        recipe = Recipe(
+            name="test",
+            description="test recipe",
+            requires_packs=["research"],
+            steps={
+                "run_it": RecipeStep(
+                    tool="run_skill",
+                    with_args={"skill_command": "${{ inputs.target_skill }}"},
+                )
+            },
+        )
+        findings = self._run_rule(recipe)
+        assert not findings
+
+    def test_unknown_skill_name_is_skipped(self):
+        """Non-existent skill reference emits no finding (handled by unknown-skill-command)."""
+        recipe = _make_recipe_with_run_skill(
+            requires_packs=["research"],
+            skill_command="/autoskillit:nonexistent-skill-xyz",
+        )
+        findings = self._run_rule(recipe)
+        assert not findings
+
+    def test_research_design_yaml_triggers_error_without_vis_lens(self):
+        """research-design.yaml with only [research] triggers vis-lens ERROR."""
+        import autoskillit.recipe  # noqa: F401 -- triggers rule registration
+
+        recipe = load_recipe(builtin_recipes_dir() / "research-design.yaml")
+        # Simulate the broken state before the YAML fix
+        original_packs = recipe.requires_packs
+        recipe.requires_packs = ["research"]
+        try:
+            findings = [
+                f for f in run_semantic_rules(recipe) if f.rule == "undeclared-pack-requirement"
+            ]
+            assert len(findings) >= 1, "Expected vis-lens to be flagged as missing"
+            vis_lens_findings = [f for f in findings if "vis-lens" in f.message]
+            assert len(vis_lens_findings) == 1
+            assert vis_lens_findings[0].severity == Severity.ERROR
+        finally:
+            recipe.requires_packs = original_packs

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -103,9 +103,19 @@ def test_all_builtin_packs_pass():
 class TestUndeclaredPackRequirement:
     """Tests for the undeclared-pack-requirement semantic rule."""
 
-    def _run_rule(self, recipe: Recipe) -> list:
+    def _run_rule(
+        self,
+        recipe: Recipe,
+        skill_category_map: dict[str, frozenset[str]] | None = None,
+    ) -> list:
         import autoskillit.recipe  # noqa: F401 -- triggers rule registration
 
+        if skill_category_map is not None:
+            from autoskillit.recipe._analysis import make_validation_context
+
+            ctx = make_validation_context(recipe)
+            ctx.skill_category_map = skill_category_map
+            return [f for f in run_semantic_rules(ctx) if f.rule == "undeclared-pack-requirement"]
         return [f for f in run_semantic_rules(recipe) if f.rule == "undeclared-pack-requirement"]
 
     def test_skill_needing_disabled_pack_without_declaration_is_error(self):
@@ -143,7 +153,8 @@ class TestUndeclaredPackRequirement:
             requires_packs=["research"],  # missing both exp-lens and vis-lens
             skill_command="/autoskillit:experiment-compare",
         )
-        findings = self._run_rule(recipe)
+        mock_map = {"experiment-compare": frozenset({"exp-lens", "vis-lens"})}
+        findings = self._run_rule(recipe, skill_category_map=mock_map)
         assert len(findings) == 2
         assert all(f.severity == Severity.ERROR for f in findings)
         pack_names = {p for f in findings for p in ["exp-lens", "vis-lens"] if p in f.message}


### PR DESCRIPTION
## Summary

The recipe validation pipeline has an asymmetric structural gap: the feature-gate axis has a complete `undeclared-feature-requirement` rule (ERROR severity) that statically cross-references every `run_skill` step's categories against `FEATURE_REGISTRY`, but the pack-gate axis has no equivalent rule. This gap caused three incidents over five weeks. The fix adds an `undeclared-pack-requirement` semantic rule mirroring the feature-gate pattern, makes `unknown-required-pack` ERROR-severity, fixes `research-design.yaml` to declare `vis-lens`, and updates the test that locked in the incorrect `requires_packs` value.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):

- `src/autoskillit/recipe/rules/rules_packs.py`
- `src/autoskillit/recipe/rules/rules_skills.py`
- `src/autoskillit/recipes/research-design.json`
- `src/autoskillit/recipes/research-design.yaml`
- `tests/recipe/test_bundled_recipes_general.py`
- `tests/recipe/test_bundled_recipes_research_design.py`
- `tests/recipe/test_rules_packs.py`

Closes #2220

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260507-235311-480573/.autoskillit/temp/rectify/rectify_undeclared_pack_requirement_2026-05-08_000100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 6.6k | 13.1k | 907.1k | 118.7k | 197 | 67.7k | 8m 41s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 40 | 9.6k | 547.7k | 53.1k | 99 | 40.0k | 4m 56s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.9M | 16.7k | 1.6M | 70.4k | 160 | 129.5k | 7m 54s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 83.5k | 2.9k | 206.4k | 34.0k | 22 | 52.2k | 1m 25s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 44.4k | 1.2k | 198.2k | 28.7k | 14 | 15.0k | 40s |
| review_pr | claude-sonnet-4-6 | 2 | 196 | 65.6k | 1.0M | 78.7k | 75 | 129.9k | 17m 50s |
| resolve_review | claude-opus-4-6 | 3 | 149 | 32.8k | 3.5M | 81.2k | 135 | 174.5k | 23m 16s |
| **Total** | | | 2.1M | 141.9k | 8.0M | 118.7k | | 608.9k | 1h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 234 | 6951.9 | 553.6 | 71.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 82 | 42378.3 | 2128.6 | 400.1 |
| **Total** | **316** | 25293.9 | 1926.9 | 449.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 6.7k | 22.7k | 1.5M | 107.7k | 13m 38s |
| MiniMax-M2.7-highspeed | 3 | 2.1M | 20.8k | 2.0M | 196.7k | 9m 59s |
| claude-opus-4-6 | 1 | 84 | 9.4k | 2.1M | 60.9k | 6m 41s |