### PR TITLE
Rectify: Recipe Content Returns Unsubstituted {{AUTOSKILLIT_TEMP}} to LLM

### DIFF
--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -45,6 +45,7 @@ from autoskillit.recipe.diagrams import (
 )
 from autoskillit.recipe.io import (
     RecipeInfo,
+    _assert_no_raw_placeholders,
     _load_recipe_dict,
     _parse_recipe,
     builtin_recipes_dir,
@@ -347,8 +348,10 @@ def load_and_validate(
     _method_traditions_hash = _compute_registry_hash(BUNDLED_METHODOLOGY_TRADITIONS_DIR)
     _user_method_traditions_dir = _pdir / ".autoskillit" / "methodology-traditions"
     _user_method_traditions_hash = _compute_registry_hash(_user_method_traditions_dir)
+    _temp_relpath = temp_dir_relpath or ".autoskillit/temp"
     cache_key = (
         name,
+        _temp_relpath,
         str(_pdir),
         tuple(sorted(suppressed)) if suppressed else (),
         tuple(sorted(ingredient_overrides.items())) if ingredient_overrides else (),
@@ -390,7 +393,7 @@ def load_and_validate(
         return {"error": f"No recipe named '{name}' found"}
 
     raw = match.content if match.content is not None else match.path.read_text()
-    _temp_relpath = temp_dir_relpath or ".autoskillit/temp"
+    raw = substitute_temp_placeholder(raw, _temp_relpath)
     suggestions: list[dict[str, Any]] = []
     valid = True
     recipe = None
@@ -552,6 +555,7 @@ def load_and_validate(
         else None
     )
 
+    _assert_no_raw_placeholders(raw, context=name)
     result: LoadRecipeResult = {
         "content": raw,
         "diagram": diagram,

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -51,6 +51,19 @@ def substitute_temp_placeholder(text: str, temp_dir_relpath: str) -> str:
     return text.replace(_TEMP_PLACEHOLDER, temp_dir_relpath)
 
 
+def _assert_no_raw_placeholders(text: str, *, context: str = "") -> None:
+    """Raise if text still contains ``{{AUTOSKILLIT_TEMP}}``.
+
+    Called at content-delivery boundaries to enforce the invariant that
+    all placeholders are resolved before content reaches the consumer.
+    """
+    if _TEMP_PLACEHOLDER in text:
+        raise ValueError(
+            f"Unresolved {_TEMP_PLACEHOLDER} in recipe content"
+            + (f" ({context})" if context else "")
+        )
+
+
 def _load_recipe_dict(
     yaml_path: Path,
     *,

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -52,11 +52,7 @@ def substitute_temp_placeholder(text: str, temp_dir_relpath: str) -> str:
 
 
 def _assert_no_raw_placeholders(text: str, *, context: str = "") -> None:
-    """Raise if text still contains ``{{AUTOSKILLIT_TEMP}}``.
-
-    Called at content-delivery boundaries to enforce the invariant that
-    all placeholders are resolved before content reaches the consumer.
-    """
+    # Content-delivery boundary guard: raises if placeholder substitution was skipped.
     if _TEMP_PLACEHOLDER in text:
         raise ValueError(
             f"Unresolved {_TEMP_PLACEHOLDER} in recipe content"

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -254,21 +254,11 @@ def test_load_and_validate_cache_invalidated_on_dir_mtime_change(tmp_path, monke
 
 
 def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_path, monkeypatch):
-    """Every load_and_validate parameter that affects the result must be in the cache key.
-
-    This is a structural test: it uses inspection to find parameters that affect
-    the result, then verifies the cache key construction includes all of them.
-    Metadata-only parameters (recipe_info, recipe_list) are intentionally excluded.
-    """
     import inspect
 
     import autoskillit.recipe._api as api_mod
 
-    # Parameters that affect the result but are NOT in the cache key (if any).
-    # These must remain stable across calls for the same cached result.
-    # Update this set when adding new result-affecting parameters.
-    # Note: resolved_defaults affects result["ingredients_table"] but is intentionally
-    # excluded from this test's scope (covers only result["content"] per the plan).
+    # resolved_defaults affects result["ingredients_table"] but is intentionally excluded here.
     RESULT_METADATA_ONLY_PARAMS: frozenset[str] = frozenset(
         {
             "recipe_info",
@@ -285,14 +275,7 @@ def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_pa
     # Find all params NOT in the metadata-only allowlist
     result_affecting_params = all_params - RESULT_METADATA_ONLY_PARAMS
 
-    # Replace _LOAD_CACHE with a fresh dict to inspect stored keys after the call
     cache_snap: dict = {}
-
-    def capturing_new():
-        return cache_snap
-
-    original_cache = api_mod._LOAD_CACHE
-    api_mod._LOAD_CACHE = cache_snap
     monkeypatch.setattr(api_mod, "_LOAD_CACHE", cache_snap)
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
@@ -301,14 +284,10 @@ def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_pa
 
     api_mod.load_and_validate("myrecipe", tmp_path)
 
-    api_mod._LOAD_CACHE = original_cache
-
     assert cache_snap, "cache was never populated"
     cache_key = next(iter(cache_snap.keys()))
 
     # Verify each result-affecting param has a corresponding position in the cache key
-    # The cache key order is: name, _temp_relpath, _pdir, suppressed, ingredient_overrides,
-    # _exp_types_hash, _user_exp_hash, _method_traditions_hash, _user_method_traditions_hash
     param_to_key_index: dict[str, int] = {
         "name": 0,
         "temp_dir_relpath": 1,

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -310,13 +310,24 @@ def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_pa
         f"cache key construction: {missing_params}"
     )
 
-    # Verify the cache key has an entry for each mapped param
-    for param, idx in param_to_key_index.items():
-        if param in result_affecting_params:
-            assert len(cache_key) > idx, (
-                f"cache_key too short for param {param} (index {idx}); "
-                f"got {len(cache_key)} elements"
-            )
+    # Verify actual values at deterministic positions
+    assert cache_key[0] == "myrecipe", f"cache_key[0] expected 'myrecipe', got {cache_key[0]!r}"
+    assert cache_key[1] == ".autoskillit/temp", (
+        f"cache_key[1] expected default temp relpath, got {cache_key[1]!r}"
+    )
+    assert cache_key[2] == str(tmp_path), (
+        f"cache_key[2] expected str(project_dir), got {cache_key[2]!r}"
+    )
+    assert cache_key[3] == (), (
+        f"cache_key[3] expected empty suppressed tuple, got {cache_key[3]!r}"
+    )
+    assert cache_key[4] == (), (
+        f"cache_key[4] expected empty ingredient_overrides tuple, got {cache_key[4]!r}"
+    )
+    for idx in (5, 6, 7, 8):
+        assert isinstance(cache_key[idx], str), (
+            f"cache_key[{idx}] expected str hash, got {type(cache_key[idx])!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -253,6 +253,93 @@ def test_load_and_validate_cache_invalidated_on_dir_mtime_change(tmp_path, monke
     assert len(calls) == 2
 
 
+def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_path, monkeypatch):
+    """Every load_and_validate parameter that affects the result must be in the cache key.
+
+    This is a structural test: it uses inspection to find parameters that affect
+    the result, then verifies the cache key construction includes all of them.
+    Metadata-only parameters (recipe_info, recipe_list) are intentionally excluded.
+    """
+    import inspect
+
+    import autoskillit.recipe._api as api_mod
+
+    # Parameters that affect the result but are NOT in the cache key (if any).
+    # These must remain stable across calls for the same cached result.
+    # Update this set when adding new result-affecting parameters.
+    # Note: resolved_defaults affects result["ingredients_table"] but is intentionally
+    # excluded from this test's scope (covers only result["content"] per the plan).
+    RESULT_METADATA_ONLY_PARAMS: frozenset[str] = frozenset(
+        {
+            "recipe_info",
+            "recipe_list",
+            "resolved_defaults",
+            "lister",
+            "temp_dir",
+        }
+    )
+
+    sig = inspect.signature(api_mod.load_and_validate)
+    all_params = set(sig.parameters.keys())
+
+    # Find all params NOT in the metadata-only allowlist
+    result_affecting_params = all_params - RESULT_METADATA_ONLY_PARAMS
+
+    # Replace _LOAD_CACHE with a fresh dict to inspect stored keys after the call
+    cache_snap: dict = {}
+
+    def capturing_new():
+        return cache_snap
+
+    original_cache = api_mod._LOAD_CACHE
+    api_mod._LOAD_CACHE = cache_snap
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", cache_snap)
+
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    (recipes_dir / "myrecipe.yaml").write_text(MINIMAL_RECIPE_YAML)
+
+    api_mod.load_and_validate("myrecipe", tmp_path)
+
+    api_mod._LOAD_CACHE = original_cache
+
+    assert cache_snap, "cache was never populated"
+    cache_key = next(iter(cache_snap.keys()))
+
+    # Verify each result-affecting param has a corresponding position in the cache key
+    # The cache key order is: name, _temp_relpath, _pdir, suppressed, ingredient_overrides,
+    # _exp_types_hash, _user_exp_hash, _method_traditions_hash, _user_method_traditions_hash
+    param_to_key_index: dict[str, int] = {
+        "name": 0,
+        "temp_dir_relpath": 1,
+        "project_dir": 2,
+        "suppressed": 3,
+        "ingredient_overrides": 4,
+        "_exp_types_hash": 5,
+        "_user_exp_hash": 6,
+        "_method_traditions_hash": 7,
+        "_user_method_traditions_hash": 8,
+    }
+
+    missing_params: list[str] = []
+    for param in result_affecting_params:
+        if param not in param_to_key_index:
+            missing_params.append(param)
+
+    assert not missing_params, (
+        f"The following result-affecting parameters are not represented in the "
+        f"cache key construction: {missing_params}"
+    )
+
+    # Verify the cache key has an entry for each mapped param
+    for param, idx in param_to_key_index.items():
+        if param in result_affecting_params:
+            assert len(cache_key) > idx, (
+                f"cache_key too short for param {param} (index {idx}); "
+                f"got {len(cache_key)} elements"
+            )
+
+
 # ---------------------------------------------------------------------------
 # Stage timing test
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_recipe_temp_substitution.py
+++ b/tests/recipe/test_recipe_temp_substitution.py
@@ -132,11 +132,11 @@ def test_load_and_validate_content_has_no_raw_placeholders(tmp_path: Path) -> No
 
 def test_load_and_validate_different_temp_dir_relpath_produces_different_content(
     tmp_path: Path,
+    monkeypatch,
 ) -> None:
-    """Different temp_dir_relpath values must produce different result['content']."""
     import autoskillit.recipe._api as api_mod
 
-    api_mod._LOAD_CACHE.clear()
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
     _setup_project_recipe_with_placeholder(tmp_path, "temp-placeholder-test")
 
     result1 = api_mod.load_and_validate(
@@ -177,13 +177,14 @@ def test_all_bundled_recipes_content_no_raw_placeholders(
     from autoskillit.recipe.io import list_recipes
 
     recipes_root = Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "recipes"
+    repo_root = Path(__file__).resolve().parents[2]
     result = list_recipes(recipes_root)
 
     offenders: list[str] = []
     for recipe_info in result.items:
         if recipe_info.content is not None and "{{AUTOSKILLIT_TEMP}}" in recipe_info.content:
-            load_result = load_and_validate(recipe_info.name, project_dir=recipes_root)
-            if "{{AUTOSKILLIT_TEMP}}" in load_result["content"]:
+            load_result = load_and_validate(recipe_info.name, project_dir=repo_root)
+            if "error" not in load_result and "{{AUTOSKILLIT_TEMP}}" in load_result["content"]:
                 offenders.append(recipe_info.name)
 
     assert not offenders, (

--- a/tests/recipe/test_recipe_temp_substitution.py
+++ b/tests/recipe/test_recipe_temp_substitution.py
@@ -81,3 +81,112 @@ def test_no_recipe_yaml_contains_literal_temp_path() -> None:
         f"Recipe YAMLs contain literal '.autoskillit/temp' (must use "
         f"'{{{{AUTOSKILLIT_TEMP}}}}' instead): {offenders}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for API-layer content integrity (load_and_validate result["content"])
+# ---------------------------------------------------------------------------
+
+_RECIPE_WITH_PLACEHOLDER = """\
+name: temp-placeholder-test
+description: test recipe with AUTOSKILLIT_TEMP placeholder
+ingredients:
+  task:
+    description: the task
+    required: true
+steps:
+  setup:
+    tool: run_cmd
+    with:
+      cmd: 'mkdir -p "{{AUTOSKILLIT_TEMP}}/worktrees"'
+  end:
+    tool: stop
+    message: done
+output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
+"""
+
+
+def _setup_project_recipe_with_placeholder(tmp_path: Path, name: str) -> Path:
+    """Write a recipe YAML containing {{AUTOSKILLIT_TEMP}} to project recipes dir."""
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    recipe_path = recipes_dir / f"{name}.yaml"
+    recipe_path.write_text(_RECIPE_WITH_PLACEHOLDER)
+    return recipe_path
+
+
+def test_load_and_validate_content_has_no_raw_placeholders(tmp_path: Path) -> None:
+    """result['content'] must not contain {{AUTOSKILLIT_TEMP}} after substitution."""
+    from autoskillit.recipe._api import load_and_validate
+
+    _setup_project_recipe_with_placeholder(tmp_path, "temp-placeholder-test")
+    result = load_and_validate("temp-placeholder-test", project_dir=tmp_path)
+
+    assert "{{AUTOSKILLIT_TEMP}}" not in result["content"], (
+        "result['content'] must have placeholders substituted; "
+        "found literal '{{AUTOSKILLIT_TEMP}}' in content"
+    )
+    # Verify the resolved path appears where placeholders were
+    assert ".autoskillit/temp" in result["content"]
+
+
+def test_load_and_validate_different_temp_dir_relpath_produces_different_content(
+    tmp_path: Path,
+) -> None:
+    """Different temp_dir_relpath values must produce different result['content']."""
+    import autoskillit.recipe._api as api_mod
+
+    api_mod._LOAD_CACHE.clear()
+    _setup_project_recipe_with_placeholder(tmp_path, "temp-placeholder-test")
+
+    result1 = api_mod.load_and_validate(
+        "temp-placeholder-test", project_dir=tmp_path, temp_dir_relpath=".autoskillit/temp"
+    )
+    result2 = api_mod.load_and_validate(
+        "temp-placeholder-test", project_dir=tmp_path, temp_dir_relpath="custom/temp-dir"
+    )
+
+    assert ".autoskillit/temp" in result1["content"]
+    assert "custom/temp-dir" in result2["content"]
+    assert result1["content"] != result2["content"], (
+        "Different temp_dir_relpath must produce different content"
+    )
+
+
+def test_assert_no_raw_placeholders_raises_on_literal_placeholder() -> None:
+    """_assert_no_raw_placeholders must raise ValueError on unresolved placeholders."""
+    from autoskillit.recipe.io import _assert_no_raw_placeholders
+
+    with pytest.raises(ValueError, match="Unresolved"):
+        _assert_no_raw_placeholders("some text with {{AUTOSKILLIT_TEMP}} inside")
+
+
+def test_assert_no_raw_placeholders_passes_on_substituted_text() -> None:
+    """_assert_no_raw_placeholders must pass silently on substituted text."""
+    from autoskillit.recipe.io import _assert_no_raw_placeholders
+
+    _assert_no_raw_placeholders("already substituted .autoskillit/temp/path")
+    _assert_no_raw_placeholders("")
+
+
+def test_all_bundled_recipes_content_no_raw_placeholders(
+    tmp_path: Path,
+) -> None:
+    """Every bundled recipe loaded via load_and_validate has no raw placeholders in content."""
+    from autoskillit.recipe._api import load_and_validate
+    from autoskillit.recipe.io import list_recipes
+
+    recipes_root = Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "recipes"
+    result = list_recipes(recipes_root)
+
+    offenders: list[str] = []
+    for recipe_info in result.items:
+        if recipe_info.content is not None and "{{AUTOSKILLIT_TEMP}}" in recipe_info.content:
+            load_result = load_and_validate(recipe_info.name, project_dir=recipes_root)
+            if "{{AUTOSKILLIT_TEMP}}" in load_result["content"]:
+                offenders.append(recipe_info.name)
+
+    assert not offenders, (
+        f"The following recipes have unsubstituted {{{{AUTOSKILLIT_TEMP}}}} in "
+        f"result['content']: {offenders}"
+    )

--- a/tests/recipe/test_recipe_temp_substitution.py
+++ b/tests/recipe/test_recipe_temp_substitution.py
@@ -182,10 +182,9 @@ def test_all_bundled_recipes_content_no_raw_placeholders(
 
     offenders: list[str] = []
     for recipe_info in result.items:
-        if recipe_info.content is not None and "{{AUTOSKILLIT_TEMP}}" in recipe_info.content:
-            load_result = load_and_validate(recipe_info.name, project_dir=repo_root)
-            if "error" not in load_result and "{{AUTOSKILLIT_TEMP}}" in load_result["content"]:
-                offenders.append(recipe_info.name)
+        load_result = load_and_validate(recipe_info.name, project_dir=repo_root)
+        if "error" not in load_result and "{{AUTOSKILLIT_TEMP}}" in load_result["content"]:
+            offenders.append(recipe_info.name)
 
     assert not offenders, (
         f"The following recipes have unsubstituted {{{{AUTOSKILLIT_TEMP}}}} in "


### PR DESCRIPTION
## Summary

`load_and_validate()` in `src/autoskillit/recipe/_api.py` was returning unsubstituted `{{AUTOSKILLIT_TEMP}}` placeholders directly to the LLM via `result["content"]`. A performance refactor (commit `525a703a`) moved `substitute_temp_placeholder()` inside `_load_recipe_dict()`, but the caller's `raw` variable was never updated, causing stale unsubstituted content to flow silently through the MCP wire. Additionally, `_LOAD_CACHE` omitted `temp_dir_relpath` from its key, creating cross-caller cache contamination. The fix restores outer-scope substitution, adds a content integrity assertion guard at the `LoadRecipeResult` construction boundary, and includes `temp_dir_relpath` in the cache key.

## Requirements


## Conflict Resolution Table

The following files had merge conflicts that were automatically resolved.

| File | Conflict Resolution |
|------|---------------------|

## Changed Files

| File | Change Type |
|------|-------------|
| `src/autoskillit/recipe/_api.py` | Modified |
| `src/autoskillit/recipe/io.py` | Modified |
| `tests/recipe/test_api.py` | Modified |
| `tests/recipe/test_recipe_temp_substitution.py` | Modified |

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260508-215626-451194/.autoskillit/temp/rectify/rectify_unsubstituted_autoskillit_temp_2026-05-08_215626.md`

## Test Plan

- Add test reproducing the bug: `load_and_validate()` returning unsubstituted placeholders in `result["content"]`
- Add test verifying `temp_dir_relpath` is included in `_LOAD_CACHE` key
- Add test for new `_assert_no_raw_placeholders()` guard function
- Add parametrized test loading all bundled recipes with `{{AUTOSKILLIT_TEMP}}` via `load_and_validate()`
- Add structural test verifying all `load_and_validate` parameters that affect results are in the cache key

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 44 | 9.0k | 748.7k | 91.2k | 149 | 50.9k | 6m 17s |
| rectify | claude-opus-4-6 | 1 | 49 | 9.7k | 510.4k | 48.5k | 51 | 41.3k | 4m 52s |
| dry_walkthrough | claude-opus-4-6 | 1 | 39 | 8.2k | 1.0M | 65.4k | 63 | 52.6k | 4m 58s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.6M | 19.6k | 1.6M | 61.1k | 135 | 88.9k | 7m 14s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 65.7k | 3.5k | 172.5k | 28.8k | 20 | 41.2k | 1m 30s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 80.3k | 2.0k | 227.2k | 28.8k | 18 | 15.2k | 58s |
| review_pr | claude-sonnet-4-6 | 2 | 1.7k | 55.8k | 1.2M | 73.0k | 88 | 112.9k | 11m 53s |
| resolve_review | claude-sonnet-4-6 | 2 | 468 | 41.6k | 3.3M | 80.3k | 139 | 130.5k | 21m 3s |
| **Total** | | | 1.7M | 149.5k | 8.8M | 91.2k | | 533.5k | 58m 48s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 215 | 7332.0 | 413.4 | 91.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 70 | 47638.8 | 1863.9 | 594.8 |
| **Total** | **285** | 30799.9 | 1872.0 | 524.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 44 | 9.0k | 748.7k | 50.9k | 6m 17s |
| claude-opus-4-6 | 2 | 88 | 17.9k | 1.5M | 93.9k | 9m 51s |
| MiniMax-M2.7-highspeed | 3 | 1.7M | 25.1k | 2.0M | 145.3k | 9m 42s |