### PR TITLE
Implementation Plan: P1-A4 — Add RetryReason.IDLE_STALL to _ABANDON_REASONS frozenset

### DIFF
--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -322,5 +322,6 @@ _ABANDON_REASONS: frozenset[str] = frozenset(
         RetryReason.THINKING_STALL,
         RetryReason.PATH_CONTAMINATION,
         RetryReason.CLONE_CONTAMINATION,
+        RetryReason.IDLE_STALL,
     }
 )

--- a/tests/fleet/test_dispatch_outcome_classifier.py
+++ b/tests/fleet/test_dispatch_outcome_classifier.py
@@ -146,14 +146,14 @@ class TestClassifyDispatchOutcomeCompletedDirty:
 
 
 class TestReasonAwareResumePolicy:
-    def test_idle_stall_with_progress_is_resumable(self):
+    def test_idle_stall_with_progress_is_failure(self):
         parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
         skill_result = dataclasses.replace(
             skill_result,
             retry_reason="idle_stall",
         )
         status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
-        assert status == DispatchStatus.RESUMABLE
+        assert status == DispatchStatus.FAILURE
         assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
 
     def test_context_exhausted_with_progress_is_failure(self):

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -1083,8 +1083,8 @@ class TestClassifyStaleDispatch:
         assert status == DispatchStatus.INTERRUPTED
         assert sidecar_path_out == ""
 
-    def test_idle_stall_kill_reason_returns_resumable(self, tmp_path: Path) -> None:
-        """kill_reason=idle_stall (non-abandon) + empty sidecar → RESUMABLE."""
+    def test_idle_stall_kill_reason_returns_interrupted(self, tmp_path: Path) -> None:
+        """kill_reason=idle_stall (abandon) + empty sidecar → INTERRUPTED."""
         sidecar = tmp_path / "sidecar.jsonl"
         sidecar.write_text("")  # empty sidecar → raw_lines=[] → not raw_lines=True
         record = DispatchRecord(
@@ -1095,8 +1095,8 @@ class TestClassifyStaleDispatch:
             infra_exit_category="",
         )
         status, sidecar_path_out = classify_stale_dispatch(record)
-        assert status == DispatchStatus.RESUMABLE
-        assert sidecar_path_out == str(sidecar)
+        assert status == DispatchStatus.INTERRUPTED
+        assert sidecar_path_out == ""
 
     def test_no_sidecar_returns_interrupted(self) -> None:
         """No sidecar path → INTERRUPTED fallback."""


### PR DESCRIPTION
## Summary

Add `RetryReason.IDLE_STALL` as the fifth member of the `_ABANDON_REASONS` frozenset in `src/autoskillit/fleet/state_types.py`. This reclassifies idle-stall-killed dispatches from RESUMABLE to FAILURE/INTERRUPTED — both `_is_abandon_reason` (fleet/_api.py) and `_is_abandon_kill_metadata` (fleet/state_recovery.py) automatically pick up the change via their membership check against `_ABANDON_REASONS`. Two existing tests that assert the old RESUMABLE behavior must be updated to expect the new classification.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-124108-802432/.autoskillit/temp/make-plan/p1_a4_add_retryreason_idle_stall_plan_2026-05-09_124500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 67 | 5.0k | 430.0k | 43.8k | 34 | 33.1k | 3m 1s |
| verify | claude-opus-4-6 | 1 | 32 | 5.8k | 478.4k | 43.7k | 45 | 33.3k | 2m 58s |
| implement* | MiniMax-M2.7-highspeed | 1 | 198.7k | 4.3k | 342.0k | 28.7k | 35 | 16.3k | 1m 31s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 80.3k | 2.7k | 230.0k | 28.7k | 19 | 41.2k | 1m 4s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 79.7k | 1.5k | 255.8k | 28.7k | 21 | 15.2k | 45s |
| review_pr | claude-sonnet-4-6 | 3 | 262 | 29.4k | 1.0M | 47.9k | 85 | 93.6k | 7m 16s |
| **Total** | | | 359.0k | 48.7k | 2.8M | 47.9k | | 232.6k | 16m 36s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 13 | 26305.3 | 1251.5 | 329.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **13** | 213807.8 | 17895.3 | 3749.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 99 | 10.8k | 908.3k | 66.4k | 5m 59s |
| MiniMax-M2.7-highspeed | 3 | 358.7k | 8.5k | 827.8k | 72.7k | 3m 20s |