### PR TITLE
P2-A8 — Add Idle Stall Watchdog Dispatch Marker Tests

### DIFF
--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import os  # noqa: F401
 import sys
 import textwrap
 import time
@@ -366,3 +367,131 @@ async def test_watch_stdout_idle_marker_false_fires_immediately(
             await trigger.wait()
 
     assert acc.idle_stall is True
+
+
+@pytest.mark.anyio
+async def test_idle_stall_suppressed_by_active_dispatch_marker(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Active dispatch marker suppresses idle stall within the suppression window."""
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_dispatch_marker",
+        lambda *a, **kw: True,
+    )
+    stdout_file = tmp_path / "stdout.txt"
+    stdout_file.write_bytes(b"")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with anyio.fail_after(4.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.5,
+                    acc,
+                    trigger,
+                    0.2,
+                    marker_dir=tmp_path,
+                )
+            )
+            await anyio.sleep(1.0)
+            tg.cancel_scope.cancel()
+
+    assert acc.idle_stall is False
+
+
+@pytest.mark.anyio
+async def test_idle_stall_fires_when_marker_absent(tmp_path: anyio.Path) -> None:
+    """No marker_dir kwarg — idle stall fires unchanged (existing behavior path)."""
+    stdout_file = tmp_path / "stdout.txt"
+    stdout_file.write_bytes(b"")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with anyio.fail_after(3.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                _watch_stdout_idle,
+                stdout_file,
+                0.5,
+                acc,
+                trigger,
+                0.2,
+            )
+            await trigger.wait()
+
+    assert acc.idle_stall is True
+
+
+@pytest.mark.anyio
+async def test_idle_stall_fires_when_marker_stale(tmp_path: anyio.Path) -> None:
+    """Marker file exists but is stale (mtime 120s ago) — watchdog fires."""
+    marker_path = tmp_path / "dispatch-in-progress-testsession-abc123.marker"
+    marker_path.write_text("{}")
+    stale_time = time.time() - 120
+    os.utime(str(marker_path), (stale_time, stale_time))
+
+    stdout_file = tmp_path / "stdout.txt"
+    stdout_file.write_bytes(b"")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with anyio.fail_after(3.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.5,
+                    acc,
+                    trigger,
+                    0.2,
+                    marker_dir=tmp_path,
+                    session_id=None,
+                )
+            )
+            await trigger.wait()
+
+    assert acc.idle_stall is True
+
+
+@pytest.mark.anyio
+async def test_idle_stall_marker_suppression_bounded(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Suppression cap exceeded — idle stall fires despite active marker."""
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_dispatch_marker",
+        lambda *a, **kw: True,
+    )
+    stdout_file = tmp_path / "stdout.txt"
+    stdout_file.write_bytes(b"")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    start = time.monotonic()
+    with anyio.fail_after(6.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.5,
+                    acc,
+                    trigger,
+                    0.2,
+                    marker_dir=tmp_path,
+                    max_suppression_seconds=1.5,
+                )
+            )
+            await trigger.wait()
+
+    elapsed = time.monotonic() - start
+    assert acc.idle_stall is True
+    assert elapsed >= 1.5

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -376,7 +376,7 @@ async def test_watch_stdout_idle_dispatch_marker_suppresses_stall(
     """Active dispatch marker suppresses idle stall within the suppression window."""
     monkeypatch.setattr(
         "autoskillit.execution.process._process_race._has_active_dispatch_marker",
-        lambda *a, **kw: True,
+        lambda marker_dir, session_id=None: True,
     )
     stdout_file = tmp_path / "stdout.txt"
     stdout_file.write_bytes(b"")
@@ -467,7 +467,7 @@ async def test_watch_stdout_idle_marker_suppression_bounded(
     """Suppression cap exceeded — idle stall fires despite active marker."""
     monkeypatch.setattr(
         "autoskillit.execution.process._process_race._has_active_dispatch_marker",
-        lambda *a, **kw: True,
+        lambda marker_dir, session_id=None: True,
     )
     stdout_file = tmp_path / "stdout.txt"
     stdout_file.write_bytes(b"")

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import functools
-import os  # noqa: F401
+import os
 import sys
 import textwrap
 import time

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -370,7 +370,7 @@ async def test_watch_stdout_idle_marker_false_fires_immediately(
 
 
 @pytest.mark.anyio
-async def test_idle_stall_suppressed_by_active_dispatch_marker(
+async def test_watch_stdout_idle_dispatch_marker_suppresses_stall(
     tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Active dispatch marker suppresses idle stall within the suppression window."""
@@ -404,7 +404,7 @@ async def test_idle_stall_suppressed_by_active_dispatch_marker(
 
 
 @pytest.mark.anyio
-async def test_idle_stall_fires_when_marker_absent(tmp_path: anyio.Path) -> None:
+async def test_watch_stdout_idle_fires_when_marker_absent(tmp_path: anyio.Path) -> None:
     """No marker_dir kwarg — idle stall fires unchanged (existing behavior path)."""
     stdout_file = tmp_path / "stdout.txt"
     stdout_file.write_bytes(b"")
@@ -428,7 +428,7 @@ async def test_idle_stall_fires_when_marker_absent(tmp_path: anyio.Path) -> None
 
 
 @pytest.mark.anyio
-async def test_idle_stall_fires_when_marker_stale(tmp_path: anyio.Path) -> None:
+async def test_watch_stdout_idle_fires_when_marker_stale(tmp_path: anyio.Path) -> None:
     """Marker file exists but is stale (mtime 120s ago) — watchdog fires."""
     marker_path = tmp_path / "dispatch-in-progress-testsession-abc123.marker"
     marker_path.write_text("{}")
@@ -461,7 +461,7 @@ async def test_idle_stall_fires_when_marker_stale(tmp_path: anyio.Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_idle_stall_marker_suppression_bounded(
+async def test_watch_stdout_idle_marker_suppression_bounded(
     tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Suppression cap exceeded — idle stall fires despite active marker."""

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -495,3 +495,4 @@ async def test_watch_stdout_idle_marker_suppression_bounded(
     elapsed = time.monotonic() - start
     assert acc.idle_stall is True
     assert elapsed >= 1.5
+    assert elapsed < 5.0


### PR DESCRIPTION
## Summary

Add four parametric test cases to `tests/execution/test_process_idle_watchdog.py` covering dispatch marker interaction with the stdout idle watchdog: fresh-marker suppression, absent-marker fire, stale-marker fire, and `max_suppression_seconds` cap enforcement. Also add `import os` to the module-level imports for the stale-marker test's `os.utime()` call.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-194808-908034/.autoskillit/temp/make-plan/p2_u8_add_idle_stall_watchdog_dispatch_marker_tests_plan_2026-05-09_194808.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 67 | 13.4k | 527.9k | 59.5k | 32 | 51.7k | 5m 36s |
| verify | claude-opus-4-6 | 1 | 61 | 14.0k | 729.8k | 66.3k | 52 | 53.2k | 6m 46s |
| implement* | MiniMax-M2.7-highspeed | 1 | 554.1k | 7.4k | 841.2k | 56.2k | 69 | 63.6k | 3m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 107.8k | 2.7k | 256.0k | 28.8k | 21 | 15.4k | 1m 15s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 64.1k | 1.5k | 256.0k | 28.8k | 19 | 15.1k | 44s |
| review_pr | claude-opus-4-6 | 3 | 95 | 32.6k | 1.2M | 63.1k | 89 | 143.1k | 10m 11s |
| resolve_review | claude-opus-4-6 | 1 | 48 | 8.4k | 1.2M | 68.2k | 42 | 55.4k | 4m 18s |
| **Total** | | | 726.2k | 80.0k | 5.0M | 68.2k | | 397.6k | 32m 38s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 129 | 6520.7 | 493.0 | 57.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 15 | 78112.2 | 3693.4 | 561.5 |
| **Total** | **144** | 34584.7 | 2760.8 | 555.2 |