### PR TITLE
P1-A5: Add TestStaleSuppressionDispatchMarker Test Class

### DIFF
--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from unittest.mock import patch
 
@@ -582,6 +583,138 @@ class TestStaleSuppressionBounded:
         bounded_in_logs = any("Suppression bounded" in str(log.get("event", "")) for log in logs)
         bounded_in_stdout = "Suppression bounded" in captured
         assert bounded_in_logs or bounded_in_stdout
+
+
+class TestStaleSuppressionDispatchMarker:
+    """Dispatch marker suppresses stale: fresh marker → suppressed; expired → pass-through.
+
+    Tests the following scenarios for dispatch marker stale suppression:
+    - T1: Active marker (True→False via monkeypatch) suppresses stale, then fires
+    - T2: Expired marker (mtime > 60s) does NOT suppress stale
+    - T3: No marker_dir (None) skips dispatch check entirely (regression guard)
+    - T4: Bounded suppression fires after max_suppression_seconds
+    - T5: Session-scoped matching — sessionA marker does not suppress sessionB
+
+    Monkeypatch target: autoskillit.execution.process._process_monitor._has_active_dispatch_marker
+    Convention: caller_session_id= is the kwarg used at call sites.
+    """
+
+    @pytest.mark.anyio
+    async def test_stale_suppressed_by_active_dispatch_marker(self, tmp_path, monkeypatch):
+        """Active dispatch marker suppresses stale, then fires when marker disappears."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        call_count = {"n": 0}
+
+        def side_effect_fn(marker_dir, session_id=None):
+            call_count["n"] += 1
+            return call_count["n"] == 1
+
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_dispatch_marker",
+            side_effect_fn,
+        )
+        with anyio.fail_after(5.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                marker_dir=tmp_path,
+                caller_session_id="test-session",
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+            )
+        assert result.status == ChannelBStatus.STALE
+
+    @pytest.mark.anyio
+    async def test_stale_not_suppressed_when_marker_expired(self, tmp_path):
+        """Expired marker (mtime > 60s) does not suppress stale."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        marker_path = tmp_path / "dispatch-in-progress-test-session-abc.marker"
+        marker_path.write_text("{}")
+        past = time.time() - 120
+        os.utime(marker_path, (past, past))
+        with anyio.fail_after(5.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                marker_dir=tmp_path,
+                caller_session_id="test-session",
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+            )
+        assert result.status == ChannelBStatus.STALE
+
+    @pytest.mark.anyio
+    async def test_stale_not_suppressed_when_no_marker(self, tmp_path):
+        """No marker_dir means dispatch check is skipped entirely."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        with anyio.fail_after(2.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                marker_dir=None,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+            )
+        assert result.status == ChannelBStatus.STALE
+
+    @pytest.mark.anyio
+    async def test_stale_marker_suppression_bounded(self, tmp_path, monkeypatch):
+        """Stale fires after max_suppression_seconds despite perpetually-fresh marker."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_dispatch_marker",
+            lambda marker_dir, session_id=None: True,
+        )
+        with anyio.fail_after(3.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                pid=None,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+                max_suppression_seconds=0.1,
+                marker_dir=tmp_path,
+                caller_session_id=None,
+            )
+        assert result.status == ChannelBStatus.STALE
+
+    @pytest.mark.anyio
+    async def test_session_scoped_marker_matching(self, tmp_path):
+        """Marker for sessionA does not suppress stale for sessionB."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+        marker_path = tmp_path / "dispatch-in-progress-sessionA-dispatch1.marker"
+        marker_path.write_text("{}")
+        with anyio.fail_after(3.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                pid=None,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+                marker_dir=tmp_path,
+                caller_session_id="sessionB",
+            )
+        assert result.status == ChannelBStatus.STALE
 
 
 class TestSessionLogMonitorSessionId:

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -590,13 +590,15 @@ class TestStaleSuppressionDispatchMarker:
 
     Tests the following scenarios for dispatch marker stale suppression:
     - T1: Active marker (True→False via monkeypatch) suppresses stale, then fires
-    - T2: Expired marker (mtime > 60s) does NOT suppress stale
+    - T2: Expired marker (mtime > 60s) does NOT suppress stale (real helper, no monkeypatch —
+      exercises the mtime-expiry threshold in _has_active_dispatch_marker directly)
     - T3: No marker_dir (None) skips dispatch check entirely (regression guard)
     - T4: Bounded suppression fires after max_suppression_seconds
     - T5: Session-scoped matching — sessionA marker does not suppress sessionB
 
     Monkeypatch target: autoskillit.execution.process._process_monitor._has_active_dispatch_marker
     Convention: caller_session_id= is the kwarg used at call sites.
+    Note: T1, T4 monkeypatch the helper; T2, T5 use real marker files to test helper internals.
     """
 
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Add a new `TestStaleSuppressionDispatchMarker` test class with 5 fully-implemented test methods to `tests/execution/test_process_session_log_monitor.py`. The class validates dispatch marker stale suppression behavior: fresh-marker suppression, expired marker pass-through, no-marker regression guard, bounded suppression timeout, and session-scoped marker matching. Also add `import os` to module-level imports (needed for `os.utime` in the expired marker test).

## Requirements

## Goal

Append a new TestStaleSuppressionDispatchMarker class docstring skeleton immediately after the TestStaleSuppressionBounded class (which ends at line 585), add `import os` to the module-level imports (currently absent — needed for os.utime in sibling WP tests), and confirm the monkeypatch target path and caller_session_id kwarg convention before sibling WPs fill in the 5 test bodies.

## Context

- Phase: Process Monitor Suppression Infrastructure (Milestone: 1-process-monitor-suppression-infrastructure)
- Assignment: P1-A5 (Add TestStaleSuppressionDispatchMarker test class)
- Depends on: P1-A1-WP1, P1-A3-WP1
- Depended on by: P1-A6-WP1

## Deliverables

- `import os` added at module level in test_process_session_log_monitor.py (between `import time` and `from unittest.mock import patch`)
- `class TestStaleSuppressionDispatchMarker` skeleton with docstring and 5 @pytest.mark.anyio stub methods appended after line 585 (end of TestStaleSuppressionBounded)
- Three new test methods added to TestStaleSuppressionDispatchMarker in tests/execution/test_process_session_log_monitor.py: test_stale_suppressed_by_active_dispatch_marker, test_stale_not_suppressed_when_marker_expired, test_stale_not_suppressed_when_no_marker
- test_stale_marker_suppression_bounded method in TestStaleSuppressionDispatchMarker: monkeypatches _has_active_dispatch_marker to always return True, sets max_suppression_seconds=0.1, asserts stale fires within anyio.fail_after(3.0)
- test_session_scoped_marker_matching method in TestStaleSuppressionDispatchMarker: writes dispatch-in-progress-sessionA-dispatch1.marker in tmp_path, calls _session_log_monitor with caller_session_id='sessionB', asserts stale fires quickly since no sessionB marker exists

## Acceptance Criteria

- `import os` appears at module level in test_process_session_log_monitor.py
- Class `TestStaleSuppressionDispatchMarker` is present immediately after the last line of `TestStaleSuppressionBounded` (line 585)
- Class docstring describes all 5 test scenarios: fresh-marker suppression, expiry, regression guard, bounded suppression, session scoping
- All 5 stub method names match: test_stale_suppressed_by_active_dispatch_marker, test_stale_not_suppressed_when_marker_expired, test_stale_not_suppressed_when_no_marker, test_stale_marker_suppression_bounded, test_session_scoped_marker_matching
- Monkeypatch target string `'autoskillit.execution.process._process_monitor._has_active_dispatch_marker'` is documented in class docstring (for sibling WP authors)
- `caller_session_id=` kwarg convention (not `session_id=`) is noted for all _session_log_monitor call sites in this class
- test_stale_suppressed_by_active_dispatch_marker: monkeypatch sets _has_active_dispatch_marker to return True on call 1 and False on call 2; result.status == ChannelBStatus.STALE; anyio.fail_after(5.0) is the outermost context manager preventing hangs
- test_stale_not_suppressed_when_marker_expired: a real marker file is written to tmp_path with mtime set to time.time() - 120 via os.utime; _session_log_monitor is called with marker_dir=tmp_path and caller_session_id='test-session'; result.status == ChannelBStatus.STALE without suppression (expired marker ignored by _has_active_dispatch_marker which checks mtime <= 60s)
- test_stale_not_suppressed_when_no_marker: _session_log_monitor called with marker_dir=None; result.status == ChannelBStatus.STALE; _has_active_dispatch_marker is NOT called (regression guard — no-marker path unchanged)
- All three methods use @pytest.mark.anyio and match the file's existing pattern: session_file = tmp_path / 'session.jsonl', spawn_time = time.time() - 10, stale_threshold=0.05, _phase1_poll=0.01, _phase2_poll=0.05
- All three tests pass in isolation and under xdist (-n 4) parallel execution (each uses tmp_path for isolation, no shared state)
- task test-check passes with the new tests included
- test_stale_marker_suppression_bounded passes: stale fires within 3s despite perpetually-fresh marker because max_suppression_seconds=0.1 is exceeded
- test_session_scoped_marker_matching passes: stale fires quickly when marker filename contains 'sessionA' but caller_session_id is 'sessionB' (glob pattern dispatch-in-progress-sessionB-*.marker matches nothing)
- Both methods use monkeypatch (not unittest.mock.patch) consistent with TestStaleSuppressionBounded pattern in same file
- Both methods are decorated with @pytest.mark.anyio and wrapped in anyio.fail_after(3.0) to prevent hangs
- No new imports required beyond what is already in the module header (time, anyio, pytest, ChannelBStatus, _session_log_monitor already imported)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
- tests/execution/test_process_session_log_monitor.py

Closes #2297

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-151652-495882/.autoskillit/temp/make-plan/p1_a5_add_teststalesuppressiondispatchmarker_plan_2026-05-09_152200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 68 | 8.4k | 551.3k | 56.1k | 39 | 61.7k | 3m 44s |
| verify | claude-opus-4-6 | 1 | 841 | 5.6k | 654.3k | 51.8k | 43 | 38.7k | 3m 21s |
| implement* | MiniMax-M2.7-highspeed | 1 | 295.4k | 3.9k | 423.0k | 35.1k | 37 | 62.7k | 1m 44s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 62.8k | 4.2k | 176.2k | 29.8k | 18 | 15.4k | 1m 18s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 42.7k | 2.2k | 176.2k | 29.8k | 14 | 15.1k | 45s |
| review_pr | claude-sonnet-4-6 | 3 | 252 | 47.0k | 1.1M | 54.0k | 87 | 118.8k | 12m 27s |
| resolve_review | claude-sonnet-4-6 | 2 | 298 | 19.8k | 1.6M | 59.7k | 86 | 87.1k | 8m 54s |
| **Total** | | | 402.4k | 91.2k | 4.6M | 59.7k | | 399.4k | 32m 15s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 133 | 3180.4 | 471.1 | 29.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 389915.8 | 21766.2 | 4957.5 |
| **Total** | **137** | 33583.6 | 2915.4 | 665.4 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 909 | 14.1k | 1.2M | 100.4k | 7m 5s |
| MiniMax-M2.7-highspeed | 3 | 401.0k | 10.3k | 775.3k | 93.2k | 3m 47s |