### PR TITLE
Rectify: Worktree Path Resolution Immunity -- Part A

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -54,6 +54,7 @@ from .paths import find_latest_session_id as find_latest_session_id
 from .paths import is_git_main_checkout as is_git_main_checkout
 from .paths import is_git_worktree as is_git_worktree
 from .paths import pkg_root as pkg_root
+from .paths import resolve_main_worktree as resolve_main_worktree
 from .runtime._linux_proc import is_session_alive as is_session_alive
 from .runtime._linux_proc import read_boot_id as read_boot_id
 from .runtime._linux_proc import read_starttime_ticks as read_starttime_ticks

--- a/src/autoskillit/core/paths.py
+++ b/src/autoskillit/core/paths.py
@@ -122,6 +122,32 @@ def is_git_main_checkout(path: Path) -> bool:
     return False
 
 
+def resolve_main_worktree(path: Path) -> Path | None:
+    """Resolve ``path`` to the main git worktree root.
+
+    If ``path`` is inside a linked worktree, returns the main checkout root.
+    If ``path`` is already the main checkout, returns that directory.
+    If ``path`` is not inside any git repository, returns None.
+
+    Uses ``git rev-parse --path-format=absolute --git-common-dir`` to locate
+    the shared .git directory, then derives the main worktree root as its parent.
+    This is the canonical resolution — works regardless of how deeply nested
+    the path is within the worktree graph.
+    """
+    import subprocess
+
+    try:
+        git_common_dir = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return Path(git_common_dir.stdout.strip()).parent.resolve()
+
+
 GENERATED_FILES: frozenset[str] = frozenset(
     {
         "src/autoskillit/hooks/hooks.json",

--- a/src/autoskillit/core/paths.py
+++ b/src/autoskillit/core/paths.py
@@ -14,6 +14,7 @@ Design rationale:
 from __future__ import annotations
 
 import importlib.resources as ir
+import subprocess
 from pathlib import Path
 
 
@@ -134,7 +135,6 @@ def resolve_main_worktree(path: Path) -> Path | None:
     This is the canonical resolution — works regardless of how deeply nested
     the path is within the worktree graph.
     """
-    import subprocess
 
     try:
         git_common_dir = subprocess.run(
@@ -143,9 +143,12 @@ def resolve_main_worktree(path: Path) -> Path | None:
             text=True,
             check=True,
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         return None
-    return Path(git_common_dir.stdout.strip()).parent.resolve()
+    output = git_common_dir.stdout.strip()
+    if not output or not Path(output).is_absolute():
+        return None
+    return Path(output).parent.resolve()
 
 
 GENERATED_FILES: frozenset[str] = frozenset(

--- a/src/autoskillit/recipe/rules/rules_worktree.py
+++ b/src/autoskillit/recipe/rules/rules_worktree.py
@@ -143,6 +143,39 @@ def _check_retry_worktree_cwd(ctx: ValidationContext) -> list[RuleFinding]:
 
 
 @semantic_rule(
+    name="relative-worktree-path-in-cmd",
+    description=(
+        "run_cmd steps must not use relative '../worktrees/' paths. "
+        "Resolve the main worktree root via git rev-parse --git-common-dir "
+        "and compute an absolute worktree path from there."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_relative_worktree_path_in_cmd(ctx: ValidationContext) -> list[RuleFinding]:
+    wf = ctx.recipe
+    findings: list[RuleFinding] = []
+    for step_name, step in wf.steps.items():
+        if step.tool != "run_cmd":
+            continue
+        cmd = step.with_args.get("cmd", "")
+        if "../worktrees/" in cmd:
+            findings.append(
+                RuleFinding(
+                    rule="relative-worktree-path-in-cmd",
+                    severity=Severity.WARNING,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' uses a relative '../worktrees/' path in its cmd. "
+                        f"This causes nested worktree directories when source_dir is "
+                        f"itself a worktree. Resolve the main repo root via "
+                        f"'git rev-parse --path-format=absolute --git-common-dir' first."
+                    ),
+                )
+            )
+    return findings
+
+
+@semantic_rule(
     name="file-writing-skill-missing-context-limit",
     description=(
         "A step invoking a write_behavior='always' skill has no on_context_limit route. "

--- a/src/autoskillit/recipes/scripts/create_worktree.sh
+++ b/src/autoskillit/recipes/scripts/create_worktree.sh
@@ -21,8 +21,9 @@ fi
 
 # Resolve to main worktree root — prevents nested worktrees/worktrees/ when
 # SOURCE_DIR is itself a linked worktree.
-MAIN_ROOT="$(git -C "$SOURCE_DIR" rev-parse --path-format=absolute --git-common-dir)"
-MAIN_ROOT="$(dirname "$MAIN_ROOT")"
+MAIN_GIT_DIR="$(git -C "$SOURCE_DIR" rev-parse --path-format=absolute --git-common-dir)"
+[ -n "$MAIN_GIT_DIR" ] || { echo "error: could not resolve git-common-dir" >&2; exit 1; }
+MAIN_ROOT="$(dirname "$MAIN_GIT_DIR")"
 
 BRANCH="research-$(date +%Y%m%d-%H%M%S)"
 WORKTREE_DIR="${MAIN_ROOT}/../worktrees"

--- a/src/autoskillit/recipes/scripts/create_worktree.sh
+++ b/src/autoskillit/recipes/scripts/create_worktree.sh
@@ -14,20 +14,27 @@ REPORT_PLAN="${7:-}"
 TEMP_NAME="${8:-.autoskillit/temp}"
 VIS_TRACE_PATH="${9:-}"
 
-if [ ! -d "$SOURCE_DIR/.git" ]; then
+if [ ! -e "$SOURCE_DIR/.git" ]; then
   git init -q "$SOURCE_DIR"
   git -C "$SOURCE_DIR" commit --allow-empty -m "autoskillit: init for research recipe" -q
 fi
 
+# Resolve to main worktree root — prevents nested worktrees/worktrees/ when
+# SOURCE_DIR is itself a linked worktree.
+MAIN_ROOT="$(git -C "$SOURCE_DIR" rev-parse --path-format=absolute --git-common-dir)"
+MAIN_ROOT="$(dirname "$MAIN_ROOT")"
+
 BRANCH="research-$(date +%Y%m%d-%H%M%S)"
-WORKTREE_PATH="../worktrees/${BRANCH}"
+WORKTREE_DIR="${MAIN_ROOT}/../worktrees"
+mkdir -p "${WORKTREE_DIR}"
+WORKTREE_PATH="${WORKTREE_DIR}/${BRANCH}"
 git -C "$SOURCE_DIR" worktree add -b "${BRANCH}" "${WORKTREE_PATH}"
-RESOLVED="$(cd "${SOURCE_DIR}/${WORKTREE_PATH}" && pwd)"
+RESOLVED="$(cd "${WORKTREE_PATH}" && pwd)"
 
 case "${RESOLVED}" in /*) ;; *) echo "error: resolved worktree path is not absolute: ${RESOLVED}" >&2; exit 1;; esac
 
-mkdir -p "${SOURCE_DIR}/${TEMP_NAME}/worktrees/${BRANCH}"
-git -C "$SOURCE_DIR" rev-parse --abbrev-ref HEAD > "${SOURCE_DIR}/${TEMP_NAME}/worktrees/${BRANCH}/base-branch"
+mkdir -p "${MAIN_ROOT}/${TEMP_NAME}/worktrees/${BRANCH}"
+git -C "$SOURCE_DIR" rev-parse --abbrev-ref HEAD > "${MAIN_ROOT}/${TEMP_NAME}/worktrees/${BRANCH}/base-branch"
 
 mkdir -p "${RESOLVED}/${TEMP_NAME}"
 cp "${EXPERIMENT_PLAN}" "${RESOLVED}/${TEMP_NAME}/experiment-plan.md"

--- a/src/autoskillit/server/git.py
+++ b/src/autoskillit/server/git.py
@@ -10,6 +10,7 @@ Public API:
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import os
 from pathlib import Path
@@ -22,6 +23,7 @@ from autoskillit.core import (
     SubprocessRunner,
     get_logger,
     is_protected_branch,
+    resolve_main_worktree,
     truncate_text,
 )
 from autoskillit.server._editable_guard import scan_editable_installs_for_worktree
@@ -389,17 +391,11 @@ async def perform_merge(
             }
 
     # 7. Discover main repo path
-    rc, wt_list, _ = await _run_git(
-        ["git", "worktree", "list", "--porcelain"], worktree_path, 10, runner
-    )
-    main_repo = ""
-    for line in wt_list.splitlines():
-        if line.startswith("worktree "):
-            main_repo = line.split(" ", 1)[1].strip()
-            break  # First entry is always the main working tree
+    main_repo_path = await asyncio.to_thread(resolve_main_worktree, Path(worktree_path))
+    main_repo = str(main_repo_path) if main_repo_path else ""
     if not main_repo:
         return {
-            "error": "Could not locate main repository from worktree list",
+            "error": "Could not locate main repository using resolve_main_worktree",
             "failed_step": MergeFailedStep.MERGE,
             "state": MergeState.WORKTREE_INTACT,
             "worktree_path": worktree_path,

--- a/src/autoskillit/server/git.py
+++ b/src/autoskillit/server/git.py
@@ -391,7 +391,10 @@ async def perform_merge(
             }
 
     # 7. Discover main repo path
-    main_repo_path = await asyncio.to_thread(resolve_main_worktree, Path(worktree_path))
+    if not worktree_path:
+        main_repo_path = None
+    else:
+        main_repo_path = await asyncio.to_thread(resolve_main_worktree, Path(worktree_path))
     main_repo = str(main_repo_path) if main_repo_path else ""
     if not main_repo:
         return {

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -97,7 +97,11 @@ worktree, discarding all partial progress. Instead, route to the next step
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 WORKTREE_NAME="research-$(date +%Y%m%d-%H%M%S)"
-WORKTREE_PATH="../worktrees/${WORKTREE_NAME}"
+MAIN_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+MAIN_ROOT="$(dirname "$MAIN_GIT_DIR")"
+WORKTREE_DIR="${MAIN_ROOT}/../worktrees"
+mkdir -p "${WORKTREE_DIR}"
+WORKTREE_PATH="${WORKTREE_DIR}/${WORKTREE_NAME}"
 git worktree add -b "${WORKTREE_NAME}" "${WORKTREE_PATH}"
 WORKTREE_PATH="$(cd "${WORKTREE_PATH}" && pwd)"
 

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -96,7 +96,11 @@ Correct orchestration on `needs_retry=true`:
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 WORKTREE_NAME="impl-{plan_name}-$(date +%Y%m%d-%H%M%S)"
-WORKTREE_PATH="../worktrees/${WORKTREE_NAME}"
+MAIN_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+MAIN_ROOT="$(dirname "$MAIN_GIT_DIR")"
+WORKTREE_DIR="${MAIN_ROOT}/../worktrees"
+mkdir -p "${WORKTREE_DIR}"
+WORKTREE_PATH="${WORKTREE_DIR}/${WORKTREE_NAME}"
 git worktree add -b "${WORKTREE_NAME}" "${WORKTREE_PATH}"
 WORKTREE_PATH="$(cd "${WORKTREE_PATH}" && pwd)"
 

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -86,7 +86,11 @@ Correct orchestration on `needs_retry=true`:
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 WORKTREE_NAME="impl-{plan_name}-$(date +%Y%m%d-%H%M%S)"
-WORKTREE_PATH="../worktrees/${WORKTREE_NAME}"
+MAIN_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+MAIN_ROOT="$(dirname "$MAIN_GIT_DIR")"
+WORKTREE_DIR="${MAIN_ROOT}/../worktrees"
+mkdir -p "${WORKTREE_DIR}"
+WORKTREE_PATH="${WORKTREE_DIR}/${WORKTREE_NAME}"
 git worktree add -b "${WORKTREE_NAME}" "${WORKTREE_PATH}"
 WORKTREE_PATH="$(cd "${WORKTREE_PATH}" && pwd)"
 mkdir -p "{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}"

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -111,8 +111,8 @@ BASE_BRANCH=$(git rev-parse --abbrev-ref @{upstream} 2>/dev/null | sed 's|^[^/]*
 
 if [ -z "$BASE_BRANCH" ]; then
     # Fallback: read explicit file store written by implement-worktree-no-merge
-    MAIN_GIT_DIR=$(git rev-parse --git-common-dir)
-    MAIN_REPO_ROOT=$(dirname "${MAIN_GIT_DIR}")
+    MAIN_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+    MAIN_REPO_ROOT="$(dirname "$MAIN_GIT_DIR")"
     WORKTREE_DIR_NAME=$(basename "$(pwd)")
     STORE_FILE="${MAIN_REPO_ROOT}/{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_DIR_NAME}/base-branch"
     BASE_BRANCH=$(cat "${STORE_FILE}" 2>/dev/null)

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -112,9 +112,9 @@ BASE_BRANCH=$(git rev-parse --abbrev-ref @{upstream} 2>/dev/null | sed 's|^[^/]*
 if [ -z "$BASE_BRANCH" ]; then
     # Fallback: read explicit file store written by implement-worktree-no-merge
     MAIN_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
-    MAIN_REPO_ROOT="$(dirname "$MAIN_GIT_DIR")"
+    MAIN_ROOT="$(dirname "$MAIN_GIT_DIR")"
     WORKTREE_DIR_NAME=$(basename "$(pwd)")
-    STORE_FILE="${MAIN_REPO_ROOT}/{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_DIR_NAME}/base-branch"
+    STORE_FILE="${MAIN_ROOT}/{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_DIR_NAME}/base-branch"
     BASE_BRANCH=$(cat "${STORE_FILE}" 2>/dev/null)
 fi
 

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -426,7 +426,6 @@ class TestGroupDApiContractPreservation:
     def test_run_managed_async_marker_params_after_session_id_timeout(self):
         """marker_dir and session_id appear after _session_id_timeout in run_managed_async."""
         sig = inspect.signature(run_managed_async)
-        p = sig.parameters
         session_id_timeout_idx = list(sig.parameters).index("_session_id_timeout")
         marker_dir_idx = list(sig.parameters).index("marker_dir")
         session_id_idx = list(sig.parameters).index("session_id")
@@ -440,7 +439,7 @@ class TestGroupDApiContractPreservation:
         assert sig.parameters["session_id"].default is None
 
     def test_default_subprocess_runner_marker_params_after_max_extension(self):
-        """marker_dir and session_id appear after max_extension_seconds in DefaultSubprocessRunner.__call__."""
+        """marker_dir/session_id appear after max_extension_seconds."""
         sig = inspect.signature(DefaultSubprocessRunner.__call__)
         max_extension_idx = list(sig.parameters).index("max_extension_seconds")
         marker_dir_idx = list(sig.parameters).index("marker_dir")
@@ -449,7 +448,7 @@ class TestGroupDApiContractPreservation:
         assert session_id_idx == marker_dir_idx + 1
 
     def test_default_subprocess_runner_satisfies_protocol_with_marker_params(self):
-        """DefaultSubprocessRunner() satisfies SubprocessRunner with marker_dir/session_id added."""
+        """DefaultSubprocessRunner() satisfies SubprocessRunner protocol."""
         from autoskillit.core.types import SubprocessRunner
 
         runner = DefaultSubprocessRunner()

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -25,6 +25,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_paths.py` | Tests for autoskillit.core.paths — is_git_worktree and pkg_root |
 | `test_plugin_cache.py` | Tests for core/_plugin_cache.py — retiring cache, kitchen registry, and schema version validation |
 | `test_resolve_temp_dir.py` | Tests for autoskillit.core.io.resolve_temp_dir |
+| `test_resolve_main_worktree.py` | Tests for autoskillit.core.paths.resolve_main_worktree — resolves any git path to the main worktree root |
 | `test_session_provenance.py` | Tests for core/runtime/session_provenance.py — provenance store for L2 sessions |
 | `test_session_checkpoint.py` | Tests for SessionCheckpoint schema validation and compute_remaining |
 | `test_session_index_schema.py` | Tests for SessionIndexEntry TypedDict field completeness |

--- a/tests/core/test_resolve_main_worktree.py
+++ b/tests/core/test_resolve_main_worktree.py
@@ -2,11 +2,25 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.medium]
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "test@test.com",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "test@test.com",
+}
+
+
+def _git(*args: str) -> None:
+    subprocess.run(["git", *args], capture_output=True, text=True, check=True, env=_GIT_ENV)
 
 
 class TestResolveMainWorktree:
@@ -14,10 +28,12 @@ class TestResolveMainWorktree:
         """Main checkout resolves to itself."""
         from autoskillit.core.paths import resolve_main_worktree
 
-        (tmp_path / ".git").mkdir()
-        result = resolve_main_worktree(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git("init", str(repo))
+        result = resolve_main_worktree(repo)
         assert result is not None
-        assert result == tmp_path.resolve()
+        assert result == repo.resolve()
 
     def test_resolve_main_worktree_from_linked_worktree(self, tmp_path: Path) -> None:
         """Worktree path resolves to the main checkout root."""
@@ -25,38 +41,32 @@ class TestResolveMainWorktree:
 
         main = tmp_path / "project"
         main.mkdir()
-        (main / ".git").mkdir()
-        worktrees_dir = main / ".git" / "worktrees"
-        worktrees_dir.mkdir(parents=True)
-        wt1 = worktrees_dir / "wt1"
-        wt1.mkdir()
-        (wt1 / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+        _git("init", str(main))
+        _git("-C", str(main), "commit", "--allow-empty", "-m", "init")
 
-        # Actually create the worktree on disk
-        real_wt = tmp_path / "worktrees" / "wt1"
-        real_wt.mkdir(parents=True)
-        (real_wt / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+        wt_path = tmp_path / "worktrees" / "wt1"
+        _git("-C", str(main), "worktree", "add", "-b", "wt1", str(wt_path))
 
-        result = resolve_main_worktree(real_wt)
+        result = resolve_main_worktree(wt_path)
         assert result is not None
         assert result == main.resolve()
 
     def test_resolve_main_worktree_from_nested_worktree(self, tmp_path: Path) -> None:
-        """Deeply nested worktree resolves to the main checkout root."""
+        """Worktree created from another worktree still resolves to main root."""
         from autoskillit.core.paths import resolve_main_worktree
 
         main = tmp_path / "project"
         main.mkdir()
-        (main / ".git").mkdir()
+        _git("init", str(main))
+        _git("-C", str(main), "commit", "--allow-empty", "-m", "init")
 
-        # Create first worktree
-        wt1 = main / ".git" / "worktrees" / "wt1"
-        wt1.mkdir(parents=True)
-        real_wt1 = tmp_path / "worktrees" / "wt1"
-        real_wt1.mkdir(parents=True)
-        (real_wt1 / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+        wt1_path = tmp_path / "worktrees" / "wt1"
+        _git("-C", str(main), "worktree", "add", "-b", "wt1", str(wt1_path))
 
-        result = resolve_main_worktree(real_wt1)
+        wt2_path = tmp_path / "worktrees" / "worktrees" / "wt2"
+        _git("-C", str(wt1_path), "worktree", "add", "-b", "wt2", str(wt2_path))
+
+        result = resolve_main_worktree(wt2_path)
         assert result is not None
         assert result == main.resolve()
 
@@ -71,10 +81,12 @@ class TestResolveMainWorktree:
         """Subdirectory of main checkout resolves to main checkout root."""
         from autoskillit.core.paths import resolve_main_worktree
 
-        (tmp_path / ".git").mkdir()
-        subdir = tmp_path / "src" / "autoskillit"
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git("init", str(repo))
+        subdir = repo / "src" / "autoskillit"
         subdir.mkdir(parents=True)
 
         result = resolve_main_worktree(subdir)
         assert result is not None
-        assert result == tmp_path.resolve()
+        assert result == repo.resolve()

--- a/tests/core/test_resolve_main_worktree.py
+++ b/tests/core/test_resolve_main_worktree.py
@@ -1,0 +1,80 @@
+"""Tests for autoskillit.core.paths.resolve_main_worktree."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+class TestResolveMainWorktree:
+    def test_resolve_main_worktree_from_main_checkout(self, tmp_path: Path) -> None:
+        """Main checkout resolves to itself."""
+        from autoskillit.core.paths import resolve_main_worktree
+
+        (tmp_path / ".git").mkdir()
+        result = resolve_main_worktree(tmp_path)
+        assert result is not None
+        assert result == tmp_path.resolve()
+
+    def test_resolve_main_worktree_from_linked_worktree(self, tmp_path: Path) -> None:
+        """Worktree path resolves to the main checkout root."""
+        from autoskillit.core.paths import resolve_main_worktree
+
+        main = tmp_path / "project"
+        main.mkdir()
+        (main / ".git").mkdir()
+        worktrees_dir = main / ".git" / "worktrees"
+        worktrees_dir.mkdir(parents=True)
+        wt1 = worktrees_dir / "wt1"
+        wt1.mkdir()
+        (wt1 / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+
+        # Actually create the worktree on disk
+        real_wt = tmp_path / "worktrees" / "wt1"
+        real_wt.mkdir(parents=True)
+        (real_wt / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+
+        result = resolve_main_worktree(real_wt)
+        assert result is not None
+        assert result == main.resolve()
+
+    def test_resolve_main_worktree_from_nested_worktree(self, tmp_path: Path) -> None:
+        """Deeply nested worktree resolves to the main checkout root."""
+        from autoskillit.core.paths import resolve_main_worktree
+
+        main = tmp_path / "project"
+        main.mkdir()
+        (main / ".git").mkdir()
+
+        # Create first worktree
+        wt1 = main / ".git" / "worktrees" / "wt1"
+        wt1.mkdir(parents=True)
+        real_wt1 = tmp_path / "worktrees" / "wt1"
+        real_wt1.mkdir(parents=True)
+        (real_wt1 / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+
+        result = resolve_main_worktree(real_wt1)
+        assert result is not None
+        assert result == main.resolve()
+
+    def test_resolve_main_worktree_from_non_git_dir_returns_none(self, tmp_path: Path) -> None:
+        """Directory with no .git returns None."""
+        from autoskillit.core.paths import resolve_main_worktree
+
+        result = resolve_main_worktree(tmp_path)
+        assert result is None
+
+    def test_resolve_main_worktree_from_subdirectory_of_main(self, tmp_path: Path) -> None:
+        """Subdirectory of main checkout resolves to main checkout root."""
+        from autoskillit.core.paths import resolve_main_worktree
+
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "src" / "autoskillit"
+        subdir.mkdir(parents=True)
+
+        result = resolve_main_worktree(subdir)
+        assert result is not None
+        assert result == tmp_path.resolve()

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -26,6 +26,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_bundled_recipes_review_pr.py` | Tests for review-pr bundled recipe structure |
 | `test_callable_contracts.py` | Contract tests for run_python callable inputs and outputs |
 | `test_campaign_loader.py` | Tests for campaign recipe loading |
+| `test_create_worktree_functional.py` | Functional tests for scripts/recipe/create_worktree.sh — actually executes the script against real git repos |
 | `test_check_ci_already_passed_routing.py` | Tests for check_ci_already_passed routing logic |
 | `test_check_repo_merge_state_routing.py` | Tests for check_repo_merge_state routing logic |
 | `test_cmd_rpc.py` | Tests for recipe/_cmd_rpc.py run_python callables |

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -150,6 +150,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_worktree.py` | Tests for worktree semantic validation rule |
 | `test_schema.py` | Tests for Recipe, RecipeStep, and DataFlowWarning schema |
 | `test_skill_emit_consistency.py` | Tests for skill emit consistency in recipe steps |
+| `test_skill_worktree_patterns.py` | Tests that SKILL.md files do not use fragile relative worktree path patterns |
 | `test_silent_type_convention.py` | Tests for silent-type-convention.md documentation |
 | `test_silent_type_flows.py` | Integration tests for silent-type convention flows (vis-lens out-of-scope path) |
 | `test_staleness_cache.py` | Tests for recipe staleness cache |

--- a/tests/recipe/test_create_worktree_functional.py
+++ b/tests/recipe/test_create_worktree_functional.py
@@ -6,6 +6,7 @@ unlike the static-analysis tests in test_research_context_tracking.py.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -13,17 +14,36 @@ import pytest
 
 from autoskillit.core.paths import pkg_root
 
-pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 SCRIPTS_DIR = pkg_root().parent.parent / "scripts" / "recipe"
 CREATE_WORKTREE_SCRIPT = SCRIPTS_DIR / "create_worktree.sh"
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "test@test.com",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "test@test.com",
+}
+
+
+def _git(*args: str) -> None:
+    subprocess.run(["git", *args], capture_output=True, text=True, check=True, env=_GIT_ENV)
+
+
+def _init_repo(path: Path) -> None:
+    """Create a real git repo with an initial commit."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", str(path))
+    _git("-C", str(path), "commit", "--allow-empty", "-m", "init")
 
 
 def _run_create_worktree(
     source_dir: Path,
     experiment_plan: Path | None = None,
     temp_name: str = ".autoskillit/temp",
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """Run create_worktree.sh with given source_dir and return the result."""
     if experiment_plan is None:
         experiment_plan = source_dir / "experiment-plan.md"
@@ -46,6 +66,7 @@ def _run_create_worktree(
         capture_output=True,
         text=True,
         cwd=str(source_dir),
+        env=_GIT_ENV,
     )
     return result
 
@@ -54,8 +75,7 @@ class TestCreateWorktreeFunctional:
     def test_worktree_created_as_sibling_of_project_root(self, tmp_path: Path) -> None:
         """Worktree is created at <tmp_path>/worktrees/<branch>, NOT inside source_dir."""
         project = tmp_path / "project"
-        project.mkdir()
-        (project / ".git").mkdir()
+        _init_repo(project)
 
         result = _run_create_worktree(project)
 
@@ -75,29 +95,16 @@ class TestCreateWorktreeFunctional:
 
     def test_worktree_from_worktree_source_dir_resolves_to_main_root(self, tmp_path: Path) -> None:
         """When source_dir is a linked worktree, new worktree goes next to main root."""
-        # Set up main repo
         main = tmp_path / "main_repo"
-        main.mkdir()
-        (main / ".git").mkdir()
+        _init_repo(main)
 
-        # Create first worktree at main/worktrees/wt1
         wt1_dir = tmp_path / "worktrees" / "wt1"
-        wt1_dir.mkdir(parents=True)
-        # Simulate worktree .git file pointing back to main
-        (wt1_dir / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+        _git("-C", str(main), "worktree", "add", "-b", "wt1", str(wt1_dir))
 
-        # Register the worktree in main's worktrees list
-        worktrees_dir = main / ".git" / "worktrees"
-        worktrees_dir.mkdir(parents=True)
-        wt1_gitdir = worktrees_dir / "wt1"
-        wt1_gitdir.mkdir()
-
-        # Now run create_worktree.sh with wt1_dir as source
         result = _run_create_worktree(wt1_dir)
 
         assert result.returncode == 0, f"Script failed: {result.stderr}"
 
-        # The new worktree should be at tmp_path/worktrees/research-*, NOT nested
         worktrees_dir = tmp_path / "worktrees"
         new_worktrees = [d for d in worktrees_dir.glob("research-*") if d != wt1_dir]
         assert len(new_worktrees) == 1, f"Expected one new worktree, found: {new_worktrees}"
@@ -106,29 +113,18 @@ class TestCreateWorktreeFunctional:
         assert not any("worktrees/worktrees" in str(p) for p in new_wt.parents), (
             f"Worktree path contains nested worktrees/: {new_wt}"
         )
-        # Verify it does NOT live inside wt1_dir
         assert not str(new_wt).startswith(str(wt1_dir)), (
             f"New worktree should not be inside source worktree: {new_wt}"
         )
 
     def test_git_init_guard_does_not_trigger_for_worktree(self, tmp_path: Path) -> None:
-        """Worktree .git is a FILE (not dir) — git init must NOT be called."""
+        """Worktree .git is a FILE (not dir) -- git init must NOT be called."""
         main = tmp_path / "main_repo"
-        main.mkdir()
-        (main / ".git").mkdir()
+        _init_repo(main)
 
-        # Create worktree at worktrees/wt1
         wt1_dir = tmp_path / "worktrees" / "wt1"
-        wt1_dir.mkdir(parents=True)
-        (wt1_dir / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+        _git("-C", str(main), "worktree", "add", "-b", "wt1", str(wt1_dir))
 
-        # Register in main's worktrees list
-        worktrees_dir = main / ".git" / "worktrees"
-        worktrees_dir.mkdir(parents=True)
-        wt1_gitdir = worktrees_dir / "wt1"
-        wt1_gitdir.mkdir()
-
-        # Check stderr for "Initialized empty Git repository" — should NOT appear
         result = _run_create_worktree(wt1_dir)
 
         assert result.returncode == 0, f"Script failed: {result.stderr}"
@@ -139,8 +135,7 @@ class TestCreateWorktreeFunctional:
     def test_worktree_path_is_absolute_in_output(self, tmp_path: Path) -> None:
         """stdout contains worktree_path=<absolute_path> without nested worktrees/."""
         project = tmp_path / "project"
-        project.mkdir()
-        (project / ".git").mkdir()
+        _init_repo(project)
 
         result = _run_create_worktree(project)
 
@@ -165,37 +160,24 @@ class TestCreateWorktreeFunctional:
     def test_sidecar_base_branch_written_under_main_root(self, tmp_path: Path) -> None:
         """base-branch sidecar is written under main repo root, not inside source worktree."""
         main = tmp_path / "main_repo"
-        main.mkdir()
-        (main / ".git").mkdir()
+        _init_repo(main)
 
-        # Create worktree at worktrees/wt1
         wt1_dir = tmp_path / "worktrees" / "wt1"
-        wt1_dir.mkdir(parents=True)
-        (wt1_dir / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
-
-        # Register in main's worktrees list
-        worktrees_dir = main / ".git" / "worktrees"
-        worktrees_dir.mkdir(parents=True)
-        wt1_gitdir = worktrees_dir / "wt1"
-        wt1_gitdir.mkdir()
+        _git("-C", str(main), "worktree", "add", "-b", "wt1", str(wt1_dir))
 
         result = _run_create_worktree(wt1_dir)
 
         assert result.returncode == 0, f"Script failed: {result.stderr}"
 
-        # Find the created worktree
-        worktrees_dir = tmp_path / "worktrees"
-        new_worktrees = [d for d in worktrees_dir.glob("research-*") if d != wt1_dir]
+        new_worktrees = [d for d in (tmp_path / "worktrees").glob("research-*") if d != wt1_dir]
         assert len(new_worktrees) == 1
 
-        # The sidecar should be under main_repo, not inside wt1_dir
         expected_sidecar = main / ".autoskillit" / "temp" / "worktrees"
         base_branch_files = list(expected_sidecar.glob("*/base-branch"))
         assert len(base_branch_files) >= 1, (
             f"base-branch should exist under main root's temp dir: {expected_sidecar}"
         )
 
-        # Verify no base-branch was written inside wt1_dir
         wt1_sidecar = wt1_dir / ".autoskillit" / "temp" / "worktrees"
         assert not wt1_sidecar.exists(), (
             f"base-branch should NOT be inside source worktree: {wt1_sidecar}"

--- a/tests/recipe/test_create_worktree_functional.py
+++ b/tests/recipe/test_create_worktree_functional.py
@@ -170,7 +170,7 @@ class TestCreateWorktreeFunctional:
         assert result.returncode == 0, f"Script failed: {result.stderr}"
 
         new_worktrees = [d for d in (tmp_path / "worktrees").glob("research-*") if d != wt1_dir]
-        assert len(new_worktrees) == 1
+        assert len(new_worktrees) == 1, f"Expected one new worktree, found: {new_worktrees}"
 
         expected_sidecar = main / ".autoskillit" / "temp" / "worktrees"
         base_branch_files = list(expected_sidecar.glob("*/base-branch"))

--- a/tests/recipe/test_create_worktree_functional.py
+++ b/tests/recipe/test_create_worktree_functional.py
@@ -12,12 +12,11 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.paths import pkg_root
+from autoskillit.recipe.io import builtin_scripts_dir
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
-SCRIPTS_DIR = pkg_root().parent.parent / "scripts" / "recipe"
-CREATE_WORKTREE_SCRIPT = SCRIPTS_DIR / "create_worktree.sh"
+CREATE_WORKTREE_SCRIPT = builtin_scripts_dir() / "create_worktree.sh"
 
 _GIT_ENV = {
     **os.environ,

--- a/tests/recipe/test_create_worktree_functional.py
+++ b/tests/recipe/test_create_worktree_functional.py
@@ -1,0 +1,202 @@
+"""Functional tests for scripts/recipe/create_worktree.sh.
+
+These tests actually execute the shell script against real temporary git repos,
+unlike the static-analysis tests in test_research_context_tracking.py.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.paths import pkg_root
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+SCRIPTS_DIR = pkg_root().parent.parent / "scripts" / "recipe"
+CREATE_WORKTREE_SCRIPT = SCRIPTS_DIR / "create_worktree.sh"
+
+
+def _run_create_worktree(
+    source_dir: Path,
+    experiment_plan: Path | None = None,
+    temp_name: str = ".autoskillit/temp",
+) -> subprocess.CompletedProcess:
+    """Run create_worktree.sh with given source_dir and return the result."""
+    if experiment_plan is None:
+        experiment_plan = source_dir / "experiment-plan.md"
+        experiment_plan.write_text("# Experiment Plan\n")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(CREATE_WORKTREE_SCRIPT),
+            str(source_dir),
+            "test-task",
+            str(experiment_plan),
+            "",  # scope_report
+            "",  # eval_dashboard
+            "",  # visualization_plan
+            "",  # report_plan
+            temp_name,
+            "",  # vis_trace_path
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(source_dir),
+    )
+    return result
+
+
+class TestCreateWorktreeFunctional:
+    def test_worktree_created_as_sibling_of_project_root(self, tmp_path: Path) -> None:
+        """Worktree is created at <tmp_path>/worktrees/<branch>, NOT inside source_dir."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+
+        result = _run_create_worktree(project)
+
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        worktrees_dir = tmp_path / "worktrees"
+        worktree_dirs = list(worktrees_dir.glob("research-*"))
+        assert len(worktree_dirs) == 1, f"Expected exactly one worktree, found: {worktree_dirs}"
+
+        worktree_path = worktree_dirs[0]
+        assert not str(worktree_path).startswith(str(project)), (
+            f"Worktree should not be inside project: {worktree_path}"
+        )
+        assert not any("worktrees/worktrees" in str(p) for p in worktree_path.parents), (
+            f"Worktree path contains nested worktrees/: {worktree_path}"
+        )
+
+    def test_worktree_from_worktree_source_dir_resolves_to_main_root(self, tmp_path: Path) -> None:
+        """When source_dir is a linked worktree, new worktree goes next to main root."""
+        # Set up main repo
+        main = tmp_path / "main_repo"
+        main.mkdir()
+        (main / ".git").mkdir()
+
+        # Create first worktree at main/worktrees/wt1
+        wt1_dir = tmp_path / "worktrees" / "wt1"
+        wt1_dir.mkdir(parents=True)
+        # Simulate worktree .git file pointing back to main
+        (wt1_dir / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+
+        # Register the worktree in main's worktrees list
+        worktrees_dir = main / ".git" / "worktrees"
+        worktrees_dir.mkdir(parents=True)
+        wt1_gitdir = worktrees_dir / "wt1"
+        wt1_gitdir.mkdir()
+
+        # Now run create_worktree.sh with wt1_dir as source
+        result = _run_create_worktree(wt1_dir)
+
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        # The new worktree should be at tmp_path/worktrees/research-*, NOT nested
+        worktrees_dir = tmp_path / "worktrees"
+        new_worktrees = [d for d in worktrees_dir.glob("research-*") if d != wt1_dir]
+        assert len(new_worktrees) == 1, f"Expected one new worktree, found: {new_worktrees}"
+
+        new_wt = new_worktrees[0]
+        assert not any("worktrees/worktrees" in str(p) for p in new_wt.parents), (
+            f"Worktree path contains nested worktrees/: {new_wt}"
+        )
+        # Verify it does NOT live inside wt1_dir
+        assert not str(new_wt).startswith(str(wt1_dir)), (
+            f"New worktree should not be inside source worktree: {new_wt}"
+        )
+
+    def test_git_init_guard_does_not_trigger_for_worktree(self, tmp_path: Path) -> None:
+        """Worktree .git is a FILE (not dir) — git init must NOT be called."""
+        main = tmp_path / "main_repo"
+        main.mkdir()
+        (main / ".git").mkdir()
+
+        # Create worktree at worktrees/wt1
+        wt1_dir = tmp_path / "worktrees" / "wt1"
+        wt1_dir.mkdir(parents=True)
+        (wt1_dir / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+
+        # Register in main's worktrees list
+        worktrees_dir = main / ".git" / "worktrees"
+        worktrees_dir.mkdir(parents=True)
+        wt1_gitdir = worktrees_dir / "wt1"
+        wt1_gitdir.mkdir()
+
+        # Check stderr for "Initialized empty Git repository" — should NOT appear
+        result = _run_create_worktree(wt1_dir)
+
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        assert "Initialized empty Git repository" not in result.stderr, (
+            "git init should NOT run when .git file exists (worktree source)"
+        )
+
+    def test_worktree_path_is_absolute_in_output(self, tmp_path: Path) -> None:
+        """stdout contains worktree_path=<absolute_path> without nested worktrees/."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+
+        result = _run_create_worktree(project)
+
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        worktree_line = next(
+            (
+                line
+                for line in result.stdout.strip().splitlines()
+                if line.startswith("worktree_path=")
+            ),
+            None,
+        )
+        assert worktree_line is not None, f"No worktree_path= in stdout: {result.stdout}"
+
+        worktree_path = Path(worktree_line.split("=", 1)[1])
+        assert worktree_path.is_absolute(), f"worktree_path is not absolute: {worktree_path}"
+        assert "worktrees/worktrees" not in str(worktree_path), (
+            f"worktree_path contains nested worktrees/: {worktree_path}"
+        )
+
+    def test_sidecar_base_branch_written_under_main_root(self, tmp_path: Path) -> None:
+        """base-branch sidecar is written under main repo root, not inside source worktree."""
+        main = tmp_path / "main_repo"
+        main.mkdir()
+        (main / ".git").mkdir()
+
+        # Create worktree at worktrees/wt1
+        wt1_dir = tmp_path / "worktrees" / "wt1"
+        wt1_dir.mkdir(parents=True)
+        (wt1_dir / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / 'wt1'}\n")
+
+        # Register in main's worktrees list
+        worktrees_dir = main / ".git" / "worktrees"
+        worktrees_dir.mkdir(parents=True)
+        wt1_gitdir = worktrees_dir / "wt1"
+        wt1_gitdir.mkdir()
+
+        result = _run_create_worktree(wt1_dir)
+
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        # Find the created worktree
+        worktrees_dir = tmp_path / "worktrees"
+        new_worktrees = [d for d in worktrees_dir.glob("research-*") if d != wt1_dir]
+        assert len(new_worktrees) == 1
+
+        # The sidecar should be under main_repo, not inside wt1_dir
+        expected_sidecar = main / ".autoskillit" / "temp" / "worktrees"
+        base_branch_files = list(expected_sidecar.glob("*/base-branch"))
+        assert len(base_branch_files) >= 1, (
+            f"base-branch should exist under main root's temp dir: {expected_sidecar}"
+        )
+
+        # Verify no base-branch was written inside wt1_dir
+        wt1_sidecar = wt1_dir / ".autoskillit" / "temp" / "worktrees"
+        assert not wt1_sidecar.exists(), (
+            f"base-branch should NOT be inside source worktree: {wt1_sidecar}"
+        )

--- a/tests/recipe/test_research_context_tracking.py
+++ b/tests/recipe/test_research_context_tracking.py
@@ -44,8 +44,8 @@ def test_create_worktree_script_has_git_init_guard():
     """create_worktree.sh must auto-init a git repo when .git is absent."""
     script_path = SCRIPTS_DIR / "create_worktree.sh"
     script = script_path.read_text()
-    assert '[ ! -d "$SOURCE_DIR/.git" ]' in script or "! -d" in script, (
-        "create_worktree.sh must check for .git directory absence"
+    assert '[ ! -e "$SOURCE_DIR/.git" ]' in script or "! -e" in script, (
+        "create_worktree.sh must check for .git existence"
     )
     assert "git init" in script, "create_worktree.sh must run git init when .git is missing"
     assert "--allow-empty" in script, (

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -639,3 +639,113 @@ def test_file_writing_skill_advisory_step_not_flagged() -> None:
         f"Advisory steps (skip_when_false) should not trigger "
         f"file-writing-skill-missing-context-limit: {findings}"
     )
+
+
+# ---------------------------------------------------------------------------
+# relative-worktree-path-in-cmd rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_cmd_with_relative_worktree_path_fires_warning() -> None:
+    """run_cmd step with '../worktrees/' in cmd fires relative-worktree-path-in-cmd WARNING."""
+    wf = _make_workflow(
+        {
+            "create_wt": {
+                "tool": "run_cmd",
+                "with": {
+                    "cmd": (
+                        'WORKTREE_PATH="../worktrees/${WORKTREE_NAME}"; '
+                        "git worktree add -b '${WORKTREE_NAME}' '${WORKTREE_PATH}'"
+                    ),
+                    "cwd": "${{ inputs.source_dir }}",
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+    )
+    findings = run_semantic_rules(wf)
+    warnings = [f for f in findings if f.severity == Severity.WARNING]
+    assert any(f.rule == "relative-worktree-path-in-cmd" for f in warnings), (
+        f"Expected relative-worktree-path-in-cmd WARNING for run_cmd with '../worktrees/' in cmd. "
+        f"Got: {findings}"
+    )
+
+
+def test_run_cmd_with_absolute_worktree_path_no_finding() -> None:
+    """run_cmd step with absolute worktree path has no relative-worktree-path-in-cmd finding."""
+    wf = _make_workflow(
+        {
+            "create_wt": {
+                "tool": "run_cmd",
+                "with": {
+                    "cmd": (
+                        'MAIN_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"; '
+                        'WORKTREE_DIR="${MAIN_GIT_DIR}/../worktrees"; '
+                        "mkdir -p '${WORKTREE_DIR}'; "
+                        "WORKTREE_PATH='${WORKTREE_DIR}/${WORKTREE_NAME}'; "
+                        "git worktree add -b '${WORKTREE_NAME}' '${WORKTREE_PATH}'"
+                    ),
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+    )
+    findings = run_semantic_rules(wf)
+    assert not any(f.rule == "relative-worktree-path-in-cmd" for f in findings), (
+        f"Unexpected relative-worktree-path-in-cmd finding for run_cmd with absolute path: "
+        f"{findings}"
+    )
+
+
+def test_run_cmd_non_worktree_cmd_no_finding() -> None:
+    """run_cmd step with no worktree path has no relative-worktree-path-in-cmd finding."""
+    wf = _make_workflow(
+        {
+            "echo": {
+                "tool": "run_cmd",
+                "with": {"cmd": "echo hello world"},
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+    )
+    findings = run_semantic_rules(wf)
+    assert not any(f.rule == "relative-worktree-path-in-cmd" for f in findings)
+
+
+def test_run_cmd_other_tool_no_finding() -> None:
+    """Non-run_cmd steps are not checked by the rule."""
+    wf = _make_workflow(
+        {
+            "implement": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:implement-worktree-no-merge plan.md"},
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+    )
+    findings = run_semantic_rules(wf)
+    assert not any(f.rule == "relative-worktree-path-in-cmd" for f in findings)
+
+
+def test_relative_worktree_path_warning_includes_step_name() -> None:
+    """The finding message contains the step name for actionable output."""
+    wf = _make_workflow(
+        {
+            "make_worktree": {
+                "tool": "run_cmd",
+                "with": {
+                    "cmd": 'WORKTREE_PATH="../worktrees/test-wt"; git worktree add test-wt',
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+    )
+    findings = run_semantic_rules(wf)
+    matched = [f for f in findings if f.rule == "relative-worktree-path-in-cmd"]
+    assert len(matched) >= 1
+    assert "make_worktree" in matched[0].message

--- a/tests/recipe/test_skill_worktree_patterns.py
+++ b/tests/recipe/test_skill_worktree_patterns.py
@@ -29,6 +29,9 @@ def _skill_md_paths() -> list[tuple[str, Path]]:
     return paths
 
 
+_SKILL_MD_PATHS = _skill_md_paths()
+
+
 # ---------------------------------------------------------------------------
 # Absolute path resolution pattern tests
 # ---------------------------------------------------------------------------
@@ -100,8 +103,8 @@ class TestNoSkillMdUsesRelativeWorktreePath:
 
     @pytest.mark.parametrize(
         "skill_name,skill_md_path",
-        _skill_md_paths(),
-        ids=[name for name, _ in _skill_md_paths()],
+        _SKILL_MD_PATHS,
+        ids=[name for name, _ in _SKILL_MD_PATHS],
     )
     def test_no_skill_md_uses_relative_worktree_path_in_bash_blocks(
         self, skill_name: str, skill_md_path: Path
@@ -124,8 +127,8 @@ class TestNoSkillMdUsesRelativeWorktreePath:
 
     @pytest.mark.parametrize(
         "skill_name,skill_md_path",
-        _skill_md_paths(),
-        ids=[name for name, _ in _skill_md_paths()],
+        _SKILL_MD_PATHS,
+        ids=[name for name, _ in _SKILL_MD_PATHS],
     )
     def test_no_worktree_creating_skill_uses_relative_path(
         self, skill_name: str, skill_md_path: Path
@@ -134,7 +137,7 @@ class TestNoSkillMdUsesRelativeWorktreePath:
         text = skill_md_path.read_text()
         creates_worktree = "git worktree add" in text
         if not creates_worktree:
-            return  # Not a worktree-creating skill, skip
+            pytest.skip("not a worktree-creating skill")
 
         # If it creates worktrees, it must not use the relative path pattern
         bash_blocks = re.findall(r"```bash(.*?)```", text, re.DOTALL)

--- a/tests/recipe/test_skill_worktree_patterns.py
+++ b/tests/recipe/test_skill_worktree_patterns.py
@@ -1,0 +1,162 @@
+"""Tests that SKILL.md files do not use fragile relative worktree path patterns.
+
+Architectural guard: any future SKILL.md that introduces '../worktrees/' in a
+bash code block context will fail these tests immediately, preventing regression
+without requiring developer awareness of this specific bug.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import pkg_root
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _skill_md_paths() -> list[tuple[str, Path]]:
+    """Return list of (skill_name, SKILL.md_path) for skills_extended skills."""
+    skills_extended = pkg_root() / "skills_extended"
+    paths = []
+    for skill_dir in sorted(skills_extended.iterdir()):
+        if skill_dir.is_dir():
+            skill_md = skill_dir / "SKILL.md"
+            if skill_md.exists():
+                paths.append((skill_dir.name, skill_md))
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Absolute path resolution pattern tests
+# ---------------------------------------------------------------------------
+
+
+class TestImplementWorktreeSkillAbsoluteResolution:
+    def test_implement_worktree_skill_uses_absolute_resolution(self) -> None:
+        """implement-worktree SKILL.md uses absolute resolution, not '../worktrees/'."""
+        skill_md = pkg_root() / "skills_extended" / "implement-worktree" / "SKILL.md"
+        text = skill_md.read_text()
+
+        # Must not contain the fragile relative path pattern in bash code blocks
+        bash_blocks = re.findall(r"```bash(.*?)```", text, re.DOTALL)
+        for block in bash_blocks:
+            if "../worktrees/" in block:
+                pytest.fail(
+                    "implement-worktree/SKILL.md contains fragile '../worktrees/' pattern "
+                    "in a bash code block. Use absolute resolution via "
+                    "'git rev-parse --path-format=absolute --git-common-dir' instead."
+                )
+
+        # Must contain the absolute resolution approach
+        assert "--path-format=absolute --git-common-dir" in text, (
+            "implement-worktree/SKILL.md must use "
+            "'git rev-parse --path-format=absolute --git-common-dir' for worktree creation"
+        )
+
+    def test_implement_worktree_no_merge_skill_uses_absolute_resolution(self) -> None:
+        """implement-worktree-no-merge SKILL.md uses absolute resolution."""
+        skill_md = pkg_root() / "skills_extended" / "implement-worktree-no-merge" / "SKILL.md"
+        text = skill_md.read_text()
+
+        bash_blocks = re.findall(r"```bash(.*?)```", text, re.DOTALL)
+        for block in bash_blocks:
+            if "../worktrees/" in block:
+                pytest.fail(
+                    "implement-worktree-no-merge/SKILL.md contains fragile '../worktrees/' "
+                    "pattern in a bash code block. Use absolute resolution via "
+                    "'git rev-parse --path-format=absolute --git-common-dir' instead."
+                )
+
+        assert "--path-format=absolute --git-common-dir" in text, (
+            "implement-worktree-no-merge/SKILL.md must use "
+            "'git rev-parse --path-format=absolute --git-common-dir' for worktree creation"
+        )
+
+    def test_implement_experiment_skill_uses_absolute_resolution(self) -> None:
+        """implement-experiment SKILL.md uses absolute resolution."""
+        skill_md = pkg_root() / "skills_extended" / "implement-experiment" / "SKILL.md"
+        text = skill_md.read_text()
+
+        bash_blocks = re.findall(r"```bash(.*?)```", text, re.DOTALL)
+        for block in bash_blocks:
+            if "../worktrees/" in block:
+                pytest.fail(
+                    "implement-experiment/SKILL.md contains fragile '../worktrees/' pattern "
+                    "in a bash code block. Use absolute resolution via "
+                    "'git rev-parse --path-format=absolute --git-common-dir' instead."
+                )
+
+        assert "--path-format=absolute --git-common-dir" in text, (
+            "implement-experiment/SKILL.md must use "
+            "'git rev-parse --path-format=absolute --git-common-dir' for worktree creation"
+        )
+
+
+class TestNoSkillMdUsesRelativeWorktreePath:
+    """Sweep test: no SKILL.md in skills_extended/ may use the relative pattern."""
+
+    @pytest.mark.parametrize(
+        "skill_name,skill_md_path",
+        _skill_md_paths(),
+        ids=[name for name, _ in _skill_md_paths()],
+    )
+    def test_no_skill_md_uses_relative_worktree_path_in_bash_blocks(
+        self, skill_name: str, skill_md_path: Path
+    ) -> None:
+        """SKILL.md files must not contain '../worktrees/' in bash code blocks.
+
+        This is the permanent architectural guard: any future skill using the
+        relative pattern will fail this test immediately.
+        """
+        text = skill_md_path.read_text()
+        bash_blocks = re.findall(r"```bash(.*?)```", text, re.DOTALL)
+
+        for block in bash_blocks:
+            if "../worktrees/" in block:
+                pytest.fail(
+                    f"{skill_name}/SKILL.md contains fragile '../worktrees/' pattern "
+                    f"in a bash code block. Worktree creation must use absolute path resolution "
+                    f"via 'git rev-parse --path-format=absolute --git-common-dir'."
+                )
+
+    @pytest.mark.parametrize(
+        "skill_name,skill_md_path",
+        _skill_md_paths(),
+        ids=[name for name, _ in _skill_md_paths()],
+    )
+    def test_no_worktree_creating_skill_uses_relative_path(
+        self, skill_name: str, skill_md_path: Path
+    ) -> None:
+        """Skills that create worktrees must not use relative '../worktrees/' paths."""
+        text = skill_md_path.read_text()
+        creates_worktree = "git worktree add" in text
+        if not creates_worktree:
+            return  # Not a worktree-creating skill, skip
+
+        # If it creates worktrees, it must not use the relative path pattern
+        bash_blocks = re.findall(r"```bash(.*?)```", text, re.DOTALL)
+        for block in bash_blocks:
+            if "git worktree add" in block and "../worktrees/" in block:
+                pytest.fail(
+                    f"{skill_name}/SKILL.md creates worktrees but uses fragile "
+                    f"relative '../worktrees/' path. Use absolute resolution via "
+                    f"'git rev-parse --path-format=absolute --git-common-dir'."
+                )
+
+
+class TestRetryWorktreeSkillPathFormat:
+    def test_retry_worktree_uses_absolute_path_format(self) -> None:
+        """retry-worktree SKILL.md uses --path-format=absolute for git-common-dir."""
+        skill_md = pkg_root() / "skills_extended" / "retry-worktree" / "SKILL.md"
+        text = skill_md.read_text()
+
+        # The retry-worktree fallback uses git-common-dir; it should use
+        # --path-format=absolute to ensure consistent resolution
+        if "git-common-dir" in text:
+            assert "--path-format=absolute --git-common-dir" in text, (
+                "retry-worktree/SKILL.md uses git-common-dir; it must use "
+                "'--path-format=absolute --git-common-dir' for reliable resolution"
+            )

--- a/tests/server/test_git.py
+++ b/tests/server/test_git.py
@@ -158,9 +158,6 @@ async def test_perform_merge_returns_success_on_green_tests(
     tester = InMemoryTestRunner(
         results=[TestResult(True, "= 50 passed =", ""), TestResult(True, "= 50 passed =", "")]
     )
-    # Queue 9 steps: rev-parse, branch, dirty check, fetch, rebase,
-    # wt-list, merge, remove, branch-D
-    # (test gate now handled by tester, not subprocess)
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))
     conftest_mock_runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
@@ -168,26 +165,24 @@ async def test_perform_merge_returns_success_on_green_tests(
     conftest_mock_runner.push(_make_result(0, "", ""))  # ref check (5.5)
     conftest_mock_runner.push(_make_result(0, "", ""))  # git log --merges (5.6 — no merge commits)
     conftest_mock_runner.push(_make_result(0, "", ""))  # rebase
-    conftest_mock_runner.push(_make_result(0, "", ""))  # git ls-files (generated file check)
-    conftest_mock_runner.push(_make_result(0, f"worktree {fake_wt}\n", ""))  # wt list
     conftest_mock_runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
     conftest_mock_runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
     conftest_mock_runner.push(_make_result(0, "", ""))  # merge
     conftest_mock_runner.push(_make_result(0, "", ""))  # wt remove
     conftest_mock_runner.push(_make_result(0, "", ""))  # branch -D
 
-    result = await perform_merge(
-        fake_wt,
-        "dev",
-        config=default_config,
-        runner=conftest_mock_runner,
-        tester=tester,
-    )
+    with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path(fake_wt)):
+        result = await perform_merge(
+            fake_wt,
+            "dev",
+            config=default_config,
+            runner=conftest_mock_runner,
+            tester=tester,
+        )
     assert result.get("merge_succeeded") is True
     assert result["merged_branch"] == "feature-branch"
     assert result["into_branch"] == "dev"
     assert tester.call_count == 2  # both pre- and post-rebase gates ran
-    # Verify merge command cwd is the main_repo (same as worktree root for this test)
     merge_call = next(
         args
         for args in conftest_mock_runner.call_args_list
@@ -240,7 +235,6 @@ async def test_perform_merge_uses_no_edit_flag(default_config, conftest_mock_run
 
     fake_wt = str(tmp_path)
     tester = InMemoryTestRunner(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
-    # Queue all 10 steps for success path
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))
     conftest_mock_runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
@@ -248,24 +242,22 @@ async def test_perform_merge_uses_no_edit_flag(default_config, conftest_mock_run
     conftest_mock_runner.push(_make_result(0, "", ""))  # ref check
     conftest_mock_runner.push(_make_result(0, "", ""))  # git log --merges (5.6 — no merge commits)
     conftest_mock_runner.push(_make_result(0, "", ""))  # rebase
-    conftest_mock_runner.push(_make_result(0, "", ""))  # git ls-files (generated file check)
-    conftest_mock_runner.push(_make_result(0, f"worktree {fake_wt}\n", ""))  # wt list
     conftest_mock_runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
     conftest_mock_runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
     conftest_mock_runner.push(_make_result(0, "", ""))  # merge
     conftest_mock_runner.push(_make_result(0, "", ""))  # wt remove
     conftest_mock_runner.push(_make_result(0, "", ""))  # branch -D
 
-    result = await perform_merge(
-        fake_wt,
-        "dev",
-        config=default_config,
-        runner=conftest_mock_runner,
-        tester=tester,
-    )
+    with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path(fake_wt)):
+        result = await perform_merge(
+            fake_wt,
+            "dev",
+            config=default_config,
+            runner=conftest_mock_runner,
+            tester=tester,
+        )
     assert result.get("merge_succeeded") is True
 
-    # Find the merge command in call_args_list
     merge_cmds = [
         args[0]
         for args in conftest_mock_runner.call_args_list
@@ -338,16 +330,16 @@ async def test_perform_merge_strips_tracked_generated_files(
     conftest_mock_runner.push(_make_result(0, "", ""))  # ref check
     conftest_mock_runner.push(_make_result(0, "", ""))  # git log --merges (5.6 — no merge commits)
     conftest_mock_runner.push(_make_result(0, "", ""))  # rebase
-    conftest_mock_runner.push(_make_result(0, f"worktree {fake_wt}\n", ""))  # wt list
     conftest_mock_runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
     conftest_mock_runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
     conftest_mock_runner.push(_make_result(0, "", ""))  # merge
     conftest_mock_runner.push(_make_result(0, "", ""))  # wt remove
     conftest_mock_runner.push(_make_result(0, "", ""))  # branch -D
 
-    result = await perform_merge(
-        fake_wt, "dev", config=default_config, runner=conftest_mock_runner, tester=tester
-    )
+    with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path(fake_wt)):
+        result = await perform_merge(
+            fake_wt, "dev", config=default_config, runner=conftest_mock_runner, tester=tester
+        )
     assert result.get("merge_succeeded") is True
 
     # Verify git ls-files was called before dirty check and rebase
@@ -389,16 +381,16 @@ async def test_perform_merge_noop_when_no_generated_files_tracked(
     conftest_mock_runner.push(_make_result(0, "", ""))  # ref check
     conftest_mock_runner.push(_make_result(0, "", ""))  # git log --merges (5.6 — no merge commits)
     conftest_mock_runner.push(_make_result(0, "", ""))  # rebase
-    conftest_mock_runner.push(_make_result(0, f"worktree {fake_wt}\n", ""))  # wt list
     conftest_mock_runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
     conftest_mock_runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
     conftest_mock_runner.push(_make_result(0, "", ""))  # merge
     conftest_mock_runner.push(_make_result(0, "", ""))  # wt remove
     conftest_mock_runner.push(_make_result(0, "", ""))  # branch -D
 
-    result = await perform_merge(
-        fake_wt, "dev", config=default_config, runner=conftest_mock_runner, tester=tester
-    )
+    with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path(fake_wt)):
+        result = await perform_merge(
+            fake_wt, "dev", config=default_config, runner=conftest_mock_runner, tester=tester
+        )
     assert result.get("merge_succeeded") is True
 
     # git rm --cached and git commit should NOT have been called
@@ -458,16 +450,16 @@ async def test_perform_merge_dirty_check_ignores_generated_files(
     conftest_mock_runner.push(_make_result(0, "", ""))  # ref check
     conftest_mock_runner.push(_make_result(0, "", ""))  # git log --merges
     conftest_mock_runner.push(_make_result(0, "", ""))  # rebase
-    conftest_mock_runner.push(_make_result(0, f"worktree {fake_wt}\n", ""))  # wt list
     conftest_mock_runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
     conftest_mock_runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
     conftest_mock_runner.push(_make_result(0, "", ""))  # merge
     conftest_mock_runner.push(_make_result(0, "", ""))  # wt remove
     conftest_mock_runner.push(_make_result(0, "", ""))  # branch -D
 
-    result = await perform_merge(
-        fake_wt, "dev", config=default_config, runner=conftest_mock_runner, tester=tester
-    )
+    with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path(fake_wt)):
+        result = await perform_merge(
+            fake_wt, "dev", config=default_config, runner=conftest_mock_runner, tester=tester
+        )
     assert result.get("merge_succeeded") is True
     assert "dirty_files" not in result
 
@@ -497,16 +489,16 @@ async def test_perform_merge_strips_generated_files_before_dirty_check(
     conftest_mock_runner.push(_make_result(0, "", ""))  # ref check
     conftest_mock_runner.push(_make_result(0, "", ""))  # git log --merges
     conftest_mock_runner.push(_make_result(0, "", ""))  # rebase
-    conftest_mock_runner.push(_make_result(0, f"worktree {fake_wt}\n", ""))  # wt list
     conftest_mock_runner.push(_make_result(0, "dev\n", ""))  # step 7.5: branch --show-current
     conftest_mock_runner.push(_make_result(0, "", ""))  # step 7.6: git status --porcelain (clean)
     conftest_mock_runner.push(_make_result(0, "", ""))  # merge
     conftest_mock_runner.push(_make_result(0, "", ""))  # wt remove
     conftest_mock_runner.push(_make_result(0, "", ""))  # branch -D
 
-    result = await perform_merge(
-        fake_wt, "dev", config=default_config, runner=conftest_mock_runner, tester=tester
-    )
+    with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path(fake_wt)):
+        result = await perform_merge(
+            fake_wt, "dev", config=default_config, runner=conftest_mock_runner, tester=tester
+        )
     assert result.get("merge_succeeded") is True
 
     calls = [args[0] for args in conftest_mock_runner.call_args_list]
@@ -536,7 +528,8 @@ def _push_full_success_sequence(
 
     Covers all git calls in perform_merge (steps 2-9, 11, 12). The test gate
     (step 4) is handled by InMemoryTestRunner, not via the runner.
-    Cleanup steps (remove_git_worktree, branch -D) use the runner default (rc=0).
+    Step 7 (resolve_main_worktree) uses subprocess.run directly — must be
+    patched separately by callers. Cleanup steps use the runner default (rc=0).
     """
     runner.push(_make_result(0, "/repo/.git/worktrees/impl-test\n"))  # rev-parse --git-dir
     runner.push(_make_result(0, "impl-test\n"))  # branch --show-current (worktree)
@@ -546,9 +539,6 @@ def _push_full_success_sequence(
     runner.push(_make_result(0, "abc123\n"))  # rev-parse --verify
     runner.push(_make_result(0, ""))  # git log --merges
     runner.push(_make_result(0, ""))  # git rebase
-    runner.push(  # worktree list --porcelain
-        _make_result(0, f"worktree /repo\nHEAD abc123\nbranch refs/heads/{base_branch}\n\n")
-    )
     runner.push(_make_result(0, f"{base_branch}\n"))  # step 7.5: branch --show-current (main_repo)
     runner.push(_make_result(0, ""))  # step 7.6: git status --porcelain (main_repo clean)
     runner.push(_make_result(0, ""))  # git merge --no-edit

--- a/tests/server/test_git.py
+++ b/tests/server/test_git.py
@@ -160,6 +160,7 @@ async def test_perform_merge_returns_success_on_green_tests(
     )
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))
+    conftest_mock_runner.push(_make_result(0, "", ""))  # git ls-files (no tracked generated files)
     conftest_mock_runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
     conftest_mock_runner.push(_make_result(0, "", ""))  # fetch
     conftest_mock_runner.push(_make_result(0, "", ""))  # ref check (5.5)
@@ -237,6 +238,7 @@ async def test_perform_merge_uses_no_edit_flag(default_config, conftest_mock_run
     tester = InMemoryTestRunner(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))
+    conftest_mock_runner.push(_make_result(0, "", ""))  # git ls-files (no tracked generated files)
     conftest_mock_runner.push(_make_result(0, "", ""))  # git status --porcelain (clean)
     conftest_mock_runner.push(_make_result(0, "", ""))  # fetch
     conftest_mock_runner.push(_make_result(0, "", ""))  # ref check
@@ -557,11 +559,14 @@ class TestPerformMergeSidecarCleanup:
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/impl-test")
 
         sidecar_calls = []
-        with patch(
-            "autoskillit.server.git.remove_worktree_sidecar",
-            side_effect=lambda proj, name: (
-                sidecar_calls.append(name) or CleanupResult(deleted=["s"])
+        with (
+            patch(
+                "autoskillit.server.git.remove_worktree_sidecar",
+                side_effect=lambda proj, name: (
+                    sidecar_calls.append(name) or CleanupResult(deleted=["s"])
+                ),
             ),
+            patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
         ):
             runner = MockSubprocessRunner()
             _push_full_success_sequence(runner, worktree_path=wt)
@@ -591,9 +596,12 @@ class TestPerformMergeSidecarCleanup:
         wt.mkdir(parents=True)
         (wt / ".git").write_text("gitdir: /repo/.git/worktrees/impl-test")
 
-        with patch(
-            "autoskillit.server.git.remove_worktree_sidecar",
-            return_value=CleanupResult(failed=[("/some/path", "permission denied")]),
+        with (
+            patch(
+                "autoskillit.server.git.remove_worktree_sidecar",
+                return_value=CleanupResult(failed=[("/some/path", "permission denied")]),
+            ),
+            patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
         ):
             runner = MockSubprocessRunner()
             _push_full_success_sequence(runner, worktree_path=wt)
@@ -622,8 +630,12 @@ class TestPerformMergeSidecarCleanup:
             remove_calls.append(path)
             return CleanupResult(deleted=[str(path)])
 
-        with patch(
-            "autoskillit.server.git.remove_git_worktree", new=AsyncMock(side_effect=_fake_remove)
+        with (
+            patch(
+                "autoskillit.server.git.remove_git_worktree",
+                new=AsyncMock(side_effect=_fake_remove),
+            ),
+            patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
         ):
             runner = MockSubprocessRunner()
             _push_full_success_sequence(runner, worktree_path=wt)
@@ -662,18 +674,17 @@ class TestPerformMergeTargetBranchVerification:
         runner.push(_make_result(0, "abc123\n"))  # rev-parse --verify
         runner.push(_make_result(0, ""))  # git log --merges
         runner.push(_make_result(0, ""))  # git rebase
-        # worktree list says main_repo is on 'main'
-        runner.push(_make_result(0, "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n"))
         # Step 7.5: git branch --show-current on main_repo returns 'main'
         runner.push(_make_result(0, "main\n"))
 
-        result = await perform_merge(
-            str(wt),
-            "dev",
-            config=AutomationConfig(),
-            runner=runner,
-            tester=tester,
-        )
+        with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")):
+            result = await perform_merge(
+                str(wt),
+                "dev",
+                config=AutomationConfig(),
+                runner=runner,
+                tester=tester,
+            )
 
         assert "error" in result
         assert result["failed_step"] == MergeFailedStep.MERGE
@@ -705,21 +716,20 @@ class TestPerformMergeTargetBranchVerification:
         runner.push(_make_result(0, "abc123\n"))  # rev-parse --verify
         runner.push(_make_result(0, ""))  # git log --merges
         runner.push(_make_result(0, ""))  # git rebase
-        # worktree list says main_repo is on 'dev'
-        runner.push(_make_result(0, "worktree /repo\nHEAD abc123\nbranch refs/heads/dev\n\n"))
         # Step 7.5: git branch --show-current on main_repo returns 'dev'
         runner.push(_make_result(0, "dev\n"))
         runner.push(_make_result(0, ""))  # step 7.6: git status --porcelain (clean)
         runner.push(_make_result(0, ""))  # git merge --no-edit
         # cleanup: remove_git_worktree + branch -D use runner defaults (rc=0)
 
-        result = await perform_merge(
-            str(wt),
-            "dev",
-            config=AutomationConfig(),
-            runner=runner,
-            tester=tester,
-        )
+        with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")):
+            result = await perform_merge(
+                str(wt),
+                "dev",
+                config=AutomationConfig(),
+                runner=runner,
+                tester=tester,
+            )
 
         assert result["merge_succeeded"] is True
         assert result["into_branch"] == "dev"
@@ -744,19 +754,19 @@ class TestPerformMergeTargetBranchVerification:
         runner.push(_make_result(0, "abc123\n"))  # rev-parse --verify
         runner.push(_make_result(0, ""))  # git log --merges
         runner.push(_make_result(0, ""))  # git rebase
-        runner.push(_make_result(0, "worktree /repo\nHEAD abc123\nbranch refs/heads/dev\n\n"))
         # Step 7.5: branch verification
         runner.push(_make_result(0, "dev\n"))
         runner.push(_make_result(0, ""))  # step 7.6: git status --porcelain (clean)
         runner.push(_make_result(0, ""))  # git merge --no-edit
 
-        result = await perform_merge(
-            str(wt),
-            "dev",
-            config=AutomationConfig(),
-            runner=runner,
-            tester=tester,
-        )
+        with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")):
+            result = await perform_merge(
+                str(wt),
+                "dev",
+                config=AutomationConfig(),
+                runner=runner,
+                tester=tester,
+            )
 
         assert result["merge_succeeded"] is True
         # Find the merge command and assert its cwd
@@ -787,19 +797,19 @@ class TestPerformMergeTargetBranchVerification:
         runner.push(_make_result(0, "abc123\n"))  # rev-parse --verify
         runner.push(_make_result(0, ""))  # git log --merges
         runner.push(_make_result(0, ""))  # git rebase
-        runner.push(_make_result(0, "worktree /repo\nHEAD abc123\nbranch refs/heads/dev\n\n"))
         # Step 7.5: verified branch
         runner.push(_make_result(0, "dev\n"))
         runner.push(_make_result(0, ""))  # step 7.6: git status --porcelain (clean)
         runner.push(_make_result(0, ""))  # merge
 
-        result = await perform_merge(
-            str(wt),
-            "dev",
-            config=AutomationConfig(),
-            runner=runner,
-            tester=tester,
-        )
+        with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")):
+            result = await perform_merge(
+                str(wt),
+                "dev",
+                config=AutomationConfig(),
+                runner=runner,
+                tester=tester,
+            )
 
         assert result["merge_succeeded"] is True
         # into_branch must match the verified branch from step 7.5

--- a/tests/server/test_git_merge_dirty_check.py
+++ b/tests/server/test_git_merge_dirty_check.py
@@ -58,9 +58,6 @@ def _push_through_verify_merge(
     runner.push(_make_result(0, "abc123\n"))  # rev-parse --verify
     runner.push(_make_result(0, ""))  # git log --merges
     runner.push(_make_result(0, ""))  # rebase
-    runner.push(
-        _make_result(0, f"worktree /repo\nHEAD abc123\nbranch refs/heads/{base_branch}\n\n")
-    )  # wt list
     runner.push(_make_result(0, f"{base_branch}\n"))  # step 7.5: branch --show-current (main_repo)
 
 
@@ -76,7 +73,10 @@ async def test_dirty_main_repo_returns_error(tmp_path):
     _push_through_verify_merge(runner, fake_wt)
     runner.push(_make_result(0, " M src/foo.py\n M tests/bar.py\n"))  # step 7.6: dirty!
 
-    with patch("autoskillit.server.git.scan_editable_installs_for_worktree", return_value=[]):
+    with (
+        patch("autoskillit.server.git.scan_editable_installs_for_worktree", return_value=[]),
+        patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
+    ):
         result = await perform_merge(
             fake_wt,
             "dev",
@@ -107,7 +107,10 @@ async def test_clean_main_repo_proceeds_to_merge(tmp_path):
     runner.push(_make_result(0, ""))  # wt remove
     runner.push(_make_result(0, ""))  # branch -D
 
-    with patch("autoskillit.server.git.scan_editable_installs_for_worktree", return_value=[]):
+    with (
+        patch("autoskillit.server.git.scan_editable_installs_for_worktree", return_value=[]),
+        patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
+    ):
         result = await perform_merge(
             fake_wt,
             "dev",
@@ -132,7 +135,10 @@ async def test_dirty_check_error_format(tmp_path):
     dirty_output = " M file1.py\n M file2.py\n?? newfile.txt\n"
     runner.push(_make_result(0, dirty_output))  # step 7.6: dirty
 
-    with patch("autoskillit.server.git.scan_editable_installs_for_worktree", return_value=[]):
+    with (
+        patch("autoskillit.server.git.scan_editable_installs_for_worktree", return_value=[]),
+        patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
+    ):
         result = await perform_merge(
             fake_wt,
             "dev",

--- a/tests/server/test_perform_merge_editable_guard.py
+++ b/tests/server/test_perform_merge_editable_guard.py
@@ -1,6 +1,7 @@
 """Integration tests verifying perform_merge() aborts before cleanup on poisoned installs."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -60,15 +61,15 @@ async def test_perform_merge_aborts_before_cleanup_on_poisoned_install(
     runner.push(_make_result(0, ""))  # ref check (step 5.5)
     runner.push(_make_result(0, ""))  # git log --merges (step 5.6 — no merge commits)
     runner.push(_make_result(0, ""))  # git rebase (step 6)
-    runner.push(_make_result(0, f"worktree {fake_wt}\n"))  # git worktree list (step 7)
     runner.push(_make_result(0, "dev\n"))  # git branch --show-current (step 7.5)
     runner.push(_make_result(0, ""))  # git status --porcelain (step 7.6)
     runner.push(_make_result(0, ""))  # git merge (step 8)
     # Step 8.5: editable guard fires (mocked above) — cleanup steps never reached
 
-    result = await perform_merge(
-        fake_wt, "dev", config=AutomationConfig(), runner=runner, tester=tester
-    )
+    with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path(fake_wt)):
+        result = await perform_merge(
+            fake_wt, "dev", config=AutomationConfig(), runner=runner, tester=tester
+        )
 
     assert result["merge_succeeded"] is True
     assert result["state"] == MergeState.MERGE_SUCCEEDED_CLEANUP_BLOCKED
@@ -118,16 +119,16 @@ async def test_perform_merge_proceeds_normally_when_guard_returns_empty(
     runner.push(_make_result(0, ""))  # ref check (step 5.5)
     runner.push(_make_result(0, ""))  # git log --merges (step 5.6)
     runner.push(_make_result(0, ""))  # git rebase (step 6)
-    runner.push(_make_result(0, f"worktree {fake_wt}\n"))  # git worktree list (step 7)
     runner.push(_make_result(0, "dev\n"))  # git branch --show-current (step 7.5)
     runner.push(_make_result(0, ""))  # git status --porcelain (step 7.6)
     runner.push(_make_result(0, ""))  # git merge (step 8)
     # Step 8.5: guard returns [] — cleanup proceeds
     # Steps 9-10 (wt remove, branch -D) use MockSubprocessRunner default (rc=0, stdout="")
 
-    result = await perform_merge(
-        fake_wt, "dev", config=AutomationConfig(), runner=runner, tester=tester
-    )
+    with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path(fake_wt)):
+        result = await perform_merge(
+            fake_wt, "dev", config=AutomationConfig(), runner=runner, tester=tester
+        )
 
     assert result.get("merge_succeeded") is True
     assert "error" not in result

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -549,19 +550,16 @@ class TestSafetyConfigWiring:
         )  # git log --merges (step 5.6 — no merge commits)
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git rebase
         tool_ctx_kitchen_open.runner.push(
-            _make_result(
-                0,
-                "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n",
-                "",
-            )
-        )  # worktree list
-        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "dev\n", "")
         )  # git branch --show-current (step 7.5)
+        tool_ctx_kitchen_open.runner.push(
+            _make_result(0, "", "")
+        )  # step 7.6: git status --porcelain (main_repo clean)
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git merge
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # worktree remove
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D
-        result = json.loads(await merge_worktree(str(wt), "dev"))
+        with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")):
+            result = json.loads(await merge_worktree(str(wt), "dev"))
         assert result["merge_succeeded"] is True
 
         # Verify no test command was called — the 5th call should be git fetch, not test

--- a/tests/server/test_tools_git.py
+++ b/tests/server/test_tools_git.py
@@ -207,14 +207,6 @@ class TestMergeWorktree:
             _make_result(0, "PASS\n= 100 passed =", "")
         )  # post-rebase test-check
         tool_ctx_kitchen_open.runner.push(
-            _make_result(
-                0,
-                "worktree /repo\nHEAD abc123\nbranch refs/heads/dev\n\n"
-                "worktree /wt\nHEAD def456\nbranch refs/heads/impl-branch\n\n",
-                "",
-            )
-        )  # worktree list --porcelain
-        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "dev\n", "")
         )  # step 7.5: branch --show-current
         tool_ctx_kitchen_open.runner.push(
@@ -223,7 +215,8 @@ class TestMergeWorktree:
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git merge
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # worktree remove
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D
-        result = json.loads(await merge_worktree(str(wt), "dev"))
+        with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")):
+            result = json.loads(await merge_worktree(str(wt), "dev"))
         assert result["merge_succeeded"] is True
         assert result["into_branch"] == "dev"
         assert result["cleanup_succeeded"] is True
@@ -383,13 +376,6 @@ class TestMergeWorktreeCleanupReporting:
             _make_result(0, "PASS\n= 100 passed =", "")
         )  # post-rebase test-check
         tool_ctx_kitchen_open.runner.push(
-            _make_result(
-                0,
-                "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n",
-                "",
-            )
-        )  # worktree list
-        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "dev\n", "")
         )  # step 7.5: branch --show-current
         tool_ctx_kitchen_open.runner.push(
@@ -397,11 +383,14 @@ class TestMergeWorktreeCleanupReporting:
         )  # step 7.6: git status --porcelain (clean)
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # git merge
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D
-        with patch(
-            "autoskillit.server.git.remove_git_worktree",
-            new=AsyncMock(
-                return_value=CleanupResult(failed=[(str(wt), "error: untracked files")])
+        with (
+            patch(
+                "autoskillit.server.git.remove_git_worktree",
+                new=AsyncMock(
+                    return_value=CleanupResult(failed=[(str(wt), "error: untracked files")])
+                ),
             ),
+            patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
         ):
             result = json.loads(await merge_worktree(str(wt), "dev"))
         assert result["merge_succeeded"] is True
@@ -440,13 +429,6 @@ class TestMergeWorktreeCleanupReporting:
             _make_result(0, "PASS\n= 100 passed =", "")
         )  # post-rebase test-check
         tool_ctx_kitchen_open.runner.push(
-            _make_result(
-                0,
-                "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n",
-                "",
-            )
-        )  # worktree list
-        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "dev\n", "")
         )  # step 7.5: branch --show-current
         tool_ctx_kitchen_open.runner.push(
@@ -457,7 +439,8 @@ class TestMergeWorktreeCleanupReporting:
         tool_ctx_kitchen_open.runner.push(
             _make_result(1, "", "error: branch not found")
         )  # branch -D FAILS
-        result = json.loads(await merge_worktree(str(wt), "dev"))
+        with patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")):
+            result = json.loads(await merge_worktree(str(wt), "dev"))
         assert result["merge_succeeded"] is True
         assert result["cleanup_succeeded"] is False
         assert result["worktree_removed"] is True
@@ -523,9 +506,6 @@ class TestMergeWorktreeCleanupWarnings:
             _make_result(0, "PASS\n= 100 passed =", "")
         )  # post-rebase test-check
         tool_ctx_kitchen_open.runner.push(
-            _make_result(0, "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n", "")
-        )
-        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "dev\n", "")
         )  # step 7.5: branch --show-current
         tool_ctx_kitchen_open.runner.push(
@@ -541,6 +521,7 @@ class TestMergeWorktreeCleanupWarnings:
                     return_value=CleanupResult(failed=[(str(wt), "error: untracked files")])
                 ),
             ),
+            patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
             structlog.testing.capture_logs() as logs,
         ):
             result = json.loads(await merge_worktree(str(wt), "dev"))
@@ -580,9 +561,6 @@ class TestMergeWorktreeCleanupWarnings:
             _make_result(0, "PASS\n= 100 passed =", "")
         )  # post-rebase test-check
         tool_ctx_kitchen_open.runner.push(
-            _make_result(0, "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n", "")
-        )
-        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "dev\n", "")
         )  # step 7.5: branch --show-current
         tool_ctx_kitchen_open.runner.push(
@@ -594,7 +572,10 @@ class TestMergeWorktreeCleanupWarnings:
             _make_result(1, "", "error: branch not found")
         )  # branch -D FAILS
 
-        with structlog.testing.capture_logs() as logs:
+        with (
+            patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
+            structlog.testing.capture_logs() as logs,
+        ):
             result = json.loads(await merge_worktree(str(wt), "dev"))
 
         assert result["merge_succeeded"] is True
@@ -632,9 +613,6 @@ class TestMergeWorktreeCleanupWarnings:
             _make_result(0, "PASS\n= 100 passed =", "")
         )  # post-rebase test-check
         tool_ctx_kitchen_open.runner.push(
-            _make_result(0, "worktree /repo\nHEAD abc\nbranch refs/heads/dev\n\n", "")
-        )
-        tool_ctx_kitchen_open.runner.push(
             _make_result(0, "dev\n", "")
         )  # step 7.5: branch --show-current
         tool_ctx_kitchen_open.runner.push(
@@ -644,7 +622,10 @@ class TestMergeWorktreeCleanupWarnings:
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # worktree remove — success
         tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))  # branch -D — success
 
-        with structlog.testing.capture_logs() as logs:
+        with (
+            patch("autoskillit.server.git.resolve_main_worktree", return_value=Path("/repo")),
+            structlog.testing.capture_logs() as logs,
+        ):
             result = json.loads(await merge_worktree(str(wt), "dev"))
 
         assert result["merge_succeeded"] is True


### PR DESCRIPTION
## Summary

`scripts/recipe/create_worktree.sh` computed worktree paths using a relative `../worktrees/${BRANCH}` path resolved against `$SOURCE_DIR`. This silently breaks when `source_dir` is itself a linked worktree inside the `worktrees/` directory — a scenario that occurs during recursive campaign dispatches and re-runs, creating unbounded nested `worktrees/worktrees/worktrees/...` directories on disk.

Part A fixes the core script bug and introduces `resolve_main_worktree()`, a canonical IL-0 utility that resolves any git path (main checkout or linked worktree) to the main worktree root, replacing ad-hoc resolution scattered across consumers.

## Requirements

### Problem

`scripts/recipe/create_worktree.sh` line 23 computes worktree paths using a relative path:

```bash
WORKTREE_PATH="../worktrees/${BRANCH}"
```

This resolves relative to `$SOURCE_DIR`. When `source_dir` is itself a worktree inside a `worktrees/` directory (which happens during recursive campaign dispatches or re-runs), the path becomes:

```
/home/talon/projects/worktrees/../worktrees/ -> /home/talon/projects/worktrees/worktrees/
```

### Confirmed on Disk

18 worktree directories exist under the double-nested path `/home/talon/projects/worktrees/worktrees/`, including a third-level `worktrees/worktrees/worktrees/` subdirectory -- unbounded recursion.

### How It Happens

1. First campaign dispatch: `source_dir = ~/projects/research-test` -> worktree at `~/projects/worktrees/research-YYYYMMDD-HHMMSS` (correct)
2. Subsequent dispatch or re-run: `source_dir = ~/projects/worktrees/research-YYYYMMDD-HHMMSS` -> worktree at `~/projects/worktrees/worktrees/research-YYYYMMDD-HHMMSS` (nested)
3. If it happens again from the nested path -> `~/projects/worktrees/worktrees/worktrees/...` (unbounded)

### Secondary Effects

- Cluttered filesystem with orphaned nested worktree directories
- Git worktree list shows correct refs but confusing paths
- `context.worktree_path` passed to downstream recipe steps points to the double-nested path, compounding other path-resolution issues

### Affected Files

- `scripts/recipe/create_worktree.sh` (line 23) -- the relative path computation

### Recommended Approach

Replace the relative path with an absolute path derived from the original project root:

1. The script should resolve `source_dir` to its git main worktree (the actual repo root) using `git -C "$SOURCE_DIR" worktree list --porcelain | head -1` or `git rev-parse --git-common-dir`
2. Compute `WORKTREE_PATH` as `<project_root>/../worktrees/${BRANCH}` using that resolved absolute path
3. This guarantees worktrees are always siblings of the project root, regardless of whether `source_dir` is the root or an existing worktree

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_worktree_path_resolution_2025-05-09_181229_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 58 | 15.4k | 1.2M | 139.8k | 196 | 60.0k | 11m 26s |
| dry_walkthrough | claude-opus-4-6 | 2 | 3.3k | 17.5k | 1.5M | 64.7k | 167 | 86.0k | 10m 13s |
| implement* | MiniMax-M2.7-highspeed | 2 | 3.1M | 28.1k | 2.7M | 82.4k | 257 | 179.6k | 12m 2s |
| prepare_pr* | MiniMax-M2.7 | 1 | 55.1k | 7.5k | 398.0k | 0 | 31 | 0 | 4m 2s |
| compose_pr* | MiniMax-M2.7 | 1 | 50.3k | 2.5k | 473.9k | 0 | 28 | 0 | 56s |
| review_pr | claude-opus-4-6 | 3 | 142 | 88.6k | 2.7M | 110.8k | 149 | 275.9k | 25m 24s |
| resolve_review | claude-opus-4-6 | 1 | 76 | 12.4k | 2.5M | 77.0k | 75 | 64.3k | 8m 7s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 30 | 3.0k | 421.8k | 45.3k | 24 | 32.1k | 1m 25s |
| diagnose_ci* | MiniMax-M2.7 | 1 | 87.6k | 19.6k | 3.2M | 0 | 125 | 0 | 11m 33s |
| resolve_ci | claude-opus-4-6 | 1 | 42 | 4.6k | 632.2k | 54.3k | 27 | 41.3k | 5m 40s |
| **Total** | | | 3.3M | 199.0k | 15.7M | 139.8k | | 739.2k | 1h 30m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 674 | 3950.2 | 266.5 | 41.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 38 | 66237.3 | 1692.6 | 325.4 |
| ci_conflict_fix | 1323 | 318.9 | 24.3 | 2.3 |
| diagnose_ci | 5 | 648281.6 | 0.0 | 3919.6 |
| resolve_ci | 10 | 63221.9 | 4131.8 | 457.7 |
| **Total** | **2050** | 7679.4 | 360.6 | 97.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 58 | 15.4k | 1.2M | 60.0k | 11m 26s |
| claude-opus-4-6 | 2 | 3.5k | 95.2k | 8.8M | 397.5k | 47m 1s |
| MiniMax-M2.7-highspeed | 1 | 3.1M | 28.1k | 2.7M | 179.6k | 12m 2s |
| MiniMax-M2.7 | 2 | 105.4k | 10.0k | 871.8k | 0 | 4m 58s |