### PR TITLE
P1-A6 — Add test_shared_suppression_timer_prevents_chaining

### DIFF
--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -584,6 +584,52 @@ class TestStaleSuppressionBounded:
         bounded_in_stdout = "Suppression bounded" in captured
         assert bounded_in_logs or bounded_in_stdout
 
+    @pytest.mark.anyio
+    async def test_shared_suppression_timer_prevents_chaining(self, tmp_path, monkeypatch):
+        """Switching suppression gates (API → marker) does not chain independent timers."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10
+
+        call_count = {"n": 0}
+
+        def _api_conn(pid):
+            call_count["n"] += 1
+            return call_count["n"] <= 2
+
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_api_connection",
+            _api_conn,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.process._process_monitor._has_active_child_processes",
+            lambda pid: False,
+        )
+
+        (tmp_path / "dispatch-in-progress-some-uuid.marker").write_text("{}")
+
+        suppression_start = time.monotonic()
+        with anyio.fail_after(8.0):
+            result = await _session_log_monitor(
+                tmp_path,
+                "DONE",
+                stale_threshold=0.05,
+                spawn_time=spawn_time,
+                pid=9999,
+                _phase1_poll=0.01,
+                _phase2_poll=0.05,
+                max_suppression_seconds=0.3,
+                marker_dir=tmp_path,
+                caller_session_id=None,
+            )
+        elapsed = time.monotonic() - suppression_start
+
+        assert result.status == ChannelBStatus.STALE
+        assert elapsed <= 0.45, f"elapsed {elapsed:.2f}s exceeds 0.45s — timer may have chained"
+        assert elapsed >= 0.15, (
+            f"elapsed {elapsed:.2f}s below 0.15s — suppression may not have fired"
+        )
+
 
 class TestStaleSuppressionDispatchMarker:
     """Dispatch marker suppresses stale: fresh marker → suppressed; expired → pass-through.


### PR DESCRIPTION
## Summary

Add a single test method `test_shared_suppression_timer_prevents_chaining` to the existing `TestStaleSuppressionBounded` class in `tests/execution/test_process_session_log_monitor.py`. This test verifies that the shared `suppression_start` timer in `_session_log_monitor` does not reset when the suppression gate transitions from API connection (`_has_active_api_connection`) to dispatch marker (`_has_active_dispatch_marker`). The total suppression duration must remain bounded by `max_suppression_seconds` (~0.3s), not chain to ~0.6s.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-160241-995641/.autoskillit/temp/make-plan/p1_a6_add_test_shared_suppression_timer_prevents_chaining_plan_2026-05-09_162600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 69 | 5.4k | 543.0k | 48.5k | 30 | 38.4k | 3m 10s |
| verify | claude-opus-4-6 | 1 | 42 | 11.1k | 633.1k | 56.8k | 41 | 43.6k | 4m 31s |
| implement* | MiniMax-M2.7-highspeed | 1 | 232.6k | 3.1k | 477.3k | 29.8k | 38 | 59.4k | 5m 15s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 73.9k | 2.8k | 235.8k | 29.8k | 19 | 15.4k | 1m 6s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 71.1k | 1.8k | 235.8k | 29.8k | 19 | 15.1k | 54s |
| review_pr | claude-sonnet-4-6 | 3 | 356 | 33.4k | 922.9k | 43.2k | 99 | 117.1k | 10m 5s |
| **Total** | | | 378.1k | 57.7k | 3.0M | 56.8k | | 289.1k | 25m 3s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 46 | 10376.3 | 1291.4 | 66.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **46** | 66260.6 | 6284.0 | 1253.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 111 | 16.5k | 1.2M | 82.0k | 7m 42s |
| MiniMax-M2.7-highspeed | 3 | 377.6k | 7.7k | 948.9k | 89.9k | 7m 16s |