### PR TITLE
Stderr from Food Truck Subprocess Not Forwarded in Dispatch Envelope

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -20,6 +20,7 @@ from autoskillit.core import (
     SkillResult,
     claude_code_log_path,
     get_logger,
+    truncate_text,
 )
 from autoskillit.fleet.result_parser import L3ParseResult, parse_l3_result_block
 from autoskillit.fleet.state import DispatchStatus
@@ -29,6 +30,8 @@ if TYPE_CHECKING:
     from autoskillit.pipeline.context import ToolContext
 
 logger = get_logger(__name__)
+
+ENVELOPE_STDERR_MAX = 2000
 
 _CAMPAIGN_REF_RE = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
 _RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
@@ -484,6 +487,7 @@ async def _run_dispatch(
             reason=FleetErrorCode.FLEET_L3_TIMEOUT,
             token_usage=normalize_dispatch_token_usage(skill_result.token_usage or {}),
             lifespan_started=skill_result.lifespan_started,
+            stderr=truncate_text(skill_result.stderr or "", ENVELOPE_STDERR_MAX),
         )
 
     jsonl_path = claude_code_log_path(str(tool_ctx.project_dir), skill_result.session_id or "")
@@ -547,6 +551,7 @@ async def _run_dispatch(
             l3_payload=parsed.payload,
             l3_parse_source=parsed.source,
             lifespan_started=skill_result.lifespan_started,
+            stderr=truncate_text(skill_result.stderr or "", ENVELOPE_STDERR_MAX),
         )
     elif parsed.outcome == "completed_dirty":
         return DispatchCompleted(
@@ -561,6 +566,7 @@ async def _run_dispatch(
             l3_parse_error=parsed.parse_error,
             l3_parse_source=parsed.source,
             lifespan_started=skill_result.lifespan_started,
+            stderr=truncate_text(skill_result.stderr or "", ENVELOPE_STDERR_MAX),
         )
     else:
         return DispatchCompleted(
@@ -574,4 +580,5 @@ async def _run_dispatch(
             l3_parse_source=parsed.source,
             lifespan_started=skill_result.lifespan_started,
             resume_checkpoint=dispatch_checkpoint.to_dict() if dispatch_checkpoint else None,
+            stderr=truncate_text(skill_result.stderr or "", ENVELOPE_STDERR_MAX),
         )

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -247,6 +247,7 @@ class DispatchCompleted:
     l3_raw_body: str | None = None
     l3_parse_error: str | None = None
     resume_checkpoint: dict[str, Any] | None = None
+    stderr: str = ""
 
     def to_envelope(self) -> str:
         d: dict[str, Any] = {
@@ -259,6 +260,7 @@ class DispatchCompleted:
             "l3_payload": self.l3_payload,
             "l3_parse_source": self.l3_parse_source,
             "lifespan_started": self.lifespan_started,
+            "stderr": self.stderr,
         }
         if self.l3_raw_body is not None:
             d["l3_raw_body"] = self.l3_raw_body

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -626,3 +626,118 @@ class TestRecipeKindDispatchGate:
         result = await _run(tool_ctx)
         assert result["success"] is False
         assert result["error"] == "fleet_invalid_recipe_kind"
+
+
+class TestStderrEnvelopeForwarding:
+    """Verify that stderr from SkillResult is forwarded in all dispatch envelope shapes."""
+
+    @pytest.mark.anyio
+    async def test_completed_clean_envelope_includes_stderr(self, tool_ctx, monkeypatch):
+        """completed_clean envelope includes stderr field with skill_result.stderr value."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, stderr="some error output")
+        )
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_completed_clean(success=True),
+        )
+
+        result = await _run(tool_ctx)
+        assert result["stderr"] == "some error output"
+
+    @pytest.mark.anyio
+    async def test_completed_dirty_envelope_includes_stderr(self, tool_ctx, monkeypatch):
+        """completed_dirty envelope includes stderr field with skill_result.stderr value."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, stderr="parse failure trace")
+        )
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_completed_dirty(),
+        )
+
+        result = await _run(tool_ctx)
+        assert result["stderr"] == "parse failure trace"
+
+    @pytest.mark.anyio
+    async def test_no_sentinel_envelope_includes_stderr(self, tool_ctx, monkeypatch):
+        """no_sentinel envelope includes stderr field with skill_result.stderr value."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT, stderr="missing sentinel trace"
+            )
+        )
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_no_sentinel(),
+        )
+
+        result = await _run(tool_ctx)
+        assert result["stderr"] == "missing sentinel trace"
+
+    @pytest.mark.anyio
+    async def test_timeout_envelope_includes_stderr_in_details(self, tool_ctx, monkeypatch):
+        """Timeout fleet_error envelope includes stderr in details dict."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT, subtype="timeout", stderr="timeout stderr"
+            )
+        )
+
+        result = await _run(tool_ctx)
+        assert result["details"]["stderr"] == "timeout stderr"
+
+    @pytest.mark.anyio
+    async def test_envelope_stderr_truncated_to_envelope_max(self, tool_ctx, monkeypatch):
+        """When skill_result.stderr exceeds ENVELOPE_STDERR_MAX, envelope truncates it."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        long_stderr = "x" * 3000
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT, stderr=long_stderr, success=False
+            )
+        )
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_completed_clean(success=False),
+        )
+
+        result = await _run(tool_ctx)
+        assert len(result["stderr"]) < 3000
+        assert "truncated" in result["stderr"]
+
+    @pytest.mark.anyio
+    async def test_envelope_stderr_empty_when_no_stderr(self, tool_ctx, monkeypatch):
+        """When skill_result.stderr is empty, envelope stderr field is empty string."""
+        _setup_dispatch(tool_ctx, monkeypatch)
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_completed_clean(success=True),
+        )
+
+        result = await _run(tool_ctx)
+        assert result["stderr"] == ""

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -728,11 +728,11 @@ class TestStderrEnvelopeForwarding:
         )
 
         result = await _run(tool_ctx)
-        assert result["details"]["stderr"] == "timeout stderr"
+        assert result["stderr"] == "timeout stderr"
 
     @pytest.mark.anyio
     async def test_timeout_envelope_stderr_truncated_to_envelope_max(self, tool_ctx, monkeypatch):
-        """Timeout fleet_error details["stderr"] is truncated when stderr exceeds ENVELOPE_STDERR_MAX."""  # noqa: E501
+        """Timeout envelope stderr is truncated when stderr exceeds ENVELOPE_STDERR_MAX."""
         import dataclasses
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
@@ -746,8 +746,8 @@ class TestStderrEnvelopeForwarding:
         )
 
         result = await _run(tool_ctx)
-        assert len(result["details"]["stderr"]) < 3000
-        assert "truncated" in result["details"]["stderr"]
+        assert len(result["stderr"]) < 3000
+        assert "truncated" in result["stderr"]
 
     @pytest.mark.anyio
     async def test_envelope_stderr_truncated_to_envelope_max(self, tool_ctx, monkeypatch):

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -708,6 +708,25 @@ class TestStderrEnvelopeForwarding:
         assert result["details"]["stderr"] == "timeout stderr"
 
     @pytest.mark.anyio
+    async def test_timeout_envelope_stderr_truncated_to_envelope_max(self, tool_ctx, monkeypatch):
+        """Timeout fleet_error details["stderr"] is truncated when stderr exceeds ENVELOPE_STDERR_MAX."""  # noqa: E501
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        long_stderr = "x" * 3000
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT, subtype="timeout", stderr=long_stderr
+            )
+        )
+
+        result = await _run(tool_ctx)
+        assert len(result["details"]["stderr"]) < 3000
+        assert "truncated" in result["details"]["stderr"]
+
+    @pytest.mark.anyio
     async def test_envelope_stderr_truncated_to_envelope_max(self, tool_ctx, monkeypatch):
         """When skill_result.stderr exceeds ENVELOPE_STDERR_MAX, envelope truncates it."""
         import dataclasses
@@ -724,6 +743,31 @@ class TestStderrEnvelopeForwarding:
         monkeypatch.setattr(
             "autoskillit.fleet._api.parse_l3_result_block",
             lambda **_: _make_completed_clean(success=False),
+        )
+
+        result = await _run(tool_ctx)
+        assert len(result["stderr"]) < 3000
+        assert "truncated" in result["stderr"]
+
+    @pytest.mark.anyio
+    async def test_completed_dirty_envelope_stderr_truncated_to_envelope_max(
+        self, tool_ctx, monkeypatch
+    ):
+        """completed_dirty envelope stderr is truncated when stderr exceeds ENVELOPE_STDERR_MAX."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        long_stderr = "x" * 3000
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT, stderr=long_stderr, success=False
+            )
+        )
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_completed_dirty(),
         )
 
         result = await _run(tool_ctx)

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -691,6 +691,29 @@ class TestStderrEnvelopeForwarding:
         assert result["stderr"] == "missing sentinel trace"
 
     @pytest.mark.anyio
+    async def test_no_sentinel_envelope_stderr_truncated_to_envelope_max(
+        self, tool_ctx, monkeypatch
+    ):
+        """no_sentinel envelope stderr is truncated when stderr exceeds ENVELOPE_STDERR_MAX."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        long_stderr = "x" * 3000
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, stderr=long_stderr)
+        )
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_no_sentinel(),
+        )
+
+        result = await _run(tool_ctx)
+        assert len(result["stderr"]) < 3000
+        assert "truncated" in result["stderr"]
+
+    @pytest.mark.anyio
     async def test_timeout_envelope_includes_stderr_in_details(self, tool_ctx, monkeypatch):
         """Timeout fleet_error envelope includes stderr in details dict."""
         import dataclasses


### PR DESCRIPTION
## Summary

`SkillResult.stderr` is populated by `_build_skill_result` in `execution/headless/_headless_result.py` (truncated to 5000 chars via `truncate_text`) but `_run_dispatch` in `fleet/_api.py` never reads it and never includes it in any of the four dispatch envelope shapes returned to the `dispatch_food_truck` MCP tool. When a dispatch fails due to auth errors, missing dependencies, or subprocess crashes, the stderr containing diagnostic information is invisible to the L3 campaign orchestrator.

The fix adds a `"stderr"` field to all four dispatch envelope return paths in `_run_dispatch`, with a dedicated envelope-specific truncation limit (`ENVELOPE_STDERR_MAX = 2000`) to keep envelopes reasonably sized for LLM consumption while preserving enough diagnostic context for failure handling.

## Requirements

(No formal ## Requirements section in issue #2238)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260508-145222-490808/.autoskillit/temp/make-plan/stderr-dispatch-envelope-forwarding_plan_2026-05-08_145600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 77 | 8.9k | 1.0M | 61.1k | 78 | 65.5k | 4m 52s |
| verify | claude-opus-4-6 | 1 | 32 | 6.3k | 562.9k | 52.5k | 55 | 39.6k | 2m 56s |
| implement* | MiniMax-M2.7-highspeed | 1 | 4.2M | 26.2k | 3.1M | 47.2k | 227 | 60.1k | 12m 35s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 60.6k | 3.0k | 178.9k | 29.8k | 21 | 42.2k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 91.5k | 2.3k | 284.5k | 28.7k | 26 | 15.1k | 56s |
| review_pr | claude-sonnet-4-6 | 3 | 780 | 50.8k | 866.4k | 52.3k | 113 | 123.7k | 13m 7s |
| resolve_review | claude-sonnet-4-6 | 3 | 595 | 39.8k | 3.5M | 75.3k | 180 | 152.7k | 14m 37s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 180 | 14.8k | 950.5k | 57.7k | 64 | 44.9k | 3m 57s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 879.9k | 7.1k | 862.1k | 28.7k | 62 | 40.9k | 3m 12s |
| resolve_ci | claude-sonnet-4-6 | 1 | 110 | 3.7k | 426.6k | 40.5k | 30 | 28.9k | 5m 8s |
| **Total** | | | 5.2M | 162.8k | 11.8M | 75.3k | | 613.5k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 122 | 25578.6 | 492.5 | 214.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 67 | 52584.7 | 2278.9 | 593.8 |
| ci_conflict_fix | 4197 | 226.5 | 10.7 | 3.5 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 8 | 53323.9 | 3618.5 | 456.8 |
| **Total** | **4394** | 2682.0 | 139.6 | 37.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 109 | 15.2k | 1.6M | 105.1k | 7m 49s |
| MiniMax-M2.7-highspeed | 3 | 4.3M | 31.5k | 3.6M | 117.4k | 14m 42s |