### PR TITLE
P2-A1: Import _has_active_dispatch_marker and Implement Idle-Stall Suppression Gate

### DIFF
--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -186,14 +186,15 @@ async def _watch_stdout_idle(
             if marker_dir is not None and _has_active_dispatch_marker(
                 marker_dir, session_id=session_id
             ):
+                now = _time.monotonic()
                 if suppression_start_marker is None:
-                    suppression_start_marker = _time.monotonic()
-                if _time.monotonic() - suppression_start_marker < max_suppression_seconds:
+                    suppression_start_marker = now
+                if now - suppression_start_marker < max_suppression_seconds:
                     logger.warning(
                         "stdout_idle_stall_suppressed",
                         marker_dir=str(marker_dir),
                         session_id=session_id,
-                        suppression_elapsed=_time.monotonic() - suppression_start_marker,
+                        suppression_elapsed=now - suppression_start_marker,
                         max_suppression_seconds=max_suppression_seconds,
                     )
                     continue

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -172,6 +172,8 @@ async def _watch_stdout_idle(
     suppression_start_marker: float | None = None
     while True:
         await anyio.sleep(_poll_interval)
+        if trigger.is_set():
+            return
         try:
             current_size = stdout_path.stat().st_size
         except OSError:

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -189,12 +189,13 @@ async def _watch_stdout_idle(
                 now = _time.monotonic()
                 if suppression_start_marker is None:
                     suppression_start_marker = now
-                if now - suppression_start_marker < max_suppression_seconds:
+                elapsed = now - suppression_start_marker
+                if elapsed < max_suppression_seconds:
                     logger.warning(
                         "stdout_idle_stall_suppressed",
                         marker_dir=str(marker_dir),
                         session_id=session_id,
-                        suppression_elapsed=now - suppression_start_marker,
+                        suppression_elapsed=elapsed,
                         max_suppression_seconds=max_suppression_seconds,
                     )
                     continue

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -14,6 +14,7 @@ from autoskillit.core import fast_loads as _fast_loads
 from autoskillit.execution.process._process_monitor import (
     _has_active_api_connection,
     _has_active_child_processes,
+    _has_active_dispatch_marker,
     _heartbeat,
     _session_log_monitor,
 )
@@ -149,16 +150,26 @@ async def _watch_stdout_idle(
     acc: RaceAccumulator,
     trigger: anyio.Event,
     _poll_interval: float = 5.0,
+    *,
+    marker_dir: Path | None = None,
+    session_id: str | None = None,
+    max_suppression_seconds: float = 1800.0,
 ) -> None:
     """Kill the child if stdout stops growing for idle_output_timeout seconds.
 
     Orthogonal to Channel A/B: NOT suppressed by active API connections.
     Monitors raw byte count (st_size), not JSONL record structure.
+
+    When ``marker_dir`` is provided and an active dispatch marker exists, the
+    idle stall is suppressed for up to ``max_suppression_seconds`` to allow
+    in-flight dispatches to complete. Growth in stdout resets the suppression
+    timer, giving a fresh window for subsequent idle periods.
     """
     import time as _time
 
     last_size: int = 0
     last_growth_time: float = _time.monotonic()
+    suppression_start_marker: float | None = None
     while True:
         await anyio.sleep(_poll_interval)
         try:
@@ -168,7 +179,22 @@ async def _watch_stdout_idle(
         if current_size > last_size:
             last_size = current_size
             last_growth_time = _time.monotonic()
+            suppression_start_marker = None
         elif _time.monotonic() - last_growth_time >= idle_output_timeout:
+            if marker_dir is not None and _has_active_dispatch_marker(
+                marker_dir, session_id=session_id
+            ):
+                if suppression_start_marker is None:
+                    suppression_start_marker = _time.monotonic()
+                if _time.monotonic() - suppression_start_marker < max_suppression_seconds:
+                    logger.warning(
+                        "stdout_idle_stall_suppressed",
+                        marker_dir=str(marker_dir),
+                        session_id=session_id,
+                        suppression_elapsed=_time.monotonic() - suppression_start_marker,
+                        max_suppression_seconds=max_suppression_seconds,
+                    )
+                    continue
             logger.warning(
                 "stdout idle for %ss — firing IDLE_STALL",
                 idle_output_timeout,
@@ -293,6 +319,8 @@ async def _watch_session_log(
     _session_id_timeout: float = 1.0,
     stdout_session_id_ready: anyio.Event | None = None,
     max_suppression_seconds: float | None = None,
+    marker_dir: Path | None = None,
+    session_id: str | None = None,
 ) -> None:
     """Monitor the session JSONL log and deposit the Channel B signal.
 
@@ -316,6 +344,10 @@ async def _watch_session_log(
     }
     if max_suppression_seconds is not None:
         _monitor_kwargs["max_suppression_seconds"] = max_suppression_seconds
+    if marker_dir is not None:
+        _monitor_kwargs["marker_dir"] = marker_dir
+    if session_id is not None:
+        _monitor_kwargs["caller_session_id"] = session_id
     monitor_result = await _session_log_monitor(
         session_log_dir,
         completion_marker,

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -152,27 +152,30 @@ async def test_watch_stdout_idle_suppressed_by_dispatch_marker(
     acc = RaceAccumulator()
     trigger = anyio.Event()
 
-    async def cancel_after_suppression() -> None:
-        await anyio.sleep(0.5)
-        trigger.set()
+    with structlog.testing.capture_logs() as cap:
 
-    async with anyio.create_task_group() as tg:
-        tg.start_soon(cancel_after_suppression)
-        with anyio.fail_after(2.0):
-            tg.start_soon(
-                functools.partial(
-                    _watch_stdout_idle,
-                    stdout_file,
-                    0.1,  # idle_output_timeout — very short
-                    acc,
-                    trigger,
-                    0.05,  # _poll_interval
-                    marker_dir=tmp_path,
-                    session_id="test-sess",
-                    max_suppression_seconds=10.0,
+        async def cancel_when_suppressed() -> None:
+            while not any(e.get("event") == "stdout_idle_stall_suppressed" for e in cap):
+                await anyio.sleep(0.01)
+            trigger.set()
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(cancel_when_suppressed)
+            with anyio.fail_after(2.0):
+                tg.start_soon(
+                    functools.partial(
+                        _watch_stdout_idle,
+                        stdout_file,
+                        0.1,  # idle_output_timeout — very short
+                        acc,
+                        trigger,
+                        0.05,  # _poll_interval
+                        marker_dir=tmp_path,
+                        session_id="test-sess",
+                        max_suppression_seconds=10.0,
+                    )
                 )
-            )
-            await trigger.wait()
+                await trigger.wait()
 
     assert acc.idle_stall is False
 
@@ -296,13 +299,15 @@ async def test_watch_stdout_idle_emits_suppression_warning(
     acc = RaceAccumulator()
     trigger = anyio.Event()
 
-    async def cancel_after_suppression() -> None:
-        await anyio.sleep(0.3)
-        trigger.set()
-
     with structlog.testing.capture_logs() as cap:
+
+        async def cancel_when_suppressed() -> None:
+            while not any(e.get("event") == "stdout_idle_stall_suppressed" for e in cap):
+                await anyio.sleep(0.01)
+            trigger.set()
+
         async with anyio.create_task_group() as tg:
-            tg.start_soon(cancel_after_suppression)
+            tg.start_soon(cancel_when_suppressed)
             with anyio.fail_after(2.0):
                 tg.start_soon(
                     functools.partial(

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import functools
 import sys
 import textwrap
 import time
 
 import anyio
 import pytest
+import structlog.testing
 
 from autoskillit.execution.process._process_race import (
     RaceAccumulator,

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -132,3 +132,230 @@ async def test_watch_stdout_idle_handles_missing_file(tmp_path: anyio.Path) -> N
             await trigger.wait()
 
     assert acc.idle_stall is True
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_suppressed_by_dispatch_marker(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Active dispatch marker suppresses idle stall within cap."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_dispatch_marker",
+        lambda marker_dir, session_id=None: True,
+    )
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    async def cancel_after_suppression() -> None:
+        await anyio.sleep(0.5)
+        trigger.set()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(cancel_after_suppression)
+        with anyio.fail_after(2.0):
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.1,  # idle_output_timeout — very short
+                    acc,
+                    trigger,
+                    0.05,  # _poll_interval
+                    marker_dir=tmp_path,
+                    session_id="test-sess",
+                    max_suppression_seconds=10.0,
+                )
+            )
+            await trigger.wait()
+
+    assert acc.idle_stall is False
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_fires_when_suppression_cap_exceeded(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Suppression cap reached — idle stall fires despite active marker."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_dispatch_marker",
+        lambda marker_dir, session_id=None: True,
+    )
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with anyio.fail_after(3.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.05,
+                    acc,
+                    trigger,
+                    0.02,
+                    marker_dir=tmp_path,
+                    session_id=None,
+                    max_suppression_seconds=0.1,
+                )
+            )
+            await trigger.wait()
+
+    assert acc.idle_stall is True
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_no_marker_dir_fires_immediately(tmp_path: anyio.Path) -> None:
+    """No marker_dir — idle stall fires unchanged (existing behavior)."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with anyio.fail_after(2.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                _watch_stdout_idle,
+                stdout_file,
+                0.1,
+                acc,
+                trigger,
+                0.02,
+            )
+            await trigger.wait()
+
+    assert acc.idle_stall is True
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_suppression_timer_resets_on_growth(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Growth resets suppression timer — second idle period gets fresh window."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial\n")
+
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_dispatch_marker",
+        lambda marker_dir, session_id=None: True,
+    )
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    async def grow_after_delay() -> None:
+        await anyio.sleep(0.15)
+        async with await anyio.open_file(stdout_file, "ab") as f:
+            await f.write(b"more data\n")
+
+    with anyio.fail_after(3.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(grow_after_delay)
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.05,
+                    acc,
+                    trigger,
+                    0.02,
+                    marker_dir=tmp_path,
+                    session_id=None,
+                    max_suppression_seconds=0.2,
+                )
+            )
+            await trigger.wait()
+
+    # Eventually fires after growth stops and cap is exceeded
+    assert acc.idle_stall is True
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_emits_suppression_warning(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Suppression emits structured warning with expected kwargs."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_dispatch_marker",
+        lambda marker_dir, session_id=None: True,
+    )
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    async def cancel_after_suppression() -> None:
+        await anyio.sleep(0.3)
+        trigger.set()
+
+    with structlog.testing.capture_logs() as cap:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(cancel_after_suppression)
+            with anyio.fail_after(2.0):
+                tg.start_soon(
+                    functools.partial(
+                        _watch_stdout_idle,
+                        stdout_file,
+                        0.05,
+                        acc,
+                        trigger,
+                        0.02,
+                        marker_dir=tmp_path,
+                        session_id="my-session",
+                        max_suppression_seconds=10.0,
+                    )
+                )
+                await trigger.wait()
+
+    warnings = [e for e in cap if e.get("event") == "stdout_idle_stall_suppressed"]
+    assert len(warnings) >= 1
+    w = warnings[0]
+    assert w["marker_dir"] == str(tmp_path)
+    assert w["session_id"] == "my-session"
+    assert "suppression_elapsed" in w
+    assert w["max_suppression_seconds"] == 10.0
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_marker_false_fires_immediately(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dispatch marker returns False — idle stall fires without suppression."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_dispatch_marker",
+        lambda marker_dir, session_id=None: False,
+    )
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with anyio.fail_after(2.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.1,
+                    acc,
+                    trigger,
+                    0.02,
+                    marker_dir=tmp_path,
+                    session_id="test",
+                )
+            )
+            await trigger.wait()
+
+    assert acc.idle_stall is True

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -1271,7 +1271,7 @@ async def test_watch_session_log_passes_marker_dir_to_monitor_kwargs(
     channel_b_ready = anyio.Event()
 
     session_file = tmp_path / "session.jsonl"
-    session_file.write_text("")
+    await anyio.Path(session_file).write_bytes(b"")
 
     with anyio.fail_after(3.0):
         await _watch_session_log(
@@ -1318,7 +1318,7 @@ async def test_watch_session_log_omits_marker_kwargs_when_none(
     channel_b_ready = anyio.Event()
 
     session_file = tmp_path / "session.jsonl"
-    session_file.write_text("")
+    await anyio.Path(session_file).write_bytes(b"")
 
     with anyio.fail_after(3.0):
         await _watch_session_log(

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -15,6 +15,7 @@ from autoskillit.execution.process import (
     _session_log_monitor,
     _watch_session_log,
 )
+from autoskillit.execution.process._process_monitor import SessionMonitorResult
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
@@ -1247,3 +1248,94 @@ class TestDispatchMarkerSuppression:
             )
         assert result.status == ChannelBStatus.STALE
         assert result.session_id == "abc123"
+
+
+@pytest.mark.anyio
+async def test_watch_session_log_passes_marker_dir_to_monitor_kwargs(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """marker_dir and session_id are injected into _monitor_kwargs."""
+    captured_kwargs: dict[str, object] = {}
+
+    async def fake_session_log_monitor(*args, **kwargs) -> SessionMonitorResult:
+        captured_kwargs.update(kwargs)
+        return SessionMonitorResult(status=ChannelBStatus.STALE, session_id="")
+
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._session_log_monitor",
+        fake_session_log_monitor,
+    )
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+    channel_b_ready = anyio.Event()
+
+    session_file = tmp_path / "session.jsonl"
+    session_file.write_text("")
+
+    with anyio.fail_after(3.0):
+        await _watch_session_log(
+            session_log_dir=tmp_path,
+            completion_marker="DONE",
+            stale_threshold=60.0,
+            spawn_time=time.time(),
+            session_record_types=frozenset({"assistant"}),
+            pid=12345,
+            completion_drain_timeout=1.0,
+            acc=acc,
+            trigger=trigger,
+            channel_b_ready=channel_b_ready,
+            _phase1_poll=0.01,
+            _phase2_poll=0.05,
+            _phase1_timeout=0.1,
+            max_suppression_seconds=1800.0,
+            marker_dir=tmp_path,
+            session_id="parent-session",
+        )
+
+    assert captured_kwargs["marker_dir"] == tmp_path
+    assert captured_kwargs["caller_session_id"] == "parent-session"
+
+
+@pytest.mark.anyio
+async def test_watch_session_log_omits_marker_kwargs_when_none(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """marker_dir=None and session_id=None — keys absent from _monitor_kwargs."""
+    captured_kwargs: dict[str, object] = {}
+
+    async def fake_session_log_monitor(*args, **kwargs) -> SessionMonitorResult:
+        captured_kwargs.update(kwargs)
+        return SessionMonitorResult(status=ChannelBStatus.STALE, session_id="")
+
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._session_log_monitor",
+        fake_session_log_monitor,
+    )
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+    channel_b_ready = anyio.Event()
+
+    session_file = tmp_path / "session.jsonl"
+    session_file.write_text("")
+
+    with anyio.fail_after(3.0):
+        await _watch_session_log(
+            session_log_dir=tmp_path,
+            completion_marker="DONE",
+            stale_threshold=60.0,
+            spawn_time=time.time(),
+            session_record_types=frozenset({"assistant"}),
+            pid=12345,
+            completion_drain_timeout=1.0,
+            acc=acc,
+            trigger=trigger,
+            channel_b_ready=channel_b_ready,
+            _phase1_poll=0.01,
+            _phase2_poll=0.05,
+            _phase1_timeout=0.1,
+        )
+
+    assert "marker_dir" not in captured_kwargs
+    assert "caller_session_id" not in captured_kwargs


### PR DESCRIPTION
## Summary

Add `_has_active_dispatch_marker` to the import block in `_process_race.py`, extend `_watch_stdout_idle` with keyword-only suppression parameters and a bounded suppression gate in the idle-stall firing path, extend `_watch_session_log` with `marker_dir`/`session_id` params, and wire those params into the `_monitor_kwargs` dict. All changes are confined to a single file (`_process_race.py`). Existing callers are unaffected because all new parameters default to `None`/`1800.0`.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

Closes #2299

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-164607-608559/.autoskillit/temp/make-plan/p2_a1_import_has_active_dispatch_marker_plan_2026-05-09_164700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 74 | 10.9k | 834.6k | 55.7k | 49 | 50.2k | 4m 35s |
| verify | claude-opus-4-6 | 1 | 33 | 16.5k | 677.2k | 56.1k | 53 | 50.6k | 6m 45s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.4M | 13.4k | 1.4M | 59.1k | 101 | 114.5k | 5m 10s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 151.8k | 4.1k | 313.6k | 28.8k | 29 | 15.4k | 1m 34s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 36.4k | 1.3k | 169.7k | 28.8k | 14 | 15.1k | 35s |
| review_pr | claude-opus-4-6 | 2 | 817 | 49.6k | 1.2M | 75.3k | 79 | 116.0k | 14m 40s |
| resolve_review | claude-opus-4-6 | 2 | 95 | 21.7k | 1.7M | 84.3k | 74 | 110.5k | 12m 8s |
| **Total** | | | 1.6M | 117.6k | 6.4M | 84.3k | | 472.2k | 45m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 351 | 4011.4 | 326.1 | 38.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 69 | 25196.9 | 1601.7 | 314.7 |
| **Total** | **420** | 15143.9 | 1124.2 | 280.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 49 | 14.6k | 795.2k | 69.2k | 7m 38s |