### PR TITLE
Rectify: Campaign Dispatch Validation — Capture-vs-Sentinel and Required-Ingredient Cross-Checks

### DIFF
--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -376,11 +376,7 @@ def _check_dispatch_required_ingredient_provided(
         for auto in _AUTO_INJECTED_CAMPAIGN_INGREDIENTS:
             effective_ingredients.add(auto)
         for key, ing in target.ingredients.items():
-            if (
-                getattr(ing, "required", False)
-                and getattr(ing, "default", None) is None
-                and key not in effective_ingredients
-            ):
+            if ing.required and ing.default is None and key not in effective_ingredients:
                 findings.append(
                     RuleFinding(
                         rule="dispatch-required-ingredient-provided",

--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -24,6 +25,27 @@ _KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 # dispatch task: field), so campaigns that rely on this injection pattern should not
 # be flagged for not explicitly forwarding them in the ingredients block.
 _AUTO_INJECTED_CAMPAIGN_INGREDIENTS: frozenset[str] = frozenset({"task"})
+
+
+_SENTINEL_JSON_RE = re.compile(r"[Ee]xample\s+sentinel:\s*(\{[^}]+\})", re.DOTALL)
+
+
+def _extract_sentinel_fields(recipe: Recipe) -> frozenset[str]:
+    """Extract declared field names from all sentinel stop step JSON examples."""
+    fields: set[str] = set()
+    for step in recipe.steps.values():
+        if step.action != "stop" or not step.message:
+            continue
+        if "sentinel" not in step.message.lower():
+            continue
+        for match in _SENTINEL_JSON_RE.finditer(step.message):
+            try:
+                parsed = json.loads(match.group(1))
+                if isinstance(parsed, dict):
+                    fields.update(parsed.keys())
+            except (json.JSONDecodeError, ValueError):
+                continue
+    return frozenset(fields)
 
 
 def _load_dispatch_target(dispatch: CampaignDispatch, project_dir: Path | None) -> Recipe | None:
@@ -332,6 +354,50 @@ def _check_campaign_dangling_ingredient(ctx: ValidationContext) -> list[RuleFind
 
 
 @semantic_rule(
+    name="dispatch-required-ingredient-provided",
+    description=(
+        "Target recipe required ingredients (no default) must be provided by the dispatch"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_dispatch_required_ingredient_provided(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings: list[RuleFinding] = []
+    for d in ctx.recipe.dispatches:
+        if d.gate:
+            continue
+        target = _load_dispatch_target(d, ctx.project_dir)
+        if target is None:
+            continue
+        effective_ingredients = set(d.ingredients.keys())
+        for auto in _AUTO_INJECTED_CAMPAIGN_INGREDIENTS:
+            effective_ingredients.add(auto)
+        for key, ing in target.ingredients.items():
+            if (
+                getattr(ing, "required", False)
+                and getattr(ing, "default", None) is None
+                and key not in effective_ingredients
+            ):
+                findings.append(
+                    RuleFinding(
+                        rule="dispatch-required-ingredient-provided",
+                        severity=Severity.ERROR,
+                        step_name="(top-level)",
+                        message=(
+                            f"Dispatch {d.name!r} targets recipe {d.recipe!r} which "
+                            f"declares ingredient {key!r} as required (no default), "
+                            f"but the dispatch does not provide it. "
+                            f"Provided: {sorted(d.ingredients)}."
+                        ),
+                    )
+                )
+    return findings
+
+
+@semantic_rule(
     name="dispatch-ingredient-values-are-strings",
     description="All dispatch ingredient values must be strings",
     severity=Severity.ERROR,
@@ -480,6 +546,7 @@ def _check_campaign_task_non_empty(ctx: ValidationContext) -> list[RuleFinding]:
 
 _IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _RESULT_TEMPLATE_RE = re.compile(r"^\$\{\{\s*result\.[\w-]+\s*\}\}$")
+_RESULT_FIELD_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
 
 
 @semantic_rule(
@@ -529,6 +596,47 @@ def _check_dispatch_capture_value_references_result(ctx: ValidationContext) -> l
                         message=(
                             f"Dispatch {d.name!r} capture[{key!r}] value {val!r} must use "
                             "${{ result.<field_name> }} syntax."
+                        ),
+                    )
+                )
+    return findings
+
+
+@semantic_rule(
+    name="dispatch-capture-field-in-sentinel",
+    description="Captured result fields should appear in target recipe's sentinel message",
+    severity=Severity.WARNING,
+)
+def _check_dispatch_capture_field_in_sentinel(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings: list[RuleFinding] = []
+    for d in ctx.recipe.dispatches:
+        if d.gate or not d.capture:
+            continue
+        target = _load_dispatch_target(d, ctx.project_dir)
+        if target is None:
+            continue
+        sentinel_fields = _extract_sentinel_fields(target)
+        if not sentinel_fields:
+            continue
+        for cap_key, cap_val in d.capture.items():
+            match = _RESULT_FIELD_RE.match(cap_val.strip())
+            if not match:
+                continue
+            field_name = match.group(1)
+            if field_name not in sentinel_fields:
+                findings.append(
+                    RuleFinding(
+                        rule="dispatch-capture-field-in-sentinel",
+                        severity=Severity.WARNING,
+                        step_name="(top-level)",
+                        message=(
+                            f"Dispatch {d.name!r} captures {cap_key!r} as "
+                            f"${{{{ result.{field_name} }}}} but target recipe "
+                            f"{d.recipe!r} has no sentinel stop step listing "
+                            f"field {field_name!r}. "
+                            f"Known sentinel fields: {sorted(sentinel_fields)}."
                         ),
                     )
                 )

--- a/tests/recipe/test_research_campaign_rules.py
+++ b/tests/recipe/test_research_campaign_rules.py
@@ -8,7 +8,7 @@ import autoskillit.recipe  # noqa: F401 -- pyright: ignore[reportUnusedImport] -
 from autoskillit.core import Severity
 from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
-from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
+from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import CampaignDispatch, Recipe
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
@@ -78,12 +78,15 @@ def test_depends_on_acyclic_passes(validation_ctx) -> None:
 
 
 def test_dispatch_capture_fields_in_sentinel_contract_passes(validation_ctx) -> None:
-    rule_name = "dispatch-capture-fields-in-sentinel-contract"
-    registered_names = {r.name for r in _RULE_REGISTRY}
-    if rule_name not in registered_names:
-        pytest.skip(f"Rule {rule_name!r} not yet registered")
+    rule_name = "dispatch-capture-field-in-sentinel"
     findings = run_semantic_rules(validation_ctx)
     matched = [f for f in findings if f.rule == rule_name]
+    assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)
+
+
+def test_dispatch_required_ingredient_provided_passes(validation_ctx) -> None:
+    findings = run_semantic_rules(validation_ctx)
+    matched = [f for f in findings if f.rule == "dispatch-required-ingredient-provided"]
     assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)
 
 

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -967,3 +967,524 @@ def test_campaign_dangling_ingredient_exempts_task(tmp_path: Path):
     )
     found = _findings(recipe, "campaign-dangling-ingredient", project_dir=tmp_path)
     assert found == []
+
+
+# ---------------------------------------------------------------------------
+# T-R1: dispatch-required-ingredient-provided
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_required_ingredient_provided_fires_on_missing(tmp_path: Path):
+    """Rule fires when target recipe has a required ingredient the dispatch doesn't provide."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "task": {"description": "The task", "required": True},
+                "source_dir": {"description": "Source directory", "required": True},
+                "base_branch": {"description": "Base branch", "default": "main"},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={"task": "do it"},
+                # source_dir is required but not provided
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-required-ingredient-provided", project_dir=tmp_path)
+    assert len(found) == 1
+    assert found[0].severity == Severity.ERROR
+    assert "source_dir" in found[0].message
+
+
+def test_dispatch_required_ingredient_provided_passes_when_all_provided(tmp_path: Path):
+    """Rule passes when all required ingredients are provided."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "task": {"description": "The task", "required": True},
+                "source_dir": {"description": "Source directory", "required": True},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={"task": "do it", "source_dir": "/tmp/src"},
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-required-ingredient-provided", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_required_ingredient_provided_ignores_defaulted(tmp_path: Path):
+    """Rule does not fire for required ingredients that have a default."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "task": {"description": "The task", "required": True},
+                "base_branch": {"description": "Base branch", "default": "main"},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={"task": "do it"},
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-required-ingredient-provided", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_required_ingredient_provided_exempts_task_auto_injection(tmp_path: Path):
+    """Rule does not fire when target declares task as required with no default."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "task": {"description": "The task", "required": True},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={},  # task is auto-injected from dispatch.task field
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-required-ingredient-provided", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_required_ingredient_provided_skips_gate_dispatches(tmp_path: Path):
+    """Rule skips gate dispatches which have no target recipe."""
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(name="gate-check", gate="confirm", message="Proceed?"),
+        ],
+    )
+    found = _findings(recipe, "dispatch-required-ingredient-provided", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_required_ingredient_provided_skips_unloadable_target(tmp_path: Path):
+    """Rule skips when target recipe cannot be loaded."""
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="nonexistent-recipe",
+                task="do it",
+                ingredients={},
+            ),
+        ],
+    )
+    found = _findings(recipe, "dispatch-required-ingredient-provided", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_required_ingredient_provided_fires_per_dispatch(tmp_path: Path):
+    """Rule fires per-dispatch; multi-dispatch campaign with one missing."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {
+                "task": {"description": "The task", "required": True},
+                "source_dir": {"description": "Source directory", "required": True},
+            },
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={"task": "do it", "source_dir": "/tmp/src"},
+            ),
+            CampaignDispatch(
+                name="phase-two",
+                recipe="target-recipe",
+                task="do it",
+                ingredients={"task": "do it"},
+                # source_dir missing
+            ),
+        ],
+    )
+    found = _findings(recipe, "dispatch-required-ingredient-provided", project_dir=tmp_path)
+    assert len(found) == 1
+    assert "phase-two" in found[0].message
+    assert "phase-one" not in found[0].message
+
+
+def test_dispatch_required_ingredient_provided_skips_non_campaign(tmp_path: Path):
+    """Rule skips non-campaign recipes."""
+    recipe = _standard_recipe()
+    found = _findings(recipe, "dispatch-required-ingredient-provided", project_dir=tmp_path)
+    assert found == []
+
+
+# ---------------------------------------------------------------------------
+# T-S1: dispatch-capture-field-in-sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_capture_field_in_sentinel_fires_on_unknown_field(tmp_path: Path):
+    """Rule fires when capture references a field not in target's sentinel."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {"task": {"description": "t", "required": True}},
+            "steps": {
+                "done": {
+                    "action": "stop",
+                    "message": (
+                        "Emit the L3 result sentinel JSON block now. "
+                        'Example sentinel: {"success": true, "output_path": "<path>"}'
+                    ),
+                }
+            },
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                capture={"bad_field": "${{ result.nonexistent_field }}"},
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
+    assert len(found) == 1
+    assert found[0].severity == Severity.WARNING
+    assert "nonexistent_field" in found[0].message
+
+
+def test_dispatch_capture_field_in_sentinel_passes_when_field_exists(tmp_path: Path):
+    """Rule passes when capture field matches sentinel fields."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {"task": {"description": "t", "required": True}},
+            "steps": {
+                "done": {
+                    "action": "stop",
+                    "message": (
+                        "Emit the L3 result sentinel JSON block now. "
+                        'Example sentinel: {"success": true, "output_path": "<path>"}'
+                    ),
+                }
+            },
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                capture={"output_path": "${{ result.output_path }}"},
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_capture_field_in_sentinel_checks_any_sentinel(tmp_path: Path):
+    """Rule passes if field is in ANY sentinel stop step."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {"task": {"description": "t", "required": True}},
+            "steps": {
+                "path-a": {
+                    "action": "stop",
+                    "message": ('Example sentinel: {"success": true, "alpha": "<val>"}'),
+                },
+                "path-b": {
+                    "action": "stop",
+                    "message": ('Example sentinel: {"success": true, "beta": "<val>"}'),
+                },
+            },
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                capture={"alpha": "${{ result.alpha }}"},
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_capture_field_in_sentinel_skips_no_sentinel(tmp_path: Path):
+    """Rule silently skips when target has no sentinel stop step."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {"task": {"description": "t", "required": True}},
+            "steps": {"stop": {"action": "stop", "message": "done"}},
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                capture={"output_path": "${{ result.output_path }}"},
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_capture_field_in_sentinel_skips_no_capture(tmp_path: Path):
+    """Rule silently skips when dispatch has no capture block."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "target-recipe.yaml",
+        {
+            "name": "target-recipe",
+            "description": "target",
+            "kind": "standard",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {"task": {"description": "t", "required": True}},
+            "steps": {
+                "done": {
+                    "action": "stop",
+                    "message": ('Example sentinel: {"success": true, "output_path": "<path>"}'),
+                }
+            },
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="target-recipe",
+                task="do it",
+                capture={},
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_capture_field_in_sentinel_skips_gate_dispatches(tmp_path: Path):
+    """Rule skips gate dispatches."""
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(name="gate-check", gate="confirm", message="Proceed?"),
+        ],
+    )
+    found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_capture_field_in_sentinel_skips_unloadable_target(tmp_path: Path):
+    """Rule skips when target recipe cannot be loaded."""
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="nonexistent-recipe",
+                task="do it",
+                capture={"output_path": "${{ result.output_path }}"},
+            ),
+        ],
+    )
+    found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
+    assert found == []
+
+
+def test_dispatch_capture_field_in_sentinel_skips_non_campaign(tmp_path: Path):
+    """Rule skips non-campaign recipes."""
+    recipe = _standard_recipe()
+    found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
+    assert found == []
+
+
+# ---------------------------------------------------------------------------
+# T-S2: _extract_sentinel_fields
+# ---------------------------------------------------------------------------
+
+
+def test_extract_sentinel_fields_parses_json_example():
+    """Helper parses JSON example block and returns field names."""
+    from autoskillit.recipe.rules.rules_campaign import _extract_sentinel_fields
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={
+            "done": RecipeStep(
+                action="stop",
+                message=(
+                    "Emit the L3 result sentinel JSON block now. "
+                    'Example sentinel: {"success": true, "output_path": "<path>"}'
+                ),
+            )
+        },
+        kitchen_rules=["NEVER"],
+    )
+    fields = _extract_sentinel_fields(recipe)
+    assert fields == {"success", "output_path"}
+
+
+def test_extract_sentinel_fields_returns_empty_for_no_json():
+    """Helper returns empty set when no JSON example block is present."""
+    from autoskillit.recipe.rules.rules_campaign import _extract_sentinel_fields
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={"done": RecipeStep(action="stop", message="done")},
+        kitchen_rules=["NEVER"],
+    )
+    fields = _extract_sentinel_fields(recipe)
+    assert fields == set()
+
+
+def test_extract_sentinel_fields_handles_multiline_json():
+    """Helper handles JSON spanning multiple lines (folded YAML block)."""
+    from autoskillit.recipe.rules.rules_campaign import _extract_sentinel_fields
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={
+            "done": RecipeStep(
+                action="stop",
+                message=(
+                    "Example sentinel:\n"
+                    "  {\n"
+                    '    "success": true,\n'
+                    '    "output_path": "<path>",\n'
+                    '    "errors": []\n'
+                    "  }"
+                ),
+            )
+        },
+        kitchen_rules=["NEVER"],
+    )
+    fields = _extract_sentinel_fields(recipe)
+    assert fields == {"success", "output_path", "errors"}
+
+
+def test_extract_sentinel_fields_handles_multiple_sentinels():
+    """Helper returns union of fields from all sentinel stop steps."""
+    from autoskillit.recipe.rules.rules_campaign import _extract_sentinel_fields
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={
+            "path-a": RecipeStep(
+                action="stop",
+                message='Example sentinel: {"success": true, "alpha": "<val>"}',
+            ),
+            "path-b": RecipeStep(
+                action="stop",
+                message='Example sentinel: {"success": true, "beta": "<val>"}',
+            ),
+        },
+        kitchen_rules=["NEVER"],
+    )
+    fields = _extract_sentinel_fields(recipe)
+    assert fields == {"success", "alpha", "beta"}

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -1055,7 +1055,7 @@ def test_dispatch_required_ingredient_provided_ignores_defaulted(tmp_path: Path)
             "kitchen_rules": ["NEVER"],
             "ingredients": {
                 "task": {"description": "The task", "required": True},
-                "base_branch": {"description": "Base branch", "default": "main"},
+                "base_branch": {"description": "Base branch", "required": True, "default": "main"},
             },
             "steps": {"stop": {"action": "stop", "message": "done"}},
         },

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -1181,7 +1181,7 @@ def test_dispatch_required_ingredient_provided_skips_non_campaign(tmp_path: Path
 
 
 # ---------------------------------------------------------------------------
-# T-S1: dispatch-capture-field-in-sentinel
+# T-S2: dispatch-capture-field-in-sentinel
 # ---------------------------------------------------------------------------
 
 
@@ -1397,7 +1397,7 @@ def test_dispatch_capture_field_in_sentinel_skips_non_campaign(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# T-S2: _extract_sentinel_fields
+# T-S3: _extract_sentinel_fields
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

The campaign semantic validation system validates dispatch wiring *syntactically* (template patterns, identifier format, ref resolution) but lacks *semantic* cross-recipe validation: it never loads a target recipe to verify that (a) captured `${{ result.<field> }}` fields actually appear in the target's sentinel message, or (b) the target's `required: true` (no default) ingredients are provided by the dispatch. These two gaps allowed the entire research campaign chain to carry 6 field-level wiring errors without any validation warning. Two new semantic rules and a shared sentinel field extraction helper close both gaps, following the established `_load_dispatch_target` pattern already used by 4 existing rules.

## Requirements

Two classes of campaign recipe wiring errors are invisible to static validation: (1) capture blocks referencing fields that the target recipe's sentinel never emits, and (2) target recipes declaring `required: true` ingredients that the campaign dispatch never provides. These caused the research campaign chain to be fundamentally broken without any validation warning. Two new semantic rules are needed.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260508-153155-490823/.autoskillit/temp/rectify/rectify_campaign_dispatch_validation_2026-05-08_153155.md`

Closes #2231

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 1.1k | 17.4k | 1.4M | 98.4k | 174 | 85.0k | 10m 31s |
| dry_walkthrough | claude-opus-4-6 | 1 | 47 | 14.5k | 1.1M | 76.4k | 78 | 64.9k | 7m 12s |
| implement* | MiniMax-M2.7 | 1 | 80.6k | 11.0k | 1.8M | 21.0k | 70 | 0 | 7m 2s |
| prepare_pr* | MiniMax-M2.7 | 1 | 45.7k | 2.6k | 247.8k | 0 | 19 | 0 | 34s |
| compose_pr* | MiniMax-M2.7 | 1 | 37.5k | 1.5k | 338.5k | 0 | 21 | 0 | 23s |
| review_pr | claude-opus-4-6 | 3 | 1.1k | 70.8k | 2.2M | 90.6k | 160 | 204.3k | 21m 54s |
| resolve_review | claude-opus-4-6 | 2 | 112 | 24.7k | 2.3M | 75.5k | 106 | 122.3k | 12m 15s |
| **Total** | | | 166.1k | 142.5k | 9.4M | 98.4k | | 476.4k | 59m 52s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 642 | 2751.7 | 0.0 | 17.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 195594.5 | 10187.9 | 2056.2 |
| **Total** | **654** | 14304.0 | 728.4 | 217.9 |