### PR TITLE
P2-A4 — Wire marker_dir/session_id through run_managed_async and DefaultSubprocessRunner

### DIFF
--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -11,6 +11,7 @@ Two composed functions wire the utilities together correctly:
 
 from __future__ import annotations
 
+import functools
 import subprocess
 import time
 from collections.abc import Callable, Mapping
@@ -208,6 +209,8 @@ async def run_managed_async(
     _heartbeat_poll: float = 0.5,
     _phase1_timeout: float = 30.0,
     _session_id_timeout: float = 1.0,
+    marker_dir: Path | None = None,
+    session_id: str | None = None,
 ) -> SubprocessResult:
     """Async subprocess execution with temp file I/O and process tree cleanup.
 
@@ -343,14 +346,21 @@ async def run_managed_async(
                         _session_id_timeout,
                         stdout_session_id_ready,
                         max_suppression_seconds,
+                        marker_dir,
+                        session_id,
                     )
                 if idle_output_timeout is not None and idle_output_timeout > 0:
                     tg.start_soon(
-                        _watch_stdout_idle,
-                        stdout_path,
-                        idle_output_timeout,
-                        acc,
-                        trigger,
+                        functools.partial(
+                            _watch_stdout_idle,
+                            stdout_path,
+                            idle_output_timeout,
+                            acc,
+                            trigger,
+                            marker_dir=marker_dir,
+                            session_id=session_id,
+                            max_suppression_seconds=max_suppression_seconds or 1800.0,
+                        ),
                     )
                 tracing_handle = None
                 if linux_tracing_config is not None and _target is not None:
@@ -579,6 +589,8 @@ class DefaultSubprocessRunner:
         on_pid_resolved: Callable[[int, int], None] | None = None,
         enable_deadline_extension: bool = False,
         max_extension_seconds: float = 7200,
+        marker_dir: Path | None = None,
+        session_id: str | None = None,
     ) -> SubprocessResult:
         return await run_managed_async(
             cmd,
@@ -597,4 +609,6 @@ class DefaultSubprocessRunner:
             on_pid_resolved=on_pid_resolved,
             enable_deadline_extension=enable_deadline_extension,
             max_extension_seconds=max_extension_seconds,
+            marker_dir=marker_dir,
+            session_id=session_id,
         )

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -342,6 +342,8 @@ class TestGroupDApiContractPreservation:
             "on_pid_resolved",
             "enable_deadline_extension",
             "max_extension_seconds",
+            "marker_dir",
+            "session_id",
         }
         assert expected == public_params, (
             f"run_managed_async public params changed.\n"
@@ -406,11 +408,53 @@ class TestGroupDApiContractPreservation:
             "on_pid_resolved",
             "enable_deadline_extension",
             "max_extension_seconds",
+            "marker_dir",
+            "session_id",
         }
         assert expected == actual, (
             f"DefaultSubprocessRunner.__call__ params changed.\n"
             f"  Missing: {expected - actual}\n"
             f"  Extra:   {actual - expected}"
+        )
+
+    def test_run_managed_async_marker_dir_session_id_defaults(self):
+        """run_managed_async marker_dir and session_id default to None."""
+        sig = inspect.signature(run_managed_async)
+        assert sig.parameters["marker_dir"].default is None
+        assert sig.parameters["session_id"].default is None
+
+    def test_run_managed_async_marker_params_after_session_id_timeout(self):
+        """marker_dir and session_id appear after _session_id_timeout in run_managed_async."""
+        sig = inspect.signature(run_managed_async)
+        p = sig.parameters
+        session_id_timeout_idx = list(sig.parameters).index("_session_id_timeout")
+        marker_dir_idx = list(sig.parameters).index("marker_dir")
+        session_id_idx = list(sig.parameters).index("session_id")
+        assert marker_dir_idx == session_id_timeout_idx + 1
+        assert session_id_idx == marker_dir_idx + 1
+
+    def test_default_subprocess_runner_marker_dir_session_id_defaults(self):
+        """DefaultSubprocessRunner.__call__ marker_dir and session_id default to None."""
+        sig = inspect.signature(DefaultSubprocessRunner.__call__)
+        assert sig.parameters["marker_dir"].default is None
+        assert sig.parameters["session_id"].default is None
+
+    def test_default_subprocess_runner_marker_params_after_max_extension(self):
+        """marker_dir and session_id appear after max_extension_seconds in DefaultSubprocessRunner.__call__."""
+        sig = inspect.signature(DefaultSubprocessRunner.__call__)
+        max_extension_idx = list(sig.parameters).index("max_extension_seconds")
+        marker_dir_idx = list(sig.parameters).index("marker_dir")
+        session_id_idx = list(sig.parameters).index("session_id")
+        assert marker_dir_idx == max_extension_idx + 1
+        assert session_id_idx == marker_dir_idx + 1
+
+    def test_default_subprocess_runner_satisfies_protocol_with_marker_params(self):
+        """DefaultSubprocessRunner() satisfies SubprocessRunner with marker_dir/session_id added."""
+        from autoskillit.core.types import SubprocessRunner
+
+        runner = DefaultSubprocessRunner()
+        assert isinstance(runner, SubprocessRunner), (
+            "DefaultSubprocessRunner no longer satisfies the SubprocessRunner protocol"
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Thread `marker_dir` and `session_id` parameters through the `run_managed_async` function and `DefaultSubprocessRunner.__call__` method, completing the parameter chain from the SubprocessRunner protocol (added in P2-A6) down to the watcher coroutines `_watch_session_log` and `_watch_stdout_idle` (which already accept these params from P2-A1). This involves adding `import functools`, extending two function signatures, wiring two `tg.start_soon` calls, and updating existing contract tests.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None

## Changed Files

- `src/autoskillit/execution/process/__init__.py`
- `src/autoskillit/execution/recording.py`
- `tests/contracts/test_protocol_satisfaction.py`

Closes #2300

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-182041-089709/.autoskillit/temp/make-plan/p2_a4_wire_marker_dir_session_id_plan_2026-05-09_182600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 68 | 7.6k | 527.9k | 51.8k | 58 | 42.8k | 3m 53s |
| verify | claude-opus-4-6 | 1 | 40 | 12.3k | 476.9k | 55.1k | 50 | 62.2k | 4m 41s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.0M | 10.0k | 1.2M | 28.8k | 103 | 35.5k | 5m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 81.4k | 2.8k | 227.3k | 28.8k | 20 | 15.4k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 59.6k | 1.7k | 198.5k | 28.8k | 16 | 15.1k | 45s |
| review_pr | claude-opus-4-6 | 3 | 107 | 51.4k | 1.4M | 60.7k | 89 | 136.3k | 13m 3s |
| resolve_review | claude-opus-4-6 | 1 | 40 | 8.0k | 621.3k | 61.0k | 29 | 48.3k | 6m 0s |
| **Total** | | | 1.2M | 93.8k | 4.7M | 61.0k | | 355.6k | 34m 52s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 74 | 16677.1 | 479.7 | 135.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **74** | 63712.9 | 4805.0 | 1267.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 3.8k | 29.9k | 1.9M | 132.8k | 17m 46s |
| claude-sonnet-4-6 | 1 | 129 | 32.6k | 2.1M | 169.9k | 27m 38s |
| MiniMax-M2.7-highspeed | 1 | 3.0M | 27.2k | 2.7M | 126.0k | 11m 19s |