### PR TITLE
P1-A3: Add marker_dir/caller_session_id params and dispatch marker suppression branch

### DIFF
--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -182,6 +182,8 @@ async def _session_log_monitor(
     _on_poll: Callable[[], None] | None = None,
     expected_session_id: str | None = None,
     max_suppression_seconds: float = 1800.0,
+    marker_dir: Path | None = None,
+    caller_session_id: str | None = None,
 ) -> SessionMonitorResult:
     """Watch Claude Code session log for completion or staleness.
 
@@ -354,6 +356,27 @@ async def _session_log_monitor(
                         "suppressing stale kill (pid=%d)",
                         elapsed,
                         pid,
+                    )
+                elif marker_dir is not None and _has_active_dispatch_marker(
+                    marker_dir, session_id=caller_session_id
+                ):
+                    if suppression_start is None:
+                        suppression_start = _time.monotonic()
+                    if _time.monotonic() - suppression_start >= max_suppression_seconds:
+                        logger.warning(
+                            "Suppression bounded: stale kill after dispatch marker "
+                            "suppression exceeded max_suppression_seconds",
+                            elapsed=_time.monotonic() - suppression_start,
+                            caller_session_id=caller_session_id,
+                            marker_dir=str(marker_dir),
+                        )
+                        return SessionMonitorResult(ChannelBStatus.STALE, _session_id)
+                    last_change = _time.monotonic()
+                    logger.warning(
+                        "JSONL silent but active dispatch marker found — suppressing stale kill",
+                        elapsed=elapsed,
+                        caller_session_id=caller_session_id,
+                        marker_dir=str(marker_dir),
                     )
                 else:
                     return SessionMonitorResult(

--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -362,11 +362,12 @@ async def _session_log_monitor(
                 ):
                     if suppression_start is None:
                         suppression_start = _time.monotonic()
-                    if _time.monotonic() - suppression_start >= max_suppression_seconds:
+                    suppression_elapsed = _time.monotonic() - suppression_start
+                    if suppression_elapsed >= max_suppression_seconds:
                         logger.warning(
                             "Suppression bounded: stale kill after dispatch marker "
                             "suppression exceeded max_suppression_seconds",
-                            elapsed=_time.monotonic() - suppression_start,
+                            suppression_elapsed=suppression_elapsed,
                             caller_session_id=caller_session_id,
                             marker_dir=str(marker_dir),
                         )
@@ -374,7 +375,7 @@ async def _session_log_monitor(
                     last_change = _time.monotonic()
                     logger.warning(
                         "JSONL silent but active dispatch marker found — suppressing stale kill",
-                        elapsed=elapsed,
+                        stale_elapsed=elapsed,
                         caller_session_id=caller_session_id,
                         marker_dir=str(marker_dir),
                     )

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -908,7 +908,7 @@ class TestDispatchMarkerSuppression:
                 )
         assert result.status == ChannelBStatus.STALE
         bounded_logs = [log for log in logs if "Suppression bounded" in str(log.get("event", ""))]
-        assert len(bounded_logs) >= 1
+        assert len(bounded_logs) == 1
 
     @pytest.mark.anyio
     async def test_dispatch_marker_suppression_emits_warning_with_fields(
@@ -958,7 +958,7 @@ class TestDispatchMarkerSuppression:
                     caller_session_id="sess-abc",
                 )
         warning_logs = [log for log in logs if "dispatch" in str(log.get("event", ""))]
-        assert len(warning_logs) >= 1
+        assert len(warning_logs) == 1
         log = warning_logs[0]
         assert log.get("caller_session_id") == "sess-abc"
         assert log.get("marker_dir") == str(tmp_path)
@@ -1001,7 +1001,7 @@ class TestDispatchMarkerSuppression:
                     max_suppression_seconds=1.0,
                 )
         bounded_logs = [log for log in logs if "Suppression bounded" in str(log.get("event", ""))]
-        assert len(bounded_logs) >= 1
+        assert len(bounded_logs) == 1
         log = bounded_logs[0]
         assert log.get("caller_session_id") == "sess-abc"
         assert log.get("marker_dir") == str(tmp_path)

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -874,6 +874,8 @@ class TestDispatchMarkerSuppression:
     @pytest.mark.anyio
     async def test_dispatch_marker_bounded_by_max_suppression(self, tmp_path, monkeypatch):
         """Stale fires after max_suppression_seconds despite active dispatch marker."""
+        import structlog.testing
+
         session_file = tmp_path / "abc123.jsonl"
         session_file.write_text("")
         spawn_time = time.time() - 10
@@ -890,20 +892,23 @@ class TestDispatchMarkerSuppression:
             "autoskillit.execution.process._process_monitor._has_active_dispatch_marker",
             lambda marker_dir, session_id=None: True,
         )
-        with anyio.fail_after(8.0):
-            result = await _session_log_monitor(
-                tmp_path,
-                "DONE",
-                stale_threshold=0.05,
-                spawn_time=spawn_time,
-                pid=9999,
-                _phase1_poll=0.01,
-                _phase2_poll=0.05,
-                marker_dir=tmp_path,
-                caller_session_id="sess-abc",
-                max_suppression_seconds=1.0,
-            )
+        with structlog.testing.capture_logs() as logs:
+            with anyio.fail_after(8.0):
+                result = await _session_log_monitor(
+                    tmp_path,
+                    "DONE",
+                    stale_threshold=0.05,
+                    spawn_time=spawn_time,
+                    pid=9999,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                    marker_dir=tmp_path,
+                    caller_session_id="sess-abc",
+                    max_suppression_seconds=1.0,
+                )
         assert result.status == ChannelBStatus.STALE
+        bounded_logs = [log for log in logs if "Suppression bounded" in str(log.get("event", ""))]
+        assert len(bounded_logs) >= 1
 
     @pytest.mark.anyio
     async def test_dispatch_marker_suppression_emits_warning_with_fields(

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -802,3 +802,262 @@ class TestSessionLogMonitorDirMissing:
         assert result.status == ChannelBStatus.DIR_MISSING
         assert elapsed < 0.1  # FileNotFoundError is immediate after the poll sleep
         assert result.session_id == ""
+
+
+class TestDispatchMarkerSuppression:
+    """Dispatch marker suppression branch via marker_dir/caller_session_id parameters."""
+
+    @pytest.mark.anyio
+    async def test_accepts_marker_dir_and_caller_session_id_params(self, tmp_path):
+        """_session_log_monitor accepts marker_dir and caller_session_id without TypeError."""
+        session_file = tmp_path / "abc123.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        with anyio.fail_after(5.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+                marker_dir=tmp_path,
+                caller_session_id="test-session",
+            )
+        assert isinstance(result.status, ChannelBStatus)
+
+    @pytest.mark.anyio
+    async def test_dispatch_marker_suppresses_stale(self, tmp_path, monkeypatch):
+        """Active dispatch marker suppresses stale kill, then fires when marker disappears."""
+        session_file = tmp_path / "abc123.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        call_count = {"n": 0}
+
+        def fake_api_conn(pid):
+            return False
+
+        def fake_child_proc(pid):
+            return False
+
+        def fake_dispatch_marker(marker_dir, session_id=None):
+            call_count["n"] += 1
+            return call_count["n"] == 1
+
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_api_connection",
+            fake_api_conn,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_child_processes",
+            fake_child_proc,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_dispatch_marker",
+            fake_dispatch_marker,
+        )
+        with anyio.fail_after(5.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                pid=9999,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+                marker_dir=tmp_path,
+                caller_session_id="sess-abc",
+            )
+        assert result.status == ChannelBStatus.STALE
+        assert call_count["n"] == 2
+
+    @pytest.mark.anyio
+    async def test_dispatch_marker_bounded_by_max_suppression(self, tmp_path, monkeypatch):
+        """Stale fires after max_suppression_seconds despite active dispatch marker."""
+        session_file = tmp_path / "abc123.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_api_connection",
+            lambda pid: False,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_child_processes",
+            lambda pid: False,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_dispatch_marker",
+            lambda marker_dir, session_id=None: True,
+        )
+        with anyio.fail_after(8.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                pid=9999,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+                marker_dir=tmp_path,
+                caller_session_id="sess-abc",
+                max_suppression_seconds=1.0,
+            )
+        assert result.status == ChannelBStatus.STALE
+
+    @pytest.mark.anyio
+    async def test_dispatch_marker_suppression_emits_warning_with_fields(
+        self, tmp_path, monkeypatch
+    ):
+        """Suppression warning includes elapsed, caller_session_id, and marker_dir."""
+        import structlog.testing
+
+        session_file = tmp_path / "abc123.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        call_count = {"n": 0}
+
+        def fake_api_conn(pid):
+            return False
+
+        def fake_child_proc(pid):
+            return False
+
+        def fake_dispatch_marker(marker_dir, session_id=None):
+            call_count["n"] += 1
+            return call_count["n"] == 1
+
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_api_connection",
+            fake_api_conn,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_child_processes",
+            fake_child_proc,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_dispatch_marker",
+            fake_dispatch_marker,
+        )
+        with structlog.testing.capture_logs() as logs:
+            with anyio.fail_after(5.0):
+                await _session_log_monitor(
+                    tmp_path,
+                    "DONE",
+                    stale_threshold=0.05,
+                    spawn_time=spawn_time,
+                    pid=9999,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                    marker_dir=tmp_path,
+                    caller_session_id="sess-abc",
+                )
+        warning_logs = [log for log in logs if "dispatch" in str(log.get("event", ""))]
+        assert len(warning_logs) >= 1
+        log = warning_logs[0]
+        assert "caller_session_id" in log or "sess-abc" in str(log.values())
+        assert "marker_dir" in log or str(tmp_path) in str(log.values())
+
+    @pytest.mark.anyio
+    async def test_dispatch_marker_bounded_kill_emits_warning_with_fields(
+        self, tmp_path, monkeypatch
+    ):
+        """Bounded kill warning includes elapsed, caller_session_id, marker_dir."""
+        import structlog.testing
+
+        session_file = tmp_path / "abc123.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_api_connection",
+            lambda pid: False,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_child_processes",
+            lambda pid: False,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_dispatch_marker",
+            lambda marker_dir, session_id=None: True,
+        )
+        with structlog.testing.capture_logs() as logs:
+            with anyio.fail_after(8.0):
+                await _session_log_monitor(
+                    tmp_path,
+                    "DONE",
+                    stale_threshold=0.05,
+                    spawn_time=spawn_time,
+                    pid=9999,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                    marker_dir=tmp_path,
+                    caller_session_id="sess-abc",
+                    max_suppression_seconds=1.0,
+                )
+        bounded_logs = [log for log in logs if "Suppression bounded" in str(log.get("event", ""))]
+        assert len(bounded_logs) >= 1
+        log = bounded_logs[0]
+        assert "caller_session_id" in log or "sess-abc" in str(log.values())
+        assert "marker_dir" in log or str(tmp_path) in str(log.values())
+
+    @pytest.mark.anyio
+    async def test_marker_dir_none_skips_dispatch_check(self, tmp_path, monkeypatch):
+        """When marker_dir is None (default), _has_active_dispatch_marker is never called."""
+        session_file = tmp_path / "abc123.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        called = {"n": False}
+
+        def fake_api_conn(pid):
+            return False
+
+        def fake_child_proc(pid):
+            return False
+
+        def track_dispatch_marker(marker_dir, session_id=None):
+            called["n"] = True
+            return False
+
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_api_connection",
+            fake_api_conn,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_child_processes",
+            fake_child_proc,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_dispatch_marker",
+            track_dispatch_marker,
+        )
+        with anyio.fail_after(5.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                pid=9999,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+            )
+        assert result.status == ChannelBStatus.STALE
+        assert not called["n"]
+
+    @pytest.mark.anyio
+    async def test_existing_callers_unaffected_by_new_params(self, tmp_path):
+        """Calling _session_log_monitor without marker_dir/caller_session_id works identically."""
+        session_file = tmp_path / "abc123.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        with anyio.fail_after(5.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+            )
+        assert result.status == ChannelBStatus.STALE
+        assert result.session_id == "abc123"

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -809,7 +809,7 @@ class TestDispatchMarkerSuppression:
 
     @pytest.mark.anyio
     async def test_accepts_marker_dir_and_caller_session_id_params(self, tmp_path):
-        """_session_log_monitor accepts marker_dir and caller_session_id without TypeError."""
+        """marker_dir and caller_session_id params are forwarded; monitor exits STALE."""
         session_file = tmp_path / "abc123.jsonl"
         session_file.write_text("")
         spawn_time = time.time() - 10
@@ -824,7 +824,7 @@ class TestDispatchMarkerSuppression:
                 marker_dir=tmp_path,
                 caller_session_id="test-session",
             )
-        assert isinstance(result.status, ChannelBStatus)
+        assert result.status == ChannelBStatus.STALE
 
     @pytest.mark.anyio
     async def test_dispatch_marker_suppresses_stale(self, tmp_path, monkeypatch):
@@ -869,7 +869,7 @@ class TestDispatchMarkerSuppression:
                 caller_session_id="sess-abc",
             )
         assert result.status == ChannelBStatus.STALE
-        assert call_count["n"] == 2
+        assert call_count["n"] >= 2
 
     @pytest.mark.anyio
     async def test_dispatch_marker_bounded_by_max_suppression(self, tmp_path, monkeypatch):
@@ -955,8 +955,8 @@ class TestDispatchMarkerSuppression:
         warning_logs = [log for log in logs if "dispatch" in str(log.get("event", ""))]
         assert len(warning_logs) >= 1
         log = warning_logs[0]
-        assert "caller_session_id" in log or "sess-abc" in str(log.values())
-        assert "marker_dir" in log or str(tmp_path) in str(log.values())
+        assert log.get("caller_session_id") == "sess-abc"
+        assert log.get("marker_dir") == str(tmp_path)
 
     @pytest.mark.anyio
     async def test_dispatch_marker_bounded_kill_emits_warning_with_fields(
@@ -998,8 +998,8 @@ class TestDispatchMarkerSuppression:
         bounded_logs = [log for log in logs if "Suppression bounded" in str(log.get("event", ""))]
         assert len(bounded_logs) >= 1
         log = bounded_logs[0]
-        assert "caller_session_id" in log or "sess-abc" in str(log.values())
-        assert "marker_dir" in log or str(tmp_path) in str(log.values())
+        assert log.get("caller_session_id") == "sess-abc"
+        assert log.get("marker_dir") == str(tmp_path)
 
     @pytest.mark.anyio
     async def test_marker_dir_none_skips_dispatch_check(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Add two keyword-only parameters (`marker_dir: Path | None = None`, `caller_session_id: str | None = None`) to `_session_log_monitor` in `_process_monitor.py`, then insert a third suppression branch between the child-processes elif and the terminal else. The new branch checks for active dispatch marker files via `_has_active_dispatch_marker` (already defined at lines 147-169), uses the shared `suppression_start` timer (from P1-A2), and follows the identical bounded-suppression pattern as the two existing branches. The new parameters use structlog keyword-argument style for warning logs (event string + kwargs) per the design doc.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-140243-989130/.autoskillit/temp/make-plan/p1_a3_add_marker_dir_caller_session_id_params_and_dispatch_marker_suppression_branch_plan_2026-05-09_142600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 71 | 8.4k | 717.0k | 60.7k | 54 | 65.7k | 4m 0s |
| verify | claude-opus-4-6 | 1 | 42 | 8.2k | 1.0M | 56.8k | 57 | 43.8k | 3m 57s |
| implement* | MiniMax-M2.7-highspeed | 1 | 326.7k | 5.2k | 533.8k | 56.5k | 40 | 71.9k | 1m 56s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 88.4k | 5.6k | 179.0k | 29.8k | 20 | 42.2k | 1m 29s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.3k | 1.5k | 176.2k | 29.8k | 13 | 15.1k | 35s |
| review_pr | claude-sonnet-4-6 | 3 | 318 | 86.7k | 1.6M | 72.4k | 117 | 172.1k | 18m 3s |
| resolve_review | claude-sonnet-4-6 | 3 | 633 | 46.2k | 4.4M | 76.1k | 191 | 182.0k | 21m 10s |
| **Total** | | | 463.5k | 161.8k | 8.6M | 76.1k | | 592.8k | 51m 12s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 282 | 1893.0 | 255.1 | 18.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 58 | 75081.2 | 3137.8 | 797.0 |
| **Total** | **340** | 25285.6 | 1743.6 | 476.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 113 | 16.6k | 1.8M | 109.5k | 7m 58s |
| MiniMax-M2.7-highspeed | 3 | 462.4k | 12.3k | 889.0k | 129.3k | 3m 59s |