### PR TITLE
Fix research campaign recipe chain: phantom captures, missing forwarding, dead declarations

### DIFF
--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -68,7 +68,9 @@
         "worktree_path": "${{ result.worktree_path }}",
         "research_dir": "${{ result.research_dir }}",
         "experiment_plan": "${{ result.experiment_plan }}",
-        "visualization_plan_path": "${{ result.visualization_plan_path }}"
+        "visualization_plan_path": "${{ result.visualization_plan_path }}",
+        "scope_report": "${{ result.scope_report }}",
+        "experiment_type": "${{ result.experiment_type }}"
       },
       "depends_on": []
     },
@@ -77,6 +79,7 @@
       "recipe": "research-implement",
       "task": "Implement the research experiment plan.",
       "ingredients": {
+        "task": "${{ inputs.task }}",
         "worktree_path": "${{ campaign.worktree_path }}",
         "research_dir": "${{ campaign.research_dir }}",
         "experiment_plan": "${{ campaign.experiment_plan }}",
@@ -87,7 +90,8 @@
         "output_mode": "${{ inputs.output_mode }}"
       },
       "capture": {
-        "report_path": "${{ result.report_path }}"
+        "report_path": "${{ result.report_path }}",
+        "experiment_results": "${{ result.experiment_results }}"
       },
       "depends_on": [
         "run-design"
@@ -98,6 +102,10 @@
       "recipe": "research-review",
       "task": "Review the research experiment and open PR.",
       "ingredients": {
+        "task": "${{ inputs.task }}",
+        "experiment_results": "${{ campaign.experiment_results }}",
+        "experiment_type": "${{ campaign.experiment_type }}",
+        "scope_report": "${{ campaign.scope_report }}",
         "worktree_path": "${{ campaign.worktree_path }}",
         "research_dir": "${{ campaign.research_dir }}",
         "experiment_plan": "${{ campaign.experiment_plan }}",
@@ -112,7 +120,6 @@
       },
       "capture": {
         "pr_url": "${{ result.pr_url }}",
-        "all_diagram_paths": "${{ result.all_diagram_paths }}",
         "report_path_after_finalize": "${{ result.report_path_after_finalize }}"
       },
       "depends_on": [
@@ -127,9 +134,7 @@
         "base_branch": "${{ inputs.base_branch }}",
         "worktree_path": "${{ campaign.worktree_path }}",
         "research_dir": "${{ campaign.research_dir }}",
-        "pr_url": "${{ campaign.pr_url }}",
-        "all_diagram_paths": "${{ campaign.all_diagram_paths }}",
-        "report_path_after_finalize": "${{ campaign.report_path_after_finalize }}"
+        "pr_url": "${{ campaign.pr_url }}"
       },
       "capture": {},
       "depends_on": [

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -74,12 +74,15 @@ dispatches:
       research_dir: "${{ result.research_dir }}"
       experiment_plan: "${{ result.experiment_plan }}"
       visualization_plan_path: "${{ result.visualization_plan_path }}"
+      scope_report: "${{ result.scope_report }}"
+      experiment_type: "${{ result.experiment_type }}"
     depends_on: []
 
   - name: run-implement
     recipe: research-implement
     task: "Implement the research experiment plan."
     ingredients:
+      task: "${{ inputs.task }}"
       worktree_path: "${{ campaign.worktree_path }}"
       research_dir: "${{ campaign.research_dir }}"
       experiment_plan: "${{ campaign.experiment_plan }}"
@@ -90,6 +93,7 @@ dispatches:
       output_mode: "${{ inputs.output_mode }}"
     capture:
       report_path: "${{ result.report_path }}"
+      experiment_results: "${{ result.experiment_results }}"
     depends_on:
       - run-design
 
@@ -97,6 +101,10 @@ dispatches:
     recipe: research-review
     task: "Review the research experiment and open PR."
     ingredients:
+      task: "${{ inputs.task }}"
+      experiment_results: "${{ campaign.experiment_results }}"
+      experiment_type: "${{ campaign.experiment_type }}"
+      scope_report: "${{ campaign.scope_report }}"
       worktree_path: "${{ campaign.worktree_path }}"
       research_dir: "${{ campaign.research_dir }}"
       experiment_plan: "${{ campaign.experiment_plan }}"
@@ -110,7 +118,6 @@ dispatches:
       audit_claims: "${{ inputs.audit_claims }}"
     capture:
       pr_url: "${{ result.pr_url }}"
-      all_diagram_paths: "${{ result.all_diagram_paths }}"
       report_path_after_finalize: "${{ result.report_path_after_finalize }}"
     depends_on:
       - run-implement
@@ -123,8 +130,6 @@ dispatches:
       worktree_path: "${{ campaign.worktree_path }}"
       research_dir: "${{ campaign.research_dir }}"
       pr_url: "${{ campaign.pr_url }}"
-      all_diagram_paths: "${{ campaign.all_diagram_paths }}"
-      report_path_after_finalize: "${{ campaign.report_path_after_finalize }}"
     capture: {}
     depends_on:
       - run-review

--- a/src/autoskillit/recipes/research-archive.json
+++ b/src/autoskillit/recipes/research-archive.json
@@ -1,6 +1,7 @@
 {
   "name": "research-archive",
   "recipe_version": "1.0.0",
+  "kind": "food-truck",
   "categories": [
     "research-family"
   ],
@@ -23,16 +24,6 @@
     },
     "pr_url": {
       "description": "URL of the original experiment PR (passed by campaign dispatch)",
-      "required": true,
-      "hidden": true
-    },
-    "all_diagram_paths": {
-      "description": "Paths to all generated diagrams (passed by campaign dispatch)",
-      "required": true,
-      "hidden": true
-    },
-    "report_path_after_finalize": {
-      "description": "Path to the finalized research report (passed by campaign dispatch)",
       "required": true,
       "hidden": true
     },

--- a/src/autoskillit/recipes/research-archive.yaml
+++ b/src/autoskillit/recipes/research-archive.yaml
@@ -1,5 +1,6 @@
 name: research-archive
 recipe_version: "1.0.0"
+kind: food-truck
 categories: [research-family]
 requires_packs: [github, ci]
 description: >
@@ -23,14 +24,6 @@ ingredients:
     hidden: true
   pr_url:
     description: URL of the original experiment PR (passed by campaign dispatch)
-    required: true
-    hidden: true
-  all_diagram_paths:
-    description: Paths to all generated diagrams (passed by campaign dispatch)
-    required: true
-    hidden: true
-  report_path_after_finalize:
-    description: Path to the finalized research report (passed by campaign dispatch)
     required: true
     hidden: true
 

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -214,7 +214,7 @@
     },
     "design_complete": {
       "action": "stop",
-      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=<context.worktree_path>, research_dir=<context.research_dir>. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\"}"
+      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=${{ context.worktree_path }}, research_dir=${{ context.research_dir }}. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\"}"
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -1,6 +1,7 @@
 {
   "name": "research-design",
   "recipe_version": "1.0.0",
+  "kind": "food-truck",
   "categories": [
     "research-family"
   ],
@@ -115,9 +116,10 @@
       },
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
-        "report_plan_path": "${{ result.report_plan_path }}"
+        "report_plan_path": "${{ result.report_plan_path }}",
+        "visualization_plan_trace_path": "${{ result.visualization_plan_trace_path }}"
       },
-      "on_success": "design_complete",
+      "on_success": "create_worktree",
       "on_failure": "escalate_stop",
       "note": "Selects 2–4 vis-lens skills via three-tier logic, runs them in parallel, and synthesizes outputs into visualization-plan.md and report-plan.md. Runs before worktree creation so outputs can be committed into the research dir.\n"
     },
@@ -192,9 +194,27 @@
       "action": "stop",
       "message": "Research pipeline halted: experiment design rejected (verdict=STOP, resolution=failed). All stop-trigger findings are structural — revision cannot address the identified flaws. Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard.\n"
     },
+    "create_worktree": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}' '${{ context.visualization_plan_trace_path }}'",
+        "cwd": "${{ inputs.source_dir }}",
+        "step_name": "create_worktree"
+      },
+      "capture": {
+        "worktree_path": "${{ result.worktree_path }}",
+        "research_dir": "${{ result.research_dir }}"
+      },
+      "optional_context_refs": [
+        "evaluation_dashboard",
+        "visualization_plan_trace_path"
+      ],
+      "on_success": "design_complete",
+      "on_failure": "escalate_stop"
+    },
     "design_complete": {
       "action": "stop",
-      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\"}"
+      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=<context.worktree_path>, research_dir=<context.research_dir>. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\"}"
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -197,7 +197,7 @@
     "create_worktree": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}' '${{ context.visualization_plan_trace_path }}'",
+        "cmd": "bash scripts/recipe/create_worktree.sh \"${{ inputs.source_dir }}\" \"${{ inputs.task }}\" \"${{ context.experiment_plan }}\" \"${{ context.scope_report }}\" \"${{ context.evaluation_dashboard }}\" \"${{ context.visualization_plan_path }}\" \"${{ context.report_plan_path }}\" \"{{AUTOSKILLIT_TEMP}}\" \"${{ context.visualization_plan_trace_path }}\"",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "create_worktree"
       },

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -178,7 +178,7 @@ steps:
   create_worktree:
     tool: run_cmd
     with:
-      cmd: "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}' '${{ context.visualization_plan_trace_path }}'"
+      cmd: "bash scripts/recipe/create_worktree.sh \"${{ inputs.source_dir }}\" \"${{ inputs.task }}\" \"${{ context.experiment_plan }}\" \"${{ context.scope_report }}\" \"${{ context.evaluation_dashboard }}\" \"${{ context.visualization_plan_path }}\" \"${{ context.report_plan_path }}\" \"{{AUTOSKILLIT_TEMP}}\" \"${{ context.visualization_plan_trace_path }}\""
       cwd: "${{ inputs.source_dir }}"
       step_name: create_worktree
     capture:

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -198,8 +198,8 @@ steps:
       visualization_plan_path=<context.visualization_plan_path>,
       report_plan_path=<context.report_plan_path>,
       experiment_type=<context.experiment_type>,
-      worktree_path=<context.worktree_path>,
-      research_dir=<context.research_dir>.
+      worktree_path=${{ context.worktree_path }},
+      research_dir=${{ context.research_dir }}.
       Example sentinel:
       {"success": true, "scope_report": "<path>", "experiment_plan": "<path>",
       "visualization_plan_path": "<path>", "report_plan_path": "<path>",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -1,5 +1,6 @@
 name: research-design
 recipe_version: "1.0.0"
+kind: food-truck
 categories: [research-family]
 requires_packs: [research, vis-lens]
 description: >
@@ -108,7 +109,8 @@ steps:
     capture:
       visualization_plan_path: "${{ result.visualization_plan_path }}"
       report_plan_path: "${{ result.report_plan_path }}"
-    on_success: design_complete
+      visualization_plan_trace_path: "${{ result.visualization_plan_trace_path }}"
+    on_success: create_worktree
     on_failure: escalate_stop
     note: >
       Selects 2–4 vis-lens skills via three-tier logic, runs them in parallel, and
@@ -173,6 +175,19 @@ steps:
       Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and
       {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard.
 
+  create_worktree:
+    tool: run_cmd
+    with:
+      cmd: "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}' '${{ context.visualization_plan_trace_path }}'"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: create_worktree
+    capture:
+      worktree_path: "${{ result.worktree_path }}"
+      research_dir: "${{ result.research_dir }}"
+    optional_context_refs: [evaluation_dashboard, visualization_plan_trace_path]
+    on_success: design_complete
+    on_failure: escalate_stop
+
   design_complete:
     action: stop
     message: >-
@@ -182,11 +197,14 @@ steps:
       experiment_plan=<context.experiment_plan>,
       visualization_plan_path=<context.visualization_plan_path>,
       report_plan_path=<context.report_plan_path>,
-      experiment_type=<context.experiment_type>.
+      experiment_type=<context.experiment_type>,
+      worktree_path=<context.worktree_path>,
+      research_dir=<context.research_dir>.
       Example sentinel:
       {"success": true, "scope_report": "<path>", "experiment_plan": "<path>",
       "visualization_plan_path": "<path>", "report_plan_path": "<path>",
-      "experiment_type": "benchmark"}
+      "experiment_type": "benchmark",
+      "worktree_path": "<path>", "research_dir": "<path>"}
 
   escalate_stop:
     action: stop

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -1,6 +1,7 @@
 {
   "name": "research-implement",
   "recipe_version": "1.0.0",
+  "kind": "food-truck",
   "categories": [
     "research-family"
   ],

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -1,5 +1,6 @@
 name: research-implement
 recipe_version: "1.0.0"
+kind: food-truck
 categories: [research-family]
 requires_packs: [research]
 description: >

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -1,6 +1,7 @@
 {
   "name": "research-review",
   "recipe_version": "1.0.0",
+  "kind": "food-truck",
   "categories": [
     "research-family"
   ],

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -1,5 +1,6 @@
 name: research-review
 recipe_version: "1.0.0"
+kind: food-truck
 categories: [research-family]
 requires_packs: [research, exp-lens, vis-lens]
 description: >

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -231,7 +231,6 @@ class TestResearchDesignRecipeStructure:
                 f"design_complete message must mention sentinel field: {field}"
             )
 
-    # T2: Design recipe has create_worktree step with correct captures
     def test_design_recipe_has_create_worktree_step(self, recipe) -> None:
         step = recipe.steps["create_worktree"]
         assert step.tool == "run_cmd"
@@ -239,7 +238,6 @@ class TestResearchDesignRecipeStructure:
         assert "research_dir" in step.capture
         assert step.on_success == "design_complete"
 
-    # T3: Design sentinel message includes worktree fields
     def test_design_sentinel_emits_worktree_fields(self, recipe) -> None:
         sentinel = recipe.steps["design_complete"]
         assert "worktree_path" in sentinel.message

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -56,7 +56,7 @@ class TestResearchDesignRecipeStructure:
         assert recipe.ingredients["issue_url"].required is False
 
     def test_step_count(self, recipe) -> None:
-        assert len(recipe.steps) == 10
+        assert len(recipe.steps) == 11
 
     def test_step_names(self, recipe) -> None:
         expected = {
@@ -64,6 +64,7 @@ class TestResearchDesignRecipeStructure:
             "plan_experiment",
             "review_design",
             "plan_visualization",
+            "create_worktree",
             "revise_design",
             "check_design_review_loop",
             "resolve_design_review",
@@ -148,7 +149,7 @@ class TestResearchDesignRecipeStructure:
             assert key in capture, f"Missing capture key: {key}"
 
     def test_plan_visualization_on_success(self, recipe) -> None:
-        assert recipe.steps["plan_visualization"].on_success == "design_complete"
+        assert recipe.steps["plan_visualization"].on_success == "create_worktree"
 
     def test_plan_visualization_on_failure(self, recipe) -> None:
         assert recipe.steps["plan_visualization"].on_failure == "escalate_stop"
@@ -223,34 +224,31 @@ class TestResearchDesignRecipeStructure:
             "visualization_plan_path",
             "report_plan_path",
             "experiment_type",
+            "worktree_path",
+            "research_dir",
         ):
             assert field in message, (
                 f"design_complete message must mention sentinel field: {field}"
             )
 
+    # T2: Design recipe has create_worktree step with correct captures
+    def test_design_recipe_has_create_worktree_step(self, recipe) -> None:
+        step = recipe.steps["create_worktree"]
+        assert step.tool == "run_cmd"
+        assert "worktree_path" in step.capture
+        assert "research_dir" in step.capture
+        assert step.on_success == "design_complete"
+
+    # T3: Design sentinel message includes worktree fields
+    def test_design_sentinel_emits_worktree_fields(self, recipe) -> None:
+        sentinel = recipe.steps["design_complete"]
+        assert "worktree_path" in sentinel.message
+        assert "research_dir" in sentinel.message
+
     def test_escalate_stop_is_stop(self, recipe) -> None:
         step = recipe.steps["escalate_stop"]
         assert step.action == "stop"
         assert step.message, "escalate_stop must have a non-empty message"
-
-    def test_no_dangling_create_worktree(self, recipe) -> None:
-        for name, step in recipe.steps.items():
-            assert "create_worktree" not in name, f"Step name '{name}' references create_worktree"
-            for attr in (
-                step.on_success,
-                step.on_failure,
-                step.on_exhausted,
-                step.on_context_limit,
-            ):
-                if attr:
-                    assert "create_worktree" not in attr, (
-                        f"Step '{name}' routes to create_worktree via {attr!r}"
-                    )
-            if step.on_result:
-                for cond in step.on_result.conditions:
-                    assert "create_worktree" not in cond.route, (
-                        f"Step '{name}' on_result routes to create_worktree"
-                    )
 
     def test_kitchen_rules_count(self, recipe) -> None:
         assert len(recipe.kitchen_rules) == 2

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -414,6 +414,8 @@ def test_research_campaign_run_design_capture():
         "research_dir",
         "experiment_plan",
         "visualization_plan_path",
+        "scope_report",
+        "experiment_type",
     }
     for key, val in d.capture.items():
         assert val == f"${{{{ result.{key} }}}}"
@@ -425,6 +427,7 @@ def test_research_campaign_run_implement_ingredients():
     d = recipe.dispatches[1]
     assert d.name == "run-implement"
     assert set(d.ingredients.keys()) == {
+        "task",
         "worktree_path",
         "research_dir",
         "experiment_plan",
@@ -434,6 +437,7 @@ def test_research_campaign_run_implement_ingredients():
         "issue_url",
         "output_mode",
     }
+    assert d.ingredients["task"] == "${{ inputs.task }}"
     assert d.ingredients["worktree_path"] == "${{ campaign.worktree_path }}"
     assert d.ingredients["research_dir"] == "${{ campaign.research_dir }}"
     assert d.ingredients["experiment_plan"] == "${{ campaign.experiment_plan }}"
@@ -449,8 +453,9 @@ def test_research_campaign_run_implement_capture():
     recipe = load_recipe(path)
     d = recipe.dispatches[1]
     assert d.name == "run-implement"
-    assert set(d.capture.keys()) == {"report_path"}
+    assert set(d.capture.keys()) == {"report_path", "experiment_results"}
     assert d.capture["report_path"] == "${{ result.report_path }}"
+    assert d.capture["experiment_results"] == "${{ result.experiment_results }}"
 
 
 def test_research_campaign_run_review_ingredients():
@@ -459,6 +464,10 @@ def test_research_campaign_run_review_ingredients():
     d = recipe.dispatches[2]
     assert d.name == "run-review"
     assert set(d.ingredients.keys()) == {
+        "task",
+        "experiment_results",
+        "experiment_type",
+        "scope_report",
         "worktree_path",
         "research_dir",
         "experiment_plan",
@@ -471,6 +480,7 @@ def test_research_campaign_run_review_ingredients():
         "review_pr",
         "audit_claims",
     }
+    assert d.ingredients["task"] == "${{ inputs.task }}"
     assert d.ingredients["source_dir"] == "${{ inputs.source_dir }}"
     assert d.ingredients["base_branch"] == "${{ inputs.base_branch }}"
     assert d.ingredients["issue_url"] == "${{ inputs.issue_url }}"
@@ -478,6 +488,9 @@ def test_research_campaign_run_review_ingredients():
     assert d.ingredients["review_pr"] == "${{ inputs.review_pr }}"
     assert d.ingredients["audit_claims"] == "${{ inputs.audit_claims }}"
     for key in [
+        "experiment_results",
+        "experiment_type",
+        "scope_report",
         "worktree_path",
         "research_dir",
         "experiment_plan",
@@ -492,9 +505,8 @@ def test_research_campaign_run_review_capture():
     recipe = load_recipe(path)
     d = recipe.dispatches[2]
     assert d.name == "run-review"
-    assert set(d.capture.keys()) == {"pr_url", "all_diagram_paths", "report_path_after_finalize"}
+    assert set(d.capture.keys()) == {"pr_url", "report_path_after_finalize"}
     assert d.capture["pr_url"] == "${{ result.pr_url }}"
-    assert d.capture["all_diagram_paths"] == "${{ result.all_diagram_paths }}"
     assert d.capture["report_path_after_finalize"] == "${{ result.report_path_after_finalize }}"
 
 
@@ -508,8 +520,6 @@ def test_research_campaign_run_archive_ingredients():
         "worktree_path",
         "research_dir",
         "pr_url",
-        "all_diagram_paths",
-        "report_path_after_finalize",
     }
     assert d.ingredients["base_branch"] == "${{ inputs.base_branch }}"
     for key in d.ingredients:

--- a/tests/recipe/test_research_archive_recipe.py
+++ b/tests/recipe/test_research_archive_recipe.py
@@ -44,8 +44,6 @@ class TestResearchArchiveRecipe:
             "worktree_path",
             "research_dir",
             "pr_url",
-            "all_diagram_paths",
-            "report_path_after_finalize",
             "base_branch",
         }
 

--- a/tests/recipe/test_research_campaign_rules.py
+++ b/tests/recipe/test_research_campaign_rules.py
@@ -9,6 +9,7 @@ from autoskillit.core import Severity
 from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
+from autoskillit.recipe.schema import CampaignDispatch, Recipe
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -27,6 +28,17 @@ def validation_ctx():
         ),
         project_dir=RECIPE_PATH.parent.parent.parent,
     )
+
+
+@pytest.fixture(scope="module")
+def campaign_recipe() -> Recipe:
+    if not RECIPE_PATH.exists():
+        pytest.skip("research-campaign.yaml not yet created")
+    return load_recipe(RECIPE_PATH)
+
+
+def _get_dispatch(recipe: Recipe, name: str) -> CampaignDispatch | None:
+    return next((d for d in recipe.dispatches if d.name == name), None)
 
 
 def test_research_campaign_file_exists() -> None:
@@ -79,3 +91,47 @@ def test_campaign_dangling_ingredient_passes(validation_ctx) -> None:
     findings = run_semantic_rules(validation_ctx)
     matched = [f for f in findings if f.rule == "campaign-dangling-ingredient"]
     assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)
+
+
+# T4: Campaign run-design captures scope_report and experiment_type
+def test_run_design_captures_scope_report_and_experiment_type(campaign_recipe: Recipe) -> None:
+    run_design = _get_dispatch(campaign_recipe, "run-design")
+    assert run_design is not None
+    assert "scope_report" in run_design.capture
+    assert "experiment_type" in run_design.capture
+
+
+# T5: Campaign run-implement captures experiment_results and forwards task
+def test_run_implement_captures_experiment_results(campaign_recipe: Recipe) -> None:
+    run_impl = _get_dispatch(campaign_recipe, "run-implement")
+    assert run_impl is not None
+    assert "experiment_results" in run_impl.capture
+
+
+def test_run_implement_forwards_task(campaign_recipe: Recipe) -> None:
+    run_impl = _get_dispatch(campaign_recipe, "run-implement")
+    assert run_impl is not None
+    assert "task" in run_impl.ingredients
+
+
+# T6: Campaign run-review forwards all required ingredients
+def test_run_review_forwards_required_research_ingredients(campaign_recipe: Recipe) -> None:
+    run_rev = _get_dispatch(campaign_recipe, "run-review")
+    assert run_rev is not None
+    for key in ("task", "experiment_results", "experiment_type", "scope_report"):
+        assert key in run_rev.ingredients, f"run-review missing ingredient: {key}"
+
+
+# T7: Campaign run-review does NOT capture all_diagram_paths
+def test_run_review_no_phantom_all_diagram_paths_capture(campaign_recipe: Recipe) -> None:
+    run_rev = _get_dispatch(campaign_recipe, "run-review")
+    assert run_rev is not None
+    assert "all_diagram_paths" not in run_rev.capture
+
+
+# T9: Campaign run-archive does not forward dead ingredients
+def test_run_archive_no_dead_ingredient_forwarding(campaign_recipe: Recipe) -> None:
+    run_arc = _get_dispatch(campaign_recipe, "run-archive")
+    assert run_arc is not None
+    assert "all_diagram_paths" not in run_arc.ingredients
+    assert "report_path_after_finalize" not in run_arc.ingredients

--- a/tests/recipe/test_research_campaign_rules.py
+++ b/tests/recipe/test_research_campaign_rules.py
@@ -93,7 +93,6 @@ def test_campaign_dangling_ingredient_passes(validation_ctx) -> None:
     assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)
 
 
-# T4: Campaign run-design captures scope_report and experiment_type
 def test_run_design_captures_scope_report_and_experiment_type(campaign_recipe: Recipe) -> None:
     run_design = _get_dispatch(campaign_recipe, "run-design")
     assert run_design is not None
@@ -101,7 +100,6 @@ def test_run_design_captures_scope_report_and_experiment_type(campaign_recipe: R
     assert "experiment_type" in run_design.capture
 
 
-# T5: Campaign run-implement captures experiment_results and forwards task
 def test_run_implement_captures_experiment_results(campaign_recipe: Recipe) -> None:
     run_impl = _get_dispatch(campaign_recipe, "run-implement")
     assert run_impl is not None
@@ -114,7 +112,6 @@ def test_run_implement_forwards_task(campaign_recipe: Recipe) -> None:
     assert "task" in run_impl.ingredients
 
 
-# T6: Campaign run-review forwards all required ingredients
 def test_run_review_forwards_required_research_ingredients(campaign_recipe: Recipe) -> None:
     run_rev = _get_dispatch(campaign_recipe, "run-review")
     assert run_rev is not None
@@ -122,14 +119,12 @@ def test_run_review_forwards_required_research_ingredients(campaign_recipe: Reci
         assert key in run_rev.ingredients, f"run-review missing ingredient: {key}"
 
 
-# T7: Campaign run-review does NOT capture all_diagram_paths
 def test_run_review_no_phantom_all_diagram_paths_capture(campaign_recipe: Recipe) -> None:
     run_rev = _get_dispatch(campaign_recipe, "run-review")
     assert run_rev is not None
     assert "all_diagram_paths" not in run_rev.capture
 
 
-# T9: Campaign run-archive does not forward dead ingredients
 def test_run_archive_no_dead_ingredient_forwarding(campaign_recipe: Recipe) -> None:
     run_arc = _get_dispatch(campaign_recipe, "run-archive")
     assert run_arc is not None

--- a/tests/recipe/test_research_campaign_structure.py
+++ b/tests/recipe/test_research_campaign_structure.py
@@ -117,6 +117,8 @@ def test_run_design_capture_keys(recipe: Recipe) -> None:
         "research_dir",
         "experiment_plan",
         "visualization_plan_path",
+        "scope_report",
+        "experiment_type",
     }
 
 
@@ -135,7 +137,7 @@ def test_run_implement_has_non_empty_capture(recipe: Recipe) -> None:
 def test_run_implement_capture_keys(recipe: Recipe) -> None:
     d = _dispatch_by_name(recipe, "run-implement")
     assert d is not None
-    assert set(d.capture.keys()) == {"report_path"}
+    assert set(d.capture.keys()) == {"report_path", "experiment_results"}
 
 
 def test_run_review_has_non_empty_capture(recipe: Recipe) -> None:
@@ -155,7 +157,6 @@ def test_run_review_capture_keys(recipe: Recipe) -> None:
     assert d is not None
     assert set(d.capture.keys()) == {
         "pr_url",
-        "all_diagram_paths",
         "report_path_after_finalize",
     }
 

--- a/tests/recipe/test_research_sub_recipe_rules.py
+++ b/tests/recipe/test_research_sub_recipe_rules.py
@@ -53,7 +53,6 @@ def test_research_sub_recipe_has_clean_dataflow(path: Path) -> None:
     )
 
 
-# T1: All four research sub-recipes declare kind: food-truck
 @pytest.mark.parametrize(
     "recipe_name",
     [
@@ -68,7 +67,6 @@ def test_research_sub_recipes_declare_food_truck_kind(recipe_name: str) -> None:
     assert recipe.kind == RecipeKind.FOOD_TRUCK
 
 
-# T8: Archive recipe has no dead ingredient declarations
 def test_archive_recipe_no_dead_required_ingredients() -> None:
     recipe = load_recipe(RECIPE_DIR / "research-archive.yaml")
     ingredient_names = set(recipe.ingredients.keys())

--- a/tests/recipe/test_research_sub_recipe_rules.py
+++ b/tests/recipe/test_research_sub_recipe_rules.py
@@ -8,11 +8,13 @@ import pytest
 
 import autoskillit.recipe  # noqa: F401 -- pyright: ignore[reportUnusedImport] -- triggers rule registration
 from autoskillit.core import Severity
-from autoskillit.recipe.io import builtin_sub_recipes_dir, load_recipe
-from autoskillit.recipe.schema import DataFlowReport
+from autoskillit.recipe.io import builtin_recipes_dir, builtin_sub_recipes_dir, load_recipe
+from autoskillit.recipe.schema import DataFlowReport, RecipeKind
 from autoskillit.recipe.validator import analyze_dataflow, run_semantic_rules
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+RECIPE_DIR = builtin_recipes_dir()
 
 _RESEARCH_SUB_RECIPE_PATHS: list[Path] = sorted(
     builtin_sub_recipes_dir().glob("research-*.yaml"),
@@ -49,3 +51,26 @@ def test_research_sub_recipe_has_clean_dataflow(path: Path) -> None:
         f"{path.stem}: {len(report.warnings)} dataflow warning(s): "
         + "; ".join(f"{w.code}@{w.step_name}: {w.message}" for w in report.warnings)
     )
+
+
+# T1: All four research sub-recipes declare kind: food-truck
+@pytest.mark.parametrize(
+    "recipe_name",
+    [
+        "research-design",
+        "research-implement",
+        "research-review",
+        "research-archive",
+    ],
+)
+def test_research_sub_recipes_declare_food_truck_kind(recipe_name: str) -> None:
+    recipe = load_recipe(RECIPE_DIR / f"{recipe_name}.yaml")
+    assert recipe.kind == RecipeKind.FOOD_TRUCK
+
+
+# T8: Archive recipe has no dead ingredient declarations
+def test_archive_recipe_no_dead_required_ingredients() -> None:
+    recipe = load_recipe(RECIPE_DIR / "research-archive.yaml")
+    ingredient_names = set(recipe.ingredients.keys())
+    assert "all_diagram_paths" not in ingredient_names
+    assert "report_path_after_finalize" not in ingredient_names


### PR DESCRIPTION
## Summary

The research campaign recipe chain (`research-campaign.yaml` → 4 sub-recipes) has 6 field-level wiring errors that make the campaign non-functional beyond the first dispatch. Phantom captures reference fields never emitted, required ingredients are never forwarded, and dead `required: true` declarations block dispatch validation. Additionally, all four sub-recipes lack `kind: food-truck`, preventing the `food-truck-has-sentinel-stop` validation rule from firing.

This plan fixes the complete data lineage: adds the missing `create_worktree` step to `research-design.yaml`, wires all campaign captures and ingredient forwarding, removes dead declarations from `research-archive.yaml`, and adds `kind: food-truck` to all four sub-recipes.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):

- `src/autoskillit/recipes/campaigns/research-campaign.json`
- `src/autoskillit/recipes/campaigns/research-campaign.yaml`
- `src/autoskillit/recipes/research-archive.json`
- `src/autoskillit/recipes/research-archive.yaml`
- `src/autoskillit/recipes/research-design.json`
- `src/autoskillit/recipes/research-design.yaml`
- `src/autoskillit/recipes/research-implement.json`
- `src/autoskillit/recipes/research-implement.yaml`
- `src/autoskillit/recipes/research-review.json`
- `src/autoskillit/recipes/research-review.yaml`
- `tests/recipe/test_bundled_recipes_research_design.py`
- `tests/recipe/test_campaign_loader.py`
- `tests/recipe/test_research_archive_recipe.py`
- `tests/recipe/test_research_campaign_rules.py`
- `tests/recipe/test_research_campaign_structure.py`
- `tests/recipe/test_research_sub_recipe_rules.py`

Closes #2230

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260508-114318-049121/.autoskillit/temp/make-plan/fix_research_campaign_recipe_chain_plan_2026-05-08_114318.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.9k | 20.1k | 747.8k | 73.8k | 112 | 60.8k | 9m 58s |
| verify | claude-sonnet-4-6 | 1 | 284 | 24.4k | 2.4M | 95.5k | 95 | 131.1k | 6m 51s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.5M | 17.5k | 1.9M | 77.2k | 148 | 90.2k | 6m 50s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 138.2k | 3.8k | 360.1k | 35.1k | 27 | 26.3k | 1m 30s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 48.5k | 1.3k | 205.8k | 29.8k | 14 | 15.1k | 38s |
| review_pr | claude-sonnet-4-6 | 3 | 923 | 81.1k | 1.2M | 80.3k | 110 | 198.6k | 18m 24s |
| resolve_review | claude-sonnet-4-6 | 2 | 2.1k | 48.2k | 4.3M | 94.5k | 191 | 159.4k | 17m 23s |
| **Total** | | | 2.7M | 196.3k | 11.1M | 95.5k | | 681.4k | 1h 1m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 178 | 10580.4 | 506.5 | 98.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 333579.5 | 12261.2 | 3705.7 |
| **Total** | **191** | 58162.6 | 3567.5 | 1027.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 3.0k | 65.5k | 5.9M | 272.5k | 24m 7s |
| MiniMax-M2.7-highspeed | 3 | 2.7M | 22.5k | 2.4M | 131.5k | 8m 58s |