### PR TITLE
Rectify: Generate-Report Multi-Group Awareness and Anti-Fabrication Immunity

### DIFF
--- a/src/autoskillit/recipe/rules/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow.py
@@ -14,7 +14,6 @@ from autoskillit.core import (
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import (
     _CONTEXT_REF_RE,
-    INPUT_REF_RE,
     RESULT_CAPTURE_RE,
     get_callable_contract,
     get_skill_contract,
@@ -610,15 +609,9 @@ def _check_downstream_context_completeness(ctx: ValidationContext) -> list[RuleF
     (a) produced by a prior step's capture: block (result.X wired to context.X), or
     (b) declared as a top-level recipe input.
     """
-    from autoskillit.recipe.contracts import _CONTEXT_REF_RE
-
     findings: list[RuleFinding] = []
 
-    # Build a set of all context variables that are produced by recipe steps
-    # A context var X is produced when some prior step captures result.Y and
-    # that capture is wired: capture: {X: "${{ result.Y }}"} makes context.X available.
     produced_context: set[str] = set()
-    # Also collect recipe inputs
     recipe_inputs: set[str] = (
         set(ctx.recipe.ingredients.keys()) if ctx.recipe.ingredients else set()
     )
@@ -628,42 +621,33 @@ def _check_downstream_context_completeness(ctx: ValidationContext) -> list[RuleF
     for step_name in ordered_steps:
         step = ctx.recipe.steps[step_name]
 
-        # First, record what THIS step produces so subsequent steps can use it
+        # Check references first so a step's own captures cannot satisfy its own refs.
+        # Captures become available to *subsequent* steps, not to the current step.
+        if step.tool in SKILL_TOOLS:
+            skill_cmd = step.with_args.get("skill_command", "")
+            if isinstance(skill_cmd, str):
+                for ref in _CONTEXT_REF_RE.findall(skill_cmd):
+                    if ref in produced_context or ref in recipe_inputs:
+                        continue
+                    findings.append(
+                        RuleFinding(
+                            rule="downstream-context-gap",
+                            severity=Severity.WARNING,
+                            step_name=step_name,
+                            message=(
+                                f"Step '{step_name}' references ${{{{ context.{ref}}}}} in its "
+                                f"skill_command but '{ref}' is not produced by any prior step's "
+                                f"capture block and is not a recipe input."
+                                " The variable is unreachable."
+                            ),
+                        )
+                    )
+
         if step.capture:
             for ctx_var, capture_expr in step.capture.items():
-                # Check if this capture wires a result.X to context.ctx_var
                 result_refs = RESULT_CAPTURE_RE.findall(capture_expr)
                 for _ in result_refs:
                     produced_context.add(ctx_var)
-
-        # Second, check if this step's skill_command references any unwired context vars
-        if step.tool not in SKILL_TOOLS:
-            continue
-        skill_cmd = step.with_args.get("skill_command", "")
-        if not isinstance(skill_cmd, str):
-            continue
-
-        ctx_refs = _CONTEXT_REF_RE.findall(skill_cmd)
-        # Also collect all inputs.X refs to know which context names are covered
-        inp_refs = set(INPUT_REF_RE.findall(skill_cmd))
-        for ref in ctx_refs:
-            if ref in produced_context or ref in recipe_inputs:
-                continue
-            # If ref matches an inputs.X name, the recipe input is available as context
-            if ref in inp_refs:
-                continue
-            findings.append(
-                RuleFinding(
-                    rule="downstream-context-gap",
-                    severity=Severity.WARNING,
-                    step_name=step_name,
-                    message=(
-                        f"Step '{step_name}' references ${{{{ context.{ref}}}}} in its "
-                        f"skill_command but '{ref}' is not produced by any prior step's "
-                        f"capture block and is not a recipe input. The variable is unreachable."
-                    ),
-                )
-            )
 
     return findings
 

--- a/src/autoskillit/recipe/rules/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow.py
@@ -14,6 +14,7 @@ from autoskillit.core import (
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import (
     _CONTEXT_REF_RE,
+    INPUT_REF_RE,
     RESULT_CAPTURE_RE,
     get_callable_contract,
     get_skill_contract,
@@ -589,6 +590,81 @@ def _check_callable_signature_mismatch(ctx: ValidationContext) -> list[RuleFindi
                     ),
                 )
             )
+    return findings
+
+
+@semantic_rule(
+    name="downstream-context-gap",
+    description=(
+        "A step's skill_command references ${{ context.X }} but X is not produced "
+        "by any prior step capture, not declared as a recipe input, and not in the "
+        "recipe's ambient context. The variable is unreachable."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_downstream_context_completeness(ctx: ValidationContext) -> list[RuleFinding]:
+    """Check that context variables referenced in skill_command are actually wired.
+
+    For each run_skill step, extract all ${{ context.X }} references from
+    skill_command and verify that X is either:
+    (a) produced by a prior step's capture: block (result.X wired to context.X), or
+    (b) declared as a top-level recipe input.
+    """
+    from autoskillit.recipe.contracts import _CONTEXT_REF_RE
+
+    findings: list[RuleFinding] = []
+
+    # Build a set of all context variables that are produced by recipe steps
+    # A context var X is produced when some prior step captures result.Y and
+    # that capture is wired: capture: {X: "${{ result.Y }}"} makes context.X available.
+    produced_context: set[str] = set()
+    # Also collect recipe inputs
+    recipe_inputs: set[str] = (
+        set(ctx.recipe.ingredients.keys()) if ctx.recipe.ingredients else set()
+    )
+
+    ordered_steps = list(ctx.recipe.steps.keys())
+
+    for step_name in ordered_steps:
+        step = ctx.recipe.steps[step_name]
+
+        # First, record what THIS step produces so subsequent steps can use it
+        if step.capture:
+            for ctx_var, capture_expr in step.capture.items():
+                # Check if this capture wires a result.X to context.ctx_var
+                result_refs = RESULT_CAPTURE_RE.findall(capture_expr)
+                for _ in result_refs:
+                    produced_context.add(ctx_var)
+
+        # Second, check if this step's skill_command references any unwired context vars
+        if step.tool not in SKILL_TOOLS:
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        if not isinstance(skill_cmd, str):
+            continue
+
+        ctx_refs = _CONTEXT_REF_RE.findall(skill_cmd)
+        # Also collect all inputs.X refs to know which context names are covered
+        inp_refs = set(INPUT_REF_RE.findall(skill_cmd))
+        for ref in ctx_refs:
+            if ref in produced_context or ref in recipe_inputs:
+                continue
+            # If ref matches an inputs.X name, the recipe input is available as context
+            if ref in inp_refs:
+                continue
+            findings.append(
+                RuleFinding(
+                    rule="downstream-context-gap",
+                    severity=Severity.WARNING,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' references ${{{{ context.{ref}}}}} in its "
+                        f"skill_command but '{ref}' is not produced by any prior step's "
+                        f"capture block and is not a recipe input. The variable is unreachable."
+                    ),
+                )
+            )
+
     return findings
 
 

--- a/src/autoskillit/recipe/rules/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow.py
@@ -624,7 +624,7 @@ def _check_downstream_context_completeness(ctx: ValidationContext) -> list[RuleF
         # Check references first so a step's own captures cannot satisfy its own refs.
         # Captures become available to *subsequent* steps, not to the current step.
         if step.tool in SKILL_TOOLS:
-            skill_cmd = step.with_args.get("skill_command", "")
+            skill_cmd = (step.with_args or {}).get("skill_command", "")
             if isinstance(skill_cmd, str):
                 for ref in _CONTEXT_REF_RE.findall(skill_cmd):
                     if ref in produced_context or ref in recipe_inputs:
@@ -644,10 +644,8 @@ def _check_downstream_context_completeness(ctx: ValidationContext) -> list[RuleF
                     )
 
         if step.capture:
-            for ctx_var, capture_expr in step.capture.items():
-                result_refs = RESULT_CAPTURE_RE.findall(capture_expr)
-                for _ in result_refs:
-                    produced_context.add(ctx_var)
+            for ctx_var in step.capture:
+                produced_context.add(ctx_var)
 
     return findings
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1380,10 +1380,13 @@ skills:
     outputs:
     - name: results_path
       type: file_path
+    - name: group_manifest
+      type: file_path
     expected_output_patterns:
     - "results_path\\s*=\\s*/.+"
+    - "group_manifest\\s*=\\s*/.+"
     pattern_examples:
-    - "results_path = /tmp/run-experiment/results.md\n%%ORDER_UP%%"
+    - "results_path = /tmp/run-experiment/results.md group_manifest = /tmp/run-experiment/group_manifest.json\n%%ORDER_UP%%"
     write_behavior: always
 
   generate-report:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1397,6 +1397,9 @@ skills:
     - name: results_path
       type: file_path
       required: true
+    - name: group_manifest
+      type: file_path
+      required: false
     outputs:
     - name: report_path
       type: file_path

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -405,13 +405,18 @@
         {
           "name": "results_path",
           "type": "file_path"
+        },
+        {
+          "name": "group_manifest",
+          "type": "file_path"
         }
       ],
       "expected_output_patterns": [
-        "results_path\\s*=\\s*/.+"
+        "results_path\\s*=\\s*/.+",
+        "group_manifest\\s*=\\s*/.+"
       ],
       "pattern_examples": [
-        "results_path = /tmp/run-experiment/results.md\n%%ORDER_UP%%"
+        "results_path = /tmp/run-experiment/results.md group_manifest = /tmp/run-experiment/group_manifest.json\n%%ORDER_UP%%"
       ],
       "write_behavior": "always"
     },
@@ -438,6 +443,12 @@
         {
           "name": "methodology_tradition",
           "type": "string",
+          "required": false,
+          "recommended": false
+        },
+        {
+          "name": "group_manifest",
+          "type": "file_path",
           "required": false,
           "recommended": false
         }

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -351,10 +351,14 @@ skills:
     outputs:
     - name: results_path
       type: file_path
+    - name: group_manifest
+      type: file_path
     expected_output_patterns:
     - results_path\s*=\s*/.+
+    - group_manifest\s*=\s*/.+
     pattern_examples:
     - 'results_path = /tmp/run-experiment/results.md
+      group_manifest = /tmp/run-experiment/group_manifest.json
 
       %%ORDER_UP%%'
     write_behavior: always
@@ -374,6 +378,10 @@ skills:
       recommended: false
     - name: methodology_tradition
       type: string
+      required: false
+      recommended: false
+    - name: group_manifest
+      type: file_path
       required: false
       recommended: false
     outputs:

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -443,7 +443,8 @@
         "step_name": "run_experiment"
       },
       "capture": {
-        "experiment_results": "${{ result.results_path }}"
+        "experiment_results": "${{ result.results_path }}",
+        "group_manifest": "${{ result.group_manifest }}"
       },
       "retries": 2,
       "on_success": "generate_report",
@@ -490,7 +491,8 @@
         "step_name": "adjust"
       },
       "capture": {
-        "experiment_results": "${{ result.results_path }}"
+        "experiment_results": "${{ result.results_path }}",
+        "group_manifest": "${{ result.group_manifest }}"
       },
       "on_success": "check_run_fix_loop",
       "on_failure": "ensure_results",
@@ -567,7 +569,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
@@ -583,7 +585,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report"
       },
@@ -884,7 +886,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'",
+        "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "re_generate_report"
       },

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -457,6 +457,7 @@ steps:
       step_name: run_experiment
     capture:
       experiment_results: "${{ result.results_path }}"
+      group_manifest: "${{ result.group_manifest }}"
     retries: 2
     on_success: generate_report
     on_failure: troubleshoot_run_failure
@@ -495,6 +496,7 @@ steps:
       step_name: adjust
     capture:
       experiment_results: "${{ result.results_path }}"
+      group_manifest: "${{ result.group_manifest }}"
     on_success: check_run_fix_loop
     on_failure: ensure_results
     on_context_limit: ensure_results
@@ -561,7 +563,7 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'"
+      skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: generate_report
     capture:
@@ -575,7 +577,7 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'"
+      skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: generate_report
     capture:
@@ -864,7 +866,7 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}'"
+      skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: re_generate_report
     capture:

--- a/src/autoskillit/skills/close-kitchen/SKILL.md
+++ b/src/autoskillit/skills/close-kitchen/SKILL.md
@@ -11,6 +11,8 @@ Call the `close_kitchen` MCP tool to hide all 24 kitchen tools for this session.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Skip calling `close_kitchen` and assume the kitchen is already closed
 - Call this skill from a headless or automated session (it is human-only)
 

--- a/src/autoskillit/skills/open-kitchen/SKILL.md
+++ b/src/autoskillit/skills/open-kitchen/SKILL.md
@@ -11,6 +11,8 @@ Call the `open_kitchen` MCP tool to reveal all 24 kitchen tools for this session
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Skip calling `open_kitchen` and assume the kitchen is already open
 - Call this skill from a headless or automated session (it is human-only)
 

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -218,6 +218,8 @@ When the user provides **more than one issue or task** in a single request:
    Present exactly **two options**. Nothing else.
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Claim "the recipe handles one issue at a time" — each pipeline instance is fully
   independent (separate clones, branches, PRs). Parallel execution is fully supported.
 - Suggest switching to `implementation-groups` — that recipe is for coordinated

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -25,6 +25,8 @@ complexity, and produce machine-readable output for the `merge-prs` recipe.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Merge, close, or modify any PR
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/merge-prs/` directory

--- a/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Include internal implementation details (that's for other lenses)
 - Show runtime behavior or state transitions

--- a/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Conflate with general process flow (that's a different lens)
 - Ignore thread safety implications

--- a/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Focus on runtime behavior (that's process flow lens)
 - Show static structure without data context

--- a/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Include code-level details
 - Show internal logic

--- a/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Include runtime architecture details
 - Show business logic

--- a/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Show happy path details (that's process flow lens)
 - Ignore validation and fail-fast patterns

--- a/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Include runtime behavior details
 - Show external system integrations in detail

--- a/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Include internal implementation details
 - Show code-level patterns

--- a/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Include static structure details (that's C4 lens)
 - Show data storage details (that's data lineage lens)

--- a/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Focus on data flow (that's data lineage lens)
 - Include business logic details

--- a/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Show internal component details
 - Include all possible scenarios (pick key ones)

--- a/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Expose actual secrets or credentials
 - Show implementation details that could aid attacks

--- a/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
@@ -28,6 +28,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Show business logic details
 - Focus on data content (focus on mutation rules)

--- a/src/autoskillit/skills_extended/audit-arch/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-arch/SKILL.md
@@ -22,6 +22,8 @@ Audit the codebase for adherence to architectural standards and rules.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Update an existing report - always generate new
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/audit-bugs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-bugs/SKILL.md
@@ -28,6 +28,8 @@ The user may provide a "since" date (e.g., `2/7`, `2026-02-07`, `last week`). If
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-bugs/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -39,6 +39,8 @@ comments and emits a verdict for recipe routing.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-claims/`
 - Approve a PR that has `changes_requested` findings
 - Post review comments when `gh` is unavailable — output `verdict=approved` and exit 0

--- a/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
@@ -26,6 +26,8 @@ Audit the codebase for internal cohesion: how well components integrate and main
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Update an existing report — always generate new
 - Duplicate findings that belong in audit-arch (rule violations)

--- a/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
@@ -26,6 +26,8 @@ Standards are added here when `/autoskillit:design-guards` recommends them and t
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Update an existing report - always generate new
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/audit-docs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-docs/SKILL.md
@@ -27,6 +27,8 @@ Audit all documentation sources for drift, staleness, and inconsistency against 
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source files
 - Update an existing report — always generate a new one
 - Compare doc-to-doc without first grounding claims in actual code behavior

--- a/src/autoskillit/skills_extended/audit-feature-gates/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-feature-gates/SKILL.md
@@ -34,6 +34,8 @@ to enumerate features.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-feature-gates/`
 - Issue subagent Task calls sequentially — ALL 6 must be in a single parallel message

--- a/src/autoskillit/skills_extended/audit-friction/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-friction/SKILL.md
@@ -28,6 +28,8 @@ The user may provide a "since" date (e.g., `2/7`, `2026-02-07`, `last month`). I
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-friction/` directory
 - Have subagents write files — they return all findings in response text only

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -46,6 +46,8 @@ requirements, scope creep, and unexpected changes. Produces a GO or NO GO verdic
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify source files, plan files, or any other files — read-only audit only
 - Run tests — this skill audits, it does not fix
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-impl/`

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -35,6 +35,8 @@ implemented. Identify review debt before it compounds.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `${AUTOSKILLIT_TEMP}/audit-review-decisions/`
 - Have triage or validation subagents make GitHub API calls (local data only for Step 2)
 - Post duplicate `[AUDIT]` markers — check for existing marker before posting

--- a/src/autoskillit/skills_extended/audit-tests/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-tests/SKILL.md
@@ -24,6 +24,8 @@ Audit the test suite to identify useless tests, consolidation opportunities, qua
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source or test code files
 - Flag tests as useless without reading and understanding them
 - Recommend removing tests that guard against real regressions

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -35,6 +35,8 @@ Space-separated issue numbers (required, minimum 2), plus optional flags:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/build-execution-map/` directory (relative to the current working directory)
 - Assume issues are independent without analysis

--- a/src/autoskillit/skills_extended/bundle-local-report/SKILL.md
+++ b/src/autoskillit/skills_extended/bundle-local-report/SKILL.md
@@ -13,6 +13,7 @@ mermaid diagrams and inserted plot images from `yaml:figure-spec` blocks.
 **NEVER:**
 - Raise a fatal error on missing diagrams or missing visualization-plan — log and continue.
 - Use the ESM mermaid build — ESM triggers CORS under `file://`; always use the UMD bundle (`mermaid.min.js`).
+- Fabricate HTML rendering details or attribute explanations when the bundling process produces unexpected output — describe what was actually produced rather than inventing plausible rendering behavior.
 - Exit without emitting `html_path = ` (even empty) as your final output — the recipe `capture:` block expects it.
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/collapse-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/collapse-issues/SKILL.md
@@ -49,6 +49,8 @@ Grouping analysis is performed as in-context LLM reasoning. No parallel sessions
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Close original issues before the combined issue is successfully created
 - Apply `batch:N` labels to combined or original issues
 - Collapse issues with different `recipe:*` labels into one combined issue

--- a/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
@@ -37,6 +37,7 @@ Does NOT invoke lens skills or other sub-skills.
 - Auto-merge or approve the PR — research PRs are for human review only
 - Fail the pipeline when `gh` is not accessible — emit `pr_url = ` (empty string) and return
 - Create files outside `{{AUTOSKILLIT_TEMP}}/compose-research-pr/` (relative to the current working directory)
+- Fabricate diagram descriptions or validation conclusions not present in the source files — report what the files actually contain, not what you assume they should contain
 - Invent mermaid classDef colors — when embedding validated diagrams, include them verbatim.
   Using ONLY classDef styles from the mermaid skill when composing the PR body.
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/design-guards/SKILL.md
+++ b/src/autoskillit/skills_extended/design-guards/SKILL.md
@@ -27,6 +27,8 @@ Path to a bug pattern audit report (typically under `{{AUTOSKILLIT_TEMP}}/audit-
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Propose bandaid fixes or direct-only patches
 - Create files outside `{{AUTOSKILLIT_TEMP}}/design-guards/` directory

--- a/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
+++ b/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
@@ -33,6 +33,8 @@ before routing to `resolve-failures`.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Run the test suite
 - Write files outside `{{AUTOSKILLIT_TEMP}}/diagnose-ci/`

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -34,6 +34,8 @@ The plan file must remain a **clean, self-contained implementation instruction s
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Implement any part of the plan
 - Add backward compatibility to the plan

--- a/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
@@ -25,6 +25,8 @@ Elaborate a single phase from a high-level migration plan into a complete, self-
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Implement any part of the plan
 - Add backward compatibility to the plan (unless a cleanup phase explicitly removes it)

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -222,6 +222,8 @@ After processing all candidates, emit to stdout:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Edit an issue body without first fetching its current content immediately before
   the edit
 - Force requirements when the issue is too vague — comment and move on

--- a/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-benchmark-representativeness/`

--- a/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-causal-assumptions/`

--- a/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code or experiment files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Accept at face value that baselines received symmetric treatment

--- a/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Accept default alpha=0.05 without checking whether it is appropriate for the decision context

--- a/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code or experiment files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-estimand-clarity/`

--- a/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-exploratory-confirmatory/`
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-fair-comparison/`

--- a/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-governance-risk/`
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Recommend one-factor-at-a-time exploration when interactions are plausible
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-iterative-learning/`

--- a/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code or experimental artifacts
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-measurement-validity/`

--- a/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-pipeline-integrity/`

--- a/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Assume comparability without tracing its source
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-randomization-blocking/`

--- a/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-reproducibility-artifacts/`

--- a/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code or experiment files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Treat "untested" as equivalent to "robust"

--- a/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
@@ -39,6 +39,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Accept a "pass" result without asking what a false result would have looked like under this design
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-severity-testing/`

--- a/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-unit-interference/`

--- a/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-validity-threats/`
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
@@ -40,6 +40,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-variance-stability/`

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -96,6 +96,8 @@ issue_count = 0
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Use `gh issue comment` — all issue content goes in the body via `--body-file`
 - Create issues individually via REST — always batch via GraphQL `createIssue` mutations
 - Skip the 1-second sleep between consecutive mutating GitHub API calls

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -31,6 +31,7 @@ results are valid findings, not failures.
 /autoskillit:generate-report {worktree_path} {results_path} [--inconclusive]
 [--output-mode {local|pr}] [--issue-url {url}]
 [--experiment-type {type}] [--methodology-traditions {tradition}]
+[--group-manifest {path}]
 ```
 
 - `{worktree_path}` — Absolute path to the worktree (required). First path-like
@@ -55,6 +56,10 @@ results are valid findings, not failures.
 - `--disambiguation-rule-applied {rule}` — Optional. Disambiguation rule applied during Tier-C routing.
 - `--tier-c-lens {lens}` — Optional. Tier-C vis-lens selected.
 - `--classification-timestamp {timestamp}` — Optional. UTC timestamp of design classification.
+- `--group-manifest {path}` — Optional. Absolute path to a JSON file containing
+  per-group experiment metadata (group names, completion status, result file paths).
+  When provided, the report enumerates all groups and their status before presenting
+  detailed findings.
 
 ## Inputs
 
@@ -69,6 +74,7 @@ In addition to the arguments above, this skill reads from the worktree:
 **NEVER:**
 - Modify source code files outside the `research/` directory
 - Fabricate or embellish results — report exactly what was measured
+- Attribute missing data to "time constraints", "resource limitations", or other invented explanations not present in the results file. When data is absent, state the factual status: what is present, what is absent, and if the results file does not explain why, state "reason not recorded in results."
 - Omit the methodology section — reproducibility requires it
 - Frame inconclusive results as failures — they are valid findings
 - Create the report outside the worktree's `research/` directory
@@ -111,6 +117,11 @@ Read all available artifacts from the worktree:
    section of the report.
 6. Experiment code: scan the worktree for scripts, fixtures, and tools
    added during implementation
+7. Group manifest: if `--group-manifest {path}` is provided, read it to determine
+   how many experiment groups were defined and their individual completion status.
+   Cross-reference group names against the results file to determine per-group
+   outcome: completed, partially completed, skipped, blocked, or not attempted.
+   In the Results section, report per-group status before presenting detailed findings.
 
 ### Step 1.5 — Inject Issue Reference Header (local mode only)
 
@@ -227,8 +238,6 @@ research/YYYY-MM-DD-{slug}/
 
 The `{slug}` is a kebab-case summary of the research topic (max 40 chars).
 
-<<<<<<< HEAD
-=======
 Write a YAML frontmatter block (fenced with `---`) at the very top of report.md,
 before the title heading. Use the values from `--experiment-type` and
 `--methodology-traditions` flags. If a flag is absent or its value is the literal
@@ -236,7 +245,6 @@ string `null`, write the key with value `null` (not omitted). Always include
 `generated_at`. If `--output-mode local` with `--issue-url`, the issue blockquote
 goes AFTER the frontmatter, before the title.
 
->>>>>>> b64b32f7 (fix(review): align --methodology-tradition synopsis to plural form)
 The report structure:
 
 ```markdown

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -40,6 +40,8 @@ tokens after the skill name for the first path-like token (starts with `/`,
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Implement without first exploring affected systems with subagents
 - Implement in the main working directory (always use the worktree)
 - Force push or perform destructive git operations

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -28,6 +28,8 @@ The worktree is left intact for the orchestrator to test and merge separately.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Implement without first exploring affected systems with subagents
 - Implement in the main working directory (always use the worktree)
 - Force push or perform destructive git operations

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -27,6 +27,8 @@ Implement a provided plan in an isolated git worktree branched from the current 
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Implement without first exploring affected systems with subagents
 - Implement in the main working directory (always use the worktree)
 - Force push or perform destructive git operations

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -67,6 +67,8 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Suggest backward compatibility solutions
 - Suggest fallbacks that hide errors

--- a/src/autoskillit/skills_extended/issue-splitter/SKILL.md
+++ b/src/autoskillit/skills_extended/issue-splitter/SKILL.md
@@ -41,6 +41,8 @@ This skill is intentionally lightweight: concern analysis is performed as in-con
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Use subagents — concern analysis is in-context LLM reasoning, not subagent delegation
 - Close the parent issue — it becomes a tracking issue
 - Apply `batch:N` labels to any GitHub object

--- a/src/autoskillit/skills_extended/make-arch-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/make-arch-diag/SKILL.md
@@ -34,6 +34,8 @@ Creates comprehensive architecture diagrams for selected components or systems u
 - Use consistent color coding across all diagrams
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create diagrams without understanding the code
 - Skip reading the actual implementation
 - Use generic placeholder names

--- a/src/autoskillit/skills_extended/make-campaign/SKILL.md
+++ b/src/autoskillit/skills_extended/make-campaign/SKILL.md
@@ -27,6 +27,8 @@ Guides users through a 6-phase interactive workflow to decompose a campaign goal
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify or write to any source code files
 - Create files outside `.autoskillit/recipes/campaigns/` (final output) or `{{AUTOSKILLIT_TEMP}}/make-campaign/` (temp/validation drafts)
 - Write the final campaign YAML without first passing `validate_recipe` in Phase 5

--- a/src/autoskillit/skills_extended/make-experiment-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/make-experiment-diag/SKILL.md
@@ -26,6 +26,8 @@ Select the right experimental design lens for your analysis. Each lens asks one 
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Skip the selection step — always confirm which lens to use
 - Modify any source code or experimental artifacts
 - Combine multiple lenses in a single invocation

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -52,6 +52,8 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/make-groups/` directory
 - Drop, split, or rewrite requirements — reference them by original ID

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -198,6 +198,8 @@ Before writing the final plan, verify:
 - Justifications based on effort, risk, or preserving existing code
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Change any code
 - Choose an approach because it's easier
 - Reject an approach because it's harder

--- a/src/autoskillit/skills_extended/make-req/SKILL.md
+++ b/src/autoskillit/skills_extended/make-req/SKILL.md
@@ -30,6 +30,8 @@ Decompose a task, plan, roadmap, or feature description into a structured set of
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/make-req/` directory
 - Prescribe implementation approaches or libraries in requirements

--- a/src/autoskillit/skills_extended/merge-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/merge-pr/SKILL.md
@@ -34,6 +34,8 @@ conflicts from earlier merges in the queue.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files directly (conflict resolution is handled by `make-plan` + `implement-worktree-no-merge`)
 - Use `git merge` to merge the PR into the integration branch — always use `gh pr merge --squash --auto` (when `autoMergeAllowed=true`) or `gh pr merge --squash` (when `autoMergeAllowed=false`)
 - Close or comment on the PR

--- a/src/autoskillit/skills_extended/mermaid/SKILL.md
+++ b/src/autoskillit/skills_extended/mermaid/SKILL.md
@@ -30,6 +30,8 @@ Create professional, color-coded mermaid diagrams with consistent styling for ar
 - Apply class styling to all nodes
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Use inline styles (use classDef instead)
 - Create diagrams without color coding
 - Omit the color legend

--- a/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
+++ b/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
@@ -32,6 +32,8 @@ The orchestrator provides all context in the prompt:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify the original script file directly
 - Skip validation via validate_recipe
 - Apply changes without checking if the pattern exists in the script

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -46,6 +46,8 @@ PR, and output `pr_url=<url>`.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `{{AUTOSKILLIT_TEMP}}/open-integration-pr/` (except the temp body file for `gh pr create --body-file`)
 - Modify any source code
 - Fail the pipeline if `gh` is unavailable or not authenticated — output `pr_url=` (empty) and exit successfully

--- a/src/autoskillit/skills_extended/pipeline-summary/SKILL.md
+++ b/src/autoskillit/skills_extended/pipeline-summary/SKILL.md
@@ -34,6 +34,8 @@ and a PR from the feature branch into the target branch.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Fail the pipeline if `gh` is not available or not authenticated — write a local summary instead
 - Create empty issues or PRs (skip if no bugs to report)
 - Modify any source code — this skill only creates GitHub artifacts and a summary file

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -47,6 +47,7 @@ incorporate the feedback before writing the plan.
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/plan-experiment/` directory
 - Write implementation code — this skill produces a plan only
+- Fabricate feasibility justifications or causal mechanism explanations when evidence is insufficient — state what is unknown and why rather than inventing plausible-sounding explanations
 - Skip the threats-to-validity section
 - Leave success criteria vague — every criterion must be measurable
 - Omit the environment assessment — always explicitly state whether a custom

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -36,6 +36,7 @@ outputs, and synthesizes a complete visualization plan.
 - Run vis-lens calls across multiple assistant messages — all selected lens calls must
   appear in a SINGLE assistant message to execute in parallel
 - Write outputs outside `{{AUTOSKILLIT_TEMP}}/plan-visualization/`
+- Fabricate lens recommendations or validation conclusions not supported by the data — report what the experiment plan and scope show, not what you assume they should show
 - Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/planner-analyze/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-analyze/SKILL.md
@@ -27,6 +27,8 @@ Detect language, framework, test infrastructure, project structure, and existing
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any target project files
 - Write analysis.json outside `$1/`
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
@@ -28,6 +28,8 @@ writes `review_approach_assessment.json` to the planner directory. Does NOT invo
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Invoke `review-approach` — this skill performs assessment only
 - Write output outside `$2/`
 - Modify input files

--- a/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
@@ -38,6 +38,8 @@ merging).
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Merge WPs from different assignments unless they have a direct dependency linking them
 - Create a merged group that would clearly exceed a medium-complexity PR (use judgment — no hard threshold)
 - Skip a WP from a manifest — every WP must appear in exactly one group (singleton = no-op)

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -26,6 +26,8 @@ is the sole writer for this phase's assignments — no concurrent write races.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Allow L0 subagents to write files directly — L0s return JSON only
 - Let an L0 failure abort the phase — always write a stub and continue
 - Write output outside `$2/assignments/`

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -33,6 +33,8 @@ independently and writes a single elaborated phase result. No dependency on
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Write output outside `$3/`
 - Read any `*_result.json` file from other phases (you have only the snapshot)
 - Require or read a context file from `check_remaining`

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -26,6 +26,8 @@ is the sole writer for this phase's WPs — no concurrent write races.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Allow L0 subagents to write files directly — L0s return JSON only
 - Let an L0 failure abort the phase — always write a stub and continue
 - Write output outside `$2/work_packages/`

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -28,6 +28,8 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any target project files
 - Abort the calling recipe on failure — log a warning and return gracefully
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/planner-reconcile-deps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-reconcile-deps/SKILL.md
@@ -34,6 +34,8 @@ spawning parallel sessions.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Load full WP result files — only `wp_index.json` (the compact array)
 - Spawn additional sessions — this skill must run as a single session for holistic reasoning
 - Write output outside `{$1}/`

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -40,6 +40,8 @@ file to `$3/refine_contexts/{phase_id}_result.json`.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Write any file outside `$3/`
 - Directly modify the context file ($1) — always write a new result file
 - Allow an L0 subagent to write files directly (L0s return structured text only)

--- a/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
@@ -33,6 +33,8 @@ conflicts, applies field-level edits to the plan, and writes `refined_plan.json`
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Write any file outside `$2/`
 - Directly modify the combined_plan.json ($1) — always write a new refined_plan.json
 - Allow an L0 subagent to write files directly (L0s return structured text only)

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -37,6 +37,8 @@ suggestions, resolves conflicts, and writes `refined_wps.json`.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Write any file outside `$4/`
 - Directly modify `combined_wps.json` ($1) — always write a new `refined_wps.json`
 - Allow an L0 subagent to write files directly (L0s return structured text only)

--- a/src/autoskillit/skills_extended/planner-refine/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine/SKILL.md
@@ -34,6 +34,8 @@ retries) before escalation.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Attempt to auto-fix missing assignments or missing WPs — these require human review
 - Remove a deliverable without reassigning it to another WP
 - Introduce new WP IDs — the skill never creates WPs; it repairs or escalates existing ones

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -27,6 +27,8 @@ zero findings.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Block the pipeline — all findings are `warning` severity
 - Write output outside `$3/`
 - Read files not passed as arguments

--- a/src/autoskillit/skills_extended/prepare-issue/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-issue/SKILL.md
@@ -408,6 +408,8 @@ gh issue edit {issue_number} --add-label "{issue_type}"
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create or modify GitHub issues without explicit user intent
 - Apply labels not in the defined set (`recipe:implementation`, `recipe:remediation`, `bug`, `enhancement`)
 - Skip the dedup check when creating a new issue (unless `--issue N` is provided)

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -33,6 +33,8 @@ in the decomposed PR flow (prepare → run_arch_lenses → compose).
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Invoke arch-lens skills or any other sub-skills
 - Create files outside `{{AUTOSKILLIT_TEMP}}/prepare-pr/`
 - Fail if closing_issue is absent or gh is unavailable — degrade gracefully

--- a/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
@@ -33,6 +33,8 @@ Does NOT invoke any exp-lens skills or create a PR.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Invoke exp-lens skills — they are run in separate sessions by the recipe orchestrator
 - Create files outside `{{AUTOSKILLIT_TEMP}}/prepare-research-pr/` (relative to the current working directory)
 - Fail silently — always emit all three output tokens as your final output

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -26,6 +26,8 @@ issues upfront, load recipe, execute session, collect result, report.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `{{AUTOSKILLIT_TEMP}}/process-issues/` directory
 - Apply `batch:N` labels to GitHub issues (batch assignments are internal — they live only
   in the manifest JSON, not on GitHub objects)

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -34,6 +34,8 @@ and creates a comprehensive promotion PR.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `{{AUTOSKILLIT_TEMP}}/promote-to-main/`
 - Modify any source code — this skill is read-only analysis + PR creation
 - Fail silently when `gh` is unavailable — output `pr_url = ` (empty) and exit successfully

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -34,6 +34,8 @@ Do not change any code.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Propose bandaid fixes, fallbacks, or direct-only fixes
 - Suggest backward compatibility shims

--- a/src/autoskillit/skills_extended/reload-session/SKILL.md
+++ b/src/autoskillit/skills_extended/reload-session/SKILL.md
@@ -21,6 +21,8 @@ restored.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Skip running `/exit` after `reload_session` — the reload does not happen until claude exits
 - Call this skill from a headless or automated session
 

--- a/src/autoskillit/skills_extended/report-bug/SKILL.md
+++ b/src/autoskillit/skills_extended/report-bug/SKILL.md
@@ -29,6 +29,8 @@ Report output path: /absolute/path/to/report.md
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files other than the specified report output path
 - Spawn subagents or Agent tool calls

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -38,6 +38,8 @@ Called by the research recipe when `audit_claims` routes `changes_requested` via
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Merge or push the branch — the recipe's `re_push_research` step handles push
 - Dismiss review threads without addressing the underlying comment
 - Create files outside `{{AUTOSKILLIT_TEMP}}/resolve-claims-review/`

--- a/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
@@ -35,6 +35,8 @@ MCP-only — not user-invocable directly.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `{{AUTOSKILLIT_TEMP}}/resolve-design-review/`
 - Modify the evaluation dashboard, experiment plan, or any source file
 - Apply fixes — this skill triages fixability only

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -27,6 +27,8 @@ Fix test failures in a worktree implemented by `/autoskillit:implement-worktree-
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Merge if ANY test fails
 - Merge via `merge_worktree` or any other mechanism
 - Call `merge_worktree` MCP tool

--- a/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
@@ -25,6 +25,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Run the full test suite — that is the pipeline `test` step's responsibility; tests already passed before `merge_to_integration` was attempted
 - Attempt partial resolution when any conflict file is LOW confidence — abort and escalate instead
 - Leave unresolved conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in any file

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -37,6 +37,8 @@ Bounded by `retries: 2` — on exhaustion routes to `research_complete`.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Merge or push the branch — the recipe's `re_push_research` step handles push
 - Dismiss review threads without addressing the underlying comment
 - Create files outside `{{AUTOSKILLIT_TEMP}}/resolve-research-review/`

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -38,6 +38,8 @@ branch already checked out.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `{{AUTOSKILLIT_TEMP}}/resolve-review/`
 - Merge, push, or call `merge_worktree`
 - Fix issues beyond the explicit scope of the reviewer's comments

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -32,6 +32,8 @@ Continue implementing a plan in an **existing** git worktree. This skill is used
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create a new worktree — the worktree already exists
 - Re-run worktree setup (e.g. `task install-worktree`) unless the environment is missing/broken
 - Re-explore systems that were already explored (skip Step 2 of implement-worktree)

--- a/src/autoskillit/skills_extended/review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/review-approach/SKILL.md
@@ -24,6 +24,8 @@ Research modern solutions, approaches, and strategies relevant to the issues or 
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/review-approach/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -35,6 +35,8 @@ best available plan.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify the plan file, any source code, or any file outside `{{AUTOSKILLIT_TEMP}}/review-design/`
 - Halt the pipeline for a REVISE verdict — emit the verdict and let the recipe route
 - Proceed to Level 2, 3, or 4 analysis when any Level 1 finding is classified as

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -38,6 +38,8 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `{{AUTOSKILLIT_TEMP}}/review-pr/`
 - Approve a PR that has `changes_requested` findings
 - Post review comments when `gh` is unavailable — output `verdict=approved` and exit 0

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -34,6 +34,8 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create files outside `{{AUTOSKILLIT_TEMP}}/review-research-pr/`
 - Approve a PR that has `changes_requested` findings
 - Post review comments when `gh` is unavailable — output `verdict=approved` and exit 0

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -44,6 +44,8 @@ plan, executes what the plan describes, and reports what happened.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify files outside the worktree
 - Merge the worktree — leave it intact for the orchestrator
 - Skip result collection — every run must produce structured output

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -236,7 +236,29 @@ the final conclusions.}
    for `generate-report` to read. Final results are published to `research/` by
    the `generate-report` skill.
 
-After saving, emit the structured output token as the very last line of your
+### Step 5b — Produce Group Manifest
+
+1. Read the experiment plan from `{{AUTOSKILLIT_TEMP}}/experiment-plan.md` to determine
+   how many groups were defined (if any).
+2. Cross-reference the experiment plan's group definitions against the results file
+   to determine each group's status: `completed`, `partially_completed`, `skipped`,
+   `blocked`, or `not_attempted`.
+3. Save a JSON manifest to:
+   `{{AUTOSKILLIT_TEMP}}/run-experiment/group_manifest.json`
+   with structure:
+   ```json
+   {
+     "total_groups": N,
+     "groups": [
+       {"name": "groupA", "status": "completed", "results_section": "line range or null"},
+       {"name": "groupB", "status": "not_attempted", "results_section": null}
+     ]
+   }
+   ```
+   If the experiment plan does not define multiple groups, emit a manifest with
+   `total_groups: 1` and a single entry.
+
+After saving, emit the structured output tokens as the very last line of your
 text output:
 
 > **IMPORTANT:** Emit the structured output tokens as **literal plain text with no
@@ -246,6 +268,7 @@ text output:
 
 ```
 results_path = {absolute_path_to_results_file}
+group_manifest = {absolute_path_to_group_manifest_json}
 ```
 
 **When pre-flight blocks hypotheses due to missing planned data:**

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -48,6 +48,7 @@ text is supplementary context.
 - Create files outside `{{AUTOSKILLIT_TEMP}}/scope/` directory
 - Propose solutions or write implementation code
 - Skip the prior art survey — always check what already exists in the codebase
+- Fabricate research findings when external sources return no results — if web searches or literature searches yield nothing, state that explicitly and note what the codebase evidence shows instead
 - Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/setup-environment/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-environment/SKILL.md
@@ -36,6 +36,8 @@ PASS and WARN proceed to `decompose_phases`; FAIL escalates immediately.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify the experiment plan
 - Write files outside `{{AUTOSKILLIT_TEMP}}/setup-environment/`
 - Skip the Docker availability probe before attempting a build

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -32,6 +32,8 @@ Explore a target project and generate tailored recipes and AutoSkillit config th
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any files in the target project without user confirmation at the summary gate
 - Run commands that change the target project
 - Create files outside `{{AUTOSKILLIT_TEMP}}/setup-project/` directory (until the summary gate)

--- a/src/autoskillit/skills_extended/smoke-task/SKILL.md
+++ b/src/autoskillit/skills_extended/smoke-task/SKILL.md
@@ -26,6 +26,8 @@ arbitrary tasks and produce capturable outputs. Not for production pipeline use.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Use this skill outside of smoke-test pipeline execution
 - Ignore explicit output-line instructions (e.g. `key=value`) — they must be emitted exactly
 

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -42,6 +42,8 @@ compute on doomed downloads.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify the experiment plan
 - Modify any source files
 - Write files outside `{{AUTOSKILLIT_TEMP}}/stage-data/`

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -25,6 +25,8 @@ Analyze open GitHub issues, classify each into a recipe route, group them into p
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create or edit Python, YAML, or config files
 - Guess recipe classification when confidence is low — escalate to user

--- a/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
@@ -35,6 +35,7 @@ Called by the `research` recipe on `implement_phase` failure before routing to
 - Modify any source code files
 - Run tests
 - Write files outside `{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment/`
+- Fabricate or invent causes for failures when log data is insufficient to determine a root cause — state "cause undetermined from available logs" rather than inferring probable causes
 - Abort when session data is missing — emit `failure_type=unknown`, `is_fixable=false` and exit cleanly
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -49,6 +49,8 @@ validated report carries a `validated: true` marker to signal downstream process
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `$AUDIT_BASE_DIR/` (the per-run directory set in Step 5)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message

--- a/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
@@ -47,6 +47,8 @@ severities. The validated report carries a `validated: true` marker to signal do
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside `$AUDIT_BASE_DIR/` (the per-run directory set in Step 5)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -42,6 +42,8 @@ signal downstream processing.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Create files outside the per-run output directory (`{{AUTOSKILLIT_TEMP}}/validate-audit-{YYYY-MM-DD_HHMMSS}/`)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message

--- a/src/autoskillit/skills_extended/verify-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/verify-diag/SKILL.md
@@ -24,6 +24,8 @@ Verify an architecture diagram's factual accuracy against the actual codebase. A
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify source code files
 - Modify the diagram during verification (report findings only)
 - Run subagents in the background (`run_in_background: true` is prohibited)

--- a/src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
@@ -41,6 +41,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-always-on/`

--- a/src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
@@ -62,6 +62,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-antipattern/`

--- a/src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
@@ -44,6 +44,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-caption-annot/`

--- a/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
@@ -94,6 +94,8 @@ metadata:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-chart-select/`

--- a/src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
@@ -43,6 +43,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-color-access/`

--- a/src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
@@ -43,6 +43,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-figure-table/`

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -195,6 +195,8 @@ when a tradition is loaded (either via `tradition_slug` or via `classify_methodo
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/`

--- a/src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
@@ -42,6 +42,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-multi-compare/`

--- a/src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
@@ -44,6 +44,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-reproducibility/`

--- a/src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
@@ -43,6 +43,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-story-arc/`

--- a/src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
@@ -43,6 +43,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-temporal/`

--- a/src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md
@@ -41,6 +41,8 @@ hooks:
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-uncertainty/`

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -30,6 +30,8 @@ No positional arguments. The skill prompts interactively for workflow details.
 ## Critical Constraints
 
 **NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+
 - Create SKILL.md files (not in `.claude/commands/`, `.claude/skills/`, or anywhere else)
 - Create Markdown companion files alongside the YAML script
 - Create files outside `.autoskillit/recipes/` directory

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -90,3 +90,26 @@ def make_dynaconf_and_automation_config():
     from autoskillit.config._config_loader import _make_dynaconf
 
     return _make_dynaconf, AutomationConfig
+
+
+def extract_never_block(skill_text: str) -> str:
+    """Extract the NEVER block from a SKILL.md text.
+
+    Finds the line starting with **NEVER:** or **NEVER** and collects all
+    subsequent ``- `` list items until the next ``**`` header or end of text.
+    Returns the raw text of the NEVER block (may be empty string if not found).
+    """
+    import re
+
+    never_match = re.search(r"(?m)^\*\*NEVER(?::\*\*|\*\*)\s*$", skill_text)
+    if not never_match:
+        return ""
+    start = never_match.end()
+    next_header = re.search(r"(?m)^\*\*[A-Z][^\n]*\*\*", skill_text[start:])
+    if next_header:
+        end = start + next_header.start()
+    else:
+        end = len(skill_text)
+    block = skill_text[start:end]
+    lines = [line for line in block.splitlines() if line.strip().startswith("- ")]
+    return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,12 +504,11 @@ def _extract_never_block(skill_text: str) -> str:
     """
     import re
 
-    never_match = re.search(r"(?m)^\*{0,2}NEVER:\*{0,2}\s*$", skill_text)
+    never_match = re.search(r"(?m)^\*\*NEVER(?::\*\*|\*\*)\s*$", skill_text)
     if not never_match:
         return ""
     start = never_match.end()
-    # Find the next ** header or end of text
-    next_header = re.search(r"(?m)^\*{0,2}[A-Z][^\n]*\*{0,2}:", skill_text[start:])
+    next_header = re.search(r"(?m)^\*\*[A-Z][^\n]*\*\*", skill_text[start:])
     if next_header:
         end = start + next_header.start()
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -490,6 +490,41 @@ def pytest_configure(config: pytest.Config) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Shared SKILL.md helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_never_block(skill_text: str) -> str:
+    """Extract the NEVER block from a SKILL.md text.
+
+    Finds the line starting with **NEVER:** or **NEVER** and collects all
+    subsequent ``- `` list items until the next ``**`` header or end of text.
+    Returns the raw text of the NEVER block (may be empty string if not found).
+    """
+    import re
+
+    never_match = re.search(r"(?m)^\*{0,2}NEVER\*{0,2}:\s*$", skill_text)
+    if not never_match:
+        return ""
+    start = never_match.end()
+    # Find the next ** header or end of text
+    next_header = re.search(r"(?m)^\*{0,2}[A-Z][^\n]*\*{0,2}:", skill_text[start:])
+    if next_header:
+        end = start + next_header.start()
+    else:
+        end = len(skill_text)
+    block = skill_text[start:end]
+    # Collect only - prefixed lines
+    lines = [line for line in block.splitlines() if line.strip().startswith("- ")]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
 @functools.lru_cache(maxsize=1)
 def _resolve_test_config() -> "AutomationConfig | None":
     """Resolve full config for test collection via full config resolution.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,7 +504,7 @@ def _extract_never_block(skill_text: str) -> str:
     """
     import re
 
-    never_match = re.search(r"(?m)^\*{0,2}NEVER\*{0,2}:\s*$", skill_text)
+    never_match = re.search(r"(?m)^\*{0,2}NEVER:\*{0,2}\s*$", skill_text)
     if not never_match:
         return ""
     start = never_match.end()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -491,35 +491,6 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Shared SKILL.md helpers
-# ---------------------------------------------------------------------------
-
-
-def _extract_never_block(skill_text: str) -> str:
-    """Extract the NEVER block from a SKILL.md text.
-
-    Finds the line starting with **NEVER:** or **NEVER** and collects all
-    subsequent ``- `` list items until the next ``**`` header or end of text.
-    Returns the raw text of the NEVER block (may be empty string if not found).
-    """
-    import re
-
-    never_match = re.search(r"(?m)^\*\*NEVER(?::\*\*|\*\*)\s*$", skill_text)
-    if not never_match:
-        return ""
-    start = never_match.end()
-    next_header = re.search(r"(?m)^\*\*[A-Z][^\n]*\*\*", skill_text[start:])
-    if next_header:
-        end = start + next_header.start()
-    else:
-        end = len(skill_text)
-    block = skill_text[start:end]
-    # Collect only - prefixed lines
-    lines = [line for line in block.splitlines() if line.strip().startswith("- ")]
-    return "\n".join(lines)
-
-
-# ---------------------------------------------------------------------------
 # Config resolution
 # ---------------------------------------------------------------------------
 

--- a/tests/contracts/test_generate_report_contracts.py
+++ b/tests/contracts/test_generate_report_contracts.py
@@ -99,6 +99,8 @@ def test_generate_report_step25_no_host_venv() -> None:
 def test_multi_group_enumeration_instruction() -> None:
     """Step 1 must instruct agent to enumerate all experiment groups."""
     text = SKILL_PATH.read_text()
+    assert "### Step 1" in text, "generate-report SKILL.md must contain '### Step 1' heading"
+    assert "### Step 2" in text, "generate-report SKILL.md must contain '### Step 2' heading"
     step1 = text.split("### Step 1")[1].split("### Step 2")[0]
     assert "group" in step1.lower(), (
         "Step 1 must instruct agent to enumerate all experiment groups"
@@ -111,6 +113,7 @@ def test_anti_fabrication_never_rule() -> None:
 
     text = SKILL_PATH.read_text()
     never_block = _extract_never_block(text)
+    assert never_block, "no NEVER block found in generate-report SKILL.md"
     assert any(
         phrase in never_block.lower()
         for phrase in ["attribute missing data", "invented explanation", "time constraints"]

--- a/tests/contracts/test_generate_report_contracts.py
+++ b/tests/contracts/test_generate_report_contracts.py
@@ -109,10 +109,10 @@ def test_multi_group_enumeration_instruction() -> None:
 
 def test_anti_fabrication_never_rule() -> None:
     """NEVER block must prohibit fabricated explanations for absent data."""
-    from tests.conftest import _extract_never_block
+    from tests._helpers import extract_never_block
 
     text = SKILL_PATH.read_text()
-    never_block = _extract_never_block(text)
+    never_block = extract_never_block(text)
     assert never_block, "no NEVER block found in generate-report SKILL.md"
     assert any(
         phrase in never_block.lower()

--- a/tests/contracts/test_generate_report_contracts.py
+++ b/tests/contracts/test_generate_report_contracts.py
@@ -96,6 +96,47 @@ def test_generate_report_step25_no_host_venv() -> None:
     )
 
 
+def test_multi_group_enumeration_instruction() -> None:
+    """Step 1 must instruct agent to enumerate all experiment groups."""
+    text = SKILL_PATH.read_text()
+    step1 = text.split("### Step 1")[1].split("### Step 2")[0]
+    assert "group" in step1.lower(), (
+        "Step 1 must instruct agent to enumerate all experiment groups"
+    )
+
+
+def test_anti_fabrication_never_rule() -> None:
+    """NEVER block must prohibit fabricated explanations for absent data."""
+    from tests.conftest import _extract_never_block
+
+    text = SKILL_PATH.read_text()
+    never_block = _extract_never_block(text)
+    assert any(
+        phrase in never_block.lower()
+        for phrase in ["attribute missing data", "invented explanation", "time constraints"]
+    ), "NEVER block must prohibit fabricated explanations for absent data"
+
+
+def test_generate_report_group_manifest_input() -> None:
+    """generate-report contract must declare group_manifest as a required input."""
+    import yaml
+
+    contract_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "src"
+        / "autoskillit"
+        / "recipes"
+        / "contracts"
+        / "research.yaml"
+    )
+    manifest = yaml.safe_load(contract_path.read_text())
+    gen_report = manifest["skills"]["generate-report"]
+    input_names = [inp["name"] for inp in gen_report.get("inputs", [])]
+    assert "group_manifest" in input_names, (
+        "generate-report contract must declare group_manifest as an input"
+    )
+
+
 def test_generate_report_step25_uses_docker_run() -> None:
     """Step 2.5 must use docker run to execute visualization scripts."""
     text = SKILL_PATH.read_text()

--- a/tests/contracts/test_generate_report_contracts.py
+++ b/tests/contracts/test_generate_report_contracts.py
@@ -134,6 +134,10 @@ def test_generate_report_group_manifest_input() -> None:
     )
     manifest = yaml.safe_load(contract_path.read_text())
     assert isinstance(manifest, dict), f"research.yaml did not parse to a dict: {type(manifest)}"
+    assert "skills" in manifest, "research.yaml missing top-level 'skills' key"
+    assert "generate-report" in manifest["skills"], (
+        "research.yaml 'skills' missing 'generate-report' entry"
+    )
     gen_report = manifest["skills"]["generate-report"]
     input_names = [inp["name"] for inp in gen_report.get("inputs", [])]
     assert "group_manifest" in input_names, (

--- a/tests/contracts/test_generate_report_contracts.py
+++ b/tests/contracts/test_generate_report_contracts.py
@@ -133,6 +133,7 @@ def test_generate_report_group_manifest_input() -> None:
         / "research.yaml"
     )
     manifest = yaml.safe_load(contract_path.read_text())
+    assert isinstance(manifest, dict), f"research.yaml did not parse to a dict: {type(manifest)}"
     gen_report = manifest["skills"]["generate-report"]
     input_names = [inp["name"] for inp in gen_report.get("inputs", [])]
     assert "group_manifest" in input_names, (

--- a/tests/contracts/test_generate_report_contracts.py
+++ b/tests/contracts/test_generate_report_contracts.py
@@ -121,7 +121,7 @@ def test_anti_fabrication_never_rule() -> None:
 
 
 def test_generate_report_group_manifest_input() -> None:
-    """generate-report contract must declare group_manifest as a required input."""
+    """generate-report contract must declare group_manifest as an optional input."""
     import yaml
 
     contract_path = (

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -454,7 +454,7 @@ class TestGroupDApiContractPreservation:
         assert sig.parameters["session_id"].default is None
 
     def test_default_subprocess_runner_marker_params_after_max_extension(self):
-        """marker_dir/session_id appear after max_extension_seconds."""
+        """marker_dir/session_id appear after max_extension_seconds in DefaultSubprocessRunner."""
         sig = inspect.signature(DefaultSubprocessRunner.__call__)
         max_extension_idx = list(sig.parameters).index("max_extension_seconds")
         marker_dir_idx = list(sig.parameters).index("marker_dir")
@@ -463,7 +463,7 @@ class TestGroupDApiContractPreservation:
         assert session_id_idx == marker_dir_idx + 1
 
     def test_default_subprocess_runner_satisfies_protocol_with_marker_params(self):
-        """DefaultSubprocessRunner() satisfies SubprocessRunner protocol."""
+        """DefaultSubprocessRunner satisfies SubprocessRunner with marker_dir/session_id."""
         from autoskillit.core.types import SubprocessRunner
 
         runner = DefaultSubprocessRunner()

--- a/tests/contracts/test_run_experiment_contracts.py
+++ b/tests/contracts/test_run_experiment_contracts.py
@@ -49,6 +49,10 @@ def test_run_experiment_group_manifest_output() -> None:
     )
     manifest = yaml.safe_load(contract_path.read_text())
     assert isinstance(manifest, dict), f"research.yaml did not parse to a dict: {type(manifest)}"
+    assert "skills" in manifest, "research.yaml missing top-level 'skills' key"
+    assert "run-experiment" in manifest["skills"], (
+        "research.yaml 'skills' missing 'run-experiment' entry"
+    )
     run_exp = manifest["skills"]["run-experiment"]
     output_names = [out["name"] for out in run_exp.get("outputs", [])]
     assert "group_manifest" in output_names, (

--- a/tests/contracts/test_run_experiment_contracts.py
+++ b/tests/contracts/test_run_experiment_contracts.py
@@ -48,6 +48,7 @@ def test_run_experiment_group_manifest_output() -> None:
         / "research.yaml"
     )
     manifest = yaml.safe_load(contract_path.read_text())
+    assert isinstance(manifest, dict), f"research.yaml did not parse to a dict: {type(manifest)}"
     run_exp = manifest["skills"]["run-experiment"]
     output_names = [out["name"] for out in run_exp.get("outputs", [])]
     assert "group_manifest" in output_names, (

--- a/tests/contracts/test_run_experiment_contracts.py
+++ b/tests/contracts/test_run_experiment_contracts.py
@@ -35,6 +35,26 @@ def test_run_experiment_env_mode_dispatch() -> None:
     )
 
 
+def test_run_experiment_group_manifest_output() -> None:
+    """run-experiment contract must declare group_manifest as an output."""
+    import yaml
+
+    contract_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "src"
+        / "autoskillit"
+        / "recipes"
+        / "contracts"
+        / "research.yaml"
+    )
+    manifest = yaml.safe_load(contract_path.read_text())
+    run_exp = manifest["skills"]["run-experiment"]
+    output_names = [out["name"] for out in run_exp.get("outputs", [])]
+    assert "group_manifest" in output_names, (
+        "run-experiment contract must declare group_manifest as an output"
+    )
+
+
 def test_run_experiment_micromamba_run_command() -> None:
     """run-experiment must include micromamba run command for host fallback."""
     text = SKILL_PATH.read_text()

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -574,6 +574,8 @@ class TestOutputPathTokensDerivedFromContracts:
             "pr_body_path",
             # setup-environment skill output (research recipe pre-flight gate)
             "env_report",
+            # run-experiment group manifest output (multi-group awareness)
+            "group_manifest",
         }
     )
 

--- a/tests/recipe/test_rules_dataflow_capture.py
+++ b/tests/recipe/test_rules_dataflow_capture.py
@@ -353,3 +353,90 @@ class TestImplicitHandoffRule:
             "once investigate declares investigation_path in skill_contracts.yaml"
         )
         assert any(f.severity == Severity.ERROR for f in ih)
+
+
+# ---------------------------------------------------------------------------
+# TestDownstreamContextCompletenessRule
+# ---------------------------------------------------------------------------
+
+
+class TestDownstreamContextCompletenessRule:
+    def test_dc1_rule_in_registry(self) -> None:
+        """T_DC1: downstream-context-gap is in _RULE_REGISTRY."""
+        from autoskillit.recipe.validator import _RULE_REGISTRY
+
+        rule_names = [r.name for r in _RULE_REGISTRY]
+        assert "downstream-context-gap" in rule_names
+
+    def test_dc2_warns_for_unwired_context_ref(self) -> None:
+        """T_DC2: downstream-context-gap fires WARNING when a step references unwired context."""
+        steps = {
+            "produce": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:scope test question"},
+                "capture": {"scope_report": "${{ result.scope_report }}"},
+                "on_success": "consume",
+            },
+            "consume": {
+                "tool": "run_skill",
+                "with": {
+                    "skill_command": "/autoskillit:plan-experiment ${{ context.unwired_var }}"
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        gap = [f for f in findings if f.rule == "downstream-context-gap"]
+        assert len(gap) >= 1, "downstream-context-gap must fire for unwired context reference"
+        assert any(f.severity == Severity.WARNING and f.step_name == "consume" for f in gap)
+
+    def test_dc3_does_not_fire_for_wired_context(self) -> None:
+        """T_DC3: downstream-context-gap does NOT fire when context var is produced upstream."""
+        steps = {
+            "produce": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:scope test question"},
+                "capture": {"my_var": "${{ result.scope_report }}"},
+                "on_success": "consume",
+            },
+            "consume": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:plan-experiment ${{ context.my_var }}"},
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        gap = [
+            f for f in findings if f.rule == "downstream-context-gap" and f.step_name == "consume"
+        ]
+        assert gap == [], f"downstream-context-gap must not fire for properly wired context: {gap}"
+
+    def test_dc4_does_not_fire_for_recipe_input(self) -> None:
+        """T_DC4: downstream-context-gap does NOT fire when context var is a recipe input."""
+        recipe_yaml = textwrap.dedent("""\
+            name: test-recipe
+            description: test
+            ingredients:
+              my_input:
+                description: Test input
+                required: true
+            steps:
+              consume:
+                tool: run_skill
+                with:
+                  skill_command: /autoskillit:scope ${{ inputs.my_input }}
+                on_success: done
+              done:
+                action: stop
+                message: Done
+        """)
+        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        findings = run_semantic_rules(recipe)
+        gap = [
+            f for f in findings if f.rule == "downstream-context-gap" and f.step_name == "consume"
+        ]
+        assert gap == [], f"downstream-context-gap must not fire for recipe input context: {gap}"

--- a/tests/recipe/test_rules_dataflow_capture.py
+++ b/tests/recipe/test_rules_dataflow_capture.py
@@ -428,7 +428,7 @@ class TestDownstreamContextCompletenessRule:
               consume:
                 tool: run_skill
                 with:
-                  skill_command: /autoskillit:scope ${{ inputs.my_input }}
+                  skill_command: /autoskillit:scope ${{ context.my_input }}
                 on_success: done
               done:
                 action: stop

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -349,7 +349,8 @@ def test_all_skills_have_anti_fabrication_guard(skill_dir: Path) -> None:
         pytest.skip("no SKILL.md")
     text = skill_md.read_text()
     never_block = _extract_never_block(text)
-    assert never_block, f"{skill_dir.name}: no NEVER block found in SKILL.md"
+    if not never_block:
+        pytest.skip(f"{skill_dir.name}: no NEVER block in SKILL.md")
     assert _FABRICATION_GUARD_RE.search(never_block), (
         f"{skill_dir.name}: NEVER block must include anti-fabrication language"
     )

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -342,13 +342,13 @@ _FABRICATION_GUARD_RE = re.compile(
 @pytest.mark.parametrize("skill_dir", _all_skill_dirs(), ids=lambda d: d.name)
 def test_all_skills_have_anti_fabrication_guard(skill_dir: Path) -> None:
     """Every skill with a NEVER block must include anti-fabrication language."""
-    from tests.conftest import _extract_never_block
+    from tests._helpers import extract_never_block
 
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.exists():
         pytest.skip("no SKILL.md")
     text = skill_md.read_text()
-    never_block = _extract_never_block(text)
+    never_block = extract_never_block(text)
     if not never_block:
         pytest.skip(f"{skill_dir.name}: no NEVER block in SKILL.md")
     assert _FABRICATION_GUARD_RE.search(never_block), (

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -349,6 +349,7 @@ def test_all_skills_have_anti_fabrication_guard(skill_dir: Path) -> None:
         pytest.skip("no SKILL.md")
     text = skill_md.read_text()
     never_block = _extract_never_block(text)
+    assert never_block, f"{skill_dir.name}: no NEVER block found in SKILL.md"
     assert _FABRICATION_GUARD_RE.search(never_block), (
         f"{skill_dir.name}: NEVER block must include anti-fabrication language"
     )

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -334,6 +334,26 @@ next lens.
     assert not violations, f"Detector falsely flagged guarded loop: {violations}"
 
 
+_FABRICATION_GUARD_RE = re.compile(
+    r"(?i)(?:fabricat|embellish|invent|hallucinat|attribute.*missing.*to)",
+)
+
+
+@pytest.mark.parametrize("skill_dir", _all_skill_dirs(), ids=lambda d: d.name)
+def test_all_skills_have_anti_fabrication_guard(skill_dir: Path) -> None:
+    """Every skill with a NEVER block must include anti-fabrication language."""
+    from tests.conftest import _extract_never_block
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        pytest.skip("no SKILL.md")
+    text = skill_md.read_text()
+    never_block = _extract_never_block(text)
+    assert _FABRICATION_GUARD_RE.search(never_block), (
+        f"{skill_dir.name}: NEVER block must include anti-fabrication language"
+    )
+
+
 def test_detector_catches_unguarded_mcp_loop() -> None:
     """Verify _check_loop_boundary detects a 'For each' loop containing
     MCP tool invocations (load_recipe, run_skill, fetch_github_issue)

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -272,6 +272,8 @@ def test_output_path_tokens_synchronized() -> None:
             "review_approach_assessment_path",
             # setup-environment skill output (research recipe pre-flight gate)
             "env_report",
+            # run-experiment group manifest output (multi-group awareness)
+            "group_manifest",
         }
     )
 


### PR DESCRIPTION
## Summary

The research recipe pipeline loses experiment group metadata at the `run_experiment` → `generate_report` boundary. `decompose_phases` produces `group_files` (a list of per-group file paths), but this context is consumed during the implementation loop and never propagated to downstream steps. The `generate_report` skill receives a single scalar `results_path` with no structured knowledge of how many groups existed or their completion status. Separately, no programmatic mechanism prevents skills from fabricating explanations for missing data — NEVER rules are prompt-only, with zero enforcement in CI.

The architectural fix introduces three structural guarantees: (1) a `group_manifest` data channel that preserves group context through the full pipeline, (2) a cross-cutting anti-fabrication compliance test that blocks any skill without explicit fabrication guards from passing CI, and (3) a dataflow completeness validation rule that detects when downstream steps reference context that upstream steps don't propagate.

## Requirements

### From Issue #2337 Fix

1. Add a Step 1 instruction: "If the experiment plan specifies multiple groups, enumerate ALL groups and their completion status in the Results section. Use the experiment plan's group definitions and compare against the results file to determine which groups completed."

2. Add a NEVER rule: "NEVER attribute missing data to 'time constraints', 'resource limitations', or other invented explanations not present in the results file. Report the factual state: what data is present, what is absent. If the results file does not explain why data is absent, state 'reason not recorded in results' rather than inventing one."

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260509-200800-917989/.autoskillit/temp/rectify/rectify_generate_report_multi_group_and_anti_fabrication_2026-05-09_201500.md`

Closes #2337

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 655 | 10.9k | 343.9k | 69.4k | 115 | 60.6k | 7m 3s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 50 | 11.1k | 1.0M | 57.6k | 121 | 44.4k | 7m 42s |
| implement* | MiniMax-M2.7-highspeed | 1 | 5.5M | 24.5k | 2.0M | 116.7k | 181 | 181.7k | 8m 58s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 137.3k | 8.9k | 288.3k | 29.1k | 23 | 15.4k | 2m 2s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 80.1k | 2.0k | 230.1k | 29.1k | 21 | 15.2k | 49s |
| review_pr | claude-sonnet-4-6 | 3 | 354 | 92.6k | 2.6M | 127.5k | 186 | 308.3k | 25m 20s |
| resolve_review | claude-sonnet-4-6 | 3 | 1.0k | 76.2k | 8.6M | 98.0k | 348 | 237.1k | 45m 54s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 155 | 5.8k | 791.0k | 55.0k | 47 | 42.2k | 1m 57s |
| **Total** | | | 5.8M | 232.0k | 15.9M | 127.5k | | 904.9k | 1h 39m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 340 | 5986.9 | 534.5 | 72.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 157 | 54892.8 | 1510.2 | 485.5 |
| ci_conflict_fix | 2520 | 313.9 | 16.8 | 2.3 |
| **Total** | **3017** | 5280.2 | 299.9 | 76.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 2.0k | 17.4k | 545.8k | 64.7k | 8m 0s |
| claude-opus-4-6 | 1 | 41 | 10.3k | 579.4k | 41.9k | 4m 15s |
| MiniMax-M2.7-highspeed | 1 | 1.6M | 12.9k | 1.2M | 89.2k | 4m 30s |