### PR TITLE
Rectify: CI Expression for AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED — Dynaconf Env Var Test Isolation Immunity

### DIFF
--- a/.github/workflows/test-filter-audit.yml
+++ b/.github/workflows/test-filter-audit.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          uv-version: "0.9.21"
+          version: "0.9.21"
 
       - name: Install go-task
         uses: arduino/setup-task@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,11 @@ jobs:
         env:
           AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: ${{ (github.event_name == 'pull_request' && github.base_ref == 'develop') || (github.event_name == 'merge_group' && contains(github.ref, '/develop/')) }}
           AUTOSKILLIT_FILTER_STATS_FILE: ${{ github.workspace }}/.autoskillit/temp/filter-stats.json
+          AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: >-
+            ${{
+              (github.event_name == 'pull_request' && github.base_ref == 'develop')
+              || (github.event_name == 'merge_group' && contains(github.ref, '/develop/'))
+            }}
         run: |
           mkdir -p .autoskillit/temp
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" ]]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,6 @@ jobs:
 
       - name: Run tests
         env:
-          AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: ${{ (github.event_name == 'pull_request' && github.base_ref == 'develop') || (github.event_name == 'merge_group' && contains(github.ref, '/develop/')) }}
           AUTOSKILLIT_FILTER_STATS_FILE: ${{ github.workspace }}/.autoskillit/temp/filter-stats.json
           AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: >-
             ${{

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -243,26 +243,6 @@ def test_env_var_fleet_uppercase_loads_without_crash(
     assert cfg.features.get("fleet") is True
 
 
-def test_load_config_experimental_immune_to_ci_env_var(monkeypatch, tmp_path):
-    """Verify is_dev_install() controls experimental_enabled even when
-    AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED is set in the environment.
-
-    This test reproduces the merge_group CI failure: the env var is set to
-    "false" but the test expects is_dev_install() to control the value.
-    Without the conftest autouse fixture clearing FEATURES__ env vars,
-    this test will fail.
-    """
-    from autoskillit.config.settings import load_config
-
-    monkeypatch.setenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", "false")
-    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
-    cfg = load_config(tmp_path)
-    # If env var leaks, cfg.experimental_enabled is False (from env var).
-    # With proper isolation, is_dev_install() returns True.
-    # This test FAILS until the autouse fixture is added, proving the gap.
-    assert cfg.experimental_enabled is True
-
-
 def test_config_dependency_validation(monkeypatch):
     """_build_features_dict raises ConfigSchemaError when B is enabled but dep A is disabled."""
 

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -236,10 +236,31 @@ def test_env_var_fleet_uppercase_loads_without_crash(
     """AUTOSKILLIT_FEATURES__FLEET=true is accepted and loaded correctly."""
     from autoskillit.config.settings import load_config
 
+    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     monkeypatch.setenv("AUTOSKILLIT_FEATURES__FLEET", "true")
     cfg = load_config(tmp_path)
     assert cfg.features.get("fleet") is True
+
+
+def test_load_config_experimental_immune_to_ci_env_var(monkeypatch, tmp_path):
+    """Verify is_dev_install() controls experimental_enabled even when
+    AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED is set in the environment.
+
+    This test reproduces the merge_group CI failure: the env var is set to
+    "false" but the test expects is_dev_install() to control the value.
+    Without the conftest autouse fixture clearing FEATURES__ env vars,
+    this test will fail.
+    """
+    from autoskillit.config.settings import load_config
+
+    monkeypatch.setenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", "false")
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
+    cfg = load_config(tmp_path)
+    # If env var leaks, cfg.experimental_enabled is False (from env var).
+    # With proper isolation, is_dev_install() returns True.
+    # This test FAILS until the autouse fixture is added, proving the gap.
+    assert cfg.experimental_enabled is True
 
 
 def test_config_dependency_validation(monkeypatch):
@@ -326,6 +347,7 @@ def test_fleet_feature_default_disabled():
 
 
 def test_build_features_dict_accepts_fleet_key(monkeypatch):
+    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     from autoskillit.config.settings import AutomationConfig
 
@@ -480,6 +502,7 @@ def test_build_features_dict_absent_experimental_enabled_auto_detects(
     """_build_features_dict calls is_dev_install() when experimental_enabled absent."""
     from autoskillit.config.settings import AutomationConfig
 
+    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
     result, exp_enabled = AutomationConfig._build_features_dict({})
     assert exp_enabled is True
@@ -497,6 +520,7 @@ def test_build_features_dict_explicit_true_overrides_auto_detect(
     """_build_features_dict returns True when explicit True, ignoring is_dev_install."""
     from autoskillit.config.settings import AutomationConfig
 
+    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     _, exp_enabled = AutomationConfig._build_features_dict({"experimental_enabled": True})
     assert exp_enabled is True
@@ -508,6 +532,7 @@ def test_build_features_dict_explicit_false_overrides_auto_detect(
     """_build_features_dict returns False when explicit False, ignoring is_dev_install."""
     from autoskillit.config.settings import AutomationConfig
 
+    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
     _, exp_enabled = AutomationConfig._build_features_dict({"experimental_enabled": False})
     assert exp_enabled is False
@@ -602,6 +627,7 @@ def test_project_config_override_beats_auto_detect(
 
     from autoskillit.config.settings import load_config
 
+    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     config_dir = tmp_path / ".autoskillit"
     config_dir.mkdir()
@@ -618,6 +644,7 @@ def test_user_config_override_beats_auto_detect(monkeypatch: pytest.MonkeyPatch,
 
     from autoskillit.config.settings import load_config
 
+    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     fake_home = tmp_path / "home"
     user_config_dir = fake_home / ".autoskillit"

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -236,7 +236,6 @@ def test_env_var_fleet_uppercase_loads_without_crash(
     """AUTOSKILLIT_FEATURES__FLEET=true is accepted and loaded correctly."""
     from autoskillit.config.settings import load_config
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     monkeypatch.setenv("AUTOSKILLIT_FEATURES__FLEET", "true")
     cfg = load_config(tmp_path)
@@ -327,7 +326,6 @@ def test_fleet_feature_default_disabled():
 
 
 def test_build_features_dict_accepts_fleet_key(monkeypatch):
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     from autoskillit.config.settings import AutomationConfig
 
@@ -482,7 +480,6 @@ def test_build_features_dict_absent_experimental_enabled_auto_detects(
     """_build_features_dict calls is_dev_install() when experimental_enabled absent."""
     from autoskillit.config.settings import AutomationConfig
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
     result, exp_enabled = AutomationConfig._build_features_dict({})
     assert exp_enabled is True
@@ -500,7 +497,6 @@ def test_build_features_dict_explicit_true_overrides_auto_detect(
     """_build_features_dict returns True when explicit True, ignoring is_dev_install."""
     from autoskillit.config.settings import AutomationConfig
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     _, exp_enabled = AutomationConfig._build_features_dict({"experimental_enabled": True})
     assert exp_enabled is True
@@ -512,7 +508,6 @@ def test_build_features_dict_explicit_false_overrides_auto_detect(
     """_build_features_dict returns False when explicit False, ignoring is_dev_install."""
     from autoskillit.config.settings import AutomationConfig
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
     _, exp_enabled = AutomationConfig._build_features_dict({"experimental_enabled": False})
     assert exp_enabled is False
@@ -551,7 +546,6 @@ def test_load_config_integration_experimental_auto_detects(
     """load_config auto-detects experimental_enabled via is_dev_install when unset."""
     from autoskillit.config.settings import load_config
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
     cfg = load_config(tmp_path)
     assert cfg.experimental_enabled is True
@@ -571,7 +565,6 @@ def test_load_config_non_dev_install_experimental_disabled(
     """load_config defaults experimental_enabled=False for non-dev install."""
     from autoskillit.config.settings import load_config
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     cfg = load_config(tmp_path)
     assert cfg.experimental_enabled is False
@@ -583,7 +576,6 @@ def test_load_config_dev_install_experimental_enabled(
     """load_config defaults experimental_enabled=True for editable dev install."""
     from autoskillit.config.settings import load_config
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
     cfg = load_config(tmp_path)
     assert cfg.experimental_enabled is True
@@ -607,7 +599,6 @@ def test_project_config_override_beats_auto_detect(
 
     from autoskillit.config.settings import load_config
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     config_dir = tmp_path / ".autoskillit"
     config_dir.mkdir()
@@ -624,7 +615,6 @@ def test_user_config_override_beats_auto_detect(monkeypatch: pytest.MonkeyPatch,
 
     from autoskillit.config.settings import load_config
 
-    monkeypatch.delenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", raising=False)
     monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     fake_home = tmp_path / "home"
     user_config_dir = fake_home / ".autoskillit"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,6 +225,36 @@ def _clear_skip_stale_check_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _clear_features_env(monkeypatch):
+    """Clear ALL AUTOSKILLIT_FEATURES__* env vars before every test.
+
+    Dynaconf reads env vars with prefix AUTOSKILLIT_ and injects them
+    into the config dict at the highest priority layer. Feature-related
+    env vars (AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED, FLEET, etc.)
+    override the is_dev_install() auto-detection and config file values,
+    breaking test isolation when CI sets these vars.
+
+    Uses prefix-based scanning so new feature env vars are automatically
+    covered without needing individual fixture additions.
+    """
+    for key in list(os.environ):
+        if key.startswith("AUTOSKILLIT_FEATURES__"):
+            monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clear_test_filter_env(monkeypatch):
+    """Clear AUTOSKILLIT_TEST_FILTER and related env vars before every test.
+
+    These env vars control test filtering behavior in CI and must not
+    leak between tests or affect tests that don't explicitly need them.
+    """
+    monkeypatch.delenv("AUTOSKILLIT_TEST_FILTER", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_TEST_BASE_REF", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_FILTER_STATS_FILE", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _reset_mcp_visibility():
     import sys
 

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -385,8 +385,12 @@ class TestCIEnvVarIsolation:
 
         missing = []
         for var in sorted(ci_env_vars):
-            prefix = var.rsplit("__", 1)[0] + "__"
-            if var not in conftest_text and prefix not in conftest_text:
+            if "__" in var:
+                prefix = var.rsplit("__", 1)[0] + "__"
+                covered = var in conftest_text or prefix in conftest_text
+            else:
+                covered = var in conftest_text
+            if not covered:
                 missing.append(var)
 
         assert not missing, (

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -383,15 +383,11 @@ class TestCIEnvVarIsolation:
                             var_name = "AUTOSKILLIT_" + parts[1].split("=")[0]
                             ci_env_vars.add(var_name.strip())
 
-        # For each CI env var, verify conftest has cleanup
         missing = []
         for var in sorted(ci_env_vars):
-            # Check for exact delenv OR prefix-based cleanup
-            if var not in conftest_text and var.split("__")[0] + "__" not in conftest_text:
-                # Check if a prefix-based loop covers it
-                prefix = var.rsplit("__", 1)[0] + "__"
-                if prefix not in conftest_text:
-                    missing.append(var)
+            prefix = var.rsplit("__", 1)[0] + "__"
+            if var not in conftest_text and prefix not in conftest_text:
+                missing.append(var)
 
         assert not missing, (
             f"CI env vars missing conftest cleanup: {missing}. "
@@ -422,7 +418,7 @@ class TestSetupUvVersionPin:
                                 f"{wf_path.name}:{job_name}: uses 'uv-version' "
                                 f"(output) instead of 'version' (input)"
                             )
-                        if "version" not in with_block:
+                        elif "version" not in with_block:
                             violations.append(f"{wf_path.name}:{job_name}: missing 'version' pin")
 
         assert not violations, "setup-uv version pin violations:\n" + "\n".join(violations)

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -15,6 +15,7 @@ import yaml
 REPO_ROOT = Path(__file__).parent.parent.parent
 PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+CONFTEST_PATH = REPO_ROOT / "tests" / "conftest.py"
 
 
 class TestPreCommitConfig:
@@ -311,3 +312,117 @@ class TestPtyTestGuard:
             'test_process_pty.py does not use shutil.which("script") — '
             "test_pty_wrapper_provides_tty needs a skipif guard for missing script binary"
         )
+
+
+class TestCIWorkflowExpressions:
+    def test_ci_experimental_expression_covers_merge_group(self):
+        """The AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED expression must
+        handle merge_group events, not just pull_request.
+
+        Without merge_group handling, the expression evaluates to 'false'
+        in the merge queue for develop-targeting PRs, incorrectly disabling
+        experimental features.
+        """
+        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        jobs = workflow["jobs"]
+        test_job = jobs["test"]
+
+        # Find the Run tests step
+        run_step = None
+        for step in test_job["steps"]:
+            if step.get("name") == "Run tests":
+                run_step = step
+                break
+
+        assert run_step is not None, "Run tests step not found"
+
+        # Check env block for AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED
+        env_block = run_step.get("env", {})
+        exp_val = env_block.get("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED")
+
+        assert exp_val is not None, (
+            "AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED must be set in the "
+            "Run tests step env block"
+        )
+
+        exp_str = str(exp_val)
+        assert "merge_group" in exp_str, (
+            "AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED expression must "
+            "handle merge_group events. Current expression: " + exp_str
+        )
+
+
+class TestCIEnvVarIsolation:
+    """Verify that every AUTOSKILLIT_* env var set in CI has a
+    corresponding cleanup mechanism in the test conftest."""
+
+    def test_ci_env_vars_have_conftest_cleanup(self):
+        """Every AUTOSKILLIT_* env var set in CI workflow env blocks
+        must have a corresponding monkeypatch.delenv autouse fixture
+        in tests/conftest.py, OR be covered by a prefix-based cleanup.
+
+        This prevents Dynaconf env var leakage into tests.
+        """
+        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        conftest_text = CONFTEST_PATH.read_text()
+
+        # Collect all AUTOSKILLIT_* env vars from CI
+        ci_env_vars = set()
+        for job in workflow["jobs"].values():
+            for step in job.get("steps", []):
+                env = step.get("env", {})
+                for key in env:
+                    if key.startswith("AUTOSKILLIT_"):
+                        ci_env_vars.add(key)
+                run_block = step.get("run", "")
+                # Also check inline exports
+                for line in run_block.splitlines():
+                    if "export AUTOSKILLIT_" in line:
+                        parts = line.split("AUTOSKILLIT_", 1)
+                        if len(parts) > 1:
+                            var_name = "AUTOSKILLIT_" + parts[1].split("=")[0]
+                            ci_env_vars.add(var_name.strip())
+
+        # For each CI env var, verify conftest has cleanup
+        missing = []
+        for var in sorted(ci_env_vars):
+            # Check for exact delenv OR prefix-based cleanup
+            if var not in conftest_text and var.split("__")[0] + "__" not in conftest_text:
+                # Check if a prefix-based loop covers it
+                prefix = var.rsplit("__", 1)[0] + "__"
+                if prefix not in conftest_text:
+                    missing.append(var)
+
+        assert not missing, (
+            f"CI env vars missing conftest cleanup: {missing}. "
+            "Add a monkeypatch.delenv autouse fixture in tests/conftest.py "
+            "or extend a prefix-based cleanup fixture."
+        )
+
+
+class TestSetupUvVersionPin:
+    def test_setup_uv_version_pin_all_workflows(self):
+        """Every workflow file that uses setup-uv must use the 'version'
+        input parameter, not 'uv-version' (which is an output, not an input).
+
+        This extends the existing test_setup_uv_action_has_version_pin to
+        cover ALL workflow files, not just tests.yml.
+        """
+        workflows_dir = CI_WORKFLOW.parent
+        violations = []
+        for wf_path in sorted(workflows_dir.glob("*.yml")):
+            workflow = yaml.safe_load(wf_path.read_text())
+            for job_name, job in workflow.get("jobs", {}).items():
+                for step in job.get("steps", []):
+                    uses = step.get("uses", "")
+                    if "setup-uv" in uses:
+                        with_block = step.get("with", {})
+                        if "uv-version" in with_block:
+                            violations.append(
+                                f"{wf_path.name}:{job_name}: uses 'uv-version' "
+                                f"(output) instead of 'version' (input)"
+                            )
+                        if "version" not in with_block:
+                            violations.append(f"{wf_path.name}:{job_name}: missing 'version' pin")
+
+        assert not violations, "setup-uv version pin violations:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary

The test suite lacks systematic protection against Dynaconf environment variable leakage from CI. Tests mock internal Python functions (`is_dev_install()`) but Dynaconf reads `AUTOSKILLIT_*` env vars at a layer *above* the mock point, short-circuiting the mocked function entirely. The existing env var cleanup pattern in `tests/conftest.py` is ad-hoc (4 individually named fixtures) and fails by omission — every new CI env var requires a manually-added fixture, with no enforcement that this happens.

The architectural solution introduces three immunity layers: (1) a prefix-based autouse fixture that clears ALL `AUTOSKILLIT_FEATURES__*` env vars automatically, providing forward-looking coverage for any new feature flag; (2) an arch enforcement test validating that CI workflow expressions cover all trigger event types; (3) a CI-to-test isolation contract test that cross-references CI env vars against conftest cleanup fixtures, making omissions fail loudly at test time.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.


Closes #2266

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260508-215626-177121/.autoskillit/temp/rectify/rectify_ci_expression_experimental_enabled_merge_group_2026-05-08_221055.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 2.6k | 13.5k | 897.0k | 64.8k | 136 | 55.4k | 8m 55s |
| rectify | claude-sonnet-4-6 | 1 | 56 | 14.1k | 575.8k | 99.0k | 171 | 71.6k | 9m 32s |
| dry_walkthrough | claude-opus-4-6 | 1 | 39 | 9.4k | 1.0M | 61.7k | 59 | 48.6k | 4m 24s |
| implement* | MiniMax-M2.7-highspeed | 1 | 864.0k | 11.0k | 752.5k | 34.0k | 71 | 116.4k | 3m 35s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 90.9k | 3.6k | 172.4k | 28.7k | 19 | 41.2k | 1m 25s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.2k | 1.3k | 143.7k | 28.7k | 13 | 40.9k | 41s |
| review_pr | claude-sonnet-4-6 | 2 | 202 | 51.1k | 946.9k | 77.0k | 70 | 106.8k | 17m 39s |
| resolve_review | claude-sonnet-4-6 | 2 | 380 | 27.3k | 2.3M | 72.9k | 116 | 103.5k | 16m 1s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 91 | 2.2k | 343.9k | 38.7k | 26 | 25.7k | 52s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 2 | 1.0M | 9.5k | 1.9M | 29.8k | 136 | 83.9k | 5m 29s |
| resolve_ci | claude-sonnet-4-6 | 2 | 254 | 9.9k | 1.1M | 48.4k | 75 | 64.3k | 10m 26s |
| **Total** | | | 2.0M | 152.9k | 10.1M | 99.0k | | 758.3k | 1h 19m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 182 | 4134.7 | 639.5 | 60.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 30 | 76592.3 | 3451.2 | 908.6 |
| ci_conflict_fix | 634 | 542.4 | 40.5 | 3.5 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 1 | 1089286.0 | 64272.0 | 9860.0 |
| **Total** | **847** | 11949.1 | 895.3 | 180.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 2.9k | 39.9k | 2.4M | 198.4k | 33m 52s |
| claude-opus-4-6 | 1 | 39 | 9.4k | 1.0M | 48.6k | 4m 24s |
| MiniMax-M2.7-highspeed | 3 | 992.1k | 15.9k | 1.1M | 198.6k | 5m 41s |