### PR TITLE
Extract Issue Filing from validate-audit into Dedicated file-audit-issues Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 133 bundled skills.
+tools and 134 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 52 MCP tools and 133 bundled skills.
+→ tests → PR → merge pipelines using 52 MCP tools and 134 bundled skills.
 
 ## Start here
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 133 bundled skills. Any new skill with an unguarded
+test that scans all 134 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 52 MCP tools and 133 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 52 MCP tools and 134 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
-The complete list of bundled skills (133 total: 3 in `src/autoskillit/skills/`,
-130 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+The complete list of bundled skills (134 total: 3 in `src/autoskillit/skills/`,
+131 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -47,7 +47,7 @@ runs:
 `prepare-pr`, `compose-pr`, `open-integration-pr`, `merge-pr`, `analyze-prs`, `review-pr`,
 `resolve-review`, `implement-worktree-no-merge`, `resolve-failures`,
 `retry-worktree`, `resolve-merge-conflicts`, `audit-impl`, `smoke-task`,
-`report-bug`, `pipeline-summary`, `diagnose-ci`, `verify-diag`,
+`report-bug`, `pipeline-summary`, `diagnose-ci`, `file-audit-issues`, `verify-diag`,
 `resolve-claims-review`, `resolve-design-review`, `resolve-research-review`,
 `compose-research-pr`, `prepare-research-pr`, `review-research-pr`,
 `promote-to-main`

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 133 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 134 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -264,6 +264,7 @@ skills:
     - report-bug
     - pipeline-summary
     - diagnose-ci
+    - file-audit-issues
     - verify-diag
     - prepare-research-pr
     - compose-research-pr

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -285,6 +285,7 @@ PACK_REGISTRY: dict[str, PackDef] = {
     "research": PackDef(False, "Research recipe and experiment skills"),
     "exp-lens": PackDef(False, "Experimental design audit lenses"),
     "vis-lens": PackDef(False, "Visualization planning lenses"),
+    "audit-pipeline": PackDef(False, "Audit pipeline internals (recipe-dispatched only)"),
 }
 
 CATEGORY_TAGS: frozenset[str] = frozenset(PACK_REGISTRY.keys())

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2111,11 +2111,13 @@ skills:
       - name: issue_count
         type: str
     expected_output_patterns:
-      - "issue_urls\\s*=\\s*\\S+"
-      - "issue_count\\s*=\\s*\\S+"
+      - "issue_urls\\s*="
+      - "issue_count\\s*=\\s*\\d+"
     pattern_examples:
       - "issue_urls = https://github.com/org/repo/issues/100,https://github.com/org/repo/issues/101\nissue_count = 2"
-    write_behavior: always
+    write_behavior: conditional
+    write_expected_when:
+      - "issue_count\\s*=\\s*\\d+"
   promote-to-main:
     inputs:
     - name: batch_branch

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2115,9 +2115,7 @@ skills:
       - "issue_count\\s*=\\s*\\d+"
     pattern_examples:
       - "issue_urls = https://github.com/org/repo/issues/100,https://github.com/org/repo/issues/101\nissue_count = 2"
-    write_behavior: conditional
-    write_expected_when:
-      - "issue_count\\s*=\\s*\\d+"
+    write_behavior: always
   promote-to-main:
     inputs:
     - name: batch_branch

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2100,6 +2100,22 @@ skills:
     write_behavior: conditional
     write_expected_when:
       - "verdict\\s*=\\s*validated"
+  file-audit-issues:
+    inputs:
+      - name: run_dir
+        type: file_path
+        required: false
+    outputs:
+      - name: issue_urls
+        type: str
+      - name: issue_count
+        type: str
+    expected_output_patterns:
+      - "issue_urls\\s*=\\s*\\S+"
+      - "issue_count\\s*=\\s*\\S+"
+    pattern_examples:
+      - "issue_urls = https://github.com/org/repo/issues/100,https://github.com/org/repo/issues/101\nissue_count = 2"
+    write_behavior: always
   promote-to-main:
     inputs:
     - name: batch_branch

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2109,7 +2109,7 @@ skills:
       - name: issue_urls
         type: str
       - name: issue_count
-        type: str
+        type: integer
     expected_output_patterns:
       - "issue_urls\\s*="
       - "issue_count\\s*=\\s*\\d+"

--- a/src/autoskillit/recipes/full-audit.json
+++ b/src/autoskillit/recipes/full-audit.json
@@ -98,6 +98,7 @@
     "create_issues": {
       "tool": "run_skill",
       "description": "File GitHub issues from validated audit ticket body files",
+      "model": "",
       "with": {
         "skill_command": "/autoskillit:file-audit-issues ${{ context.audit_run_dir }}",
         "cwd": "${{ inputs.workspace }}",
@@ -105,8 +106,7 @@
       },
       "note": "BATCHED ISSUE FILING — The file-audit-issues skill discovers all ticket_body_{source}_{N}_{ts}.md files in the audit run directory, deduplicates against existing open issues, batch-creates via GraphQL createIssue mutations with aliases (chunked at 20), applies labels, appends validation summaries to created issues, and writes a filed_issues_manifest.json for traceability.\nThe AUTOSKILLIT_AUDIT_RUN_DIR env var scopes discovery to the per-run directory created by init_audit_run.\n",
       "capture": {
-        "issue_urls": "${{ result.issue_urls }}",
-        "issue_count": "${{ result.issue_count }}"
+        "issue_urls": "${{ result.issue_urls }}"
       },
       "on_success": "done",
       "on_failure": "escalate_stop",

--- a/src/autoskillit/recipes/full-audit.json
+++ b/src/autoskillit/recipes/full-audit.json
@@ -5,7 +5,8 @@
   "recipe_version": "1.2.0",
   "requires_packs": [
     "audit",
-    "github"
+    "github",
+    "audit-pipeline"
   ],
   "ingredients": {
     "workspace": {
@@ -95,15 +96,14 @@
       "on_exhausted": "escalate_stop"
     },
     "create_issues": {
-      "tool": "run_python",
-      "description": "Batch-create GitHub issues via GraphQL from validated ticket body files",
+      "tool": "run_skill",
+      "description": "File GitHub issues from validated audit ticket body files",
       "with": {
-        "callable": "autoskillit.recipe._cmd_rpc.batch_create_issues",
-        "workspace": "${{ inputs.workspace }}",
-        "audit_run_dir": "${{ context.audit_run_dir }}",
-        "timeout": 120
+        "skill_command": "/autoskillit:file-audit-issues ${{ context.audit_run_dir }}",
+        "cwd": "${{ inputs.workspace }}",
+        "step_name": "create_issues"
       },
-      "note": "BATCHED ISSUE CREATION via GraphQL — The callable discovers all ticket_body_{source}_{N}_{ts}.md files in the validate-audit temp directory, parses titles and bodies, includes validation summaries, resolves repository and label IDs, and executes a single batched createIssue mutation with aliases. Chunks at 20 issues per request if needed.\nNo headless sessions are spawned. Rate-limit cost: 5 pts per chunk (vs 90 pts for 18 sequential REST calls).\n",
+      "note": "BATCHED ISSUE FILING — The file-audit-issues skill discovers all ticket_body_{source}_{N}_{ts}.md files in the audit run directory, deduplicates against existing open issues, batch-creates via GraphQL createIssue mutations with aliases (chunked at 20), applies labels, appends validation summaries to created issues, and writes a filed_issues_manifest.json for traceability.\nThe AUTOSKILLIT_AUDIT_RUN_DIR env var scopes discovery to the per-run directory created by init_audit_run.\n",
       "capture": {
         "issue_urls": "${{ result.issue_urls }}",
         "issue_count": "${{ result.issue_count }}"

--- a/src/autoskillit/recipes/full-audit.json
+++ b/src/autoskillit/recipes/full-audit.json
@@ -106,7 +106,8 @@
       },
       "note": "BATCHED ISSUE FILING — The file-audit-issues skill discovers all ticket_body_{source}_{N}_{ts}.md files in the audit run directory, deduplicates against existing open issues, batch-creates via GraphQL createIssue mutations with aliases (chunked at 20), applies labels, appends validation summaries to created issues, and writes a filed_issues_manifest.json for traceability.\nThe AUTOSKILLIT_AUDIT_RUN_DIR env var scopes discovery to the per-run directory created by init_audit_run.\n",
       "capture": {
-        "issue_urls": "${{ result.issue_urls }}"
+        "issue_urls": "${{ result.issue_urls }}",
+        "issue_count": "${{ result.issue_count }}"
       },
       "on_success": "done",
       "on_failure": "escalate_stop",

--- a/src/autoskillit/recipes/full-audit.json
+++ b/src/autoskillit/recipes/full-audit.json
@@ -116,7 +116,7 @@
     },
     "done": {
       "action": "stop",
-      "message": "Full audit complete. GitHub issues created from validated audit reports. Emit the L3 result sentinel. context.issue_urls is a comma-separated string of the created issue URLs — include it directly in the sentinel JSON: {\"success\": true, \"reason\": \"completed\", \"summary\": \"Full audit complete. GitHub issues created.\", \"issue_urls\": \"${{ context.issue_urls }}\"} Artifacts are in {{AUTOSKILLIT_TEMP}}/."
+      "message": "Full audit complete. GitHub issues created from validated audit reports. Emit the L3 result sentinel. context.issue_urls is a comma-separated string of the created issue URLs — include it directly in the sentinel JSON: {\"success\": true, \"reason\": \"completed\", \"summary\": \"Full audit complete. GitHub issues created.\", \"issue_urls\": \"${{ context.issue_urls }}\", \"issue_count\": \"${{ context.issue_count }}\"} Artifacts are in {{AUTOSKILLIT_TEMP}}/."
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/full-audit.json
+++ b/src/autoskillit/recipes/full-audit.json
@@ -104,7 +104,7 @@
         "cwd": "${{ inputs.workspace }}",
         "step_name": "create_issues"
       },
-      "note": "BATCHED ISSUE FILING — The file-audit-issues skill discovers all ticket_body_{source}_{N}_{ts}.md files in the audit run directory, deduplicates against existing open issues, batch-creates via GraphQL createIssue mutations with aliases (chunked at 20), applies labels, appends validation summaries to created issues, and writes a filed_issues_manifest.json for traceability.\nThe AUTOSKILLIT_AUDIT_RUN_DIR env var scopes discovery to the per-run directory created by init_audit_run.\n",
+      "note": "Runs /autoskillit:file-audit-issues — discovers ticket_body_*.md in audit_run_dir, deduplicates, batch-creates GitHub issues via GraphQL, applies labels, appends validation summaries.",
       "capture": {
         "issue_urls": "${{ result.issue_urls }}",
         "issue_count": "${{ result.issue_count }}"

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -164,6 +164,7 @@ steps:
   create_issues:
     tool: run_skill
     description: "File GitHub issues from validated audit ticket body files"
+    model: ""
     with:
       skill_command: "/autoskillit:file-audit-issues ${{ context.audit_run_dir }}"
       cwd: "${{ inputs.workspace }}"
@@ -180,7 +181,6 @@ steps:
       per-run directory created by init_audit_run.
     capture:
       issue_urls: "${{ result.issue_urls }}"
-      issue_count: "${{ result.issue_count }}"
     on_success: done
     on_failure: escalate_stop
     retries: 1

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -194,7 +194,8 @@ steps:
       Emit the L3 result sentinel. context.issue_urls is a comma-separated
       string of the created issue URLs — include it directly in the sentinel JSON:
       {"success": true, "reason": "completed", "summary": "Full audit complete.
-      GitHub issues created.", "issue_urls": "${{ context.issue_urls }}"}
+      GitHub issues created.", "issue_urls": "${{ context.issue_urls }}",
+      "issue_count": "${{ context.issue_count }}"}
       Artifacts are in {{AUTOSKILLIT_TEMP}}/.
 
   escalate_stop:

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -181,6 +181,7 @@ steps:
       per-run directory created by init_audit_run.
     capture:
       issue_urls: "${{ result.issue_urls }}"
+      issue_count: "${{ result.issue_count }}"
     on_success: done
     on_failure: escalate_stop
     retries: 1

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -169,16 +169,7 @@ steps:
       skill_command: "/autoskillit:file-audit-issues ${{ context.audit_run_dir }}"
       cwd: "${{ inputs.workspace }}"
       step_name: "create_issues"
-    note: >
-      BATCHED ISSUE FILING — The file-audit-issues skill discovers all
-      ticket_body_{source}_{N}_{ts}.md files in the audit run directory,
-      deduplicates against existing open issues, batch-creates via GraphQL
-      createIssue mutations with aliases (chunked at 20), applies labels,
-      appends validation summaries to created issues, and writes a
-      filed_issues_manifest.json for traceability.
-
-      The AUTOSKILLIT_AUDIT_RUN_DIR env var scopes discovery to the
-      per-run directory created by init_audit_run.
+    note: "Runs /autoskillit:file-audit-issues — discovers ticket_body_*.md in audit_run_dir, deduplicates, batch-creates GitHub issues via GraphQL, applies labels, appends validation summaries."
     capture:
       issue_urls: "${{ result.issue_urls }}"
       issue_count: "${{ result.issue_count }}"

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -5,7 +5,7 @@ description: >-
   GitHub issue from each validated report.
 summary: "branch → audit×6 ∥ → validate×6 ∥ → issue×6 ∥ → done"
 recipe_version: "1.2.0"
-requires_packs: [audit, github]
+requires_packs: [audit, github, audit-pipeline]
 
 ingredients:
   workspace:
@@ -162,22 +162,22 @@ steps:
     on_exhausted: escalate_stop
 
   create_issues:
-    tool: run_python
-    description: "Batch-create GitHub issues via GraphQL from validated ticket body files"
+    tool: run_skill
+    description: "File GitHub issues from validated audit ticket body files"
     with:
-      callable: "autoskillit.recipe._cmd_rpc.batch_create_issues"
-      workspace: "${{ inputs.workspace }}"
-      audit_run_dir: "${{ context.audit_run_dir }}"
-      timeout: 120
+      skill_command: "/autoskillit:file-audit-issues ${{ context.audit_run_dir }}"
+      cwd: "${{ inputs.workspace }}"
+      step_name: "create_issues"
     note: >
-      BATCHED ISSUE CREATION via GraphQL — The callable discovers all
-      ticket_body_{source}_{N}_{ts}.md files in the validate-audit temp directory,
-      parses titles and bodies, includes validation summaries, resolves repository
-      and label IDs, and executes a single batched createIssue mutation with aliases.
-      Chunks at 20 issues per request if needed.
+      BATCHED ISSUE FILING — The file-audit-issues skill discovers all
+      ticket_body_{source}_{N}_{ts}.md files in the audit run directory,
+      deduplicates against existing open issues, batch-creates via GraphQL
+      createIssue mutations with aliases (chunked at 20), applies labels,
+      appends validation summaries to created issues, and writes a
+      filed_issues_manifest.json for traceability.
 
-      No headless sessions are spawned. Rate-limit cost: 5 pts per chunk
-      (vs 90 pts for 18 sequential REST calls).
+      The AUTOSKILLIT_AUDIT_RUN_DIR env var scopes discovery to the
+      per-run directory created by init_audit_run.
     capture:
       issue_urls: "${{ result.issue_urls }}"
       issue_count: "${{ result.issue_count }}"

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -48,7 +48,7 @@ Collect created issue URLs and numbers.
 
 ## Step 5 — Apply Source-Specific Labels
 
-Parse the source from each ticket body filename (`ticket_body_{source}_{N}.md`). For each unique
+Parse the source from each ticket body filename (`ticket_body_{source}_{N}_{ts}.md`). For each unique
 source, ensure a label exists (e.g., `audit:tests`, `audit:arch`, `audit:cohesion`, etc.).
 Batch-apply source labels via GraphQL `addLabelsToLabelable` mutation with aliases.
 

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: file-audit-issues
+categories: [audit-pipeline]
+description: >-
+  Batch-create GitHub issues from validated audit ticket body files. Discovers
+  ticket bodies from the audit run directory, deduplicates against existing open
+  issues, creates via batched GraphQL mutations, applies labels, appends
+  validation summaries, and writes a filed-issues manifest. Pipeline-only skill
+  dispatched by the full-audit recipe.
+hooks:
+  PreToolUse:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: "echo '[SKILL: file-audit-issues] Filing audit issues from validated reports...'"
+          once: true
+---
+
+## Step 1 — Resolve Run Directory
+
+Check `AUTOSKILLIT_AUDIT_RUN_DIR` env var first. If unset, check positional argument
+(`{run_dir_or_paths}`). If neither, discover the most recent `validate-audit-*` directory
+under `{{AUTOSKILLIT_TEMP}}/`. Error and exit if no run directory found.
+
+## Step 2 — Discover Ticket Body Files
+
+Glob `ticket_body_*.md` in the resolved run directory. Parse each file: extract H1 title
+via first `# ` line, read full body text. If no ticket body files found, emit
+`issue_urls = ` and `issue_count = 0` and exit.
+
+## Step 3 — Dedup Against Existing Issues
+
+For each ticket body file, extract 2–3 key terms from the title. Run:
+```
+gh issue list --search "{key terms}" --json number,title,state --limit 5 --state open
+```
+in the workspace. If any existing open issue title has high similarity (shares 3+ significant
+words with the ticket title), mark that ticket body as a duplicate and skip it. Log skipped
+duplicates to terminal.
+
+## Step 4 — Batch-Create Issues via GraphQL
+
+Resolve repo identity: `gh api repos/{owner}/{repo} --jq '.node_id'` (or `gh repo view --json owner,name,id`).
+Resolve label IDs for `audit` and `recipe:implementation` labels (ensure they exist via `gh label create --force`).
+Build batched GraphQL `createIssue` mutations with aliases (`issue0`, `issue1`, ...), chunked at 20 per request.
+Execute via `gh api graphql --input -`. Sleep 1 second between chunks (per GitHub API discipline).
+Collect created issue URLs and numbers.
+
+## Step 5 — Apply Source-Specific Labels
+
+Parse the source from each ticket body filename (`ticket_body_{source}_{N}.md`). For each unique
+source, ensure a label exists (e.g., `audit:tests`, `audit:arch`, `audit:cohesion`, etc.).
+Batch-apply source labels via GraphQL `addLabelsToLabelable` mutation with aliases.
+
+## Step 6 — Append Validation Summaries
+
+For each created issue, find the corresponding `validation_summary_{source}*.md` in the run directory.
+For each: fetch current issue body via `gh issue view {number} --json body --jq .body`.
+Verify fetched body is non-empty (skip append if empty to avoid overwriting). Append horizontal
+rule + validation summary content. Write combined text to temp file, run `gh issue edit {number} --body-file "$FILE"`.
+Sleep 1 second between edits (per GitHub API discipline).
+
+## Step 7 — Write Filed Issues Manifest
+
+Write `filed_issues_manifest_{timestamp}.json` to the run directory with:
+- `created_at` (ISO timestamp)
+- `run_dir` (absolute path)
+- `issues` array: `[{number, url, title, source, labels, ticket_body_file}]`
+- `skipped_duplicates` array: `[{title, matched_issue_number, ticket_body_file}]`
+- `total_created` and `total_skipped` counts
+
+## Step 8 — Emit Structured Output
+
+```
+issue_urls = {comma-separated URLs}
+issue_count = {N}
+```
+
+**Critical constraints:**
+- NEVER use `gh issue comment` — all content goes in the issue body
+- NEVER create issues individually via REST — always batch via GraphQL
+- Sleep 1 second between consecutive mutating GitHub API calls
+- Use `--body-file` for all body content (never `--body` inline for large content)
+- When `AUTOSKILLIT_HEADLESS` is `1`, skip all prompts and execute directly

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -34,13 +34,20 @@ For each ticket body file, extract 2–3 key terms from the title. Run:
 ```
 gh issue list --search "{key terms}" --json number,title,state --limit 5 --state open
 ```
-in the workspace. If any existing open issue title has high similarity (shares 3+ significant
-words with the ticket title), mark that ticket body as a duplicate and skip it. Log skipped
-duplicates to terminal.
+in the workspace. If any existing open issue title has high similarity, mark that ticket body
+as a duplicate and skip it. Log skipped duplicates to terminal.
+
+**Similarity definition:** Tokenize both titles to lowercase words; discard stopwords
+(`a`, `an`, `the`, `in`, `of`, `to`, `with`, `for`, `and`, `or`, `is`, `are`, `that`,
+`this`, `it`, `be`, `at`, `by`, `from`). Count the number of shared tokens between the
+two sets. Three or more shared tokens ⇒ duplicate.
 
 ## Step 4 — Batch-Create Issues via GraphQL
 
 Resolve repo identity: `gh api repos/{owner}/{repo} --jq '.node_id'` (or `gh repo view --json owner,name,id`).
+If this call fails or returns an empty node_id (missing `GH_TOKEN`, wrong remote, insufficient
+permissions), abort immediately with a clear error message: `"Error: could not resolve repo node_id
+— check GH_TOKEN and remote URL. Aborting."` Do not proceed with GraphQL mutations using an empty node_id.
 Resolve label IDs for `audit` and `recipe:implementation` labels (ensure they exist via `gh label create --force`).
 Build batched GraphQL `createIssue` mutations with aliases (`issue0`, `issue1`, ...), chunked at 20 per request.
 Execute via `gh api graphql --input -`. Sleep 1 second between chunks (per GitHub API discipline).
@@ -55,7 +62,10 @@ Batch-apply source labels via GraphQL `addLabelsToLabelable` mutation with alias
 ## Step 6 — Append Validation Summaries
 
 For each created issue, find the corresponding `validation_summary_{source}*.md` in the run directory.
-For each: fetch current issue body via `gh issue view {number} --json body --jq .body`.
+If no matching summary file exists for a given source, log a warning
+(`"Warning: no validation summary found for source '{source}' — skipping append for issue #{number}"`)
+and skip the append for that issue; do not abort the step.
+For each matched issue: fetch current issue body via `gh issue view {number} --json body --jq .body`.
 Verify fetched body is non-empty (skip append if empty to avoid overwriting). Append horizontal
 rule + validation summary content. Write combined text to temp file, run `gh issue edit {number} --body-file "$FILE"`.
 Sleep 1 second between edits (per GitHub API discipline).

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -26,7 +26,7 @@ under `{{AUTOSKILLIT_TEMP}}/`. Abort with an error when no run directory can be 
 
 Glob `ticket_body_*.md` in the resolved run directory. Parse each file: extract H1 title
 via first `# ` line, read full body text. When the discovery produces zero ticket body
-files, emit `issue_urls = ` and `issue_count = 0` and exit.
+files, emit `issue_urls = ` and `issue_count = 0` and exit with success (exit code 0).
 
 ## Step 3 — Dedup Against Existing Issues
 
@@ -44,7 +44,7 @@ two sets. Three or more shared tokens ⇒ duplicate.
 
 ## Step 4 — Batch-Create Issues via GraphQL
 
-Resolve repo identity: `gh api repos/{owner}/{repo} --jq '.node_id'` (or `gh repo view --json owner,name,id`).
+Resolve repo identity: use `gh repo view --json owner,name` to get the canonical owner and repo name, then fetch `gh api repos/{owner}/{repo} --jq '.node_id'`.
 If this call fails or returns an empty node_id (missing `GH_TOKEN`, wrong remote, insufficient
 permissions), abort immediately with a clear error message: `"Error: could not resolve repo node_id
 — check GH_TOKEN and remote URL. Aborting."` Do not proceed with GraphQL mutations using an empty node_id.

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -76,9 +76,25 @@ issue_urls = {comma-separated URLs}
 issue_count = {N}
 ```
 
-**Critical constraints:**
-- NEVER use `gh issue comment` — all content goes in the issue body
-- NEVER create issues individually via REST — always batch via GraphQL
-- Sleep 1 second between consecutive mutating GitHub API calls
-- Use `--body-file` for all body content (never `--body` inline for large content)
-- When `AUTOSKILLIT_HEADLESS` is `1`, skip all prompts and execute directly
+When no ticket body files are found, emit empty values and exit immediately:
+
+```
+issue_urls = 
+issue_count = 0
+```
+
+## Critical Constraints
+
+**NEVER:**
+- Use `gh issue comment` — all issue content goes in the body via `--body-file`
+- Create issues individually via REST — always batch via GraphQL `createIssue` mutations
+- Skip the 1-second sleep between consecutive mutating GitHub API calls
+- Use `--body` inline for large content — always write to temp file and use `--body-file`
+- Prompt interactively when `AUTOSKILLIT_HEADLESS` is `1` — execute all steps directly
+
+**ALWAYS:**
+- Emit `issue_count = {N}` and `issue_urls = {urls}` as the final structured output (emit `issue_urls = ` with empty value when N=0)
+- Deduplicate against existing open issues before creating any new ones
+- Write `filed_issues_manifest_{timestamp}.json` to the audit run directory
+- Sleep 1 second between each chunk of batch GraphQL mutations
+- Use absolute paths for all temp files written during this skill

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -20,13 +20,13 @@ hooks:
 
 Check `AUTOSKILLIT_AUDIT_RUN_DIR` env var first. If unset, check positional argument
 (`{run_dir_or_paths}`). If neither, discover the most recent `validate-audit-*` directory
-under `{{AUTOSKILLIT_TEMP}}/`. Error and exit if no run directory found.
+under `{{AUTOSKILLIT_TEMP}}/`. Abort with an error when no run directory can be resolved.
 
 ## Step 2 — Discover Ticket Body Files
 
 Glob `ticket_body_*.md` in the resolved run directory. Parse each file: extract H1 title
-via first `# ` line, read full body text. If no ticket body files found, emit
-`issue_urls = ` and `issue_count = 0` and exit.
+via first `# ` line, read full body text. When the discovery produces zero ticket body
+files, emit `issue_urls = ` and `issue_count = 0` and exit.
 
 ## Step 3 — Dedup Against Existing Issues
 

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -493,16 +493,10 @@ verdict = validated
 
 > Write validated report and contested findings files? [Y/n]
 
-On Y or empty input, write all files. After writing, offer:
-
-> Run `/autoskillit:prepare-issue` for each ticket group? [Y/n]
-
-On Y, call `prepare-issue` for each ticket body file (in parallel). After issue creation,
-append the validation summary to each created issue body using `gh issue edit --body-file`:
-fetch the current issue body, verify the fetched body is non-empty (abort the append for
-that issue if empty to avoid overwriting with summary-only content), append a horizontal
-rule and the validation summary content, write the combined text to a temp file, then run
-`gh issue edit {issue_number} --body-file` with that temp file. Do NOT use `gh issue comment`.
+On Y or empty input, write all files and print the same terminal summary as headless mode
+(excluding the structured output tokens). Issue filing is handled separately by the
+`file-audit-issues` skill — direct the user there if they want to create GitHub issues
+from the ticket body files.
 
 ---
 
@@ -531,4 +525,4 @@ $AUDIT_BASE_DIR/
 - `/autoskillit:audit-feature-gates` — produces reports this skill validates
 - `/autoskillit:audit-docs` — produces reports this skill validates
 - `/autoskillit:audit-review-decisions` — produces reports this skill validates
-- `/autoskillit:prepare-issue` — offered interactively for contested findings
+- `/autoskillit:file-audit-issues` — batch-creates issues from ticket body files (pipeline-only, run via full-audit recipe)

--- a/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
@@ -474,16 +474,10 @@ verdict = validated
 
 > Write validated report and contested findings files? [Y/n]
 
-On Y or empty input, write all files. After writing, offer:
-
-> Run `/autoskillit:prepare-issue` for each ticket group? [Y/n]
-
-On Y, call `prepare-issue` for each ticket body file (in parallel). After issue creation,
-append the validation summary to each created issue body using `gh issue edit --body-file`:
-fetch the current issue body, verify the fetched body is non-empty (abort the append for
-that issue if empty to avoid overwriting with summary-only content), append a horizontal
-rule and the validation summary content, write the combined text to a temp file, then run
-`gh issue edit {issue_number} --body-file` with that temp file. Do NOT use `gh issue comment`.
+On Y or empty input, write all files and print the same terminal summary as headless mode
+(excluding the structured output tokens). Issue filing is handled separately by the
+`file-audit-issues` skill — direct the user there if they want to create GitHub issues
+from the ticket body files.
 
 ---
 
@@ -507,4 +501,4 @@ $AUDIT_BASE_DIR/
 - `/autoskillit:audit-review-decisions` — produces reports this skill validates
 - `/autoskillit:validate-audit` — generic audit validator for other audit types
 - `/autoskillit:validate-test-audit` — specialized validator for test audit reports
-- `/autoskillit:prepare-issue` — offered interactively for ticket groups
+- `/autoskillit:file-audit-issues` — batch-creates issues from ticket body files (pipeline-only, run via full-audit recipe)

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -494,16 +494,10 @@ verdict = validated
 
 > Write validated report and contested findings files? [Y/n]
 
-On Y or empty input, write all files. After writing, offer:
-
-> Run `/autoskillit:prepare-issue` for each ticket group? [Y/n]
-
-On Y, call `prepare-issue` for each ticket body file (in parallel). After issue creation,
-append the validation summary to each created issue body using `gh issue edit --body-file`:
-fetch the current issue body, verify the fetched body is non-empty (abort the append for
-that issue if empty to avoid overwriting with summary-only content), append a horizontal
-rule and the validation summary content, write the combined text to a temp file, then run
-`gh issue edit {issue_number} --body-file` with that temp file. Do NOT use `gh issue comment`.
+On Y or empty input, write all files and print the same terminal summary as headless mode
+(excluding the structured output tokens). Issue filing is handled separately by the
+`file-audit-issues` skill — direct the user there if they want to create GitHub issues
+from the ticket body files.
 
 ---
 
@@ -524,4 +518,4 @@ All output files are written under `{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM
 
 - `/autoskillit:audit-tests` — produces reports this skill validates
 - `/autoskillit:validate-audit` — validates all other audit types (arch, cohesion, feature_gates, docs, review_decisions)
-- `/autoskillit:prepare-issue` — offered interactively for contested findings
+- `/autoskillit:file-audit-issues` — batch-creates issues from ticket body files (pipeline-only, run via full-audit recipe)

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -249,7 +249,7 @@ exp-lens-error-budget, exp-lens-estimand-clarity, exp-lens-exploratory-confirmat
 exp-lens-governance-risk, exp-lens-iterative-learning, exp-lens-measurement-validity, exp-lens-pipeline-integrity,
 exp-lens-randomization-blocking, exp-lens-reproducibility-artifacts, exp-lens-sensitivity-robustness,
 exp-lens-severity-testing, exp-lens-unit-interference, exp-lens-validity-threats, exp-lens-variance-stability,
-implement-experiment, implement-worktree, implement-worktree-no-merge, investigate, issue-splitter, make-arch-diag,
+file-audit-issues, implement-experiment, implement-worktree, implement-worktree-no-merge, investigate, issue-splitter, make-arch-diag,
 make-campaign, make-experiment-diag, make-groups, make-plan, make-req, merge-pr, mermaid, migrate-recipes, open-integration-pr,
 open-kitchen, pipeline-summary, plan-experiment, plan-visualization, planner-analyze, planner-assess-review-approach, planner-consolidate-wps, planner-elaborate-assignments, planner-elaborate-phase, planner-elaborate-wps, planner-extract-domain, planner-generate-phases, planner-reconcile-deps, planner-refine, planner-refine-assignments, planner-refine-phases, planner-refine-wps, planner-validate-task-alignment, prepare-issue, prepare-pr, prepare-research-pr, process-issues, promote-to-main, rectify, reload-session, report-bug,
 resolve-claims-review, resolve-design-review, resolve-failures, resolve-merge-conflicts, resolve-research-review, resolve-review, retry-worktree, review-approach, review-design, review-pr, review-research-pr, run-experiment,

--- a/tests/config/test_skills_config.py
+++ b/tests/config/test_skills_config.py
@@ -51,6 +51,12 @@ class TestSkillsConfig:
         assert "make-plan" in cfg.skills.tier2
         assert "compose-pr" in cfg.skills.tier3
 
+    def test_file_audit_issues_in_tier3(self) -> None:
+        from autoskillit.config import load_config
+
+        cfg = load_config()
+        assert "file-audit-issues" in cfg.skills.tier3
+
     def test_skills_config_exported_from_config_package(self) -> None:
         """SkillsConfig is importable from autoskillit.config and has expected fields."""
         from autoskillit.config import SkillsConfig

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -54,6 +54,17 @@ def test_pack_registry_new_packs_are_default_disabled() -> None:
     assert PACK_REGISTRY["exp-lens"].default_enabled is False
 
 
+def test_audit_pipeline_pack_in_registry() -> None:
+    from autoskillit.core import PACK_REGISTRY
+
+    assert "audit-pipeline" in PACK_REGISTRY
+    assert PACK_REGISTRY["audit-pipeline"].default_enabled is False
+    assert (
+        PACK_REGISTRY["audit-pipeline"].description
+        == "Audit pipeline internals (recipe-dispatched only)"
+    )
+
+
 def test_pack_registry_importable_from_core() -> None:
     from autoskillit.core import PACK_REGISTRY, PackDef
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -314,10 +314,10 @@ def test_docs_state_37_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 37)
 
 
-def test_skill_visibility_states_133_skills() -> None:
-    # 133 = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 130 extended.
-    # DefaultSkillResolver.list_all() returns 132 (excludes sous-chef from public surface).
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 133)
+def test_skill_visibility_states_134_skills() -> None:
+    # 134 = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 131 extended.
+    # DefaultSkillResolver.list_all() returns 133 (excludes sous-chef from public surface).
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 134)
 
 
 def test_safety_hooks_states_21_hooks() -> None:

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -664,6 +664,7 @@ ALWAYS_WRITE_SKILLS = {
     "design-guards",
     "diagnose-ci",
     "dry-walkthrough",
+    "file-audit-issues",
     "generate-report",
     "implement-experiment",
     "implement-worktree",

--- a/tests/recipe/test_full_audit_recipe.py
+++ b/tests/recipe/test_full_audit_recipe.py
@@ -135,6 +135,7 @@ def test_full_audit_semantic_rules_no_errors() -> None:
             "validate-audit",
             "validate-test-audit",
             "validate-review-decisions",
+            "file-audit-issues",
         }
     )
     ctx = make_validation_context(recipe, available_skills=known_skills)
@@ -238,8 +239,8 @@ def test_full_audit_create_issues_uses_batched_graphql() -> None:
 
     data = yaml.safe_load(RECIPE_PATH.read_text())
     step = data["steps"]["create_issues"]
-    assert step["tool"] == "run_python"
-    assert "batch_create_issues" in step["with"]["callable"]
+    assert step["tool"] == "run_skill"
+    assert "file-audit-issues" in step["with"]["skill_command"]
     note = step["note"].lower()
     assert "batched" in note or "graphql" in note
 

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -97,6 +97,14 @@ def test_all_builtin_packs_pass():
     assert not findings, f"Built-in packs must not trigger unknown-required-pack: {findings}"
 
 
+def test_full_audit_declares_audit_pipeline_pack() -> None:
+    from autoskillit.core import pkg_root
+    from autoskillit.recipe.io import load_recipe
+
+    recipe = load_recipe(pkg_root() / "recipes" / "full-audit.yaml")
+    assert "audit-pipeline" in recipe.requires_packs
+
+
 # ----------------------------------------------------------------------
 # undeclared-pack-requirement tests
 # ----------------------------------------------------------------------

--- a/tests/workspace/test_session_skills_filtering.py
+++ b/tests/workspace/test_session_skills_filtering.py
@@ -213,6 +213,32 @@ def test_resolve_effective_disabled_recipe_packs_overrides_default() -> None:
     assert "research" not in result  # enabled by recipe
 
 
+def test_audit_pipeline_disabled_by_default() -> None:
+    from autoskillit.core import PACK_REGISTRY
+    from autoskillit.workspace.session_skills import _resolve_effective_disabled
+
+    result = _resolve_effective_disabled(
+        explicit_disabled=[],
+        pack_registry=PACK_REGISTRY,
+        packs_enabled=[],
+        recipe_packs=None,
+    )
+    assert "audit-pipeline" in result
+
+
+def test_audit_pipeline_enabled_by_recipe_packs() -> None:
+    from autoskillit.core import PACK_REGISTRY
+    from autoskillit.workspace.session_skills import _resolve_effective_disabled
+
+    result = _resolve_effective_disabled(
+        explicit_disabled=[],
+        pack_registry=PACK_REGISTRY,
+        packs_enabled=[],
+        recipe_packs=frozenset(["audit-pipeline"]),
+    )
+    assert "audit-pipeline" not in result
+
+
 def test_resolve_effective_disabled_includes_feature_tags() -> None:
     from autoskillit.core import PACK_REGISTRY
     from autoskillit.workspace.session_skills import _resolve_effective_disabled


### PR DESCRIPTION
## Summary

Create a new Tier 3 pipeline-only skill `file-audit-issues` that is the sole owner of GitHub issue creation from validated audit reports. The skill is gated behind a new `audit-pipeline` pack (`default_enabled=False`) so it is invisible in interactive sessions but unlocked by the `full-audit` recipe via `requires_packs`. Three validator skills (`validate-audit`, `validate-test-audit`, `validate-review-decisions`) have their Step 9 interactive issue-filing logic removed — they now end after writing ticket body files. The `full-audit.yaml` recipe's `create_issues` step changes from `run_python` (direct `batch_create_issues` callable) to `run_skill` dispatching the new skill, which adds dedup checking, validation summary appending, and manifest writing on top of the existing batched GraphQL creation.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260508-212838-806183/.autoskillit/temp/make-plan/extract_issue_filing_plan_2026-05-09_043627.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.5k | 15.8k | 918.9k | 74.8k | 126 | 68.4k | 10m 32s |
| verify | claude-sonnet-4-6 | 1 | 1.3k | 14.4k | 768.2k | 63.2k | 135 | 70.4k | 9m 31s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.1M | 20.9k | 1.7M | 73.2k | 169 | 84.1k | 7m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 200.6k | 5.1k | 370.6k | 28.7k | 26 | 15.3k | 1m 49s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 76.4k | 2.0k | 255.7k | 28.7k | 23 | 15.1k | 57s |
| review_pr | claude-sonnet-4-6 | 3 | 278 | 92.7k | 1.5M | 77.4k | 110 | 200.9k | 22m 25s |
| resolve_review | claude-sonnet-4-6 | 3 | 709 | 54.7k | 4.5M | 76.6k | 322 | 173.4k | 40m 45s |
| **Total** | | | 2.4M | 205.4k | 10.0M | 77.4k | | 627.7k | 1h 33m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 241 | 6980.6 | 349.0 | 86.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 48 | 94168.7 | 3612.8 | 1138.9 |
| **Total** | **289** | 34505.9 | 2171.9 | 710.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 6.4k | 39.1k | 2.6M | 197.5k | 26m 7s |
| claude-opus-4-6 | 2 | 2.7k | 73.3k | 5.3M | 331.5k | 45m 1s |
| MiniMax-M2.7-highspeed | 1 | 4.2M | 46.3k | 4.0M | 268.1k | 17m 32s |