### PR TITLE
_clear_dispatch_for_retry leaks stale kill_reason and infra_exit_category

### DIFF
--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -105,6 +105,8 @@ def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
     d.started_at = 0.0
     d.ended_at = 0.0
     d.sidecar_path = None
+    d.kill_reason = ""
+    d.infra_exit_category = ""
 
 
 def reset_failed_dispatch(state_path: Path, dispatch_name: str) -> bool:

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -16,6 +18,7 @@ from autoskillit.fleet import (
     resume_campaign_from_state,
     write_initial_state,
 )
+from autoskillit.fleet.state import _clear_dispatch_for_retry
 from autoskillit.fleet.state_types import _validate_transition
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
@@ -73,6 +76,8 @@ class TestResetFailedDispatch:
                 started_at=1000.0,
                 ended_at=2000.0,
                 sidecar_path="/old/sidecar",
+                kill_reason="stale",
+                infra_exit_category="timeout",
             ),
         )
 
@@ -94,6 +99,8 @@ class TestResetFailedDispatch:
         assert d2.started_at == 0.0
         assert d2.ended_at == 0.0
         assert d2.sidecar_path is None
+        assert d2.kill_reason == ""
+        assert d2.infra_exit_category == ""
 
     def test_returns_true_on_success(self, tmp_path: Path):
         """Returns True when the dispatch was actually reset."""
@@ -239,3 +246,70 @@ class TestResumeResetOnRetry:
 
         assert decision is not None
         assert decision.completed_dispatches_block == "- d1: success"
+
+    def test_stale_kill_reason_does_not_survive_retry(self, tmp_path: Path):
+        """Stale kill_reason from prior failure must not leak through retry reset."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1", "d2"))
+        append_dispatch_record(sp, DispatchRecord(name="d1", status=DispatchStatus.SUCCESS))
+        append_dispatch_record(
+            sp,
+            DispatchRecord(
+                name="d2",
+                status=DispatchStatus.FAILURE,
+                kill_reason="stale",
+                infra_exit_category="timeout",
+            ),
+        )
+
+        resume_campaign_from_state(sp, continue_on_failure=False, reset_on_retry=True)
+
+        state = read_state(sp)
+        assert state is not None
+        d2 = next(d for d in state.dispatches if d.name == "d2")
+        assert d2.kill_reason == ""
+        assert d2.infra_exit_category == ""
+
+
+# --- structural guard: field coverage ---
+
+
+class TestClearDispatchFieldCoverage:
+    """Structural guard: _clear_dispatch_for_retry must reset all execution-metadata fields."""
+
+    _IDENTITY_FIELDS = frozenset({"name", "campaign_id", "caller_session_id"})
+
+    def test_clear_covers_all_execution_metadata_fields(self):
+        """Every non-identity field must be reset to its default by _clear_dispatch_for_retry."""
+        dirty_values: dict[str, Any] = {
+            "name": "test",
+            "status": DispatchStatus.FAILURE,
+            "dispatch_id": "dirty-id",
+            "campaign_id": "cid",
+            "caller_session_id": "csid",
+            "dispatched_session_id": "dirty-sess",
+            "dispatched_session_log_dir": "/dirty/log",
+            "dispatched_pid": 99999,
+            "dispatched_starttime_ticks": 12345,
+            "dispatched_boot_id": "dirty-boot",
+            "reason": "dirty-reason",
+            "kill_reason": "stale",
+            "infra_exit_category": "timeout",
+            "token_usage": {"prompt_tokens": 500},
+            "started_at": 1000.0,
+            "ended_at": 2000.0,
+            "sidecar_path": "/dirty/sidecar",
+        }
+        d = DispatchRecord(**dirty_values)
+        _clear_dispatch_for_retry(d)
+
+        for f in dataclasses.fields(d):
+            if f.name in self._IDENTITY_FIELDS:
+                continue
+            default = (
+                f.default_factory() if f.default_factory is not dataclasses.MISSING else f.default
+            )
+            assert getattr(d, f.name) == default, (
+                f"_clear_dispatch_for_retry did not reset {f.name!r} to its default "
+                f"({default!r}); got {getattr(d, f.name)!r}"
+            )

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -283,23 +283,29 @@ class TestClearDispatchFieldCoverage:
         """Every non-identity field must be reset to its default by _clear_dispatch_for_retry."""
         dirty_values: dict[str, Any] = {
             "name": "test",
-            "status": DispatchStatus.FAILURE,
-            "dispatch_id": "dirty-id",
             "campaign_id": "cid",
             "caller_session_id": "csid",
-            "dispatched_session_id": "dirty-sess",
-            "dispatched_session_log_dir": "/dirty/log",
-            "dispatched_pid": 99999,
-            "dispatched_starttime_ticks": 12345,
-            "dispatched_boot_id": "dirty-boot",
-            "reason": "dirty-reason",
-            "kill_reason": "stale",
-            "infra_exit_category": "timeout",
-            "token_usage": {"prompt_tokens": 500},
-            "started_at": 1000.0,
-            "ended_at": 2000.0,
-            "sidecar_path": "/dirty/sidecar",
         }
+        for f in dataclasses.fields(DispatchRecord):
+            if f.name in dirty_values:
+                continue
+            default = (
+                f.default_factory() if f.default_factory is not dataclasses.MISSING else f.default
+            )
+            if isinstance(default, str):
+                dirty_values[f.name] = f"dirty-{f.name}"
+            elif isinstance(default, int):
+                dirty_values[f.name] = 99999
+            elif isinstance(default, float):
+                dirty_values[f.name] = 9999.0
+            elif isinstance(default, dict):
+                dirty_values[f.name] = {"prompt_tokens": 500}
+            elif default is None:
+                dirty_values[f.name] = "/dirty/path"
+            elif isinstance(default, DispatchStatus):
+                dirty_values[f.name] = DispatchStatus.FAILURE
+            else:
+                raise AssertionError(f"Unhandled default type for {f.name!r}: {type(default)}")
         d = DispatchRecord(**dirty_values)
         _clear_dispatch_for_retry(d)
 


### PR DESCRIPTION
## Summary

`_clear_dispatch_for_retry` (`fleet/state.py:93-107`) resets 12 execution-metadata fields on a `DispatchRecord` but omits `kill_reason` and `infra_exit_category`. When a dispatch previously killed with `RetryReason.STALE` is retried and the retry crashes, `crash_recover_dispatch` reads the stale `kill_reason="stale"` from the prior run. `_is_abandon_kill_reason` matches it against `_ABANDON_KILL_REASONS` and classifies the dispatch as INTERRUPTED instead of RESUMABLE — silently poisoning crash recovery.

The fix adds two field resets and a structural guard test that prevents future field omissions.

Closes #2234

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260508-114318-799383/.autoskillit/temp/make-plan/clear_dispatch_for_retry_leaks_stale_kill_reason_plan_2026-05-08_114500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 67 | 6.3k | 471.9k | 50.0k | 55 | 40.5k | 3m 36s |
| verify | claude-sonnet-4-6 | 1 | 124 | 9.6k | 557.6k | 54.7k | 40 | 81.1k | 2m 45s |
| implement* | MiniMax-M2.7-highspeed | 1 | 303.6k | 7.4k | 631.2k | 50.2k | 49 | 41.4k | 3m 49s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 77.1k | 3.1k | 235.6k | 29.8k | 19 | 15.4k | 1m 5s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 36.6k | 1.3k | 176.0k | 29.8k | 14 | 15.1k | 39s |
| review_pr | claude-sonnet-4-6 | 3 | 300 | 37.6k | 1.3M | 51.6k | 112 | 109.3k | 9m 20s |
| resolve_review | claude-sonnet-4-6 | 1 | 177 | 11.4k | 946.3k | 61.8k | 53 | 49.3k | 4m 19s |
| **Total** | | | 418.0k | 76.7k | 4.3M | 61.8k | | 352.1k | 25m 36s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 76 | 8304.9 | 545.2 | 97.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 34 | 27833.6 | 1449.6 | 336.7 |
| **Total** | **110** | 39502.0 | 3201.2 | 697.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 67 | 6.3k | 471.9k | 40.5k | 3m 36s |
| claude-sonnet-4-6 | 1 | 124 | 9.6k | 557.6k | 81.1k | 2m 45s |
| MiniMax-M2.7-highspeed | 3 | 417.3k | 11.8k | 1.0M | 71.9k | 5m 33s |