### PR TITLE
Pre-Dispatch Validation Errors Write No State Record

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -146,6 +146,29 @@ def _post_dispatch_cleanup(
             )
 
 
+def _write_campaign_refusal(
+    campaign_state_path: Path | None,
+    effective_name: str,
+    error_code: FleetErrorCode,
+) -> None:
+    """Write a REFUSED dispatch record to the campaign state file."""
+    if campaign_state_path is None:
+        return
+    from autoskillit.fleet.state import (  # noqa: PLC0415
+        DispatchRecord,
+        DispatchStatus,
+        upsert_dispatch_record_by_name,
+    )
+
+    try:
+        upsert_dispatch_record_by_name(
+            campaign_state_path,
+            DispatchRecord(name=effective_name, status=DispatchStatus.REFUSED, reason=error_code),
+        )
+    except Exception:
+        logger.warning("failed to record refusal to campaign state", exc_info=True)
+
+
 async def execute_dispatch(
     tool_ctx: ToolContext,
     recipe: str,
@@ -170,29 +193,11 @@ async def execute_dispatch(
     Returns DispatchOutcome (DispatchCompleted | DispatchRejected).
     """
     effective_name = dispatch_name or recipe
-    from autoskillit.fleet.state import (  # noqa: PLC0415
-        DispatchRecord,
-        DispatchStatus,
-        upsert_dispatch_record_by_name,
-    )
 
     def _reject(error_code: FleetErrorCode, message: str, **kwargs: Any) -> DispatchRejected:
+        """Pre-lock, pre-dispatch-id rejection path — no per-dispatch state file exists yet."""
         rejection = DispatchRejected(error_code=error_code, message=message, **kwargs)
-        if campaign_state_path is not None:
-            try:
-                upsert_dispatch_record_by_name(
-                    campaign_state_path,
-                    DispatchRecord(
-                        name=effective_name,
-                        status=DispatchStatus.REFUSED,
-                        reason=error_code,
-                    ),
-                )
-            except Exception:
-                logger.warning(
-                    "execute_dispatch: failed to record rejection to campaign state",
-                    exc_info=True,
-                )
+        _write_campaign_refusal(campaign_state_path, effective_name, error_code)
         return rejection
 
     if ingredients is not None:
@@ -390,6 +395,7 @@ async def _run_dispatch(
     )
 
     def _reject_with_state(error_code: FleetErrorCode, message: str) -> DispatchRejected:
+        """Post-dispatch-id rejection path — writes both per-dispatch and campaign state."""
         try:
             append_dispatch_record(
                 state_path,
@@ -401,18 +407,7 @@ async def _run_dispatch(
             )
         except Exception:
             logger.warning("_reject_with_state: per-dispatch state write failed", exc_info=True)
-        if campaign_state_path is not None:
-            try:
-                upsert_dispatch_record_by_name(
-                    campaign_state_path,
-                    DispatchRecord(
-                        name=effective_name,
-                        status=DispatchStatus.REFUSED,
-                        reason=error_code,
-                    ),
-                )
-            except Exception:
-                logger.warning("_reject_with_state: campaign state write failed", exc_info=True)
+        _write_campaign_refusal(campaign_state_path, effective_name, error_code)
         return DispatchRejected(error_code=error_code, message=message, dispatch_id=dispatch_id)
 
     if effective_ingredients:

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -170,17 +170,16 @@ async def execute_dispatch(
     Returns DispatchOutcome (DispatchCompleted | DispatchRejected).
     """
     effective_name = dispatch_name or recipe
+    from autoskillit.fleet.state import (  # noqa: PLC0415
+        DispatchRecord,
+        DispatchStatus,
+        upsert_dispatch_record_by_name,
+    )
 
     def _reject(error_code: FleetErrorCode, message: str, **kwargs: Any) -> DispatchRejected:
         rejection = DispatchRejected(error_code=error_code, message=message, **kwargs)
         if campaign_state_path is not None:
             try:
-                from autoskillit.fleet.state import (
-                    DispatchRecord,
-                    DispatchStatus,
-                    upsert_dispatch_record_by_name,
-                )
-
                 upsert_dispatch_record_by_name(
                     campaign_state_path,
                     DispatchRecord(
@@ -467,7 +466,6 @@ async def _run_dispatch(
 
     dispatch_sidecar_path = str(compute_sidecar_path(dispatch_id, tool_ctx.project_dir))
 
-    campaign_id = tool_ctx.kitchen_id
     prompt = prompt_builder(
         recipe=recipe,
         task=task,
@@ -478,18 +476,9 @@ async def _run_dispatch(
     )
 
     if tool_ctx.executor is None:
-        append_dispatch_record(
-            state_path,
-            DispatchRecord(
-                name=effective_name,
-                status=DispatchStatus.REFUSED,
-                reason=FleetErrorCode.FLEET_MANIFEST_MISSING,
-            ),
-        )
-        return DispatchRejected(
-            error_code=FleetErrorCode.FLEET_MANIFEST_MISSING,
-            message="Executor not configured.",
-            dispatch_id=dispatch_id,
+        return _reject_with_state(
+            FleetErrorCode.FLEET_MANIFEST_MISSING,
+            "Executor not configured.",
         )
 
     started_at = time.time()

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -162,28 +162,56 @@ async def execute_dispatch(
     resume_checkpoint: SessionCheckpoint | None = None,
     idle_output_timeout: int | None = None,
     caller_session_id: str = "",
+    campaign_state_path: Path | None = None,
 ) -> DispatchOutcome:
     """Execute a single food truck dispatch.
 
     Orchestrates: lock → validate → quota → prompt → dispatch → parse → state → cleanup.
     Returns DispatchOutcome (DispatchCompleted | DispatchRejected).
     """
+    effective_name = dispatch_name or recipe
+
+    def _reject(error_code: FleetErrorCode, message: str, **kwargs: Any) -> DispatchRejected:
+        rejection = DispatchRejected(error_code=error_code, message=message, **kwargs)
+        if campaign_state_path is not None:
+            try:
+                from autoskillit.fleet.state import (
+                    DispatchRecord,
+                    DispatchStatus,
+                    upsert_dispatch_record_by_name,
+                )
+
+                upsert_dispatch_record_by_name(
+                    campaign_state_path,
+                    DispatchRecord(
+                        name=effective_name,
+                        status=DispatchStatus.REFUSED,
+                        reason=error_code,
+                    ),
+                )
+            except Exception:
+                logger.warning(
+                    "execute_dispatch: failed to record rejection to campaign state",
+                    exc_info=True,
+                )
+        return rejection
+
     if ingredients is not None:
         bad_vals = [k for k, v in ingredients.items() if not isinstance(v, str)]
         if bad_vals:
-            return DispatchRejected(
-                error_code=FleetErrorCode.FLEET_UNKNOWN_INGREDIENT,
-                message=f"Ingredient values must be strings. Non-string keys: {bad_vals}",
+            return _reject(
+                FleetErrorCode.FLEET_UNKNOWN_INGREDIENT,
+                f"Ingredient values must be strings. Non-string keys: {bad_vals}",
             )
 
     lock = tool_ctx.fleet_lock
     if lock is None:
-        return DispatchRejected(
+        return _reject(
             error_code=FleetErrorCode.FLEET_LOCK_NOT_INITIALIZED,
             message="Fleet lock not initialized — open_kitchen with fleet mode.",
         )
     if lock.at_capacity():
-        return DispatchRejected(
+        return _reject(
             error_code=FleetErrorCode.FLEET_PARALLEL_REFUSED,
             message=(
                 f"Fleet at capacity ({lock.active_count}/{lock.max_concurrent}"
@@ -194,7 +222,7 @@ async def execute_dispatch(
     try:
         await lock.acquire()
     except TimeoutError:
-        return DispatchRejected(
+        return _reject(
             error_code=FleetErrorCode.FLEET_ACQUIRE_TIMEOUT,
             message=(
                 f"Timed out waiting for fleet semaphore after {lock.timeout}s "
@@ -218,12 +246,13 @@ async def execute_dispatch(
             resume_checkpoint=resume_checkpoint,
             idle_output_timeout=idle_output_timeout,
             caller_session_id=caller_session_id,
+            campaign_state_path=campaign_state_path,
         )
     except asyncio.CancelledError:
         raise
     except Exception as exc:
         logger.error("execute_dispatch failed", exc_info=True)
-        return DispatchRejected(
+        return _reject(
             error_code=FleetErrorCode.FLEET_L3_STARTUP_OR_CRASH,
             message=f"{type(exc).__name__}: {exc}",
         )
@@ -291,6 +320,7 @@ async def _run_dispatch(
     resume_checkpoint: SessionCheckpoint | None = None,
     idle_output_timeout: int | None = None,
     caller_session_id: str = "",
+    campaign_state_path: Path | None = None,
 ) -> DispatchOutcome:
     """Inner dispatch body — called after lock acquisition."""
     from autoskillit.fleet.state import (
@@ -337,70 +367,11 @@ async def _run_dispatch(
     effective_ingredients = ingredients or {}
     if "task" in full_recipe.ingredients and "task" not in effective_ingredients:
         effective_ingredients = {"task": task, **effective_ingredients}
-    if effective_ingredients:
-        unknown = set(effective_ingredients.keys()) - set(full_recipe.ingredients.keys())
-        if unknown:
-            return DispatchRejected(
-                error_code=FleetErrorCode.FLEET_UNKNOWN_INGREDIENT,
-                message=f"Unknown ingredient keys: {sorted(unknown)}. "
-                f"Valid keys: {sorted(full_recipe.ingredients.keys())}",
-            )
 
-    missing_required = [
-        key
-        for key, ing in full_recipe.ingredients.items()
-        if getattr(ing, "required", False)
-        and getattr(ing, "default", None) is None
-        and key not in effective_ingredients
-    ]
-    if missing_required:
-        return DispatchRejected(
-            error_code=FleetErrorCode.FLEET_MISSING_INGREDIENT,
-            message=f"Missing required ingredients: {sorted(missing_required)}. "
-            f"These have no default and must be supplied.",
-        )
-
-    from autoskillit.fleet.state import read_all_campaign_captures  # noqa: PLC0415
-
-    dispatches_dir = tool_ctx.temp_dir / "dispatches"
-    accumulated_captures = read_all_campaign_captures(dispatches_dir, tool_ctx.kitchen_id)
-
-    _has_campaign_refs = any(_CAMPAIGN_REF_RE.search(v) for v in effective_ingredients.values())
-    if _has_campaign_refs:
-        try:
-            effective_ingredients = _interpolate_campaign_refs(
-                effective_ingredients, accumulated_captures
-            )
-        except ValueError as exc:
-            logger.warning("ingredient interpolation failed", exc_info=True)
-            return DispatchRejected(
-                error_code=FleetErrorCode.FLEET_UNKNOWN_INGREDIENT,
-                message=str(exc),
-            )
-
-    quota_result = await quota_checker(tool_ctx.config.quota_guard)
-    if quota_result.get("should_sleep"):
-        await asyncio.sleep(quota_result.get("sleep_seconds", 0))
-
+    effective_name = dispatch_name or recipe
     identity = DispatchIdentity.fresh()
     dispatch_id = identity.dispatch_id
-    completion_marker = identity.completion_marker
-    sentinel_contract = identity.sentinel_contract
-    from autoskillit.fleet.sidecar import sidecar_path as compute_sidecar_path  # noqa: PLC0415
-
-    dispatch_sidecar_path = str(compute_sidecar_path(dispatch_id, tool_ctx.project_dir))
-    effective_name = dispatch_name or recipe
-
     campaign_id = tool_ctx.kitchen_id
-    prompt = prompt_builder(
-        recipe=recipe,
-        task=task,
-        ingredients=effective_ingredients,
-        dispatch_id=dispatch_id,
-        campaign_id=campaign_id,
-        l3_timeout_sec=timeout_sec or 1800,
-    )
-
     state_path = tool_ctx.temp_dir / "dispatches" / f"{dispatch_id}.json"
     state_path.parent.mkdir(parents=True, exist_ok=True)
     recipe_snapshot = {
@@ -419,6 +390,93 @@ async def _run_dispatch(
         recipe_snapshot=recipe_snapshot,
     )
 
+    def _reject_with_state(error_code: FleetErrorCode, message: str) -> DispatchRejected:
+        try:
+            append_dispatch_record(
+                state_path,
+                DispatchRecord(
+                    name=effective_name,
+                    status=DispatchStatus.REFUSED,
+                    reason=error_code,
+                ),
+            )
+        except Exception:
+            logger.warning("_reject_with_state: per-dispatch state write failed", exc_info=True)
+        if campaign_state_path is not None:
+            try:
+                upsert_dispatch_record_by_name(
+                    campaign_state_path,
+                    DispatchRecord(
+                        name=effective_name,
+                        status=DispatchStatus.REFUSED,
+                        reason=error_code,
+                    ),
+                )
+            except Exception:
+                logger.warning("_reject_with_state: campaign state write failed", exc_info=True)
+        return DispatchRejected(error_code=error_code, message=message, dispatch_id=dispatch_id)
+
+    if effective_ingredients:
+        unknown = set(effective_ingredients.keys()) - set(full_recipe.ingredients.keys())
+        if unknown:
+            return _reject_with_state(
+                FleetErrorCode.FLEET_UNKNOWN_INGREDIENT,
+                f"Unknown ingredient keys: {sorted(unknown)}. "
+                f"Valid keys: {sorted(full_recipe.ingredients.keys())}",
+            )
+
+    missing_required = [
+        key
+        for key, ing in full_recipe.ingredients.items()
+        if getattr(ing, "required", False)
+        and getattr(ing, "default", None) is None
+        and key not in effective_ingredients
+    ]
+    if missing_required:
+        return _reject_with_state(
+            FleetErrorCode.FLEET_MISSING_INGREDIENT,
+            f"Missing required ingredients: {sorted(missing_required)}. "
+            f"These have no default and must be supplied.",
+        )
+
+    from autoskillit.fleet.state import read_all_campaign_captures  # noqa: PLC0415
+
+    dispatches_dir = tool_ctx.temp_dir / "dispatches"
+    accumulated_captures = read_all_campaign_captures(dispatches_dir, tool_ctx.kitchen_id)
+
+    _has_campaign_refs = any(_CAMPAIGN_REF_RE.search(v) for v in effective_ingredients.values())
+    if _has_campaign_refs:
+        try:
+            effective_ingredients = _interpolate_campaign_refs(
+                effective_ingredients, accumulated_captures
+            )
+        except ValueError as exc:
+            logger.warning("ingredient interpolation failed", exc_info=True)
+            return _reject_with_state(
+                FleetErrorCode.FLEET_UNKNOWN_INGREDIENT,
+                str(exc),
+            )
+
+    quota_result = await quota_checker(tool_ctx.config.quota_guard)
+    if quota_result.get("should_sleep"):
+        await asyncio.sleep(quota_result.get("sleep_seconds", 0))
+
+    completion_marker = identity.completion_marker
+    sentinel_contract = identity.sentinel_contract
+    from autoskillit.fleet.sidecar import sidecar_path as compute_sidecar_path  # noqa: PLC0415
+
+    dispatch_sidecar_path = str(compute_sidecar_path(dispatch_id, tool_ctx.project_dir))
+
+    campaign_id = tool_ctx.kitchen_id
+    prompt = prompt_builder(
+        recipe=recipe,
+        task=task,
+        ingredients=effective_ingredients,
+        dispatch_id=dispatch_id,
+        campaign_id=campaign_id,
+        l3_timeout_sec=timeout_sec or 1800,
+    )
+
     if tool_ctx.executor is None:
         append_dispatch_record(
             state_path,
@@ -431,6 +489,7 @@ async def _run_dispatch(
         return DispatchRejected(
             error_code=FleetErrorCode.FLEET_MANIFEST_MISSING,
             message="Executor not configured.",
+            dispatch_id=dispatch_id,
         )
 
     started_at = time.time()

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -232,16 +232,18 @@ class DispatchRejected:
     error_code: FleetErrorCode
     message: str
     details: dict[str, Any] | None = None
+    dispatch_id: str = ""
 
     def to_envelope(self) -> str:
-        return json.dumps(
-            {
-                "success": False,
-                "error": self.error_code,
-                "user_visible_message": self.message,
-                "details": self.details,
-            }
-        )
+        d: dict[str, Any] = {
+            "success": False,
+            "error": self.error_code,
+            "user_visible_message": self.message,
+            "details": self.details,
+        }
+        if self.dispatch_id:
+            d["dispatch_id"] = self.dispatch_id
+        return json.dumps(d)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -171,7 +171,7 @@ async def dispatch_food_truck(
                 )
 
         from autoskillit.core import SessionCheckpoint  # noqa: PLC0415
-        from autoskillit.fleet import execute_dispatch
+        from autoskillit.fleet import DispatchCompleted, execute_dispatch  # noqa: PLC0415
         from autoskillit.server import _get_ctx
         from autoskillit.server._misc import (  # noqa: PLC0415
             _refresh_quota_cache,
@@ -206,7 +206,7 @@ async def dispatch_food_truck(
             campaign_state_path=Path(campaign_state_path_str) if campaign_state_path_str else None,
         )
 
-        if campaign_state_path_str:
+        if campaign_state_path_str and isinstance(result, DispatchCompleted):
             _write_dispatch_to_campaign_state(
                 campaign_state_path_str,
                 effective_name,

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -186,6 +186,7 @@ async def dispatch_food_truck(
         from autoskillit.core import find_caller_session_id
 
         caller_session_id = find_caller_session_id(project_dir=tool_ctx.project_dir)
+        effective_name = dispatch_name or recipe
         result = await execute_dispatch(
             tool_ctx=tool_ctx,
             recipe=recipe,
@@ -202,12 +203,13 @@ async def dispatch_food_truck(
             resume_checkpoint=parsed_checkpoint,
             idle_output_timeout=idle_output_timeout,
             caller_session_id=caller_session_id,
+            campaign_state_path=Path(campaign_state_path_str) if campaign_state_path_str else None,
         )
 
-        if campaign_state_path_str and dispatch_name:
+        if campaign_state_path_str:
             _write_dispatch_to_campaign_state(
                 campaign_state_path_str,
-                dispatch_name,
+                effective_name,
                 result,
             )
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -569,13 +569,14 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             # Execution file-level entries:
             "execution/test_headless_path_validation.py",
             "execution/test_zero_write_detection.py",
-            # Fleet file-level entries (5 of N import autoskillit.recipe):
+            # Fleet file-level entries (7 of N import autoskillit.recipe):
             "fleet/test_fleet_e2e.py",
             "fleet/test_campaign_capture.py",
             "fleet/test_pack_enforcement.py",
             "fleet/test_pack_enforcement_e2e.py",
             "fleet/test_dispatch_failure_semantics.py",
             "fleet/test_research_campaign_dispatch.py",
+            "fleet/test_gate_state_persistence.py",
             # Other file-level entries:
             "infra/test_pretty_output_recipe.py",
             "skills/test_planner_skill_contracts.py",

--- a/tests/fleet/conftest.py
+++ b/tests/fleet/conftest.py
@@ -1,1 +1,12 @@
 """Shared fixtures for tests/fleet/."""
+
+from __future__ import annotations
+
+from autoskillit.fleet import FleetSemaphore
+
+
+def fleet_lock_from_ctx(tool_ctx) -> FleetSemaphore:
+    """Return a fresh FleetSemaphore for a tool_ctx that needs a fleet lock."""
+    lock = FleetSemaphore(max_concurrent=1)
+    tool_ctx.fleet_lock = lock
+    return lock

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -333,8 +333,7 @@ class TestValidationFailureCampaignState:
         # but the lock itself is not the rejection source — ingredients are.
         from tests.fleet.conftest import fleet_lock_from_ctx
 
-        lock = fleet_lock_from_ctx(tool_ctx)
-        tool_ctx.fleet_lock = lock
+        fleet_lock_from_ctx(tool_ctx)
 
         from autoskillit.fleet import execute_dispatch
 
@@ -404,7 +403,6 @@ class TestValidationFailureCampaignState:
             quota_refresher=lambda **kw: None,
             campaign_state_path=None,
         )
-        import json
 
         dispatches_dir = tool_ctx.temp_dir / "dispatches"
         dispatch_files = list(dispatches_dir.glob("*.json"))

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -15,6 +15,7 @@ from autoskillit.fleet import (
     resume_campaign_from_state,
     write_initial_state,
 )
+from tests.fleet.conftest import fleet_lock_from_ctx
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -329,10 +330,6 @@ class TestValidationFailureCampaignState:
         """T1: execute_dispatch writes REFUSED to campaign state on type validation error."""
 
         sp = _init_state(tmp_path, "step1")
-        # Give the context a fleet lock so the early type-check path is skipped
-        # but the lock itself is not the rejection source — ingredients are.
-        from tests.fleet.conftest import fleet_lock_from_ctx
-
         fleet_lock_from_ctx(tool_ctx)
 
         from autoskillit.fleet import execute_dispatch

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -354,7 +354,7 @@ class TestValidationFailureCampaignState:
 
     @pytest.mark.anyio
     async def test_run_dispatch_writes_per_dispatch_state_on_missing_ingredient(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx, tmp_path
     ):
         """T2: _run_dispatch creates per-dispatch state file on missing required ingredient."""
         from autoskillit.core import RecipeSource
@@ -407,12 +407,12 @@ class TestValidationFailureCampaignState:
         with open(dispatch_files[0]) as f:
             records = [DispatchRecord.from_dict(r) for r in json.load(f)["dispatches"]]
         refused = [r for r in records if r.status == DispatchStatus.REFUSED]
-        assert len(refused) >= 1
+        assert len(refused) == 1
         assert refused[0].reason == "fleet_missing_ingredient"
 
     @pytest.mark.anyio
     async def test_run_dispatch_writes_campaign_state_on_unknown_ingredient(
-        self, tool_ctx, monkeypatch, tmp_path
+        self, tool_ctx, tmp_path
     ):
         """T3: _run_dispatch writes REFUSED to campaign state on unknown ingredient."""
         from autoskillit.core import RecipeSource
@@ -518,7 +518,7 @@ class TestValidationFailureCampaignState:
         assert decision.completed_dispatches_block == "fleet_halted_on_failure"
 
     @pytest.mark.anyio
-    async def test_dispatch_rejected_carries_dispatch_id(self, tool_ctx, monkeypatch, tmp_path):
+    async def test_dispatch_rejected_carries_dispatch_id(self, tool_ctx, tmp_path):
         """T6: DispatchRejected returned from execute_dispatch carries non-empty dispatch_id."""
         from autoskillit.core import RecipeSource
         from autoskillit.fleet import FleetSemaphore

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -235,9 +235,10 @@ class TestDispatchFoodTruckCampaignState:
         assert not (tmp_path / "campaign" / "state.json").exists()
 
     @pytest.mark.anyio
-    async def test_dispatch_food_truck_skips_campaign_state_without_dispatch_name(
+    async def test_dispatch_food_truck_uses_recipe_name_when_dispatch_name_is_none(
         self, tool_ctx_kitchen_open, monkeypatch, tmp_path
     ):
+        """Verify dispatch_name=None falls back to recipe name for campaign state write."""
         sp = _init_state(tmp_path, "full-audit")
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(sp))
         monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
@@ -263,7 +264,7 @@ class TestDispatchFoodTruckCampaignState:
         state = read_state(sp)
         assert state is not None
         d = next(d for d in state.dispatches if d.name == "full-audit")
-        assert d.status == DispatchStatus.PENDING
+        assert d.status == DispatchStatus.SUCCESS
 
 
 # ---------------------------------------------------------------------------
@@ -309,3 +310,264 @@ def test_refused_gate_resume_selects_next(tmp_path):
     assert decision is not None
     assert decision.next_dispatch_name == "phase-one"
     assert "- gate-check: refused" in decision.completed_dispatches_block
+
+
+# ---------------------------------------------------------------------------
+# Tests T1-T6: validation-failure state persistence
+# ---------------------------------------------------------------------------
+
+
+class TestValidationFailureCampaignState:
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
+    @pytest.mark.anyio
+    async def test_execute_dispatch_records_type_rejection_to_campaign_state(
+        self, tool_ctx, monkeypatch, tmp_path
+    ):
+        """T1: execute_dispatch writes REFUSED to campaign state on type validation error."""
+
+        sp = _init_state(tmp_path, "step1")
+        # Give the context a fleet lock so the early type-check path is skipped
+        # but the lock itself is not the rejection source — ingredients are.
+        from tests.fleet.conftest import fleet_lock_from_ctx
+
+        lock = fleet_lock_from_ctx(tool_ctx)
+        tool_ctx.fleet_lock = lock
+
+        from autoskillit.fleet import execute_dispatch
+
+        # Trigger FLEET_UNKNOWN_INGREDIENT (non-string ingredient value)
+        await execute_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="t",
+            ingredients={"key": 123},  # type error — values must be strings
+            dispatch_name="step1",
+            timeout_sec=None,
+            prompt_builder=lambda **kw: "",
+            quota_checker=lambda **kw: {},
+            quota_refresher=lambda **kw: None,
+            campaign_state_path=sp,
+        )
+        state = read_state(sp)
+        d = next(d for d in state.dispatches if d.name == "step1")
+        assert d.status == DispatchStatus.REFUSED
+        assert d.reason == "fleet_unknown_ingredient"
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_writes_per_dispatch_state_on_missing_ingredient(
+        self, tool_ctx, monkeypatch, tmp_path
+    ):
+        """T2: _run_dispatch creates per-dispatch state file on missing required ingredient."""
+        from autoskillit.core import RecipeSource
+        from autoskillit.fleet import FleetSemaphore
+        from autoskillit.recipe.schema import Recipe, RecipeInfo, RecipeIngredient, RecipeKind
+        from tests.fakes import InMemoryRecipeRepository
+
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        repo = InMemoryRecipeRepository()
+        recipe_path = tmp_path / "test-recipe.yaml"
+        repo.add_recipe(
+            "test-recipe",
+            RecipeInfo(
+                name="test-recipe",
+                description="test",
+                source=RecipeSource.PROJECT,
+                path=recipe_path,
+            ),
+        )
+        repo.add_full_recipe(
+            recipe_path,
+            Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={"required_key": RecipeIngredient(description="", required=True)},
+                requires_packs=[],
+            ),
+        )
+        tool_ctx.recipes = repo
+
+        from autoskillit.fleet import execute_dispatch
+
+        await execute_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="t",
+            ingredients={},  # missing required_key
+            dispatch_name="step1",
+            timeout_sec=None,
+            prompt_builder=lambda **kw: "",
+            quota_checker=lambda **kw: {},
+            quota_refresher=lambda **kw: None,
+            campaign_state_path=None,
+        )
+        import json
+
+        dispatches_dir = tool_ctx.temp_dir / "dispatches"
+        dispatch_files = list(dispatches_dir.glob("*.json"))
+        assert len(dispatch_files) == 1
+        with open(dispatch_files[0]) as f:
+            records = [DispatchRecord.from_dict(r) for r in json.load(f)["dispatches"]]
+        refused = [r for r in records if r.status == DispatchStatus.REFUSED]
+        assert len(refused) >= 1
+        assert refused[0].reason == "fleet_missing_ingredient"
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_writes_campaign_state_on_unknown_ingredient(
+        self, tool_ctx, monkeypatch, tmp_path
+    ):
+        """T3: _run_dispatch writes REFUSED to campaign state on unknown ingredient."""
+        from autoskillit.core import RecipeSource
+        from autoskillit.fleet import FleetSemaphore
+        from autoskillit.recipe.schema import Recipe, RecipeInfo, RecipeIngredient, RecipeKind
+        from tests.fakes import InMemoryRecipeRepository
+
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        sp = _init_state(tmp_path, "step1")
+
+        repo = InMemoryRecipeRepository()
+        recipe_path = tmp_path / "test-recipe.yaml"
+        repo.add_recipe(
+            "test-recipe",
+            RecipeInfo(
+                name="test-recipe",
+                description="test",
+                source=RecipeSource.PROJECT,
+                path=recipe_path,
+            ),
+        )
+        repo.add_full_recipe(
+            recipe_path,
+            Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={"task": RecipeIngredient(description="", required=False)},
+                requires_packs=[],
+            ),
+        )
+        tool_ctx.recipes = repo
+
+        from autoskillit.fleet import execute_dispatch
+
+        await execute_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="t",
+            ingredients={"nonexistent_key": "val"},  # unknown ingredient
+            dispatch_name="step1",
+            timeout_sec=None,
+            prompt_builder=lambda **kw: "",
+            quota_checker=lambda **kw: {},
+            quota_refresher=lambda **kw: None,
+            campaign_state_path=sp,
+        )
+        state = read_state(sp)
+        d = next(d for d in state.dispatches if d.name == "step1")
+        assert d.status == DispatchStatus.REFUSED
+        assert d.reason == "fleet_unknown_ingredient"
+
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_writes_campaign_state_without_dispatch_name(
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
+    ):
+        """T4: dispatch_food_truck uses recipe name when dispatch_name is None."""
+        sp = _init_state(tmp_path, "my-recipe")
+        monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(sp))
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+
+        async def _fake_execute(**kwargs):
+            return DispatchCompleted(
+                success=False,
+                dispatch_status=DispatchStatus.FAILURE,
+                dispatch_id="d1",
+                dispatched_session_id="s1",
+                reason="fleet_missing_ingredient",
+                token_usage={},
+            )
+
+        import autoskillit.fleet
+
+        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+
+        from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
+
+        raw = await dispatch_food_truck(recipe="my-recipe", task="t", dispatch_name=None)
+        result = json.loads(raw)
+        assert result["success"] is False
+
+        state = read_state(sp)
+        d = next(d for d in state.dispatches if d.name == "my-recipe")
+        assert d.status == DispatchStatus.FAILURE
+
+    @pytest.mark.anyio
+    async def test_campaign_resume_halts_on_validation_refused(self, tmp_path):
+        """T5: resume_campaign_from_state halts on REFUSED dispatch."""
+        from autoskillit.fleet.state import append_dispatch_record
+
+        sp = _init_state(tmp_path, "step1")
+        append_dispatch_record(
+            sp,
+            DispatchRecord(
+                name="step1",
+                status=DispatchStatus.REFUSED,
+                reason="fleet_missing_ingredient",
+            ),
+        )
+
+        decision = resume_campaign_from_state(sp, continue_on_failure=False, reset_on_retry=False)
+        assert decision is not None
+        assert decision.completed_dispatches_block == "fleet_halted_on_failure"
+
+    @pytest.mark.anyio
+    async def test_dispatch_rejected_carries_dispatch_id(self, tool_ctx, monkeypatch, tmp_path):
+        """T6: DispatchRejected returned from execute_dispatch carries non-empty dispatch_id."""
+        from autoskillit.core import RecipeSource
+        from autoskillit.fleet import FleetSemaphore
+        from autoskillit.recipe.schema import Recipe, RecipeInfo, RecipeIngredient, RecipeKind
+        from tests.fakes import InMemoryRecipeRepository
+
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        repo = InMemoryRecipeRepository()
+        recipe_path = tmp_path / "test-recipe.yaml"
+        repo.add_recipe(
+            "test-recipe",
+            RecipeInfo(
+                name="test-recipe",
+                description="test",
+                source=RecipeSource.PROJECT,
+                path=recipe_path,
+            ),
+        )
+        repo.add_full_recipe(
+            recipe_path,
+            Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={"required_key": RecipeIngredient(description="", required=True)},
+                requires_packs=[],
+            ),
+        )
+        tool_ctx.recipes = repo
+
+        from autoskillit.fleet import execute_dispatch
+
+        result = await execute_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="t",
+            ingredients={},
+            dispatch_name="step1",
+            timeout_sec=None,
+            prompt_builder=lambda **kw: "",
+            quota_checker=lambda **kw: {},
+            quota_refresher=lambda **kw: None,
+            campaign_state_path=None,
+        )
+
+        assert hasattr(result, "dispatch_id")
+        assert result.dispatch_id != ""

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -10,6 +10,7 @@ import pytest
 from autoskillit.fleet import (
     DispatchCompleted,
     DispatchRecord,
+    DispatchRejected,
     DispatchStatus,
     read_state,
     resume_campaign_from_state,
@@ -409,6 +410,7 @@ class TestValidationFailureCampaignState:
         refused = [r for r in records if r.status == DispatchStatus.REFUSED]
         assert len(refused) == 1
         assert refused[0].reason == "fleet_missing_ingredient"
+        assert refused[0].name == "step1"
 
     @pytest.mark.anyio
     async def test_run_dispatch_writes_campaign_state_on_unknown_ingredient(
@@ -498,8 +500,7 @@ class TestValidationFailureCampaignState:
         d = next(d for d in state.dispatches if d.name == "my-recipe")
         assert d.status == DispatchStatus.FAILURE
 
-    @pytest.mark.anyio
-    async def test_campaign_resume_halts_on_validation_refused(self, tmp_path):
+    def test_campaign_resume_halts_on_validation_refused(self, tmp_path):
         """T5: resume_campaign_from_state halts on REFUSED dispatch."""
         from autoskillit.fleet.state import append_dispatch_record
 
@@ -564,5 +565,5 @@ class TestValidationFailureCampaignState:
             campaign_state_path=None,
         )
 
-        assert hasattr(result, "dispatch_id")
+        assert isinstance(result, DispatchRejected)
         assert result.dispatch_id != ""


### PR DESCRIPTION
## Summary

Pre-dispatch validation errors in `_run_dispatch` (`fleet/_api.py`, lines 337-379) return `DispatchRejected` before `dispatch_id` is generated and `write_initial_state` is called. No per-dispatch state file is created, and when `dispatch_name` is not passed to the MCP tool, no campaign state update occurs either. The dispatch remains PENDING in the campaign state file, causing `resume_campaign_from_state` to re-dispatch it indefinitely on campaign resume.

The fix has three layers:
1. **`_run_dispatch`**: Generate `dispatch_id` and write initial PENDING state **before** ingredient validation. On validation failure, update per-dispatch state to REFUSED and write REFUSED to the campaign state directly.
2. **`execute_dispatch`**: Record all `DispatchRejected` outcomes to campaign state via a closure that captures the campaign path and effective name.
3. **MCP tool layer**: Remove the `dispatch_name` guard on `_write_dispatch_to_campaign_state` and use `dispatch_name or recipe` as fallback, providing defense-in-depth.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
● src/autoskillit/fleet/_api.py
● src/autoskillit/fleet/state_types.py
● src/autoskillit/server/tools/tools_fleet_dispatch.py
● tests/_test_filter.py
● tests/fleet/conftest.py
● tests/fleet/test_gate_state_persistence.py

Closes #2272

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-084507-333622/.autoskillit/temp/make-plan/pre_dispatch_validation_state_plan_2026-05-09_090000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 1.0k | 41.6k | 1.8M | 116.7k | 115 | 103.5k | 19m 6s |
| review | claude-sonnet-4-6 | 1 | 3.0k | 4.4k | 159.7k | 36.8k | 33 | 26.5k | 3m 13s |
| verify | claude-opus-4-6 | 1 | 2.8k | 18.3k | 1.3M | 71.4k | 90 | 58.2k | 9m 50s |
| implement* | MiniMax-M2.7-highspeed | 1 | 7.0M | 39.6k | 3.1M | 29.8k | 240 | 117.6k | 21m 8s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 115.0k | 3.4k | 255.8k | 28.7k | 24 | 15.4k | 1m 25s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 57.9k | 1.9k | 169.6k | 28.7k | 15 | 15.2k | 50s |
| review_pr | claude-sonnet-4-6 | 3 | 780 | 104.5k | 2.0M | 86.4k | 142 | 218.3k | 26m 50s |
| resolve_review | claude-sonnet-4-6 | 3 | 959 | 80.6k | 7.9M | 95.4k | 289 | 229.1k | 37m 34s |
| **Total** | | | 7.2M | 294.3k | 16.6M | 116.7k | | 783.8k | 1h 59m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 434 | 7138.4 | 271.0 | 91.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 114 | 69123.2 | 2009.9 | 706.7 |
| **Total** | **548** | 30327.7 | 1430.2 | 537.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 35 | 2.1k | 81.1k | 12.4k | 1m 34s |