### PR TITLE
Rectify: Structural Immunity for Missing Step Routing Fields

### DIFF
--- a/src/autoskillit/recipe/rules/rules_graph.py
+++ b/src/autoskillit/recipe/rules/rules_graph.py
@@ -254,6 +254,68 @@ def _check_on_result_missing_failure_route(ctx: ValidationContext) -> list[RuleF
 
 
 @semantic_rule(
+    name="tool-step-missing-failure-route",
+    description=(
+        "All tool and python steps must declare on_failure. When a tool call "
+        "returns success: false, the orchestrator needs a deterministic route. "
+        "Without on_failure, failure handling is deferred to model improvisation."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_tool_step_missing_failure_route(ctx: ValidationContext) -> list[RuleFinding]:
+    wf = ctx.recipe
+    findings: list[RuleFinding] = []
+    for step_name, step in wf.steps.items():
+        is_tool_invocation = step.tool is not None or step.python is not None
+        if not (is_tool_invocation and step.on_failure is None):
+            continue
+        findings.append(
+            RuleFinding(
+                rule="tool-step-missing-failure-route",
+                severity=Severity.ERROR,
+                step_name=step_name,
+                message=(
+                    f"Step '{step_name}' invokes a tool/python callable but has no "
+                    f"on_failure route. Add on_failure: <target> (use 'escalate' to "
+                    f"abort the recipe on failure)."
+                ),
+            )
+        )
+    return findings
+
+
+@semantic_rule(
+    name="tool-step-missing-success-route",
+    description=(
+        "Tool and python steps should declare on_success or on_result. Without "
+        "a success route, the orchestrator has no defined next step after a "
+        "successful tool call."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_tool_step_missing_success_route(ctx: ValidationContext) -> list[RuleFinding]:
+    wf = ctx.recipe
+    findings: list[RuleFinding] = []
+    for step_name, step in wf.steps.items():
+        is_tool_invocation = step.tool is not None or step.python is not None
+        has_success_route = step.on_success is not None or step.on_result is not None
+        if not (is_tool_invocation and not has_success_route):
+            continue
+        findings.append(
+            RuleFinding(
+                rule="tool-step-missing-success-route",
+                severity=Severity.WARNING,
+                step_name=step_name,
+                message=(
+                    f"Step '{step_name}' invokes a tool/python callable but has no "
+                    f"success route (on_success or on_result). Add on_success: <target>."
+                ),
+            )
+        )
+    return findings
+
+
+@semantic_rule(
     name="push-before-audit",
     description="push_to_remote reachable without passing through audit-impl first",
     severity=Severity.WARNING,

--- a/src/autoskillit/recipe/validator.py
+++ b/src/autoskillit/recipe/validator.py
@@ -148,7 +148,7 @@ def validate_recipe_structure(recipe: Recipe) -> list[str]:
         # Routing target validation
         for goto_field in ("on_success", "on_failure", "on_context_limit"):
             target = getattr(step, goto_field)
-            if target and target not in step_names and target != "done":
+            if target and target not in step_names and target not in _TERMINAL_TARGETS:
                 errors.append(
                     f"Step '{step_name}'.{goto_field} references unknown step '{target}'."
                 )

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -139,6 +139,12 @@ Summary: `needs_retry=true` + `retry_reason=resume` + `subtype=stale` → re-exe
          `needs_retry=true` + `retry_reason=stale` → decrement retries counter → `on_failure` when exhausted (no partial progress, not a context limit).
          `needs_retry=true` + `retry_reason=stale` + worktree-creating step → one-shot re-execute (bypasses retries budget; on_failure if repeated stale).
 
+**Fallback — `on_failure` is undefined (None):**
+If the routing decision is to follow `on_failure` but the step has no `on_failure`
+declared, this is a recipe authoring error. Emit the L3 result sentinel with
+`success=false` and `reason=missing_on_failure`, then halt. Do NOT improvise a
+routing target — the recipe is structurally incomplete.
+
 ---
 
 ## AUDIT-IMPL ACROSS MULTI-GROUP PIPELINES

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -672,8 +672,7 @@ def test_orchestrator_prompt_contains_missing_on_failure_instruction():
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
     prompt = _build_orchestrator_prompt("my-recipe", mcp_prefix=DIRECT_PREFIX)
-    assert "missing route" in prompt
-    assert "recipe authoring error" in prompt
+    assert "recipe authoring error. Stop the pipeline and report the missing route." in prompt
 
 
 def test_campaign_prompt_tool_list_still_enumerates_six_tools():

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -667,6 +667,15 @@ def test_orchestrator_prompt_documents_all_action_types(action_type):
     assert f'action: "{action_type}"' in prompt or f"action: {action_type}" in prompt
 
 
+def test_orchestrator_prompt_contains_missing_on_failure_instruction():
+    """The L1 orchestrator prompt must instruct the model to stop on missing on_failure."""
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my-recipe", mcp_prefix=DIRECT_PREFIX)
+    assert "missing route" in prompt
+    assert "recipe authoring error" in prompt
+
+
 def test_campaign_prompt_tool_list_still_enumerates_six_tools():
     """The 6 operational tools must still be listed in the campaign prompt after the fix."""
     from unittest.mock import MagicMock

--- a/tests/fleet/test_food_truck_prompt.py
+++ b/tests/fleet/test_food_truck_prompt.py
@@ -52,3 +52,18 @@ def test_fleet_prompt_contains_budget_exceeded_routing():
     )
     assert "QUOTA WAIT REQUIRED" in prompt
     assert "QUOTA BUDGET EXCEEDED" in prompt
+
+
+def test_fleet_prompt_contains_missing_on_failure_sentinel():
+    """The L2 fleet prompt must instruct the model to emit missing_on_failure sentinel."""
+    prompt = _build_food_truck_prompt(
+        recipe="test-recipe",
+        task="Test task",
+        ingredients={},
+        mcp_prefix=DIRECT_PREFIX,
+        dispatch_id="test-dispatch",
+        campaign_id="test-campaign",
+        l3_timeout_sec=300,
+    )
+    assert "missing_on_failure" in prompt
+    assert "recipe authoring error" in prompt

--- a/tests/fleet/test_food_truck_prompt.py
+++ b/tests/fleet/test_food_truck_prompt.py
@@ -65,5 +65,5 @@ def test_fleet_prompt_contains_missing_on_failure_sentinel():
         campaign_id="test-campaign",
         l3_timeout_sec=300,
     )
-    assert "missing_on_failure" in prompt
-    assert "recipe authoring error" in prompt
+    assert "recipe authoring error. Emit the sentinel block with success=false" in prompt
+    assert 'reason="missing_on_failure"' in prompt

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -103,6 +103,17 @@ def test_all_predicate_steps_have_on_failure() -> None:
                 )
 
 
+def test_all_tool_steps_have_on_failure() -> None:
+    """Every tool/python step in every bundled recipe must have on_failure."""
+    for yaml_file in sorted(builtin_recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(yaml_file)
+        for step_name, step in recipe.steps.items():
+            if step.tool is not None or step.python is not None:
+                assert step.on_failure is not None, (
+                    f"{recipe.name}:{step_name} is a tool/python step with no on_failure"
+                )
+
+
 def test_audit_impl_on_failure_routes_to_escalation() -> None:
     """audit_impl.on_failure must route to an escalation step in each recipe."""
     impl = load_recipe(builtin_recipes_dir() / "implementation.yaml")

--- a/tests/recipe/test_rules_graph.py
+++ b/tests/recipe/test_rules_graph.py
@@ -7,6 +7,7 @@ import pytest
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, StepResultRoute
+from autoskillit.recipe.validator import validate_recipe_structure
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -313,6 +314,182 @@ def test_action_step_not_flagged() -> None:
     findings = run_semantic_rules(recipe)
     flagged = [f for f in findings if f.rule == "on-result-missing-failure-route"]
     assert flagged == []
+
+
+# ---------------------------------------------------------------------------
+# tool-step-missing-failure-route
+# ---------------------------------------------------------------------------
+
+
+def test_tool_step_without_on_failure_is_error() -> None:
+    """A tool step with on_success but no on_failure must be flagged."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(tool="run_cmd", with_args={"cmd": "echo x"}, on_success="done"),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "tool-step-missing-failure-route"]
+    assert len(flagged) == 1
+    assert flagged[0].severity == Severity.ERROR
+    assert "start" in flagged[0].message
+
+
+def test_python_step_without_on_failure_is_error() -> None:
+    """A python step with on_success but no on_failure must be flagged."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(python="module.func", on_success="done"),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "tool-step-missing-failure-route"]
+    assert len(flagged) == 1
+    assert flagged[0].severity == Severity.ERROR
+
+
+def test_tool_step_with_on_failure_passes() -> None:
+    """A tool step with both on_success and on_failure passes the rule."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo x"},
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "tool-step-missing-failure-route"]
+    assert flagged == []
+
+
+def test_constant_step_without_on_failure_passes() -> None:
+    """Constant steps don't invoke tools — on_failure is not required."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(constant="value", on_success="done"),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "tool-step-missing-failure-route"]
+    assert flagged == []
+
+
+def test_action_stop_without_on_failure_passes() -> None:
+    """Stop steps are terminal — on_failure is not required."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(action="stop", message="All done."),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "tool-step-missing-failure-route"]
+    assert flagged == []
+
+
+# ---------------------------------------------------------------------------
+# tool-step-missing-success-route
+# ---------------------------------------------------------------------------
+
+
+def test_tool_step_without_success_route_is_warning() -> None:
+    """A tool step with on_failure but no on_success/on_result is flagged."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(
+                tool="run_cmd", with_args={"cmd": "echo x"}, on_failure="escalate"
+            ),
+            "escalate": RecipeStep(action="stop", message="failed"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "tool-step-missing-success-route"]
+    assert len(flagged) == 1
+    assert flagged[0].severity == Severity.WARNING
+
+
+def test_tool_step_with_on_result_passes_success_route() -> None:
+    """A tool step with on_result (instead of on_success) has a success route."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo x"},
+                on_result=StepResultRoute(
+                    conditions=[StepResultCondition(route="done", when=None)]
+                ),
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+            "escalate": RecipeStep(action="stop", message="failed"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "tool-step-missing-success-route"]
+    assert flagged == []
+
+
+# ---------------------------------------------------------------------------
+# Terminal target expansion (escalate is valid for on_failure/on_success/on_context_limit)
+# ---------------------------------------------------------------------------
+
+
+def test_on_failure_escalate_is_valid_terminal() -> None:
+    """on_failure: escalate should be accepted without a step named 'escalate'."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo x"},
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    errors = validate_recipe_structure(recipe)
+    assert not any("unknown step 'escalate'" in e for e in errors)
+
+
+def test_on_success_escalate_is_valid_terminal() -> None:
+    """on_success: escalate should be accepted without a step named 'escalate'."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo x"},
+                on_success="escalate",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    errors = validate_recipe_structure(recipe)
+    assert not any("unknown step 'escalate'" in e for e in errors)
+
+
+def test_on_context_limit_escalate_is_valid_terminal() -> None:
+    """on_context_limit: escalate should be accepted as a terminal target."""
+    recipe = _make_recipe(
+        {
+            "start": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo x"},
+                on_success="done",
+                on_failure="done",
+                on_context_limit="escalate",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    errors = validate_recipe_structure(recipe)
+    assert not any("unknown step 'escalate'" in e for e in errors)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -120,6 +120,7 @@ class TestValidateRecipeTool:
             "      cmd: echo hello\n"
             "      cwd: .\n"
             "    on_success: done\n"
+            "    on_failure: escalate\n"
             "  done:\n"
             "    action: stop\n"
             '    message: "Done."\n'
@@ -237,6 +238,7 @@ class TestValidateRecipeTool:
             "    tool: test_check\n"
             "    model: sonnet\n"
             "    on_success: done\n"
+            "    on_failure: escalate\n"
             "  done:\n"
             "    action: stop\n"
             '    message: "Done."\n'


### PR DESCRIPTION
## Summary

Recipe step routing fields (`on_failure`, `on_success`, `on_context_limit`) default to `None` and have no validation gate requiring them on `tool:`/`python:` steps. The sole runtime defense is a prompt-level instruction telling the LLM to emit a sentinel or stop — entirely model-behavioral with zero test coverage. Meanwhile, `on_exhausted` is structurally immune to this class of bug via a non-None default, parser-level fallback, and terminal sentinel recognition. The fix applies the `on_exhausted` immunity pattern to the other routing fields through a new ERROR-severity semantic rule, expanded terminal target recognition in the structural validator, and contract tests for the prompt-level defense-in-depth layer.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260508-113454-782130/.autoskillit/temp/rectify/rectify_on_failure_undefined_abort_2026-05-08_184500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 60 | 8.8k | 642.0k | 120.2k | 279 | 72.9k | 7m 8s |
| rectify | claude-sonnet-4-6 | 1 | 10.6k | 14.5k | 836.6k | 119.8k | 201 | 57.0k | 12m 17s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 148 | 16.4k | 794.7k | 60.5k | 91 | 67.9k | 7m 46s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.8M | 12.6k | 1.3M | 35.1k | 166 | 142.8k | 6m 41s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 95.9k | 3.3k | 208.7k | 29.8k | 22 | 42.3k | 1m 7s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 58.7k | 1.6k | 176.0k | 29.8k | 16 | 15.1k | 45s |
| review_pr | claude-sonnet-4-6 | 3 | 320 | 109.0k | 1.8M | 90.1k | 116 | 195.7k | 20m 54s |
| resolve_review | claude-sonnet-4-6 | 1 | 213 | 11.6k | 1.2M | 58.8k | 65 | 45.7k | 4m 40s |
| ci_conflict_fix | claude-sonnet-4-6 | 2 | 184 | 4.8k | 662.8k | 38.3k | 50 | 50.1k | 1m 48s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 137.9k | 2.3k | 325.0k | 29.8k | 26 | 15.1k | 1m 12s |
| resolve_ci | claude-sonnet-4-6 | 1 | 118 | 6.6k | 636.4k | 60.4k | 37 | 47.3k | 5m 37s |
| **Total** | | | 2.1M | 191.5k | 8.6M | 120.2k | | 751.7k | 1h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 282 | 4555.8 | 506.3 | 44.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 7 | 171193.4 | 6531.9 | 1661.1 |
| ci_conflict_fix | 1846 | 359.1 | 27.1 | 2.6 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 2 | 318190.0 | 23674.5 | 3293.5 |
| **Total** | **2137** | 4028.8 | 351.8 | 89.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 10.8k | 39.7k | 2.3M | 197.7k | 27m 12s |
| MiniMax-M2.7-highspeed | 3 | 1.9M | 17.5k | 1.7M | 200.1k | 8m 34s |