### PR TITLE
[FIX] Rectify: SkillResult Field Propagation Immunity

### DIFF
--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -94,11 +94,7 @@ def _apply_budget_guard(
     audit: AuditLog | None,
     max_consecutive_retries: int,
 ) -> SkillResult:
-    """Override needs_retry to False when the consecutive-failure budget is exhausted.
-
-    The audit log records the raw failure (needs_retry=True) before this guard
-    runs; the guard is a post-processing filter on the returned SkillResult only.
-    """
+    """Override needs_retry to False when the consecutive-failure budget is exhausted."""
     if not sr.needs_retry or audit is None or not skill_command:
         return sr
     consecutive = audit.consecutive_failures(skill_command)
@@ -122,12 +118,7 @@ def _resolve_skill_session_id(
     session: ClaudeSessionResult | None,
     result: SubprocessResult,
 ) -> str:
-    """Return the best-available Claude session UUID.
-
-    Precedence: stdout-parsed session_id (Channel A) > transport-resolved
-    session_id (process.py) > Channel B JSONL filename stem.
-    Returns "" only when all sources are empty.
-    """
+    """Return the best-available Claude session UUID."""
     if session is not None and session.session_id:
         return session.session_id
     return result.session_id or result.channel_b_session_id
@@ -144,12 +135,7 @@ def _make_terminated_result(
     retry_reason: RetryReason,
     provider_used: str = "",
 ) -> SkillResult:
-    """Construct SkillResult for infrastructure-terminated sessions.
-
-    Centralizes field propagation for stale/idle_stall branches so that
-    kill_reason, token_usage, and other diagnostic fields cannot be
-    accidentally omitted.
-    """
+    """Construct SkillResult for infrastructure-terminated sessions (stale/idle_stall)."""
     return SkillResult(
         success=success,
         result=result_text,

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -133,6 +133,41 @@ def _resolve_skill_session_id(
     return result.session_id or result.channel_b_session_id
 
 
+def _make_terminated_result(
+    *,
+    result: SubprocessResult,
+    session: ClaudeSessionResult,
+    success: bool,
+    result_text: str,
+    subtype: str,
+    needs_retry: bool,
+    retry_reason: RetryReason,
+    provider_used: str = "",
+) -> SkillResult:
+    """Construct SkillResult for infrastructure-terminated sessions.
+
+    Centralizes field propagation for stale/idle_stall branches so that
+    kill_reason, token_usage, and other diagnostic fields cannot be
+    accidentally omitted.
+    """
+    return SkillResult(
+        success=success,
+        result=result_text,
+        session_id=session.session_id or _resolve_skill_session_id(session, result),
+        subtype=subtype,
+        is_error=session.is_error if success else False,
+        exit_code=result.returncode if result.returncode is not None else -1,
+        needs_retry=needs_retry,
+        retry_reason=retry_reason,
+        stderr=result.stderr if result.stderr else "",
+        token_usage=session.token_usage,
+        kill_reason=result.kill_reason,
+        last_stop_reason=session.last_stop_reason,
+        lifespan_started=session.lifespan_started,
+        provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
+    )
+
+
 def _build_skill_result(
     result: SubprocessResult,
     completion_marker: str = "",
@@ -187,21 +222,15 @@ def _build_skill_result(
                 logger.warning(
                     "Session went stale but stdout contained a valid result; recovering"
                 )
-                return SkillResult(
+                return _make_terminated_result(
+                    result=result,
+                    session=stale_session,
                     success=True,
-                    result=_truncate(stale_session.agent_result),
-                    session_id=stale_session.session_id or _resolve_skill_session_id(None, result),
+                    result_text=_truncate(stale_session.agent_result),
                     subtype="recovered_from_stale",
-                    is_error=False,
-                    exit_code=stale_returncode,
                     needs_retry=False,
                     retry_reason=RetryReason.NONE,
-                    stderr=result.stderr if result.stderr else "",
-                    token_usage=stale_session.token_usage,
-                    last_stop_reason=stale_session.last_stop_reason,
-                    provider=ProviderOutcome(
-                        provider_used=provider_used, fallback_activated=False
-                    ),
+                    provider_used=provider_used,
                 )
         # No valid result in stdout — fall through to original stale response
         _capture_failure(
@@ -213,21 +242,18 @@ def _build_skill_result(
             stderr=result.stderr if result.stderr else "",
             audit=audit,
         )
-        stale_sr = SkillResult(
+        stale_sr = _make_terminated_result(
+            result=result,
+            session=stale_session,
             success=False,
-            result=(
+            result_text=(
                 "Session went stale (no activity for configured threshold). "
                 "Partial progress may have been made. Retry to continue."
             ),
-            session_id=_resolve_skill_session_id(None, result),
             subtype="stale",
-            is_error=False,
-            exit_code=-1,
             needs_retry=True,
             retry_reason=RetryReason.STALE,
-            stderr="",
-            token_usage=None,
-            provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
+            provider_used=provider_used,
         )
         return _apply_budget_guard(stale_sr, skill_command, audit, max_consecutive_retries)
 
@@ -251,22 +277,15 @@ def _build_skill_result(
                 logger.warning(
                     "Session idle-stalled but stdout contained a valid result; recovering"
                 )
-                return SkillResult(
+                return _make_terminated_result(
+                    result=result,
+                    session=idle_session,
                     success=True,
-                    result=_truncate(idle_session.agent_result),
-                    session_id=idle_session.session_id or _resolve_skill_session_id(None, result),
+                    result_text=_truncate(idle_session.agent_result),
                     subtype="recovered_from_idle_stall",
-                    is_error=False,
-                    exit_code=idle_returncode,
                     needs_retry=False,
                     retry_reason=RetryReason.NONE,
-                    stderr=result.stderr if result.stderr else "",
-                    token_usage=idle_session.token_usage,
-                    last_stop_reason=idle_session.last_stop_reason,
-                    lifespan_started=idle_session.lifespan_started,
-                    provider=ProviderOutcome(
-                        provider_used=provider_used, fallback_activated=False
-                    ),
+                    provider_used=provider_used,
                 )
         _capture_failure(
             skill_command,
@@ -280,22 +299,18 @@ def _build_skill_result(
         logger.warning(
             "Headless session killed: stdout idle for configured threshold (IDLE_STALL)"
         )
-        idle_sr = SkillResult(
+        idle_sr = _make_terminated_result(
+            result=result,
+            session=idle_session,
             success=False,
-            result=(
+            result_text=(
                 "Session killed: stdout idle for configured threshold (no output growth). "
                 "Partial progress may have been made. Retry to continue."
             ),
-            session_id=idle_session.session_id or _resolve_skill_session_id(None, result),
             subtype="idle_stall",
-            is_error=False,
-            exit_code=-1,
             needs_retry=True,
             retry_reason=RetryReason.IDLE_STALL,
-            stderr="",
-            token_usage=idle_session.token_usage,
-            lifespan_started=idle_session.lifespan_started,
-            provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
+            provider_used=provider_used,
         )
         return _apply_budget_guard(idle_sr, skill_command, audit, max_consecutive_retries)
 
@@ -537,6 +552,7 @@ def _build_skill_result(
             write_path_warnings=write_path_warnings,
             write_call_count=write_call_count,
             fs_writes_detected=fs_writes_detected,
+            kill_reason=result.kill_reason,
             last_stop_reason=session.last_stop_reason,
             lifespan_started=session.lifespan_started,
             provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -28,6 +28,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_filter_contracts.py` | AST-based contract test enforcing signature compatibility between two apply_manifest implementations |
 | `test_gfm_rendering_guard.py` | Architectural guard: GFM table rendering must route through _render_gfm_table |
 | `test_headless_split.py` | Structural guards for the test_headless.py split (P1-F01 audit fix) |
+| `test_skill_result_construction_guard.py` | AST guard: every SkillResult() construction must include kill_reason keyword arg |
 | `test_import_layer_labels.py` | Regression guard: no bare L-number labels in import-layer contexts |
 | `test_import_linter_contracts.py` | Tests verifying import-linter contract documentation (REQ-ARCH-007) |
 | `test_import_paths.py` | Structural import-path compliance tests (REQ-IMP-001, REQ-IMP-002) |

--- a/tests/arch/test_skill_result_construction_guard.py
+++ b/tests/arch/test_skill_result_construction_guard.py
@@ -65,7 +65,7 @@ class TestSkillResultConstructionGuard:
                 missing_kill_reason.append(call.lineno)
 
         assert not missing_kill_reason, (
-            f"SkillResult() calls missing kill_reason keyword arg at lines: {missing_kill_reason}. "
+            f"SkillResult() calls missing kill_reason kwarg at lines: {missing_kill_reason}. "
             "All SkillResult() constructions must pass kill_reason=result.kill_reason "
             "to avoid silently defaulting to KillReason.NATURAL_EXIT."
         )

--- a/tests/arch/test_skill_result_construction_guard.py
+++ b/tests/arch/test_skill_result_construction_guard.py
@@ -1,12 +1,4 @@
-"""AST guard: verify all SkillResult() constructions include kill_reason keyword arg.
-
-This guard prevents the class of bug where a new early-return branch constructs
-SkillResult without passing kill_reason=result.kill_reason, silently defaulting to
-KillReason.NATURAL_EXIT instead of preserving the subprocess's actual kill reason.
-
-Scans _headless_result.py for direct SkillResult() calls and asserts each call
-includes kill_reason as a keyword argument.
-"""
+"""AST guard: verify all SkillResult() constructions in _headless_result.py include kill_reason."""
 
 from __future__ import annotations
 
@@ -48,12 +40,7 @@ HEADLESS_RESULT_PATH = (
 
 class TestSkillResultConstructionGuard:
     def test_all_skill_result_calls_include_kill_reason(self):
-        """Every direct SkillResult() call must pass kill_reason as a keyword arg.
-
-        This prevents new construction sites from accidentally omitting kill_reason,
-        which silently defaults to NATURAL_EXIT instead of propagating the actual
-        subprocess kill reason (INFRA_KILL for stale/idle/exception terminations).
-        """
+        assert HEADLESS_RESULT_PATH.exists(), f"Production file not found: {HEADLESS_RESULT_PATH}"
         src = HEADLESS_RESULT_PATH.read_text()
         calls = _find_skill_result_calls(src)
 

--- a/tests/arch/test_skill_result_construction_guard.py
+++ b/tests/arch/test_skill_result_construction_guard.py
@@ -1,0 +1,71 @@
+"""AST guard: verify all SkillResult() constructions include kill_reason keyword arg.
+
+This guard prevents the class of bug where a new early-return branch constructs
+SkillResult without passing kill_reason=result.kill_reason, silently defaulting to
+KillReason.NATURAL_EXIT instead of preserving the subprocess's actual kill reason.
+
+Scans _headless_result.py for direct SkillResult() calls and asserts each call
+includes kill_reason as a keyword argument.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def _find_skill_result_calls(src: str) -> list[ast.Call]:
+    """Walk AST and return all direct SkillResult(...) calls."""
+    tree = ast.parse(src)
+    calls: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            # Direct SkillResult(...) call (not module.SkillResult or attribute)
+            if isinstance(func, ast.Name) and func.id == "SkillResult":
+                calls.append(node)
+    return calls
+
+
+def _has_kill_reason_kwarg(call: ast.Call) -> bool:
+    """Return True if the call has kill_reason as a keyword argument."""
+    return any(kw.arg == "kill_reason" for kw in call.keywords)
+
+
+HEADLESS_RESULT_PATH = (
+    Path(__file__).parents[2]
+    / "src"
+    / "autoskillit"
+    / "execution"
+    / "headless"
+    / "_headless_result.py"
+)
+
+
+class TestSkillResultConstructionGuard:
+    def test_all_skill_result_calls_include_kill_reason(self):
+        """Every direct SkillResult() call must pass kill_reason as a keyword arg.
+
+        This prevents new construction sites from accidentally omitting kill_reason,
+        which silently defaults to NATURAL_EXIT instead of propagating the actual
+        subprocess kill reason (INFRA_KILL for stale/idle/exception terminations).
+        """
+        src = HEADLESS_RESULT_PATH.read_text()
+        calls = _find_skill_result_calls(src)
+
+        assert len(calls) > 0, "Expected to find at least one SkillResult() call"
+
+        missing_kill_reason: list[int] = []
+        for call in calls:
+            if not _has_kill_reason_kwarg(call):
+                missing_kill_reason.append(call.lineno)
+
+        assert not missing_kill_reason, (
+            f"SkillResult() calls missing kill_reason keyword arg at lines: {missing_kill_reason}. "
+            "All SkillResult() constructions must pass kill_reason=result.kill_reason "
+            "to avoid silently defaulting to KillReason.NATURAL_EXIT."
+        )

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -130,12 +130,6 @@ class TestIdleStallLifespanStarted:
 
 
 class TestKillReasonPropagation:
-    """Verify kill_reason propagates through all early-return branches.
-
-    Each branch should preserve kill_reason from the SubprocessResult rather than
-    silently defaulting to KillReason.NATURAL_EXIT.
-    """
-
     def test_stale_failure_propagates_infra_kill(self):
         result = _stale_result(kill_reason=KillReason.INFRA_KILL)
         skill_result = _build_skill_result(result)
@@ -149,13 +143,13 @@ class TestKillReasonPropagation:
     def test_recovered_stale_propagates_infra_kill(self):
         stdout = _success_result_json()
         result = _stale_result(kill_reason=KillReason.INFRA_KILL, stdout=stdout)
-        skill_result = _build_skill_result(result, completion_marker="DONE")
+        skill_result = _build_skill_result(result, completion_marker="done")
         assert skill_result.kill_reason == KillReason.INFRA_KILL
 
     def test_recovered_idle_stall_propagates_infra_kill(self):
         stdout = _success_result_json()
         result = _idle_stall_result_with_kill(kill_reason=KillReason.INFRA_KILL, stdout=stdout)
-        skill_result = _build_skill_result(result, completion_marker="DONE")
+        skill_result = _build_skill_result(result, completion_marker="done")
         assert skill_result.kill_reason == KillReason.INFRA_KILL
 
     def test_path_contamination_propagates_kill_reason(self):

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -200,19 +200,3 @@ class TestStaleTokenUsagePropagation:
         assert tu["output_tokens"] == 200
         assert tu["cache_creation_input_tokens"] == 50
         assert tu["cache_read_input_tokens"] == 75
-
-
-class TestFieldCompleteness:
-    """Verify diagnostic fields are non-default across all construction branches."""
-
-    def test_stale_infra_kill_not_natural_exit(self):
-        result = _stale_result(kill_reason=KillReason.INFRA_KILL)
-        skill_result = _build_skill_result(result)
-        assert skill_result.kill_reason == KillReason.INFRA_KILL
-        assert skill_result.kill_reason != KillReason.NATURAL_EXIT
-
-    def test_idle_stall_infra_kill_not_natural_exit(self):
-        result = _idle_stall_result_with_kill(kill_reason=KillReason.INFRA_KILL)
-        skill_result = _build_skill_result(result)
-        assert skill_result.kill_reason == KillReason.INFRA_KILL
-        assert skill_result.kill_reason != KillReason.NATURAL_EXIT

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-from autoskillit.core.types import SubprocessResult, TerminationReason
+from autoskillit.core.types import KillReason, SubprocessResult, TerminationReason
 from autoskillit.execution.headless import _build_skill_result
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small, pytest.mark.feature("fleet")]
@@ -43,6 +43,79 @@ def _tool_use_ndjson(tool_name: str = "Write", **input_kwargs: object) -> str:
     )
 
 
+def _success_result_json(result_text: str = "done", session_id: str = "test-sess") -> str:
+    """Build a success result NDJSON line."""
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": result_text,
+            "session_id": session_id,
+            "is_error": False,
+        }
+    )
+
+
+def _stale_result(
+    kill_reason: KillReason = KillReason.NATURAL_EXIT, stdout: str = ""
+) -> SubprocessResult:
+    """Build a SubprocessResult with STALE termination and explicit kill_reason."""
+    return SubprocessResult(
+        returncode=-1,
+        stdout=stdout,
+        stderr="",
+        termination=TerminationReason.STALE,
+        kill_reason=kill_reason,
+        pid=12345,
+        session_id="sess-stale-1",
+        channel_b_session_id="",
+    )
+
+
+def _idle_stall_result_with_kill(
+    kill_reason: KillReason = KillReason.NATURAL_EXIT,
+    stdout: str = "",
+) -> SubprocessResult:
+    """Build a SubprocessResult with IDLE_STALL termination and explicit kill_reason."""
+    return SubprocessResult(
+        returncode=-1,
+        stdout=stdout,
+        stderr="",
+        termination=TerminationReason.IDLE_STALL,
+        kill_reason=kill_reason,
+        pid=12345,
+        session_id="sess-idle-1",
+        channel_b_session_id="",
+    )
+
+
+def _stale_result_with_token_usage(
+    usage: dict[str, int],
+    kill_reason: KillReason = KillReason.INFRA_KILL,
+) -> SubprocessResult:
+    """Build a stale SubprocessResult whose stdout contains token usage."""
+    result_json = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "work complete",
+            "session_id": "sess-stale-token",
+            "is_error": False,
+            "usage": usage,
+        }
+    )
+    return SubprocessResult(
+        returncode=-1,
+        stdout=result_json,
+        stderr="",
+        termination=TerminationReason.STALE,
+        kill_reason=kill_reason,
+        pid=12345,
+        session_id="sess-stale-token",
+        channel_b_session_id="",
+    )
+
+
 class TestIdleStallLifespanStarted:
     def test_idle_stall_failure_preserves_lifespan_started_true(self):
         stdout = _tool_use_ndjson("Write", file_path="/worktree/src/foo.py")
@@ -54,3 +127,92 @@ class TestIdleStallLifespanStarted:
         result = _idle_stall_result("")
         skill_result = _build_skill_result(result)
         assert skill_result.lifespan_started is False
+
+
+class TestKillReasonPropagation:
+    """Verify kill_reason propagates through all early-return branches.
+
+    Each branch should preserve kill_reason from the SubprocessResult rather than
+    silently defaulting to KillReason.NATURAL_EXIT.
+    """
+
+    def test_stale_failure_propagates_infra_kill(self):
+        result = _stale_result(kill_reason=KillReason.INFRA_KILL)
+        skill_result = _build_skill_result(result)
+        assert skill_result.kill_reason == KillReason.INFRA_KILL
+
+    def test_idle_stall_failure_propagates_infra_kill(self):
+        result = _idle_stall_result_with_kill(kill_reason=KillReason.INFRA_KILL)
+        skill_result = _build_skill_result(result)
+        assert skill_result.kill_reason == KillReason.INFRA_KILL
+
+    def test_recovered_stale_propagates_infra_kill(self):
+        stdout = _success_result_json()
+        result = _stale_result(kill_reason=KillReason.INFRA_KILL, stdout=stdout)
+        skill_result = _build_skill_result(result, completion_marker="DONE")
+        assert skill_result.kill_reason == KillReason.INFRA_KILL
+
+    def test_recovered_idle_stall_propagates_infra_kill(self):
+        stdout = _success_result_json()
+        result = _idle_stall_result_with_kill(kill_reason=KillReason.INFRA_KILL, stdout=stdout)
+        skill_result = _build_skill_result(result, completion_marker="DONE")
+        assert skill_result.kill_reason == KillReason.INFRA_KILL
+
+    def test_path_contamination_propagates_kill_reason(self):
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "done",
+                "session_id": "sess-contam",
+                "is_error": False,
+            }
+        )
+        result = SubprocessResult(
+            returncode=-1,
+            stdout=stdout,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            kill_reason=KillReason.INFRA_KILL,
+            pid=12345,
+            session_id="sess-contam",
+            channel_b_session_id="",
+        )
+        skill_result = _build_skill_result(result, cwd="/wrong/path")
+        assert skill_result.kill_reason == KillReason.INFRA_KILL
+
+
+class TestStaleTokenUsagePropagation:
+    """Verify stale branch propagates token_usage from parsed session, not hardcoded None."""
+
+    def test_stale_failure_propagates_token_usage(self):
+        usage = {
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "cache_creation_input_tokens": 50,
+            "cache_read_input_tokens": 75,
+        }
+        result = _stale_result_with_token_usage(usage, kill_reason=KillReason.INFRA_KILL)
+        skill_result = _build_skill_result(result)
+        assert skill_result.token_usage is not None
+        tu = skill_result.token_usage
+        assert tu["input_tokens"] == 100
+        assert tu["output_tokens"] == 200
+        assert tu["cache_creation_input_tokens"] == 50
+        assert tu["cache_read_input_tokens"] == 75
+
+
+class TestFieldCompleteness:
+    """Verify diagnostic fields are non-default across all construction branches."""
+
+    def test_stale_infra_kill_not_natural_exit(self):
+        result = _stale_result(kill_reason=KillReason.INFRA_KILL)
+        skill_result = _build_skill_result(result)
+        assert skill_result.kill_reason == KillReason.INFRA_KILL
+        assert skill_result.kill_reason != KillReason.NATURAL_EXIT
+
+    def test_idle_stall_infra_kill_not_natural_exit(self):
+        result = _idle_stall_result_with_kill(kill_reason=KillReason.INFRA_KILL)
+        skill_result = _build_skill_result(result)
+        assert skill_result.kill_reason == KillReason.INFRA_KILL
+        assert skill_result.kill_reason != KillReason.NATURAL_EXIT


### PR DESCRIPTION
## Summary

`_build_skill_result()` in `_headless_result.py` constructs `SkillResult` at **six independent sites**. Only the canonical "normal" path (line 546) passes `kill_reason=result.kill_reason`. The other five sites omit it, silently defaulting to `KillReason.NATURAL_EXIT` — a semantically meaningful value that claims the process exited naturally, even for sessions killed by infrastructure (`STALE`, `IDLE_STALL`). The stale failure path also hardcodes `token_usage=None` despite `stale_session.token_usage` being in scope.

The proposed immunity eliminates duplicated construction via a **factory function for infrastructure-terminated branches**, adds an **AST guard** preventing new direct constructions, and adds **value-level propagation tests** with non-default input data that would have caught all three defects at first commit.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.



## Changed Files

### New (★):
- tests/arch/CLAUDE.md
- tests/arch/test_skill_result_construction_guard.py

### Modified (●):
- src/autoskillit/execution/headless/_headless_result.py
- tests/execution/test_headless_result.py

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260509-083444-236650/.autoskillit/temp/rectify/rectify_skill_result_field_propagation_2026-05-09_084500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 2.9k | 16.4k | 1.1M | 89.3k | 144 | 97.3k | 16m 44s |
| review | claude-sonnet-4-6 | 1 | 1.8k | 5.6k | 162.0k | 37.9k | 36 | 28.1k | 2m 56s |
| dry_walkthrough | claude-opus-4-6 | 1 | 45 | 16.3k | 891.5k | 64.7k | 92 | 52.4k | 10m 39s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.2M | 17.6k | 1.7M | 65.0k | 133 | 81.5k | 11m 29s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 83.9k | 2.9k | 205.8k | 29.8k | 19 | 15.4k | 1m 13s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 55.2k | 1.5k | 169.6k | 28.7k | 14 | 15.1k | 39s |
| review_pr | claude-sonnet-4-6 | 2 | 152 | 64.4k | 672.9k | 74.2k | 63 | 125.9k | 15m 32s |
| resolve_review | claude-sonnet-4-6 | 2 | 1.6k | 36.9k | 3.5M | 90.2k | 134 | 220.0k | 19m 24s |
| **Total** | | | 2.4M | 161.5k | 8.4M | 90.2k | | 635.6k | 1h 18m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 332 | 5064.8 | 245.4 | 52.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 43 | 81376.5 | 5116.7 | 857.5 |
| **Total** | **375** | 22484.5 | 1695.0 | 430.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 4.9k | 41.0k | 2.8M | 196.2k | 31m 50s |
| claude-opus-4-6 | 1 | 45 | 16.3k | 891.5k | 52.4k | 10m 39s |
| MiniMax-M2.7-highspeed | 3 | 2.4M | 21.9k | 2.1M | 111.9k | 13m 21s |