### PR TITLE
[FIX] Forward missing campaign ingredients to sub-recipe dispatches

### DIFF
--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -20,6 +20,11 @@ logger = get_logger(__name__)
 
 _KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
+# _run_dispatch() auto-injects these from dispatch-level fields (e.g. task: from the
+# dispatch task: field), so campaigns that rely on this injection pattern should not
+# be flagged for not explicitly forwarding them in the ingredients block.
+_AUTO_INJECTED_CAMPAIGN_INGREDIENTS: frozenset[str] = frozenset({"task"})
+
 
 def _load_dispatch_target(dispatch: CampaignDispatch, project_dir: Path | None) -> Recipe | None:
     """Load the target recipe for a dispatch. Returns None if not loadable."""
@@ -298,6 +303,8 @@ def _check_campaign_dangling_ingredient(ctx: ValidationContext) -> list[RuleFind
         return []
     findings: list[RuleFinding] = []
     for d in ctx.recipe.dispatches:
+        # Gated dispatches are conditional — they may not run at all, so requiring
+        # them to forward every campaign ingredient would produce false positives.
         if d.gate:
             continue
         target = _load_dispatch_target(d, ctx.project_dir)
@@ -305,10 +312,7 @@ def _check_campaign_dangling_ingredient(ctx: ValidationContext) -> list[RuleFind
             continue
         forwarded_keys = set(d.ingredients.keys())
         for ing_name in campaign_ingredients:
-            if ing_name == "task":
-                # _run_dispatch() auto-injects task from the dispatch-level
-                # task: field when the ingredient block omits it. Skip to
-                # avoid false positives on campaigns that rely on this.
+            if ing_name in _AUTO_INJECTED_CAMPAIGN_INGREDIENTS:
                 continue
             if ing_name in target.ingredients and ing_name not in forwarded_keys:
                 findings.append(

--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -284,6 +284,50 @@ def _check_dispatch_ingredients_keys_in_target_schema(ctx: ValidationContext) ->
 
 
 @semantic_rule(
+    name="campaign-dangling-ingredient",
+    description=(
+        "Campaign ingredients should be forwarded to dispatches whose target recipe declares them"
+    ),
+    severity=Severity.WARNING,
+)
+def _check_campaign_dangling_ingredient(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    campaign_ingredients = set(ctx.recipe.ingredients.keys())
+    if not campaign_ingredients:
+        return []
+    findings: list[RuleFinding] = []
+    for d in ctx.recipe.dispatches:
+        if d.gate:
+            continue
+        target = _load_dispatch_target(d, ctx.project_dir)
+        if target is None:
+            continue
+        forwarded_keys = set(d.ingredients.keys())
+        for ing_name in campaign_ingredients:
+            if ing_name == "task":
+                # _run_dispatch() auto-injects task from the dispatch-level
+                # task: field when the ingredient block omits it. Skip to
+                # avoid false positives on campaigns that rely on this.
+                continue
+            if ing_name in target.ingredients and ing_name not in forwarded_keys:
+                findings.append(
+                    RuleFinding(
+                        rule="campaign-dangling-ingredient",
+                        severity=Severity.WARNING,
+                        step_name="(top-level)",
+                        message=(
+                            f"Campaign ingredient {ing_name!r} is declared by target "
+                            f"recipe {d.recipe!r} (dispatch {d.name!r}) but is not "
+                            f"forwarded in the dispatch's ingredients block. The sub-recipe "
+                            f"will use its own default instead of the campaign-level value."
+                        ),
+                    )
+                )
+    return findings
+
+
+@semantic_rule(
     name="dispatch-ingredient-values-are-strings",
     description="All dispatch ingredient values must be strings",
     severity=Severity.ERROR,

--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -58,8 +58,11 @@
       "recipe": "research-design",
       "task": "Run the research design phase: scope the question, plan the experiment, and optionally review the design.",
       "ingredients": {
+        "task": "${{ inputs.task }}",
         "issue_url": "${{ inputs.issue_url }}",
-        "source_dir": "${{ inputs.source_dir }}"
+        "source_dir": "${{ inputs.source_dir }}",
+        "base_branch": "${{ inputs.base_branch }}",
+        "review_design": "${{ inputs.review_design }}"
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}",
@@ -78,7 +81,10 @@
         "research_dir": "${{ campaign.research_dir }}",
         "experiment_plan": "${{ campaign.experiment_plan }}",
         "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
-        "source_dir": "${{ inputs.source_dir }}"
+        "source_dir": "${{ inputs.source_dir }}",
+        "base_branch": "${{ inputs.base_branch }}",
+        "issue_url": "${{ inputs.issue_url }}",
+        "output_mode": "${{ inputs.output_mode }}"
       },
       "capture": {
         "report_path": "${{ result.report_path }}"
@@ -97,7 +103,12 @@
         "experiment_plan": "${{ campaign.experiment_plan }}",
         "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
         "report_path": "${{ campaign.report_path }}",
-        "source_dir": "${{ inputs.source_dir }}"
+        "source_dir": "${{ inputs.source_dir }}",
+        "base_branch": "${{ inputs.base_branch }}",
+        "issue_url": "${{ inputs.issue_url }}",
+        "output_mode": "${{ inputs.output_mode }}",
+        "review_pr": "${{ inputs.review_pr }}",
+        "audit_claims": "${{ inputs.audit_claims }}"
       },
       "capture": {
         "pr_url": "${{ result.pr_url }}",

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -64,8 +64,11 @@ dispatches:
     recipe: research-design
     task: "Run the research design phase: scope the question, plan the experiment, and optionally review the design."
     ingredients:
+      task: "${{ inputs.task }}"
       issue_url: "${{ inputs.issue_url }}"
       source_dir: "${{ inputs.source_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
+      review_design: "${{ inputs.review_design }}"
     capture:
       worktree_path: "${{ result.worktree_path }}"
       research_dir: "${{ result.research_dir }}"
@@ -82,6 +85,9 @@ dispatches:
       experiment_plan: "${{ campaign.experiment_plan }}"
       visualization_plan_path: "${{ campaign.visualization_plan_path }}"
       source_dir: "${{ inputs.source_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
+      issue_url: "${{ inputs.issue_url }}"
+      output_mode: "${{ inputs.output_mode }}"
     capture:
       report_path: "${{ result.report_path }}"
     depends_on:
@@ -97,6 +103,11 @@ dispatches:
       visualization_plan_path: "${{ campaign.visualization_plan_path }}"
       report_path: "${{ campaign.report_path }}"
       source_dir: "${{ inputs.source_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
+      issue_url: "${{ inputs.issue_url }}"
+      output_mode: "${{ inputs.output_mode }}"
+      review_pr: "${{ inputs.review_pr }}"
+      audit_claims: "${{ inputs.audit_claims }}"
     capture:
       pr_url: "${{ result.pr_url }}"
       all_diagram_paths: "${{ result.all_diagram_paths }}"

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -430,12 +430,18 @@ def test_research_campaign_run_implement_ingredients():
         "experiment_plan",
         "visualization_plan_path",
         "source_dir",
+        "base_branch",
+        "issue_url",
+        "output_mode",
     }
     assert d.ingredients["worktree_path"] == "${{ campaign.worktree_path }}"
     assert d.ingredients["research_dir"] == "${{ campaign.research_dir }}"
     assert d.ingredients["experiment_plan"] == "${{ campaign.experiment_plan }}"
     assert d.ingredients["visualization_plan_path"] == "${{ campaign.visualization_plan_path }}"
     assert d.ingredients["source_dir"] == "${{ inputs.source_dir }}"
+    assert d.ingredients["base_branch"] == "${{ inputs.base_branch }}"
+    assert d.ingredients["issue_url"] == "${{ inputs.issue_url }}"
+    assert d.ingredients["output_mode"] == "${{ inputs.output_mode }}"
 
 
 def test_research_campaign_run_implement_capture():
@@ -459,8 +465,18 @@ def test_research_campaign_run_review_ingredients():
         "visualization_plan_path",
         "report_path",
         "source_dir",
+        "base_branch",
+        "issue_url",
+        "output_mode",
+        "review_pr",
+        "audit_claims",
     }
     assert d.ingredients["source_dir"] == "${{ inputs.source_dir }}"
+    assert d.ingredients["base_branch"] == "${{ inputs.base_branch }}"
+    assert d.ingredients["issue_url"] == "${{ inputs.issue_url }}"
+    assert d.ingredients["output_mode"] == "${{ inputs.output_mode }}"
+    assert d.ingredients["review_pr"] == "${{ inputs.review_pr }}"
+    assert d.ingredients["audit_claims"] == "${{ inputs.audit_claims }}"
     for key in [
         "worktree_path",
         "research_dir",

--- a/tests/recipe/test_research_campaign_rules.py
+++ b/tests/recipe/test_research_campaign_rules.py
@@ -25,6 +25,7 @@ def validation_ctx():
         available_recipes=frozenset(
             {"research-design", "research-implement", "research-review", "research-archive"}
         ),
+        project_dir=RECIPE_PATH.parent.parent.parent,
     )
 
 
@@ -71,4 +72,10 @@ def test_dispatch_capture_fields_in_sentinel_contract_passes(validation_ctx) -> 
         pytest.skip(f"Rule {rule_name!r} not yet registered")
     findings = run_semantic_rules(validation_ctx)
     matched = [f for f in findings if f.rule == rule_name]
+    assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)
+
+
+def test_campaign_dangling_ingredient_passes(validation_ctx) -> None:
+    findings = run_semantic_rules(validation_ctx)
+    matched = [f for f in findings if f.rule == "campaign-dangling-ingredient"]
     assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -743,3 +743,226 @@ def test_dispatch_ingredients_keys_exempts_gate_dispatches():
     )
     found = _findings(recipe, "dispatch-ingredients-keys-in-target-schema")
     assert found == []
+
+
+# ---------------------------------------------------------------------------
+# T-D1: campaign-dangling-ingredient
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_dangling_ingredient_fires_on_missing_forwarding(tmp_path: Path):
+    """Rule fires when campaign ingredient is declared by target but dispatch omits it."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "review_pr": {"description": "Review PR", "default": "false"},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        ingredients={"review_pr": {"description": "Review PR", "default": "false"}},
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={},
+            ),
+        ],
+    )
+    found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
+    assert len(found) == 1
+    assert found[0].severity == Severity.WARNING
+    assert "review_pr" in found[0].message
+
+
+def test_campaign_dangling_ingredient_passes_when_forwarded(tmp_path: Path):
+    """Rule passes when ingredient is forwarded."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "review_pr": {"description": "Review PR", "default": "false"},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        ingredients={"review_pr": {"description": "Review PR", "default": "false"}},
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={"review_pr": "${{ inputs.review_pr }}"},
+            ),
+        ],
+    )
+    found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
+    assert found == []
+
+
+def test_campaign_dangling_ingredient_passes_when_target_does_not_declares(tmp_path: Path):
+    """Rule passes when target sub-recipe does not declare the ingredient."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "other_ing": {"description": "Other", "default": "x"},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        ingredients={"output_mode": {"description": "Output mode", "default": "local"}},
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={},
+            ),
+        ],
+    )
+    found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
+    assert found == []
+
+
+def test_campaign_dangling_ingredient_skips_unloadable_target(tmp_path: Path):
+    """Rule skips when target recipe is not loadable."""
+    recipe = _campaign(
+        ingredients={"review_pr": {"description": "Review PR", "default": "false"}},
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="nonexistent-recipe",
+                task="do it",
+                ingredients={},
+            ),
+        ],
+    )
+    found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
+    assert found == []
+
+
+def test_campaign_dangling_ingredient_fires_per_dispatch(tmp_path: Path):
+    """Rule fires per-dispatch for multi-dispatch campaigns."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-forwarding.yaml",
+        {
+            "name": "target-forwarding",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "output_mode": {"description": "Output mode", "default": "local"},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    _write_recipe_yaml(
+        recipes_dir / "target-omitting.yaml",
+        {
+            "name": "target-omitting",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "output_mode": {"description": "Output mode", "default": "local"},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        ingredients={"output_mode": {"description": "Output mode", "default": "local"}},
+        dispatches=[
+            CampaignDispatch(
+                name="phase-forward",
+                recipe="target-forwarding",
+                task="do it",
+                ingredients={"output_mode": "${{ inputs.output_mode }}"},
+            ),
+            CampaignDispatch(
+                name="phase-omit",
+                recipe="target-omitting",
+                task="do it",
+                ingredients={},
+            ),
+        ],
+    )
+    found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
+    assert len(found) == 1
+    assert "phase-omit" in found[0].message
+
+
+def test_campaign_dangling_ingredient_ignores_gate_dispatches(tmp_path: Path):
+    """Rule ignores gate dispatches."""
+    recipe = _campaign(
+        ingredients={"review_pr": {"description": "Review PR", "default": "false"}},
+        dispatches=[
+            CampaignDispatch(name="gate-check", gate="confirm", message="Proceed?"),
+        ],
+    )
+    found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
+    assert found == []
+
+
+def test_campaign_dangling_ingredient_ignores_non_campaign_recipes(tmp_path: Path):
+    """Rule ignores non-campaign recipes."""
+    recipe = _standard_recipe()
+    found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
+    assert found == []
+
+
+def test_campaign_dangling_ingredient_exempts_task(tmp_path: Path):
+    """Rule accounts for task auto-injection and should not fire for it."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "task": {"description": "The task", "required": True},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        ingredients={"task": {"description": "The task", "required": True}},
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="Do the thing",  # task field set, but not forwarded in ingredients
+                ingredients={},
+            ),
+        ],
+    )
+    found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
+    assert found == []

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -816,7 +816,7 @@ def test_campaign_dangling_ingredient_passes_when_forwarded(tmp_path: Path):
     assert found == []
 
 
-def test_campaign_dangling_ingredient_passes_when_target_does_not_declares(tmp_path: Path):
+def test_campaign_dangling_ingredient_passes_when_target_does_not_declare(tmp_path: Path):
     """Rule passes when target sub-recipe does not declare the ingredient."""
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -915,6 +915,7 @@ def test_campaign_dangling_ingredient_fires_per_dispatch(tmp_path: Path):
     found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
     assert len(found) == 1
     assert "phase-omit" in found[0].message
+    assert "phase-forward" not in found[0].message
 
 
 def test_campaign_dangling_ingredient_ignores_gate_dispatches(tmp_path: Path):


### PR DESCRIPTION
## Summary

The `research-campaign.yaml` declares 8 campaign-level ingredients but only forwards a subset to each dispatch's `ingredients:` block. Several ingredients (`task`, `review_design`, `output_mode`, `review_pr`, `audit_claims`) that sub-recipes declare are never forwarded — they silently fall back to sub-recipe defaults (or to the `_run_dispatch` auto-injection in the case of `task`), ignoring the user's campaign-level values.

This plan fixes the YAML forwarding gaps and adds a new static validation rule (`campaign-dangling-ingredient`) that catches this class of bug at authoring time.

## Requirements

(Embedded in the issue body — issue #2215 describes the problem and solution in detail)

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260508-010013-712390/.autoskillit/temp/make-plan/research_campaign_ingredient_forwarding_plan_2026-05-08_010600.md`

## Changed Files

### Modified (●):
● src/autoskillit/recipe/rules/rules_campaign.py
● src/autoskillit/recipes/campaigns/research-campaign.json
● src/autoskillit/recipes/campaigns/research-campaign.yaml
● tests/recipe/test_campaign_loader.py
● tests/recipe/test_research_campaign_rules.py
● tests/recipe/test_rules_campaign.py

Closes #2215

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 78 | 13.1k | 649.7k | 68.6k | 78 | 59.9k | 6m 11s |
| verify | claude-opus-4-6 | 1 | 897 | 6.2k | 625.9k | 70.5k | 81 | 57.3k | 4m 27s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 10.7k | 974.1k | 28.7k | 83 | 51.5k | 7m 50s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 133.1k | 3.0k | 341.7k | 28.7k | 24 | 15.2k | 1m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.0k | 1.4k | 169.5k | 28.7k | 14 | 15.1k | 44s |
| review_pr | claude-sonnet-4-6 | 3 | 362 | 86.0k | 1.9M | 72.4k | 134 | 175.7k | 16m 59s |
| resolve_review | claude-sonnet-4-6 | 1 | 205 | 14.5k | 1.5M | 77.4k | 65 | 64.9k | 4m 54s |
| **Total** | | | 1.2M | 134.8k | 6.1M | 77.4k | | 439.6k | 42m 28s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 297 | 3279.6 | 173.5 | 35.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 15 | 96802.9 | 4324.7 | 966.4 |
| **Total** | **312** | 19663.6 | 1409.1 | 432.2 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 975 | 19.3k | 1.3M | 117.2k | 10m 38s |
| MiniMax-M2.7-highspeed | 3 | 1.2M | 15.0k | 1.5M | 81.9k | 9m 55s |
| claude-sonnet-4-6 | 1 | 174 | 8.1k | 929.2k | 48.3k | 3m 47s |