### PR TITLE
Implementation Plan: P1-A1 — Add module-level import time and _has_active_dispatch_marker helper

### DIFF
--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -45,6 +45,7 @@ from autoskillit.execution.process._process_kill import (
 from autoskillit.execution.process._process_monitor import (
     _has_active_api_connection,
     _has_active_child_processes,
+    _has_active_dispatch_marker,
     _heartbeat,
     _session_log_monitor,
 )
@@ -81,6 +82,7 @@ __all__ = [
     "RaceSignals",
     "_has_active_api_connection",
     "_has_active_child_processes",
+    "_has_active_dispatch_marker",
     "_heartbeat",
     "_jsonl_contains_marker",
     "_jsonl_has_record_type",

--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import NamedTuple
@@ -141,6 +142,31 @@ def _has_active_child_processes(pid: int) -> bool:
         _child_process_cache.pop(stale_pid, None)
 
     return active
+
+
+def _has_active_dispatch_marker(
+    marker_dir: Path,
+    session_id: str | None = None,
+    max_marker_age: float = 60.0,
+) -> bool:
+    """Return True if any dispatch-in-progress marker was touched within max_marker_age seconds."""
+    try:
+        now = time.time()
+        pattern = (
+            f"dispatch-in-progress-{session_id}-*.marker"
+            if session_id is not None
+            else "dispatch-in-progress-*.marker"
+        )
+        for p in marker_dir.glob(pattern):
+            try:
+                st = p.stat()
+                if now - st.st_mtime <= max_marker_age:
+                    return True
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return False
 
 
 async def _session_log_monitor(

--- a/tests/execution/test_process_heartbeat.py
+++ b/tests/execution/test_process_heartbeat.py
@@ -3,6 +3,8 @@ and orphaned tool result detection."""
 
 from __future__ import annotations
 
+import ast
+import inspect
 import os as _os
 import sys
 import time
@@ -640,8 +642,6 @@ class TestHasActiveDispatchMarker:
 
     def test_dispatch_marker_no_logger_calls(self):
         """The function body contains no logger.* attribute access calls."""
-        import ast
-        import inspect
 
         source = inspect.getsource(_has_active_dispatch_marker)
         tree = ast.parse(source)

--- a/tests/execution/test_process_heartbeat.py
+++ b/tests/execution/test_process_heartbeat.py
@@ -3,6 +3,7 @@ and orphaned tool result detection."""
 
 from __future__ import annotations
 
+import os as _os
 import sys
 import time
 from unittest.mock import MagicMock, patch
@@ -616,7 +617,6 @@ class TestHasActiveDispatchMarker:
         marker = tmp_path / "dispatch-in-progress-xyz-001.marker"
         marker.touch()
         old_time = time.time() - 120
-        import os as _os
 
         _os.utime(marker, (old_time, old_time))
         result = _has_active_dispatch_marker(tmp_path, max_marker_age=60.0)
@@ -646,5 +646,9 @@ class TestHasActiveDispatchMarker:
         source = inspect.getsource(_has_active_dispatch_marker)
         tree = ast.parse(source)
         for node in ast.walk(tree):
-            if isinstance(node, ast.Attribute) and node.attr.startswith("logger"):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "logger"
+            ):
                 pytest.fail(f"Found logger.{node.attr} in _has_active_dispatch_marker body")

--- a/tests/execution/test_process_heartbeat.py
+++ b/tests/execution/test_process_heartbeat.py
@@ -15,6 +15,7 @@ from autoskillit.core.types import ChannelBStatus, TerminationReason
 from autoskillit.execution.process import (
     _has_active_api_connection,
     _has_active_child_processes,
+    _has_active_dispatch_marker,
     _heartbeat,
     _session_log_monitor,
     run_managed_async,
@@ -593,3 +594,57 @@ class TestOrphanedToolResultDetection:
 
         assert result.status == ChannelBStatus.COMPLETION
         assert result.orphaned_tool_result is False
+
+
+class TestHasActiveDispatchMarker:
+    """Unit tests for _has_active_dispatch_marker."""
+
+    def test_dispatch_marker_nonexistent_dir_returns_false(self, tmp_path):
+        """Nonexistent marker directory returns False without raising."""
+        result = _has_active_dispatch_marker(tmp_path / "nonexistent")
+        assert result is False
+
+    def test_dispatch_marker_fresh_marker_returns_true(self, tmp_path):
+        """A fresh marker file causes the function to return True."""
+        marker = tmp_path / "dispatch-in-progress-sess1-abc.marker"
+        marker.touch()
+        result = _has_active_dispatch_marker(tmp_path)
+        assert result is True
+
+    def test_dispatch_marker_expired_marker_returns_false(self, tmp_path):
+        """A marker file with mtime older than max_marker_age returns False."""
+        marker = tmp_path / "dispatch-in-progress-xyz-001.marker"
+        marker.touch()
+        old_time = time.time() - 120
+        import os as _os
+
+        _os.utime(marker, (old_time, old_time))
+        result = _has_active_dispatch_marker(tmp_path, max_marker_age=60.0)
+        assert result is False
+
+    def test_dispatch_marker_session_id_filters(self, tmp_path):
+        """When session_id is provided, only markers matching that session are considered."""
+        (tmp_path / "dispatch-in-progress-abc-001.marker").touch()
+        (tmp_path / "dispatch-in-progress-xyz-002.marker").touch()
+        result_matching = _has_active_dispatch_marker(tmp_path, session_id="abc")
+        result_non_matching = _has_active_dispatch_marker(tmp_path, session_id="def")
+        assert result_matching is True
+        assert result_non_matching is False
+
+    def test_dispatch_marker_none_session_id_matches_all(self, tmp_path):
+        """session_id=None matches any dispatch-in-progress marker."""
+        marker = tmp_path / "dispatch-in-progress-xyz-001.marker"
+        marker.touch()
+        result = _has_active_dispatch_marker(tmp_path, session_id=None)
+        assert result is True
+
+    def test_dispatch_marker_no_logger_calls(self):
+        """The function body contains no logger.* attribute access calls."""
+        import ast
+        import inspect
+
+        source = inspect.getsource(_has_active_dispatch_marker)
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr.startswith("logger"):
+                pytest.fail(f"Found logger.{node.attr} in _has_active_dispatch_marker body")

--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -21,6 +21,7 @@ _EXPECTED_PROCESS_SYMBOLS: frozenset[str] = frozenset(
         "RaceSignals",
         "_has_active_api_connection",
         "_has_active_child_processes",
+        "_has_active_dispatch_marker",
         "_heartbeat",
         "_jsonl_contains_marker",
         "_jsonl_has_record_type",
@@ -98,6 +99,7 @@ def test_process_monitor_exports():
     are defined in _process_monitor submodule."""
     from autoskillit.execution.process._process_monitor import (
         _has_active_api_connection,
+        _has_active_dispatch_marker,
         _heartbeat,
         _session_log_monitor,
     )
@@ -109,6 +111,10 @@ def test_process_monitor_exports():
     assert callable(_has_active_api_connection)
     assert (
         _has_active_api_connection.__module__ == "autoskillit.execution.process._process_monitor"
+    )
+    assert callable(_has_active_dispatch_marker)
+    assert (
+        _has_active_dispatch_marker.__module__ == "autoskillit.execution.process._process_monitor"
     )
 
 
@@ -130,7 +136,7 @@ def test_process_race_exports():
 
 
 def test_process_facade_reexports_all_public_symbols():
-    """process.py facade re-exports exactly the expected 27 public symbols."""
+    """process.py facade re-exports exactly the expected 28 public symbols."""
     from autoskillit.execution import process
 
     assert hasattr(process, "__all__")


### PR DESCRIPTION
## Summary

Add `import time` to the stdlib import group of `_process_monitor.py` and insert a new `_has_active_dispatch_marker` function between `_has_active_child_processes` and `_session_log_monitor`. The function checks for fresh dispatch-in-progress marker files via glob, with full OSError guarding. The function must also be re-exported through the `process/__init__.py` facade and its structural guard tests updated.

Closes #2293

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-124107-172362/.autoskillit/temp/make-plan/p1_a1_add_module_level_import_time_and_has_active_dispatch_marker_plan_2026-05-09_124500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 71 | 6.9k | 628.1k | 51.0k | 52 | 41.7k | 4m 34s |
| verify | claude-opus-4-6 | 1 | 38 | 8.4k | 555.4k | 69.3k | 38 | 60.0k | 4m 20s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 10.0k | 1.2M | 67.9k | 103 | 74.8k | 6m 16s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 75.3k | 3.3k | 227.0k | 28.7k | 20 | 15.4k | 1m 4s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 58.3k | 1.6k | 198.3k | 28.7k | 15 | 15.1k | 44s |
| review_pr | claude-sonnet-4-6 | 3 | 361 | 59.5k | 1.1M | 58.2k | 91 | 134.1k | 13m 57s |
| resolve_review | claude-sonnet-4-6 | 3 | 563 | 32.0k | 3.0M | 65.0k | 156 | 141.5k | 18m 39s |
| **Total** | | | 1.4M | 121.8k | 7.0M | 69.3k | | 482.6k | 49m 38s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 91 | 13566.4 | 821.5 | 110.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 252871.2 | 11795.6 | 2670.2 |
| **Total** | **103** | 67495.6 | 4685.9 | 1182.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 109 | 15.3k | 1.2M | 101.7k | 8m 55s |
| MiniMax-M2.7-highspeed | 3 | 1.4M | 14.9k | 1.7M | 105.3k | 8m 4s |