### PR TITLE
[FIX] Rectify: Info-Sverity Auto-DISCUSS Conflation Pollutes Deferred Observations

### DIFF
--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -163,7 +163,7 @@ skills:
       type: integer
     - name: deferred_observations_path
       type: string
-      description: "Written when mode=local (accumulated DISCUSS findings) or when mode=github (posted from prior local rounds)."
+      description: "Written when mode=local (accumulated critical/warning DISCUSS findings, excluding info-severity) or when mode=github (posted from prior local rounds)."
       required: false
     - name: reject_patterns_path
       type: string

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -129,7 +129,8 @@ DEFERRED_FILE="{{AUTOSKILLIT_TEMP}}/resolve-review/deferred_observations_${PR_NU
 
 If the file exists and contains entries:
 1. Load the deferred observations array from the file
-2. Post ALL entries as a single batch review via `POST /repos/{owner}/{repo}/pulls/{pr_number}/reviews`:
+2. **Filter loaded entries:** exclude any entry where `severity == "info"`. This is a boundary guard — deferred_observations should never contain info entries (see Step 3.6), but the posting boundary enforces the invariant independently.
+3. Post the filtered entries as a single batch review via `POST /repos/{owner}/{repo}/pulls/{pr_number}/reviews`:
    - `event`: `"COMMENT"` (not requesting changes — these are observations for discussion)
    - `body`: `"Observations accumulated from {N} local review rounds:"`
    - `commit_id`: current HEAD commit SHA (from `gh pr view {pr_number} --json headRefOid -q .headRefOid`)
@@ -148,10 +149,10 @@ If the file exists and contains entries:
        <!-- REVIEW-FLAG: severity={severity} dimension={dimension} -->
        ```
 
-3. Use the batch review endpoint (never post individual comments unless the batch call fails)
-4. **Fallback:** If the batch POST returns HTTP 422 (e.g., stale line numbers), retry by posting each observation individually via `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --method POST` with 1s delay between calls
-5. After all deferred observations are posted successfully, rename the file to `deferred_observations_${PR_NUMBER}_posted.json` to prevent re-posting on retry
-6. These review threads are left UNRESOLVED (same behavior as DISCUSS in github mode)
+4. Use the batch review endpoint (never post individual comments unless the batch call fails)
+5. **Fallback:** If the batch POST returns HTTP 422 (e.g., stale line numbers), retry by posting each observation individually via `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --method POST` with 1s delay between calls
+6. After all deferred observations are posted successfully, rename the file to `deferred_observations_${PR_NUMBER}_posted.json` to prevent re-posting on retry
+7. These review threads are left UNRESOLVED (same behavior as DISCUSS in github mode)
 
 If the file does not exist or is empty, skip this step and proceed to Step 2.
 
@@ -302,7 +303,7 @@ From **top-level reviews**, extract:
 
 When a finding matches multiple tiers, use the highest severity.
 
-Critical and warning findings proceed to intent validation (Step 3.5). Info findings are auto-classified as `DISCUSS` — they do not enter Step 3.5.
+Critical and warning findings proceed to intent validation (Step 3.5). Info findings are classified with `verdict="INFO"` — they do not enter Step 3.5. Only `ACCEPT`, `REJECT`, and `DISCUSS` verdicts are assigned by Step 3.5 sub-agents; `INFO` is assigned at classification time.
 
 ### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes)
 
@@ -398,7 +399,7 @@ Each entry must also carry two additional fields populated at merge time (not de
 - `severity` — `diff_context_map.get((path, line), {}).get("severity", locally_classified_severity)` where `locally_classified_severity` is the severity computed in Step 3 (`critical`/`warning`/`info` from keyword matching). This ensures a meaningful value even when no review-pr handoff entry exists for this `(path, line)`.
 - `dimension` — `diff_context_map.get((path, line), {}).get("dimension", "unknown")` (`arch|tests|bugs|defense|cohesion|slop|deletion_regression|unknown`). `"unknown"` is the correct sentinel when `diff_context_map` has no entry.
 
-For auto-classified INFO findings (those classified as DISCUSS in Step 3 without entering Step 3.5): add them to `classification_map` with `severity="info"` and `dimension=diff_context_map.get((path, line), {}).get("dimension", "unknown")`.
+For INFO-verdict findings (classified in Step 3, not validated by sub-agents): add them to `classification_map` with `verdict="INFO"`, `severity="info"`, and `dimension=diff_context_map.get((path, line), {}).get("dimension", "unknown")`.
 
 **Write analysis report** to `{{AUTOSKILLIT_TEMP}}/resolve-review/analysis_{pr_number}_{ts}.md` before
 any code changes are made. The report must include a summary banner:
@@ -431,10 +432,12 @@ existing = []
 if deferred_file.exists():
     existing = json.loads(deferred_file.read_text())
 
-# Build new entries from classification_map (DISCUSS only)
+# Build new entries from classification_map (DISCUSS only, info-severity excluded)
 discuss_entries = []
 for c in classification_map.values():
     if c.get("verdict") != "DISCUSS":
+        continue
+    if c.get("severity") == "info":
         continue
     entry = {
         "round": iteration_number,
@@ -442,7 +445,7 @@ for c in classification_map.values():
         "line": c.get("line"),
         "body": c.get("body"),
         "evidence": c.get("evidence", ""),
-        "severity": c.get("severity", "warning"),
+        "severity": c["severity"],
         "dimension": c.get("dimension", "unknown"),
         "verdict": "DISCUSS",
         "category": c.get("category", "design_decision"),
@@ -458,6 +461,8 @@ all_entries = existing + new_entries
 deferred_file.write_text(json.dumps(all_entries, indent=2))
 print(f"Accumulated {len(new_entries)} new DISCUSS findings ({len(all_entries)} total)")
 ```
+
+Info-severity findings are acknowledged in the current round via Step 6.5's INFO reply template and are not carried forward to deferred observations. Only genuine DISCUSS verdicts from Step 3.5 sub-agent validation — representing findings that require a human design decision — are accumulated.
 
 The `round` value is the iteration number from `local_findings_{pr_number}.json` (written
 by review-pr with auto-incrementing logic).
@@ -594,7 +599,7 @@ BODY="Investigated — this is intentional. ${evidence}
 BODY="Valid observation — flagged for design decision. ${evidence}
 <!-- REVIEW-FLAG: severity=${severity} dimension=${dimension} -->
 <!-- autoskillit:resolved comment_id=${comment_id} verdict=DISCUSS -->"
-# INFO (auto-classified DISCUSS):
+# INFO (verdict=INFO from Step 3):
 BODY="Acknowledged — minor suggestion noted.
 <!-- REVIEW-FLAG: severity=info dimension=${dimension} -->
 <!-- autoskillit:resolved comment_id=${comment_id} verdict=INFO -->"

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -533,9 +533,9 @@ The `--field` approach creates one array entry per flag (not one object per comm
 not be used for the `comments` array:
 
 ```bash
-# Build comments JSON array from FILTERED_FINDINGS only
+# Build comments JSON array from FILTERED_FINDINGS only (critical/warning only)
 COMMENTS_JSON=$(jq -n --argjson findings "$FILTERED_FINDINGS" '
-  $findings | map({
+  $findings | map(select(.severity == "critical" or .severity == "warning")) | map({
     path: .file,
     line: .line,
     side: "RIGHT",
@@ -600,12 +600,14 @@ best-effort supplementary visibility. Do not fall through to Tier 1/Tier 2 for t
 
 **Fallback Tier 1 — Individual Comments (if batch POST fails):**
 
-Attempt to post each finding from `FILTERED_FINDINGS` individually via:
+Iterate only critical and warning findings from `FILTERED_FINDINGS`. Skip info-severity findings — they do not warrant individual GitHub comments.
+
+Attempt to post each critical/warning finding individually via:
 
 ```bash
 COMMIT_ID=$(gh pr view {pr_number} --json headRefOid -q .headRefOid)
 
-# For each finding in FILTERED_FINDINGS:
+# For each critical/warning finding in FILTERED_FINDINGS:
 gh api /repos/{owner}/{repo}/pulls/{pr_number}/comments \
   --method POST \
   --field path="{finding.file}" \

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -270,9 +270,9 @@ in the updated file).
 Build a proper JSON payload where each comment is a complete object, then post via `--input -`.
 
 ```bash
-# Build comments JSON array from findings
+# Build comments JSON array from findings (critical/warning only)
 COMMENTS_JSON=$(jq -n --argjson findings "$FILTERED_FINDINGS" '
-  $findings | map({
+  $findings | map(select(.severity == "critical" or .severity == "warning")) | map({
     path: .file,
     line: .line,
     side: "RIGHT",

--- a/tests/contracts/test_review_local_mode_contracts.py
+++ b/tests/contracts/test_review_local_mode_contracts.py
@@ -204,3 +204,28 @@ def test_resolve_review_mode_default_github():
     assert mode_input.get("required") is not True, (
         "mode parameter should not be required (has default: github)"
     )
+
+
+def test_deferred_observations_contract_excludes_info():
+    """deferred_observations_path description must exclude info-severity findings.
+
+    The description must make clear that only critical/warning DISCUSS findings
+    are accumulated, not all DISCUSS findings (which would include info-severity
+    auto-classified as DISCUSS in the old design).
+    """
+    contracts = _contracts()
+    outputs = contracts.get("skills", {}).get("resolve-review", {}).get("outputs", [])
+    deferred_obs = next(
+        (o for o in outputs if o.get("name") == "deferred_observations_path"),
+        None,
+    )
+    assert deferred_obs is not None, (
+        "deferred_observations_path must exist in resolve-review outputs"
+    )
+    desc = deferred_obs.get("description", "")
+    # Must mention critical or warning, not just "DISCUSS findings"
+    assert any(kw in desc.lower() for kw in ["critical", "warning", "exclud"]), (
+        "deferred_observations_path description must qualify that only critical/warning "
+        "findings are accumulated (not all DISCUSS findings). "
+        "Expected description to mention 'critical', 'warning', or 'exclud'."
+    )

--- a/tests/skills/test_resolve_review_local_mode.py
+++ b/tests/skills/test_resolve_review_local_mode.py
@@ -260,9 +260,7 @@ def test_resolve_review_step36_excludes_info_severity():
     # This requires a severity condition (severity == "info" skip, or severity != "info" proceed).
     has_severity_check = (
         'severity == "info"' in step36_section
-        or 'severity == "info"' in step36_section.lower()
         or 'severity != "info"' in step36_section
-        or 'severity != "info"' in step36_section.lower()
         or (
             "severity" in step36_section
             and "skip" in step36_section.lower()

--- a/tests/skills/test_resolve_review_local_mode.py
+++ b/tests/skills/test_resolve_review_local_mode.py
@@ -245,6 +245,70 @@ def test_resolve_review_local_mode_transforms_local_findings():
     )
 
 
+def test_resolve_review_step36_excludes_info_severity():
+    """Step 3.6 accumulation filter must exclude info-severity findings.
+
+    The deferred_observations file must only contain critical and warning
+    DISCUSS entries. Info-severity findings are acknowledged via Step 6.5's
+    INFO reply template and must not be carried forward to deferred observations.
+    """
+    text = _skill_text()
+    step36_idx = text.find("### Step 3.6")
+    assert step36_idx >= 0, "SKILL.md must have Step 3.6 for DISCUSS accumulation"
+    step36_section = text[step36_idx : step36_idx + 2000]
+    # Must have an explicit severity check in the accumulation code that excludes info-severity.
+    # This requires a severity condition (severity == "info" skip, or severity != "info" proceed).
+    has_severity_check = (
+        'severity == "info"' in step36_section
+        or 'severity == "info"' in step36_section.lower()
+        or 'severity != "info"' in step36_section
+        or 'severity != "info"' in step36_section.lower()
+        or (
+            "severity" in step36_section
+            and "skip" in step36_section.lower()
+            and "info" in step36_section.lower()
+        )
+        or (
+            "severity" in step36_section
+            and "exclud" in step36_section.lower()
+            and "info" in step36_section.lower()
+        )
+    )
+    assert has_severity_check, (
+        "Step 3.6 must have an explicit severity check that excludes info-severity "
+        "findings from deferred_observations accumulation. "
+        "The filter must gate on severity in addition to verdict==DISCUSS."
+    )
+
+
+def test_resolve_review_step15_filters_info_before_posting():
+    """Step 1.5 must filter info-severity entries before posting to GitHub.
+
+    Even though Step 3.6 should exclude info from deferred_observations,
+    the posting boundary enforces the invariant independently — deferred_observations
+    should never contain info entries, but the posting boundary is a second guard.
+    """
+    text = _skill_text()
+    step15_idx = text.find("### Step 1.5")
+    assert step15_idx >= 0, "SKILL.md must have Step 1.5 for posting deferred observations"
+    step15_section = text[step15_idx : step15_idx + 2500]
+    # Must have a severity filter before the POST call — an explicit check or explicit prose
+    # that tells the model to skip/filter info entries.
+    has_severity_gate = (
+        (
+            "severity" in step15_section.lower()
+            and "info" in step15_section.lower()
+            and any(kw in step15_section.lower() for kw in ["skip", "exclud", "filter"])
+        )
+        or 'severity == "info"' in step15_section.lower()
+        or 'severity != "info"' in step15_section.lower()
+    )
+    assert has_severity_gate, (
+        "Step 1.5 must filter out info-severity entries before building "
+        "the comments[] array for the POST /repos/{owner}/{repo}/pulls/{pr_number}/reviews call"
+    )
+
+
 def test_resolve_review_local_mode_reject_patterns_no_timestamp():
     """Assert SKILL.md local mode uses stable reject_patterns filename without timestamp
     (accumulating across rounds)."""

--- a/tests/skills/test_resolve_review_severity_and_reject_resolution.py
+++ b/tests/skills/test_resolve_review_severity_and_reject_resolution.py
@@ -12,8 +12,13 @@ assert SKILL_PATH.exists(), f"SKILL.md not found at {SKILL_PATH}"
 SKILL_TEXT = SKILL_PATH.read_text()
 
 
-def test_info_findings_auto_classified_as_discuss() -> None:
-    """Step 3 must state info findings are auto-classified as DISCUSS, bypassing Step 3.5."""
+def test_info_findings_classified_as_verdict_info_not_discuss() -> None:
+    """Step 3 must classify info findings with verdict=INFO, not verdict=DISCUSS.
+
+    The DISCUSS verdict is reserved for findings that require a human design decision
+    (validated by Step 3.5 sub-agents). Info-severity findings are classified with
+    verdict=INFO at Step 3 and acknowledged via the Step 6.5 INFO reply template.
+    """
     step3_idx = SKILL_TEXT.find("### Step 3:")
     if step3_idx == -1:
         step3_idx = SKILL_TEXT.find("### Step 3")
@@ -21,19 +26,37 @@ def test_info_findings_auto_classified_as_discuss() -> None:
     step35_idx = SKILL_TEXT.find("### Step 3.5")
     assert step35_idx != -1, "SKILL.md must have a Step 3.5 section"
     step3_section = SKILL_TEXT[step3_idx:step35_idx]
-    assert (
-        "auto-classified" in step3_section.lower()
-        or "auto-classify" in step3_section.lower()
-        or ("discuss" in step3_section and "info" in step3_section.lower())
-    ), "Step 3 must state that info findings are auto-classified as DISCUSS"
-    assert (
-        "do not enter" in step3_section.lower()
-        or "bypass" in step3_section.lower()
-        or (
-            "not enter step 3.5" in step3_section.lower()
-            or "do not enter step" in step3_section.lower()
-        )
-    ), "Step 3 must state that info findings do not enter Step 3.5"
+    # Must mention INFO verdict for info findings
+    assert "verdict" in step3_section.lower() and "INFO" in step3_section, (
+        "Step 3 must use verdict=INFO for info findings (not DISCUSS)"
+    )
+    # Info findings must not be described as DISCUSS
+    assert not (
+        "info" in step3_section.lower()
+        and "auto-classified" in step3_section.lower()
+        and "DISCUSS" in step3_section
+    ), "Step 3 must not describe info findings as auto-classified as DISCUSS"
+
+
+def test_verdict_taxonomy_info_is_distinct_from_discuss() -> None:
+    """Info findings must never be described as being classified with DISCUSS verdict.
+
+    This is a regression guard against re-introducing the verdict conflation
+    where info-severity findings were incorrectly given verdict=DISCUSS.
+    """
+    assert not __skill_text_matches("info.*auto.*discuss"), (
+        "SKILL.md must never describe info findings as 'auto-classified as DISCUSS'"
+    )
+    assert not __skill_text_matches("info.*classified as.*DISCUSS"), (
+        "SKILL.md must never describe info findings as 'classified as DISCUSS'"
+    )
+
+
+def __skill_text_matches(pattern: str) -> bool:
+    """Check if pattern matches anywhere in SKILL.md (case-insensitive)."""
+    import re
+
+    return bool(re.search(pattern, SKILL_TEXT, re.IGNORECASE))
 
 
 def test_intent_validation_restricted_to_critical_and_warning() -> None:

--- a/tests/skills/test_resolve_review_severity_and_reject_resolution.py
+++ b/tests/skills/test_resolve_review_severity_and_reject_resolution.py
@@ -44,15 +44,15 @@ def test_verdict_taxonomy_info_is_distinct_from_discuss() -> None:
     This is a regression guard against re-introducing the verdict conflation
     where info-severity findings were incorrectly given verdict=DISCUSS.
     """
-    assert not __skill_text_matches("info.*auto.*discuss"), (
+    assert not _skill_text_matches("info.*auto.*discuss"), (
         "SKILL.md must never describe info findings as 'auto-classified as DISCUSS'"
     )
-    assert not __skill_text_matches("info.*classified as.*DISCUSS"), (
+    assert not _skill_text_matches("info.*classified as.*DISCUSS"), (
         "SKILL.md must never describe info findings as 'classified as DISCUSS'"
     )
 
 
-def __skill_text_matches(pattern: str) -> bool:
+def _skill_text_matches(pattern: str) -> bool:
     """Check if pattern matches anywhere in SKILL.md (case-insensitive)."""
     import re
 

--- a/tests/skills/test_resolve_review_severity_and_reject_resolution.py
+++ b/tests/skills/test_resolve_review_severity_and_reject_resolution.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 SKILL_PATH = (
@@ -54,7 +55,6 @@ def test_verdict_taxonomy_info_is_distinct_from_discuss() -> None:
 
 def _skill_text_matches(pattern: str) -> bool:
     """Check if pattern matches anywhere in SKILL.md (case-insensitive)."""
-    import re
 
     return bool(re.search(pattern, SKILL_TEXT, re.IGNORECASE))
 

--- a/tests/skills/test_review_pr_inline_comment_guards.py
+++ b/tests/skills/test_review_pr_inline_comment_guards.py
@@ -561,7 +561,7 @@ def test_step6_jq_includes_severity_filter():
     assert step65_start != -1
     step6_section = SKILL_TEXT[step6_start:step65_start]
     # Must have a jq select that filters on severity
-    assert "select" in step6_section and "severity" in step6_section, (
+    assert "select(.severity" in step6_section, (
         "Step 6 jq expression must include a select filter on severity "
         "to exclude info-severity findings before building comment objects"
     )
@@ -582,7 +582,7 @@ def test_research_pr_step6_jq_includes_severity_filter():
     assert step6_start != -1
     assert step65_start != -1
     step6_section = RESEARCH_SKILL_TEXT[step6_start:step65_start]
-    assert "select" in step6_section and "severity" in step6_section, (
+    assert "select(.severity" in step6_section, (
         "review-research-pr Step 6 jq expression must include a select filter on severity"
     )
     assert "critical" in step6_section.lower() and "warning" in step6_section.lower(), (

--- a/tests/skills/test_review_pr_inline_comment_guards.py
+++ b/tests/skills/test_review_pr_inline_comment_guards.py
@@ -548,6 +548,76 @@ def test_resolve_review_handles_null_line_file_level_threads():
     )
 
 
+def test_step6_jq_includes_severity_filter():
+    """Step 6 jq expression must filter to critical/warning before building comment objects.
+
+    The jq expression maps FILTERED_FINDINGS but must not pass info-severity findings
+    to the GitHub API. A severity select filter (select(.severity == "critical" or
+    .severity == "warning")) must be applied before the map.
+    """
+    step6_start = SKILL_TEXT.find("### Step 6")
+    step65_start = SKILL_TEXT.find("### Step 6.5")
+    assert step6_start != -1
+    assert step65_start != -1
+    step6_section = SKILL_TEXT[step6_start:step65_start]
+    # Must have a jq select that filters on severity
+    assert "select" in step6_section and "severity" in step6_section, (
+        "Step 6 jq expression must include a select filter on severity "
+        "to exclude info-severity findings before building comment objects"
+    )
+    # Must filter to critical/warning (positive allowlist)
+    assert "critical" in step6_section.lower() and "warning" in step6_section.lower(), (
+        "Step 6 jq severity filter must restrict to critical and warning"
+    )
+
+
+def test_research_pr_step6_jq_includes_severity_filter():
+    """review-research-pr Step 6 jq expression must filter to critical/warning.
+
+    Same severity filter requirement as review-pr Step 6. Info-severity findings
+    must not be posted as GitHub comments.
+    """
+    step6_start = RESEARCH_SKILL_TEXT.find("### Step 6")
+    step65_start = RESEARCH_SKILL_TEXT.find("### Step 6.5")
+    assert step6_start != -1
+    assert step65_start != -1
+    step6_section = RESEARCH_SKILL_TEXT[step6_start:step65_start]
+    assert "select" in step6_section and "severity" in step6_section, (
+        "review-research-pr Step 6 jq expression must include a select filter on severity"
+    )
+    assert "critical" in step6_section.lower() and "warning" in step6_section.lower(), (
+        "review-research-pr Step 6 jq severity filter must restrict to critical and warning"
+    )
+
+
+def test_tier1_fallback_includes_severity_filter():
+    """Tier 1 fallback must iterate only critical/warning findings, skipping info.
+
+    When the batch POST fails and individual POSTs are attempted, the iteration
+    must not process info-severity findings — they do not warrant individual
+    GitHub comments.
+    """
+    tier1_idx = SKILL_TEXT.find("Fallback Tier 1")
+    assert tier1_idx >= 0, "Tier 1 fallback section not found in review-pr SKILL.md"
+    tier2_idx = SKILL_TEXT.find("Tier 2", tier1_idx)
+    tier1_section = SKILL_TEXT[tier1_idx:tier2_idx] if tier2_idx >= 0 else SKILL_TEXT[tier1_idx:]
+    # Must have an explicit instruction to skip/filter info-severity.
+    # A bare mention of "severity" (from {finding.severity}) is not sufficient.
+    has_severity_gate = (
+        "info" in tier1_section.lower()
+        and any(kw in tier1_section.lower() for kw in ["skip", "exclud", "filter"])
+    ) or (
+        "critical" in tier1_section.lower()
+        and "warning" in tier1_section.lower()
+        and any(kw in tier1_section.lower() for kw in ["only", "limit", "restrict"])
+    )
+    assert has_severity_gate, (
+        "Tier 1 fallback must include instructions to skip info-severity findings "
+        "when iterating for individual comment POSTs. "
+        "The section must explicitly say to only process critical/warning findings."
+    )
+
+
 def test_resolve_research_review_handles_null_line_file_level_threads():
     """resolve-research-review must handle null-line file-level comment threads gracefully."""
     text = RESOLVE_RESEARCH_SKILL_TEXT


### PR DESCRIPTION
## Summary

The `DISCUSS` verdict is semantically overloaded: it means both "sub-agent determined human decision needed" (genuine) and "info-severity auto-classified for token efficiency" (shortcut). All downstream consumers that filter on `verdict == "DISCUSS"` cannot distinguish the two populations, causing info noise to leak into GitHub PR threads meant for design decisions.

The architectural fix has two layers:
1. **Eliminate the overloading at source**: Give info findings `verdict="INFO"` (not `"DISCUSS"`) from Step 3 onward.
2. **Defense-in-depth severity gates at every external boundary**: Add explicit severity filters at every point where findings data crosses from internal processing to external posting (GitHub API).

Closes #2340

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260509-193434-357066/.autoskillit/temp/rectify/rectify_info_severity_auto_discuss_conflation_2026-05-09_193434.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 58 | 6.7k | 436.4k | 58.6k | 80 | 34.7k | 4m 27s |
| rectify | claude-sonnet-4-6 | 1 | 10.9k | 12.1k | 522.5k | 119.4k | 174 | 56.1k | 18m 53s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 3.7k | 10.4k | 1.0M | 87.7k | 98 | 51.6k | 7m 2s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.2M | 25.6k | 2.1M | 81.3k | 189 | 105.0k | 11m 30s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 151.8k | 3.9k | 346.6k | 29.1k | 25 | 15.4k | 1m 39s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.7k | 1.6k | 201.0k | 29.1k | 15 | 15.2k | 39s |
| review_pr | claude-sonnet-4-6 | 3 | 270 | 90.2k | 1.4M | 79.2k | 106 | 194.7k | 22m 28s |
| resolve_review | claude-sonnet-4-6 | 3 | 1.6k | 35.0k | 3.5M | 69.8k | 190 | 145.3k | 20m 17s |
| **Total** | | | 3.5M | 185.5k | 9.6M | 119.4k | | 617.9k | 1h 26m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 253 | 8363.7 | 415.2 | 101.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 14 | 253152.7 | 10376.1 | 2503.4 |
| **Total** | **267** | 35788.0 | 2314.1 | 694.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 1.8k | 28.0k | 1.2M | 130.0k | 20m 6s |