### PR TITLE
Rectify: Campaign Capture-Lineage Immunity — sentinel validation and runtime guards

### DIFF
--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -4,8 +4,8 @@ Gateway exports per REQ-IMP-001 — consumers import from
 ``autoskillit.fleet``, not from sub-modules.
 """
 
+from ._api import CaptureCompletenessError, classify_dispatch_outcome, execute_dispatch
 from ._api import _write_pid as _write_pid
-from ._api import classify_dispatch_outcome, execute_dispatch
 from ._checkpoint_bridge import checkpoint_from_sidecar
 from ._liveness import is_dispatch_session_alive
 from ._prompts import _build_admiral_dispatch_block as _build_admiral_dispatch_block
@@ -70,6 +70,7 @@ from .summary import (
 
 __all__ = [
     "_write_pid",
+    "CaptureCompletenessError",
     "classify_dispatch_outcome",
     "execute_dispatch",
     "_build_food_truck_prompt",

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -73,7 +73,7 @@ def _extract_captures(
         else:
             logger.warning(
                 "capture_field_missing_from_payload",
-                capture_key=key,
+                capture_name=key,
                 expected_field=field_name,
                 available_fields=sorted(str(k) for k in payload.keys()),
             )

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -39,6 +39,11 @@ logger = get_logger(__name__)
 
 ENVELOPE_STDERR_MAX = 2000
 
+
+class CaptureCompletenessError(RuntimeError):
+    """Raised when a capture spec extracts zero fields from the payload."""
+
+
 _CAMPAIGN_REF_RE = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
 _RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
 
@@ -50,17 +55,34 @@ def _extract_captures(
     """Extract captured values from an L3 result payload.
 
     For each entry in `capture_spec` whose value matches ``${{ result.field }}``,
-    reads `payload[field]` and converts it to str. Missing payload keys are skipped.
+    reads `payload[field]` and converts it to str. Missing payload keys are logged
+    as warnings. If the capture spec has entries but all fields are absent from the
+    payload, raises CaptureCompletenessError.
     """
     result: dict[str, str] = {}
+    expected_fields: list[str] = []
     for key, template in capture_spec.items():
         m = _RESULT_REF_RE.match(template.strip())
         if m is None:
             continue
         field_name = m.group(1)
+        expected_fields.append(field_name)
         if field_name in payload:
             value = payload[field_name]
             result[key] = value if isinstance(value, str) else json.dumps(value, default=str)
+        else:
+            logger.warning(
+                "capture_field_missing_from_payload",
+                capture_key=key,
+                expected_field=field_name,
+                available_fields=sorted(str(k) for k in payload.keys()),
+            )
+    if expected_fields and not result:
+        raise CaptureCompletenessError(
+            f"Capture spec expected fields {expected_fields} but none were "
+            f"present in payload. Available: {sorted(str(k) for k in payload.keys())}. "
+            f"This indicates a sentinel/capture misalignment."
+        )
     return result
 
 

--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -601,7 +601,7 @@ def _check_dispatch_capture_value_references_result(ctx: ValidationContext) -> l
 @semantic_rule(
     name="dispatch-capture-field-in-sentinel",
     description="Captured result fields should appear in target recipe's sentinel message",
-    severity=Severity.WARNING,
+    severity=Severity.ERROR,
 )
 def _check_dispatch_capture_field_in_sentinel(ctx: ValidationContext) -> list[RuleFinding]:
     if ctx.recipe.kind != RecipeKind.CAMPAIGN:
@@ -625,7 +625,7 @@ def _check_dispatch_capture_field_in_sentinel(ctx: ValidationContext) -> list[Ru
                 findings.append(
                     RuleFinding(
                         rule="dispatch-capture-field-in-sentinel",
-                        severity=Severity.WARNING,
+                        severity=Severity.ERROR,
                         step_name="(top-level)",
                         message=(
                             f"Dispatch {d.name!r} captures {cap_key!r} as "
@@ -633,6 +633,76 @@ def _check_dispatch_capture_field_in_sentinel(ctx: ValidationContext) -> list[Ru
                             f"{d.recipe!r} has no sentinel stop step listing "
                             f"field {field_name!r}. "
                             f"Known sentinel fields: {sorted(sentinel_fields)}."
+                        ),
+                    )
+                )
+    return findings
+
+
+def _extract_sentinel_fields_per_stop(recipe: Recipe) -> list[frozenset[str]]:
+    """Extract field sets from each individual sentinel stop step.
+
+    Returns a list of frozensets, one per sentinel stop, rather than
+    the union. This enables per-path validation.
+    """
+    per_stop: list[frozenset[str]] = []
+    for step in recipe.steps.values():
+        if step.action != "stop" or not step.message:
+            continue
+        if "sentinel" not in step.message.lower():
+            continue
+        fields: set[str] = set()
+        for match in _SENTINEL_JSON_RE.finditer(step.message):
+            try:
+                parsed = json.loads(match.group(1))
+                if isinstance(parsed, dict):
+                    fields.update(parsed.keys())
+            except (json.JSONDecodeError, ValueError):
+                continue
+        if fields:
+            per_stop.append(frozenset(fields))
+    return per_stop
+
+
+@semantic_rule(
+    name="dispatch-capture-field-in-all-sentinels",
+    description="Captured result fields must appear in ALL sentinel stop paths of target recipe",
+    severity=Severity.ERROR,
+)
+def _check_dispatch_capture_field_in_all_sentinels(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings: list[RuleFinding] = []
+    for d in ctx.recipe.dispatches:
+        if d.gate or not d.capture:
+            continue
+        target = _load_dispatch_target(d, ctx.project_dir)
+        if target is None:
+            continue
+        per_stop = _extract_sentinel_fields_per_stop(target)
+        if len(per_stop) < 2:
+            continue
+        for cap_key, cap_val in d.capture.items():
+            match = _RESULT_FIELD_RE.match(cap_val.strip())
+            if not match:
+                continue
+            field_name = match.group(1)
+            missing_in = [i for i, fields in enumerate(per_stop) if field_name not in fields]
+            if missing_in:
+                findings.append(
+                    RuleFinding(
+                        rule="dispatch-capture-field-in-all-sentinels",
+                        severity=Severity.ERROR,
+                        step_name="(top-level)",
+                        message=(
+                            f"Dispatch {d.name!r} captures {cap_key!r} as "
+                            f"${{{{ result.{field_name} }}}} but not all sentinel "
+                            f"stop paths in target recipe {d.recipe!r} emit "
+                            f"field {field_name!r}. The field is missing from "
+                            f"{len(missing_in)} of {len(per_stop)} sentinel paths. "
+                            f"All sentinel paths must emit all captured fields."
                         ),
                     )
                 )

--- a/src/autoskillit/recipe/rules/rules_food_truck.py
+++ b/src/autoskillit/recipe/rules/rules_food_truck.py
@@ -11,7 +11,7 @@ from autoskillit.recipe.schema import RecipeKind
 @semantic_rule(
     name="food-truck-has-sentinel-stop",
     description="Food-truck recipes must have a stop step referencing L3 sentinel",
-    severity=Severity.WARNING,
+    severity=Severity.ERROR,
 )
 def _check_food_truck_has_sentinel_stop(ctx: ValidationContext) -> list[RuleFinding]:
     if ctx.recipe.kind != RecipeKind.FOOD_TRUCK:
@@ -22,7 +22,7 @@ def _check_food_truck_has_sentinel_stop(ctx: ValidationContext) -> list[RuleFind
     return [
         RuleFinding(
             rule="food-truck-has-sentinel-stop",
-            severity=Severity.WARNING,
+            severity=Severity.ERROR,
             step_name="(top-level)",
             message=(
                 "Food-truck recipe has no stop step referencing L3 sentinel. "

--- a/src/autoskillit/recipes/research-archive.json
+++ b/src/autoskillit/recipes/research-archive.json
@@ -127,7 +127,7 @@
     },
     "research_complete": {
       "action": "stop",
-      "message": "Research archival complete. Artifacts separated into a dedicated PR, experiment branch tagged and preserved, original PR closed with cross-references to the artifact PR and archive tag.\n"
+      "message": "Research archival complete. Artifacts separated into a dedicated PR, experiment branch tagged and preserved, original PR closed with cross-references to the artifact PR and archive tag. Emit the L3 result sentinel JSON block now. The sentinel must include: success=true. Example sentinel: {\"success\": true}"
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/research-archive.yaml
+++ b/src/autoskillit/recipes/research-archive.yaml
@@ -121,10 +121,14 @@ steps:
 
   research_complete:
     action: stop
-    message: >
+    message: >-
       Research archival complete. Artifacts separated into a dedicated PR,
       experiment branch tagged and preserved, original PR closed with
       cross-references to the artifact PR and archive tag.
+      Emit the L3 result sentinel JSON block now.
+      The sentinel must include: success=true.
+      Example sentinel:
+      {"success": true}
 
   escalate_stop:
     action: stop

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -473,7 +473,7 @@
     },
     "review_local_complete": {
       "action": "stop",
-      "message": "Review phase complete (local mode). Local bundle exported successfully. Emit the L3 result sentinel JSON block now. The sentinel must include: success=true, local_bundle_path=${{ context.local_bundle_path }}. Example sentinel: {\"success\": true, \"local_bundle_path\": \"<path>\"}"
+      "message": "Review phase complete (local mode). Local bundle exported successfully. Emit the L3 result sentinel JSON block now. The sentinel must include: success=true, local_bundle_path=${{ context.local_bundle_path }}, pr_url=\"\" (empty string — no PR in local mode), report_path_after_finalize=\"\" (empty string — no finalization in local mode). Example sentinel: {\"success\": true, \"local_bundle_path\": \"<path>\", \"pr_url\": \"\", \"report_path_after_finalize\": \"\"}"
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -462,9 +462,11 @@ steps:
       Review phase complete (local mode). Local bundle exported successfully.
       Emit the L3 result sentinel JSON block now.
       The sentinel must include: success=true,
-      local_bundle_path=${{ context.local_bundle_path }}.
+      local_bundle_path=${{ context.local_bundle_path }},
+      pr_url="" (empty string — no PR in local mode),
+      report_path_after_finalize="" (empty string — no finalization in local mode).
       Example sentinel:
-      {"success": true, "local_bundle_path": "<path>"}
+      {"success": true, "local_bundle_path": "<path>", "pr_url": "", "report_path_after_finalize": ""}
 
   escalate_stop:
     action: stop

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -565,7 +565,9 @@ def test_extract_captures_logs_warning_for_missing_spec_keys():
 
     assert "pr_url" in result
     assert "report_path" not in result
-    assert any(entry.get("expected_field") == "report_path" for entry in logs)
+    assert any(
+        e.get("log_level") == "warning" and e.get("expected_field") == "report_path" for e in logs
+    )
 
 
 def test_extract_captures_raises_on_complete_capture_miss():

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -548,11 +548,6 @@ async def test_unresolved_campaign_ref_in_ingredients_returns_fleet_error(tool_c
     assert "error" in result
 
 
-# ---------------------------------------------------------------------------
-# Capture completeness tests
-# ---------------------------------------------------------------------------
-
-
 def test_extract_captures_logs_warning_for_missing_spec_keys():
     """_extract_captures must log a WARNING for every capture spec key
     whose result field is absent from the payload, rather than silently skipping.
@@ -592,16 +587,3 @@ def test_extract_captures_raises_on_complete_capture_miss():
 
     with pytest.raises(CaptureCompletenessError):
         _extract_captures(capture_spec, payload)
-
-
-def test_extract_captures_missing_field_raises_completeness_error():
-    """When the only capture spec field is absent, CaptureCompletenessError is raised."""
-    import pytest
-
-    from autoskillit.fleet._api import CaptureCompletenessError, _extract_captures
-
-    with pytest.raises(CaptureCompletenessError):
-        _extract_captures(
-            {"missing_key": "${{ result.missing_key }}"},
-            {"other": "value"},
-        )

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -25,9 +25,7 @@ def test_extract_captures_from_payload():
     assert result == {"sources_manifest": "/tmp/sources.json"}
 
 
-def test_extract_captures_missing_field_skipped():
-    import pytest
-
+def test_extract_captures_all_fields_missing_raises():
     from autoskillit.fleet._api import CaptureCompletenessError, _extract_captures
 
     with pytest.raises(CaptureCompletenessError):
@@ -575,8 +573,6 @@ def test_extract_captures_raises_on_complete_capture_miss():
     _extract_captures must raise CaptureCompletenessError rather than
     returning an empty dict that silently poisons the campaign state.
     """
-    import pytest
-
     from autoskillit.fleet._api import CaptureCompletenessError, _extract_captures
 
     capture_spec = {

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -26,13 +26,15 @@ def test_extract_captures_from_payload():
 
 
 def test_extract_captures_missing_field_skipped():
-    from autoskillit.fleet._api import _extract_captures
+    import pytest
 
-    result = _extract_captures(
-        {"missing_key": "${{ result.missing_key }}"},
-        {"other": "value"},
-    )
-    assert "missing_key" not in result
+    from autoskillit.fleet._api import CaptureCompletenessError, _extract_captures
+
+    with pytest.raises(CaptureCompletenessError):
+        _extract_captures(
+            {"missing_key": "${{ result.missing_key }}"},
+            {"other": "value"},
+        )
 
 
 def test_extract_captures_non_result_template_skipped():
@@ -544,3 +546,62 @@ async def test_unresolved_campaign_ref_in_ingredients_returns_fleet_error(tool_c
     result = json.loads(raw.to_envelope())
     assert result["success"] is False
     assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Capture completeness tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_captures_logs_warning_for_missing_spec_keys():
+    """_extract_captures must log a WARNING for every capture spec key
+    whose result field is absent from the payload, rather than silently skipping.
+    """
+    import structlog
+
+    from autoskillit.fleet._api import _extract_captures
+
+    capture_spec = {
+        "pr_url": "${{ result.pr_url }}",
+        "report_path": "${{ result.report_path }}",
+    }
+    payload = {"pr_url": "https://github.com/..."}  # report_path absent
+
+    with structlog.testing.capture_logs() as logs:
+        result = _extract_captures(capture_spec, payload)
+
+    assert "pr_url" in result
+    assert "report_path" not in result
+    assert any(entry.get("expected_field") == "report_path" for entry in logs)
+
+
+def test_extract_captures_raises_on_complete_capture_miss():
+    """When ALL capture spec fields are absent from the payload,
+    _extract_captures must raise CaptureCompletenessError rather than
+    returning an empty dict that silently poisons the campaign state.
+    """
+    import pytest
+
+    from autoskillit.fleet._api import CaptureCompletenessError, _extract_captures
+
+    capture_spec = {
+        "pr_url": "${{ result.pr_url }}",
+        "report_path": "${{ result.report_path }}",
+    }
+    payload = {"success": True}  # No captured fields present at all
+
+    with pytest.raises(CaptureCompletenessError):
+        _extract_captures(capture_spec, payload)
+
+
+def test_extract_captures_missing_field_raises_completeness_error():
+    """When the only capture spec field is absent, CaptureCompletenessError is raised."""
+    import pytest
+
+    from autoskillit.fleet._api import CaptureCompletenessError, _extract_captures
+
+    with pytest.raises(CaptureCompletenessError):
+        _extract_captures(
+            {"missing_key": "${{ result.missing_key }}"},
+            {"other": "value"},
+        )

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -255,12 +255,15 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     campaign_path = builtin_recipes_dir() / "campaigns" / "research-campaign.yaml"
     campaign = load_recipe(campaign_path)
 
+    from autoskillit.fleet import FleetSemaphore
+
     repo = InMemoryRecipeRepository()
     for dispatch in campaign.dispatches:
+        recipe_path = builtin_recipes_dir() / f"{dispatch.recipe}.yaml"
+        actual_recipe = load_recipe(recipe_path)
         info = _make_recipe_info(dispatch.recipe)
         repo.add_recipe(dispatch.recipe, info)
-
-    from autoskillit.fleet import FleetSemaphore
+        repo.add_full_recipe(info.path, actual_recipe)
 
     tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=4)
     tool_ctx.recipes = repo

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -260,7 +260,9 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
         info = _make_recipe_info(dispatch.recipe)
         repo.add_recipe(dispatch.recipe, info)
 
-    tool_ctx.fleet_lock = None  # Not needed for single-dispatch sequencing
+    from autoskillit.fleet import FleetSemaphore
+
+    tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=4)
     tool_ctx.recipes = repo
     tool_ctx.executor = InMemoryHeadlessExecutor()
 
@@ -516,4 +518,3 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     assert captured_during_archive["pr_url"] == "https://github.com/example/repo/pull/123"
     assert captured_during_archive["worktree_path"] == "/tmp/wt/proj"
     assert captured_during_archive["research_dir"] == "/tmp/wt/proj/.research"
-    assert "campaign.research_dir" in result["user_visible_message"]

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -397,12 +397,15 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
 
     # Update accumulated captures
     state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
-    assert len(state_files) == 2
     impl_state = next(
-        f
-        for f in state_files
-        if json.loads(f.read_text()).get("campaign_name") == "research-implement"
+        (
+            f
+            for f in state_files
+            if json.loads(f.read_text()).get("campaign_name") == "research-implement"
+        ),
+        None,
     )
+    assert impl_state is not None, "research-implement dispatch state file not found"
     impl_data = json.loads(impl_state.read_text())
     accumulated.update(impl_data.get("captured_values", {}))
 
@@ -475,10 +478,14 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     # Update accumulated captures
     state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
     review_state = next(
-        f
-        for f in state_files
-        if json.loads(f.read_text()).get("campaign_name") == "research-review"
+        (
+            f
+            for f in state_files
+            if json.loads(f.read_text()).get("campaign_name") == "research-review"
+        ),
+        None,
     )
+    assert review_state is not None, "research-review dispatch state file not found"
     review_data = json.loads(review_state.read_text())
     accumulated.update(review_data.get("captured_values", {}))
 

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -272,7 +272,6 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     dispatch_names = [d.name for d in campaign.dispatches]
     assert dispatch_names == ["run-design", "run-implement", "run-review", "run-archive"]
 
-    # Track accumulated captures across dispatches
     accumulated: dict[str, str] = {}
 
     # Step 1: run-design
@@ -399,8 +398,11 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     # Update accumulated captures
     state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
     assert len(state_files) == 2
-    # Find most recent
-    impl_state = max(state_files, key=lambda f: f.stat().st_mtime)
+    impl_state = next(
+        f
+        for f in state_files
+        if json.loads(f.read_text()).get("campaign_name") == "research-implement"
+    )
     impl_data = json.loads(impl_state.read_text())
     accumulated.update(impl_data.get("captured_values", {}))
 
@@ -472,7 +474,11 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
 
     # Update accumulated captures
     state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
-    review_state = max(state_files, key=lambda f: f.stat().st_mtime)
+    review_state = next(
+        f
+        for f in state_files
+        if json.loads(f.read_text()).get("campaign_name") == "research-review"
+    )
     review_data = json.loads(review_state.read_text())
     accumulated.update(review_data.get("captured_values", {}))
 

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -229,4 +229,291 @@ async def test_partial_capture_propagates_only_captured_keys(tool_ctx, monkeypat
     result = json.loads(raw.to_envelope())
     assert result["success"] is False
     assert "error" in result
+
+
+@pytest.mark.anyio
+async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, monkeypatch):
+    """Run all four research campaign dispatches in sequence and verify
+    that every campaign.* reference is resolvable from prior captures.
+
+    This is the integration-level guard against phantom captures: if any
+    dispatch emits a sentinel missing a field that a downstream dispatch
+    references via campaign.*, this test fails.
+    """
+    from autoskillit.fleet._api import execute_dispatch
+    from autoskillit.fleet.result_parser import L3ParseResult
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+    from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+    from ._helpers import (
+        _make_recipe_info,
+        _no_sleep_quota_checker,
+        _noop_quota_refresher,
+    )
+
+    # Load the actual campaign and set up in-memory repo with all sub-recipes
+    campaign_path = builtin_recipes_dir() / "campaigns" / "research-campaign.yaml"
+    campaign = load_recipe(campaign_path)
+
+    repo = InMemoryRecipeRepository()
+    for dispatch in campaign.dispatches:
+        info = _make_recipe_info(dispatch.recipe)
+        repo.add_recipe(dispatch.recipe, info)
+
+    tool_ctx.fleet_lock = None  # Not needed for single-dispatch sequencing
+    tool_ctx.recipes = repo
+    tool_ctx.executor = InMemoryHeadlessExecutor()
+
+    dispatch_names = [d.name for d in campaign.dispatches]
+    assert dispatch_names == ["run-design", "run-implement", "run-review", "run-archive"]
+
+    # Track accumulated captures across dispatches
+    accumulated: dict[str, str] = {}
+
+    # Step 1: run-design
+    def _make_design_result(**_):
+        return L3ParseResult(
+            outcome="completed_clean",
+            payload={
+                "success": True,
+                "worktree_path": "/tmp/wt/proj",
+                "research_dir": "/tmp/wt/proj/.research",
+                "experiment_plan": "/tmp/wt/proj/.research/plan.md",
+                "visualization_plan_path": "/tmp/wt/proj/.research/vis.md",
+                "scope_report": "/tmp/wt/proj/.research/scope.md",
+                "experiment_type": "observational",
+            },
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        )
+
+    monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _make_design_result)
+
+    captured_during_design: dict = {}
+
+    def _capture_prompt_builder(**kwargs):
+        captured_during_design.update(kwargs.get("ingredients", {}))
+        return "prompt"
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-design",
+        task="Design the research",
+        ingredients={
+            "task": "do it",
+            "issue_url": "",
+            "source_dir": "",
+            "base_branch": "main",
+            "review_design": "false",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={
+            "worktree_path": "${{ result.worktree_path }}",
+            "research_dir": "${{ result.research_dir }}",
+            "experiment_plan": "${{ result.experiment_plan }}",
+            "visualization_plan_path": "${{ result.visualization_plan_path }}",
+            "scope_report": "${{ result.scope_report }}",
+            "experiment_type": "${{ result.experiment_type }}",
+        },
+        prompt_builder=_capture_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    result = json.loads(raw.to_envelope())
+    assert result["success"] is True, f"run-design failed: {result}"
+
+    # Verify design captures
+    state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    assert len(state_files) == 1
+    design_state = json.loads(state_files[0].read_text())
+    accumulated.update(design_state.get("captured_values", {}))
+
+    assert accumulated["worktree_path"] == "/tmp/wt/proj"
+    assert accumulated["research_dir"] == "/tmp/wt/proj/.research"
+    assert accumulated["experiment_plan"] == "/tmp/wt/proj/.research/plan.md"
+    assert accumulated["experiment_type"] == "observational"
+
+    # Step 2: run-implement
+    def _make_implement_result(**_):
+        return L3ParseResult(
+            outcome="completed_clean",
+            payload={
+                "success": True,
+                "report_path": "/tmp/wt/proj/.research/report.md",
+                "experiment_results": "/tmp/wt/proj/.research/results.json",
+            },
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        )
+
+    monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _make_implement_result)
+
+    captured_during_implement: dict = {}
+
+    def _implement_prompt_builder(**kwargs):
+        captured_during_implement.update(kwargs.get("ingredients", {}))
+        return "prompt"
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-implement",
+        task="Implement the research",
+        ingredients={
+            "task": "do it",
+            "worktree_path": "${{ campaign.worktree_path }}",
+            "research_dir": "${{ campaign.research_dir }}",
+            "experiment_plan": "${{ campaign.experiment_plan }}",
+            "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
+            "source_dir": "",
+            "base_branch": "main",
+            "issue_url": "",
+            "output_mode": "pr",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={
+            "report_path": "${{ result.report_path }}",
+            "experiment_results": "${{ result.experiment_results }}",
+        },
+        prompt_builder=_implement_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    result = json.loads(raw.to_envelope())
+    assert result["success"] is True, f"run-implement failed: {result}"
+
+    # Verify implement resolved all campaign refs from design captures
+    assert captured_during_implement["worktree_path"] == "/tmp/wt/proj"
+    assert captured_during_implement["research_dir"] == "/tmp/wt/proj/.research"
+    assert captured_during_implement["experiment_plan"] == "/tmp/wt/proj/.research/plan.md"
+    assert captured_during_implement["visualization_plan_path"] == "/tmp/wt/proj/.research/vis.md"
+
+    # Update accumulated captures
+    state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    assert len(state_files) == 2
+    # Find most recent
+    impl_state = max(state_files, key=lambda f: f.stat().st_mtime)
+    impl_data = json.loads(impl_state.read_text())
+    accumulated.update(impl_data.get("captured_values", {}))
+
+    assert accumulated["report_path"] == "/tmp/wt/proj/.research/report.md"
+    assert accumulated["experiment_results"] == "/tmp/wt/proj/.research/results.json"
+
+    # Step 3: run-review (PR mode)
+    def _make_review_result(**_):
+        return L3ParseResult(
+            outcome="completed_clean",
+            payload={
+                "success": True,
+                "pr_url": "https://github.com/example/repo/pull/123",
+                "report_path_after_finalize": "/tmp/wt/proj/.research/final-report.md",
+            },
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        )
+
+    monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _make_review_result)
+
+    captured_during_review: dict = {}
+
+    def _review_prompt_builder(**kwargs):
+        captured_during_review.update(kwargs.get("ingredients", {}))
+        return "prompt"
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-review",
+        task="Review and open PR",
+        ingredients={
+            "task": "do it",
+            "experiment_results": "${{ campaign.experiment_results }}",
+            "experiment_type": "${{ campaign.experiment_type }}",
+            "scope_report": "${{ campaign.scope_report }}",
+            "worktree_path": "${{ campaign.worktree_path }}",
+            "research_dir": "${{ campaign.research_dir }}",
+            "experiment_plan": "${{ campaign.experiment_plan }}",
+            "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
+            "report_path": "${{ campaign.report_path }}",
+            "source_dir": "",
+            "base_branch": "main",
+            "issue_url": "",
+            "output_mode": "pr",
+            "review_pr": "true",
+            "audit_claims": "false",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={
+            "pr_url": "${{ result.pr_url }}",
+            "report_path_after_finalize": "${{ result.report_path_after_finalize }}",
+        },
+        prompt_builder=_review_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    result = json.loads(raw.to_envelope())
+    assert result["success"] is True, f"run-review failed: {result}"
+
+    # Verify review resolved all campaign refs from prior captures
+    assert captured_during_review["experiment_results"] == "/tmp/wt/proj/.research/results.json"
+    assert captured_during_review["experiment_type"] == "observational"
+    assert captured_during_review["scope_report"] == "/tmp/wt/proj/.research/scope.md"
+    assert captured_during_review["worktree_path"] == "/tmp/wt/proj"
+    assert captured_during_review["report_path"] == "/tmp/wt/proj/.research/report.md"
+
+    # Update accumulated captures
+    state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    review_state = max(state_files, key=lambda f: f.stat().st_mtime)
+    review_data = json.loads(review_state.read_text())
+    accumulated.update(review_data.get("captured_values", {}))
+
+    assert accumulated["pr_url"] == "https://github.com/example/repo/pull/123"
+    assert accumulated["report_path_after_finalize"] == "/tmp/wt/proj/.research/final-report.md"
+
+    # Step 4: run-archive (verifies pr_url from review is available)
+    def _make_archive_result(**_):
+        return L3ParseResult(
+            outcome="completed_clean",
+            payload={"success": True},
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        )
+
+    monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _make_archive_result)
+
+    captured_during_archive: dict = {}
+
+    def _archive_prompt_builder(**kwargs):
+        captured_during_archive.update(kwargs.get("ingredients", {}))
+        return "prompt"
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-archive",
+        task="Archive artifacts",
+        ingredients={
+            "base_branch": "main",
+            "worktree_path": "${{ campaign.worktree_path }}",
+            "research_dir": "${{ campaign.research_dir }}",
+            "pr_url": "${{ campaign.pr_url }}",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={},
+        prompt_builder=_archive_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    result = json.loads(raw.to_envelope())
+    assert result["success"] is True, f"run-archive failed: {result}"
+
+    # Verify archive resolved pr_url from review captures
+    assert captured_during_archive["pr_url"] == "https://github.com/example/repo/pull/123"
+    assert captured_during_archive["worktree_path"] == "/tmp/wt/proj"
+    assert captured_during_archive["research_dir"] == "/tmp/wt/proj/.research"
     assert "campaign.research_dir" in result["user_visible_message"]

--- a/tests/recipe/test_research_campaign_rules.py
+++ b/tests/recipe/test_research_campaign_rules.py
@@ -133,3 +133,17 @@ def test_run_archive_no_dead_ingredient_forwarding(campaign_recipe: Recipe) -> N
     assert run_arc is not None
     assert "all_diagram_paths" not in run_arc.ingredients
     assert "report_path_after_finalize" not in run_arc.ingredients
+
+
+def test_dispatch_capture_field_in_all_sentinels_contract_passes(validation_ctx) -> None:
+    """Per-sentinel-path validation: captures must appear in ALL sentinel paths, not just union.
+
+    Uses the existing module-scoped `validation_ctx` fixture.
+    """
+    findings = run_semantic_rules(validation_ctx)
+    all_sentinel_findings = [
+        f for f in findings if f.rule == "dispatch-capture-field-in-all-sentinels"
+    ]
+    assert all_sentinel_findings == [], (
+        f"Per-path sentinel validation failures: {all_sentinel_findings}"
+    )

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -1499,7 +1499,10 @@ def test_dispatch_capture_field_in_sentinel_severity_is_error():
     """
     from autoskillit.recipe.registry import _RULE_REGISTRY
 
-    rule = next(r for r in _RULE_REGISTRY if r.name == "dispatch-capture-field-in-sentinel")
+    rule = next(
+        (r for r in _RULE_REGISTRY if r.name == "dispatch-capture-field-in-sentinel"), None
+    )
+    assert rule is not None, "Rule 'dispatch-capture-field-in-sentinel' not found in registry"
     assert rule.severity == Severity.ERROR
 
 
@@ -1507,7 +1510,10 @@ def test_dispatch_capture_field_in_all_sentinels_severity_is_error():
     """Guard: dispatch-capture-field-in-all-sentinels must be ERROR, not WARNING."""
     from autoskillit.recipe.registry import _RULE_REGISTRY
 
-    rule = next(r for r in _RULE_REGISTRY if r.name == "dispatch-capture-field-in-all-sentinels")
+    rule = next(
+        (r for r in _RULE_REGISTRY if r.name == "dispatch-capture-field-in-all-sentinels"), None
+    )
+    assert rule is not None, "Rule 'dispatch-capture-field-in-all-sentinels' not found in registry"
     assert rule.severity == Severity.ERROR
 
 

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -1490,11 +1490,6 @@ def test_extract_sentinel_fields_handles_multiple_sentinels():
     assert fields == {"success", "alpha", "beta"}
 
 
-# ---------------------------------------------------------------------------
-# Severity-pinning contract tests
-# ---------------------------------------------------------------------------
-
-
 def test_dispatch_capture_field_in_sentinel_severity_is_error():
     """Guard: dispatch-capture-field-in-sentinel must be ERROR, not WARNING.
 

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -1220,7 +1220,7 @@ def test_dispatch_capture_field_in_sentinel_fires_on_unknown_field(tmp_path: Pat
     )
     found = _findings(recipe, "dispatch-capture-field-in-sentinel", project_dir=tmp_path)
     assert len(found) == 1
-    assert found[0].severity == Severity.WARNING
+    assert found[0].severity == Severity.ERROR
     assert "nonexistent_field" in found[0].message
 
 
@@ -1488,3 +1488,82 @@ def test_extract_sentinel_fields_handles_multiple_sentinels():
     )
     fields = _extract_sentinel_fields(recipe)
     assert fields == {"success", "alpha", "beta"}
+
+
+# ---------------------------------------------------------------------------
+# Severity-pinning contract tests
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_capture_field_in_sentinel_severity_is_error():
+    """Guard: dispatch-capture-field-in-sentinel must be ERROR, not WARNING.
+
+    Phantom captures that pass validation at WARNING severity caused
+    cascading runtime failures in campaign dispatch chains (see #2276).
+    This test prevents the severity from being downgraded.
+    """
+    from autoskillit.recipe.registry import _RULE_REGISTRY
+
+    rule = next(r for r in _RULE_REGISTRY if r.name == "dispatch-capture-field-in-sentinel")
+    assert rule.severity == Severity.ERROR
+
+
+def test_dispatch_capture_field_in_all_sentinels_severity_is_error():
+    """Guard: dispatch-capture-field-in-all-sentinels must be ERROR, not WARNING."""
+    from autoskillit.recipe.registry import _RULE_REGISTRY
+
+    rule = next(r for r in _RULE_REGISTRY if r.name == "dispatch-capture-field-in-all-sentinels")
+    assert rule.severity == Severity.ERROR
+
+
+def test_dispatch_capture_field_in_all_sentinels_fires_on_path_exclusive_field(tmp_path):
+    """A capture referencing a field emitted by only ONE sentinel path must fire ERROR.
+
+    Reproduces the review_local_complete gap: pr_url is emitted by
+    review_pr_complete but not review_local_complete. The union check
+    passes, but the per-path check must fail.
+    """
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    _write_recipe_yaml(
+        recipes_dir / "dual-sentinel-target.yaml",
+        {
+            "name": "dual-sentinel-target",
+            "description": "target with two sentinel paths",
+            "kind": "food-truck",
+            "kitchen_rules": ["NEVER"],
+            "ingredients": {"task": {"description": "t", "required": True}},
+            "steps": {
+                "path_a": {
+                    "action": "stop",
+                    "message": (
+                        "Emit the L3 result sentinel JSON block now. "
+                        'Example sentinel: {"success": true, "pr_url": "<url>", '
+                        '"report_path": "<path>"}'
+                    ),
+                },
+                "path_b": {
+                    "action": "stop",
+                    "message": (
+                        "Emit the L3 result sentinel JSON block now. "
+                        'Example sentinel: {"success": true, "local_path": "<path>"}'
+                    ),
+                },
+            },
+        },
+    )
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="dual-sentinel-target",
+                task="do it",
+                capture={"pr_url": "${{ result.pr_url }}"},
+            ),
+        ]
+    )
+    found = _findings(recipe, "dispatch-capture-field-in-all-sentinels", project_dir=tmp_path)
+    assert len(found) == 1
+    assert found[0].severity == Severity.ERROR
+    assert "pr_url" in found[0].message
+    assert "not all sentinel" in found[0].message.lower()

--- a/tests/recipe/test_rules_food_truck.py
+++ b/tests/recipe/test_rules_food_truck.py
@@ -83,11 +83,6 @@ def test_food_truck_has_sentinel_stop_rule_skips_standard():
     assert found == []
 
 
-# ---------------------------------------------------------------------------
-# Severity-pinning contract test
-# ---------------------------------------------------------------------------
-
-
 def test_food_truck_has_sentinel_stop_severity_is_error():
     """Guard: food-truck-has-sentinel-stop must be ERROR, not WARNING."""
     from autoskillit.recipe.registry import _RULE_REGISTRY

--- a/tests/recipe/test_rules_food_truck.py
+++ b/tests/recipe/test_rules_food_truck.py
@@ -87,5 +87,6 @@ def test_food_truck_has_sentinel_stop_severity_is_error():
     """Guard: food-truck-has-sentinel-stop must be ERROR, not WARNING."""
     from autoskillit.recipe.registry import _RULE_REGISTRY
 
-    rule = next(r for r in _RULE_REGISTRY if r.name == "food-truck-has-sentinel-stop")
+    rule = next((r for r in _RULE_REGISTRY if r.name == "food-truck-has-sentinel-stop"), None)
+    assert rule is not None, "Rule 'food-truck-has-sentinel-stop' not found in registry"
     assert rule.severity == Severity.ERROR

--- a/tests/recipe/test_rules_food_truck.py
+++ b/tests/recipe/test_rules_food_truck.py
@@ -52,7 +52,7 @@ def test_food_truck_has_sentinel_stop_rule_fires_on_missing_sentinel():
     )
     found = _findings(recipe, "food-truck-has-sentinel-stop")
     assert found
-    assert found[0].severity == Severity.WARNING
+    assert found[0].severity == Severity.ERROR
 
 
 # ---------------------------------------------------------------------------
@@ -81,3 +81,16 @@ def test_food_truck_has_sentinel_stop_rule_skips_standard():
     recipe = _standard_recipe()
     found = _findings(recipe, "food-truck-has-sentinel-stop")
     assert found == []
+
+
+# ---------------------------------------------------------------------------
+# Severity-pinning contract test
+# ---------------------------------------------------------------------------
+
+
+def test_food_truck_has_sentinel_stop_severity_is_error():
+    """Guard: food-truck-has-sentinel-stop must be ERROR, not WARNING."""
+    from autoskillit.recipe.registry import _RULE_REGISTRY
+
+    rule = next(r for r in _RULE_REGISTRY if r.name == "food-truck-has-sentinel-stop")
+    assert rule.severity == Severity.ERROR


### PR DESCRIPTION
## Summary

Campaign dispatch chains suffer from a class of bug where capture declarations reference sentinel fields that are absent at runtime — phantom captures, missing forwards, and multi-path sentinel field misalignment. The architecture has validation rules that detect these issues but they are advisory (WARNING severity), never block dispatch, and use union semantics that mask per-path field gaps. The runtime capture extractor silently skips missing payload fields, delaying failure to a downstream dispatch that may be hours later. This plan makes the architecture innately immune by: (1) elevating sentinel-capture rules to blocking ERROR severity, (2) introducing per-path sentinel field validation, (3) adding a runtime capture completeness assertion, and (4) establishing severity-pinning contract tests.

Closes #2276

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260509-085001-797476/.autoskillit/temp/rectify/rectify_campaign_capture_lineage_immunity_2026-05-09_085001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 64 | 9.0k | 873.6k | 81.6k | 193 | 58.3k | 8m 42s |
| rectify | claude-sonnet-4-6 | 1 | 49 | 15.0k | 785.6k | 101.5k | 138 | 59.3k | 13m 24s |
| dry_walkthrough | claude-opus-4-6 | 1 | 2.1k | 20.8k | 1.9M | 95.8k | 109 | 82.6k | 9m 33s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.7M | 22.6k | 2.2M | 84.9k | 176 | 157.6k | 8m 31s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 105.3k | 3.5k | 208.6k | 29.8k | 22 | 42.3k | 1m 12s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.0k | 1.3k | 175.9k | 29.8k | 13 | 15.1k | 36s |
| review_pr | claude-sonnet-4-6 | 3 | 1.8k | 111.3k | 1.4M | 92.0k | 149 | 266.5k | 27m 45s |
| resolve_review | claude-sonnet-4-6 | 3 | 909 | 68.1k | 7.7M | 112.4k | 277 | 245.3k | 44m 49s |
| **Total** | | | 2.9M | 251.6k | 15.2M | 112.4k | | 927.0k | 1h 54m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 584 | 3690.6 | 269.9 | 38.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 89 | 86359.7 | 2756.1 | 765.7 |
| **Total** | **673** | 22629.3 | 1377.4 | 373.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 481 | 45.9k | 4.6M | 204.7k | 32m 20s |
| claude-opus-4-6 | 1 | 2.1k | 20.8k | 1.9M | 82.6k | 9m 33s |
| MiniMax-M2.7-highspeed | 3 | 2.8M | 27.4k | 2.5M | 214.9k | 10m 19s |