### PR TITLE
Rectify: DispatchRecord Attempt History Field Immunity

### DIFF
--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -128,6 +128,11 @@ def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
         default = (
             f.default_factory() if f.default_factory is not dataclasses.MISSING else f.default
         )
+        if default is dataclasses.MISSING:
+            raise RuntimeError(
+                f"Field {f.name!r} has neither a default nor a default_factory; "
+                "cannot reset to default for retry"
+            )
         setattr(d, f.name, default)
 
 

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -6,6 +6,7 @@ All writes use core.io.atomic_write for crash-safety (tmp + os.replace).
 
 from __future__ import annotations
 
+import dataclasses
 import fcntl
 import time
 from pathlib import Path
@@ -27,6 +28,7 @@ from autoskillit.fleet.state_types import (
     _ALLOWED_TRANSITIONS,  # noqa: F401
     _COMPLETED_STATUSES,  # noqa: F401
     _INFRASTRUCTURE_FAILURE_REASONS,  # noqa: F401
+    _RETRY_IDENTITY_FIELDS,
     _VISIBLE_IN_BLOCK_STATUSES,  # noqa: F401
     FLEET_HALTED_SENTINEL,
     FLEET_STATE_SCHEMA_VERSION,
@@ -104,35 +106,29 @@ def write_initial_state(
 def _clear_dispatch_for_retry(d: DispatchRecord) -> None:
     """Clear a dispatch record for retry."""
     _validate_transition(d.status, DispatchStatus.PENDING, d.name)
-    d.attempt_history.append(
-        {
-            "status": str(d.status),
-            "dispatch_id": d.dispatch_id,
-            "dispatched_session_id": d.dispatched_session_id,
-            "dispatched_pid": d.dispatched_pid,
-            "reason": d.reason,
-            "kill_reason": d.kill_reason,
-            "infra_exit_category": d.infra_exit_category,
-            "started_at": d.started_at,
-            "ended_at": d.ended_at,
-            "token_usage": dict(d.token_usage) if d.token_usage is not None else {},
-        }
-    )
-    d.status = DispatchStatus.PENDING
-    d.reason = ""
-    d.dispatch_id = ""
-    d.dispatched_session_id = ""
-    d.dispatched_session_log_dir = ""
-    d.dispatched_pid = 0
-    d.dispatched_starttime_ticks = 0
-    d.dispatched_boot_id = ""
-    d.dispatched_create_time = 0.0
-    d.token_usage = {}
-    d.started_at = 0.0
-    d.ended_at = 0.0
-    d.sidecar_path = None
-    d.kill_reason = ""
-    d.infra_exit_category = ""
+
+    # Snapshot all non-identity fields before resetting
+    snapshot: dict[str, Any] = {}
+    for f in dataclasses.fields(d):
+        if f.name in _RETRY_IDENTITY_FIELDS:
+            continue
+        val = getattr(d, f.name)
+        if f.name == "status":
+            snapshot[f.name] = str(val)
+        elif isinstance(val, dict):
+            snapshot[f.name] = dict(val)
+        else:
+            snapshot[f.name] = val
+    d.attempt_history.append(snapshot)
+
+    # Reset all non-identity fields to their defaults
+    for f in dataclasses.fields(d):
+        if f.name in _RETRY_IDENTITY_FIELDS:
+            continue
+        default = (
+            f.default_factory() if f.default_factory is not dataclasses.MISSING else f.default
+        )
+        setattr(d, f.name, default)
 
 
 def reset_blocking_dispatch(state_path: Path, dispatch_name: str) -> bool:

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -16,6 +16,15 @@ FLEET_STATE_SCHEMA_VERSION = 5
 
 FLEET_HALTED_SENTINEL = "fleet_halted_on_failure"
 
+_RETRY_IDENTITY_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "campaign_id",
+        "caller_session_id",
+        "attempt_history",
+    }
+)
+
 
 class DispatchStatus(StrEnum):
     """Status of a single dispatch within a campaign."""

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -397,8 +397,9 @@ class TestSnapshotCompleteness:
 
     _IDENTITY_FIELDS = _RETRY_IDENTITY_FIELDS
 
-    def test_snapshot_captures_all_non_identity_fields(self):
-        """Every non-identity field must appear as a key in the attempt_history snapshot."""
+    @staticmethod
+    def _make_dirty_values() -> dict[str, Any]:
+        """Build a DispatchRecord kwargs dict with every field set to a non-default dirty value."""
         dirty_values: dict[str, Any] = {
             "name": "test",
             "campaign_id": "cid",
@@ -425,6 +426,11 @@ class TestSnapshotCompleteness:
                 dirty_values[f.name] = DispatchStatus.FAILURE
             else:
                 raise AssertionError(f"Unhandled default type for {f.name!r}: {type(default)}")
+        return dirty_values
+
+    def test_snapshot_captures_all_non_identity_fields(self):
+        """Every non-identity field must appear as a key in the attempt_history snapshot."""
+        dirty_values = self._make_dirty_values()
         d = DispatchRecord(**dirty_values)
         _clear_dispatch_for_retry(d)
         assert len(d.attempt_history) == 1
@@ -441,32 +447,7 @@ class TestSnapshotCompleteness:
 
     def test_snapshot_values_match_pre_clear_state(self):
         """Each snapshot value must equal the field value before clear."""
-        dirty_values: dict[str, Any] = {
-            "name": "test",
-            "campaign_id": "cid",
-            "caller_session_id": "csid",
-            "attempt_history": [],
-        }
-        for f in dataclasses.fields(DispatchRecord):
-            if f.name in dirty_values:
-                continue
-            default = (
-                f.default_factory() if f.default_factory is not dataclasses.MISSING else f.default
-            )
-            if isinstance(default, str):
-                dirty_values[f.name] = f"dirty-{f.name}"
-            elif isinstance(default, int):
-                dirty_values[f.name] = 99999
-            elif isinstance(default, float):
-                dirty_values[f.name] = 9999.0
-            elif isinstance(default, dict):
-                dirty_values[f.name] = {"prompt_tokens": 500}
-            elif default is None:
-                dirty_values[f.name] = "/dirty/path"
-            elif isinstance(default, DispatchStatus):
-                dirty_values[f.name] = DispatchStatus.FAILURE
-            else:
-                raise AssertionError(f"Unhandled default type for {f.name!r}: {type(default)}")
+        dirty_values = self._make_dirty_values()
         d = DispatchRecord(**dirty_values)
 
         # Capture expected values before clear
@@ -483,7 +464,7 @@ class TestSnapshotCompleteness:
             assert key in snapshot, f"Field {key!r} missing from snapshot"
             if key == "status":
                 assert snapshot[key] == str(expected_val)
-            elif key == "token_usage":
+            elif isinstance(expected_val, dict):
                 assert snapshot[key] == dict(expected_val)
             else:
                 assert snapshot[key] == expected_val, (

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -19,7 +19,7 @@ from autoskillit.fleet import (
     write_initial_state,
 )
 from autoskillit.fleet.state import _clear_dispatch_for_retry
-from autoskillit.fleet.state_types import _validate_transition
+from autoskillit.fleet.state_types import _RETRY_IDENTITY_FIELDS, _validate_transition
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -347,7 +347,7 @@ class TestAttemptHistoryOnRetry:
 class TestClearDispatchFieldCoverage:
     """Structural guard: _clear_dispatch_for_retry must reset all execution-metadata fields."""
 
-    _IDENTITY_FIELDS = frozenset({"name", "campaign_id", "caller_session_id", "attempt_history"})
+    _IDENTITY_FIELDS = _RETRY_IDENTITY_FIELDS
 
     def test_clear_covers_all_execution_metadata_fields(self):
         """Every non-identity field must be reset to its default by _clear_dispatch_for_retry."""
@@ -390,3 +390,102 @@ class TestClearDispatchFieldCoverage:
                 f"_clear_dispatch_for_retry did not reset {f.name!r} to its default "
                 f"({default!r}); got {getattr(d, f.name)!r}"
             )
+
+
+class TestSnapshotCompleteness:
+    """Guard: every non-identity field must appear in the attempt_history snapshot."""
+
+    _IDENTITY_FIELDS = _RETRY_IDENTITY_FIELDS
+
+    def test_snapshot_captures_all_non_identity_fields(self):
+        """Every non-identity field must appear as a key in the attempt_history snapshot."""
+        dirty_values: dict[str, Any] = {
+            "name": "test",
+            "campaign_id": "cid",
+            "caller_session_id": "csid",
+            "attempt_history": [],
+        }
+        for f in dataclasses.fields(DispatchRecord):
+            if f.name in dirty_values:
+                continue
+            default = (
+                f.default_factory() if f.default_factory is not dataclasses.MISSING else f.default
+            )
+            if isinstance(default, str):
+                dirty_values[f.name] = f"dirty-{f.name}"
+            elif isinstance(default, int):
+                dirty_values[f.name] = 99999
+            elif isinstance(default, float):
+                dirty_values[f.name] = 9999.0
+            elif isinstance(default, dict):
+                dirty_values[f.name] = {"prompt_tokens": 500}
+            elif default is None:
+                dirty_values[f.name] = "/dirty/path"
+            elif isinstance(default, DispatchStatus):
+                dirty_values[f.name] = DispatchStatus.FAILURE
+            else:
+                raise AssertionError(f"Unhandled default type for {f.name!r}: {type(default)}")
+        d = DispatchRecord(**dirty_values)
+        _clear_dispatch_for_retry(d)
+        assert len(d.attempt_history) == 1
+        snapshot_keys = set(d.attempt_history[0].keys())
+        expected_keys = {
+            f.name
+            for f in dataclasses.fields(DispatchRecord)
+            if f.name not in self._IDENTITY_FIELDS
+        }
+        assert snapshot_keys == expected_keys, (
+            f"Snapshot missing fields: {expected_keys - snapshot_keys}; "
+            f"Extra fields: {snapshot_keys - expected_keys}"
+        )
+
+    def test_snapshot_values_match_pre_clear_state(self):
+        """Each snapshot value must equal the field value before clear."""
+        dirty_values: dict[str, Any] = {
+            "name": "test",
+            "campaign_id": "cid",
+            "caller_session_id": "csid",
+            "attempt_history": [],
+        }
+        for f in dataclasses.fields(DispatchRecord):
+            if f.name in dirty_values:
+                continue
+            default = (
+                f.default_factory() if f.default_factory is not dataclasses.MISSING else f.default
+            )
+            if isinstance(default, str):
+                dirty_values[f.name] = f"dirty-{f.name}"
+            elif isinstance(default, int):
+                dirty_values[f.name] = 99999
+            elif isinstance(default, float):
+                dirty_values[f.name] = 9999.0
+            elif isinstance(default, dict):
+                dirty_values[f.name] = {"prompt_tokens": 500}
+            elif default is None:
+                dirty_values[f.name] = "/dirty/path"
+            elif isinstance(default, DispatchStatus):
+                dirty_values[f.name] = DispatchStatus.FAILURE
+            else:
+                raise AssertionError(f"Unhandled default type for {f.name!r}: {type(default)}")
+        d = DispatchRecord(**dirty_values)
+
+        # Capture expected values before clear
+        expected = {
+            f.name: getattr(d, f.name)
+            for f in dataclasses.fields(DispatchRecord)
+            if f.name not in self._IDENTITY_FIELDS
+        }
+
+        _clear_dispatch_for_retry(d)
+        snapshot = d.attempt_history[0]
+
+        for key, expected_val in expected.items():
+            assert key in snapshot, f"Field {key!r} missing from snapshot"
+            if key == "status":
+                assert snapshot[key] == str(expected_val)
+            elif key == "token_usage":
+                assert snapshot[key] == dict(expected_val)
+            else:
+                assert snapshot[key] == expected_val, (
+                    f"Snapshot[{key!r}] = {snapshot[key]!r}, expected {expected_val!r}"
+                )

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from pathlib import Path
 
@@ -373,10 +374,6 @@ class TestDispatchRecordToDict:
 
     def test_to_dict_keys_match_dataclass_fields(self) -> None:
         """to_dict() must emit exactly the dataclass field names."""
-        import dataclasses
-
-        from autoskillit.fleet import DispatchRecord
-
         record = DispatchRecord(name="test")
         actual = set(record.to_dict().keys())
         expected = {f.name for f in dataclasses.fields(DispatchRecord)}

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -371,6 +371,17 @@ class TestDispatchRecordToDict:
         assert roundtripped["name"] == "test-job"
         assert roundtripped["token_usage"] == {"x": 1}
 
+    def test_to_dict_keys_match_dataclass_fields(self) -> None:
+        """to_dict() must emit exactly the dataclass field names."""
+        import dataclasses
+
+        from autoskillit.fleet import DispatchRecord
+
+        record = DispatchRecord(name="test")
+        actual = set(record.to_dict().keys())
+        expected = {f.name for f in dataclasses.fields(DispatchRecord)}
+        assert actual == expected
+
 
 class TestDispatchRecordSchemaV3:
     def test_normalize_maps_cache_keys_to_canonical_names(self) -> None:


### PR DESCRIPTION
## Summary

`_clear_dispatch_for_retry` in `fleet/state.py` uses manual field enumeration to build the attempt_history snapshot dict (10 keys) and then manually resets 15 fields. Five execution-metadata fields (`dispatched_session_log_dir`, `dispatched_starttime_ticks`, `dispatched_boot_id`, `dispatched_create_time`, `sidecar_path`) are reset but never captured — permanently lost for failed dispatch attempts.

The proposed solution eliminates manual field enumeration from `_clear_dispatch_for_retry` entirely, deriving both the snapshot dict and the reset values from `dataclasses.fields()` at runtime. This makes the capture-then-clear cycle structurally immune to field additions — a new field on `DispatchRecord` is automatically captured and reset without any code change in `_clear_dispatch_for_retry`.

## Requirements

### Missing Fields (to be captured in attempt_history before reset)

| Field | Reset Value | Impact of Loss |
|---|---|---|
| `dispatched_session_log_dir` | `""` | Session log path for the failed attempt is unrecoverable |
| `dispatched_starttime_ticks` | `0` | PID liveness identity for prior attempt is lost |
| `dispatched_boot_id` | `""` | Boot-epoch PID-reuse guard identity is lost |
| `dispatched_create_time` | `0.0` | macOS psutil fallback identity is lost |
| `sidecar_path` | `None` | Per-issue JSONL sidecar reference for failed attempt is lost |

### Structural Immunity

- Derive snapshot dict keys dynamically from `dataclasses.fields(DispatchRecord)` minus identity fields
- Derive reset values dynamically from the same field introspection
- Add `_RETRY_IDENTITY_FIELDS` constant to production code (`state_types.py`)
- Add `AttemptEntry` TypedDict for type safety (optional enhancement)

## Conflict Resolution Table

## Changed Files

### Modified (●):
- `src/autoskillit/fleet/state.py`
- `src/autoskillit/fleet/state_types.py`
- `tests/fleet/test_retry_failed_dispatch.py`
- `tests/fleet/test_state_schema.py`

Closes #2269

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260509-083445-288359/.autoskillit/temp/rectify/rectify_dispatch_attempt_history_field_immunity_2026-05-09_083900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 52 | 10.7k | 741.2k | 67.2k | 88 | 61.2k | 16m 3s |
| review | claude-sonnet-4-6 | 1 | 60 | 7.6k | 223.8k | 45.9k | 108 | 37.4k | 5m 30s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 41 | 8.3k | 814.8k | 75.8k | 99 | 62.7k | 5m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 8.6k | 1.2M | 67.5k | 88 | 50.8k | 3m 41s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 70.8k | 3.1k | 205.9k | 29.8k | 17 | 15.4k | 1m 8s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.8k | 1.6k | 169.6k | 28.8k | 14 | 15.1k | 40s |
| review_pr | claude-sonnet-4-6 | 2 | 972 | 35.5k | 823.7k | 57.0k | 71 | 88.4k | 9m 31s |
| resolve_review | claude-sonnet-4-6 | 1 | 241 | 15.8k | 1.5M | 67.3k | 72 | 54.4k | 6m 6s |
| **Total** | | | 1.2M | 91.3k | 5.7M | 75.8k | | 385.4k | 47m 50s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 177 | 6871.4 | 287.0 | 48.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 49 | 30406.9 | 1110.7 | 323.5 |
| **Total** | **226** | 25155.7 | 1705.4 | 404.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 153 | 26.7k | 1.8M | 161.3k | 26m 42s |
| MiniMax-M2.7-highspeed | 3 | 1.2M | 13.3k | 1.6M | 81.3k | 5m 30s |