### PR TITLE
Rectify: Campaign State Schema Version Not Validated

### DIFF
--- a/src/autoskillit/cli/doctor/__init__.py
+++ b/src/autoskillit/cli/doctor/__init__.py
@@ -29,6 +29,7 @@ from ._doctor_fleet import (
     _check_campaign_manifest_clone_dests,
     _check_campaign_onboarding_hint,
     _check_fleet_dispatch_guard_registered,
+    _check_fleet_state_schema,
     _check_script_version_health,
     _check_sous_chef_bundled,
     _check_stale_fleet_state,
@@ -176,6 +177,9 @@ def run_doctor(*, output_json: bool = False) -> None:
 
         # Check 28: Campaign manifest clone destination collisions
         results.append(_check_campaign_manifest_clone_dests())
+
+        # Check 29: Fleet state schema version drift
+        results.append(_check_fleet_state_schema())
 
     # Output
     if output_json:

--- a/src/autoskillit/cli/doctor/_doctor_fleet.py
+++ b/src/autoskillit/cli/doctor/_doctor_fleet.py
@@ -217,7 +217,8 @@ def _check_campaign_manifest_clone_dests(project_dir: Path | None = None) -> Doc
 
 def _check_fleet_state_schema(dispatches_dir: Path | None = None) -> DoctorResult:
     """Check fleet state files for schema version drift."""
-    from autoskillit.fleet import FLEET_STATE_SCHEMA_VERSION as _SCHEMA_VERSION
+    from autoskillit.core import read_versioned_json
+    from autoskillit.fleet import FLEET_STATE_SCHEMA_VERSION
 
     check_name = "fleet_state_schema"
     if dispatches_dir is None:
@@ -226,13 +227,8 @@ def _check_fleet_state_schema(dispatches_dir: Path | None = None) -> DoctorResul
         return DoctorResult(Severity.OK, check_name, "No dispatches directory")
     stale_files: list[str] = []
     for path in dispatches_dir.glob("*.json"):
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-            observed = raw.get("schema_version") if isinstance(raw, dict) else None
-            if observed != _SCHEMA_VERSION:
-                stale_files.append(f"{path}: observed={observed!r}, expected={_SCHEMA_VERSION}")
-        except (json.JSONDecodeError, OSError):
-            continue
+        if read_versioned_json(path, FLEET_STATE_SCHEMA_VERSION, logger=logger) is None:
+            stale_files.append(str(path))
     if stale_files:
         return DoctorResult(
             Severity.WARNING,

--- a/src/autoskillit/cli/doctor/_doctor_fleet.py
+++ b/src/autoskillit/cli/doctor/_doctor_fleet.py
@@ -217,7 +217,7 @@ def _check_campaign_manifest_clone_dests(project_dir: Path | None = None) -> Doc
 
 def _check_fleet_state_schema(dispatches_dir: Path | None = None) -> DoctorResult:
     """Check fleet state files for schema version drift."""
-    from autoskillit.fleet.state_types import _SCHEMA_VERSION
+    from autoskillit.fleet import FLEET_STATE_SCHEMA_VERSION as _SCHEMA_VERSION
 
     check_name = "fleet_state_schema"
     if dispatches_dir is None:

--- a/src/autoskillit/cli/doctor/_doctor_fleet.py
+++ b/src/autoskillit/cli/doctor/_doctor_fleet.py
@@ -213,3 +213,30 @@ def _check_campaign_manifest_clone_dests(project_dir: Path | None = None) -> Doc
             f"Use unique clone paths per dispatch.",
         )
     return DoctorResult(Severity.OK, check_name, "All dispatch clone destinations unique")
+
+
+def _check_fleet_state_schema(dispatches_dir: Path | None = None) -> DoctorResult:
+    """Check fleet state files for schema version drift."""
+    from autoskillit.fleet.state_types import _SCHEMA_VERSION
+
+    check_name = "fleet_state_schema"
+    if dispatches_dir is None:
+        dispatches_dir = Path.cwd() / ".autoskillit" / "temp" / "dispatches"
+    if not dispatches_dir.is_dir():
+        return DoctorResult(Severity.OK, check_name, "No dispatches directory")
+    stale_files: list[str] = []
+    for path in dispatches_dir.glob("*.json"):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            observed = raw.get("schema_version") if isinstance(raw, dict) else None
+            if observed != _SCHEMA_VERSION:
+                stale_files.append(f"{path}: observed={observed!r}, expected={_SCHEMA_VERSION}")
+        except (json.JSONDecodeError, OSError):
+            continue
+    if stale_files:
+        return DoctorResult(
+            Severity.WARNING,
+            check_name,
+            f"Fleet state schema drift: {'; '.join(stale_files)}",
+        )
+    return DoctorResult(Severity.OK, check_name, "All fleet state files at current schema version")

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -41,6 +41,7 @@ from .io import atomic_write as atomic_write
 from .io import dump_yaml_str as dump_yaml_str
 from .io import ensure_project_temp as ensure_project_temp
 from .io import load_yaml as load_yaml
+from .io import read_versioned_json as read_versioned_json
 from .io import resolve_temp_dir as resolve_temp_dir
 from .io import temp_dir_display_str as temp_dir_display_str
 from .io import write_versioned_json as write_versioned_json

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import fcntl
-import json
 import os
 import shutil
 from datetime import UTC, datetime, timedelta
@@ -12,7 +11,7 @@ from typing import IO
 
 import psutil
 
-from .io import write_versioned_json
+from .io import read_versioned_json, write_versioned_json
 from .logging import get_logger
 
 logger = get_logger(__name__)
@@ -62,10 +61,8 @@ def append_retiring_entry(version: str, path: str) -> None:
     try:
         entries: list[dict[str, str]] = []
         if cache.exists():
-            try:
-                entries = json.loads(cache.read_text()).get("retiring", [])
-            except (json.JSONDecodeError, AttributeError):
-                entries = []
+            data = read_versioned_json(cache, _SCHEMA_VERSION, logger=logger)
+            entries = data.get("retiring", []) if data is not None else []
         entries.append(
             {"version": version, "path": path, "retired_at": datetime.now(UTC).isoformat()}
         )
@@ -81,11 +78,10 @@ def sweep_retiring_cache(grace_hours: int = 2) -> int:
         return 0
     fh = _open_lock(lock)
     try:
-        try:
-            data = json.loads(cache.read_text())
-            entries: list[dict[str, str]] = data.get("retiring", [])
-        except (json.JSONDecodeError, AttributeError, OSError):
+        data = read_versioned_json(cache, _SCHEMA_VERSION, logger=logger)
+        if data is None:
             return 0
+        entries: list[dict[str, str]] = data.get("retiring", [])
 
         survivors: list[dict[str, str]] = []
         count = 0
@@ -181,10 +177,8 @@ def register_active_kitchen(kitchen_id: str, pid: int, project_path: str) -> Non
     try:
         entries: list[dict[str, object]] = []
         if akp.exists():
-            try:
-                entries = json.loads(akp.read_text()).get("kitchens", [])
-            except (json.JSONDecodeError, AttributeError):
-                entries = []
+            data = read_versioned_json(akp, _SCHEMA_VERSION, logger=logger)
+            entries = data.get("kitchens", []) if data is not None else []
         try:
             create_time: float | None = psutil.Process(pid).create_time()
         except psutil.NoSuchProcess:
@@ -210,10 +204,8 @@ def unregister_active_kitchen(kitchen_id: str) -> None:
     try:
         entries: list[dict[str, object]] = []
         if akp.exists():
-            try:
-                entries = json.loads(akp.read_text()).get("kitchens", [])
-            except (json.JSONDecodeError, AttributeError):
-                entries = []
+            data = read_versioned_json(akp, _SCHEMA_VERSION, logger=logger)
+            entries = data.get("kitchens", []) if data is not None else []
         survivors = [e for e in entries if e.get("kitchen_id") != kitchen_id]
         write_versioned_json(akp, {"kitchens": survivors}, schema_version=_SCHEMA_VERSION)
     finally:
@@ -227,10 +219,8 @@ def clear_kitchens_for_pid(pid: int) -> None:
     try:
         entries: list[dict[str, object]] = []
         if akp.exists():
-            try:
-                entries = json.loads(akp.read_text()).get("kitchens", [])
-            except (json.JSONDecodeError, AttributeError):
-                entries = []
+            data = read_versioned_json(akp, _SCHEMA_VERSION, logger=logger)
+            entries = data.get("kitchens", []) if data is not None else []
         survivors = [e for e in entries if e.get("pid") != pid]
         write_versioned_json(akp, {"kitchens": survivors}, schema_version=_SCHEMA_VERSION)
     finally:
@@ -244,10 +234,10 @@ def any_kitchen_open(project_path: str | None = None) -> bool:
         return False
     fh = _open_lock(lock)
     try:
-        try:
-            entries: list[dict[str, object]] = json.loads(akp.read_text()).get("kitchens", [])
-        except (json.JSONDecodeError, AttributeError, OSError):
+        data = read_versioned_json(akp, _SCHEMA_VERSION, logger=logger)
+        if data is None:
             return False
+        entries: list[dict[str, object]] = data.get("kitchens", [])
         survivors = []
         for entry in entries:
             pid = entry.get("pid")

--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import threading
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -48,6 +49,7 @@ class _WarningLogger(Protocol):
 
 
 _SCHEMA_DRIFT_LOGGED: set[tuple[str, int]] = set()
+_SCHEMA_DRIFT_LOCK = threading.Lock()
 
 
 def resolve_temp_dir(project_dir: Path, override: str | None = None) -> Path:
@@ -161,20 +163,23 @@ def read_versioned_json(
     observed = raw.get("schema_version")
     if observed != expected_version:
         cache_key = (str(path.resolve()), expected_version)
-        if cache_key not in _SCHEMA_DRIFT_LOGGED:
-            _SCHEMA_DRIFT_LOGGED.add(cache_key)
-            if logger is not None:
-                logger.warning(
-                    "schema_drift",
-                    path=str(path),
-                    expected=expected_version,
-                    observed=observed,
-                )
+        with _SCHEMA_DRIFT_LOCK:
+            if cache_key not in _SCHEMA_DRIFT_LOGGED:
+                _SCHEMA_DRIFT_LOGGED.add(cache_key)
             else:
-                warnings.warn(
-                    f"schema_drift: path={path} expected={expected_version} observed={observed}",
-                    stacklevel=2,
-                )
+                return None
+        if logger is not None:
+            logger.warning(
+                "schema_drift",
+                path=str(path),
+                expected=expected_version,
+                observed=observed,
+            )
+        else:
+            warnings.warn(
+                f"schema_drift: path={path} expected={expected_version} observed={observed}",
+                stacklevel=2,
+            )
         return None
     return raw
 

--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -160,10 +160,10 @@ def read_versioned_json(
             _SCHEMA_DRIFT_LOGGED.add(cache_key)
             if logger is not None:
                 logger.warning(
-                    "schema_drift: path=%s expected=%s observed=%s",
-                    path,
-                    expected_version,
-                    observed,
+                    "schema_drift",
+                    path=str(path),
+                    expected=expected_version,
+                    observed=observed,
                 )
             else:
                 warnings.warn(

--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import yaml
 from yaml import YAMLError as YAMLError  # explicit re-export for callers and type checkers
@@ -42,7 +42,12 @@ __all__ = [
     "read_versioned_json",
 ]
 
-_SCHEMA_DRIFT_LOGGED: set[str] = set()
+
+class _WarningLogger(Protocol):
+    def warning(self, event: str, /, **kw: Any) -> None: ...
+
+
+_SCHEMA_DRIFT_LOGGED: set[tuple[str, int]] = set()
 
 
 def resolve_temp_dir(project_dir: Path, override: str | None = None) -> Path:
@@ -136,7 +141,7 @@ def read_versioned_json(
     path: Path,
     expected_version: int,
     *,
-    logger: Any = None,
+    logger: _WarningLogger | None = None,
 ) -> dict[str, Any] | None:
     """Read a versioned JSON artifact and validate its schema_version.
 
@@ -155,7 +160,7 @@ def read_versioned_json(
         return None
     observed = raw.get("schema_version")
     if observed != expected_version:
-        cache_key = str(path.resolve())
+        cache_key = (str(path.resolve()), expected_version)
         if cache_key not in _SCHEMA_DRIFT_LOGGED:
             _SCHEMA_DRIFT_LOGGED.add(cache_key)
             if logger is not None:

--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -39,7 +39,10 @@ __all__ = [
     "resolve_temp_dir",
     "temp_dir_display_str",
     "write_versioned_json",
+    "read_versioned_json",
 ]
+
+_SCHEMA_DRIFT_LOGGED: set[str] = set()
 
 
 def resolve_temp_dir(project_dir: Path, override: str | None = None) -> Path:
@@ -127,6 +130,53 @@ def write_versioned_json(path: Path, payload: dict[str, Any], schema_version: in
         raise TypeError("write_versioned_json requires a dict payload")
     enriched = {**payload, "schema_version": schema_version}
     atomic_write(path, _fast_dumps(enriched, indent=True))
+
+
+def read_versioned_json(
+    path: Path,
+    expected_version: int,
+    *,
+    logger: Any = None,
+) -> dict[str, Any] | None:
+    """Read a versioned JSON artifact and validate its schema_version.
+
+    Returns the parsed dict on version match, None on any failure
+    (missing file, corrupt JSON, non-dict, missing/mismatched schema_version).
+    Logs a deduped drift warning on version mismatch.
+    """
+    import json as _json
+    import warnings
+
+    try:
+        raw = _json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, _json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    observed = raw.get("schema_version")
+    if observed != expected_version:
+        cache_key = str(path.resolve())
+        if cache_key not in _SCHEMA_DRIFT_LOGGED:
+            _SCHEMA_DRIFT_LOGGED.add(cache_key)
+            if logger is not None:
+                logger.warning(
+                    "schema_drift: path=%s expected=%s observed=%s",
+                    path,
+                    expected_version,
+                    observed,
+                )
+            else:
+                warnings.warn(
+                    f"schema_drift: path={path} expected={expected_version} observed={observed}",
+                    stacklevel=2,
+                )
+        return None
+    return raw
+
+
+def _reset_schema_drift_logged_for_tests() -> None:
+    """Test-only helper: clear the once-per-process drift-log set."""
+    _SCHEMA_DRIFT_LOGGED.clear()
 
 
 _AUTOSKILLIT_GITIGNORE_ENTRIES = [

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -15,14 +15,14 @@ from typing import Any
 
 import httpx
 
-from autoskillit.core import get_logger, write_versioned_json
+from autoskillit.core import get_logger
+from autoskillit.core.io import read_versioned_json, write_versioned_json
 
 logger = get_logger(__name__)
 
 _DEFAULT_BASE_URL: str = "https://api.anthropic.com"
 
 QUOTA_CACHE_SCHEMA_VERSION: int = 3
-_SCHEMA_DRIFT_LOGGED: set[str] = set()
 
 # Canonical Anthropic quota API window names, as returned by GET /api/oauth/usage.
 # Update these when Anthropic adds or renames windows — the contract tests will
@@ -44,11 +44,6 @@ LONG_WINDOW_NAMES: frozenset[str] = frozenset(
         "seven_day",
     }
 )
-
-
-def _reset_schema_drift_logged_for_tests() -> None:
-    """Test-only helper: clear the once-per-process drift-log set."""
-    _SCHEMA_DRIFT_LOGGED.clear()
 
 
 @dataclass
@@ -187,20 +182,14 @@ def _read_credentials(credentials_path: str) -> str:
 
 def _read_cache(cache_path: str, max_age: int) -> QuotaStatus | None:
     """Return a fresh QuotaStatus from local cache, or None if stale/missing/old-format."""
+    raw = read_versioned_json(
+        Path(cache_path).expanduser(),
+        QUOTA_CACHE_SCHEMA_VERSION,
+        logger=logger,
+    )
+    if raw is None:
+        return None
     try:
-        raw = json.loads(Path(cache_path).expanduser().read_text())
-        if not isinstance(raw, dict):
-            return None
-        if raw.get("schema_version") != QUOTA_CACHE_SCHEMA_VERSION:
-            cache_key = str(Path(cache_path).expanduser())
-            if cache_key not in _SCHEMA_DRIFT_LOGGED:
-                _SCHEMA_DRIFT_LOGGED.add(cache_key)
-                logger.warning(
-                    "quota_cache_schema_drift",
-                    cache_path=cache_key,
-                    observed=raw.get("schema_version"),
-                )
-            return None
         fetched_at = datetime.fromisoformat(raw["fetched_at"])
         age = (datetime.now(UTC) - fetched_at).total_seconds()
         if age > max_age:
@@ -215,7 +204,7 @@ def _read_cache(cache_path: str, max_age: int) -> QuotaStatus | None:
             should_block=bool(b.get("should_block", False)),
             effective_threshold=float(b.get("effective_threshold", 0.0)),
         )
-    except (FileNotFoundError, KeyError, ValueError, TypeError, json.JSONDecodeError):
+    except (KeyError, ValueError, TypeError):
         return None
 
 

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -15,8 +15,7 @@ from typing import Any
 
 import httpx
 
-from autoskillit.core import get_logger
-from autoskillit.core.io import read_versioned_json, write_versioned_json
+from autoskillit.core import get_logger, read_versioned_json, write_versioned_json
 
 logger = get_logger(__name__)
 

--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -50,7 +50,7 @@ from .state_recovery import (
     classify_stale_dispatch,
     derive_orchestrator_resume_spec,
 )
-from .state_types import _SCHEMA_VERSION as FLEET_STATE_SCHEMA_VERSION
+from .state_types import FLEET_STATE_SCHEMA_VERSION
 from .summary import (
     CampaignParseResult,
     CampaignSummary,

--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -50,6 +50,7 @@ from .state_recovery import (
     classify_stale_dispatch,
     derive_orchestrator_resume_spec,
 )
+from .state_types import _SCHEMA_VERSION as FLEET_STATE_SCHEMA_VERSION
 from .summary import (
     CampaignParseResult,
     CampaignSummary,
@@ -108,6 +109,7 @@ __all__ = [
     "write_initial_state",
     "normalize_dispatch_token_usage",
     "classify_stale_dispatch",
+    "FLEET_STATE_SCHEMA_VERSION",
     "derive_orchestrator_resume_spec",
     "checkpoint_from_sidecar",
     "is_dispatch_session_alive",

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -26,9 +26,9 @@ from autoskillit.fleet.state_types import (
     _ALLOWED_TRANSITIONS,  # noqa: F401
     _COMPLETED_STATUSES,  # noqa: F401
     _INFRASTRUCTURE_FAILURE_REASONS,  # noqa: F401
-    _SCHEMA_VERSION,  # noqa: F401
     _VISIBLE_IN_BLOCK_STATUSES,  # noqa: F401
     FLEET_HALTED_SENTINEL,
+    FLEET_STATE_SCHEMA_VERSION,
     TERMINAL_DISPATCH_STATUSES,
     CampaignState,
     DispatchRecord,
@@ -90,7 +90,7 @@ def write_initial_state(
         "started_at": time.time(),
         "dispatches": [d.to_dict() for d in dispatches],
     }
-    write_versioned_json(state_path, payload, schema_version=_SCHEMA_VERSION)
+    write_versioned_json(state_path, payload, schema_version=FLEET_STATE_SCHEMA_VERSION)
 
 
 def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
@@ -137,7 +137,7 @@ def read_state(state_path: Path) -> CampaignState | None:
     Returns None on missing file, malformed JSON, or schema mismatch.
     Never raises.
     """
-    data = read_versioned_json(state_path, _SCHEMA_VERSION, logger=logger)
+    data = read_versioned_json(state_path, FLEET_STATE_SCHEMA_VERSION, logger=logger)
     if data is None:
         return None
     try:
@@ -236,7 +236,7 @@ def _write_state(state_path: Path, state: CampaignState) -> None:
         "captured_values": state.captured_values,
         "orchestrator_session_id": state.orchestrator_session_id,
     }
-    write_versioned_json(state_path, payload, schema_version=_SCHEMA_VERSION)
+    write_versioned_json(state_path, payload, schema_version=FLEET_STATE_SCHEMA_VERSION)
 
 
 def mark_dispatch_running(
@@ -369,7 +369,7 @@ def build_protected_campaign_ids(project_dir: Path) -> frozenset[str]:
         if not dispatches_dir.is_dir():
             return frozenset()
         for state_file in dispatches_dir.glob("*.json"):
-            data = read_versioned_json(state_file, _SCHEMA_VERSION, logger=logger)
+            data = read_versioned_json(state_file, FLEET_STATE_SCHEMA_VERSION, logger=logger)
             if data is None:
                 continue
             try:
@@ -436,7 +436,7 @@ def read_all_campaign_captures(
     if not dispatches_dir.is_dir():
         return result
     for path in dispatches_dir.glob("*.json"):
-        data = read_versioned_json(path, _SCHEMA_VERSION, logger=logger)
+        data = read_versioned_json(path, FLEET_STATE_SCHEMA_VERSION, logger=logger)
         if data is None:
             continue
         try:

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -7,7 +7,6 @@ All writes use core.io.atomic_write for crash-safety (tmp + os.replace).
 from __future__ import annotations
 
 import fcntl
-import json
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -144,7 +143,6 @@ def read_state(state_path: Path) -> CampaignState | None:
     try:
         dispatches = [DispatchRecord.from_dict(d) for d in data["dispatches"]]
         return CampaignState(
-            schema_version=_SCHEMA_VERSION,
             campaign_id=data["campaign_id"],
             campaign_name=data["campaign_name"],
             manifest_path=data["manifest_path"],
@@ -371,10 +369,10 @@ def build_protected_campaign_ids(project_dir: Path) -> frozenset[str]:
         if not dispatches_dir.is_dir():
             return frozenset()
         for state_file in dispatches_dir.glob("*.json"):
+            data = read_versioned_json(state_file, _SCHEMA_VERSION, logger=logger)
+            if data is None:
+                continue
             try:
-                data = json.loads(state_file.read_text(encoding="utf-8"))
-                if data.get("schema_version") != _SCHEMA_VERSION:
-                    continue
                 cid = data.get("campaign_id", "")
                 if not cid:
                     continue
@@ -387,7 +385,7 @@ def build_protected_campaign_ids(project_dir: Path) -> frozenset[str]:
                     if status not in TERMINAL_DISPATCH_STATUSES:
                         protected.add(cid)
                         break
-            except (json.JSONDecodeError, OSError):
+            except (KeyError, TypeError):
                 continue
         return frozenset(protected)
     except Exception:
@@ -438,10 +436,10 @@ def read_all_campaign_captures(
     if not dispatches_dir.is_dir():
         return result
     for path in dispatches_dir.glob("*.json"):
+        data = read_versioned_json(path, _SCHEMA_VERSION, logger=logger)
+        if data is None:
+            continue
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if data.get("schema_version") != _SCHEMA_VERSION:
-                continue
             if data.get("campaign_id") != campaign_id:
                 continue
             caps = data.get("captured_values", {})
@@ -451,7 +449,7 @@ def read_all_campaign_captures(
             all_success = all(d.get("status") == DispatchStatus.SUCCESS for d in dispatches)
             if all_success and dispatches:
                 result.update(caps)
-        except (json.JSONDecodeError, OSError) as exc:
+        except (KeyError, TypeError) as exc:
             logger.warning("read_all_campaign_captures: skipping %s: %s", path, exc)
             continue
     return result

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from types import TracebackType
     from typing import IO
 
-from autoskillit.core import get_logger, write_versioned_json
+from autoskillit.core import get_logger, read_versioned_json, write_versioned_json
 from autoskillit.fleet.state_gates import record_gate_outcome
 from autoskillit.fleet.state_recovery import (
     has_failed_dispatch,
@@ -138,14 +138,13 @@ def read_state(state_path: Path) -> CampaignState | None:
     Returns None on missing file, malformed JSON, or schema mismatch.
     Never raises.
     """
-    try:
-        data = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    data = read_versioned_json(state_path, _SCHEMA_VERSION, logger=logger)
+    if data is None:
         return None
     try:
         dispatches = [DispatchRecord.from_dict(d) for d in data["dispatches"]]
         return CampaignState(
-            schema_version=data["schema_version"],
+            schema_version=_SCHEMA_VERSION,
             campaign_id=data["campaign_id"],
             campaign_name=data["campaign_name"],
             manifest_path=data["manifest_path"],
@@ -155,7 +154,7 @@ def read_state(state_path: Path) -> CampaignState | None:
             orchestrator_session_id=data.get("orchestrator_session_id") or "",
         )
     except (KeyError, ValueError, TypeError) as exc:
-        logger.warning("read_state: schema mismatch or corrupt payload in %s: %s", state_path, exc)
+        logger.warning("read_state: corrupt payload in %s: %s", state_path, exc)
         return None
 
 
@@ -239,7 +238,7 @@ def _write_state(state_path: Path, state: CampaignState) -> None:
         "captured_values": state.captured_values,
         "orchestrator_session_id": state.orchestrator_session_id,
     }
-    write_versioned_json(state_path, payload, schema_version=state.schema_version)
+    write_versioned_json(state_path, payload, schema_version=_SCHEMA_VERSION)
 
 
 def mark_dispatch_running(
@@ -374,6 +373,8 @@ def build_protected_campaign_ids(project_dir: Path) -> frozenset[str]:
         for state_file in dispatches_dir.glob("*.json"):
             try:
                 data = json.loads(state_file.read_text(encoding="utf-8"))
+                if data.get("schema_version") != _SCHEMA_VERSION:
+                    continue
                 cid = data.get("campaign_id", "")
                 if not cid:
                     continue
@@ -439,6 +440,8 @@ def read_all_campaign_captures(
     for path in dispatches_dir.glob("*.json"):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
+            if data.get("schema_version") != _SCHEMA_VERSION:
+                continue
             if data.get("campaign_id") != campaign_id:
                 continue
             caps = data.get("captured_values", {})

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -152,7 +152,7 @@ def read_state(state_path: Path) -> CampaignState | None:
             orchestrator_session_id=data.get("orchestrator_session_id") or "",
         )
     except (KeyError, ValueError, TypeError) as exc:
-        logger.warning("read_state: corrupt payload in %s: %s", state_path, exc)
+        logger.warning("read_state_corrupt_payload", path=str(state_path), exc=str(exc))
         return None
 
 

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -127,11 +127,11 @@ class DispatchRecord:
 class CampaignState:
     """Top-level campaign state file content."""
 
-    schema_version: int
     campaign_id: str
     campaign_name: str
     manifest_path: str
     started_at: float
+    schema_version: int = _SCHEMA_VERSION
     dispatches: list[DispatchRecord] = field(default_factory=list)
     captured_values: dict[str, str] = field(default_factory=dict)
     orchestrator_session_id: str = ""

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -11,7 +11,7 @@ from autoskillit.core import FleetErrorCode, RetryReason
 
 _resume_lock = threading.Lock()
 
-_SCHEMA_VERSION = 4
+FLEET_STATE_SCHEMA_VERSION = 4
 
 FLEET_HALTED_SENTINEL = "fleet_halted_on_failure"
 
@@ -131,7 +131,7 @@ class CampaignState:
     campaign_name: str
     manifest_path: str
     started_at: float
-    schema_version: int = _SCHEMA_VERSION
+    schema_version: int = FLEET_STATE_SCHEMA_VERSION
     dispatches: list[DispatchRecord] = field(default_factory=list)
     captured_values: dict[str, str] = field(default_factory=dict)
     orchestrator_session_id: str = ""

--- a/tests/cli/CLAUDE.md
+++ b/tests/cli/CLAUDE.md
@@ -29,6 +29,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_doctor.py` | Tests for CLI doctor command and related utilities |
 | `test_doctor_migration.py` | Tests for doctor quota cache schema, install classification, version consistency, and drift |
 | `test_doctor_scripts.py` | Tests for doctor script/recipe version health checks |
+| `test_doctor_fleet.py` | Tests for fleet state schema version doctor check |
 | `test_doctor_split.py` | Structural guards: test_doctor.py split into three files (P1-F02) |
 | `test_features_cli.py` | Tests for the features CLI subcommand |
 | `test_fleet_campaign.py` | Tests: fleet CLI campaign command |

--- a/tests/cli/_fleet_helpers.py
+++ b/tests/cli/_fleet_helpers.py
@@ -149,12 +149,13 @@ def _setup_campaign_with_sessions(
 def _make_state(*, statuses: list[str]) -> CampaignState:
     """Build an in-memory CampaignState for unit-testing _compute_exit_code."""
     from autoskillit.fleet import CampaignState, DispatchRecord, DispatchStatus
+    from autoskillit.fleet.state_types import _SCHEMA_VERSION
 
     dispatches = [
         DispatchRecord(name=f"d{i}", status=DispatchStatus(s)) for i, s in enumerate(statuses)
     ]
     return CampaignState(
-        schema_version=2,
+        schema_version=_SCHEMA_VERSION,
         campaign_id="test-id",
         campaign_name="test",
         manifest_path="manifest.yaml",
@@ -166,6 +167,7 @@ def _make_state(*, statuses: list[str]) -> CampaignState:
 def _make_state_with_tokens(*, input_total: int) -> CampaignState:
     """Build an in-memory CampaignState with known token totals."""
     from autoskillit.fleet import CampaignState, DispatchRecord, DispatchStatus
+    from autoskillit.fleet.state_types import _SCHEMA_VERSION
 
     dispatches = [
         DispatchRecord(
@@ -175,7 +177,7 @@ def _make_state_with_tokens(*, input_total: int) -> CampaignState:
         )
     ]
     return CampaignState(
-        schema_version=2,
+        schema_version=_SCHEMA_VERSION,
         campaign_id="test-id",
         campaign_name="test",
         manifest_path="manifest.yaml",

--- a/tests/cli/_fleet_helpers.py
+++ b/tests/cli/_fleet_helpers.py
@@ -149,13 +149,11 @@ def _setup_campaign_with_sessions(
 def _make_state(*, statuses: list[str]) -> CampaignState:
     """Build an in-memory CampaignState for unit-testing _compute_exit_code."""
     from autoskillit.fleet import CampaignState, DispatchRecord, DispatchStatus
-    from autoskillit.fleet.state_types import _SCHEMA_VERSION
 
     dispatches = [
         DispatchRecord(name=f"d{i}", status=DispatchStatus(s)) for i, s in enumerate(statuses)
     ]
     return CampaignState(
-        schema_version=_SCHEMA_VERSION,
         campaign_id="test-id",
         campaign_name="test",
         manifest_path="manifest.yaml",
@@ -167,7 +165,6 @@ def _make_state(*, statuses: list[str]) -> CampaignState:
 def _make_state_with_tokens(*, input_total: int) -> CampaignState:
     """Build an in-memory CampaignState with known token totals."""
     from autoskillit.fleet import CampaignState, DispatchRecord, DispatchStatus
-    from autoskillit.fleet.state_types import _SCHEMA_VERSION
 
     dispatches = [
         DispatchRecord(
@@ -177,7 +174,6 @@ def _make_state_with_tokens(*, input_total: int) -> CampaignState:
         )
     ]
     return CampaignState(
-        schema_version=_SCHEMA_VERSION,
         campaign_id="test-id",
         campaign_name="test",
         manifest_path="manifest.yaml",

--- a/tests/cli/test_doctor_fleet.py
+++ b/tests/cli/test_doctor_fleet.py
@@ -1,0 +1,63 @@
+"""Tests for fleet doctor checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.cli.doctor._doctor_fleet import _check_fleet_state_schema
+from autoskillit.fleet.state_types import _SCHEMA_VERSION
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+
+
+class TestCheckFleetStateSchema:
+    def test_check_fleet_state_schema_ok_on_current_version(self, tmp_path: Path) -> None:
+        dispatches_dir = tmp_path / "dispatches"
+        dispatches_dir.mkdir()
+        state_file = dispatches_dir / "campaign_abc.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": _SCHEMA_VERSION,
+                    "campaign_id": "abc",
+                    "campaign_name": "test",
+                    "manifest_path": "/m.yaml",
+                    "started_at": 0.0,
+                    "dispatches": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _check_fleet_state_schema(dispatches_dir)
+        assert result.severity.name == "OK"
+
+    def test_check_fleet_state_schema_warns_on_stale_version(self, tmp_path: Path) -> None:
+        dispatches_dir = tmp_path / "dispatches"
+        dispatches_dir.mkdir()
+        state_file = dispatches_dir / "campaign_stale.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "campaign_id": "stale",
+                    "campaign_name": "test",
+                    "manifest_path": "/m.yaml",
+                    "started_at": 0.0,
+                    "dispatches": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _check_fleet_state_schema(dispatches_dir)
+        assert result.severity.name == "WARNING"
+        assert "drift" in result.message.lower()
+        assert "stale" in result.message
+
+    def test_check_fleet_state_schema_ok_on_empty_dir(self, tmp_path: Path) -> None:
+        dispatches_dir = tmp_path / "dispatches"
+        dispatches_dir.mkdir()
+        result = _check_fleet_state_schema(dispatches_dir)
+        assert result.severity.name == "OK"

--- a/tests/cli/test_doctor_fleet.py
+++ b/tests/cli/test_doctor_fleet.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.cli.doctor._doctor_fleet import _check_fleet_state_schema
-from autoskillit.fleet.state_types import _SCHEMA_VERSION
+from autoskillit.fleet import FLEET_STATE_SCHEMA_VERSION
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
@@ -21,7 +21,7 @@ class TestCheckFleetStateSchema:
         state_file.write_text(
             json.dumps(
                 {
-                    "schema_version": _SCHEMA_VERSION,
+                    "schema_version": FLEET_STATE_SCHEMA_VERSION,
                     "campaign_id": "abc",
                     "campaign_name": "test",
                     "manifest_path": "/m.yaml",

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -23,6 +23,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_label_lifecycle.py` | Tests for IssueLabelState, LabelDef, LABEL_LIFECYCLE_REGISTRY, LABEL_TRANSITIONS, and validate_label_transition |
 | `test_logging.py` | Tests for autoskillit.core.logging — centralized structlog configuration |
 | `test_paths.py` | Tests for autoskillit.core.paths — is_git_worktree and pkg_root |
+| `test_plugin_cache.py` | Tests for core/_plugin_cache.py — retiring cache, kitchen registry, and schema version validation |
 | `test_resolve_temp_dir.py` | Tests for autoskillit.core.io.resolve_temp_dir |
 | `test_session_provenance.py` | Tests for core/runtime/session_provenance.py — provenance store for L2 sessions |
 | `test_session_checkpoint.py` | Tests for SessionCheckpoint schema validation and compute_remaining |

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -371,3 +371,16 @@ class TestReadVersionedJson:
             _warnings.simplefilter("always")
             read_versioned_json(target, expected_version=3)
         assert len(w2) == 1
+
+    def test_read_versioned_json_deduplicates_per_path_and_version(self, tmp_path: Path) -> None:
+        import warnings as _warnings
+
+        from autoskillit.core.io import write_versioned_json
+
+        target = tmp_path / "v1.json"
+        write_versioned_json(target, {"a": 1}, schema_version=1)
+        with _warnings.catch_warnings(record=True) as w:
+            _warnings.simplefilter("always")
+            read_versioned_json(target, expected_version=3)
+            read_versioned_json(target, expected_version=5)
+        assert len(w) == 2

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
-from autoskillit.core.io import write_versioned_json
+from autoskillit.core.io import read_versioned_json, write_versioned_json
 
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
@@ -252,3 +253,121 @@ def test_write_versioned_json_produces_indented_output(tmp_path):
     lines = raw.strip().splitlines()
     assert len(lines) > 1, "Output must be multi-line (indented)"
     assert json.loads(raw) == {"a": 1, "b": [2, 3], "schema_version": 1}
+
+
+# read_versioned_json — schema version validation helper
+
+
+class TestReadVersionedJson:
+    def setup_method(self):
+        from autoskillit.core.io import _reset_schema_drift_logged_for_tests
+
+        _reset_schema_drift_logged_for_tests()
+
+    def test_read_versioned_json_returns_payload_on_match(self, tmp_path: Path) -> None:
+        from autoskillit.core.io import write_versioned_json
+
+        target = tmp_path / "v3.json"
+        write_versioned_json(target, {"a": 1}, schema_version=3)
+        result = read_versioned_json(target, expected_version=3)
+        assert result == {"a": 1, "schema_version": 3}
+
+    def test_read_versioned_json_returns_none_on_version_mismatch(self, tmp_path: Path) -> None:
+        from autoskillit.core.io import write_versioned_json
+
+        target = tmp_path / "v1.json"
+        write_versioned_json(target, {"a": 1}, schema_version=1)
+        result = read_versioned_json(target, expected_version=3)
+        assert result is None
+
+    def test_read_versioned_json_logs_drift_warning_on_mismatch(self, tmp_path: Path) -> None:
+        import warnings as _warnings
+
+        from autoskillit.core.io import write_versioned_json
+
+        target = tmp_path / "v1.json"
+        write_versioned_json(target, {"a": 1}, schema_version=1)
+        with _warnings.catch_warnings(record=True) as w:
+            _warnings.simplefilter("always")
+            result = read_versioned_json(target, expected_version=3)
+        assert result is None
+        assert len(w) == 1
+        assert "schema_drift" in str(w[0].message)
+
+    def test_read_versioned_json_deduplicates_drift_warnings(self, tmp_path: Path) -> None:
+        import warnings as _warnings
+
+        from autoskillit.core.io import write_versioned_json
+
+        target = tmp_path / "v1.json"
+        write_versioned_json(target, {"a": 1}, schema_version=1)
+        with _warnings.catch_warnings(record=True) as w:
+            _warnings.simplefilter("always")
+            read_versioned_json(target, expected_version=3)
+            read_versioned_json(target, expected_version=3)
+        assert len(w) == 1
+
+    def test_read_versioned_json_deduplicates_per_path_not_globally(self, tmp_path: Path) -> None:
+        import warnings as _warnings
+
+        from autoskillit.core.io import write_versioned_json
+
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        write_versioned_json(a, {"a": 1}, schema_version=1)
+        write_versioned_json(b, {"b": 2}, schema_version=1)
+        with _warnings.catch_warnings(record=True) as w:
+            _warnings.simplefilter("always")
+            read_versioned_json(a, expected_version=3)
+            read_versioned_json(b, expected_version=3)
+        assert len(w) == 2
+
+    def test_read_versioned_json_returns_none_on_missing_file(self, tmp_path: Path) -> None:
+
+        result = read_versioned_json(tmp_path / "nonexistent.json", expected_version=1)
+        assert result is None
+
+    def test_read_versioned_json_returns_none_on_corrupt_json(self, tmp_path: Path) -> None:
+
+        target = tmp_path / "bad.json"
+        target.write_text("not valid json {{{", encoding="utf-8")
+        result = read_versioned_json(target, expected_version=1)
+        assert result is None
+
+    def test_read_versioned_json_returns_none_on_non_dict(self, tmp_path: Path) -> None:
+
+        target = tmp_path / "array.json"
+        target.write_text("[1,2,3]", encoding="utf-8")
+        result = read_versioned_json(target, expected_version=1)
+        assert result is None
+
+    def test_read_versioned_json_returns_none_on_missing_schema_version_key(
+        self, tmp_path: Path
+    ) -> None:
+
+        target = tmp_path / "no_ver.json"
+        target.write_text('{"a": 1}', encoding="utf-8")
+        result = read_versioned_json(target, expected_version=1)
+        assert result is None
+
+    def test_read_versioned_json_reset_drift_set_clears_dedup(self, tmp_path: Path) -> None:
+        import warnings as _warnings
+
+        from autoskillit.core.io import (
+            _reset_schema_drift_logged_for_tests,
+            write_versioned_json,
+        )
+
+        target = tmp_path / "v1.json"
+        write_versioned_json(target, {"a": 1}, schema_version=1)
+        with _warnings.catch_warnings(record=True) as w1:
+            _warnings.simplefilter("always")
+            read_versioned_json(target, expected_version=3)
+        assert len(w1) == 1
+
+        _reset_schema_drift_logged_for_tests()
+
+        with _warnings.catch_warnings(record=True) as w2:
+            _warnings.simplefilter("always")
+            read_versioned_json(target, expected_version=3)
+        assert len(w2) == 1

--- a/tests/core/test_plugin_cache.py
+++ b/tests/core/test_plugin_cache.py
@@ -89,12 +89,13 @@ class TestRetiringCacheSchemaValidation:
             }
         ]
 
-    def test_sweep_retiring_cache_ignores_stale_version(self, tmp_path):
+    def test_sweep_retiring_cache_ignores_stale_version(self, monkeypatch, tmp_path):
         """sweep_retiring_cache must treat a stale retiring_cache.json as empty.
 
         When the file has schema_version != _SCHEMA_VERSION, the function must
         return 0 (nothing to sweep) rather than crashing or sweeping stale data.
         """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         cache = tmp_path / ".autoskillit" / "retiring_cache.json"
         _make_retiring_file(
             cache,
@@ -155,12 +156,13 @@ class TestRetiringCacheSchemaValidation:
         # New kitchen must be present
         assert "new-kitchen" in ids
 
-    def test_any_kitchen_open_returns_false_on_stale_version(self, tmp_path):
+    def test_any_kitchen_open_returns_false_on_stale_version(self, monkeypatch, tmp_path):
         """any_kitchen_open must return False when active_kitchens.json has stale schema version.
 
         Even if the stale file contains kitchen entries, the stale version causes
         it to be treated as absent, so the function returns False.
         """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         kitchens_path = tmp_path / ".autoskillit" / "active_kitchens.json"
         _make_kitchen_file(
             kitchens_path,

--- a/tests/core/test_plugin_cache.py
+++ b/tests/core/test_plugin_cache.py
@@ -1,0 +1,247 @@
+"""Tests for core/_plugin_cache.py — retiring cache, kitchen registry, and schema version validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core._plugin_cache import (
+    any_kitchen_open,
+    append_retiring_entry,
+    clear_kitchens_for_pid,
+    register_active_kitchen,
+    sweep_retiring_cache,
+    unregister_active_kitchen,
+)
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_kitchen_file(path: Path, schema_version: int, kitchens: list[dict]) -> None:
+    """Write a valid active_kitchens.json file with the given schema version."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"schema_version": schema_version, "kitchens": kitchens}))
+
+
+def _make_retiring_file(path: Path, schema_version: int, retiring: list[dict]) -> None:
+    """Write a valid retiring_cache.json file with the given schema version."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"schema_version": schema_version, "retiring": retiring}))
+
+
+# ---------------------------------------------------------------------------
+# Schema version validation — stale retiring cache
+# ---------------------------------------------------------------------------
+
+
+class TestRetiringCacheSchemaValidation:
+    def setup_method(self):
+        from autoskillit.core.io import _reset_schema_drift_logged_for_tests
+
+        _reset_schema_drift_logged_for_tests()
+
+    def test_append_retiring_entry_reads_ignore_stale_version(self, monkeypatch, tmp_path):
+        """Stale retiring_cache.json (schema_version=99) must be treated as empty.
+
+        append_retiring_entry reads the existing cache before writing.
+        When the file has a stale schema version, it must be discarded and only
+        the new entry must be written.
+        """
+        cache = tmp_path / ".autoskillit" / "retiring_cache.json"
+        _make_retiring_file(
+            cache, schema_version=99, retiring=[{"version": "old", "path": "/old/path"}]
+        )
+
+        # Intercept filesystem writes so we can inspect what gets persisted
+        written: list[str] = []
+
+        def spy_write(path, data, schema_version):
+            written.append(json.loads(Path(path).read_text()))
+            from autoskillit.core.io import write_versioned_json as real
+
+            real(path, data, schema_version)
+
+        monkeypatch.setattr("autoskillit.core._plugin_cache.write_versioned_json", spy_write)
+
+        append_retiring_entry("1.0", "/new/path")
+
+        # The stale entries must not appear in any write
+        for w in written:
+            versioned_entries = w.get("retiring", [])
+            stale = [e for e in versioned_entries if e["version"] == "old"]
+            assert len(stale) == 0, "Stale entries must not be carried forward"
+        # Only the new entry should be present
+        last = written[-1]
+        assert last["retiring"] == [
+            {
+                "version": "1.0",
+                "path": "/new/path",
+                "retired_at": last["retiring"][0]["retired_at"],
+            }
+        ]
+
+    def test_sweep_retiring_cache_ignores_stale_version(self, tmp_path):
+        """sweep_retiring_cache must treat a stale retiring_cache.json as empty.
+
+        When the file has schema_version != _SCHEMA_VERSION, the function must
+        return 0 (nothing to sweep) rather than crashing or sweeping stale data.
+        """
+        cache = tmp_path / ".autoskillit" / "retiring_cache.json"
+        _make_retiring_file(
+            cache,
+            schema_version=99,
+            retiring=[
+                {
+                    "version": "0.9",
+                    "path": str(tmp_path / "old"),
+                    "retired_at": "2020-01-01T00:00:00+00:00",
+                }
+            ],
+        )
+        # Create the directory so shutil.rmtree doesn't crash
+        (tmp_path / "old").mkdir()
+
+        result = sweep_retiring_cache(grace_hours=0)
+
+        assert result == 0, "Must return 0 when file has stale schema version"
+
+    def test_register_active_kitchen_ignores_stale_version(self, monkeypatch, tmp_path):
+        """Stale active_kitchens.json must be overwritten with fresh data.
+
+        register_active_kitchen reads the existing file before writing.
+        When the file has a stale schema version, it must be treated as empty
+        and the newly registered kitchen must be the only entry.
+        """
+        kitchens_path = tmp_path / ".autoskillit" / "active_kitchens.json"
+        _make_kitchen_file(
+            kitchens_path,
+            schema_version=99,
+            kitchens=[
+                {
+                    "kitchen_id": "old-kitchen",
+                    "pid": 99999,
+                    "create_time": None,
+                    "project_path": "/old",
+                }
+            ],
+        )
+
+        written: list[str] = []
+
+        def spy_write(path, data, schema_version):
+            written.append(json.loads(Path(path).read_text()))
+            from autoskillit.core.io import write_versioned_json as real
+
+            real(path, data, schema_version)
+
+        monkeypatch.setattr("autoskillit.core._plugin_cache.write_versioned_json", spy_write)
+
+        register_active_kitchen("new-kitchen", 12345, "/new")
+
+        last = written[-1]
+        # Stale kitchen must not be present
+        ids = [k["kitchen_id"] for k in last.get("kitchens", [])]
+        assert "old-kitchen" not in ids
+        # New kitchen must be present
+        assert "new-kitchen" in ids
+
+    def test_any_kitchen_open_returns_false_on_stale_version(self, tmp_path):
+        """any_kitchen_open must return False when active_kitchens.json has stale schema version.
+
+        Even if the stale file contains kitchen entries, the stale version causes
+        it to be treated as absent, so the function returns False.
+        """
+        kitchens_path = tmp_path / ".autoskillit" / "active_kitchens.json"
+        _make_kitchen_file(
+            kitchens_path,
+            schema_version=99,
+            kitchens=[
+                {
+                    "kitchen_id": "stale-kitchen",
+                    "pid": 99999,
+                    "create_time": None,
+                    "project_path": "/x",
+                }
+            ],
+        )
+
+        result = any_kitchen_open()
+
+        assert result is False, "Must return False for stale schema version"
+
+
+class TestActiveKitchensSchemaValidation:
+    def setup_method(self):
+        from autoskillit.core.io import _reset_schema_drift_logged_for_tests
+
+        _reset_schema_drift_logged_for_tests()
+
+    def test_unregister_active_kitchen_ignores_stale_version(self, monkeypatch, tmp_path):
+        """Stale active_kitchens.json must be treated as empty during unregister."""
+        kitchens_path = tmp_path / ".autoskillit" / "active_kitchens.json"
+        _make_kitchen_file(
+            kitchens_path,
+            schema_version=99,
+            kitchens=[
+                {
+                    "kitchen_id": "stale-kitchen",
+                    "pid": 99999,
+                    "create_time": None,
+                    "project_path": "/x",
+                }
+            ],
+        )
+
+        written: list[str] = []
+
+        def spy_write(path, data, schema_version):
+            written.append(json.loads(Path(path).read_text()))
+            from autoskillit.core.io import write_versioned_json as real
+
+            real(path, data, schema_version)
+
+        monkeypatch.setattr("autoskillit.core._plugin_cache.write_versioned_json", spy_write)
+
+        unregister_active_kitchen("stale-kitchen")
+
+        # Must not crash; the stale file is treated as empty so nothing is written
+        last = written[-1]
+        assert last["kitchens"] == []
+
+    def test_clear_kitchens_for_pid_ignores_stale_version(self, monkeypatch, tmp_path):
+        """Stale active_kitchens.json must be treated as empty during clear_kitchens_for_pid."""
+        kitchens_path = tmp_path / ".autoskillit" / "active_kitchens.json"
+        _make_kitchen_file(
+            kitchens_path,
+            schema_version=99,
+            kitchens=[
+                {
+                    "kitchen_id": "some-kitchen",
+                    "pid": 12345,
+                    "create_time": None,
+                    "project_path": "/x",
+                }
+            ],
+        )
+
+        written: list[str] = []
+
+        def spy_write(path, data, schema_version):
+            written.append(json.loads(Path(path).read_text()))
+            from autoskillit.core.io import write_versioned_json as real
+
+            real(path, data, schema_version)
+
+        monkeypatch.setattr("autoskillit.core._plugin_cache.write_versioned_json", spy_write)
+
+        clear_kitchens_for_pid(12345)
+
+        last = written[-1]
+        assert last["kitchens"] == []

--- a/tests/core/test_plugin_cache.py
+++ b/tests/core/test_plugin_cache.py
@@ -1,4 +1,5 @@
-"""Tests for core/_plugin_cache.py — retiring cache, kitchen registry, and schema version validation."""
+"""Tests for core/_plugin_cache.py — retiring cache, kitchen registry, and schema version
+validation."""
 
 from __future__ import annotations
 
@@ -54,6 +55,7 @@ class TestRetiringCacheSchemaValidation:
         When the file has a stale schema version, it must be discarded and only
         the new entry must be written.
         """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         cache = tmp_path / ".autoskillit" / "retiring_cache.json"
         _make_retiring_file(
             cache, schema_version=99, retiring=[{"version": "old", "path": "/old/path"}]
@@ -63,10 +65,10 @@ class TestRetiringCacheSchemaValidation:
         written: list[str] = []
 
         def spy_write(path, data, schema_version):
-            written.append(json.loads(Path(path).read_text()))
             from autoskillit.core.io import write_versioned_json as real
 
             real(path, data, schema_version)
+            written.append(json.loads(Path(path).read_text()))
 
         monkeypatch.setattr("autoskillit.core._plugin_cache.write_versioned_json", spy_write)
 
@@ -119,6 +121,7 @@ class TestRetiringCacheSchemaValidation:
         When the file has a stale schema version, it must be treated as empty
         and the newly registered kitchen must be the only entry.
         """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         kitchens_path = tmp_path / ".autoskillit" / "active_kitchens.json"
         _make_kitchen_file(
             kitchens_path,
@@ -136,10 +139,10 @@ class TestRetiringCacheSchemaValidation:
         written: list[str] = []
 
         def spy_write(path, data, schema_version):
-            written.append(json.loads(Path(path).read_text()))
             from autoskillit.core.io import write_versioned_json as real
 
             real(path, data, schema_version)
+            written.append(json.loads(Path(path).read_text()))
 
         monkeypatch.setattr("autoskillit.core._plugin_cache.write_versioned_json", spy_write)
 
@@ -185,6 +188,7 @@ class TestActiveKitchensSchemaValidation:
 
     def test_unregister_active_kitchen_ignores_stale_version(self, monkeypatch, tmp_path):
         """Stale active_kitchens.json must be treated as empty during unregister."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         kitchens_path = tmp_path / ".autoskillit" / "active_kitchens.json"
         _make_kitchen_file(
             kitchens_path,
@@ -202,10 +206,10 @@ class TestActiveKitchensSchemaValidation:
         written: list[str] = []
 
         def spy_write(path, data, schema_version):
-            written.append(json.loads(Path(path).read_text()))
             from autoskillit.core.io import write_versioned_json as real
 
             real(path, data, schema_version)
+            written.append(json.loads(Path(path).read_text()))
 
         monkeypatch.setattr("autoskillit.core._plugin_cache.write_versioned_json", spy_write)
 
@@ -217,6 +221,7 @@ class TestActiveKitchensSchemaValidation:
 
     def test_clear_kitchens_for_pid_ignores_stale_version(self, monkeypatch, tmp_path):
         """Stale active_kitchens.json must be treated as empty during clear_kitchens_for_pid."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         kitchens_path = tmp_path / ".autoskillit" / "active_kitchens.json"
         _make_kitchen_file(
             kitchens_path,
@@ -234,10 +239,10 @@ class TestActiveKitchensSchemaValidation:
         written: list[str] = []
 
         def spy_write(path, data, schema_version):
-            written.append(json.loads(Path(path).read_text()))
             from autoskillit.core.io import write_versioned_json as real
 
             real(path, data, schema_version)
+            written.append(json.loads(Path(path).read_text()))
 
         monkeypatch.setattr("autoskillit.core._plugin_cache.write_versioned_json", spy_write)
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -239,15 +239,15 @@ def test_doctor_check_count_is_31() -> None:
     # in run_doctor() — 17 numbered base markers + 6 lettered sub-check markers
     # (2b, 2c, 2d, 2e, 4b, 7b) + 4 ambient env checks (18–21)
     # + 2 new unconditional feature checks (22–23)
-    # + 5 gated franchise checks (24–28) = 34 total.
+    # + 6 gated franchise checks (24–29) = 35 total.
     # test_installation_states_17_doctor_checks checks the *user-visible* count
     # from docs/installation.md ("15 numbered + 2 lettered sub-checks 4b and 7b
     # = 17").  The gap of 5 is intentional: Check 2, Check 4, and Check 7 each
     # appear as separate implementation markers but the docs present them as single
     # numbered entries that subsume their sub-variants.
     # Update both tests whenever a new doctor check is added.
-    assert _count_doctor_checks() == 34, (
-        f"Expected 34 doctor checks; found {_count_doctor_checks()}"
+    assert _count_doctor_checks() == 35, (
+        f"Expected 35 doctor checks; found {_count_doctor_checks()}"
     )
 
 

--- a/tests/execution/test_quota_io.py
+++ b/tests/execution/test_quota_io.py
@@ -203,7 +203,7 @@ class TestCacheSchemaVersion:
     """Phase 4 (#711 Part B): quota cache schema versioning tests."""
 
     def setup_method(self):
-        from autoskillit.execution.quota import _reset_schema_drift_logged_for_tests
+        from autoskillit.core.io import _reset_schema_drift_logged_for_tests
 
         _reset_schema_drift_logged_for_tests()
 
@@ -313,10 +313,9 @@ class TestCacheSchemaVersion:
         with structlog.testing.capture_logs() as cap:
             _read_cache(str(cache_path), max_age=60)
 
-        drift_logs = [r for r in cap if "quota_cache_schema_drift" in r.get("event", "")]
+        drift_logs = [r for r in cap if "schema_drift" in r.get("event", "")]
         assert len(drift_logs) == 1
-        assert "cache_path" in drift_logs[0]
-        assert drift_logs[0]["observed"] is None
+        assert "path" in drift_logs[0]
 
     def test_read_cache_logs_drift_exactly_once_per_path_per_process(self, tmp_path):
         import structlog.testing
@@ -335,7 +334,7 @@ class TestCacheSchemaVersion:
             for _ in range(5):
                 _read_cache(str(cache_path), max_age=60)
 
-        drift_logs = [r for r in cap if "quota_cache_schema_drift" in r.get("event", "")]
+        drift_logs = [r for r in cap if "schema_drift" in r.get("event", "")]
         assert len(drift_logs) == 1
 
     def test_read_cache_logs_drift_once_per_path_not_globally(self, tmp_path):
@@ -359,16 +358,14 @@ class TestCacheSchemaVersion:
             _read_cache(str(tmp_path / "cache_a.json"), max_age=60)
             _read_cache(str(tmp_path / "cache_b.json"), max_age=60)
 
-        drift_logs = [r for r in cap if "quota_cache_schema_drift" in r.get("event", "")]
+        drift_logs = [r for r in cap if "schema_drift" in r.get("event", "")]
         assert len(drift_logs) == 2
 
     def test_read_cache_drift_set_is_module_scoped_and_reset_helper_works(self, tmp_path):
         import structlog.testing
 
-        from autoskillit.execution.quota import (
-            _read_cache,
-            _reset_schema_drift_logged_for_tests,
-        )
+        from autoskillit.core.io import _reset_schema_drift_logged_for_tests
+        from autoskillit.execution.quota import _read_cache
 
         cache_path = tmp_path / "cache.json"
         cache_path.write_text(
@@ -383,13 +380,13 @@ class TestCacheSchemaVersion:
 
         with structlog.testing.capture_logs() as cap1:
             _read_cache(str(cache_path), max_age=60)
-        assert len([r for r in cap1 if "quota_cache_schema_drift" in r.get("event", "")]) == 1
+        assert len([r for r in cap1 if "schema_drift" in r.get("event", "")]) == 1
 
         _reset_schema_drift_logged_for_tests()
 
         with structlog.testing.capture_logs() as cap2:
             _read_cache(str(cache_path), max_age=60)
-        assert len([r for r in cap2 if "quota_cache_schema_drift" in r.get("event", "")]) == 1
+        assert len([r for r in cap2 if "schema_drift" in r.get("event", "")]) == 1
 
     @pytest.mark.anyio
     async def test_old_format_cache_gets_rewritten_with_new_format_on_next_fetch(
@@ -425,6 +422,48 @@ class TestCacheSchemaVersion:
         await check_and_sleep_if_needed(config)
         new_data = json.loads(cache_path.read_text())
         assert new_data["schema_version"] == 3
+
+    def test_read_cache_uses_shared_read_versioned_json(self, tmp_path, monkeypatch):
+        """_read_cache must call read_versioned_json (not inline validation)."""
+        from autoskillit.core.io import read_versioned_json
+        from autoskillit.execution.quota import (
+            QUOTA_CACHE_SCHEMA_VERSION,
+            _read_cache,
+        )
+
+        now = datetime.now(UTC)
+        cache_data = {
+            "schema_version": QUOTA_CACHE_SCHEMA_VERSION,
+            "fetched_at": (now - timedelta(seconds=30)).isoformat(),
+            "windows": {
+                "five_hour": {
+                    "utilization": 87.3,
+                    "resets_at": "2026-02-27T20:15:00+00:00",
+                }
+            },
+            "binding": {
+                "window_name": "five_hour",
+                "utilization": 87.3,
+                "resets_at": "2026-02-27T20:15:00+00:00",
+                "should_block": True,
+                "effective_threshold": 85.0,
+            },
+        }
+        cache_path = tmp_path / "usage_cache.json"
+        cache_path.write_text(json.dumps(cache_data))
+
+        calls = []
+
+        def spy(path, expected_version, *, logger=None):
+            calls.append({"path": path, "expected_version": expected_version})
+            return read_versioned_json(path, expected_version, logger=logger)
+
+        monkeypatch.setattr("autoskillit.execution.quota.read_versioned_json", spy)
+        status = _read_cache(str(cache_path), max_age=120)
+
+        assert status is not None
+        assert len(calls) == 1
+        assert calls[0]["expected_version"] == QUOTA_CACHE_SCHEMA_VERSION
 
 
 class TestInvalidateCache:

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -27,7 +27,7 @@ from autoskillit.fleet import (
     write_captured_values,
     write_initial_state,
 )
-from autoskillit.fleet.state import _SCHEMA_VERSION
+from autoskillit.fleet.state import FLEET_STATE_SCHEMA_VERSION
 from autoskillit.fleet.state import _write_state as fleet_write_state
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
@@ -1102,7 +1102,7 @@ class TestClassifyStaleDispatch:
 
 class TestWriteStateSchemaVersionPinning:
     def test_write_state_pins_schema_version_to_constant(self, tmp_path: Path) -> None:
-        """_write_state must stamp the current _SCHEMA_VERSION, not state.schema_version."""
+        """_write_state must stamp FLEET_STATE_SCHEMA_VERSION, not state.schema_version."""
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
         state = read_state(sp)
@@ -1112,7 +1112,7 @@ class TestWriteStateSchemaVersionPinning:
         bad_state.schema_version = 2  # type: ignore[attr-defined]
         fleet_write_state(sp, bad_state)
         raw = json.loads(sp.read_text())
-        assert raw["schema_version"] == _SCHEMA_VERSION
+        assert raw["schema_version"] == FLEET_STATE_SCHEMA_VERSION
 
     def test_round_trip_version_upgrade(self, tmp_path: Path) -> None:
         """A v4 state file written back after mutation stays v4."""
@@ -1120,10 +1120,10 @@ class TestWriteStateSchemaVersionPinning:
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
         state = read_state(sp)
         assert state is not None
-        assert state.schema_version == _SCHEMA_VERSION
+        assert state.schema_version == FLEET_STATE_SCHEMA_VERSION
         mark_dispatch_running(sp, "a", dispatch_id="d1", dispatched_pid=42)
         raw = json.loads(sp.read_text())
-        assert raw["schema_version"] == _SCHEMA_VERSION
+        assert raw["schema_version"] == FLEET_STATE_SCHEMA_VERSION
 
 
 class TestBuildProtectedCampaignIdsSchemaValidation:
@@ -1156,7 +1156,7 @@ class TestBuildProtectedCampaignIdsSchemaValidation:
         current_file.write_text(
             json.dumps(
                 {
-                    "schema_version": _SCHEMA_VERSION,
+                    "schema_version": FLEET_STATE_SCHEMA_VERSION,
                     "campaign_id": "cid-current",
                     "campaign_name": "test",
                     "manifest_path": "/m.yaml",
@@ -1201,7 +1201,7 @@ class TestReadAllCampaignCapturesSchemaValidation:
         current_file.write_text(
             json.dumps(
                 {
-                    "schema_version": _SCHEMA_VERSION,
+                    "schema_version": FLEET_STATE_SCHEMA_VERSION,
                     "campaign_id": "cid-current",
                     "campaign_name": "test",
                     "manifest_path": "/m.yaml",

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -16,6 +16,7 @@ from autoskillit.fleet import (
     DispatchRecord,
     DispatchStatus,
     append_dispatch_record,
+    build_protected_campaign_ids,
     classify_stale_dispatch,
     has_failed_dispatch,
     mark_dispatch_resumable,
@@ -26,6 +27,8 @@ from autoskillit.fleet import (
     write_captured_values,
     write_initial_state,
 )
+from autoskillit.fleet.state import _SCHEMA_VERSION
+from autoskillit.fleet.state import _write_state as fleet_write_state
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -389,7 +392,8 @@ class TestCapturedValuesRoundTrip:
 
 
 class TestReadV2StateFileDefaultsCapturedValues:
-    def test_read_v2_state_file_defaults_captured_values(self, tmp_path: Path) -> None:
+    def test_read_v2_state_file_rejected(self, tmp_path: Path) -> None:
+        """v2 state files are rejected (stale schema version)."""
         sp = _state_path(tmp_path)
         sp.parent.mkdir(parents=True, exist_ok=True)
         v2_data = {
@@ -403,8 +407,7 @@ class TestReadV2StateFileDefaultsCapturedValues:
         sp.write_text(json.dumps(v2_data), encoding="utf-8")
 
         state = read_state(sp)
-        assert state is not None
-        assert state.captured_values == {}
+        assert state is None
 
 
 class TestReadAllCampaignCaptures:
@@ -1095,3 +1098,119 @@ class TestClassifyStaleDispatch:
         status, sidecar_path_out = classify_stale_dispatch(record)
         assert status == DispatchStatus.INTERRUPTED
         assert sidecar_path_out == ""
+
+
+class TestWriteStateSchemaVersionPinning:
+    def test_write_state_pins_schema_version_to_constant(self, tmp_path: Path) -> None:
+        """_write_state must stamp the current _SCHEMA_VERSION, not state.schema_version."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
+        state = read_state(sp)
+        assert state is not None
+        # Artificially corrupt the in-memory schema_version
+        bad_state = state
+        bad_state.schema_version = 2  # type: ignore[attr-defined]
+        fleet_write_state(sp, bad_state)
+        raw = json.loads(sp.read_text())
+        assert raw["schema_version"] == _SCHEMA_VERSION
+
+    def test_round_trip_version_upgrade(self, tmp_path: Path) -> None:
+        """A v4 state file written back after mutation stays v4."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
+        state = read_state(sp)
+        assert state is not None
+        assert state.schema_version == _SCHEMA_VERSION
+        mark_dispatch_running(sp, "a", dispatch_id="d1", dispatched_pid=42)
+        raw = json.loads(sp.read_text())
+        assert raw["schema_version"] == _SCHEMA_VERSION
+
+
+class TestBuildProtectedCampaignIdsSchemaValidation:
+    def test_build_protected_campaign_ids_skips_stale_version(self, tmp_path: Path) -> None:
+        """build_protected_campaign_ids must skip files with stale schema_version."""
+        dispatches_dir = tmp_path / ".autoskillit" / "temp" / "dispatches"
+        dispatches_dir.mkdir(parents=True)
+        stale_file = dispatches_dir / "cid-stale.json"
+        stale_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,  # stale
+                    "campaign_id": "cid-stale",
+                    "campaign_name": "test",
+                    "manifest_path": "/m.yaml",
+                    "started_at": 0.0,
+                    "dispatches": [{"name": "d1", "status": "running"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = build_protected_campaign_ids(tmp_path)
+        assert "cid-stale" not in result
+
+    def test_build_protected_campaign_ids_includes_current_version(self, tmp_path: Path) -> None:
+        """build_protected_campaign_ids includes files with current schema_version."""
+        dispatches_dir = tmp_path / ".autoskillit" / "temp" / "dispatches"
+        dispatches_dir.mkdir(parents=True)
+        current_file = dispatches_dir / "cid-current.json"
+        current_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": _SCHEMA_VERSION,
+                    "campaign_id": "cid-current",
+                    "campaign_name": "test",
+                    "manifest_path": "/m.yaml",
+                    "started_at": 0.0,
+                    "dispatches": [{"name": "d1", "status": "running"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = build_protected_campaign_ids(tmp_path)
+        assert "cid-current" in result
+
+
+class TestReadAllCampaignCapturesSchemaValidation:
+    def test_read_all_campaign_captures_skips_stale_version(self, tmp_path: Path) -> None:
+        """read_all_campaign_captures must skip files with stale schema_version."""
+        dispatches_dir = tmp_path / "dispatches"
+        dispatches_dir.mkdir()
+        stale_file = dispatches_dir / "cid-stale.json"
+        stale_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,  # stale
+                    "campaign_id": "cid-stale",
+                    "campaign_name": "test",
+                    "manifest_path": "/m.yaml",
+                    "started_at": 0.0,
+                    "dispatches": [{"name": "d1", "status": "success"}],
+                    "captured_values": {"key": "value"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = read_all_campaign_captures(dispatches_dir, "cid-stale")
+        assert result == {}
+
+    def test_read_all_campaign_captures_includes_current_version(self, tmp_path: Path) -> None:
+        """read_all_campaign_captures includes files with current schema_version."""
+        dispatches_dir = tmp_path / "dispatches"
+        dispatches_dir.mkdir()
+        current_file = dispatches_dir / "cid-current.json"
+        current_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": _SCHEMA_VERSION,
+                    "campaign_id": "cid-current",
+                    "campaign_name": "test",
+                    "manifest_path": "/m.yaml",
+                    "started_at": 0.0,
+                    "dispatches": [{"name": "d1", "status": "success"}],
+                    "captured_values": {"key": "value"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = read_all_campaign_captures(dispatches_dir, "cid-current")
+        assert result == {"key": "value"}

--- a/tests/fleet/test_state_protection.py
+++ b/tests/fleet/test_state_protection.py
@@ -146,4 +146,4 @@ def test_build_protected_ids_stale_schema_version_skipped(tmp_path: Path) -> Non
     }
     (dispatches_dir / "stale.json").write_text(json.dumps(stale_payload), encoding="utf-8")
     result = build_protected_campaign_ids(tmp_path)
-    assert "stale-campaign" not in result
+    assert result == frozenset()

--- a/tests/fleet/test_state_protection.py
+++ b/tests/fleet/test_state_protection.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.fleet import FLEET_STATE_SCHEMA_VERSION
 from autoskillit.fleet.state import build_protected_campaign_ids
-from autoskillit.fleet.state_types import _SCHEMA_VERSION
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.feature("fleet"), pytest.mark.small]
 
@@ -16,7 +16,7 @@ pytestmark = [pytest.mark.layer("fleet"), pytest.mark.feature("fleet"), pytest.m
 def _write_dispatch_file(dispatches_dir: Path, filename: str, data: dict) -> None:
     dispatches_dir.mkdir(parents=True, exist_ok=True)
     # Inject current schema version so build_protected_campaign_ids accepts the file
-    payload = {"schema_version": _SCHEMA_VERSION, **data}
+    payload = {"schema_version": FLEET_STATE_SCHEMA_VERSION, **data}
     (dispatches_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -133,3 +133,17 @@ def test_build_protected_ids_exported_from_fleet(tmp_path: Path) -> None:
 
     assert callable(fn)
     assert fn(tmp_path) == frozenset()
+
+
+def test_build_protected_ids_stale_schema_version_skipped(tmp_path: Path) -> None:
+    """PROT_10: State file with stale schema_version is skipped, not protected."""
+    dispatches_dir = tmp_path / ".autoskillit" / "temp" / "dispatches"
+    dispatches_dir.mkdir(parents=True, exist_ok=True)
+    stale_payload = {
+        "schema_version": FLEET_STATE_SCHEMA_VERSION - 1,
+        "campaign_id": "stale-campaign",
+        "dispatches": [{"name": "d1", "status": "running"}],
+    }
+    (dispatches_dir / "stale.json").write_text(json.dumps(stale_payload), encoding="utf-8")
+    result = build_protected_campaign_ids(tmp_path)
+    assert "stale-campaign" not in result

--- a/tests/fleet/test_state_protection.py
+++ b/tests/fleet/test_state_protection.py
@@ -8,13 +8,16 @@ from pathlib import Path
 import pytest
 
 from autoskillit.fleet.state import build_protected_campaign_ids
+from autoskillit.fleet.state_types import _SCHEMA_VERSION
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.feature("fleet"), pytest.mark.small]
 
 
 def _write_dispatch_file(dispatches_dir: Path, filename: str, data: dict) -> None:
     dispatches_dir.mkdir(parents=True, exist_ok=True)
-    (dispatches_dir / filename).write_text(json.dumps(data), encoding="utf-8")
+    # Inject current schema version so build_protected_campaign_ids accepts the file
+    payload = {"schema_version": _SCHEMA_VERSION, **data}
+    (dispatches_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
 
 
 def test_build_protected_ids_missing_dispatches_dir(tmp_path: Path) -> None:

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.fleet import (
+    FLEET_STATE_SCHEMA_VERSION,
     DispatchRecord,
     DispatchStatus,
     DispatchTokenUsage,
@@ -16,7 +17,6 @@ from autoskillit.fleet import (
     read_state,
     write_initial_state,
 )
-from autoskillit.fleet.state import _SCHEMA_VERSION
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -66,7 +66,7 @@ class TestDispatchRecordSchemaV2:
         assert dispatch_raw["dispatched_boot_id"] == "abc-boot"
 
     def test_schema_version_is_4(self) -> None:
-        assert _SCHEMA_VERSION == 4
+        assert FLEET_STATE_SCHEMA_VERSION == 4
 
     def test_read_state_returns_none_on_version_mismatch(self, tmp_path: Path) -> None:
         """read_state returns None when schema_version is stale (v1)."""
@@ -119,12 +119,12 @@ class TestDispatchRecordSchemaV2:
         assert len(drift_logs) == 1
 
     def test_read_state_succeeds_on_current_version(self, tmp_path: Path) -> None:
-        """read_state succeeds when schema_version matches _SCHEMA_VERSION."""
+        """read_state succeeds when schema_version matches FLEET_STATE_SCHEMA_VERSION."""
         state_path = tmp_path / "state.json"
         write_initial_state(state_path, "cmp-ok", "test", "/m.yaml", [DispatchRecord(name="d1")])
         state = read_state(state_path)
         assert state is not None
-        assert state.schema_version == _SCHEMA_VERSION
+        assert state.schema_version == FLEET_STATE_SCHEMA_VERSION
 
     def test_read_state_rejects_stale_schema_version(self, tmp_path: Path) -> None:
         """read_state must reject schema v3 state files (stale version)."""

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -68,8 +68,66 @@ class TestDispatchRecordSchemaV2:
     def test_schema_version_is_4(self) -> None:
         assert _SCHEMA_VERSION == 4
 
-    def test_read_state_accepts_legacy_l2_field_names(self, tmp_path: Path) -> None:
-        """read_state must parse schema v3 state files that use old l2_* field names."""
+    def test_read_state_returns_none_on_version_mismatch(self, tmp_path: Path) -> None:
+        """read_state returns None when schema_version is stale (v1)."""
+        stale_payload = {
+            "schema_version": 1,
+            "campaign_id": "cmp",
+            "campaign_name": "test",
+            "manifest_path": "/m.yaml",
+            "started_at": 1.0,
+            "dispatches": [],
+        }
+        state_path = tmp_path / "state.json"
+        state_path.write_text(json.dumps(stale_payload))
+        state = read_state(state_path)
+        assert state is None
+
+    def test_read_state_returns_none_on_future_version(self, tmp_path: Path) -> None:
+        """read_state returns None when schema_version is a future version."""
+        future_payload = {
+            "schema_version": 99,
+            "campaign_id": "cmp",
+            "campaign_name": "test",
+            "manifest_path": "/m.yaml",
+            "started_at": 1.0,
+            "dispatches": [],
+        }
+        state_path = tmp_path / "state.json"
+        state_path.write_text(json.dumps(future_payload))
+        state = read_state(state_path)
+        assert state is None
+
+    def test_read_state_logs_drift_warning_on_mismatch(self, tmp_path: Path) -> None:
+        """read_state logs a drift warning when schema_version is stale."""
+        import structlog.testing
+
+        stale_payload = {
+            "schema_version": 3,
+            "campaign_id": "cmp",
+            "campaign_name": "test",
+            "manifest_path": "/m.yaml",
+            "started_at": 1.0,
+            "dispatches": [],
+        }
+        state_path = tmp_path / "state.json"
+        state_path.write_text(json.dumps(stale_payload))
+        with structlog.testing.capture_logs() as cap:
+            state = read_state(state_path)
+        assert state is None
+        drift_logs = [r for r in cap if "schema_drift" in r.get("event", "")]
+        assert len(drift_logs) >= 1
+
+    def test_read_state_succeeds_on_current_version(self, tmp_path: Path) -> None:
+        """read_state succeeds when schema_version matches _SCHEMA_VERSION."""
+        state_path = tmp_path / "state.json"
+        write_initial_state(state_path, "cmp-ok", "test", "/m.yaml", [DispatchRecord(name="d1")])
+        state = read_state(state_path)
+        assert state is not None
+        assert state.schema_version == _SCHEMA_VERSION
+
+    def test_read_state_rejects_stale_schema_version(self, tmp_path: Path) -> None:
+        """read_state must reject schema v3 state files (stale version)."""
         legacy_payload = {
             "schema_version": 3,
             "campaign_id": "cmp-legacy",
@@ -92,13 +150,7 @@ class TestDispatchRecordSchemaV2:
         state_path = tmp_path / "state.json"
         state_path.write_text(json.dumps(legacy_payload))
         state = read_state(state_path)
-        assert state is not None
-        d = state.dispatches[0]
-        assert d.dispatched_session_id == "sess-old"
-        assert d.dispatched_session_log_dir == "/old/logs"
-        assert d.dispatched_pid == 1234
-        assert d.dispatched_starttime_ticks == 5678
-        assert d.dispatched_boot_id == "boot-old"
+        assert state is None
 
     def test_dispatch_record_serializes_dispatched_field_names(self) -> None:
         """DispatchRecord.to_dict() must use dispatched_* field names."""
@@ -109,8 +161,8 @@ class TestDispatchRecordSchemaV2:
         assert "l2_pid" not in raw
         assert "l2_session_id" not in raw
 
-    def test_read_state_accepts_legacy_l3_field_names(self, tmp_path: Path) -> None:
-        """read_state must parse schema v3 state files that use old l3_* field names."""
+    def test_read_state_rejects_v3_schema(self, tmp_path: Path) -> None:
+        """read_state must reject schema v3 state files (stale version)."""
         legacy_payload = {
             "schema_version": 3,
             "campaign_id": "cmp-legacy-l3",
@@ -133,17 +185,10 @@ class TestDispatchRecordSchemaV2:
         state_path = tmp_path / "state.json"
         state_path.write_text(json.dumps(legacy_payload))
         state = read_state(state_path)
-        assert state is not None
-        d = state.dispatches[0]
-        assert d.dispatched_session_id == "sess-old-l3"
-        assert d.dispatched_session_log_dir == "/old/l3/logs"
-        assert d.dispatched_pid == 1234
-        assert d.dispatched_starttime_ticks == 5678
-        assert d.dispatched_boot_id == "boot-old-l3"
-        assert d.caller_session_id == ""
+        assert state is None
 
-    def test_read_state_handles_v1_without_ticks(self, tmp_path: Path) -> None:
-        """read_state on a v1 file missing dispatched_starttime_ticks or dispatched_boot_id."""
+    def test_read_state_rejects_v1_schema(self, tmp_path: Path) -> None:
+        """read_state must reject schema v1 state files (stale version)."""
         sp = tmp_path / "state_v1.json"
         v1_payload = {
             "schema_version": 1,
@@ -168,11 +213,7 @@ class TestDispatchRecordSchemaV2:
         }
         sp.write_text(json.dumps(v1_payload))
         state = read_state(sp)
-        assert state is not None
-        d = state.dispatches[0]
-        assert d.dispatched_pid == 9999
-        assert d.dispatched_starttime_ticks == 0
-        assert d.dispatched_boot_id == ""
+        assert state is None
 
 
 class TestCampaignIdField:
@@ -360,6 +401,7 @@ class TestDispatchRecordSchemaV3:
     def test_backward_compat_missing_campaign_id_defaults_to_empty_string(
         self, tmp_path: Path
     ) -> None:
+        """v1 state files are rejected (stale schema version)."""
         sp = tmp_path / "state_v1.json"
         v1_payload = {
             "schema_version": 1,
@@ -384,5 +426,4 @@ class TestDispatchRecordSchemaV3:
         }
         sp.write_text(json.dumps(v1_payload))
         state = read_state(sp)
-        assert state is not None
-        assert state.dispatches[0].campaign_id == ""
+        assert state is None

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -398,9 +398,7 @@ class TestDispatchRecordSchemaV3:
         assert state.dispatches[0].campaign_id == "camp-xyz"
         assert json.loads(sp.read_text())["dispatches"][0]["campaign_id"] == "camp-xyz"
 
-    def test_backward_compat_missing_campaign_id_defaults_to_empty_string(
-        self, tmp_path: Path
-    ) -> None:
+    def test_v1_state_file_is_rejected(self, tmp_path: Path) -> None:
         """v1 state files are rejected (stale schema version)."""
         sp = tmp_path / "state_v1.json"
         v1_payload = {

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -116,7 +116,7 @@ class TestDispatchRecordSchemaV2:
             state = read_state(state_path)
         assert state is None
         drift_logs = [r for r in cap if "schema_drift" in r.get("event", "")]
-        assert len(drift_logs) >= 1
+        assert len(drift_logs) == 1
 
     def test_read_state_succeeds_on_current_version(self, tmp_path: Path) -> None:
         """read_state succeeds when schema_version matches _SCHEMA_VERSION."""

--- a/tests/infra/CLAUDE.md
+++ b/tests/infra/CLAUDE.md
@@ -45,6 +45,7 @@ CI/CD configuration, security, guard coverage, and release sanity tests.
 | `test_release_workflows.py` | Structural contract tests for the release CI workflows |
 | `test_remove_clone_guard.py` | Tests for the remove_clone_guard PreToolUse hook |
 | `test_schema_version_convention.py` | Allowlist ratchet: enforce that new JSON dict write sites use write_versioned_json |
+| `test_schema_read_convention.py` | Read-side ratchet: enforce that write_versioned_json callers have corresponding read-side validation |
 | `test_security_config.py` | Structural tests for security configuration integrity |
 | `test_session_scope_enforcement.py` | Structural enforcement tests: session-scope metadata on HookDef |
 | `test_skill_cmd_check.py` | Unit tests for the skill_cmd_check PreToolUse hook |

--- a/tests/infra/test_schema_read_convention.py
+++ b/tests/infra/test_schema_read_convention.py
@@ -1,4 +1,5 @@
-"""Read-side ratchet: enforce that write_versioned_json callers have corresponding read-side validation.
+"""Read-side ratchet: enforce that write_versioned_json callers have corresponding read-side
+validation.
 
 AST-scans src/autoskillit/ for modules that call write_versioned_json.
 Each such module must also call read_versioned_json (or be in the exception list),
@@ -74,12 +75,12 @@ def _scan_read_versioned_json_callers() -> set[str]:
 # Documented exceptions: modules that write versioned JSON but do not read it back.
 # Rationale for each is in the comment.
 _READ_SIDE_EXCEPTIONS: dict[str, str] = {
-    "src/autoskillit/planner/manifests.py": "Transient single-pipeline-run artifacts — writer and reader are always same code version",
+    "src/autoskillit/planner/manifests.py": "Transient artifacts — always same code version",
     "src/autoskillit/planner/compiler.py": "Transient single-pipeline-run artifacts",
     "src/autoskillit/planner/merge.py": "Transient single-pipeline-run artifacts",
     "src/autoskillit/planner/consolidation.py": "Transient single-pipeline-run artifacts",
     "src/autoskillit/planner/validation.py": "Transient single-pipeline-run artifacts",
-    "src/autoskillit/execution/_recording_skills.py": "Informational manifest — never read back by autoskillit",
+    "src/autoskillit/execution/_recording_skills.py": "Informational manifest — never read back",
 }
 
 
@@ -95,7 +96,7 @@ class TestSchemaReadConvention:
             if module not in readers and module not in _READ_SIDE_EXCEPTIONS:
                 missing_read[module] = (
                     f"{module} calls write_versioned_json but not read_versioned_json. "
-                    f"Add read_versioned_json to reads, or add an exception in _READ_SIDE_EXCEPTIONS."
+                    f"Add read_versioned_json to reads, or add to _READ_SIDE_EXCEPTIONS."
                 )
 
         assert not missing_read, "\n".join(

--- a/tests/infra/test_schema_read_convention.py
+++ b/tests/infra/test_schema_read_convention.py
@@ -1,0 +1,152 @@
+"""Read-side ratchet: enforce that write_versioned_json callers have corresponding read-side validation.
+
+AST-scans src/autoskillit/ for modules that call write_versioned_json.
+Each such module must also call read_versioned_json (or be in the exception list),
+ensuring symmetric read/write schema validation.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _scan_write_versioned_json_callers() -> set[str]:
+    """AST-scan src/autoskillit/ for modules that call write_versioned_json.
+
+    Returns set of repo-relative module paths (e.g. "src/autoskillit/fleet/state.py").
+    """
+    src_root = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+    modules: set[str] = set()
+
+    for py_file in src_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_write_versioned_json = (
+                isinstance(func, ast.Name) and func.id == "write_versioned_json"
+            ) or (isinstance(func, ast.Attribute) and func.attr == "write_versioned_json")
+            if is_write_versioned_json:
+                rel = str(py_file.relative_to(src_root.parent.parent))
+                modules.add(rel)
+                break  # one match per module is enough
+
+    return modules
+
+
+def _scan_read_versioned_json_callers() -> set[str]:
+    """AST-scan src/autoskillit/ for modules that call read_versioned_json.
+
+    Returns set of repo-relative module paths.
+    """
+    src_root = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+    modules: set[str] = set()
+
+    for py_file in src_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_read_versioned_json = (
+                isinstance(func, ast.Name) and func.id == "read_versioned_json"
+            ) or (isinstance(func, ast.Attribute) and func.attr == "read_versioned_json")
+            if is_read_versioned_json:
+                rel = str(py_file.relative_to(src_root.parent.parent))
+                modules.add(rel)
+                break
+
+    return modules
+
+
+# Documented exceptions: modules that write versioned JSON but do not read it back.
+# Rationale for each is in the comment.
+_READ_SIDE_EXCEPTIONS: dict[str, str] = {
+    "src/autoskillit/planner/manifests.py": "Transient single-pipeline-run artifacts — writer and reader are always same code version",
+    "src/autoskillit/planner/compiler.py": "Transient single-pipeline-run artifacts",
+    "src/autoskillit/planner/merge.py": "Transient single-pipeline-run artifacts",
+    "src/autoskillit/planner/consolidation.py": "Transient single-pipeline-run artifacts",
+    "src/autoskillit/planner/validation.py": "Transient single-pipeline-run artifacts",
+    "src/autoskillit/execution/_recording_skills.py": "Informational manifest — never read back by autoskillit",
+}
+
+
+class TestSchemaReadConvention:
+    def test_write_versioned_json_callers_have_read_side_validation(self):
+        """Every module that calls write_versioned_json must also call read_versioned_json,
+        unless it is in _READ_SIDE_EXCEPTIONS."""
+        writers = _scan_write_versioned_json_callers()
+        readers = _scan_read_versioned_json_callers()
+
+        missing_read: dict[str, str] = {}
+        for module in sorted(writers):
+            if module not in readers and module not in _READ_SIDE_EXCEPTIONS:
+                missing_read[module] = (
+                    f"{module} calls write_versioned_json but not read_versioned_json. "
+                    f"Add read_versioned_json to reads, or add an exception in _READ_SIDE_EXCEPTIONS."
+                )
+
+        assert not missing_read, "\n".join(
+            f"  {m}: {reason}" for m, reason in missing_read.items()
+        )
+
+    def test_read_side_exceptions_are_documented(self):
+        """Every entry in _READ_SIDE_EXCEPTIONS must have a non-empty rationale comment."""
+        for module, reason in _READ_SIDE_EXCEPTIONS.items():
+            assert reason, f"{module} has an empty exception reason — document why it is exempt"
+
+    def test_new_write_versioned_json_caller_without_read_side_fails(self, monkeypatch):
+        """Meta-test: injecting a fake writer without a reader must cause the ratchet to fail."""
+        original_writers = _scan_write_versioned_json_callers
+
+        def patched_writers():
+            writers = original_writers()
+            # Add a fake module that writes but doesn't read
+            writers.add("src/autoskillit/fake_writer_module.py")
+            return writers
+
+        monkeypatch.setattr(
+            "tests.infra.test_schema_read_convention._scan_write_versioned_json_callers",
+            patched_writers,
+        )
+        with pytest.raises(AssertionError, match="fake_writer_module"):
+            self.test_write_versioned_json_callers_have_read_side_validation()
+
+    def test_exception_list_does_not_include_nonexistent_modules(self):
+        """Entries in _READ_SIDE_EXCEPTIONS must actually be writer modules."""
+        writers = _scan_write_versioned_json_callers()
+        for module in _READ_SIDE_EXCEPTIONS:
+            # Exception list can include modules that no longer exist (graceful stale entries)
+            # but they should not appear as writers in the current scan
+            if module in writers:
+                # An exception that is also a current writer — this is valid (transient artifact)
+                pass
+
+    def test_all_current_readers_are_also_writers_or_exceptions(self):
+        """Every module that calls read_versioned_json must either also write or be exempt.
+
+        (A module can read versioned JSON without writing it — e.g. consumers of fleet/state.py.
+        This is not an error; this test just documents the expectation that reader-only modules
+        do not need to be in the exceptions list.)
+        """
+        # This is a documentation test — it always passes but asserts invariants
+        readers = _scan_read_versioned_json_callers()
+        writers = _scan_write_versioned_json_callers()
+
+        # Readers that are not writers and not exceptions are fine (downstream consumers)
+        # This test mainly serves as documentation that the ratchet only requires
+        # writers to also be readers, not vice versa.
+        assert isinstance(readers, set)
+        assert isinstance(writers, set)

--- a/tests/infra/test_schema_read_convention.py
+++ b/tests/infra/test_schema_read_convention.py
@@ -126,28 +126,14 @@ class TestSchemaReadConvention:
             self.test_write_versioned_json_callers_have_read_side_validation()
 
     def test_exception_list_does_not_include_nonexistent_modules(self):
-        """Entries in _READ_SIDE_EXCEPTIONS must actually be writer modules."""
-        writers = _scan_write_versioned_json_callers()
-        for module in _READ_SIDE_EXCEPTIONS:
-            # Exception list can include modules that no longer exist (graceful stale entries)
-            # but they should not appear as writers in the current scan
-            if module in writers:
-                # An exception that is also a current writer — this is valid (transient artifact)
-                pass
+        """Entries in _READ_SIDE_EXCEPTIONS must be current writer modules.
 
-    def test_all_current_readers_are_also_writers_or_exceptions(self):
-        """Every module that calls read_versioned_json must either also write or be exempt.
-
-        (A module can read versioned JSON without writing it — e.g. consumers of fleet/state.py.
-        This is not an error; this test just documents the expectation that reader-only modules
-        do not need to be in the exceptions list.)
+        Stale exception entries for modules that no longer call write_versioned_json
+        indicate dead exception list entries that should be removed.
         """
-        # This is a documentation test — it always passes but asserts invariants
-        readers = _scan_read_versioned_json_callers()
         writers = _scan_write_versioned_json_callers()
-
-        # Readers that are not writers and not exceptions are fine (downstream consumers)
-        # This test mainly serves as documentation that the ratchet only requires
-        # writers to also be readers, not vice versa.
-        assert isinstance(readers, set)
-        assert isinstance(writers, set)
+        stale = {m for m in _READ_SIDE_EXCEPTIONS if m not in writers}
+        assert not stale, (
+            "These modules are in _READ_SIDE_EXCEPTIONS but no longer call "
+            "write_versioned_json — remove stale entries: " + ", ".join(sorted(stale))
+        )

--- a/tests/server/test_tools_dispatch_halt.py
+++ b/tests/server/test_tools_dispatch_halt.py
@@ -18,11 +18,13 @@ def _write_campaign_state(state_path: Path, dispatches: list[dict]) -> None:
     """Write a minimal campaign state file with the given dispatch records."""
     import time
 
+    from autoskillit.fleet import FLEET_STATE_SCHEMA_VERSION
+
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(
         json.dumps(
             {
-                "schema_version": 1,
+                "schema_version": FLEET_STATE_SCHEMA_VERSION,
                 "campaign_id": "test-campaign",
                 "campaign_name": "test",
                 "manifest_path": "/fake/manifest.yaml",


### PR DESCRIPTION
## Summary

`read_state()` in `fleet/state.py:140` accepts any `schema_version` from disk without comparing it to `_SCHEMA_VERSION`, and `_write_state()` at line 178 writes back `state.schema_version` (whatever was read) instead of pinning to the current constant. This perpetuates stale schema versions indefinitely across read-modify-write cycles. The root cause is that `core/io.py` provides `write_versioned_json` (write-side convention) but has no read-side counterpart — each module rolls its own read logic, and fleet state simply omitted the validation. The quota module (`execution/quota.py:194`) demonstrates the correct pattern with an explicit equality check, deduped drift warning, and `None` return on mismatch.

Part A introduces a shared `read_versioned_json` utility in `core/io.py`, fixes both `read_state` and `_write_state` in fleet/state.py, hardens the two bypass paths (`build_protected_campaign_ids`, `read_all_campaign_captures`), adds a fleet state schema doctor check, and delivers comprehensive tests modeled on the quota cache test suite. Part B will cover codebase-wide adoption of `read_versioned_json` in other consumers and an infra enforcement ratchet for read-side validation — implement as a separate task.

Closes #2239

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260508-113455-493792/.autoskillit/temp/rectify/rectify_campaign_state_schema_version_2026-05-08_120000_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 2.3k | 9.4k | 834.5k | 97.7k | 197 | 51.3k | 5m 38s |
| rectify | claude-opus-4-6 | 1 | 1.1k | 16.3k | 795.4k | 80.2k | 74 | 67.2k | 6m 26s |
| dry_walkthrough | claude-sonnet-4-6 | 2 | 368 | 29.2k | 2.4M | 82.0k | 129 | 155.7k | 8m 12s |
| implement* | MiniMax-M2.7-highspeed | 2 | 15.2M | 68.8k | 7.4M | 145.4k | 547 | 687.8k | 37m 10s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 132.2k | 3.7k | 298.2k | 29.8k | 22 | 42.2k | 1m 17s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 63.2k | 1.9k | 235.7k | 29.8k | 18 | 15.2k | 47s |
| review_pr | claude-sonnet-4-6 | 2 | 943 | 67.4k | 1.6M | 105.7k | 130 | 177.4k | 15m 24s |
| resolve_review | claude-sonnet-4-6 | 2 | 1.5k | 102.8k | 18.3M | 137.2k | 465 | 366.0k | 35m 50s |
| resolve_queue_merge_conflicts | claude-sonnet-4-6 | 1 | 236 | 15.9k | 1.7M | 83.9k | 68 | 71.2k | 5m 1s |
| **Total** | | | 15.4M | 315.2k | 33.7M | 145.4k | | 1.6M | 1h 55m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 1058 | 7021.3 | 650.1 | 65.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 203 | 90236.9 | 1802.7 | 506.2 |
| resolve_queue_merge_conflicts | 1846 | 939.5 | 38.6 | 8.6 |
| **Total** | **3107** | 10840.6 | 525.9 | 101.4 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 3.1k | 80.6k | 7.0M | 371.3k | 36m 39s |
| claude-opus-4-6 | 1 | 1.1k | 16.3k | 795.4k | 67.2k | 6m 26s |
| MiniMax-M2.7-highspeed | 3 | 15.4M | 74.3k | 8.0M | 745.2k | 39m 14s |