### PR TITLE
Fleet Campaign Session Missing initial_message Greeting Trigger

### DIFF
--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -26,6 +26,7 @@ from autoskillit.cli.fleet._fleet_lifecycle import (
     _reap_stale_dispatches,
 )
 from autoskillit.cli.fleet._fleet_preview import (
+    _FLEET_CAMPAIGN_GREETINGS,
     _FLEET_DISPATCH_GREETINGS,
     _print_dispatch_preview,
 )
@@ -224,6 +225,10 @@ def fleet_campaign(
     if not proceed:
         return
 
+    import random
+
+    greeting = random.choice(_FLEET_CAMPAIGN_GREETINGS).format(campaign_name=campaign_name)
+
     _launch_fleet_session(
         parsed,
         campaign_id,
@@ -231,6 +236,7 @@ def fleet_campaign(
         resume_metadata,
         fleet_mode="campaign",
         ingredients_table=_itable,
+        initial_message=greeting,
     )
 
 

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import shutil
 import sys
 from datetime import UTC, datetime
@@ -95,10 +96,7 @@ def fleet_dispatch() -> None:
     if confirm.lower() in ("n", "no"):
         return
 
-    import random
-
     greeting = random.choice(_FLEET_DISPATCH_GREETINGS).format(recipe_table=recipe_table)
-
     _launch_fleet_session(
         None,
         None,
@@ -225,10 +223,7 @@ def fleet_campaign(
     if not proceed:
         return
 
-    import random
-
     greeting = random.choice(_FLEET_CAMPAIGN_GREETINGS).format(campaign_name=campaign_name)
-
     _launch_fleet_session(
         parsed,
         campaign_id,

--- a/src/autoskillit/cli/fleet/_fleet_preview.py
+++ b/src/autoskillit/cli/fleet/_fleet_preview.py
@@ -34,6 +34,12 @@ _FLEET_DISPATCH_GREETINGS: list[str] = [
     ),
 ]
 
+_FLEET_CAMPAIGN_GREETINGS: list[str] = [
+    "Campaign ready: {campaign_name}. Let me display the ingredients and get started.",
+    "Launching campaign: {campaign_name}. Reviewing ingredients now.",
+    "Campaign {campaign_name} loaded. Checking ingredients before dispatch.",
+]
+
 
 def _print_dispatch_preview() -> str:
     """Print the pre-launch summary for fleet dispatch (mirrors cook's pre-launch display).

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -141,10 +141,12 @@ def _launch_fleet_session(
         seen_reload_ids = set[str]()
         current_resume_spec = NoResume()
         infra_resume_count = 0
+        current_initial_message = initial_message
 
         while True:
             session_signal = _run_interactive_session(
                 prompt,
+                initial_message=current_initial_message,
                 extra_env=extra_env,
                 resume_spec=current_resume_spec,
                 project_dir=project_dir,
@@ -162,6 +164,8 @@ def _launch_fleet_session(
             else:
                 _check_reload_guard(session_signal, seen_reload_ids)
                 current_resume_spec = NamedResume(session_id=session_signal)
+
+            current_initial_message = None
 
             fresh_metadata = resume_campaign_from_state(
                 state_path, campaign_recipe.continue_on_failure

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -6,7 +6,7 @@ import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from autoskillit.core import NamedResume, NoResume, get_logger
+from autoskillit.core import NamedResume, NoResume, dump_yaml_str, get_logger
 
 logger = get_logger(__name__)
 
@@ -92,7 +92,6 @@ def _launch_fleet_session(
         if state_path is None:
             raise ValueError("state_path must not be None in campaign-driven mode")
         from autoskillit.cli._prompts import _build_fleet_campaign_prompt
-        from autoskillit.core import dump_yaml_str
         from autoskillit.fleet import FLEET_HALTED_SENTINEL, resume_campaign_from_state
 
         manifest_yaml = dump_yaml_str(

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -264,3 +264,25 @@ class TestFleetCampaignResumeHaltedExits:
         with pytest.raises(SystemExit):
             _fleet_campaign("test-campaign", resume_campaign=campaign_id)
         assert not launch_called
+
+
+def test_fleet_campaign_passes_initial_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """fleet_campaign() passes a non-None initial_message containing the campaign name."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+    captured_kwargs: dict = {}
+
+    def mock_launch_session(*a: object, **kw: object) -> None:
+        captured_kwargs.update(kw)
+
+    monkeypatch.setattr("autoskillit.cli.fleet._launch_fleet_session", mock_launch_session)
+    monkeypatch.setattr(
+        "autoskillit.cli._preview._pre_launch_campaign",
+        lambda *a, **kw: ("", True),
+    )
+    _fleet_campaign("test-campaign")
+    assert captured_kwargs.get("initial_message") is not None
+    assert "test-campaign" in captured_kwargs["initial_message"]

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -286,3 +286,118 @@ def test_fleet_campaign_passes_initial_message(
     _fleet_campaign("test-campaign")
     assert captured_kwargs.get("initial_message") is not None
     assert "test-campaign" in captured_kwargs["initial_message"]
+
+
+def test_fleet_campaign_greetings_have_campaign_name_placeholder() -> None:
+    """All _FLEET_CAMPAIGN_GREETINGS entries must contain {campaign_name}."""
+    from autoskillit.cli.fleet._fleet_preview import _FLEET_CAMPAIGN_GREETINGS
+
+    assert len(_FLEET_CAMPAIGN_GREETINGS) >= 3
+    for greeting in _FLEET_CAMPAIGN_GREETINGS:
+        assert "{campaign_name}" in greeting
+
+
+def test_launch_fleet_session_forwards_initial_message_campaign(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_launch_fleet_session in campaign mode forwards initial_message on first launch only."""
+    monkeypatch.chdir(tmp_path)
+    captured_calls: list[dict] = []
+
+    def mock_run(system_prompt: str, **kwargs: object) -> None:
+        captured_calls.append(dict(kwargs))
+        return None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        mock_run,
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+        lambda *a, **kw: "campaign-prompt",
+    )
+    monkeypatch.setattr("autoskillit.cli.fleet._fleet_session.dump_yaml_str", lambda *a, **kw: "")
+    from autoskillit.fleet import ResumeDecision
+
+    monkeypatch.setattr(
+        "autoskillit.fleet.resume_campaign_from_state",
+        lambda *a, **kw: ResumeDecision(
+            completed_dispatches_block="",
+            next_dispatch_name="",
+            is_resumable=False,
+            dispatched_session_id="",
+            kill_reason="",
+        ),
+    )
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+    recipe = MagicMock()
+    recipe.dispatches = []
+    recipe.continue_on_failure = False
+
+    _launch_fleet_session(
+        recipe,
+        "test-campaign-id",
+        tmp_path / "state.json",
+        None,
+        fleet_mode="campaign",
+        initial_message="Hello, campaign!",
+    )
+    assert len(captured_calls) == 1
+    assert captured_calls[0].get("initial_message") == "Hello, campaign!"
+
+
+def test_launch_fleet_session_clears_initial_message_on_reload_campaign(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """On reload in campaign mode, initial_message must be None (only injected on first launch)."""
+    monkeypatch.chdir(tmp_path)
+    call_count = 0
+    captured_messages: list = []
+
+    def mock_run(system_prompt: str, **kwargs: object) -> object:
+        nonlocal call_count
+        captured_messages.append(kwargs.get("initial_message"))
+        call_count += 1
+        return "reload-session-abc" if call_count == 1 else None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        mock_run,
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+        lambda *a, **kw: "campaign-prompt",
+    )
+    monkeypatch.setattr("autoskillit.cli.fleet._fleet_session.dump_yaml_str", lambda *a, **kw: "")
+    from autoskillit.fleet import ResumeDecision
+
+    monkeypatch.setattr(
+        "autoskillit.fleet.resume_campaign_from_state",
+        lambda *a, **kw: ResumeDecision(
+            completed_dispatches_block="",
+            next_dispatch_name="",
+            is_resumable=False,
+            dispatched_session_id="",
+            kill_reason="",
+        ),
+    )
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+    recipe = MagicMock()
+    recipe.dispatches = []
+    recipe.continue_on_failure = False
+
+    _launch_fleet_session(
+        recipe,
+        "test-campaign-id",
+        tmp_path / "state.json",
+        None,
+        fleet_mode="campaign",
+        initial_message="Hello!",
+    )
+    assert len(captured_messages) >= 2, (
+        f"expected reload to fire but got only {len(captured_messages)} call(s)"
+    )
+    assert captured_messages[0] == "Hello!"
+    assert captured_messages[1] is None

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -571,120 +570,6 @@ def test_launch_fleet_session_clears_initial_message_on_reload(
         None,
         None,
         fleet_mode="dispatch",
-        initial_message="Hello!",
-    )
-    assert len(captured_messages) >= 2, (
-        f"expected reload to fire but got only {len(captured_messages)} call(s)"
-    )
-    assert captured_messages[0] == "Hello!"
-    assert captured_messages[1] is None
-
-
-def test_fleet_campaign_greetings_have_campaign_name_placeholder() -> None:
-    """All _FLEET_CAMPAIGN_GREETINGS entries must contain {campaign_name}."""
-    from autoskillit.cli.fleet._fleet_preview import _FLEET_CAMPAIGN_GREETINGS
-
-    assert len(_FLEET_CAMPAIGN_GREETINGS) >= 3
-    for greeting in _FLEET_CAMPAIGN_GREETINGS:
-        assert "{campaign_name}" in greeting
-
-
-def test_launch_fleet_session_forwards_initial_message_campaign(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """_launch_fleet_session in campaign mode forwards initial_message."""
-    monkeypatch.chdir(tmp_path)
-    captured_kwargs: dict = {}
-
-    def mock_run(system_prompt: str, **kwargs: object) -> None:
-        captured_kwargs.update(kwargs)
-        return None
-
-    monkeypatch.setattr(
-        "autoskillit.cli.session._session_launch._run_interactive_session",
-        mock_run,
-    )
-    monkeypatch.setattr(
-        "autoskillit.cli._prompts._build_fleet_campaign_prompt",
-        lambda *a, **kw: "campaign-prompt",
-    )
-    monkeypatch.setattr("autoskillit.cli.fleet._fleet_session.dump_yaml_str", lambda *a, **kw: "")
-    from autoskillit.fleet import ResumeDecision
-
-    monkeypatch.setattr(
-        "autoskillit.fleet.resume_campaign_from_state",
-        lambda *a, **kw: ResumeDecision(
-            completed_dispatches_block="",
-            next_dispatch_name="",
-            is_resumable=False,
-            dispatched_session_id="",
-            kill_reason="",
-        ),
-    )
-    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
-
-    recipe = MagicMock()
-    recipe.dispatches = []
-    recipe.continue_on_failure = False
-
-    _launch_fleet_session(
-        recipe,
-        "test-campaign-id",
-        tmp_path / "state.json",
-        None,
-        fleet_mode="campaign",
-        initial_message="Hello, campaign!",
-    )
-    assert captured_kwargs.get("initial_message") == "Hello, campaign!"
-
-
-def test_launch_fleet_session_clears_initial_message_on_reload_campaign(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """On reload in campaign mode, initial_message must be None (only injected on first launch)."""
-    monkeypatch.chdir(tmp_path)
-    call_count = 0
-    captured_messages: list = []
-
-    def mock_run(system_prompt: str, **kwargs: object) -> object:
-        nonlocal call_count
-        captured_messages.append(kwargs.get("initial_message"))
-        call_count += 1
-        return "reload-session-abc" if call_count == 1 else None
-
-    monkeypatch.setattr(
-        "autoskillit.cli.session._session_launch._run_interactive_session",
-        mock_run,
-    )
-    monkeypatch.setattr(
-        "autoskillit.cli._prompts._build_fleet_campaign_prompt",
-        lambda *a, **kw: "campaign-prompt",
-    )
-    monkeypatch.setattr("autoskillit.cli.fleet._fleet_session.dump_yaml_str", lambda *a, **kw: "")
-    from autoskillit.fleet import ResumeDecision
-
-    monkeypatch.setattr(
-        "autoskillit.fleet.resume_campaign_from_state",
-        lambda *a, **kw: ResumeDecision(
-            completed_dispatches_block="",
-            next_dispatch_name="",
-            is_resumable=False,
-            dispatched_session_id="",
-            kill_reason="",
-        ),
-    )
-    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
-
-    recipe = MagicMock()
-    recipe.dispatches = []
-    recipe.continue_on_failure = False
-
-    _launch_fleet_session(
-        recipe,
-        "test-campaign-id",
-        tmp_path / "state.json",
-        None,
-        fleet_mode="campaign",
         initial_message="Hello!",
     )
     assert len(captured_messages) >= 2, (

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -570,6 +571,120 @@ def test_launch_fleet_session_clears_initial_message_on_reload(
         None,
         None,
         fleet_mode="dispatch",
+        initial_message="Hello!",
+    )
+    assert len(captured_messages) >= 2, (
+        f"expected reload to fire but got only {len(captured_messages)} call(s)"
+    )
+    assert captured_messages[0] == "Hello!"
+    assert captured_messages[1] is None
+
+
+def test_fleet_campaign_greetings_have_campaign_name_placeholder() -> None:
+    """All _FLEET_CAMPAIGN_GREETINGS entries must contain {campaign_name}."""
+    from autoskillit.cli.fleet._fleet_preview import _FLEET_CAMPAIGN_GREETINGS
+
+    assert len(_FLEET_CAMPAIGN_GREETINGS) >= 3
+    for greeting in _FLEET_CAMPAIGN_GREETINGS:
+        assert "{campaign_name}" in greeting
+
+
+def test_launch_fleet_session_forwards_initial_message_campaign(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_launch_fleet_session in campaign mode forwards initial_message."""
+    monkeypatch.chdir(tmp_path)
+    captured_kwargs: dict = {}
+
+    def mock_run(system_prompt: str, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        mock_run,
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+        lambda *a, **kw: "campaign-prompt",
+    )
+    monkeypatch.setattr("autoskillit.cli._prompts.dump_yaml_str", lambda *a, **kw: "")
+    from autoskillit.fleet import ResumeDecision
+
+    monkeypatch.setattr(
+        "autoskillit.fleet.resume_campaign_from_state",
+        lambda *a, **kw: ResumeDecision(
+            completed_dispatches_block="",
+            next_dispatch_name="",
+            is_resumable=False,
+            dispatched_session_id="",
+            kill_reason="",
+        ),
+    )
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+    recipe = MagicMock()
+    recipe.dispatches = []
+    recipe.continue_on_failure = False
+
+    _launch_fleet_session(
+        recipe,
+        "test-campaign-id",
+        tmp_path / "state.json",
+        None,
+        fleet_mode="campaign",
+        initial_message="Hello, campaign!",
+    )
+    assert captured_kwargs.get("initial_message") == "Hello, campaign!"
+
+
+def test_launch_fleet_session_clears_initial_message_on_reload_campaign(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """On reload in campaign mode, initial_message must be None (only injected on first launch)."""
+    monkeypatch.chdir(tmp_path)
+    call_count = 0
+    captured_messages: list = []
+
+    def mock_run(system_prompt: str, **kwargs: object) -> object:
+        nonlocal call_count
+        captured_messages.append(kwargs.get("initial_message"))
+        call_count += 1
+        return "reload-session-abc" if call_count == 1 else None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        mock_run,
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+        lambda *a, **kw: "campaign-prompt",
+    )
+    monkeypatch.setattr("autoskillit.cli._prompts.dump_yaml_str", lambda *a, **kw: "")
+    from autoskillit.fleet import ResumeDecision
+
+    monkeypatch.setattr(
+        "autoskillit.fleet.resume_campaign_from_state",
+        lambda *a, **kw: ResumeDecision(
+            completed_dispatches_block="",
+            next_dispatch_name="",
+            is_resumable=False,
+            dispatched_session_id="",
+            kill_reason="",
+        ),
+    )
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+    recipe = MagicMock()
+    recipe.dispatches = []
+    recipe.continue_on_failure = False
+
+    _launch_fleet_session(
+        recipe,
+        "test-campaign-id",
+        tmp_path / "state.json",
+        None,
+        fleet_mode="campaign",
         initial_message="Hello!",
     )
     assert len(captured_messages) >= 2, (

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -608,7 +608,7 @@ def test_launch_fleet_session_forwards_initial_message_campaign(
         "autoskillit.cli._prompts._build_fleet_campaign_prompt",
         lambda *a, **kw: "campaign-prompt",
     )
-    monkeypatch.setattr("autoskillit.cli._prompts.dump_yaml_str", lambda *a, **kw: "")
+    monkeypatch.setattr("autoskillit.cli.fleet._fleet_session.dump_yaml_str", lambda *a, **kw: "")
     from autoskillit.fleet import ResumeDecision
 
     monkeypatch.setattr(
@@ -660,7 +660,7 @@ def test_launch_fleet_session_clears_initial_message_on_reload_campaign(
         "autoskillit.cli._prompts._build_fleet_campaign_prompt",
         lambda *a, **kw: "campaign-prompt",
     )
-    monkeypatch.setattr("autoskillit.cli._prompts.dump_yaml_str", lambda *a, **kw: "")
+    monkeypatch.setattr("autoskillit.cli.fleet._fleet_session.dump_yaml_str", lambda *a, **kw: "")
     from autoskillit.fleet import ResumeDecision
 
     monkeypatch.setattr(

--- a/tests/cli/test_fleet_session.py
+++ b/tests/cli/test_fleet_session.py
@@ -146,6 +146,7 @@ class TestReloadLoopRefreshesMetadata:
             extra_env: dict,
             resume_spec: object,
             project_dir: Path,
+            **kwargs: object,
         ) -> str | None:
             return next(call_sequence)
 
@@ -197,6 +198,7 @@ class TestReloadLoopRefreshesMetadata:
             extra_env: dict,
             resume_spec: object,
             project_dir: Path,
+            **kwargs: object,
         ) -> str | None:
             return next(call_sequence)
 
@@ -267,6 +269,7 @@ class TestReloadLoopSentinelGuard:
             extra_env: dict,
             resume_spec: object,
             project_dir: Path,
+            **kwargs: object,
         ) -> str | None:
             session_call_count["n"] += 1
             return "reload-id-sentinel"
@@ -319,6 +322,7 @@ class TestReloadLoopSafetyGuards:
             extra_env: dict,
             resume_spec: object,
             project_dir: Path,
+            **kwargs: object,
         ) -> str:
             counter["n"] += 1
             return f"unique-reload-id-{counter['n']}"
@@ -370,6 +374,7 @@ class TestReloadLoopSafetyGuards:
             extra_env: dict,
             resume_spec: object,
             project_dir: Path,
+            **kwargs: object,
         ) -> str:
             return "repeated-reload-id"
 
@@ -422,6 +427,7 @@ class TestReloadLoopUsesNamedResume:
             extra_env: dict,
             resume_spec: object,
             project_dir: Path,
+            **kwargs: object,
         ) -> str | None:
             captured_specs.append(resume_spec)
             return next(call_sequence)


### PR DESCRIPTION
## Summary

The `fleet campaign` session launches without an `initial_message`, so Claude has no first user turn to trigger the `FIRST ACTION` block that displays the ingredient table. The `fleet dispatch` path and `order` path both correctly pass a greeting as `initial_message`. The fix adds a `_FLEET_CAMPAIGN_GREETINGS` list and wires it through the campaign launch path, mirroring the existing dispatch pattern.

Closes #2214

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260508-010012-804577/.autoskillit/temp/make-plan/fleet_campaign_session_missing_initial_message_greeting_trigger_plan_2026-05-08_010012.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 75 | 9.1k | 933.1k | 62.0k | 71 | 52.3k | 5m 8s |
| verify | claude-opus-4-6 | 1 | 37 | 7.3k | 734.2k | 46.7k | 59 | 33.5k | 4m 3s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 12.7k | 1.0M | 34.0k | 100 | 56.4k | 5m 43s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 169.7k | 4.1k | 402.1k | 28.7k | 37 | 41.2k | 1m 56s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 52.2k | 1.2k | 227.0k | 28.7k | 16 | 15.1k | 42s |
| review_pr | claude-sonnet-4-6 | 3 | 278 | 84.0k | 1.3M | 77.7k | 107 | 172.1k | 17m 15s |
| resolve_review | claude-sonnet-4-6 | 1 | 247 | 19.0k | 1.6M | 76.5k | 80 | 64.3k | 8m 58s |
| **Total** | | | 1.3M | 137.5k | 6.3M | 77.7k | | 435.0k | 43m 48s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 153 | 6606.7 | 368.5 | 83.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 230 | 7156.4 | 279.6 | 82.5 |
| **Total** | **383** | 16436.5 | 1135.7 | 359.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 112 | 16.5k | 1.7M | 85.8k | 9m 11s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 18.1k | 1.6M | 112.8k | 8m 22s |
| claude-sonnet-4-6 | 1 | 374 | 30.8k | 3.4M | 92.9k | 11m 35s |