### PR TITLE
[FEATURE] Formalize Issue Label Lifecycle as a Discrete System with `queued` State

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -193,6 +193,8 @@ class GitHubConfig:
             IssueLabelState.STAGED: self.staged_label,
             IssueLabelState.FAIL: self.fail_label,
         }
+        if state not in _map:
+            raise ValueError(f"No label configured for state {state!r}")
         return _map[state]
 
     def state_for_label(self, label: str) -> IssueLabelState | None:
@@ -203,6 +205,28 @@ class GitHubConfig:
 
     def labels_for_states(self, states: frozenset[IssueLabelState]) -> list[str]:
         return [self.label_for_state(s) for s in states]
+
+    def resolve_label_metadata(self, label: str) -> tuple[str, str, list[str]]:
+        """Return (color, description, remove_labels) for a lifecycle label.
+
+        Uses the registry when label maps to a lifecycle state; falls back to
+        IN_PROGRESS defaults for custom labels not in the registry.
+        """
+        from autoskillit.core import LABEL_LIFECYCLE_REGISTRY  # noqa: PLC0415
+
+        state = self.state_for_label(label)
+        if state is not None:
+            label_def = LABEL_LIFECYCLE_REGISTRY[state]
+            return (
+                label_def.color,
+                label_def.description,
+                self.labels_for_states(label_def.removes_on_entry),
+            )
+        return (
+            "fbca04",
+            "Issue is actively being processed by a pipeline session",
+            [self.fail_label],
+        )
 
     def all_lifecycle_labels(self) -> list[str]:
         return [self.label_for_state(s) for s in IssueLabelState]

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -201,6 +201,12 @@ class GitHubConfig:
                 return state
         return None
 
+    def labels_for_states(self, states: frozenset[IssueLabelState]) -> list[str]:
+        return [self.label_for_state(s) for s in states]
+
+    def all_lifecycle_labels(self) -> list[str]:
+        return [self.label_for_state(s) for s in IssueLabelState]
+
     def check_labels_allowed(self, labels: list[str]) -> str | None:
         """Return None if all labels are permitted, or an error message for the first violation.
 

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from autoskillit.core import OutputFormat, get_logger
+from autoskillit.core import IssueLabelState, OutputFormat, get_logger
 
 logger = get_logger(__name__)
 
@@ -164,14 +164,18 @@ class GitHubConfig:
     in_progress_label: str = "in-progress"
     staged_label: str = "staged"
     fail_label: str = "fail"
+    queued_label: str = "queued"
     allowed_labels: list[str] = field(default_factory=list)
 
     def check_label_allowed(self, label: str) -> str | None:
         """Return None if label is permitted, or an error message string if not.
 
         When allowed_labels is empty, all labels are permitted (unrestricted/opt-out mode).
+        Lifecycle labels (QUEUED, IN_PROGRESS, STAGED, FAIL) are always permitted.
         """
         if not self.allowed_labels:
+            return None
+        if self.state_for_label(label) is not None:
             return None
         if label not in self.allowed_labels:
             allowed_sorted = sorted(self.allowed_labels)
@@ -180,6 +184,21 @@ class GitHubConfig:
                 f"Allowed: {allowed_sorted}. "
                 f"Add '{label}' to github.allowed_labels in your config to permit it."
             )
+        return None
+
+    def label_for_state(self, state: IssueLabelState) -> str:
+        _map: dict[IssueLabelState, str] = {
+            IssueLabelState.QUEUED: self.queued_label,
+            IssueLabelState.IN_PROGRESS: self.in_progress_label,
+            IssueLabelState.STAGED: self.staged_label,
+            IssueLabelState.FAIL: self.fail_label,
+        }
+        return _map[state]
+
+    def state_for_label(self, label: str) -> IssueLabelState | None:
+        for state in IssueLabelState:
+            if self.label_for_state(state) == label:
+                return state
         return None
 
     def check_labels_allowed(self, labels: list[str]) -> str | None:

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from autoskillit.core import IssueLabelState, OutputFormat, get_logger
+from autoskillit.core import LABEL_LIFECYCLE_REGISTRY, IssueLabelState, OutputFormat, get_logger
 
 logger = get_logger(__name__)
 
@@ -212,7 +212,6 @@ class GitHubConfig:
         Uses the registry when label maps to a lifecycle state; falls back to
         IN_PROGRESS defaults for custom labels not in the registry.
         """
-        from autoskillit.core import LABEL_LIFECYCLE_REGISTRY  # noqa: PLC0415
 
         state = self.state_for_label(label)
         if state is not None:

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -83,9 +83,11 @@ github:
   in_progress_label: "in-progress"
   staged_label: "staged"
   fail_label: "fail"
+  queued_label: "queued"
   allowed_labels:
     - "bug"
     - "enhancement"
+    - "queued"
     - "in-progress"
     - "staged"
     - "fail"

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -435,6 +435,7 @@ class AutomationConfig:
                 in_progress_label=str(val(gh, "in_progress_label", _gh["in_progress_label"])),
                 staged_label=str(val(gh, "staged_label", _gh["staged_label"])),
                 fail_label=str(val(gh, "fail_label", _gh["fail_label"])),
+                queued_label=str(val(gh, "queued_label", _gh["queued_label"])),
                 allowed_labels=list(val(gh, "allowed_labels", _gh["allowed_labels"])),
             ),
             report_bug=ReportBugConfig(

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -170,7 +170,11 @@ from .types import GitHubApiLog as GitHubApiLog
 from .types import GitHubFetcher as GitHubFetcher
 from .types import HeadlessExecutor as HeadlessExecutor
 from .types import InfraExitCategory as InfraExitCategory
+from .types import IssueLabelState as IssueLabelState
 from .types import KillReason as KillReason
+from .types import LabelDef as LabelDef
+from .types import LABEL_LIFECYCLE_REGISTRY as LABEL_LIFECYCLE_REGISTRY
+from .types import LABEL_TRANSITIONS as LABEL_TRANSITIONS
 from .types import LoadReport as LoadReport
 from .types import LoadResult as LoadResult
 from .types import MarketplaceInstall as MarketplaceInstall
@@ -230,3 +234,4 @@ from .types import resolve_target_skill as resolve_target_skill
 from .types import resume_spec_from_cli as resume_spec_from_cli
 from .types import session_type as session_type
 from .types import truncate_text as truncate_text
+from .types import validate_label_transition as validate_label_transition

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -472,13 +472,15 @@ LABEL_LIFECYCLE_REGISTRY: dict[IssueLabelState, LabelDef] = {
         state=IssueLabelState.STAGED,
         color="0075ca",
         description="Issue resolved, PR staged for promotion",
-        removes_on_entry=frozenset({IssueLabelState.IN_PROGRESS, IssueLabelState.FAIL}),
+        removes_on_entry=frozenset(
+            {IssueLabelState.IN_PROGRESS, IssueLabelState.FAIL, IssueLabelState.QUEUED}
+        ),
     ),
     IssueLabelState.FAIL: LabelDef(
         state=IssueLabelState.FAIL,
         color="d73a4a",
         description="Recipe execution failed",
-        removes_on_entry=frozenset({IssueLabelState.IN_PROGRESS}),
+        removes_on_entry=frozenset({IssueLabelState.IN_PROGRESS, IssueLabelState.QUEUED}),
     ),
 }
 

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -10,7 +10,7 @@ from datetime import date
 from importlib.metadata import version
 from typing import NamedTuple
 
-from ._type_enums import FeatureLifecycle, FleetErrorCode
+from ._type_enums import FeatureLifecycle, FleetErrorCode, IssueLabelState
 
 __all__ = [
     "AUTOSKILLIT_INSTALLED_VERSION",
@@ -54,6 +54,10 @@ __all__ = [
     "FeatureDef",
     "FEATURE_REGISTRY",
     "RETIRED_FEATURES",
+    "LabelDef",
+    "LABEL_LIFECYCLE_REGISTRY",
+    "LABEL_TRANSITIONS",
+    "validate_label_transition",
     "RETIRED_SKILL_NAMES",
     "SKILL_FILE_ADVISORY_MAP",
     "SKILL_ACTIVATE_DEPS_REQUIRED",
@@ -439,6 +443,80 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
         since_version="0.9.351",
     ),
 }
+
+
+@dataclass(frozen=True, slots=True)
+class LabelDef:
+    """Metadata for a lifecycle label managed by the issue state machine."""
+
+    state: IssueLabelState
+    color: str
+    description: str
+    removes_on_entry: frozenset[IssueLabelState]
+
+
+LABEL_LIFECYCLE_REGISTRY: dict[IssueLabelState, LabelDef] = {
+    IssueLabelState.QUEUED: LabelDef(
+        state=IssueLabelState.QUEUED,
+        color="c2e0c6",
+        description="Issue claimed by orchestrator, waiting for recipe pickup",
+        removes_on_entry=frozenset({IssueLabelState.FAIL}),
+    ),
+    IssueLabelState.IN_PROGRESS: LabelDef(
+        state=IssueLabelState.IN_PROGRESS,
+        color="fbca04",
+        description="Issue is actively being processed by a pipeline session",
+        removes_on_entry=frozenset({IssueLabelState.QUEUED, IssueLabelState.FAIL}),
+    ),
+    IssueLabelState.STAGED: LabelDef(
+        state=IssueLabelState.STAGED,
+        color="0075ca",
+        description="Issue resolved, PR staged for promotion",
+        removes_on_entry=frozenset({IssueLabelState.IN_PROGRESS, IssueLabelState.FAIL}),
+    ),
+    IssueLabelState.FAIL: LabelDef(
+        state=IssueLabelState.FAIL,
+        color="d73a4a",
+        description="Recipe execution failed",
+        removes_on_entry=frozenset({IssueLabelState.IN_PROGRESS}),
+    ),
+}
+
+LABEL_TRANSITIONS: dict[IssueLabelState | None, frozenset[IssueLabelState | None]] = {
+    None: frozenset({IssueLabelState.QUEUED, IssueLabelState.IN_PROGRESS}),
+    IssueLabelState.QUEUED: frozenset({IssueLabelState.IN_PROGRESS, None}),
+    IssueLabelState.IN_PROGRESS: frozenset(
+        {
+            IssueLabelState.STAGED,
+            IssueLabelState.FAIL,
+            None,
+        }
+    ),
+    IssueLabelState.STAGED: frozenset(),
+    IssueLabelState.FAIL: frozenset({IssueLabelState.QUEUED, IssueLabelState.IN_PROGRESS}),
+}
+
+
+def validate_label_transition(
+    current: IssueLabelState | None,
+    target: IssueLabelState | None,
+) -> None:
+    """Raise ValueError if the label state transition is not allowed."""
+    allowed = LABEL_TRANSITIONS.get(current)
+    if allowed is not None and target not in allowed:
+        msg = f"Invalid label transition: {current!r} -> {target!r}"
+        raise ValueError(msg)
+
+
+for _ls in IssueLabelState:
+    if _ls not in LABEL_LIFECYCLE_REGISTRY:
+        raise AssertionError(f"IssueLabelState.{_ls.name} missing from LABEL_LIFECYCLE_REGISTRY")
+    if _ls not in LABEL_TRANSITIONS:
+        raise AssertionError(f"IssueLabelState.{_ls.name} missing from LABEL_TRANSITIONS")
+if None not in LABEL_TRANSITIONS:
+    raise AssertionError("LABEL_TRANSITIONS must contain a None (unlabeled) entry")
+del _ls
+
 
 RETIRED_FEATURES: frozenset[str] = frozenset()
 

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -28,6 +28,7 @@ __all__ = [
     "SessionType",
     "FleetErrorCode",
     "FeatureLifecycle",
+    "IssueLabelState",
     "DispatchGateType",
     "ClaudeContentBlockType",
     "InfraExitCategory",
@@ -424,6 +425,15 @@ class FeatureLifecycle(StrEnum):
     STABLE = "stable"
     DEPRECATED = "deprecated"
     DISABLED = "disabled"
+
+
+class IssueLabelState(StrEnum):
+    """Lifecycle state of a GitHub issue managed by the label state machine."""
+
+    QUEUED = "queued"
+    IN_PROGRESS = "in-progress"
+    STAGED = "staged"
+    FAIL = "fail"
 
 
 @unique

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -136,9 +136,7 @@ async def claim_and_resolve_issue(
             label_def = LABEL_LIFECYCLE_REGISTRY[target_state]
             ensure_color = label_def.color
             ensure_description = label_def.description
-            remove_labels = [
-                tool_ctx.config.github.label_for_state(s) for s in label_def.removes_on_entry
-            ]
+            remove_labels = tool_ctx.config.github.labels_for_states(label_def.removes_on_entry)
         else:
             ensure_color = "fbca04"
             ensure_description = "Issue is actively being processed by a pipeline session"

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -9,7 +9,6 @@ from typing import Any
 import structlog
 
 from autoskillit.core import (
-    LABEL_LIFECYCLE_REGISTRY,
     _parse_issue_ref,
     get_logger,
 )
@@ -131,16 +130,9 @@ async def claim_and_resolve_issue(
                 }
             )
 
-        target_state = tool_ctx.config.github.state_for_label(effective_label)
-        if target_state is not None:
-            label_def = LABEL_LIFECYCLE_REGISTRY[target_state]
-            ensure_color = label_def.color
-            ensure_description = label_def.description
-            remove_labels = tool_ctx.config.github.labels_for_states(label_def.removes_on_entry)
-        else:
-            ensure_color = "fbca04"
-            ensure_description = "Issue is actively being processed by a pipeline session"
-            remove_labels = [tool_ctx.config.github.fail_label]
+        ensure_color, ensure_description, remove_labels = (
+            tool_ctx.config.github.resolve_label_metadata(effective_label)
+        )
 
         await tool_ctx.github_client.ensure_label(
             owner,

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -8,7 +8,11 @@ from typing import Any
 
 import structlog
 
-from autoskillit.core import _parse_issue_ref, get_logger
+from autoskillit.core import (
+    LABEL_LIFECYCLE_REGISTRY,
+    _parse_issue_ref,
+    get_logger,
+)
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._notify import track_response_size
@@ -127,19 +131,32 @@ async def claim_and_resolve_issue(
                 }
             )
 
+        target_state = tool_ctx.config.github.state_for_label(effective_label)
+        if target_state is not None:
+            label_def = LABEL_LIFECYCLE_REGISTRY[target_state]
+            ensure_color = label_def.color
+            ensure_description = label_def.description
+            remove_labels = [
+                tool_ctx.config.github.label_for_state(s) for s in label_def.removes_on_entry
+            ]
+        else:
+            ensure_color = "fbca04"
+            ensure_description = "Issue is actively being processed by a pipeline session"
+            remove_labels = [tool_ctx.config.github.fail_label]
+
         await tool_ctx.github_client.ensure_label(
             owner,
             repo,
             effective_label,
-            color="fbca04",
-            description="Issue is actively being processed by a pipeline session",
+            color=ensure_color,
+            description=ensure_description,
         )
 
         swap_result = await tool_ctx.github_client.swap_labels(
             owner,
             repo,
             issue_number,
-            remove_labels=[tool_ctx.config.github.fail_label],
+            remove_labels=remove_labels,
             add_labels=[effective_label],
         )
         claim_ms = int((time.monotonic() - _claim_start) * 1000)

--- a/src/autoskillit/server/tools/tools_issue_lifecycle.py
+++ b/src/autoskillit/server/tools/tools_issue_lifecycle.py
@@ -10,7 +10,13 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import RetryReason, _parse_issue_ref, get_logger
+from autoskillit.core import (
+    LABEL_LIFECYCLE_REGISTRY,
+    IssueLabelState,
+    RetryReason,
+    _parse_issue_ref,
+    get_logger,
+)
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block
@@ -446,19 +452,32 @@ async def claim_issue(
                 }
             )
 
+        target_state = tool_ctx.config.github.state_for_label(effective_label)
+        if target_state is not None:
+            label_def = LABEL_LIFECYCLE_REGISTRY[target_state]
+            ensure_color = label_def.color
+            ensure_description = label_def.description
+            remove_labels = [
+                tool_ctx.config.github.label_for_state(s) for s in label_def.removes_on_entry
+            ]
+        else:
+            ensure_color = "fbca04"
+            ensure_description = "Issue is actively being processed by a pipeline session"
+            remove_labels = [tool_ctx.config.github.fail_label]
+
         await tool_ctx.github_client.ensure_label(
             owner,
             repo,
             effective_label,
-            color="fbca04",
-            description="Issue is actively being processed by a pipeline session",
+            color=ensure_color,
+            description=ensure_description,
         )
 
         swap_result = await tool_ctx.github_client.swap_labels(
             owner,
             repo,
             issue_number,
-            remove_labels=[tool_ctx.config.github.fail_label],
+            remove_labels=remove_labels,
             add_labels=[effective_label],
         )
         if not swap_result.get("success"):
@@ -541,10 +560,6 @@ async def release_issue(
         config_fail_label = tool_ctx.config.github.fail_label
         effective_staged_label = staged_label or tool_ctx.config.github.staged_label
 
-        remove_set = [effective_label]
-        if config_fail_label:
-            remove_set.append(config_fail_label)
-
         if should_stage:
             if err := tool_ctx.config.github.check_label_allowed(effective_staged_label):
                 return json.dumps(
@@ -556,14 +571,34 @@ async def release_issue(
                     }
                 )
 
+            staged_state = tool_ctx.config.github.state_for_label(effective_staged_label)
+            if staged_state is not None:
+                staged_def = LABEL_LIFECYCLE_REGISTRY[staged_state]
+                staged_color = staged_def.color
+                staged_description = staged_def.description
+                remove_labels = [
+                    tool_ctx.config.github.label_for_state(s) for s in staged_def.removes_on_entry
+                ]
+                queued_lbl = tool_ctx.config.github.queued_label
+                if queued_lbl not in remove_labels:
+                    remove_labels.append(queued_lbl)
+            else:
+                staged_color = "0075ca"
+                staged_description = (
+                    f"Implementation staged and waiting for promotion to {promotion_target}"
+                )
+                remove_labels = [
+                    effective_label,
+                    config_fail_label,
+                    tool_ctx.config.github.queued_label,
+                ]
+
             ensure_result = await tool_ctx.github_client.ensure_label(
                 owner,
                 repo,
                 effective_staged_label,
-                color="0075ca",
-                description=(
-                    f"Implementation staged and waiting for promotion to {promotion_target}"
-                ),
+                color=staged_color,
+                description=staged_description,
             )
             if not ensure_result.get("success"):
                 return json.dumps(
@@ -581,7 +616,7 @@ async def release_issue(
                 owner,
                 repo,
                 issue_number,
-                remove_labels=remove_set,
+                remove_labels=remove_labels,
                 add_labels=[effective_staged_label],
             )
             if not swap_result.get("success"):
@@ -605,11 +640,28 @@ async def release_issue(
                     }
                 )
 
+            fail_state = tool_ctx.config.github.state_for_label(fail_label)
+            if fail_state is not None:
+                fail_def = LABEL_LIFECYCLE_REGISTRY[fail_state]
+                fail_color = fail_def.color
+                fail_description = fail_def.description
+                remove_labels = [
+                    tool_ctx.config.github.label_for_state(s) for s in fail_def.removes_on_entry
+                ]
+                queued_lbl = tool_ctx.config.github.queued_label
+                if queued_lbl not in remove_labels:
+                    remove_labels.append(queued_lbl)
+            else:
+                fail_color = "d73a4a"
+                fail_description = "Recipe execution failed"
+                remove_labels = [effective_label, tool_ctx.config.github.queued_label]
+
             ensure_result = await tool_ctx.github_client.ensure_label(
                 owner,
                 repo,
                 fail_label,
-                color="d73a4a",
+                color=fail_color,
+                description=fail_description,
             )
             if not ensure_result.get("success"):
                 return json.dumps(
@@ -627,7 +679,7 @@ async def release_issue(
                 owner,
                 repo,
                 issue_number,
-                remove_labels=[effective_label],
+                remove_labels=remove_labels,
                 add_labels=[fail_label],
             )
             if not swap_result.get("success"):
@@ -654,11 +706,14 @@ async def release_issue(
                 "release_issue bare removal (no fail_label or target_branch) for %s",
                 issue_url,
             )
+            all_lifecycle_labels = [
+                tool_ctx.config.github.label_for_state(s) for s in IssueLabelState
+            ]
             swap_result = await tool_ctx.github_client.swap_labels(
                 owner,
                 repo,
                 issue_number,
-                remove_labels=remove_set,
+                remove_labels=all_lifecycle_labels,
                 add_labels=[],
             )
             if not swap_result.get("success"):

--- a/src/autoskillit/server/tools/tools_issue_lifecycle.py
+++ b/src/autoskillit/server/tools/tools_issue_lifecycle.py
@@ -11,7 +11,6 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import (
-    LABEL_LIFECYCLE_REGISTRY,
     RetryReason,
     _parse_issue_ref,
     get_logger,
@@ -451,16 +450,9 @@ async def claim_issue(
                 }
             )
 
-        target_state = tool_ctx.config.github.state_for_label(effective_label)
-        if target_state is not None:
-            label_def = LABEL_LIFECYCLE_REGISTRY[target_state]
-            ensure_color = label_def.color
-            ensure_description = label_def.description
-            remove_labels = tool_ctx.config.github.labels_for_states(label_def.removes_on_entry)
-        else:
-            ensure_color = "fbca04"
-            ensure_description = "Issue is actively being processed by a pipeline session"
-            remove_labels = [tool_ctx.config.github.fail_label]
+        ensure_color, ensure_description, remove_labels = (
+            tool_ctx.config.github.resolve_label_metadata(effective_label)
+        )
 
         await tool_ctx.github_client.ensure_label(
             owner,
@@ -568,17 +560,10 @@ async def release_issue(
                     }
                 )
 
-            staged_state = tool_ctx.config.github.state_for_label(effective_staged_label)
-            if staged_state is not None:
-                staged_def = LABEL_LIFECYCLE_REGISTRY[staged_state]
-                staged_color = staged_def.color
-                staged_description = staged_def.description
-                remove_labels = tool_ctx.config.github.labels_for_states(
-                    staged_def.removes_on_entry
+            if tool_ctx.config.github.state_for_label(effective_staged_label) is not None:
+                staged_color, staged_description, remove_labels = (
+                    tool_ctx.config.github.resolve_label_metadata(effective_staged_label)
                 )
-                queued_lbl = tool_ctx.config.github.queued_label
-                if queued_lbl not in remove_labels:
-                    remove_labels.append(queued_lbl)
             else:
                 staged_color = "0075ca"
                 staged_description = (
@@ -637,15 +622,10 @@ async def release_issue(
                     }
                 )
 
-            fail_state = tool_ctx.config.github.state_for_label(fail_label)
-            if fail_state is not None:
-                fail_def = LABEL_LIFECYCLE_REGISTRY[fail_state]
-                fail_color = fail_def.color
-                fail_description = fail_def.description
-                remove_labels = tool_ctx.config.github.labels_for_states(fail_def.removes_on_entry)
-                queued_lbl = tool_ctx.config.github.queued_label
-                if queued_lbl not in remove_labels:
-                    remove_labels.append(queued_lbl)
+            if tool_ctx.config.github.state_for_label(fail_label) is not None:
+                fail_color, fail_description, remove_labels = (
+                    tool_ctx.config.github.resolve_label_metadata(fail_label)
+                )
             else:
                 fail_color = "d73a4a"
                 fail_description = "Recipe execution failed"

--- a/src/autoskillit/server/tools/tools_issue_lifecycle.py
+++ b/src/autoskillit/server/tools/tools_issue_lifecycle.py
@@ -12,7 +12,6 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import (
     LABEL_LIFECYCLE_REGISTRY,
-    IssueLabelState,
     RetryReason,
     _parse_issue_ref,
     get_logger,
@@ -457,9 +456,7 @@ async def claim_issue(
             label_def = LABEL_LIFECYCLE_REGISTRY[target_state]
             ensure_color = label_def.color
             ensure_description = label_def.description
-            remove_labels = [
-                tool_ctx.config.github.label_for_state(s) for s in label_def.removes_on_entry
-            ]
+            remove_labels = tool_ctx.config.github.labels_for_states(label_def.removes_on_entry)
         else:
             ensure_color = "fbca04"
             ensure_description = "Issue is actively being processed by a pipeline session"
@@ -576,9 +573,9 @@ async def release_issue(
                 staged_def = LABEL_LIFECYCLE_REGISTRY[staged_state]
                 staged_color = staged_def.color
                 staged_description = staged_def.description
-                remove_labels = [
-                    tool_ctx.config.github.label_for_state(s) for s in staged_def.removes_on_entry
-                ]
+                remove_labels = tool_ctx.config.github.labels_for_states(
+                    staged_def.removes_on_entry
+                )
                 queued_lbl = tool_ctx.config.github.queued_label
                 if queued_lbl not in remove_labels:
                     remove_labels.append(queued_lbl)
@@ -645,9 +642,7 @@ async def release_issue(
                 fail_def = LABEL_LIFECYCLE_REGISTRY[fail_state]
                 fail_color = fail_def.color
                 fail_description = fail_def.description
-                remove_labels = [
-                    tool_ctx.config.github.label_for_state(s) for s in fail_def.removes_on_entry
-                ]
+                remove_labels = tool_ctx.config.github.labels_for_states(fail_def.removes_on_entry)
                 queued_lbl = tool_ctx.config.github.queued_label
                 if queued_lbl not in remove_labels:
                     remove_labels.append(queued_lbl)
@@ -706,14 +701,11 @@ async def release_issue(
                 "release_issue bare removal (no fail_label or target_branch) for %s",
                 issue_url,
             )
-            all_lifecycle_labels = [
-                tool_ctx.config.github.label_for_state(s) for s in IssueLabelState
-            ]
             swap_result = await tool_ctx.github_client.swap_labels(
                 owner,
                 repo,
                 issue_number,
-                remove_labels=all_lifecycle_labels,
+                remove_labels=tool_ctx.config.github.all_lifecycle_labels(),
                 add_labels=[],
             )
             if not swap_result.get("success"):

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -80,20 +80,26 @@ Launch up to 8 parallel `sonnet` subagents, one per issue. Each subagent:
    `affected_files` or `depends_on`. The issue body is read directly by the parent in Step 2.
 
 In the same parallel wave, launch **one additional task** to fetch the ambient in-progress
-context:
+and queued context:
 
 ```bash
 gh issue list --state open --label "{{github.in_progress_label}}" \
   --json number,title,body,labels,updatedAt --limit 50
+
+gh issue list --state open --label "{{github.queued_label}}" \
+  --json number,title,body,labels,updatedAt --limit 50
 ```
 
-Use the config value `github.in_progress_label` (default: `"in-progress"`) as the label
-name. From the returned list:
+Use the config value `github.in_progress_label` (default: `"in-progress"`) and
+`github.queued_label` (default: `"queued"`) as the label names. Merge both result sets
+(deduplicate by issue number) into the ambient context. From the combined list:
 - **Exclude** any issue whose number appears in the current target set — those are being
   handled by this session and are already represented in the pairwise assessment.
 - **Exclude** any issue whose labels contain the staged label (`github.staged_label`,
   default: `"staged"`) — staged issues have already landed on the integration branch.
-- The remaining issues form the **in-progress context** set.
+- Treat queued issues with lower default conflict severity than in-progress issues
+  since they haven't started file modifications yet.
+- The remaining issues form the **ambient context** set.
 
 If the `gh issue list` call fails (auth error, network failure), log the error and set the
 in-progress context to an empty list — do not abort the skill. An empty in-progress context

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -201,8 +201,7 @@ Processing X issues:
 
 3. **Promote queued → in-progress for this issue:**
    Call `claim_issue(issue_url=<url>, allow_reentry=true)`
-   (No label argument — defaults to in-progress. The registry-driven
-   swap_labels removes "queued" via IN_PROGRESS.removes_on_entry
+   (No label argument — defaults to in-progress; removes the "queued" label
    and adds "in-progress".)
 
 4. **Optionally append pickup status to issue body** (if `--status-updates` is active):

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -162,7 +162,7 @@ completed_urls   = []   # issues whose recipe fully returned
 Collect all issues from all batches that will be processed (respecting `--batch N` filtering).
 
 For each issue in the collected list:
-1. Call `claim_issue(issue_url=<url>)` — **no** `allow_reentry` (default `False`)
+1. Call `claim_issue(issue_url=<url>, label="queued")` — **no** `allow_reentry` (default `False`)
 2. If `result.claimed == true`:
    - append `issue_url` to `pre_claimed_urls`
 3. If `result.claimed == false`:
@@ -199,7 +199,13 @@ Processing X issues:
    Skipped issues are recorded as `status: skipped` (not `status: failure`), so the
    batch failure gate below counts only the original failure(s) that triggered the skip.
 
-3. **Optionally append pickup status to issue body** (if `--status-updates` is active):
+3. **Promote queued → in-progress for this issue:**
+   Call `claim_issue(issue_url=<url>, allow_reentry=true)`
+   (No label argument — defaults to in-progress. The registry-driven
+   swap_labels removes "queued" via IN_PROGRESS.removes_on_entry
+   and adds "in-progress".)
+
+4. **Optionally append pickup status to issue body** (if `--status-updates` is active):
    ```bash
    PROCESS_BODY_FILE="{{AUTOSKILLIT_TEMP}}/process-issues/status_{number}_$(date +%s).md"
    mkdir -p "$(dirname "$PROCESS_BODY_FILE")"

--- a/tests/config/CLAUDE.md
+++ b/tests/config/CLAUDE.md
@@ -20,6 +20,7 @@ Configuration loading, defaults, and schema tests.
 | `test_review_config.py` | Tests for ReviewConfig and local_review_rounds wiring |
 | `test_settings_allowed_labels.py` | Tests for GitHubConfig.allowed_labels field and check_label_allowed validation |
 | `test_settings_staged_label.py` | Tests for GitHubConfig.staged_label field and config layer resolution |
+| `test_settings_queued_label.py` | Tests for GitHubConfig.queued_label field and label-state mapping methods |
 | `test_skills_config.py` | Tests for SkillsConfig loading and validation |
 | `test_timeout_coherence.py` | Tests for idle_output_timeout config coherence validation gate |
 | `test_subsets_config.py` | Tests for SubsetsConfig loading and validation |

--- a/tests/config/test_settings_allowed_labels.py
+++ b/tests/config/test_settings_allowed_labels.py
@@ -79,6 +79,7 @@ class TestDefaultsYamlAllowedLabels:
         expected = {
             "bug",
             "enhancement",
+            "queued",
             "in-progress",
             "staged",
             "autoreported",

--- a/tests/config/test_settings_queued_label.py
+++ b/tests/config/test_settings_queued_label.py
@@ -18,7 +18,7 @@ class TestQueuedLabelField:
         cfg = GitHubConfig()
         assert cfg.queued_label == "queued"
 
-    def test_loads_from_env_var(self, monkeypatch, tmp_path):
+    def test_loads_from_env_var(self, monkeypatch):
         """queued_label is loaded from AUTOSKILLIT_GITHUB__QUEUED_LABEL env var."""
         monkeypatch.setenv("AUTOSKILLIT_GITHUB__QUEUED_LABEL", "waiting")
         d = _make_dynaconf()

--- a/tests/config/test_settings_queued_label.py
+++ b/tests/config/test_settings_queued_label.py
@@ -1,0 +1,61 @@
+"""Tests for GitHubConfig.queued_label field and label-state mapping methods."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.config import AutomationConfig
+from autoskillit.config._config_loader import _make_dynaconf
+from autoskillit.config.settings import GitHubConfig
+from autoskillit.core.types import IssueLabelState
+
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
+
+
+class TestQueuedLabelField:
+    def test_default_is_queued(self):
+        """GitHubConfig has queued_label field with default 'queued'."""
+        cfg = GitHubConfig()
+        assert cfg.queued_label == "queued"
+
+    def test_loads_from_env_var(self, monkeypatch, tmp_path):
+        """queued_label is loaded from AUTOSKILLIT_GITHUB__QUEUED_LABEL env var."""
+        monkeypatch.setenv("AUTOSKILLIT_GITHUB__QUEUED_LABEL", "waiting")
+        d = _make_dynaconf()
+        cfg = AutomationConfig.from_dynaconf(d)
+        assert cfg.github.queued_label == "waiting"
+
+
+class TestLabelStateMapping:
+    def test_label_for_state_returns_configured_string(self):
+        """label_for_state returns the configured label string for each IssueLabelState."""
+        cfg = GitHubConfig()
+        assert cfg.label_for_state(IssueLabelState.QUEUED) == "queued"
+        assert cfg.label_for_state(IssueLabelState.IN_PROGRESS) == "in-progress"
+        assert cfg.label_for_state(IssueLabelState.STAGED) == "staged"
+        assert cfg.label_for_state(IssueLabelState.FAIL) == "fail"
+
+    def test_label_for_state_respects_custom_config(self):
+        """label_for_state uses per-field overrides when set."""
+        cfg = GitHubConfig(queued_label="waiting")
+        assert cfg.label_for_state(IssueLabelState.QUEUED) == "waiting"
+
+    def test_state_for_label_roundtrip(self):
+        """state_for_label(label_for_state(state)) == state for all states."""
+        cfg = GitHubConfig()
+        for state in IssueLabelState:
+            label = cfg.label_for_state(state)
+            assert cfg.state_for_label(label) == state
+
+    def test_state_for_label_returns_none_for_classification_labels(self):
+        """state_for_label returns None for non-lifecycle labels."""
+        cfg = GitHubConfig()
+        assert cfg.state_for_label("bug") is None
+        assert cfg.state_for_label("recipe:implementation") is None
+
+    def test_label_for_state_covers_all_members(self):
+        """label_for_state returns a non-empty string for every IssueLabelState."""
+        cfg = GitHubConfig()
+        for state in IssueLabelState:
+            label = cfg.label_for_state(state)
+            assert label

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -20,6 +20,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_io.py` | Extended YAML I/O tests for core/io.py consolidation |
 | `test_json.py` | Tests for autoskillit.core._json — fast_loads and fast_dumps |
 | `test_kitchen_state.py` | Tests for KitchenMarker hash field support |
+| `test_label_lifecycle.py` | Tests for IssueLabelState, LabelDef, LABEL_LIFECYCLE_REGISTRY, LABEL_TRANSITIONS, and validate_label_transition |
 | `test_logging.py` | Tests for autoskillit.core.logging — centralized structlog configuration |
 | `test_paths.py` | Tests for autoskillit.core.paths — is_git_worktree and pkg_root |
 | `test_resolve_temp_dir.py` | Tests for autoskillit.core.io.resolve_temp_dir |

--- a/tests/core/test_label_lifecycle.py
+++ b/tests/core/test_label_lifecycle.py
@@ -77,14 +77,14 @@ class TestLabelDef:
             {IssueLabelState.FAIL}
         )
 
-    def test_staged_removes_in_progress_and_fail(self):
+    def test_staged_removes_in_progress_fail_and_queued(self):
         assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.STAGED].removes_on_entry == frozenset(
-            {IssueLabelState.IN_PROGRESS, IssueLabelState.FAIL}
+            {IssueLabelState.IN_PROGRESS, IssueLabelState.FAIL, IssueLabelState.QUEUED}
         )
 
-    def test_fail_removes_in_progress(self):
+    def test_fail_removes_in_progress_and_queued(self):
         assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.FAIL].removes_on_entry == frozenset(
-            {IssueLabelState.IN_PROGRESS}
+            {IssueLabelState.IN_PROGRESS, IssueLabelState.QUEUED}
         )
 
 

--- a/tests/core/test_label_lifecycle.py
+++ b/tests/core/test_label_lifecycle.py
@@ -1,0 +1,160 @@
+"""Tests for IssueLabelState, LabelDef, LABEL_LIFECYCLE_REGISTRY, LABEL_TRANSITIONS, and validate_label_transition."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types import (
+    LABEL_LIFECYCLE_REGISTRY,
+    LABEL_TRANSITIONS,
+    IssueLabelState,
+    validate_label_transition,
+)
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+class TestIssueLabelState:
+    def test_all_members_have_registry_entry(self):
+        """Every IssueLabelState member exists as a key in LABEL_LIFECYCLE_REGISTRY."""
+        for state in IssueLabelState:
+            assert state in LABEL_LIFECYCLE_REGISTRY
+
+    def test_registry_has_no_extra_keys(self):
+        """Every key in LABEL_LIFECYCLE_REGISTRY is a valid IssueLabelState member."""
+        for key in LABEL_LIFECYCLE_REGISTRY:
+            assert isinstance(key, IssueLabelState)
+
+    def test_queued_value(self):
+        assert IssueLabelState.QUEUED == "queued"
+
+    def test_in_progress_value(self):
+        assert IssueLabelState.IN_PROGRESS == "in-progress"
+
+    def test_staged_value(self):
+        assert IssueLabelState.STAGED == "staged"
+
+    def test_fail_value(self):
+        assert IssueLabelState.FAIL == "fail"
+
+
+class TestLabelDef:
+    def test_all_defs_have_nonempty_color(self):
+        """Every LabelDef in the registry has a truthy .color string."""
+        for defn in LABEL_LIFECYCLE_REGISTRY.values():
+            assert defn.color
+
+    def test_all_defs_have_nonempty_description(self):
+        """Every LabelDef in the registry has a truthy .description string."""
+        for defn in LABEL_LIFECYCLE_REGISTRY.values():
+            assert defn.description
+
+    def test_removes_on_entry_reference_valid_states(self):
+        """Every state in every LabelDef.removes_on_entry is a valid IssueLabelState member."""
+        for defn in LABEL_LIFECYCLE_REGISTRY.values():
+            for removed in defn.removes_on_entry:
+                assert isinstance(removed, IssueLabelState)
+
+    def test_queued_color(self):
+        assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.QUEUED].color == "c2e0c6"
+
+    def test_in_progress_color(self):
+        assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.IN_PROGRESS].color == "fbca04"
+
+    def test_staged_color(self):
+        assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.STAGED].color == "0075ca"
+
+    def test_fail_color(self):
+        assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.FAIL].color == "d73a4a"
+
+    def test_in_progress_removes_queued_and_fail(self):
+        assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.IN_PROGRESS].removes_on_entry == frozenset(
+            {IssueLabelState.QUEUED, IssueLabelState.FAIL}
+        )
+
+    def test_queued_removes_fail(self):
+        assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.QUEUED].removes_on_entry == frozenset(
+            {IssueLabelState.FAIL}
+        )
+
+    def test_staged_removes_in_progress_and_fail(self):
+        assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.STAGED].removes_on_entry == frozenset(
+            {IssueLabelState.IN_PROGRESS, IssueLabelState.FAIL}
+        )
+
+    def test_fail_removes_in_progress(self):
+        assert LABEL_LIFECYCLE_REGISTRY[IssueLabelState.FAIL].removes_on_entry == frozenset(
+            {IssueLabelState.IN_PROGRESS}
+        )
+
+
+class TestLabelTransitions:
+    def test_unlabeled_to_queued(self):
+        """validate_label_transition accepts unlabeled -> queued."""
+        validate_label_transition(None, IssueLabelState.QUEUED)
+
+    def test_unlabeled_to_in_progress(self):
+        """validate_label_transition accepts unlabeled -> in-progress."""
+        validate_label_transition(None, IssueLabelState.IN_PROGRESS)
+
+    def test_queued_to_in_progress(self):
+        """validate_label_transition accepts queued -> in-progress."""
+        validate_label_transition(IssueLabelState.QUEUED, IssueLabelState.IN_PROGRESS)
+
+    def test_queued_to_none(self):
+        """validate_label_transition accepts queued -> None (release/unlabel)."""
+        validate_label_transition(IssueLabelState.QUEUED, None)
+
+    def test_in_progress_to_staged(self):
+        """validate_label_transition accepts in-progress -> staged."""
+        validate_label_transition(IssueLabelState.IN_PROGRESS, IssueLabelState.STAGED)
+
+    def test_in_progress_to_fail(self):
+        """validate_label_transition accepts in-progress -> fail."""
+        validate_label_transition(IssueLabelState.IN_PROGRESS, IssueLabelState.FAIL)
+
+    def test_in_progress_to_none(self):
+        """validate_label_transition accepts in-progress -> None (bare removal)."""
+        validate_label_transition(IssueLabelState.IN_PROGRESS, None)
+
+    def test_fail_to_queued(self):
+        """validate_label_transition accepts fail -> queued (retry reclaim)."""
+        validate_label_transition(IssueLabelState.FAIL, IssueLabelState.QUEUED)
+
+    def test_fail_to_in_progress(self):
+        """validate_label_transition accepts fail -> in-progress (retry reclaim)."""
+        validate_label_transition(IssueLabelState.FAIL, IssueLabelState.IN_PROGRESS)
+
+    def test_invalid_in_progress_to_queued(self):
+        """validate_label_transition rejects in-progress -> queued."""
+        with pytest.raises(ValueError, match="Invalid label transition"):
+            validate_label_transition(IssueLabelState.IN_PROGRESS, IssueLabelState.QUEUED)
+
+    def test_invalid_staged_to_in_progress(self):
+        """validate_label_transition rejects staged -> in-progress."""
+        with pytest.raises(ValueError, match="Invalid label transition"):
+            validate_label_transition(IssueLabelState.STAGED, IssueLabelState.IN_PROGRESS)
+
+    def test_invalid_staged_to_queued(self):
+        """validate_label_transition rejects staged -> queued."""
+        with pytest.raises(ValueError, match="Invalid label transition"):
+            validate_label_transition(IssueLabelState.STAGED, IssueLabelState.QUEUED)
+
+    def test_invalid_queued_to_staged(self):
+        """validate_label_transition rejects queued -> staged."""
+        with pytest.raises(ValueError, match="Invalid label transition"):
+            validate_label_transition(IssueLabelState.QUEUED, IssueLabelState.STAGED)
+
+    def test_invalid_queued_to_fail(self):
+        """validate_label_transition rejects queued -> fail."""
+        with pytest.raises(ValueError, match="Invalid label transition"):
+            validate_label_transition(IssueLabelState.QUEUED, IssueLabelState.FAIL)
+
+    def test_every_enum_member_in_transition_table(self):
+        """Every IssueLabelState member appears as a key in LABEL_TRANSITIONS."""
+        for state in IssueLabelState:
+            assert state in LABEL_TRANSITIONS
+
+    def test_none_in_transition_table(self):
+        """None (unlabeled) appears as a key in LABEL_TRANSITIONS."""
+        assert None in LABEL_TRANSITIONS

--- a/tests/core/test_label_lifecycle.py
+++ b/tests/core/test_label_lifecycle.py
@@ -1,4 +1,4 @@
-"""Tests for IssueLabelState, LabelDef, LABEL_LIFECYCLE_REGISTRY, LABEL_TRANSITIONS, and validate_label_transition."""
+"""Tests for IssueLabelState, LabelDef, LABEL_LIFECYCLE_REGISTRY, and LABEL_TRANSITIONS."""
 
 from __future__ import annotations
 

--- a/tests/server/test_release_issue_fail_label.py
+++ b/tests/server/test_release_issue_fail_label.py
@@ -34,13 +34,9 @@ class TestReleaseIssueFailLabel:
         mock_client.ensure_label.assert_called_once_with(
             "owner", "repo", "fail", color="d73a4a", description="Recipe execution failed"
         )
-        mock_client.swap_labels.assert_called_once_with(
-            "owner",
-            "repo",
-            42,
-            remove_labels=["in-progress"],
-            add_labels=["fail"],
-        )
+        swap_call = mock_client.swap_labels.call_args
+        assert set(swap_call.kwargs["remove_labels"]) == {"in-progress", "queued"}
+        assert swap_call.kwargs["add_labels"] == ["fail"]
 
     @pytest.mark.anyio
     async def test_release_issue_success_removes_fail_label(

--- a/tests/server/test_release_issue_fail_label.py
+++ b/tests/server/test_release_issue_fail_label.py
@@ -62,6 +62,7 @@ class TestReleaseIssueFailLabel:
         swap_call = mock_client.swap_labels.call_args
         assert "in-progress" in swap_call.kwargs["remove_labels"]
         assert "fail" in swap_call.kwargs["remove_labels"]
+        assert "queued" in swap_call.kwargs["remove_labels"]
         assert "staged" in swap_call.kwargs["add_labels"]
 
     @pytest.mark.anyio
@@ -83,6 +84,7 @@ class TestReleaseIssueFailLabel:
         swap_call = mock_client.swap_labels.call_args
         assert "in-progress" in swap_call.kwargs["remove_labels"]
         assert "fail" in swap_call.kwargs["remove_labels"]
+        assert "queued" in swap_call.kwargs["remove_labels"]
 
 
 class TestClaimIssueFailLabelCleanup:
@@ -111,11 +113,7 @@ class TestClaimIssueFailLabelCleanup:
 
         assert result["success"] is True
         assert result["claimed"] is True
-        mock_client.swap_labels.assert_called_once_with(
-            "owner",
-            "repo",
-            42,
-            remove_labels=["fail"],
-            add_labels=["in-progress"],
-        )
+        call_kwargs = mock_client.swap_labels.call_args.kwargs
+        assert set(call_kwargs["remove_labels"]) == {"queued", "fail"}
+        assert call_kwargs["add_labels"] == ["in-progress"]
         mock_client.add_labels.assert_not_called()

--- a/tests/server/test_release_issue_fail_label.py
+++ b/tests/server/test_release_issue_fail_label.py
@@ -31,7 +31,9 @@ class TestReleaseIssueFailLabel:
         assert result["success"] is True
         assert result["failed"] is True
         assert result["fail_label"] == "fail"
-        mock_client.ensure_label.assert_called_once_with("owner", "repo", "fail", color="d73a4a")
+        mock_client.ensure_label.assert_called_once_with(
+            "owner", "repo", "fail", color="d73a4a", description="Recipe execution failed"
+        )
         mock_client.swap_labels.assert_called_once_with(
             "owner",
             "repo",

--- a/tests/server/test_tools_bootstrap.py
+++ b/tests/server/test_tools_bootstrap.py
@@ -220,9 +220,9 @@ class TestClaimAndResolveIssue:
             color="c2e0c6",
             description="Issue claimed by orchestrator, waiting for recipe pickup",
         )
-        tool_ctx_kitchen_open.github_client.swap_labels.assert_called_once_with(
-            "owner", "repo", 42, remove_labels=["fail"], add_labels=["queued"]
-        )
+        call_kwargs = tool_ctx_kitchen_open.github_client.swap_labels.call_args.kwargs
+        assert set(call_kwargs["remove_labels"]) == {"fail"}
+        assert call_kwargs["add_labels"] == ["queued"]
 
     @pytest.mark.anyio
     async def test_claim_and_resolve_default_removes_queued(self, tool_ctx_kitchen_open):

--- a/tests/server/test_tools_bootstrap.py
+++ b/tests/server/test_tools_bootstrap.py
@@ -195,6 +195,55 @@ class TestClaimAndResolveIssue:
         assert "fetch_title_ms" in result["timings"]
         assert "claim_ms" in result["timings"]
 
+    @pytest.mark.anyio
+    async def test_claim_and_resolve_with_queued_label(self, tool_ctx_kitchen_open):
+        """claim_and_resolve_issue with label=queued uses registry color and removes fail."""
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
+            return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
+        )
+        tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+            return_value={"success": True, "labels": []}
+        )
+        tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(
+            return_value={"success": True}
+        )
+        tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
+        result = json.loads(
+            await claim_and_resolve_issue(issue_url="owner/repo#42", label="queued")
+        )
+        assert result["claimed"] is True
+        tool_ctx_kitchen_open.github_client.ensure_label.assert_called_once_with(
+            "owner",
+            "repo",
+            "queued",
+            color="c2e0c6",
+            description="Issue claimed by orchestrator, waiting for recipe pickup",
+        )
+        tool_ctx_kitchen_open.github_client.swap_labels.assert_called_once_with(
+            "owner", "repo", 42, remove_labels=["fail"], add_labels=["queued"]
+        )
+
+    @pytest.mark.anyio
+    async def test_claim_and_resolve_default_removes_queued(self, tool_ctx_kitchen_open):
+        """claim_and_resolve_issue with default label removes both queued and fail."""
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
+            return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
+        )
+        tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+            return_value={"success": True, "labels": []}
+        )
+        tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(
+            return_value={"success": True}
+        )
+        tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
+        result = json.loads(await claim_and_resolve_issue(issue_url="owner/repo#42"))
+        assert result["claimed"] is True
+        call_kwargs = tool_ctx_kitchen_open.github_client.swap_labels.call_args.kwargs
+        assert set(call_kwargs["remove_labels"]) >= {"queued", "fail"}
+        assert call_kwargs["add_labels"] == ["in-progress"]
+
 
 class TestCreateAndPublishBranch:
     @pytest.mark.anyio

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -161,9 +161,9 @@ class TestClaimIssueTool:
             color="c2e0c6",
             description="Issue claimed by orchestrator, waiting for recipe pickup",
         )
-        mock_client.swap_labels.assert_called_once_with(
-            "owner", "repo", 1, remove_labels=["fail"], add_labels=["queued"]
-        )
+        call_kwargs = mock_client.swap_labels.call_args.kwargs
+        assert set(call_kwargs["remove_labels"]) == {"fail"}
+        assert call_kwargs["add_labels"] == ["queued"]
 
     @pytest.mark.anyio
     async def test_claim_issue_default_removes_queued_and_fail(self, tool_ctx_kitchen_open):

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -137,9 +137,9 @@ class TestClaimIssueTool:
         assert result["success"] is True
         assert result["claimed"] is True
         assert result.get("reentry", False) is False
-        mock_client.swap_labels.assert_called_once_with(
-            "owner", "repo", 42, remove_labels=["fail"], add_labels=["in-progress"]
-        )
+        call_kwargs = mock_client.swap_labels.call_args.kwargs
+        assert set(call_kwargs["remove_labels"]) == {"queued", "fail"}
+        assert call_kwargs["add_labels"] == ["in-progress"]
 
     @pytest.mark.anyio
     async def test_claim_issue_with_queued_label(self, tool_ctx_kitchen_open):

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -141,6 +141,52 @@ class TestClaimIssueTool:
             "owner", "repo", 42, remove_labels=["fail"], add_labels=["in-progress"]
         )
 
+    @pytest.mark.anyio
+    async def test_claim_issue_with_queued_label(self, tool_ctx_kitchen_open):
+        """claim_issue with label=queued uses registry color/description and removes fail."""
+        mock_client = AsyncMock()
+        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.ensure_label.return_value = {"success": True, "created": True}
+        mock_client.swap_labels.return_value = {"success": True, "labels": ["queued"]}
+        tool_ctx_kitchen_open.github_client = mock_client
+        result = json.loads(
+            await claim_issue(issue_url="https://github.com/owner/repo/issues/1", label="queued")
+        )
+        assert result["success"] is True
+        assert result["claimed"] is True
+        mock_client.ensure_label.assert_called_once_with(
+            "owner",
+            "repo",
+            "queued",
+            color="c2e0c6",
+            description="Issue claimed by orchestrator, waiting for recipe pickup",
+        )
+        mock_client.swap_labels.assert_called_once_with(
+            "owner", "repo", 1, remove_labels=["fail"], add_labels=["queued"]
+        )
+
+    @pytest.mark.anyio
+    async def test_claim_issue_default_removes_queued_and_fail(self, tool_ctx_kitchen_open):
+        """claim_issue with default label removes both queued and fail labels."""
+        mock_client = AsyncMock()
+        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.ensure_label.return_value = {"success": True, "created": True}
+        mock_client.swap_labels.return_value = {"success": True, "labels": ["in-progress"]}
+        tool_ctx_kitchen_open.github_client = mock_client
+        result = json.loads(await claim_issue(issue_url="https://github.com/owner/repo/issues/1"))
+        assert result["success"] is True
+        assert result["claimed"] is True
+        mock_client.ensure_label.assert_called_once_with(
+            "owner",
+            "repo",
+            "in-progress",
+            color="fbca04",
+            description="Issue is actively being processed by a pipeline session",
+        )
+        call_kwargs = mock_client.swap_labels.call_args.kwargs
+        assert set(call_kwargs["remove_labels"]) >= {"queued", "fail"}
+        assert call_kwargs["add_labels"] == ["in-progress"]
+
 
 class TestReleaseIssueTool:
     def test_release_issue_is_gated(self):

--- a/tests/server/test_tools_integrations_release.py
+++ b/tests/server/test_tools_integrations_release.py
@@ -38,7 +38,7 @@ class TestReleaseIssueStagedLifecycle:
             "repo",
             "staged",
             color="0075ca",
-            description="Implementation staged and waiting for promotion to main",
+            description="Issue resolved, PR staged for promotion",
         )
         mock_client.swap_labels.assert_called_once()
 

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -76,6 +76,24 @@ class TestClaimIssueWhitelist:
         )
         assert result["success"] is True
 
+    @pytest.mark.anyio
+    async def test_queued_label_is_allowed_by_default(self, tool_ctx_kitchen_open, monkeypatch):
+        """claim_issue with label=queued succeeds when allowed_labels defaults to empty."""
+        tool_ctx_kitchen_open.config.github.allowed_labels = []
+        mock_client = AsyncMock()
+        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.ensure_label.return_value = {"success": True, "created": True}
+        mock_client.swap_labels.return_value = {"success": True, "labels": ["queued"]}
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
+
+        result = json.loads(
+            await claim_issue(
+                issue_url="https://github.com/owner/repo/issues/1",
+                label="queued",
+            )
+        )
+        assert result["success"] is True
+
 
 class TestReleaseIssueWhitelist:
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Formalize the issue label lifecycle as a first-class discrete system by introducing an `IssueLabelState` enum, a `LabelDef` registry with per-state metadata (color, description, swap semantics), and a transition table with validation — modeled after the fleet `DispatchStatus` pattern. Add `queued` as the fifth lifecycle state. Refactor `claim_issue`, `release_issue`, and `claim_and_resolve_issue` to derive colors, descriptions, and swap-remove sets from the registry instead of hardcoding them. Update `process-issues` Phase 0.5 to apply `queued` (not `in-progress`) during upfront claiming, and add a `queued → in-progress` swap at recipe pickup.

## Requirements

### R1: Formalize Label Lifecycle as a Discrete System

Create an architectural component (enum + registry or Protocol-based approach) where each **lifecycle label** (as distinct from classification labels like `recipe:implementation`) is a first-class entity that declares:

1. **Label name** — the GitHub label string (e.g., `"queued"`, `"in-progress"`, `"staged"`, `"fail"`)
2. **Color** — hex color for `ensure_label` (currently hardcoded: `fbca04` for in-progress, `0075ca` for staged, `d73a4a` for fail)
3. **Description** — human-readable description for `ensure_label`
4. **Swap semantics** — which labels to remove when entering this state (e.g., entering `in-progress` removes `queued` and `fail`)
5. **Valid transitions** — which states this label can transition to (modeled after `_ALLOWED_TRANSITIONS` in fleet)

When a new lifecycle label is added, the system must enforce that all of these are defined. No hanging labels — every label in the lifecycle participates in the tracking history.

### R2: Add `queued` Lifecycle State

Add a `queued` label with the following lifecycle position:

```
[unlabeled / triaged]
        │
        │ upfront claim (Phase 0.5)
        ▼
    [queued]          ← claimed by orchestrator, not yet processing
        │
        │ recipe session begins
        ▼
  [in-progress]      ← recipe actively executing
        │
        ├─ success → [staged]
        ├─ failure → [fail]
        └─ bare    → [unlabeled]
```

Transitions for `queued`:
- **Entry**: from unlabeled/fail (upfront claim swaps `fail` → `queued`)
- **Exit**: to `in-progress` (recipe pickup), or to unlabeled (fatal cleanup release)

### R3: Integrate with `process-issues` Workflow

Update `process-issues/SKILL.md` Phase 0.5 and Step 3:

- **Phase 0.5 (upfront claiming)**: `claim_issue` should apply `queued` instead of `in-progress`
- **Step 3b.1 (recipe pickup)**: Before loading the recipe, swap `queued` → `in-progress` for the specific issue being processed
- **Fatal failure cleanup**: Release all `queued` issues (not just `in-progress`) back to unlabeled
- **Recipe `claim_and_resolve` step**: When `upfront_claimed=true`, the issue arrives with `queued` (not `in-progress`), so the reentry path needs to handle the `queued` → `in-progress` swap

### R4: Integration Points

These components need updates:

| Component | File | Change |
|-----------|------|--------|
| `GitHubConfig` | `config/_config_dataclasses.py` | Add `queued_label` field (or migrate to registry) |
| `defaults.yaml` | `config/defaults.yaml` | Add `queued` to `allowed_labels` and label config |
| `claim_issue` | `server/tools/tools_issue_lifecycle.py` | Support claiming with `queued` label |
| `claim_and_resolve_issue` | `server/tools/tools_issue_composite.py` | Handle `queued` → `in-progress` transition |
| `release_issue` | `server/tools/tools_issue_lifecycle.py` | Remove `queued` in cleanup paths |
| `swap_labels` | `execution/github.py` | No change needed (generic) |
| `process-issues` | `skills_extended/process-issues/SKILL.md` | Phase 0.5 uses `queued`, Step 3 swaps to `in-progress` |
| `build-execution-map` | `skills_extended/build-execution-map/SKILL.md` | Query `queued` label alongside `in-progress` for conflict detection |

### R5: Classification vs. Lifecycle Label Distinction

The system should distinguish between:
- **Lifecycle labels** (`queued`, `in-progress`, `staged`, `fail`) — managed by the state machine, subject to atomic swaps and transition validation
- **Classification labels** (`recipe:implementation`, `recipe:remediation`, `bug`, `enhancement`, `autoreported`) — applied by triage/reporting, never removed by the pipeline, not part of the state machine

This distinction should be encoded in the architecture, not just documented.

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260508-023057-647423/.autoskillit/temp/make-plan/formalize_issue_label_lifecycle_plan_2026-05-08_023500_part_a.md`
- `/home/talon/projects/autoskillit-runs/impl-20260508-023057-647423/.autoskillit/temp/make-plan/formalize_issue_label_lifecycle_plan_2026-05-08_023500_part_b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 80 | 32.2k | 840.0k | 81.9k | 100 | 82.2k | 18m 26s |
| verify | claude-sonnet-4-6 | 2 | 1.9k | 27.0k | 1.9M | 77.8k | 210 | 108.7k | 15m 53s |
| implement* | MiniMax-M2.7-highspeed | 2 | 5.8M | 44.2k | 4.9M | 87.5k | 374 | 272.0k | 25m 15s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 91.2k | 8.3k | 206.6k | 34.2k | 25 | 60.5k | 2m 7s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 44.8k | 2.3k | 169.6k | 28.7k | 14 | 15.1k | 55s |
| review_pr | claude-sonnet-4-6 | 2 | 242 | 68.4k | 1.6M | 92.5k | 85 | 159.0k | 15m 47s |
| resolve_review | claude-sonnet-4-6 | 2 | 748 | 61.7k | 8.1M | 131.6k | 289 | 194.0k | 24m 33s |
| **Total** | | | 6.0M | 244.1k | 17.7M | 131.6k | | 891.6k | 1h 42m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 604 | 8054.5 | 450.4 | 73.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 112 | 72601.6 | 1732.5 | 551.1 |
| **Total** | **716** | 24692.2 | 1245.2 | 340.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 2.3k | 80.7k | 6.0M | 289.2k | 51m 34s |
| MiniMax-M2.7-highspeed | 3 | 6.0M | 54.8k | 5.2M | 347.7k | 28m 17s |