### PR TITLE
Split CI Test Suite into Two Parallel Shards

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,15 +92,19 @@ jobs:
         id: test-paths
         run: |
           SHARD_A_DIRS="tests/execution tests/contracts tests/core tests/planner tests/pipeline tests/migration tests/integration"
+          if find tests/ -maxdepth 1 -name 'test_*.py' -print0 | grep -qz ' '; then
+            echo "::error::Test filenames with spaces are not supported by the shard path splitter"
+            exit 1
+          fi
           if [[ "${{ matrix.shard }}" == "execution" ]]; then
-            ROOT_FILES=$(find tests/ -maxdepth 1 -name "test_*.py" | sort | tr '\n' ' ')
+            ROOT_FILES=$(find tests/ -maxdepth 1 -name 'test_*.py' | sort | tr '\n' ' ')
             echo "PYTEST_TEST_PATHS=${SHARD_A_DIRS} ${ROOT_FILES}" >> "$GITHUB_ENV"
           else
             IGNORES=""
             for d in $SHARD_A_DIRS; do
               IGNORES="$IGNORES --ignore=$d"
             done
-            ROOT_IGNORES=$(find tests/ -maxdepth 1 -name "test_*.py" -exec echo "--ignore={}" \; | sort | tr '\n' ' ')
+            ROOT_IGNORES=$(find tests/ -maxdepth 1 -name 'test_*.py' | sort | sed 's|^|--ignore=|' | tr '\n' ' ')
             echo "PYTEST_TEST_PATHS=tests/" >> "$GITHUB_ENV"
             echo "PYTEST_IGNORE_PATHS=${IGNORES} ${ROOT_IGNORES}" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,13 +44,14 @@ jobs:
           uv run python --version
 
   test:
-    name: Test on ${{ matrix.os }}
+    name: Test (${{ matrix.shard }}) on ${{ matrix.os }}
     needs: preflight
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.preflight.outputs.os-matrix) }}
+        shard: [execution, general]
 
     steps:
       - uses: actions/checkout@v4
@@ -87,6 +88,27 @@ jobs:
       - name: Generate recipe diagrams
         run: uv run autoskillit recipes render
 
+      - name: Compute test paths
+        id: test-paths
+        run: |
+          SHARD_A_DIRS="tests/execution tests/contracts tests/core tests/planner tests/pipeline tests/migration tests/integration"
+          if [[ "${{ matrix.shard }}" == "execution" ]]; then
+            ROOT_FILES=$(find tests/ -maxdepth 1 -name "test_*.py" | sort | tr '\n' ' ')
+            echo "PYTEST_TEST_PATHS=${SHARD_A_DIRS} ${ROOT_FILES}" >> "$GITHUB_ENV"
+          else
+            IGNORES=""
+            for d in $SHARD_A_DIRS; do
+              IGNORES="$IGNORES --ignore=$d"
+            done
+            ROOT_IGNORES=$(find tests/ -maxdepth 1 -name "test_*.py" -exec echo "--ignore={}" \; | sort | tr '\n' ' ')
+            echo "PYTEST_TEST_PATHS=tests/" >> "$GITHUB_ENV"
+            echo "PYTEST_IGNORE_PATHS=${IGNORES} ${ROOT_IGNORES}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Lint imports
+        if: matrix.shard == 'execution'
+        run: uv run lint-imports
+
       - name: Run tests
         env:
           AUTOSKILLIT_FILTER_STATS_FILE: ${{ github.workspace }}/.autoskillit/temp/filter-stats.json
@@ -100,12 +122,12 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" ]]; then
             export AUTOSKILLIT_TEST_FILTER=conservative
           fi
-          task test-all
+          task test-check
 
       - name: Upload filter stats
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: filter-stats-${{ matrix.os }}
+          name: filter-stats-${{ matrix.os }}-${{ matrix.shard }}
           path: .autoskillit/temp/filter-stats.json
           if-no-files-found: ignore

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
 
         set -o pipefail
         set +e
-        $PYTEST_CMD tests/ -q --tb=short -n 4 -m "not smoke and not canary" --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        $PYTEST_CMD ${PYTEST_TEST_PATHS:-tests/} -q --tb=short -n 4 -m "not smoke and not canary" ${PYTEST_IGNORE_PATHS:-} --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
         PYTEST_EXIT=$?
         set +o pipefail
         set -e
@@ -67,7 +67,7 @@ tasks:
 
         set -o pipefail
         set +e
-        $PYTEST_CMD tests/ -q --tb=short -n 4 -m "not smoke and not canary" --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        $PYTEST_CMD ${PYTEST_TEST_PATHS:-tests/} -q --tb=short -n 4 -m "not smoke and not canary" ${PYTEST_IGNORE_PATHS:-} --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
         PYTEST_EXIT=$?
         set +o pipefail
         set -e

--- a/tests/infra/CLAUDE.md
+++ b/tests/infra/CLAUDE.md
@@ -15,6 +15,7 @@ CI/CD configuration, security, guard coverage, and release sanity tests.
 | `test_branch_protection_guard.py` | Tests for hooks/branch_protection_guard.py — PreToolUse branch protection |
 | `test_ci_dev_config.py` | Structural enforcement: CI workflow and pre-commit configuration must contain required quality gates |
 | `test_ci_workflow.py` | CI workflow structural tests |
+| `test_ci_shard_config.py` | Tests for CI shard directory configuration consistency |
 | `test_claude_md_critical_rules.py` | Tests that CLAUDE.md contains required critical rules (FRICT-1B-3, FRICT-3A-1) |
 | `test_command_guard_completeness.py` | Structural meta-test: command-inspecting guards must cover all command-executing tools |
 | `test_coverage_audit.py` | Tests for scripts/compare-coverage-ast.py — AST extraction and coverage comparison |

--- a/tests/infra/test_ci_shard_config.py
+++ b/tests/infra/test_ci_shard_config.py
@@ -1,0 +1,41 @@
+# tests/infra/test_ci_shard_config.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SHARD_A_DIRS = [
+    "tests/execution",
+    "tests/contracts",
+    "tests/core",
+    "tests/planner",
+    "tests/pipeline",
+    "tests/migration",
+    "tests/integration",
+]
+
+
+class TestCIShardConfig:
+    def test_shard_a_directories_exist(self) -> None:
+        for d in SHARD_A_DIRS:
+            assert (REPO_ROOT / d).is_dir(), f"Shard A directory {d} does not exist"
+
+    def test_shard_a_directories_contain_tests(self) -> None:
+        for d in SHARD_A_DIRS:
+            test_files = list((REPO_ROOT / d).rglob("test_*.py"))
+            assert test_files, f"Shard A directory {d} contains no test files"
+
+    def test_shard_a_directories_are_subset_of_test_dirs(self) -> None:
+        all_test_dirs = {
+            p.name
+            for p in (REPO_ROOT / "tests").iterdir()
+            if p.is_dir() and not p.name.startswith("_") and not p.name.startswith(".")
+        }
+        shard_a_names = {Path(d).name for d in SHARD_A_DIRS}
+        extra = shard_a_names - all_test_dirs
+        assert not extra, f"Shard A references non-existent test directories: {extra}"

--- a/tests/infra/test_ci_shard_config.py
+++ b/tests/infra/test_ci_shard_config.py
@@ -1,6 +1,7 @@
 # tests/infra/test_ci_shard_config.py
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -8,16 +9,33 @@ import pytest
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "tests.yml"
 
-SHARD_A_DIRS = [
-    "tests/execution",
-    "tests/contracts",
-    "tests/core",
-    "tests/planner",
-    "tests/pipeline",
-    "tests/migration",
-    "tests/integration",
-]
+KNOWN_GENERAL_SHARD_DIRS = {
+    "arch",
+    "assets",
+    "cli",
+    "config",
+    "docs",
+    "fleet",
+    "hooks",
+    "infra",
+    "recipe",
+    "server",
+    "skills",
+    "skills_extended",
+    "workspace",
+}
+
+
+def _parse_shard_a_dirs_from_workflow() -> list[str]:
+    text = WORKFLOW_PATH.read_text()
+    match = re.search(r'SHARD_A_DIRS="([^"]+)"', text)
+    assert match, "Could not find SHARD_A_DIRS definition in tests.yml"
+    return match.group(1).split()
+
+
+SHARD_A_DIRS = _parse_shard_a_dirs_from_workflow()
 
 
 class TestCIShardConfig:
@@ -30,12 +48,16 @@ class TestCIShardConfig:
             test_files = list((REPO_ROOT / d).rglob("test_*.py"))
             assert test_files, f"Shard A directory {d} contains no test files"
 
-    def test_shard_a_directories_are_subset_of_test_dirs(self) -> None:
+    def test_all_test_dirs_assigned_to_shard(self) -> None:
         all_test_dirs = {
             p.name
             for p in (REPO_ROOT / "tests").iterdir()
             if p.is_dir() and not p.name.startswith("_") and not p.name.startswith(".")
         }
         shard_a_names = {Path(d).name for d in SHARD_A_DIRS}
-        extra = shard_a_names - all_test_dirs
-        assert not extra, f"Shard A references non-existent test directories: {extra}"
+        assigned = shard_a_names | KNOWN_GENERAL_SHARD_DIRS
+        unassigned = all_test_dirs - assigned
+        assert not unassigned, (
+            f"Test directories not assigned to any shard: {unassigned}. "
+            "Add to SHARD_A_DIRS in tests.yml or KNOWN_GENERAL_SHARD_DIRS in this file."
+        )

--- a/tests/infra/test_ci_shard_config.py
+++ b/tests/infra/test_ci_shard_config.py
@@ -30,11 +30,17 @@ KNOWN_GENERAL_SHARD_DIRS = {
 
 def _parse_shard_a_dirs_from_workflow() -> list[str]:
     if not WORKFLOW_PATH.exists():
-        pytest.skip(f"Workflow file not found: {WORKFLOW_PATH}")
+        pytest.skip(
+            f"Workflow file not found: {WORKFLOW_PATH}",
+            allow_module_level=True,
+        )
     text = WORKFLOW_PATH.read_text()
     match = re.search(r'SHARD_A_DIRS="([^"]+)"', text)
     if not match:
-        pytest.skip("SHARD_A_DIRS not found in tests.yml — skipping shard config tests")
+        pytest.skip(
+            "SHARD_A_DIRS not found in tests.yml — skipping shard config tests",
+            allow_module_level=True,
+        )
     return match.group(1).split()
 
 
@@ -69,7 +75,7 @@ class TestCIShardConfig:
             for p in (REPO_ROOT / "tests").iterdir()
             if p.is_dir() and not p.name.startswith("_") and not p.name.startswith(".")
         }
-        shard_a_names = {Path(d).name for d in SHARD_A_DIRS}
+        shard_a_names = {d.removeprefix("tests/") for d in SHARD_A_DIRS}
         assigned = shard_a_names | KNOWN_GENERAL_SHARD_DIRS
         unassigned = all_test_dirs - assigned
         assert not unassigned, (

--- a/tests/infra/test_ci_shard_config.py
+++ b/tests/infra/test_ci_shard_config.py
@@ -29,9 +29,12 @@ KNOWN_GENERAL_SHARD_DIRS = {
 
 
 def _parse_shard_a_dirs_from_workflow() -> list[str]:
+    if not WORKFLOW_PATH.exists():
+        pytest.skip(f"Workflow file not found: {WORKFLOW_PATH}")
     text = WORKFLOW_PATH.read_text()
     match = re.search(r'SHARD_A_DIRS="([^"]+)"', text)
-    assert match, "Could not find SHARD_A_DIRS definition in tests.yml"
+    if not match:
+        pytest.skip("SHARD_A_DIRS not found in tests.yml — skipping shard config tests")
     return match.group(1).split()
 
 
@@ -47,6 +50,18 @@ class TestCIShardConfig:
         for d in SHARD_A_DIRS:
             test_files = list((REPO_ROOT / d).rglob("test_*.py"))
             assert test_files, f"Shard A directory {d} contains no test files"
+
+    def test_known_general_dirs_exist(self) -> None:
+        all_test_dirs = {
+            p.name
+            for p in (REPO_ROOT / "tests").iterdir()
+            if p.is_dir() and not p.name.startswith("_") and not p.name.startswith(".")
+        }
+        stale = KNOWN_GENERAL_SHARD_DIRS - all_test_dirs
+        assert not stale, (
+            f"KNOWN_GENERAL_SHARD_DIRS contains stale entries: {stale}. "
+            "Remove entries that no longer exist under tests/."
+        )
 
     def test_all_test_dirs_assigned_to_shard(self) -> None:
         all_test_dirs = {


### PR DESCRIPTION
## Summary

Split the single `test` job in `.github/workflows/tests.yml` into two parallel shards using a matrix strategy. Shard A ("execution") positive-selects the heavy test directories (`tests/execution/`, `tests/contracts/`, `tests/core/`, `tests/planner/`, `tests/pipeline/`, `tests/migration/`, `tests/integration/`, and root-level `tests/test_*.py` files). Shard B ("general") is a catch-all that runs `tests/` with `--ignore` flags for every Shard A path, ensuring new test directories automatically land in Shard B without workflow changes.

The Taskfile is modified to accept `PYTEST_TEST_PATHS` and `PYTEST_IGNORE_PATHS` environment variables (defaulting to `tests/` and empty respectively), keeping local usage unchanged while enabling CI sharding. `lint-imports` is extracted to a separate CI step so it runs exactly once, not per-shard.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Architecture Impact

## Changed Files

### New (★):
tests/infra/test_ci_shard_config.py

### Modified (●):
.github/workflows/tests.yml
Taskfile.yml
tests/infra/CLAUDE.md

## Implementation Plan

Plan file: /home/talon/projects/autoskillit-runs/impl-20260509-174835-412085/.autoskillit/temp/make-plan/split_ci_test_shards_plan_2026-05-09_175800.md

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 1.6k | 13.8k | 697.4k | 55.6k | 45 | 46.7k | 6m 4s |
| verify | claude-opus-4-6 | 1 | 47 | 17.9k | 467.1k | 62.4k | 58 | 49.2k | 7m 51s |
| implement* | MiniMax-M2.7-highspeed | 1 | 440.5k | 5.1k | 661.4k | 28.8k | 53 | 66.1k | 2m 24s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.2k | 2.9k | 239.1k | 0 | 17 | 0 | 1m 3s |
| compose_pr* | MiniMax-M2.7 | 1 | 41.3k | 1.9k | 196.2k | 0 | 17 | 0 | 1m 8s |
| review_pr | claude-opus-4-6 | 3 | 122 | 67.0k | 1.2M | 65.7k | 81 | 198.8k | 17m 12s |
| resolve_review | claude-opus-4-6 | 3 | 159 | 40.1k | 3.6M | 73.1k | 156 | 158.1k | 17m 14s |
| **Total** | | | 526.9k | 148.8k | 7.0M | 73.1k | | 518.9k | 52m 58s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 74 | 8937.4 | 893.4 | 68.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 83 | 42879.3 | 1904.2 | 483.2 |
| **Total** | **157** | 44854.7 | 3305.4 | 947.5 |