### PR TITLE
Rectify: Dispatch Status State Machine — Structural Immunity for Dead-End Non-Terminal States

### DIFF
--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -41,7 +41,7 @@ from .state import (
     read_all_campaign_captures,
     read_state,
     record_gate_outcome,
-    reset_failed_dispatch,
+    reset_blocking_dispatch,
     resume_campaign_from_state,
     update_orchestrator_session_id,
     upsert_dispatch_record_by_name,
@@ -51,6 +51,7 @@ from .state import (
 from .state_recovery import (
     classify_stale_dispatch,
     derive_orchestrator_resume_spec,
+    has_blocking_dispatch,
 )
 from .state_types import FLEET_STATE_SCHEMA_VERSION, DispatchOutcome
 from .summary import (
@@ -99,6 +100,7 @@ __all__ = [
     "GateRecordResult",
     "append_dispatch_record",
     "build_protected_campaign_ids",
+    "has_blocking_dispatch",
     "has_failed_dispatch",
     "record_gate_outcome",
     "mark_dispatch_interrupted",
@@ -106,7 +108,7 @@ __all__ = [
     "mark_dispatch_running",
     "read_all_campaign_captures",
     "read_state",
-    "reset_failed_dispatch",
+    "reset_blocking_dispatch",
     "resume_campaign_from_state",
     "update_orchestrator_session_id",
     "upsert_dispatch_record_by_name",

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 from autoskillit.core import get_logger, read_versioned_json, write_versioned_json
 from autoskillit.fleet.state_gates import record_gate_outcome
 from autoskillit.fleet.state_recovery import (
+    has_blocking_dispatch,
     has_failed_dispatch,
     resume_campaign_from_state,
 )
@@ -305,9 +306,8 @@ def mark_dispatch_running(
             raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
         for d in m.state.dispatches:
             if d.name == dispatch_name:
-                if d.status == DispatchStatus.RESUMABLE:
-                    d.kill_reason = ""
-                    d.infra_exit_category = ""
+                d.kill_reason = ""
+                d.infra_exit_category = ""
                 _validate_transition(d.status, DispatchStatus.RUNNING, d.name)
                 d.status = DispatchStatus.RUNNING
                 d.dispatch_id = dispatch_id

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -45,6 +45,7 @@ __all__ = [
     # re-exported from state_gates
     "record_gate_outcome",
     # re-exported from state_recovery
+    "has_blocking_dispatch",
     "has_failed_dispatch",
     "resume_campaign_from_state",
     # re-exported from state_types
@@ -64,7 +65,7 @@ __all__ = [
     "mark_dispatch_running",
     "mark_dispatch_interrupted",
     "mark_dispatch_resumable",
-    "reset_failed_dispatch",
+    "reset_blocking_dispatch",
     "append_dispatch_record",
     "upsert_dispatch_record_by_name",
     "build_protected_campaign_ids",
@@ -132,19 +133,23 @@ def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
     d.infra_exit_category = ""
 
 
-def reset_failed_dispatch(state_path: Path, dispatch_name: str) -> bool:
-    """Reset a FAILURE dispatch to PENDING, clearing all execution metadata.
+def reset_blocking_dispatch(state_path: Path, dispatch_name: str) -> bool:
+    """Reset a blocking dispatch (FAILURE, INTERRUPTED, or REFUSED) to PENDING.
 
-    Returns True if the dispatch was found in FAILURE state and reset,
-    False if the dispatch was not found, not in FAILURE, or the state file
-    is missing/corrupted. OSError raised by _write_state propagates to
-    the caller — write failures are not silently converted to False.
+    Returns True if the dispatch was found in a blocking state and reset,
+    False if the dispatch was not found, not in a blocking state, or the
+    state file is missing/corrupted. OSError raised by _write_state propagates
+    to the caller — write failures are not silently converted to False.
     """
     with CampaignStateMutator(state_path) as m:
         if m.state is None:
             return False
         for d in m.state.dispatches:
-            if d.name == dispatch_name and d.status == DispatchStatus.FAILURE:
+            if d.name == dispatch_name and d.status in {
+                DispatchStatus.FAILURE,
+                DispatchStatus.INTERRUPTED,
+                DispatchStatus.REFUSED,
+            }:
                 _clear_dispatch_for_retry(d)
                 m.mark_dirty()
                 return True
@@ -300,6 +305,9 @@ def mark_dispatch_running(
             raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
         for d in m.state.dispatches:
             if d.name == dispatch_name:
+                if d.status == DispatchStatus.RESUMABLE:
+                    d.kill_reason = ""
+                    d.infra_exit_category = ""
                 _validate_transition(d.status, DispatchStatus.RUNNING, d.name)
                 d.status = DispatchStatus.RUNNING
                 d.dispatch_id = dispatch_id

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -26,6 +26,14 @@ __all__ = [
 
 logger = get_logger(__name__)
 
+_RETRIABLE_NON_SUCCESS = frozenset(
+    {
+        DispatchStatus.FAILURE,
+        DispatchStatus.INTERRUPTED,
+        DispatchStatus.REFUSED,
+    }
+)
+
 
 def has_failed_dispatch(state_path: Path) -> bool:
     """Check whether any dispatch has a FAILURE status attributable to logic (not infrastructure).
@@ -158,12 +166,6 @@ def resume_campaign_from_state(
         if m.state is None:
             return None
 
-        was_blocked = frozenset(
-            d.name
-            for d in m.state.dispatches
-            if d.status in {DispatchStatus.INTERRUPTED, DispatchStatus.REFUSED}
-        )
-
         for d in m.state.dispatches:
             if d.status == DispatchStatus.RUNNING:
                 if is_dispatch_session_alive(d):
@@ -175,17 +177,9 @@ def resume_campaign_from_state(
                     d.sidecar_path = sidecar_path
                 m.mark_dirty()
 
-        _RETRIABLE_NON_SUCCESS = frozenset(
-            {
-                DispatchStatus.FAILURE,
-                DispatchStatus.INTERRUPTED,
-                DispatchStatus.REFUSED,
-            }
-        )
-
         if continue_on_failure and reset_on_retry:
             for d in m.state.dispatches:
-                if d.status in {DispatchStatus.INTERRUPTED, DispatchStatus.REFUSED}:
+                if d.status in _RETRIABLE_NON_SUCCESS:
                     _clear_dispatch_for_retry(d)
                     m.mark_dirty()
 

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -34,6 +34,13 @@ _RETRIABLE_NON_SUCCESS = frozenset(
     }
 )
 
+_ALWAYS_BLOCKING_STATUSES = frozenset(
+    {
+        DispatchStatus.INTERRUPTED,
+        DispatchStatus.REFUSED,
+    }
+)
+
 
 def has_failed_dispatch(state_path: Path) -> bool:
     """Check whether any dispatch has a FAILURE status attributable to logic (not infrastructure).
@@ -73,7 +80,7 @@ def has_blocking_dispatch(state_path: Path) -> bool:
     if state is None:
         return False
     for d in state.dispatches:
-        if d.status in {DispatchStatus.INTERRUPTED, DispatchStatus.REFUSED}:
+        if d.status in _ALWAYS_BLOCKING_STATUSES:
             return True
         if d.status == DispatchStatus.FAILURE and d.reason not in _INFRASTRUCTURE_FAILURE_REASONS:
             return True
@@ -179,7 +186,7 @@ def resume_campaign_from_state(
 
         if continue_on_failure and reset_on_retry:
             for d in m.state.dispatches:
-                if d.status in {DispatchStatus.INTERRUPTED, DispatchStatus.REFUSED}:
+                if d.status in _ALWAYS_BLOCKING_STATUSES:
                     _clear_dispatch_for_retry(d)
                     m.mark_dirty()
 

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -26,20 +26,14 @@ __all__ = [
 
 logger = get_logger(__name__)
 
-_RETRIABLE_NON_SUCCESS = frozenset(
-    {
-        DispatchStatus.FAILURE,
-        DispatchStatus.INTERRUPTED,
-        DispatchStatus.REFUSED,
-    }
-)
-
 _ALWAYS_BLOCKING_STATUSES = frozenset(
     {
         DispatchStatus.INTERRUPTED,
         DispatchStatus.REFUSED,
     }
 )
+
+_RETRIABLE_NON_SUCCESS = _ALWAYS_BLOCKING_STATUSES | frozenset({DispatchStatus.FAILURE})
 
 
 def has_failed_dispatch(state_path: Path) -> bool:

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -179,7 +179,7 @@ def resume_campaign_from_state(
 
         if continue_on_failure and reset_on_retry:
             for d in m.state.dispatches:
-                if d.status in _RETRIABLE_NON_SUCCESS:
+                if d.status in {DispatchStatus.INTERRUPTED, DispatchStatus.REFUSED}:
                     _clear_dispatch_for_retry(d)
                     m.mark_dirty()
 

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -19,6 +19,7 @@ from autoskillit.fleet.state_types import (
 __all__ = [
     "classify_stale_dispatch",
     "derive_orchestrator_resume_spec",
+    "has_blocking_dispatch",
     "has_failed_dispatch",
     "resume_campaign_from_state",
 ]
@@ -46,6 +47,29 @@ def has_failed_dispatch(state_path: Path) -> bool:
         d.status == DispatchStatus.FAILURE and d.reason not in _INFRASTRUCTURE_FAILURE_REASONS
         for d in state.dispatches
     )
+
+
+def has_blocking_dispatch(state_path: Path) -> bool:
+    """Check whether any dispatch should block further campaign dispatches.
+
+    INTERRUPTED and REFUSED dispatches always block (they are retriable but not
+    terminal). FAILURE blocks only when it is a logic failure (not infrastructure).
+
+    Returns False when the file is missing or corrupted (fail-open).
+    """
+    from autoskillit.fleet.state import read_state  # noqa: PLC0415
+
+    if not state_path.exists():
+        return False
+    state = read_state(state_path)
+    if state is None:
+        return False
+    for d in state.dispatches:
+        if d.status in {DispatchStatus.INTERRUPTED, DispatchStatus.REFUSED}:
+            return True
+        if d.status == DispatchStatus.FAILURE and d.reason not in _INFRASTRUCTURE_FAILURE_REASONS:
+            return True
+    return False
 
 
 def _is_abandon_kill_metadata(kill_reason: str, infra_exit_category: str) -> bool:
@@ -134,6 +158,12 @@ def resume_campaign_from_state(
         if m.state is None:
             return None
 
+        was_blocked = frozenset(
+            d.name
+            for d in m.state.dispatches
+            if d.status in {DispatchStatus.INTERRUPTED, DispatchStatus.REFUSED}
+        )
+
         for d in m.state.dispatches:
             if d.status == DispatchStatus.RUNNING:
                 if is_dispatch_session_alive(d):
@@ -145,8 +175,22 @@ def resume_campaign_from_state(
                     d.sidecar_path = sidecar_path
                 m.mark_dirty()
 
+        _RETRIABLE_NON_SUCCESS = frozenset(
+            {
+                DispatchStatus.FAILURE,
+                DispatchStatus.INTERRUPTED,
+                DispatchStatus.REFUSED,
+            }
+        )
+
+        if continue_on_failure and reset_on_retry:
+            for d in m.state.dispatches:
+                if d.status in {DispatchStatus.INTERRUPTED, DispatchStatus.REFUSED}:
+                    _clear_dispatch_for_retry(d)
+                    m.mark_dirty()
+
         for d in m.state.dispatches:
-            if d.status == DispatchStatus.FAILURE and not continue_on_failure:
+            if d.status in _RETRIABLE_NON_SUCCESS and not continue_on_failure:
                 if reset_on_retry:
                     _clear_dispatch_for_retry(d)
                     m.mark_dirty()
@@ -173,8 +217,8 @@ def resume_campaign_from_state(
                 d.status
                 not in {
                     DispatchStatus.INTERRUPTED,
-                    DispatchStatus.RUNNING,
                     DispatchStatus.REFUSED,
+                    DispatchStatus.RUNNING,
                     DispatchStatus.RELEASED,
                     DispatchStatus.FAILURE,
                     DispatchStatus.RESUMABLE,

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -292,6 +292,8 @@ _VISIBLE_IN_BLOCK_STATUSES = _COMPLETED_STATUSES | frozenset(
     {
         DispatchStatus.RELEASED,
         DispatchStatus.RUNNING,
+        DispatchStatus.INTERRUPTED,
+        DispatchStatus.REFUSED,
     }
 )
 

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -183,11 +183,16 @@ _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     ),
     DispatchStatus.FAILURE: frozenset({DispatchStatus.PENDING}),
     DispatchStatus.SUCCESS: frozenset(),
-    DispatchStatus.INTERRUPTED: frozenset(),
+    DispatchStatus.INTERRUPTED: frozenset({DispatchStatus.PENDING}),
     DispatchStatus.SKIPPED: frozenset(),
-    DispatchStatus.REFUSED: frozenset(),
+    DispatchStatus.REFUSED: frozenset({DispatchStatus.PENDING}),
     DispatchStatus.RELEASED: frozenset(),
 }
+
+for _ds in DispatchStatus:
+    if _ds not in _ALLOWED_TRANSITIONS:
+        raise AssertionError(f"DispatchStatus.{_ds.name} missing from _ALLOWED_TRANSITIONS")
+del _ds
 
 
 def _validate_transition(current: str, new: str, dispatch_name: str) -> None:
@@ -285,23 +290,13 @@ _COMPLETED_STATUSES = frozenset(
 
 _VISIBLE_IN_BLOCK_STATUSES = _COMPLETED_STATUSES | frozenset(
     {
-        DispatchStatus.INTERRUPTED,
-        DispatchStatus.REFUSED,
         DispatchStatus.RELEASED,
         DispatchStatus.RUNNING,
     }
 )
 
-# FAILURE is included here (stops forward progress) but can transition back to PENDING
-# via explicit retry.
 TERMINAL_DISPATCH_STATUSES: frozenset[str] = frozenset(
-    {
-        DispatchStatus.SUCCESS,
-        DispatchStatus.FAILURE,
-        DispatchStatus.SKIPPED,
-        DispatchStatus.RELEASED,
-        DispatchStatus.REFUSED,
-    }
+    status for status, transitions in _ALLOWED_TRANSITIONS.items() if not transitions
 )
 
 

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -146,7 +146,12 @@ async def dispatch_food_truck(
 
             campaign_sp = Path(campaign_state_path_str)
             if dispatch_name:
-                reset_blocking_dispatch(campaign_sp, dispatch_name)
+                if not reset_blocking_dispatch(campaign_sp, dispatch_name):
+                    logger.warning(
+                        "reset_blocking_dispatch: dispatch %r not found in a blocking state"
+                        " — campaign block may originate from a different dispatch",
+                        dispatch_name,
+                    )
             if has_blocking_dispatch(campaign_sp):
                 return fleet_error(
                     FleetErrorCode.FLEET_CAMPAIGN_HALTED,

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -147,11 +147,21 @@ async def dispatch_food_truck(
             campaign_sp = Path(campaign_state_path_str)
             if dispatch_name:
                 if not reset_blocking_dispatch(campaign_sp, dispatch_name):
+                    still_blocked = has_blocking_dispatch(campaign_sp)
                     logger.warning(
-                        "reset_blocking_dispatch: dispatch %r not found in a blocking state"
-                        " — campaign block may originate from a different dispatch",
+                        "reset_blocking_dispatch: dispatch %r not found in a blocking state — %s",
                         dispatch_name,
+                        "campaign is blocked by a different dispatch"
+                        if still_blocked
+                        else "no active campaign block detected",
                     )
+                    if still_blocked:
+                        return fleet_error(
+                            FleetErrorCode.FLEET_CAMPAIGN_HALTED,
+                            "Campaign halted: a prior dispatch failed and "
+                            "continue_on_failure is false. "
+                            "No further dispatches permitted.",
+                        )
             if has_blocking_dispatch(campaign_sp):
                 return fleet_error(
                     FleetErrorCode.FLEET_CAMPAIGN_HALTED,

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -140,14 +140,14 @@ async def dispatch_food_truck(
         continue_on_failure_str = os.environ.get("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
         if campaign_state_path_str and continue_on_failure_str.lower() != "true":
             from autoskillit.fleet import (  # noqa: PLC0415
-                has_failed_dispatch,
-                reset_failed_dispatch,
+                has_blocking_dispatch,
+                reset_blocking_dispatch,
             )
 
             campaign_sp = Path(campaign_state_path_str)
             if dispatch_name:
-                reset_failed_dispatch(campaign_sp, dispatch_name)
-            if has_failed_dispatch(campaign_sp):
+                reset_blocking_dispatch(campaign_sp, dispatch_name)
+            if has_blocking_dispatch(campaign_sp):
                 return fleet_error(
                     FleetErrorCode.FLEET_CAMPAIGN_HALTED,
                     "Campaign halted: a prior dispatch failed and "

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -296,12 +296,6 @@ class TestCampaignResumeChain:
         assert "review-gate" in decision.completed_dispatches_block
 
 
-def test_refused_dispatch_is_terminal():
-    from autoskillit.fleet.state_types import TERMINAL_DISPATCH_STATUSES
-
-    assert DispatchStatus.REFUSED in TERMINAL_DISPATCH_STATUSES
-
-
 def test_refused_gate_resume_selects_next(tmp_path):
     sp = _init_state(tmp_path, "gate-check", "phase-one")
     from autoskillit.fleet.state_gates import record_gate_outcome

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -14,7 +14,7 @@ from autoskillit.fleet import (
     DispatchStatus,
     append_dispatch_record,
     read_state,
-    reset_failed_dispatch,
+    reset_blocking_dispatch,
     resume_campaign_from_state,
     write_initial_state,
 )
@@ -46,10 +46,10 @@ class TestFailureToPendingTransition:
             _validate_transition(DispatchStatus.FAILURE, DispatchStatus.RUNNING, "d1")
 
 
-# --- reset_failed_dispatch ---
+# --- reset_blocking_dispatch ---
 
 
-class TestResetFailedDispatch:
+class TestResetBlockingDispatch:
     def test_resets_failure_to_pending(self, tmp_path: Path):
         """FAILURE dispatch is reset to PENDING with cleared metadata."""
         sp = _state_path(tmp_path)
@@ -81,7 +81,7 @@ class TestResetFailedDispatch:
             ),
         )
 
-        result = reset_failed_dispatch(sp, "d2")
+        result = reset_blocking_dispatch(sp, "d2")
 
         assert result is True
         state = read_state(sp)
@@ -108,7 +108,7 @@ class TestResetFailedDispatch:
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"))
         append_dispatch_record(sp, DispatchRecord(name="d1", status=DispatchStatus.FAILURE))
 
-        result = reset_failed_dispatch(sp, "d1")
+        result = reset_blocking_dispatch(sp, "d1")
 
         assert result is True
 
@@ -118,7 +118,7 @@ class TestResetFailedDispatch:
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"))
         append_dispatch_record(sp, DispatchRecord(name="d1", status=DispatchStatus.SUCCESS))
 
-        result = reset_failed_dispatch(sp, "d1")
+        result = reset_blocking_dispatch(sp, "d1")
 
         assert result is False
 
@@ -128,7 +128,7 @@ class TestResetFailedDispatch:
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("d1"))
         append_dispatch_record(sp, DispatchRecord(name="d1", status=DispatchStatus.FAILURE))
 
-        result = reset_failed_dispatch(sp, "nonexistent")
+        result = reset_blocking_dispatch(sp, "nonexistent")
 
         assert result is False
 
@@ -136,7 +136,7 @@ class TestResetFailedDispatch:
         """Returns False when state file does not exist (fail-safe)."""
         sp = tmp_path / "nonexistent" / "state.json"
 
-        result = reset_failed_dispatch(sp, "d1")
+        result = reset_blocking_dispatch(sp, "d1")
 
         assert result is False
 
@@ -162,7 +162,7 @@ class TestResetFailedDispatch:
             ),
         )
 
-        reset_failed_dispatch(sp, "d2")
+        reset_blocking_dispatch(sp, "d2")
 
         state = read_state(sp)
         assert state is not None

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -333,7 +333,7 @@ class TestAttemptHistoryOnRetry:
                 ended_at=200.0,
             ),
         )
-        reset_failed_dispatch(sp, "d1")
+        reset_blocking_dispatch(sp, "d1")
         state = read_state(sp)
         assert state is not None
         d1 = next(d for d in state.dispatches if d.name == "d1")

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -770,7 +770,7 @@ class TestAppendDispatchRecordIllegalTransition:
         assert latest.status == DispatchStatus.SUCCESS
 
 
-class TestResumeShowsRefusedInBlock:
+class TestRefusedDispatchSkippedInBlock:
     def test_refused_dispatch_skipped_next_is_b(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B"))
@@ -781,6 +781,10 @@ class TestResumeShowsRefusedInBlock:
         assert decision is not None
         assert decision.next_dispatch_name == "B"
         assert "A" not in decision.completed_dispatches_block
+        state = read_state(sp)
+        assert state is not None
+        a = next(d for d in state.dispatches if d.name == "A")
+        assert a.status == DispatchStatus.REFUSED
 
 
 class TestResumeShowsReleasedInBlock:
@@ -795,7 +799,7 @@ class TestResumeShowsReleasedInBlock:
         assert "released" in decision.completed_dispatches_block.lower()
 
 
-class TestResumeIncludesInterruptedInBlock:
+class TestInterruptedDispatchSkippedInBlock:
     def test_interrupted_dispatch_skipped_next_is_c(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B", "C"))
@@ -808,6 +812,8 @@ class TestResumeIncludesInterruptedInBlock:
         decision = resume_campaign_from_state(sp, continue_on_failure=True)
         assert decision is not None
         assert decision.next_dispatch_name == "C"
+        assert "A" in decision.completed_dispatches_block
+        assert "B" not in decision.completed_dispatches_block
 
 
 class TestResumeIncludesRunningAliveInBlock:
@@ -1368,15 +1374,13 @@ class TestAllInterruptedCampaignDoesNotSilentlyComplete:
         decision = resume_campaign_from_state(sp, continue_on_failure=False)
 
         assert decision is not None
-        assert (
-            decision.next_dispatch_name != ""
-            or decision.completed_dispatches_block == FLEET_HALTED_SENTINEL
-        ), "All-INTERRUPTED campaign returned empty next_name with no halt sentinel — silent stall"
+        assert decision.next_dispatch_name == ""
+        assert decision.completed_dispatches_block == FLEET_HALTED_SENTINEL
 
     def test_all_interrupted_continue_on_failure_true_resets_to_pending(
         self, tmp_path: Path
     ) -> None:
-        """resume_campaign_from_state with continue_on_failure=True resets INTERRUPTED to PENDING."""
+        """continue_on_failure=True resets INTERRUPTED dispatch to PENDING."""
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
         from autoskillit.fleet import upsert_dispatch_record_by_name
@@ -1409,10 +1413,8 @@ class TestAllRefusedCampaignDoesNotSilentlyComplete:
         decision = resume_campaign_from_state(sp, continue_on_failure=False)
 
         assert decision is not None
-        assert (
-            decision.next_dispatch_name != ""
-            or decision.completed_dispatches_block == FLEET_HALTED_SENTINEL
-        ), "All-REFUSED campaign returned empty next_name with no halt sentinel — silent stall"
+        assert decision.next_dispatch_name == ""
+        assert decision.completed_dispatches_block == FLEET_HALTED_SENTINEL
 
     def test_all_refused_continue_on_failure_true_resets_to_pending(self, tmp_path: Path) -> None:
         """resume_campaign_from_state with continue_on_failure=True resets REFUSED to PENDING."""
@@ -1439,18 +1441,24 @@ class TestKillReasonNotStaleAfterResumableRedispatch:
 
     def test_kill_reason_cleared_on_resumable_to_running(self, tmp_path: Path) -> None:
         """mark_dispatch_running clears kill_reason when re-dispatching a RESUMABLE dispatch."""
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
         sp = _state_path(tmp_path)
         sidecar = tmp_path / "sidecar.jsonl"
         sidecar.write_text("")
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
         mark_dispatch_running(sp, "A", dispatch_id="d1", dispatched_pid=42)
         mark_dispatch_resumable(sp, "A", sidecar_path=str(sidecar))
-        data = json.loads(sp.read_text())
-        for d in data["dispatches"]:
-            if d["name"] == "A":
-                d["kill_reason"] = "idle_stall"
-                d["infra_exit_category"] = "something"
-        sp.write_text(json.dumps(data))
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(
+                name="A",
+                status=DispatchStatus.RESUMABLE,
+                kill_reason="idle_stall",
+                infra_exit_category="something",
+                sidecar_path=str(sidecar),
+            ),
+        )
 
         mark_dispatch_running(sp, "A", dispatch_id="d2", dispatched_pid=43)
 

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -1506,3 +1506,49 @@ class TestL3GateBlocksOnInterruptedDispatch:
         append_dispatch_record(sp, DispatchRecord(name="B", status=DispatchStatus.SUCCESS))
 
         assert has_blocking_dispatch(sp) is False
+
+
+class TestContinueOnFailureDoesNotResetFailureDispatches:
+    """FAILURE dispatches must NOT be reset when continue_on_failure=True.
+
+    Design intent: continue_on_failure skips halting on FAILURE but deliberately
+    does not retry FAILURE dispatches — only INTERRUPTED/REFUSED are reset.
+    Confirmed by commit b1476f2d.
+    """
+
+    def test_failure_not_reset_under_continue_on_failure(self, tmp_path: Path) -> None:
+        """resume_campaign_from_state with continue_on_failure=True must not reset FAILURE."""
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B"))
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(name="A", status=DispatchStatus.FAILURE, reason="task-failed"),
+        )
+
+        resume_campaign_from_state(sp, continue_on_failure=True, reset_on_retry=True)
+
+        state = read_state(sp)
+        assert state is not None
+        a = next(d for d in state.dispatches if d.name == "A")
+        assert a.status == DispatchStatus.FAILURE, (
+            "FAILURE dispatch must not be reset to PENDING under continue_on_failure=True"
+        )
+
+    def test_interrupted_still_reset_under_continue_on_failure(self, tmp_path: Path) -> None:
+        """INTERRUPTED dispatches ARE reset when continue_on_failure=True (not FAILURE)."""
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B"))
+        upsert_dispatch_record_by_name(
+            sp, DispatchRecord(name="A", status=DispatchStatus.INTERRUPTED)
+        )
+
+        resume_campaign_from_state(sp, continue_on_failure=True, reset_on_retry=True)
+
+        state = read_state(sp)
+        assert state is not None
+        a = next(d for d in state.dispatches if d.name == "A")
+        assert a.status == DispatchStatus.PENDING

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -770,8 +770,8 @@ class TestAppendDispatchRecordIllegalTransition:
         assert latest.status == DispatchStatus.SUCCESS
 
 
-class TestRefusedDispatchSkippedInBlock:
-    def test_refused_dispatch_skipped_next_is_b(self, tmp_path: Path) -> None:
+class TestRefusedDispatchVisibleInBlock:
+    def test_refused_dispatch_visible_next_is_b(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B"))
         from autoskillit.fleet import upsert_dispatch_record_by_name
@@ -780,7 +780,8 @@ class TestRefusedDispatchSkippedInBlock:
         decision = resume_campaign_from_state(sp, continue_on_failure=True)
         assert decision is not None
         assert decision.next_dispatch_name == "B"
-        assert "A" not in decision.completed_dispatches_block
+        assert "A" in decision.completed_dispatches_block
+        assert "refused" in decision.completed_dispatches_block.lower()
         state = read_state(sp)
         assert state is not None
         a = next(d for d in state.dispatches if d.name == "A")
@@ -799,8 +800,8 @@ class TestResumeShowsReleasedInBlock:
         assert "released" in decision.completed_dispatches_block.lower()
 
 
-class TestInterruptedDispatchSkippedInBlock:
-    def test_interrupted_dispatch_skipped_next_is_c(self, tmp_path: Path) -> None:
+class TestInterruptedDispatchVisibleInBlock:
+    def test_interrupted_dispatch_visible_next_is_c(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B", "C"))
         append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.SUCCESS))
@@ -813,7 +814,8 @@ class TestInterruptedDispatchSkippedInBlock:
         assert decision is not None
         assert decision.next_dispatch_name == "C"
         assert "A" in decision.completed_dispatches_block
-        assert "B" not in decision.completed_dispatches_block
+        assert "B" in decision.completed_dispatches_block
+        assert "interrupted" in decision.completed_dispatches_block.lower()
 
 
 class TestResumeIncludesRunningAliveInBlock:

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -1364,7 +1364,7 @@ class TestAllInterruptedCampaignDoesNotSilentlyComplete:
     """A campaign where every dispatch is INTERRUPTED must halt or retry, not silently complete."""
 
     def test_all_interrupted_continue_on_failure_false_halts(self, tmp_path: Path) -> None:
-        """resume_campaign_from_state must not return next_dispatch_name='' for all-INTERRUPTED."""
+        """All-INTERRUPTED + continue_on_failure=False: empty name and FLEET_HALTED_SENTINEL."""
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
         from autoskillit.fleet import upsert_dispatch_record_by_name
@@ -1405,7 +1405,7 @@ class TestAllRefusedCampaignDoesNotSilentlyComplete:
     """A campaign where every dispatch is REFUSED must halt or retry, not silently complete."""
 
     def test_all_refused_continue_on_failure_false_halts(self, tmp_path: Path) -> None:
-        """resume_campaign_from_state must not return next_dispatch_name='' for all-REFUSED."""
+        """All-REFUSED + continue_on_failure=False: empty name and FLEET_HALTED_SENTINEL."""
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
         from autoskillit.fleet import upsert_dispatch_record_by_name

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -771,15 +771,16 @@ class TestAppendDispatchRecordIllegalTransition:
 
 
 class TestResumeShowsRefusedInBlock:
-    def test_refused_dispatch_visible_next_is_b(self, tmp_path: Path) -> None:
+    def test_refused_dispatch_skipped_next_is_b(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B"))
-        append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.REFUSED))
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        upsert_dispatch_record_by_name(sp, DispatchRecord(name="A", status=DispatchStatus.REFUSED))
         decision = resume_campaign_from_state(sp, continue_on_failure=True)
         assert decision is not None
         assert decision.next_dispatch_name == "B"
-        assert "A" in decision.completed_dispatches_block
-        assert "refused" in decision.completed_dispatches_block.lower()
+        assert "A" not in decision.completed_dispatches_block
 
 
 class TestResumeShowsReleasedInBlock:
@@ -795,16 +796,17 @@ class TestResumeShowsReleasedInBlock:
 
 
 class TestResumeIncludesInterruptedInBlock:
-    def test_interrupted_dispatch_visible_in_completed_block(self, tmp_path: Path) -> None:
+    def test_interrupted_dispatch_skipped_next_is_c(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B", "C"))
         append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.SUCCESS))
-        mark_dispatch_running(sp, "B", dispatch_id="d-b", dispatched_pid=99)
-        append_dispatch_record(sp, DispatchRecord(name="B", status=DispatchStatus.INTERRUPTED))
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        upsert_dispatch_record_by_name(
+            sp, DispatchRecord(name="B", status=DispatchStatus.INTERRUPTED)
+        )
         decision = resume_campaign_from_state(sp, continue_on_failure=True)
         assert decision is not None
-        assert "B" in decision.completed_dispatches_block
-        assert "interrupted" in decision.completed_dispatches_block.lower()
         assert decision.next_dispatch_name == "C"
 
 
@@ -1304,3 +1306,195 @@ class TestV4BackwardCompat:
         assert state.ended_at == 0.0
         assert state.recipe_snapshot == {}
         assert state.dispatches[0].attempt_history == []
+
+
+class TestDispatchStatusStateMachineInvariants:
+    """Structural immunity tests for the DispatchStatus state machine.
+
+    These tests verify that _ALLOWED_TRANSITIONS and TERMINAL_DISPATCH_STATUSES
+    are consistent by construction, preventing the class of bugs where a status
+    has empty transitions but is not marked terminal (causing silent campaign stalls).
+    """
+
+    def test_every_dispatch_status_in_allowed_transitions(self) -> None:
+        """Every DispatchStatus member must appear as a key in _ALLOWED_TRANSITIONS."""
+        from autoskillit.fleet.state_types import _ALLOWED_TRANSITIONS
+
+        for status in DispatchStatus:
+            assert status in _ALLOWED_TRANSITIONS, (
+                f"DispatchStatus.{status.name} missing from _ALLOWED_TRANSITIONS"
+            )
+
+    def test_nonterminal_status_has_outgoing_transitions(self) -> None:
+        """Every non-terminal status must have at least one outgoing transition."""
+        from autoskillit.fleet.state_types import (
+            _ALLOWED_TRANSITIONS,
+            TERMINAL_DISPATCH_STATUSES,
+        )
+
+        for status in DispatchStatus:
+            if status not in TERMINAL_DISPATCH_STATUSES:
+                assert len(_ALLOWED_TRANSITIONS[status]) > 0, (
+                    f"Non-terminal status {status!r} has no outgoing transitions"
+                )
+
+    def test_terminal_set_matches_empty_transitions(self) -> None:
+        """TERMINAL_DISPATCH_STATUSES must equal the set of statuses with empty transitions."""
+        from autoskillit.fleet.state_types import (
+            _ALLOWED_TRANSITIONS,
+            TERMINAL_DISPATCH_STATUSES,
+        )
+
+        empty_transition_statuses = frozenset(s for s, t in _ALLOWED_TRANSITIONS.items() if not t)
+        assert TERMINAL_DISPATCH_STATUSES == empty_transition_statuses, (
+            f"TERMINAL_DISPATCH_STATUSES {TERMINAL_DISPATCH_STATUSES!r} != "
+            f"derived empty-transition set {empty_transition_statuses!r}"
+        )
+
+
+class TestAllInterruptedCampaignDoesNotSilentlyComplete:
+    """A campaign where every dispatch is INTERRUPTED must halt or retry, not silently complete."""
+
+    def test_all_interrupted_continue_on_failure_false_halts(self, tmp_path: Path) -> None:
+        """resume_campaign_from_state must not return next_dispatch_name='' for all-INTERRUPTED."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        upsert_dispatch_record_by_name(
+            sp, DispatchRecord(name="A", status=DispatchStatus.INTERRUPTED)
+        )
+
+        decision = resume_campaign_from_state(sp, continue_on_failure=False)
+
+        assert decision is not None
+        assert (
+            decision.next_dispatch_name != ""
+            or decision.completed_dispatches_block == FLEET_HALTED_SENTINEL
+        ), "All-INTERRUPTED campaign returned empty next_name with no halt sentinel — silent stall"
+
+    def test_all_interrupted_continue_on_failure_true_resets_to_pending(
+        self, tmp_path: Path
+    ) -> None:
+        """resume_campaign_from_state with continue_on_failure=True resets INTERRUPTED to PENDING."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(name="A", status=DispatchStatus.INTERRUPTED, kill_reason="stale"),
+        )
+
+        decision = resume_campaign_from_state(sp, continue_on_failure=True, reset_on_retry=True)
+
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].status == DispatchStatus.PENDING
+        assert decision is not None
+        assert decision.next_dispatch_name == "A"
+
+
+class TestAllRefusedCampaignDoesNotSilentlyComplete:
+    """A campaign where every dispatch is REFUSED must halt or retry, not silently complete."""
+
+    def test_all_refused_continue_on_failure_false_halts(self, tmp_path: Path) -> None:
+        """resume_campaign_from_state must not return next_dispatch_name='' for all-REFUSED."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        upsert_dispatch_record_by_name(sp, DispatchRecord(name="A", status=DispatchStatus.REFUSED))
+
+        decision = resume_campaign_from_state(sp, continue_on_failure=False)
+
+        assert decision is not None
+        assert (
+            decision.next_dispatch_name != ""
+            or decision.completed_dispatches_block == FLEET_HALTED_SENTINEL
+        ), "All-REFUSED campaign returned empty next_name with no halt sentinel — silent stall"
+
+    def test_all_refused_continue_on_failure_true_resets_to_pending(self, tmp_path: Path) -> None:
+        """resume_campaign_from_state with continue_on_failure=True resets REFUSED to PENDING."""
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(name="A", status=DispatchStatus.REFUSED),
+        )
+
+        decision = resume_campaign_from_state(sp, continue_on_failure=True, reset_on_retry=True)
+
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].status == DispatchStatus.PENDING
+        assert decision is not None
+        assert decision.next_dispatch_name == "A"
+
+
+class TestKillReasonNotStaleAfterResumableRedispatch:
+    """kill_reason must be cleared when a RESUMABLE dispatch is redispatched to RUNNING."""
+
+    def test_kill_reason_cleared_on_resumable_to_running(self, tmp_path: Path) -> None:
+        """mark_dispatch_running clears kill_reason when re-dispatching a RESUMABLE dispatch."""
+        sp = _state_path(tmp_path)
+        sidecar = tmp_path / "sidecar.jsonl"
+        sidecar.write_text("")
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
+        mark_dispatch_running(sp, "A", dispatch_id="d1", dispatched_pid=42)
+        mark_dispatch_resumable(sp, "A", sidecar_path=str(sidecar))
+        data = json.loads(sp.read_text())
+        for d in data["dispatches"]:
+            if d["name"] == "A":
+                d["kill_reason"] = "idle_stall"
+                d["infra_exit_category"] = "something"
+        sp.write_text(json.dumps(data))
+
+        mark_dispatch_running(sp, "A", dispatch_id="d2", dispatched_pid=43)
+
+        state = read_state(sp)
+        assert state is not None
+        a = next(d for d in state.dispatches if d.name == "A")
+        assert a.kill_reason == "", "kill_reason was not cleared on RESUMABLE→RUNNING transition"
+        assert a.infra_exit_category == "", (
+            "infra_exit_category was not cleared on RESUMABLE→RUNNING transition"
+        )
+
+
+class TestL3GateBlocksOnInterruptedDispatch:
+    """The L3 dispatch gate must block on INTERRUPTED and REFUSED dispatches."""
+
+    def test_has_blocking_dispatch_detects_interrupted(self, tmp_path: Path) -> None:
+        """A campaign with an INTERRUPTED dispatch must be detected by has_blocking_dispatch."""
+        from autoskillit.fleet import has_blocking_dispatch, upsert_dispatch_record_by_name
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
+        upsert_dispatch_record_by_name(
+            sp, DispatchRecord(name="A", status=DispatchStatus.INTERRUPTED)
+        )
+
+        assert has_blocking_dispatch(sp) is True
+
+    def test_has_blocking_dispatch_detects_refused(self, tmp_path: Path) -> None:
+        """A campaign with a REFUSED dispatch must be detected by has_blocking_dispatch."""
+        from autoskillit.fleet import has_blocking_dispatch, upsert_dispatch_record_by_name
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A"))
+        upsert_dispatch_record_by_name(sp, DispatchRecord(name="A", status=DispatchStatus.REFUSED))
+
+        assert has_blocking_dispatch(sp) is True
+
+    def test_has_blocking_dispatch_allows_success_only(self, tmp_path: Path) -> None:
+        """A campaign with only SUCCESS dispatches must not be blocked."""
+        from autoskillit.fleet import has_blocking_dispatch
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B"))
+        append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.SUCCESS))
+        append_dispatch_record(sp, DispatchRecord(name="B", status=DispatchStatus.SUCCESS))
+
+        assert has_blocking_dispatch(sp) is False

--- a/tests/fleet/test_state_lock_contract.py
+++ b/tests/fleet/test_state_lock_contract.py
@@ -23,7 +23,7 @@ from autoskillit.fleet import (
     mark_dispatch_resumable,
     mark_dispatch_running,
     read_state,
-    reset_failed_dispatch,
+    reset_blocking_dispatch,
     update_orchestrator_session_id,
     upsert_dispatch_record_by_name,
     write_captured_values,
@@ -38,7 +38,7 @@ _MUTATION_FUNCTIONS: dict[str, object] = {
     "mark_dispatch_resumable": mark_dispatch_resumable,
     "append_dispatch_record": append_dispatch_record,
     "write_captured_values": write_captured_values,
-    "reset_failed_dispatch": reset_failed_dispatch,
+    "reset_blocking_dispatch": reset_blocking_dispatch,
     "update_orchestrator_session_id": update_orchestrator_session_id,
     "upsert_dispatch_record_by_name": upsert_dispatch_record_by_name,
 }
@@ -145,7 +145,7 @@ class TestAllMutationsAcquireLock:
                 fn(sp, DispatchRecord(name="d1", status=DispatchStatus.SUCCESS))  # type: ignore[operator]
             elif fn_name == "write_captured_values":
                 fn(sp, {"key": "val"})  # type: ignore[operator]
-            elif fn_name == "reset_failed_dispatch":
+            elif fn_name == "reset_blocking_dispatch":
                 append_dispatch_record(
                     sp, DispatchRecord(name="d1", status=DispatchStatus.FAILURE)
                 )

--- a/tests/fleet/test_state_protection.py
+++ b/tests/fleet/test_state_protection.py
@@ -81,9 +81,8 @@ def test_build_protected_ids_all_terminal_not_protected(tmp_path: Path) -> None:
             "campaign_id": "campaign-done",
             "dispatches": [
                 {"name": "d1", "status": "success"},
-                {"name": "d2", "status": "failure"},
-                {"name": "d3", "status": "skipped"},
-                {"name": "d4", "status": "released"},
+                {"name": "d2", "status": "skipped"},
+                {"name": "d3", "status": "released"},
             ],
         },
     )


### PR DESCRIPTION
## Summary

The DispatchStatus state machine has a structural inconsistency: INTERRUPTED and REFUSED have empty transition sets in _ALLOWED_TRANSITIONS but are absent from TERMINAL_DISPATCH_STATUSES. This creates a dead-end where campaigns with these statuses appear "active" but cannot make progress — resume_campaign_from_state returns next_dispatch_name="" which is indistinguishable from "campaign complete."

The fix makes the state machine self-consistent by construction:
1. Add INTERRUPTED→PENDING and REFUSED→PENDING recovery transitions
2. Derive TERMINAL_DISPATCH_STATUSES from _ALLOWED_TRANSITIONS (computed property, not manual set)
3. Add module-level import-time assertions for completeness (mirroring IssueLabelState pattern)
4. Extend halt check to include INTERRUPTED/REFUSED (with continue_on_failure respect)
5. Clear kill_reason on RESUMABLE→RUNNING transition (prevents stale classification)
6. Expand L3 gate to block on INTERRUPTED/REFUSED alongside FAILURE
7. Add structural immunity tests

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260508-160919-699934/.autoskillit/temp/rectify/rectify_dispatch_status_state_machine_immunity_2026-05-08_161500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 6.6k | 11.7k | 831.0k | 80.8k | 113 | 58.9k | 6m 25s |
| dry_walkthrough | claude-opus-4-6 | 1 | 62 | 18.8k | 2.6M | 78.0k | 112 | 65.2k | 8m 20s |
| implement* | MiniMax-M2.7-highspeed | 1 | 7.2M | 46.9k | 4.0M | 123.6k | 266 | 310.6k | 17m 46s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 43.4k | 3.9k | 174.9k | 34.1k | 22 | 25.8k | 1m 28s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.3k | 1.4k | 198.3k | 28.7k | 14 | 15.2k | 43s |
| review_pr | claude-sonnet-4-6 | 3 | 278 | 103.2k | 1.5M | 83.0k | 112 | 213.5k | 23m 34s |
| resolve_review | claude-sonnet-4-6 | 3 | 1.2k | 87.1k | 10.9M | 116.3k | 335 | 261.2k | 29m 30s |
| ci_conflict_fix | claude-sonnet-4-6 | 2 | 423 | 39.8k | 2.8M | 85.8k | 122 | 130.8k | 11m 29s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 107.2k | 2.0k | 201.3k | 28.8k | 19 | 40.9k | 57s |
| resolve_ci | claude-sonnet-4-6 | 1 | 166 | 9.5k | 960.0k | 63.4k | 50 | 50.3k | 4m 35s |
| **Total** | | | 7.4M | 324.2k | 24.2M | 123.6k | | 1.2M | 1h 44m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 345 | 11507.0 | 900.3 | 135.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 178 | 61440.4 | 1467.5 | 489.2 |
| ci_conflict_fix | 1713 | 1626.3 | 76.4 | 23.3 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 6 | 159997.2 | 8387.7 | 1580.0 |
| **Total** | **2242** | 10793.3 | 523.0 | 144.6 |