### PR TITLE
Fleet Orphan Reaper Identity Check — macOS Fallback

### DIFF
--- a/src/autoskillit/cli/fleet/_fleet_lifecycle.py
+++ b/src/autoskillit/cli/fleet/_fleet_lifecycle.py
@@ -112,6 +112,24 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
             # Process is alive — check identity
             current_ticks = read_starttime_ticks(pid)
             if current_ticks is not None and current_ticks == dispatch.dispatched_starttime_ticks:
+                # Linux: /proc identity confirmed
+                identity_confirmed = True
+            elif current_ticks is None and dispatch.dispatched_create_time > 0.0:
+                # Non-Linux fallback: psutil create_time
+                try:
+                    actual_ct = psutil.Process(pid).create_time()
+                    identity_confirmed = abs(actual_ct - dispatch.dispatched_create_time) < 1.0
+                except psutil.NoSuchProcess:
+                    if dry_run:
+                        logger.info("reap: [WOULD MARK]  %s  pid=%d  (process dead)", name, pid)
+                    else:
+                        _apply_stale_dispatch(dispatch, "reaped_dead_pid", m)
+                        logger.info("reap: [MARKED]      %s  pid=%d  (process dead)", name, pid)
+                    continue
+            else:
+                identity_confirmed = False
+
+            if identity_confirmed:
                 if dry_run:
                     logger.info(
                         "reap: [WOULD KILL]  %s  pid=%d  (orphan, identity match)", name, pid

--- a/src/autoskillit/cli/fleet/_fleet_lifecycle.py
+++ b/src/autoskillit/cli/fleet/_fleet_lifecycle.py
@@ -132,6 +132,8 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                 except psutil.NoSuchProcess:
                     _mark_dead_pid(dry_run, name, pid, dispatch, m)
                     continue
+                except psutil.AccessDenied:
+                    identity_confirmed = False
             else:
                 identity_confirmed = False
 

--- a/src/autoskillit/cli/fleet/_fleet_lifecycle.py
+++ b/src/autoskillit/cli/fleet/_fleet_lifecycle.py
@@ -33,6 +33,20 @@ def _apply_stale_dispatch(
     m.mark_dirty()
 
 
+def _mark_dead_pid(
+    dry_run: bool,
+    name: str,
+    pid: int,
+    dispatch: DispatchRecord,
+    m: CampaignStateMutator,
+) -> None:
+    if dry_run:
+        logger.info("reap: [WOULD MARK]  %s  pid=%d  (process dead)", name, pid)
+    else:
+        _apply_stale_dispatch(dispatch, "reaped_dead_pid", m)
+        logger.info("reap: [MARKED]      %s  pid=%d  (process dead)", name, pid)
+
+
 def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
     """Reap stale RUNNING dispatches with PID-recycling-safe identity checks.
 
@@ -102,11 +116,7 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                 continue
 
             if not psutil.pid_exists(pid):
-                if dry_run:
-                    logger.info("reap: [WOULD MARK]  %s  pid=%d  (process dead)", name, pid)
-                else:
-                    _apply_stale_dispatch(dispatch, "reaped_dead_pid", m)
-                    logger.info("reap: [MARKED]      %s  pid=%d  (process dead)", name, pid)
+                _mark_dead_pid(dry_run, name, pid, dispatch, m)
                 continue
 
             # Process is alive — check identity
@@ -120,11 +130,7 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                     actual_ct = psutil.Process(pid).create_time()
                     identity_confirmed = abs(actual_ct - dispatch.dispatched_create_time) < 1.0
                 except psutil.NoSuchProcess:
-                    if dry_run:
-                        logger.info("reap: [WOULD MARK]  %s  pid=%d  (process dead)", name, pid)
-                    else:
-                        _apply_stale_dispatch(dispatch, "reaped_dead_pid", m)
-                        logger.info("reap: [MARKED]      %s  pid=%d  (process dead)", name, pid)
+                    _mark_dead_pid(dry_run, name, pid, dispatch, m)
                     continue
             else:
                 identity_confirmed = False

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -96,6 +96,7 @@ def _write_pid(
     pid: int,
     starttime_ticks: int,
     sidecar_path: str | None = None,
+    create_time: float = 0.0,
 ) -> None:
     """on_spawn callback: atomically mark dispatch as running with dispatched_pid."""
     from autoskillit.core import read_boot_id
@@ -109,6 +110,7 @@ def _write_pid(
             dispatched_pid=pid,
             starttime_ticks=starttime_ticks,
             boot_id=read_boot_id() or "",
+            create_time=create_time,
             sidecar_path=sidecar_path,
         )
     except Exception:
@@ -435,7 +437,15 @@ async def _run_dispatch(
 
     def _on_spawn(pid: int, ticks: int) -> None:
         _dispatched_pid.append(pid)
-        _write_pid(state_path, effective_name, dispatch_id, pid, ticks, dispatch_sidecar_path)
+        import psutil  # noqa: PLC0415
+
+        try:
+            create_time = psutil.Process(pid).create_time()
+        except psutil.NoSuchProcess:
+            create_time = 0.0
+        _write_pid(
+            state_path, effective_name, dispatch_id, pid, ticks, dispatch_sidecar_path, create_time
+        )
 
     skill_result = await tool_ctx.executor.dispatch_food_truck(
         orchestrator_prompt=prompt,

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import psutil
 import regex as re
 
 from autoskillit.core import (
@@ -96,7 +97,7 @@ def _write_pid(
     pid: int,
     starttime_ticks: int,
     sidecar_path: str | None = None,
-    create_time: float = 0.0,
+    dispatched_create_time: float = 0.0,
 ) -> None:
     """on_spawn callback: atomically mark dispatch as running with dispatched_pid."""
     from autoskillit.core import read_boot_id
@@ -110,7 +111,7 @@ def _write_pid(
             dispatched_pid=pid,
             starttime_ticks=starttime_ticks,
             boot_id=read_boot_id() or "",
-            create_time=create_time,
+            dispatched_create_time=dispatched_create_time,
             sidecar_path=sidecar_path,
         )
     except Exception:
@@ -437,8 +438,6 @@ async def _run_dispatch(
 
     def _on_spawn(pid: int, ticks: int) -> None:
         _dispatched_pid.append(pid)
-        import psutil  # noqa: PLC0415
-
         try:
             create_time = psutil.Process(pid).create_time()
         except psutil.NoSuchProcess:

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -126,6 +126,7 @@ def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
     d.dispatched_pid = 0
     d.dispatched_starttime_ticks = 0
     d.dispatched_boot_id = ""
+    d.dispatched_create_time = 0.0
     d.token_usage = {}
     d.started_at = 0.0
     d.ended_at = 0.0
@@ -298,6 +299,7 @@ def mark_dispatch_running(
     dispatched_pid: int,
     starttime_ticks: int = 0,
     boot_id: str = "",
+    create_time: float = 0.0,
     sidecar_path: str | None = None,
 ) -> None:
     """Atomically mark a dispatch as running with its dispatch_id and dispatched_pid."""
@@ -314,6 +316,7 @@ def mark_dispatch_running(
                 d.dispatched_pid = dispatched_pid
                 d.dispatched_starttime_ticks = starttime_ticks
                 d.dispatched_boot_id = boot_id
+                d.dispatched_create_time = create_time
                 d.started_at = time.time()
                 d.sidecar_path = sidecar_path
                 m.mark_dirty()

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -299,7 +299,7 @@ def mark_dispatch_running(
     dispatched_pid: int,
     starttime_ticks: int = 0,
     boot_id: str = "",
-    create_time: float = 0.0,
+    dispatched_create_time: float = 0.0,
     sidecar_path: str | None = None,
 ) -> None:
     """Atomically mark a dispatch as running with its dispatch_id and dispatched_pid."""
@@ -316,7 +316,7 @@ def mark_dispatch_running(
                 d.dispatched_pid = dispatched_pid
                 d.dispatched_starttime_ticks = starttime_ticks
                 d.dispatched_boot_id = boot_id
-                d.dispatched_create_time = create_time
+                d.dispatched_create_time = dispatched_create_time
                 d.started_at = time.time()
                 d.sidecar_path = sidecar_path
                 m.mark_dirty()

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -48,6 +48,7 @@ class DispatchRecord:
     dispatched_pid: int = 0
     dispatched_starttime_ticks: int = 0
     dispatched_boot_id: str = ""
+    dispatched_create_time: float = 0.0
     reason: str = ""
     kill_reason: str = ""
     infra_exit_category: str = ""
@@ -69,6 +70,7 @@ class DispatchRecord:
             "dispatched_pid": self.dispatched_pid,
             "dispatched_starttime_ticks": self.dispatched_starttime_ticks,
             "dispatched_boot_id": self.dispatched_boot_id,
+            "dispatched_create_time": self.dispatched_create_time,
             "reason": self.reason,
             "kill_reason": self.kill_reason,
             "infra_exit_category": self.infra_exit_category,
@@ -116,6 +118,7 @@ class DispatchRecord:
             dispatched_boot_id=(
                 d.get("dispatched_boot_id") or d.get("l3_boot_id") or d.get("l2_boot_id", "")
             ),
+            dispatched_create_time=d.get("dispatched_create_time", 0.0),
             reason=d.get("reason", ""),
             kill_reason=d.get("kill_reason", ""),
             infra_exit_category=d.get("infra_exit_category", ""),

--- a/tests/cli/test_reap.py
+++ b/tests/cli/test_reap.py
@@ -237,11 +237,11 @@ class TestReap:
             dispatched_create_time=1000000.5,
         )
         with (
-            patch("psutil.pid_exists", return_value=True),
+            patch("autoskillit.cli.fleet._fleet_lifecycle.psutil.pid_exists", return_value=True),
             patch("autoskillit.execution.read_starttime_ticks", return_value=None),
             patch("autoskillit.execution.read_boot_id", return_value=BOOT_ID),
             patch("autoskillit.execution.kill_process_tree") as mock_kill,
-            patch("psutil.Process") as mock_proc_cls,
+            patch("autoskillit.cli.fleet._fleet_lifecycle.psutil.Process") as mock_proc_cls,
         ):
             mock_proc_cls.return_value.create_time.return_value = 1000000.5
             _reap(sp)
@@ -259,11 +259,11 @@ class TestReap:
             dispatched_create_time=1000000.5,
         )
         with (
-            patch("psutil.pid_exists", return_value=True),
+            patch("autoskillit.cli.fleet._fleet_lifecycle.psutil.pid_exists", return_value=True),
             patch("autoskillit.execution.read_starttime_ticks", return_value=None),
             patch("autoskillit.execution.read_boot_id", return_value=BOOT_ID),
             patch("autoskillit.execution.kill_process_tree") as mock_kill,
-            patch("psutil.Process") as mock_proc_cls,
+            patch("autoskillit.cli.fleet._fleet_lifecycle.psutil.Process") as mock_proc_cls,
         ):
             mock_proc_cls.return_value.create_time.return_value = 9999999.0
             _reap(sp)
@@ -281,7 +281,7 @@ class TestReap:
             dispatched_create_time=0.0,
         )
         with (
-            patch("psutil.pid_exists", return_value=True),
+            patch("autoskillit.cli.fleet._fleet_lifecycle.psutil.pid_exists", return_value=True),
             patch("autoskillit.execution.read_starttime_ticks", return_value=None),
             patch("autoskillit.execution.read_boot_id", return_value=BOOT_ID),
             patch("autoskillit.execution.kill_process_tree") as mock_kill,
@@ -301,12 +301,13 @@ class TestReap:
             dispatched_create_time=1000000.5,
         )
         with (
-            patch("psutil.pid_exists", return_value=True),
+            patch("autoskillit.cli.fleet._fleet_lifecycle.psutil.pid_exists", return_value=True),
             patch("autoskillit.execution.read_starttime_ticks", return_value=None),
             patch("autoskillit.execution.read_boot_id", return_value=BOOT_ID),
             patch("autoskillit.execution.kill_process_tree") as mock_kill,
-            patch("psutil.Process", side_effect=psutil.NoSuchProcess(12345)),
+            patch("autoskillit.cli.fleet._fleet_lifecycle.psutil.Process") as mock_proc_cls,
         ):
+            mock_proc_cls.return_value.create_time.side_effect = psutil.NoSuchProcess(12345)
             _reap(sp)
 
         mock_kill.assert_not_called()

--- a/tests/cli/test_reap.py
+++ b/tests/cli/test_reap.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import psutil
 import pytest
 
 from autoskillit.fleet import (
@@ -28,6 +29,7 @@ def _make_running_state(
     dispatched_pid: int = 12345,
     dispatched_starttime_ticks: int = 1000,
     dispatched_boot_id: str = BOOT_ID,
+    dispatched_create_time: float = 0.0,
 ) -> Path:
     """Create a state file with a single RUNNING dispatch."""
     sp = tmp_path / "state.json"
@@ -43,6 +45,7 @@ def _make_running_state(
             "dispatched_pid": dispatched_pid,
             "dispatched_starttime_ticks": dispatched_starttime_ticks,
             "dispatched_boot_id": dispatched_boot_id,
+            "dispatched_create_time": dispatched_create_time,
             "started_at": 1000.0,
         }
     )
@@ -225,3 +228,88 @@ class TestReap:
         state = read_state(sp)
         assert state is not None
         assert state.dispatches[0].status == DispatchStatus.INTERRUPTED
+
+    def test_reap_kills_orphan_via_create_time_fallback(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_create_time=1000000.5,
+        )
+        with (
+            patch("psutil.pid_exists", return_value=True),
+            patch("autoskillit.execution.read_starttime_ticks", return_value=None),
+            patch("autoskillit.execution.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.execution.kill_process_tree") as mock_kill,
+            patch("psutil.Process") as mock_proc_cls,
+        ):
+            mock_proc_cls.return_value.create_time.return_value = 1000000.5
+            _reap(sp)
+
+        mock_kill.assert_called_once_with(12345)
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].reason == "reaped_orphan"
+
+    def test_reap_skips_recycled_pid_via_create_time(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_create_time=1000000.5,
+        )
+        with (
+            patch("psutil.pid_exists", return_value=True),
+            patch("autoskillit.execution.read_starttime_ticks", return_value=None),
+            patch("autoskillit.execution.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.execution.kill_process_tree") as mock_kill,
+            patch("psutil.Process") as mock_proc_cls,
+        ):
+            mock_proc_cls.return_value.create_time.return_value = 9999999.0
+            _reap(sp)
+
+        mock_kill.assert_not_called()
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].reason == "reaped_pid_recycled"
+
+    def test_reap_no_create_time_marks_recycled(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=0,
+            dispatched_create_time=0.0,
+        )
+        with (
+            patch("psutil.pid_exists", return_value=True),
+            patch("autoskillit.execution.read_starttime_ticks", return_value=None),
+            patch("autoskillit.execution.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.execution.kill_process_tree") as mock_kill,
+        ):
+            _reap(sp)
+
+        mock_kill.assert_not_called()
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].reason == "reaped_pid_recycled"
+
+    def test_reap_create_time_nosuchprocess_marks_dead(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_create_time=1000000.5,
+        )
+        with (
+            patch("psutil.pid_exists", return_value=True),
+            patch("autoskillit.execution.read_starttime_ticks", return_value=None),
+            patch("autoskillit.execution.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.execution.kill_process_tree") as mock_kill,
+            patch("psutil.Process", side_effect=psutil.NoSuchProcess(12345)),
+        ):
+            _reap(sp)
+
+        mock_kill.assert_not_called()
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].reason == "reaped_dead_pid"

--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -291,7 +291,7 @@ def _force_running_state(
     ticks: int,
     boot_id: str,
     *,
-    create_time: float = 0.0,
+    dispatched_create_time: float = 0.0,
 ) -> None:
     """Directly set a dispatch to RUNNING with PID identity fields in the JSON."""
     data = json.loads(state_path.read_text(encoding="utf-8"))
@@ -301,7 +301,7 @@ def _force_running_state(
             d["dispatched_pid"] = pid
             d["dispatched_starttime_ticks"] = ticks
             d["dispatched_boot_id"] = boot_id
-            d["dispatched_create_time"] = create_time
+            d["dispatched_create_time"] = dispatched_create_time
             d["started_at"] = time.time()
             break
     state_path.write_text(json.dumps(data), encoding="utf-8")
@@ -746,7 +746,7 @@ async def test_orphan_l3_reaping(fleet_runtime: FleetRuntime, tmp_path: Path) ->
             orphan_pid,
             orphan_ticks,
             boot_id,
-            create_time=orphan_create_time,
+            dispatched_create_time=orphan_create_time,
         )
 
         _reap_stale_dispatches(state_path, dry_run=False)

--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -290,6 +290,8 @@ def _force_running_state(
     pid: int,
     ticks: int,
     boot_id: str,
+    *,
+    create_time: float = 0.0,
 ) -> None:
     """Directly set a dispatch to RUNNING with PID identity fields in the JSON."""
     data = json.loads(state_path.read_text(encoding="utf-8"))
@@ -299,6 +301,7 @@ def _force_running_state(
             d["dispatched_pid"] = pid
             d["dispatched_starttime_ticks"] = ticks
             d["dispatched_boot_id"] = boot_id
+            d["dispatched_create_time"] = create_time
             d["started_at"] = time.time()
             break
     state_path.write_text(json.dumps(data), encoding="utf-8")
@@ -725,6 +728,7 @@ async def test_orphan_l3_reaping(fleet_runtime: FleetRuntime, tmp_path: Path) ->
     orphan = subprocess.Popen(["sleep", "999"])
     orphan_pid = orphan.pid
     orphan_ticks = read_starttime_ticks(orphan_pid) or 0
+    orphan_create_time = psutil.Process(orphan_pid).create_time()
     boot_id = read_boot_id() or ""
 
     try:
@@ -736,7 +740,14 @@ async def test_orphan_l3_reaping(fleet_runtime: FleetRuntime, tmp_path: Path) ->
             str(state_path),
             [DispatchRecord(name="orphaned")],
         )
-        _force_running_state(state_path, "orphaned", orphan_pid, orphan_ticks, boot_id)
+        _force_running_state(
+            state_path,
+            "orphaned",
+            orphan_pid,
+            orphan_ticks,
+            boot_id,
+            create_time=orphan_create_time,
+        )
 
         _reap_stale_dispatches(state_path, dry_run=False)
 

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -415,7 +415,7 @@ class TestDispatchRecordSchemaV3:
             dispatched_pid=9999,
             starttime_ticks=0,
             boot_id="",
-            create_time=1700000000.5,
+            dispatched_create_time=1700000000.5,
         )
         state = read_state(sp)
         assert state is not None

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -42,6 +42,12 @@ class TestDispatchRecordSchemaV2:
         assert d.dispatched_boot_id == ""
         assert isinstance(d.dispatched_boot_id, str)
 
+    def test_dispatch_record_has_dispatched_create_time(self) -> None:
+        d = DispatchRecord(name="x")
+        assert hasattr(d, "dispatched_create_time")
+        assert d.dispatched_create_time == 0.0
+        assert isinstance(d.dispatched_create_time, float)
+
     def test_mark_dispatch_running_stores_starttime_ticks(self, tmp_path: Path) -> None:
         sp = _make_state(tmp_path, "a")
         mark_dispatch_running(
@@ -332,6 +338,7 @@ class TestDispatchRecordToDict:
             "dispatched_pid",
             "dispatched_starttime_ticks",
             "dispatched_boot_id",
+            "dispatched_create_time",
             "reason",
             "kill_reason",
             "infra_exit_category",
@@ -398,6 +405,25 @@ class TestDispatchRecordSchemaV3:
         assert state is not None
         assert state.dispatches[0].campaign_id == "camp-xyz"
         assert json.loads(sp.read_text())["dispatches"][0]["campaign_id"] == "camp-xyz"
+
+    def test_dispatched_create_time_roundtrip(self, tmp_path: Path) -> None:
+        sp = _make_state(tmp_path, "a")
+        mark_dispatch_running(
+            sp,
+            "a",
+            dispatch_id="did-1",
+            dispatched_pid=9999,
+            starttime_ticks=0,
+            boot_id="",
+            create_time=1700000000.5,
+        )
+        state = read_state(sp)
+        assert state is not None
+        d = state.dispatches[0]
+        assert d.dispatched_create_time == 1700000000.5
+
+        raw = json.loads(sp.read_text())
+        assert raw["dispatches"][0]["dispatched_create_time"] == 1700000000.5
 
     def test_v1_state_file_is_rejected(self, tmp_path: Path) -> None:
         """v1 state files are rejected (stale schema version)."""


### PR DESCRIPTION
## Summary

The fleet orphan reaper's PID identity check uses `read_starttime_ticks(pid)` from `/proc/{pid}/stat`, which returns `None` on non-Linux platforms. When `None`, the reaper marks the dispatch as `reaped_pid_recycled` without killing the orphan process — a silent behavioral gap.

The fix adds a cross-platform `psutil.Process.create_time()` fallback for PID-reuse detection. A new `dispatched_create_time` field on `DispatchRecord` stores the process creation timestamp at dispatch time. When `/proc` ticks are unavailable, the reaper compares `psutil.Process(pid).create_time()` against the stored value (with ±1.0s tolerance, matching the existing `_plugin_cache._pid_alive` pattern). The e2e test `test_orphan_l3_reaping` is also updated to supply the create_time field so it passes on macOS.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260508-185420-331712/.autoskillit/temp/make-plan/fleet_orphan_reaper_identity_check_macos_fallback_plan_2026-05-08_185500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.5k | 14.0k | 1.3M | 75.9k | 113 | 67.7k | 7m 31s |
| review | claude-opus-4-6 | 1 | 25 | 4.0k | 191.5k | 40.5k | 21 | 29.7k | 3m 42s |
| verify | claude-sonnet-4-6 | 1 | 32 | 7.3k | 643.7k | 59.6k | 91 | 58.4k | 5m 53s |
| implement* | MiniMax-M2.7 | 1 | 82.4k | 14.2k | 3.1M | 21.0k | 112 | 0 | 5m 25s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 76.2k | 4.1k | 198.3k | 28.7k | 18 | 15.4k | 1m 25s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 45.5k | 1.2k | 198.3k | 28.7k | 14 | 15.1k | 40s |
| review_pr | claude-sonnet-4-6 | 2 | 170 | 80.9k | 857.0k | 83.4k | 71 | 138.8k | 19m 4s |
| resolve_review | claude-sonnet-4-6 | 2 | 1.1k | 43.6k | 4.9M | 96.9k | 184 | 127.2k | 13m 48s |
| **Total** | | | 208.8k | 169.3k | 11.4M | 96.9k | | 452.2k | 57m 31s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 163 | 19134.2 | 0.0 | 87.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 62 | 79191.6 | 2052.1 | 703.3 |
| **Total** | **225** | 50546.9 | 2009.6 | 752.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 3.5k | 18.0k | 1.4M | 97.4k | 11m 14s |
| claude-sonnet-4-6 | 1 | 32 | 7.3k | 643.7k | 58.4k | 5m 53s |
| MiniMax-M2.7 | 1 | 82.4k | 14.2k | 3.1M | 0 | 5m 25s |
| MiniMax-M2.7-highspeed | 2 | 121.7k | 5.4k | 396.6k | 30.4k | 2m 4s |