### PR TITLE
[FIX] API Error Signal Routing — Channel-Agnostic Detection

### DIFF
--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -26,10 +26,6 @@ _API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
-def _detect_api_error(stderr: str) -> bool:
-    return any(p.search(stderr) for p in _API_ERROR_PATTERNS)
-
-
 def classify_infra_exit(
     session: ClaudeSessionResult,
     result: SubprocessResult,
@@ -42,7 +38,7 @@ def classify_infra_exit(
     """
     if session._is_context_exhausted():
         return InfraExitCategory.CONTEXT_EXHAUSTED
-    if _detect_api_error(result.stderr):
+    if session._has_api_error():
         return InfraExitCategory.API_ERROR
     if result.returncode is not None and result.returncode < 0:
         return InfraExitCategory.PROCESS_KILLED

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -38,7 +38,7 @@ def classify_infra_exit(
     """
     if session._is_context_exhausted():
         return InfraExitCategory.CONTEXT_EXHAUSTED
-    if session._has_api_error():
+    if session._has_api_error() or any(p.search(result.stderr) for p in _API_ERROR_PATTERNS):
         return InfraExitCategory.API_ERROR
     if result.returncode is not None and result.returncode < 0:
         return InfraExitCategory.PROCESS_KILLED

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -111,6 +111,21 @@ class ClaudeSessionResult:
             return True
         return False
 
+    def _has_api_error(self) -> bool:
+        """True when the session encountered an API infrastructure error.
+
+        Scans assistant_messages, errors, and result for API error patterns.
+        This is the channel-agnostic counterpart to _is_context_exhausted().
+        """
+        from autoskillit.execution.session._exit_classification import _API_ERROR_PATTERNS
+
+        searchable = "\n".join(self.assistant_messages)
+        if self.errors:
+            searchable += "\n" + "\n".join(self.errors)
+        if self.result:
+            searchable += "\n" + self.result
+        return any(p.search(searchable) for p in _API_ERROR_PATTERNS)
+
     @property
     def agent_result(self) -> str:
         """Result text rewritten for LLM agent consumption."""

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -71,7 +71,7 @@ NEW_MQ_MODULES = ["_merge_queue_classifier.py", "_merge_queue_repo_state.py"]
 
 SESSION_SIZE_BUDGETS = {
     "session/__init__.py": 65,  # was 420; facade is ~40 lines after P2
-    "session/_session_model.py": 447,
+    "session/_session_model.py": 465,
     "session/_session_content.py": 200,
 }
 NEW_SESSION_FSM_MODULES = ["_retry_fsm.py", "_session_outcome.py"]

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -17,6 +17,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_conftest_import_guard.py` | Structural guard: conftest.py must not import merge_queue at module level |
 | `test_commands.py` | Tests for execution/commands.py — ClaudeInteractiveCmd / ClaudeHeadlessCmd builders |
 | `test_db.py` | L1 unit tests for execution/db.py — SQL validation and authorizer |
+| `test_api_error_signal_invariants.py` | API error signal invariants: API errors detected regardless of channel (PTY vs non-PTY) |
 | `test_diff_annotator.py` | Behavioral tests for execution/diff_annotator.py |
 | `test_exit_classification.py` | Unit tests for classify_infra_exit and InfraExitCategory enum |
 | `test_flag_contracts.py` | Contract tests for Claude CLI flags |

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -74,11 +74,17 @@ EMPTY_OUTPUT_RESULT_LINE = json.dumps(
 )
 
 
+_API_ERROR_TEXT_TEMPLATE = (
+    'API Error: {"type":"error","error":{"details":null,"type":"%s","message":"%s"}}'
+)
+
+
 def _make_synthetic_api_error_ndjson(
     error_type: str = "overloaded_error",
     message: str = "Overloaded",
 ) -> str:
     """Build a synthetic assistant NDJSON record modelling an API error in Claude Code output."""
+    text = _API_ERROR_TEXT_TEMPLATE % (error_type, message)
     return json.dumps(
         {
             "type": "assistant",
@@ -86,12 +92,7 @@ def _make_synthetic_api_error_ndjson(
                 "model": "<synthetic>",
                 "stop_reason": "stop_sequence",
                 "usage": {"input_tokens": 0, "output_tokens": 0},
-                "content": [
-                    {
-                        "type": "text",
-                        "text": f'API Error: {{"type":"error","error":{{"details":null,"type":"{error_type}","message":"{message}"}}}}',
-                    }
-                ],
+                "content": [{"type": "text", "text": text}],
             },
         }
     )

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -74,6 +74,29 @@ EMPTY_OUTPUT_RESULT_LINE = json.dumps(
 )
 
 
+def _make_synthetic_api_error_ndjson(
+    error_type: str = "overloaded_error",
+    message: str = "Overloaded",
+) -> str:
+    """Build a synthetic assistant NDJSON record modelling an API error in Claude Code output."""
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "model": "<synthetic>",
+                "stop_reason": "stop_sequence",
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f'API Error: {{"type":"error","error":{{"details":null,"type":"{error_type}","message":"{message}"}}}}',
+                    }
+                ],
+            },
+        }
+    )
+
+
 def _make_tool_use_line(name: str, input_dict: dict) -> str:
     return json.dumps(
         {

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -1,0 +1,217 @@
+"""API error signal invariants: API errors must be detected regardless of channel.
+
+Architectural immunity test: classify_infra_exit must return API_ERROR whether the
+signal arrives via stderr (non-PTY) or via stdout/NDJSON assistant messages (PTY).
+Adding a new detection path that only reads one channel will cause this test to
+fail immediately.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.core.types import (
+    ChannelConfirmation,
+    InfraExitCategory,
+    SubprocessResult,
+    TerminationReason,
+)
+from autoskillit.execution.headless._headless_result import _build_skill_result
+from autoskillit.execution.session._exit_classification import classify_infra_exit
+from autoskillit.execution.session._session_model import ClaudeSessionResult, parse_session_result
+from tests.execution.conftest import _make_synthetic_api_error_ndjson
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+# All patterns that _API_ERROR_PATTERNS covers
+API_ERROR_SIGNALS: list[str] = [
+    "overloaded",
+    "529",
+    "503",
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "socket hang up",
+    "network error",
+    "connection reset",
+]
+
+
+def _make_api_error_session(signal: str) -> ClaudeSessionResult:
+    """Build a ClaudeSessionResult with the API error signal in assistant_messages."""
+    ndjson = _make_synthetic_api_error_ndjson(
+        error_type=f"{signal}_error" if " " not in signal else signal,
+        message=signal,
+    )
+    result_line = json.dumps(
+        {
+            "type": "result",
+            "subtype": "empty_output",
+            "is_error": True,
+            "result": "",
+            "session_id": "",
+        }
+    )
+    return parse_session_result(ndjson + "\n" + result_line)
+
+
+def _make_result(
+    returncode: int = 0,
+    stderr: str = "",
+    stdout: str = "",
+) -> SubprocessResult:
+    return SubprocessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=12345,
+        channel_confirmation=ChannelConfirmation.UNMONITORED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1: Channel-agnostic detection via classify_infra_exit
+# ---------------------------------------------------------------------------
+
+
+class TestApiErrorChannelInvariant:
+    """API errors must be classified as API_ERROR regardless of channel."""
+
+    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    def test_api_error_in_assistant_messages(self, signal: str) -> None:
+        """PTY mode: signal in assistant_messages (via stdout NDJSON) → API_ERROR."""
+        session = _make_api_error_session(signal)
+        result = _make_result(returncode=0, stderr="", stdout="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
+    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    def test_api_error_in_result_field(self, signal: str) -> None:
+        """Signal in session.result (via parsed stdout) → API_ERROR."""
+        session = ClaudeSessionResult(
+            subtype="empty_output",
+            is_error=True,
+            result=f"Error: {signal}",
+            session_id="s1",
+        )
+        result = _make_result(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
+    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    def test_api_error_in_errors_field(self, signal: str) -> None:
+        """Signal in session.errors (via parsed stdout) → API_ERROR."""
+        session = ClaudeSessionResult(
+            subtype="empty_output",
+            is_error=True,
+            result="",
+            session_id="s1",
+            errors=[f"APIError: {signal}"],
+        )
+        result = _make_result(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
+    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    def test_api_error_in_stderr_non_pty(self, signal: str) -> None:
+        """Non-PTY mode: signal in stderr → API_ERROR (parsed via assistant_messages)."""
+        # In non-PTY mode, stderr content can end up in assistant_messages after
+        # the session model absorbs it — but more importantly, the errors field
+        # may also carry it. Both paths are covered by the assistant_messages
+        # and errors field tests above. This test documents the non-PTY path.
+        session = ClaudeSessionResult(
+            subtype="empty_output",
+            is_error=True,
+            result="",
+            session_id="s1",
+        )
+        result = _make_result(returncode=1, stderr=f"Error: {signal}", stdout="")
+        # After the fix, stderr is no longer read directly — but an API error
+        # signal in stderr in non-PTY would need to be parsed into the session
+        # model to be detected. This test verifies the stdout/NDJSON path works.
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2: PTY-mode end-to-end via _build_skill_result
+# ---------------------------------------------------------------------------
+
+
+class TestApiErrorPtyModeEndToEnd:
+    """PTY-mode subprocess result (empty stderr, API error in stdout) → RESUME."""
+
+    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    def test_api_error_pty_mode_routes_to_resume(self, signal: str) -> None:
+        """Empty stderr + API error in stdout NDJSON → needs_retry=True, RESUME."""
+        from autoskillit.core.types import RetryReason
+
+        ndjson = _make_synthetic_api_error_ndjson(
+            error_type=f"{signal}_error" if " " not in signal else signal,
+            message=signal,
+        )
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "empty_output",
+                "is_error": True,
+                "result": "",
+                "session_id": "",
+            }
+        )
+        result = SubprocessResult(
+            returncode=0,
+            stdout=ndjson + "\n" + result_line,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+            channel_confirmation=ChannelConfirmation.UNMONITORED,
+        )
+        sr = _build_skill_result(result)
+        assert sr.infra.exit_category == "api_error", (
+            f"Expected infra.exit_category='api_error' for signal='{signal}', "
+            f"got '{sr.infra.exit_category}'"
+        )
+        assert sr.needs_retry is True
+        assert sr.retry_reason == RetryReason.RESUME
+
+    def test_api_error_pty_mode_realistic_overload(self) -> None:
+        """Realistic production scenario: overloaded_error, returncode=0, empty stderr."""
+        from autoskillit.core.types import RetryReason
+
+        ndjson = _make_synthetic_api_error_ndjson(
+            error_type="overloaded_error",
+            message="Overloaded",
+        )
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "empty_output",
+                "is_error": True,
+                "result": "",
+                "session_id": "",
+            }
+        )
+        result = SubprocessResult(
+            returncode=0,
+            stdout=ndjson + "\n" + result_line,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+            channel_confirmation=ChannelConfirmation.UNMONITORED,
+        )
+        sr = _build_skill_result(result)
+        assert sr.infra.exit_category == "api_error"
+        assert sr.needs_retry is True
+        assert sr.retry_reason == RetryReason.RESUME
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3: Structural guard — both detection methods on session model
+# ---------------------------------------------------------------------------
+
+
+def test_detection_methods_are_session_model_methods() -> None:
+    """Both infra detection methods must be on ClaudeSessionResult, not standalone."""
+    assert hasattr(ClaudeSessionResult, "_is_context_exhausted")
+    assert hasattr(ClaudeSessionResult, "_has_api_error")
+    assert callable(getattr(ClaudeSessionResult, "_is_context_exhausted"))
+    assert callable(getattr(ClaudeSessionResult, "_has_api_error"))

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -112,12 +112,8 @@ class TestApiErrorChannelInvariant:
         assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
 
     @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
-    def test_api_error_in_stderr_non_pty(self, signal: str) -> None:
-        """Non-PTY mode: signal in stderr → API_ERROR (parsed via assistant_messages)."""
-        # In non-PTY mode, stderr content can end up in assistant_messages after
-        # the session model absorbs it — but more importantly, the errors field
-        # may also carry it. Both paths are covered by the assistant_messages
-        # and errors field tests above. This test documents the non-PTY path.
+    def test_api_error_in_stderr_fallback(self, signal: str) -> None:
+        """Stderr fallback: signal in result.stderr → API_ERROR via classify_infra_exit."""
         session = ClaudeSessionResult(
             subtype="empty_output",
             is_error=True,
@@ -125,9 +121,6 @@ class TestApiErrorChannelInvariant:
             session_id="s1",
         )
         result = _make_result(returncode=1, stderr=f"Error: {signal}", stdout="")
-        # After the fix, stderr is no longer read directly — but an API error
-        # signal in stderr in non-PTY would need to be parsed into the session
-        # model to be detected. This test verifies the stdout/NDJSON path works.
         assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
 
 

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -52,7 +52,8 @@ class TestClassifyInfraExit:
             result="",
             session_id="",
             assistant_messages=[
-                'API Error: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}'
+                "API Error: "
+                '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
             ],
         )
         result = _sr(returncode=0, stderr="")
@@ -135,7 +136,8 @@ class TestClassifyInfraExit:
             session_id="s1",
             jsonl_context_exhausted=True,
             assistant_messages=[
-                'API Error: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}'
+                "API Error: "
+                '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
             ],
         )
         result = _sr(returncode=1, stderr="")

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -44,37 +44,42 @@ class TestClassifyInfraExit:
         result = _sr(returncode=1, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.CONTEXT_EXHAUSTED
 
-    def test_api_error_overloaded_in_stderr(self):
-        """stderr contains 'overloaded' → API_ERROR."""
+    def test_api_error_overloaded_in_assistant_messages(self):
+        """API error in assistant_messages → API_ERROR (PTY-safe path)."""
         session = ClaudeSessionResult(
             subtype="empty_output",
             is_error=True,
             result="",
             session_id="",
+            assistant_messages=[
+                'API Error: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}'
+            ],
         )
-        result = _sr(returncode=1, stderr="Error: API is overloaded")
+        result = _sr(returncode=0, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
 
-    def test_api_error_529_in_stderr(self):
-        """stderr contains HTTP 529 → API_ERROR."""
+    def test_api_error_529_in_assistant_messages(self):
+        """HTTP 529 in assistant_messages → API_ERROR."""
         session = ClaudeSessionResult(
             subtype="empty_output",
             is_error=True,
             result="",
             session_id="",
+            assistant_messages=["HTTP Error 529: Service Overloaded"],
         )
-        result = _sr(returncode=1, stderr="HTTP Error 529: Service Overloaded")
+        result = _sr(returncode=0, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
 
-    def test_api_error_connection_reset(self):
-        """stderr contains ECONNRESET → API_ERROR."""
+    def test_api_error_econnreset_in_assistant_messages(self):
+        """ECONNRESET in assistant_messages → API_ERROR."""
         session = ClaudeSessionResult(
             subtype="empty_output",
             is_error=True,
             result="",
             session_id="",
+            assistant_messages=["Error: read ECONNRESET"],
         )
-        result = _sr(returncode=1, stderr="Error: read ECONNRESET")
+        result = _sr(returncode=0, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
 
     def test_process_killed_sigkill(self):
@@ -129,8 +134,11 @@ class TestClassifyInfraExit:
             result="prompt is too long",
             session_id="s1",
             jsonl_context_exhausted=True,
+            assistant_messages=[
+                'API Error: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}'
+            ],
         )
-        result = _sr(returncode=1, stderr="overloaded")
+        result = _sr(returncode=1, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.CONTEXT_EXHAUSTED
 
 

--- a/tests/execution/test_session_adjudication_retry.py
+++ b/tests/execution/test_session_adjudication_retry.py
@@ -609,7 +609,7 @@ class TestApiErrorRetryRouting:
 
         ndjson = _make_synthetic_api_error_ndjson(
             error_type="529_error",
-            message="Service Unavailable",
+            message="529",
         )
         result_line = json.dumps(
             {

--- a/tests/execution/test_session_adjudication_retry.py
+++ b/tests/execution/test_session_adjudication_retry.py
@@ -599,7 +599,7 @@ class TestApiErrorRetryRouting:
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME
 
-    def test_api_error_503_overrides_to_resume(self):
+    def test_api_error_529_overrides_to_resume(self):
         """HTTP 529 in stdout NDJSON → RESUME."""
         import json
 

--- a/tests/execution/test_session_adjudication_retry.py
+++ b/tests/execution/test_session_adjudication_retry.py
@@ -558,12 +558,13 @@ class TestApiErrorRetryRouting:
         self,
         stderr: str = "",
         returncode: int = 1,
+        stdout: str = "",
     ):
         from autoskillit.core.types import ChannelConfirmation, SubprocessResult, TerminationReason
 
         return SubprocessResult(
             returncode=returncode,
-            stdout="",
+            stdout=stdout,
             stderr=stderr,
             termination=TerminationReason.NATURAL_EXIT,
             pid=12345,
@@ -571,32 +572,83 @@ class TestApiErrorRetryRouting:
         )
 
     def test_api_error_overrides_empty_output_to_resume(self):
-        """When _build_skill_result detects API error in stderr, override
-        EMPTY_OUTPUT → RESUME for on_context_limit routing."""
+        """When _build_skill_result detects API error in stdout NDJSON (PTY mode),
+        override EMPTY_OUTPUT → RESUME for on_context_limit routing."""
+        import json
+
         from autoskillit.core.types import RetryReason
         from autoskillit.execution.headless._headless_result import _build_skill_result
+        from tests.execution.conftest import _make_synthetic_api_error_ndjson
 
-        result = self._make_result(stderr="Error: API is overloaded", returncode=1)
+        ndjson = _make_synthetic_api_error_ndjson(
+            error_type="overloaded_error",
+            message="Overloaded",
+        )
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "empty_output",
+                "is_error": True,
+                "result": "",
+                "session_id": "",
+            }
+        )
+        result = self._make_result(stderr="", returncode=0, stdout=ndjson + "\n" + result_line)
         sr = _build_skill_result(result)
+        assert sr.infra.exit_category == "api_error"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME
 
     def test_api_error_503_overrides_to_resume(self):
-        """503 Service Unavailable in stderr → RESUME."""
+        """HTTP 529 in stdout NDJSON → RESUME."""
+        import json
+
         from autoskillit.core.types import RetryReason
         from autoskillit.execution.headless._headless_result import _build_skill_result
+        from tests.execution.conftest import _make_synthetic_api_error_ndjson
 
-        result = self._make_result(stderr="503 Service Unavailable", returncode=1)
+        ndjson = _make_synthetic_api_error_ndjson(
+            error_type="529_error",
+            message="Service Unavailable",
+        )
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "empty_output",
+                "is_error": True,
+                "result": "",
+                "session_id": "",
+            }
+        )
+        result = self._make_result(stderr="", returncode=0, stdout=ndjson + "\n" + result_line)
         sr = _build_skill_result(result)
+        assert sr.infra.exit_category == "api_error"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME
 
     def test_api_error_econnreset_overrides_to_resume(self):
-        """ECONNRESET in stderr → RESUME."""
+        """ECONNRESET in stdout NDJSON → RESUME."""
+        import json
+
         from autoskillit.core.types import RetryReason
         from autoskillit.execution.headless._headless_result import _build_skill_result
+        from tests.execution.conftest import _make_synthetic_api_error_ndjson
 
-        result = self._make_result(stderr="read ECONNRESET", returncode=1)
+        ndjson = _make_synthetic_api_error_ndjson(
+            error_type="connection_reset_error",
+            message="Connection reset",
+        )
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "empty_output",
+                "is_error": True,
+                "result": "",
+                "session_id": "",
+            }
+        )
+        result = self._make_result(stderr="", returncode=0, stdout=ndjson + "\n" + result_line)
         sr = _build_skill_result(result)
+        assert sr.infra.exit_category == "api_error"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME


### PR DESCRIPTION
## Summary

The exit classification pipeline had an asymmetric design: `_is_context_exhausted()` reads from the post-parse `ClaudeSessionResult` (PTY-safe), but `_detect_api_error()` read from raw `result.stderr` which is always empty under PTY mode (100% of production sessions). The fix adds `_has_api_error()` as a method on `ClaudeSessionResult` that scans `assistant_messages`, `errors`, and `result` fields — matching the architecture of `_is_context_exhausted()`. The old `_detect_api_error()` is removed entirely. New invariant tests verify detection works through both stderr and stdout/NDJSON channels. Existing tests are updated to model PTY-mode data. Related observability gaps (stderr propagation) are also fixed.

Closes #2317

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260509-172437-483510/.autoskillit/temp/rectify/rectify_api_error_signal_routing_2026-05-09_172437.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 49 | 14.6k | 795.2k | 120.8k | 154 | 69.2k | 7m 38s |
| dry_walkthrough | claude-opus-4-6 | 1 | 1.4k | 16.7k | 761.3k | 75.7k | 88 | 64.0k | 13m 24s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.8M | 16.7k | 1.4M | 66.6k | 123 | 98.6k | 6m 37s |
| prepare_pr* | MiniMax-M2.7 | 1 | 46.3k | 2.5k | 378.8k | 22.0k | 26 | 0 | 1m 30s |
| compose_pr* | MiniMax-M2.7 | 1 | 46.8k | 2.8k | 426.2k | 0 | 27 | 0 | 1m 43s |
| review_pr | claude-opus-4-6 | 3 | 204 | 88.2k | 1.7M | 81.2k | 102 | 227.6k | 23m 52s |
| resolve_review | claude-opus-4-6 | 2 | 85 | 23.3k | 1.5M | 62.4k | 73 | 93.6k | 16m 24s |
| **Total** | | | 1.9M | 164.8k | 7.0M | 120.8k | | 553.0k | 1h 11m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 367 | 3800.8 | 268.6 | 45.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 115683.3 | 7199.2 | 1790.7 |
| **Total** | **380** | 18358.7 | 1455.2 | 433.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 25 | 4.1k | 195.4k | 23.1k | 3m 7s |