### PR TITLE
P2-A6 — Extend SubprocessRunner Protocol with marker_dir and session_id

### DIFF
--- a/src/autoskillit/core/types/_type_subprocess.py
+++ b/src/autoskillit/core/types/_type_subprocess.py
@@ -125,7 +125,21 @@ class SubprocessResult:
 
 @runtime_checkable
 class SubprocessRunner(Protocol):
-    """Protocol for async subprocess execution. Matches run_managed_async signature."""
+    """Protocol for async subprocess execution. Matches run_managed_async signature.
+
+    Parameters
+    ----------
+    marker_dir : Path | None
+        Directory containing ``dispatch-in-progress-{session_id}-*.marker`` files.
+        When non-None, the session log monitor checks for active dispatch markers
+        before issuing stale-kill signals, suppressing kills while a fleet dispatch
+        is in progress. Default ``None`` (no suppression).
+    session_id : str | None
+        Caller's session identity, used to scope dispatch-marker glob patterns to
+        the originating fleet session. Threaded from fleet dispatch through headless
+        execution to ``_session_log_monitor``'s ``caller_session_id`` parameter.
+        Default ``None`` (match any marker).
+    """
 
     def __call__(
         self,
@@ -146,4 +160,6 @@ class SubprocessRunner(Protocol):
         on_pid_resolved: Callable[[int, int], None] | None = None,
         enable_deadline_extension: bool = False,
         max_extension_seconds: float = 7200,
+        marker_dir: Path | None = None,
+        session_id: str | None = None,
     ) -> Awaitable[SubprocessResult]: ...

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -358,6 +358,62 @@ def test_subprocess_runner_protocol_pty_mode_default_false():
 
 
 # ---------------------------------------------------------------------------
+# P2-A6 — SubprocessRunner marker_dir and session_id params
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_runner_protocol_marker_dir_default_none():
+    import inspect
+
+    from autoskillit.core import SubprocessRunner
+
+    sig = inspect.signature(SubprocessRunner.__call__)
+    assert sig.parameters["marker_dir"].default is None
+
+
+def test_subprocess_runner_protocol_session_id_default_none():
+    import inspect
+
+    from autoskillit.core import SubprocessRunner
+
+    sig = inspect.signature(SubprocessRunner.__call__)
+    assert sig.parameters["session_id"].default is None
+
+
+def test_subprocess_runner_protocol_marker_params_after_max_extension():
+    import inspect
+
+    from autoskillit.core import SubprocessRunner
+
+    sig = inspect.signature(SubprocessRunner.__call__)
+    params = list(sig.parameters)
+    max_ext_idx = params.index("max_extension_seconds")
+    marker_idx = params.index("marker_dir")
+    session_idx = params.index("session_id")
+    assert marker_idx == max_ext_idx + 1, (
+        f"marker_dir must immediately follow max_extension_seconds, "
+        f"got indices {max_ext_idx} and {marker_idx}"
+    )
+    assert session_idx == marker_idx + 1, (
+        f"session_id must immediately follow marker_dir, "
+        f"got indices {marker_idx} and {session_idx}"
+    )
+
+
+def test_subprocess_runner_protocol_marker_params_are_keyword_only():
+    import inspect
+
+    from autoskillit.core import SubprocessRunner
+
+    sig = inspect.signature(SubprocessRunner.__call__)
+    for name in ("marker_dir", "session_id"):
+        param = sig.parameters[name]
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{name} must be keyword-only, got {param.kind.name}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # CIRunScope event field
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add `marker_dir: Path | None = None` and `session_id: str | None = None` as the final two keyword-only parameters to `SubprocessRunner.__call__` in `src/autoskillit/core/types/_type_subprocess.py`, and replace the single-line class docstring with a multi-line docstring documenting their dispatch-marker-suppression-threading purpose. This is a Protocol-only change — concrete implementations (DefaultSubprocessRunner, RecordingSubprocessRunner, etc.) are updated by dependent work packages (P2-A4-WP1, P2-A7-WP1, P2-A7-WP2).

## Requirements

## Goal

Extend SubprocessRunner.__call__ with marker_dir and session_id keyword-only params so Pyright can typecheck the full dispatch-kill-suppression call chain from fleet through headless to run_managed_async.

## Context

- Phase: Idle Stall Watchdog Suppression and Parameter Threading (Milestone: 2-idle-stall-watchdog-suppression-and-parameter-threading)
- Assignment: P2-A6 (Add marker_dir and session_id keyword-only params to SubprocessRunner Protocol in core/types/_type_subprocess.py)
- Depends on: None
- Depended on by: P2-A4-WP1, P2-A7-WP1, P3-A1-WP1

## Deliverables

- `SubprocessRunner.__call__ signature extended with `marker_dir: Path | None = None` and `session_id: str | None = None` as the final two keyword-only parameters (after max_extension_seconds).`
- `SubprocessRunner class docstring updated to document the new params' purpose: threading dispatch-marker-suppression context from fleet callers through to run_managed_async's kill-channel watchers.`

## Technical Steps

1. In `src/autoskillit/core/types/_type_subprocess.py`, locate SubprocessRunner.__call__ (lines 130-149). After `max_extension_seconds: float = 7200,` on line 148, insert two new keyword-only parameters: `marker_dir: Path | None = None,` and `session_id: str | None = None,`. No import changes needed — `Path` is already imported on line 11.
2. Replace the single-line class docstring on line 128 with a multi-line docstring that retains the original description and adds documentation of the two new params: their types, defaults, and purpose (dispatch-marker kill-suppression threading).
3. Verify the file is syntactically valid.

## Acceptance Criteria

- `SubprocessRunner.__call__` declares `marker_dir: Path | None = None` and `session_id: str | None = None` as the last two keyword-only parameters, positionally after `max_extension_seconds: float = 7200`.
- The class docstring explicitly documents both new params' types, defaults, and suppression-threading purpose.
- No new imports are added — `Path` is already present from `pathlib` on line 11.
- The file passes `pre-commit run --all-files` without errors.
- Sibling WPs (P2-A5-WP1, P2-A7-WP1, P2-A7-WP2) can add matching params to their concrete implementations without Protocol violation.

## Conflict Resolution Table

## Changed Files

### Modified (●):
- `src/autoskillit/core/types/_type_subprocess.py`
- `tests/core/test_types.py`

Closes #2301

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-164606-639518/.autoskillit/temp/make-plan/p2_a6_extend_subprocessrunner_protocol_plan_2026-05-09_170000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 69 | 9.1k | 624.9k | 75.5k | 104 | 51.0k | 4m 46s |
| verify | claude-sonnet-4-6 | 1 | 36 | 9.0k | 331.9k | 57.4k | 80 | 39.1k | 5m 26s |
| implement* | MiniMax-M2.7-highspeed | 1 | 407.6k | 5.1k | 632.8k | 28.8k | 52 | 42.3k | 2m 7s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 82.9k | 3.7k | 201.4k | 28.8k | 20 | 41.2k | 1m 22s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 76.4k | 2.1k | 227.3k | 28.8k | 17 | 15.0k | 49s |
| review_pr | claude-opus-4-6 | 3 | 100 | 24.9k | 953.6k | 46.2k | 85 | 98.5k | 8m 4s |
| **Total** | | | 567.1k | 53.9k | 3.0M | 75.5k | | 287.3k | 22m 36s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 74 | 8551.8 | 571.4 | 69.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **74** | 40160.3 | 3881.8 | 728.4 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 49 | 14.6k | 795.2k | 69.2k | 7m 38s |