### PR TITLE
CampaignState Missing Operational Fields + FleetSemaphore Acquire Timeout

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -354,6 +354,7 @@ class FleetConfig:
     enable_deadline_extension: bool = True
     max_extension_seconds: float = 7200
     idle_output_timeout: float = 1800
+    acquire_timeout_sec: float = 300.0
 
     def validate(self, feature_enabled: bool) -> None:
         """Validate only when the feature is active."""
@@ -381,6 +382,10 @@ class FleetConfig:
         if self.idle_output_timeout < 0:
             raise ValueError(
                 f"idle_output_timeout must be non-negative, got {self.idle_output_timeout}"
+            )
+        if self.acquire_timeout_sec <= 0:
+            raise ValueError(
+                f"acquire_timeout_sec must be positive, got {self.acquire_timeout_sec}"
             )
 
 

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -510,6 +510,9 @@ class AutomationConfig:
                 idle_output_timeout=float(
                     val(fr, "idle_output_timeout", _fr["idle_output_timeout"])
                 ),
+                acquire_timeout_sec=float(
+                    val(fr, "acquire_timeout_sec", _fr["acquire_timeout_sec"])
+                ),
             ),
             providers=ProvidersConfig(
                 default_provider=val(pvd, "default_provider", _pvd["default_provider"]),

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -410,6 +410,7 @@ class FleetErrorCode(StrEnum):
     FLEET_GATE_UNKNOWN_DISPATCH = "fleet_gate_unknown_dispatch"
     FLEET_GATE_ALREADY_RECORDED = "fleet_gate_already_recorded"
     FLEET_GATE_NO_CAMPAIGN = "fleet_gate_no_campaign"
+    FLEET_ACQUIRE_TIMEOUT = "fleet_acquire_timeout"
 
 
 class FeatureLifecycle(StrEnum):

--- a/src/autoskillit/core/types/_type_protocols_infra.py
+++ b/src/autoskillit/core/types/_type_protocols_infra.py
@@ -65,6 +65,9 @@ class FleetLock(Protocol):
     @property
     def max_concurrent(self) -> int: ...
 
+    @property
+    def timeout(self) -> float | None: ...
+
 
 @runtime_checkable
 class QuotaRefreshTask(Protocol):

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -183,10 +183,12 @@ async def execute_dispatch(
     try:
         await lock.acquire()
     except TimeoutError:
-        return fleet_error(
-            FleetErrorCode.FLEET_ACQUIRE_TIMEOUT,
-            f"Timed out waiting for fleet semaphore after {lock.timeout}s "
-            f"({lock.active_count}/{lock.max_concurrent} dispatches running).",
+        return DispatchRejected(
+            error_code=FleetErrorCode.FLEET_ACQUIRE_TIMEOUT,
+            message=(
+                f"Timed out waiting for fleet semaphore after {lock.timeout}s "
+                f"({lock.active_count}/{lock.max_concurrent} dispatches running)."
+            ),
         )
     try:
         return await _run_dispatch(

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -180,7 +180,14 @@ async def execute_dispatch(
             ),
         )
 
-    await lock.acquire()
+    try:
+        await lock.acquire()
+    except TimeoutError:
+        return fleet_error(
+            FleetErrorCode.FLEET_ACQUIRE_TIMEOUT,
+            f"Timed out waiting for fleet semaphore after {lock.timeout}s "
+            f"({lock.active_count}/{lock.max_concurrent} dispatches running).",
+        )
     try:
         return await _run_dispatch(
             tool_ctx=tool_ctx,
@@ -393,12 +400,20 @@ async def _run_dispatch(
 
     state_path = tool_ctx.temp_dir / "dispatches" / f"{dispatch_id}.json"
     state_path.parent.mkdir(parents=True, exist_ok=True)
+    recipe_snapshot = {
+        "recipe_name": recipe_obj.name,
+        "recipe_path": str(recipe_obj.path),
+        "recipe_version": recipe_obj.recipe_version or "",
+        "content_hash": recipe_obj.content_hash or "",
+        "effective_ingredients": dict(effective_ingredients),
+    }
     write_initial_state(
         state_path,
         campaign_id=campaign_id,
         campaign_name=effective_name,
         manifest_path="",
         dispatches=[DispatchRecord(name=effective_name, caller_session_id=caller_session_id)],
+        recipe_snapshot=recipe_snapshot,
     )
 
     if tool_ctx.executor is None:

--- a/src/autoskillit/fleet/_semaphore.py
+++ b/src/autoskillit/fleet/_semaphore.py
@@ -8,18 +8,22 @@ import asyncio
 class FleetSemaphore:
     """Configurable semaphore implementing FleetLock for fleet dispatch concurrency."""
 
-    def __init__(self, max_concurrent: int = 1) -> None:
+    def __init__(self, max_concurrent: int = 1, timeout: float | None = None) -> None:
         if max_concurrent <= 0:
             raise ValueError(f"max_concurrent must be > 0, got {max_concurrent}")
         self._semaphore = asyncio.BoundedSemaphore(max_concurrent)
         self._active = 0
         self._max = max_concurrent
+        self._timeout = timeout
 
     def at_capacity(self) -> bool:
         return self._active >= self._max
 
     async def acquire(self) -> None:
-        await self._semaphore.acquire()
+        if self._timeout is not None:
+            await asyncio.wait_for(self._semaphore.acquire(), timeout=self._timeout)
+        else:
+            await self._semaphore.acquire()
         self._active += 1
 
     def release(self) -> None:
@@ -33,3 +37,7 @@ class FleetSemaphore:
     @property
     def max_concurrent(self) -> int:
         return self._max
+
+    @property
+    def timeout(self) -> float | None:
+        return self._timeout

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -151,15 +151,32 @@ def reset_failed_dispatch(state_path: Path, dispatch_name: str) -> bool:
         return False
 
 
+_LEGACY_SCHEMA_VERSIONS = frozenset({4})
+
+
+def _read_raw_json(state_path: Path) -> dict[str, Any] | None:
+    import json as _json
+
+    try:
+        raw = _json.loads(state_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, _json.JSONDecodeError, OSError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
 def read_state(state_path: Path) -> CampaignState | None:
     """Load campaign state from disk.
 
     Returns None on missing file, malformed JSON, or schema mismatch.
+    Accepts the current schema version and legacy versions in _LEGACY_SCHEMA_VERSIONS.
     Never raises.
     """
     data = read_versioned_json(state_path, FLEET_STATE_SCHEMA_VERSION, logger=logger)
     if data is None:
-        return None
+        raw = _read_raw_json(state_path)
+        if raw is None or raw.get("schema_version") not in _LEGACY_SCHEMA_VERSIONS:
+            return None
+        data = raw
     try:
         dispatches = [DispatchRecord.from_dict(d) for d in data["dispatches"]]
         return CampaignState(

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -113,7 +113,7 @@ def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
             "infra_exit_category": d.infra_exit_category,
             "started_at": d.started_at,
             "ended_at": d.ended_at,
-            "token_usage": dict(d.token_usage),
+            "token_usage": dict(d.token_usage) if d.token_usage is not None else {},
         }
     )
     d.status = DispatchStatus.PENDING
@@ -197,6 +197,10 @@ class CampaignStateMutator:
         _resume_lock.acquire()
         try:
             self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+            # Lock files are intentionally not deleted after use. Safe cleanup after
+            # fcntl release requires inode-comparison to avoid a TOCTOU race; the
+            # files are empty and bounded to one per state file, so accumulation cost
+            # is negligible compared to the complexity of safe deletion.
             fh = open(self._lock_path, "wb")
             try:
                 fcntl.flock(fh, fcntl.LOCK_EX)

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -345,6 +345,8 @@ def append_dispatch_record(
 
     If a dispatch with the same name exists, it is replaced in-place.
     Otherwise the record is appended to the end.
+
+    Thread-safe: uses _resume_lock + fcntl.LOCK_EX.
     """
     with CampaignStateMutator(state_path) as m:
         if m.state is None:

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -82,6 +82,7 @@ def write_initial_state(
     campaign_name: str,
     manifest_path: str,
     dispatches: list[DispatchRecord],
+    recipe_snapshot: dict[str, Any] | None = None,
 ) -> None:
     """Create the campaign state file with all dispatches in pending status.
 
@@ -93,6 +94,7 @@ def write_initial_state(
         "manifest_path": manifest_path,
         "started_at": time.time(),
         "dispatches": [d.to_dict() for d in dispatches],
+        "recipe_snapshot": recipe_snapshot or {},
     }
     write_versioned_json(state_path, payload, schema_version=FLEET_STATE_SCHEMA_VERSION)
 
@@ -100,6 +102,20 @@ def write_initial_state(
 def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
     """Clear a dispatch record for retry."""
     _validate_transition(d.status, DispatchStatus.PENDING, d.name)
+    d.attempt_history.append(
+        {
+            "status": str(d.status),
+            "dispatch_id": d.dispatch_id,
+            "dispatched_session_id": d.dispatched_session_id,
+            "dispatched_pid": d.dispatched_pid,
+            "reason": d.reason,
+            "kill_reason": d.kill_reason,
+            "infra_exit_category": d.infra_exit_category,
+            "started_at": d.started_at,
+            "ended_at": d.ended_at,
+            "token_usage": dict(d.token_usage),
+        }
+    )
     d.status = DispatchStatus.PENDING
     d.reason = ""
     d.dispatch_id = ""
@@ -154,6 +170,8 @@ def read_state(state_path: Path) -> CampaignState | None:
             dispatches=dispatches,
             captured_values=data.get("captured_values", {}),
             orchestrator_session_id=data.get("orchestrator_session_id") or "",
+            ended_at=data.get("ended_at", 0.0),
+            recipe_snapshot=data.get("recipe_snapshot", {}),
         )
     except (KeyError, ValueError, TypeError) as exc:
         logger.warning("read_state_corrupt_payload", path=str(state_path), exc=str(exc))
@@ -239,6 +257,8 @@ def _write_state(state_path: Path, state: CampaignState) -> None:
         "dispatches": [d.to_dict() for d in state.dispatches],
         "captured_values": state.captured_values,
         "orchestrator_session_id": state.orchestrator_session_id,
+        "ended_at": state.ended_at,
+        "recipe_snapshot": state.recipe_snapshot,
     }
     write_versioned_json(state_path, payload, schema_version=FLEET_STATE_SCHEMA_VERSION)
 
@@ -333,9 +353,15 @@ def append_dispatch_record(
             if d.name == record.name:
                 _validate_transition(d.status, record.status, d.name)
                 m.state.dispatches[i] = record
-                m.mark_dirty()
-                return
-        m.state.dispatches.append(record)
+                break
+        else:
+            m.state.dispatches.append(record)
+        if (
+            m.state.ended_at == 0.0
+            and m.state.dispatches
+            and all(d.status in TERMINAL_DISPATCH_STATUSES for d in m.state.dispatches)
+        ):
+            m.state.ended_at = time.time()
         m.mark_dirty()
 
 

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -12,7 +12,7 @@ from autoskillit.core import FleetErrorCode, RetryReason
 
 _resume_lock = threading.Lock()
 
-FLEET_STATE_SCHEMA_VERSION = 4
+FLEET_STATE_SCHEMA_VERSION = 5
 
 FLEET_HALTED_SENTINEL = "fleet_halted_on_failure"
 
@@ -55,6 +55,7 @@ class DispatchRecord:
     started_at: float = 0.0
     ended_at: float = 0.0
     sidecar_path: str | None = None
+    attempt_history: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -75,6 +76,7 @@ class DispatchRecord:
             "started_at": self.started_at,
             "ended_at": self.ended_at,
             "sidecar_path": self.sidecar_path,
+            "attempt_history": list(self.attempt_history),
         }
 
     @classmethod
@@ -121,6 +123,7 @@ class DispatchRecord:
             started_at=d.get("started_at", 0.0),
             ended_at=d.get("ended_at", 0.0),
             sidecar_path=d.get("sidecar_path"),
+            attempt_history=d.get("attempt_history", []),
         )
 
 
@@ -136,6 +139,8 @@ class CampaignState:
     dispatches: list[DispatchRecord] = field(default_factory=list)
     captured_values: dict[str, str] = field(default_factory=dict)
     orchestrator_session_id: str = ""
+    ended_at: float = 0.0
+    recipe_snapshot: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -333,7 +333,10 @@ def make_context(
         fleet_lock=(
             fleet_lock
             if fleet_lock is not None
-            else FleetSemaphore(max_concurrent=config.fleet.max_concurrent_dispatches)
+            else FleetSemaphore(
+                max_concurrent=config.fleet.max_concurrent_dispatches,
+                timeout=config.fleet.acquire_timeout_sec,
+            )
         ),
     )
 

--- a/tests/fleet/test_error_envelope.py
+++ b/tests/fleet/test_error_envelope.py
@@ -46,6 +46,7 @@ class TestFleetErrorCodeEnum:
             "fleet_gate_no_campaign",
             "fleet_missing_ingredient",
             "fleet_campaign_halted",
+            "fleet_acquire_timeout",
         }
         assert {c.value for c in FleetErrorCode} == expected_values
 

--- a/tests/fleet/test_fleet_semaphore.py
+++ b/tests/fleet/test_fleet_semaphore.py
@@ -77,3 +77,36 @@ class TestFleetSemaphoreConstructorGuard:
     def test_max_concurrent_negative_raises(self) -> None:
         with pytest.raises(ValueError):
             FleetSemaphore(max_concurrent=-1)
+
+
+@pytest.mark.anyio
+async def test_fleet_semaphore_acquire_raises_timeout():
+    """acquire() raises TimeoutError when timeout expires."""
+    s = FleetSemaphore(max_concurrent=1, timeout=0.05)
+    await s.acquire()
+    with pytest.raises(TimeoutError):
+        await s.acquire()
+
+
+@pytest.mark.anyio
+async def test_fleet_semaphore_acquire_succeeds_within_timeout():
+    """acquire() succeeds when slot becomes available before timeout."""
+    import asyncio
+
+    s = FleetSemaphore(max_concurrent=1, timeout=5.0)
+    await s.acquire()
+
+    async def release_soon():
+        await asyncio.sleep(0.05)
+        s.release()
+
+    asyncio.create_task(release_soon())
+    await s.acquire()
+    assert s.active_count == 1
+
+
+@pytest.mark.anyio
+async def test_fleet_semaphore_no_timeout_is_default():
+    """timeout=None means no timeout (backward compat)."""
+    s = FleetSemaphore(max_concurrent=1)
+    assert s.timeout is None

--- a/tests/fleet/test_fleet_semaphore.py
+++ b/tests/fleet/test_fleet_semaphore.py
@@ -100,9 +100,17 @@ async def test_fleet_semaphore_acquire_succeeds_within_timeout():
         await asyncio.sleep(0.05)
         s.release()
 
-    asyncio.create_task(release_soon())
-    await s.acquire()
-    assert s.active_count == 1
+    task = asyncio.create_task(release_soon())
+    try:
+        await s.acquire()
+        assert s.active_count == 1
+    finally:
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 @pytest.mark.anyio

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -271,13 +271,83 @@ class TestResumeResetOnRetry:
         assert d2.infra_exit_category == ""
 
 
+class TestAttemptHistoryOnRetry:
+    def test_clear_dispatch_for_retry_populates_attempt_history(self):
+        """_clear_dispatch_for_retry snapshots execution metadata into attempt_history."""
+        d = DispatchRecord(
+            name="d1",
+            status=DispatchStatus.FAILURE,
+            campaign_id="cid",
+            dispatch_id="old-id",
+            dispatched_session_id="old-sess",
+            dispatched_pid=12345,
+            reason="task_failed",
+            kill_reason="stale",
+            infra_exit_category="timeout",
+            started_at=1000.0,
+            ended_at=2000.0,
+            token_usage={"input": 100},
+        )
+        _clear_dispatch_for_retry(d)
+        assert len(d.attempt_history) == 1
+        attempt = d.attempt_history[0]
+        assert attempt["dispatch_id"] == "old-id"
+        assert attempt["status"] == "failure"
+        assert attempt["kill_reason"] == "stale"
+        assert attempt["started_at"] == 1000.0
+        assert attempt["ended_at"] == 2000.0
+
+    def test_attempt_history_grows_on_successive_retries(self):
+        """Each retry appends a new entry to attempt_history."""
+        d = DispatchRecord(
+            name="d1",
+            status=DispatchStatus.FAILURE,
+            campaign_id="cid",
+            dispatch_id="attempt-1",
+            started_at=100.0,
+            ended_at=200.0,
+        )
+        _clear_dispatch_for_retry(d)
+        assert len(d.attempt_history) == 1
+
+        d.status = DispatchStatus.FAILURE
+        d.dispatch_id = "attempt-2"
+        d.started_at = 300.0
+        d.ended_at = 400.0
+        _clear_dispatch_for_retry(d)
+        assert len(d.attempt_history) == 2
+        assert d.attempt_history[0]["dispatch_id"] == "attempt-1"
+        assert d.attempt_history[1]["dispatch_id"] == "attempt-2"
+
+    def test_attempt_history_persists_through_round_trip(self, tmp_path: Path):
+        """attempt_history survives write/read cycle."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"))
+        append_dispatch_record(
+            sp,
+            DispatchRecord(
+                name="d1",
+                status=DispatchStatus.FAILURE,
+                dispatch_id="old",
+                started_at=100.0,
+                ended_at=200.0,
+            ),
+        )
+        reset_failed_dispatch(sp, "d1")
+        state = read_state(sp)
+        assert state is not None
+        d1 = next(d for d in state.dispatches if d.name == "d1")
+        assert len(d1.attempt_history) == 1
+        assert d1.attempt_history[0]["dispatch_id"] == "old"
+
+
 # --- structural guard: field coverage ---
 
 
 class TestClearDispatchFieldCoverage:
     """Structural guard: _clear_dispatch_for_retry must reset all execution-metadata fields."""
 
-    _IDENTITY_FIELDS = frozenset({"name", "campaign_id", "caller_session_id"})
+    _IDENTITY_FIELDS = frozenset({"name", "campaign_id", "caller_session_id", "attempt_history"})
 
     def test_clear_covers_all_execution_metadata_fields(self):
         """Every non-identity field must be reset to its default by _clear_dispatch_for_retry."""
@@ -285,6 +355,7 @@ class TestClearDispatchFieldCoverage:
             "name": "test",
             "campaign_id": "cid",
             "caller_session_id": "csid",
+            "attempt_history": [{"dispatch_id": "dirty"}],
         }
         for f in dataclasses.fields(DispatchRecord):
             if f.name in dirty_values:

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -49,7 +49,7 @@ class TestInitialState:
 
         state = read_state(sp)
         assert state is not None
-        assert state.schema_version == 4
+        assert state.schema_version == 5
         assert state.campaign_id == "cid-1"
         assert state.campaign_name == "my-campaign"
         assert state.manifest_path == "/m.yaml"
@@ -1115,7 +1115,7 @@ class TestWriteStateSchemaVersionPinning:
         assert raw["schema_version"] == FLEET_STATE_SCHEMA_VERSION
 
     def test_round_trip_version_upgrade(self, tmp_path: Path) -> None:
-        """A v4 state file written back after mutation stays v4."""
+        """A v5 state file written back after mutation stays v5."""
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
         state = read_state(sp)
@@ -1214,3 +1214,93 @@ class TestReadAllCampaignCapturesSchemaValidation:
         )
         result = read_all_campaign_captures(dispatches_dir, "cid-current")
         assert result == {"key": "value"}
+
+
+class TestCampaignEndedAt:
+    def test_campaign_ended_at_defaults_to_zero(self, tmp_path: Path) -> None:
+        """CampaignState.ended_at defaults to 0.0 on fresh state file."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"))
+        state = read_state(sp)
+        assert state is not None
+        assert state.ended_at == 0.0
+
+    def test_campaign_ended_at_round_trips(self, tmp_path: Path) -> None:
+        """ended_at persists through write/read cycle."""
+        from autoskillit.fleet.state import _write_state
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"))
+        state = read_state(sp)
+        assert state is not None
+        state.ended_at = 1234567890.0
+        _write_state(sp, state)
+        reloaded = read_state(sp)
+        assert reloaded is not None
+        assert reloaded.ended_at == 1234567890.0
+
+    def test_campaign_ended_at_set_when_all_dispatches_terminal(self, tmp_path: Path) -> None:
+        """ended_at is auto-set when append_dispatch_record makes all dispatches terminal."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"))
+        append_dispatch_record(sp, DispatchRecord(name="d1", status=DispatchStatus.SUCCESS))
+        state = read_state(sp)
+        assert state is not None
+        assert state.ended_at > 0.0
+
+    def test_campaign_ended_at_not_set_when_pending_remains(self, tmp_path: Path) -> None:
+        """ended_at stays 0.0 when non-terminal dispatches remain."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1", "d2"))
+        append_dispatch_record(sp, DispatchRecord(name="d1", status=DispatchStatus.SUCCESS))
+        state = read_state(sp)
+        assert state is not None
+        assert state.ended_at == 0.0
+
+
+class TestRecipeSnapshot:
+    def test_recipe_snapshot_defaults_to_empty(self, tmp_path: Path) -> None:
+        """recipe_snapshot defaults to {} on state files without it."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"))
+        state = read_state(sp)
+        assert state is not None
+        assert state.recipe_snapshot == {}
+
+    def test_recipe_snapshot_round_trips(self, tmp_path: Path) -> None:
+        """recipe_snapshot is written and read back faithfully."""
+        sp = _state_path(tmp_path)
+        snapshot = {
+            "recipe_name": "fix-bugs",
+            "content_hash": "sha256:abc123",
+            "effective_ingredients": {"task": "fix issue #42"},
+        }
+        write_initial_state(
+            sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"), recipe_snapshot=snapshot
+        )
+        state = read_state(sp)
+        assert state is not None
+        assert state.recipe_snapshot == snapshot
+
+
+class TestV4BackwardCompat:
+    def test_v4_state_file_loads_with_defaults(self, tmp_path: Path) -> None:
+        """State file without new fields (v4) loads with correct defaults."""
+        sp = _state_path(tmp_path)
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        v4_data = {
+            "schema_version": 4,
+            "campaign_id": "cid",
+            "campaign_name": "camp",
+            "manifest_path": "/m.yaml",
+            "started_at": 1000.0,
+            "dispatches": [{"name": "d1", "status": "pending"}],
+            "captured_values": {},
+            "orchestrator_session_id": "",
+        }
+        sp.write_text(json.dumps(v4_data))
+        state = read_state(sp)
+        assert state is not None
+        assert state.ended_at == 0.0
+        assert state.recipe_snapshot == {}
+        assert state.dispatches[0].attempt_history == []

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -65,8 +65,8 @@ class TestDispatchRecordSchemaV2:
         assert dispatch_raw["dispatched_starttime_ticks"] == 42
         assert dispatch_raw["dispatched_boot_id"] == "abc-boot"
 
-    def test_schema_version_is_4(self) -> None:
-        assert FLEET_STATE_SCHEMA_VERSION == 4
+    def test_schema_version_is_5(self) -> None:
+        assert FLEET_STATE_SCHEMA_VERSION == 5
 
     def test_read_state_returns_none_on_version_mismatch(self, tmp_path: Path) -> None:
         """read_state returns None when schema_version is stale (v1)."""
@@ -339,6 +339,7 @@ class TestDispatchRecordToDict:
             "started_at",
             "ended_at",
             "sidecar_path",
+            "attempt_history",
         }
 
     def test_dispatch_record_to_dict_token_usage_is_shallow_copy(self) -> None:
@@ -425,3 +426,27 @@ class TestDispatchRecordSchemaV3:
         sp.write_text(json.dumps(v1_payload))
         state = read_state(sp)
         assert state is None
+
+
+class TestAttemptHistoryFields:
+    def test_attempt_history_in_to_dict(self) -> None:
+        """to_dict includes attempt_history."""
+        d = DispatchRecord(
+            name="d1", attempt_history=[{"dispatch_id": "old", "status": "failure"}]
+        )
+        result = d.to_dict()
+        assert "attempt_history" in result
+        assert result["attempt_history"] == [{"dispatch_id": "old", "status": "failure"}]
+
+    def test_attempt_history_from_dict_missing_defaults_empty(self) -> None:
+        """from_dict handles missing attempt_history (v4 compat)."""
+        d = DispatchRecord.from_dict({"name": "d1"})
+        assert d.attempt_history == []
+
+    def test_attempt_history_round_trips_through_to_dict(self) -> None:
+        """attempt_history survives to_dict round-trip."""
+        d = DispatchRecord(
+            name="d1", attempt_history=[{"dispatch_id": "attempt-1", "status": "failure"}]
+        )
+        roundtripped = DispatchRecord.from_dict(d.to_dict())
+        assert roundtripped.attempt_history == [{"dispatch_id": "attempt-1", "status": "failure"}]


### PR DESCRIPTION
## Summary

Two operational completeness gaps are addressed:

**M4 — CampaignState operational fields:** Add `ended_at` (campaign completion timestamp), `attempt_history` on `DispatchRecord` (append-only retry history preserving error metadata from prior attempts), and `recipe_snapshot` on `CampaignState` (INIT_ONLY record of recipe identity + resolved ingredients at campaign creation time). Bump `_SCHEMA_VERSION` from 4 to 5.

**M6 — FleetSemaphore acquire timeout:** Add configurable timeout to `FleetSemaphore.acquire()` via `asyncio.wait_for`, with a new `acquire_timeout_sec` config field and `FLEET_ACQUIRE_TIMEOUT` error code. A hung dispatch no longer blocks all subsequent waiters indefinitely.

Closes #2240

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260508-145223-431686/.autoskillit/temp/make-plan/campaignstate_operational_fields_plan_2026-05-08_150000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.1k | 16.2k | 1.2M | 80.8k | 144 | 78.7k | 8m 47s |
| verify | claude-opus-4-6 | 1 | 51 | 14.7k | 2.0M | 78.8k | 125 | 66.0k | 8m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 4.3M | 21.7k | 2.2M | 107.4k | 183 | 142.7k | 8m 10s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 81.6k | 3.4k | 198.3k | 28.7k | 21 | 15.3k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 54.5k | 1.4k | 227.1k | 28.7k | 16 | 15.1k | 41s |
| review_pr | claude-sonnet-4-6 | 3 | 740 | 104.4k | 1.7M | 90.8k | 121 | 220.3k | 21m 6s |
| resolve_review | claude-sonnet-4-6 | 3 | 497 | 41.0k | 2.9M | 77.7k | 182 | 155.0k | 24m 11s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 379 | 42.4k | 4.7M | 138.5k | 119 | 125.6k | 11m 34s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 270.0k | 2.5k | 399.5k | 28.7k | 28 | 15.0k | 1m 24s |
| resolve_ci | claude-sonnet-4-6 | 1 | 200 | 11.2k | 1.3M | 68.7k | 64 | 55.6k | 6m 57s |
| **Total** | | | 4.7M | 258.8k | 16.8M | 138.5k | | 889.4k | 1h 32m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 312 | 7119.9 | 457.5 | 69.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 50 | 57573.7 | 3099.2 | 820.0 |
| ci_conflict_fix | 4225 | 1124.0 | 29.7 | 10.0 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 19 | 66173.8 | 2926.1 | 590.1 |
| **Total** | **4606** | 3656.1 | 193.1 | 56.2 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 3.2k | 30.9k | 3.2M | 144.7k | 16m 55s |
| MiniMax-M2.7-highspeed | 3 | 4.5M | 26.5k | 2.6M | 173.2k | 10m 3s |
| claude-sonnet-4-6 | 1 | 126 | 3.6k | 547.3k | 35.0k | 8m 25s |