### PR TITLE
Refactor Shared Suppression Timer in _session_log_monitor

### DIFF
--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -248,8 +248,7 @@ async def _session_log_monitor(
     last_change = _time.monotonic()
     scan_pos = 0
     os_error_count = 0
-    suppression_start_api: float | None = None
-    suppression_start_child: float | None = None
+    suppression_start: float | None = None
     _last_record_type: str | None = None
 
     while True:
@@ -268,8 +267,7 @@ async def _session_log_monitor(
         if current_size > last_size:
             last_size = current_size
             last_change = _time.monotonic()
-            suppression_start_api = None
-            suppression_start_child = None
+            suppression_start = None
 
             # Check new content for completion marker (structured)
             try:
@@ -294,14 +292,13 @@ async def _session_log_monitor(
             elapsed = _time.monotonic() - last_change
             if elapsed >= stale_threshold:
                 if pid is not None and _has_active_api_connection(pid):
-                    suppression_start_child = None
-                    if suppression_start_api is None:
-                        suppression_start_api = _time.monotonic()
-                    if _time.monotonic() - suppression_start_api >= max_suppression_seconds:
+                    if suppression_start is None:
+                        suppression_start = _time.monotonic()
+                    if _time.monotonic() - suppression_start >= max_suppression_seconds:
                         logger.warning(
                             "Suppression bounded: stale kill after %.0fs consecutive "
                             "suppression (max_suppression_seconds=%.0f, pid=%d)",
-                            _time.monotonic() - suppression_start_api,
+                            _time.monotonic() - suppression_start,
                             max_suppression_seconds,
                             pid,
                         )
@@ -314,14 +311,13 @@ async def _session_log_monitor(
                         pid,
                     )
                 elif pid is not None and _has_active_child_processes(pid):
-                    suppression_start_api = None
-                    if suppression_start_child is None:
-                        suppression_start_child = _time.monotonic()
-                    if _time.monotonic() - suppression_start_child >= max_suppression_seconds:
+                    if suppression_start is None:
+                        suppression_start = _time.monotonic()
+                    if _time.monotonic() - suppression_start >= max_suppression_seconds:
                         logger.warning(
                             "Suppression bounded: stale kill after %.0fs consecutive "
                             "suppression (max_suppression_seconds=%.0f, pid=%d)",
-                            _time.monotonic() - suppression_start_child,
+                            _time.monotonic() - suppression_start,
                             max_suppression_seconds,
                             pid,
                         )


### PR DESCRIPTION
## Summary

Replace the two independent per-gate suppression timer variables (`suppression_start_api` and `suppression_start_child`) in `_session_log_monitor` with a single shared `suppression_start: float | None = None` variable. Remove the cross-reset statements that cleared the opposing timer on branch entry. This establishes the unified suppression timer foundation required by downstream work packages (P1-A3-WP1 and beyond).

The refactoring touches exactly one file: `src/autoskillit/execution/process/_process_monitor.py`, lines 251–324. All changes are within `_session_log_monitor`'s Phase 2 loop.

Closes #2294

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-124108-180394/.autoskillit/temp/make-plan/p1_a2_refactor_shared_suppression_timer_plan_2026-05-09_124600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 80 | 6.9k | 678.3k | 55.8k | 43 | 42.6k | 3m 43s |
| verify | claude-opus-4-6 | 1 | 468 | 3.9k | 230.2k | 36.8k | 36 | 24.4k | 2m 10s |
| implement* | MiniMax-M2.7-highspeed | 1 | 351.7k | 3.7k | 571.8k | 28.7k | 44 | 16.4k | 6m 7s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 44.4k | 2.8k | 169.6k | 28.7k | 17 | 15.4k | 1m 2s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 57.4k | 2.2k | 198.3k | 28.7k | 20 | 15.1k | 55s |
| review_pr | claude-sonnet-4-6 | 3 | 268 | 32.0k | 1.1M | 47.5k | 99 | 98.8k | 8m 52s |
| resolve_review | claude-sonnet-4-6 | 1 | 119 | 8.4k | 557.6k | 52.7k | 36 | 40.4k | 5m 6s |
| **Total** | | | 454.4k | 59.9k | 3.5M | 55.8k | | 253.0k | 27m 57s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 24 | 23826.9 | 683.2 | 154.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **24** | 145475.8 | 10543.5 | 2497.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 548 | 10.8k | 908.5k | 67.0k | 5m 53s |
| MiniMax-M2.7-highspeed | 3 | 453.5k | 8.7k | 939.7k | 46.9k | 8m 4s |