### PR TITLE
P2-A7 — Update Recording/ReplayingSubprocessRunner with marker_dir/session_id

### DIFF
--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -104,6 +104,8 @@ class RecordingSubprocessRunner(SubprocessRunner):
         on_pid_resolved: Callable[[int, int], None] | None = None,
         enable_deadline_extension: bool = False,
         max_extension_seconds: float = 7200,
+        marker_dir: Path | None = None,
+        session_id: str | None = None,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 
@@ -132,6 +134,8 @@ class RecordingSubprocessRunner(SubprocessRunner):
             on_pid_resolved=on_pid_resolved,
             enable_deadline_extension=enable_deadline_extension,
             max_extension_seconds=max_extension_seconds,
+            marker_dir=marker_dir,
+            session_id=session_id,
         )
 
         if step_name:
@@ -249,6 +253,8 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         on_pid_resolved: Callable[[int, int], None] | None = None,
         enable_deadline_extension: bool = False,
         max_extension_seconds: float = 7200,
+        marker_dir: Path | None = None,
+        session_id: str | None = None,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -563,3 +563,90 @@ def test_replaying_runner_restore_missing_step_returns_none(tmp_path):
     runner = ReplayingSubprocessRunner({}, {}, skill_snapshots={})
     result = runner.restore_skill_snapshot("missing", tmp_path / "sessions", "headless-abc")
     assert result is None
+
+
+# --- T-MARKER-FWD: RecordingSubprocessRunner forwards marker_dir and session_id to inner ---
+
+
+@pytest.mark.anyio
+async def test_recording_runner_forwards_marker_dir_and_session_id(tmp_path):
+    """Non-session branch passes marker_dir and session_id to self._inner()."""
+    mock_recorder = Mock()
+    inner = MockSubprocessRunner()
+    inner.set_default(_make_result(returncode=0))
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+
+    marker = tmp_path / "markers"
+    cmd = ["pytest", "tests/"]
+    env = {"SCENARIO_STEP_NAME": "test-check"}
+
+    await runner(
+        cmd,
+        cwd=Path("/tmp"),
+        timeout=60,
+        env=env,
+        pty_mode=False,
+        marker_dir=marker,
+        session_id="sess-abc",
+    )
+
+    assert len(inner.call_args_list) == 1
+    kwargs = inner.call_args_list[0][3]
+    assert kwargs["marker_dir"] == marker
+    assert kwargs["session_id"] == "sess-abc"
+
+
+# --- T-MARKER-SESSION-BRANCH: session branch does not forward marker_dir/session_id ---
+
+
+@pytest.mark.anyio
+async def test_recording_runner_session_branch_ignores_marker_params(tmp_path):
+    """pty_mode=True + step_name → _record_session; marker_dir/session_id not forwarded."""
+    mock_recorder = Mock()
+    mock_recorder.record_step.return_value = FakeStepResult(
+        cassette_exit_code=0,
+        cassette_path=str(tmp_path / "cassette"),
+        cassette_duration_ms=5000,
+    )
+    inner = MockSubprocessRunner()
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+
+    cmd = ["claude", "--model", "sonnet", "--print", "do stuff"]
+    env = {"AUTOSKILLIT_HEADLESS": "1", "SCENARIO_STEP_NAME": "investigate"}
+
+    result = await runner(
+        cmd,
+        cwd=Path("/tmp"),
+        timeout=300,
+        env=env,
+        pty_mode=True,
+        marker_dir=tmp_path / "markers",
+        session_id="sess-xyz",
+    )
+
+    assert inner.call_args_list == []  # inner NOT called
+    assert result.returncode == 0
+
+
+# --- T-MARKER-REPLAY-ACCEPTS: ReplayingSubprocessRunner accepts marker params ---
+
+
+@pytest.mark.anyio
+async def test_replaying_runner_accepts_marker_params(tmp_path):
+    """ReplayingSubprocessRunner.__call__ accepts marker_dir and session_id without error."""
+    non_session = {"check": {"exit_code": 0, "stdout_head": "ok", "stderr": ""}}
+    runner = ReplayingSubprocessRunner({}, non_session)
+
+    cmd = ["task", "test-check"]
+    env = {"SCENARIO_STEP_NAME": "check"}
+    result = await runner(
+        cmd,
+        cwd=tmp_path,
+        timeout=60,
+        env=env,
+        marker_dir=tmp_path / "markers",
+        session_id="sess-123",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "ok"

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -582,7 +582,7 @@ async def test_recording_runner_forwards_marker_dir_and_session_id(tmp_path):
 
     await runner(
         cmd,
-        cwd=Path("/tmp"),
+        cwd=tmp_path,
         timeout=60,
         env=env,
         pty_mode=False,
@@ -616,7 +616,7 @@ async def test_recording_runner_session_branch_ignores_marker_params(tmp_path):
 
     result = await runner(
         cmd,
-        cwd=Path("/tmp"),
+        cwd=tmp_path,
         timeout=300,
         env=env,
         pty_mode=True,


### PR DESCRIPTION
## Summary

Add `marker_dir: Path | None = None` and `session_id: str | None = None` keyword-only parameters to both `RecordingSubprocessRunner.__call__` and `ReplayingSubprocessRunner.__call__` in `src/autoskillit/execution/recording.py`, and forward them through the `self._inner(...)` delegation call in `RecordingSubprocessRunner`. This brings both implementations into conformance with the updated `SubprocessRunner` Protocol (P2-A6).

Closes #2302

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-182040-470979/.autoskillit/temp/make-plan/p2_a7_update_recording_replaying_subprocess_runner_plan_2026-05-09_182300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| verify | claude-opus-4-6 | 1 | 34 | 6.6k | 743.9k | 64.7k | 64 | 74.7k | 3m 56s |
| implement* | MiniMax-M2.7-highspeed | 1 | 477.2k | 5.8k | 661.7k | 28.8k | 55 | 65.8k | 2m 35s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 117.2k | 3.1k | 342.4k | 28.8k | 24 | 15.4k | 1m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 66.5k | 1.8k | 227.3k | 28.8k | 18 | 15.1k | 51s |
| review_pr | claude-opus-4-6 | 3 | 1.1k | 42.5k | 1.5M | 56.9k | 131 | 125.3k | 15m 18s |
| resolve_review | claude-opus-4-6 | 1 | 43 | 5.2k | 723.6k | 53.5k | 30 | 40.7k | 4m 18s |
| **Total** | | | 662.1k | 65.0k | 4.2M | 64.7k | | 337.0k | 28m 21s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| verify | 0 | — | — | — |
| implement | 93 | 7114.7 | 707.8 | 61.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 180904.5 | 10171.5 | 1307.8 |
| **Total** | **97** | 43435.3 | 3474.2 | 670.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 3.8k | 29.9k | 1.9M | 132.8k | 17m 46s |
| claude-sonnet-4-6 | 1 | 129 | 32.6k | 2.1M | 169.9k | 27m 38s |
| MiniMax-M2.7-highspeed | 1 | 3.0M | 27.2k | 2.7M | 126.0k | 11m 19s |