### PR TITLE
Implementation Plan: P3-A1 — Wire marker_dir/session_id Through Headless Execution and Dispatch Stack

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_execution.py
+++ b/src/autoskillit/core/types/_type_protocols_execution.py
@@ -93,6 +93,8 @@ class HeadlessExecutor(Protocol):
         provider_fallback_env: dict[str, str] | None = None,
         provider_fallback_name: str = "",
         sentinel_contract: str = "",
+        marker_dir: Path | None = None,
+        session_id: str | None = None,
     ) -> SkillResult: ...
 
 

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -304,9 +304,7 @@ async def _execute_claude_headless(
     _result: SubprocessResult | None = None
     result: SubprocessResult
     skill_result: SkillResult
-
-    # NOTE: session_id is dispatch_id (DispatchIdentity UUID) at call time,
-    # NOT a post-run Claude Code session UUID
+    # session_id is dispatch_id (DispatchIdentity UUID), not a post-run Claude Code session UUID
     effective_marker_dir = marker_dir or (claude_code_project_dir(cwd) if cwd else None)
     while True:
         try:

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -304,8 +304,6 @@ async def _execute_claude_headless(
     _result: SubprocessResult | None = None
     result: SubprocessResult
     skill_result: SkillResult
-    # session_id is dispatch_id (DispatchIdentity UUID), not a post-run Claude Code session UUID
-    effective_marker_dir = marker_dir or (claude_code_project_dir(cwd) if cwd else None)
     while True:
         try:
             _result = await runner(
@@ -324,7 +322,7 @@ async def _execute_claude_headless(
                 on_pid_resolved=on_spawn,
                 enable_deadline_extension=enable_deadline_extension,
                 max_extension_seconds=max_extension_seconds,
-                marker_dir=effective_marker_dir,
+                marker_dir=marker_dir,
                 session_id=session_id,
             )
         except Exception as exc:

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -231,6 +231,8 @@ async def _execute_claude_headless(
     provider_extras: Mapping[str, str] | None = None,
     enable_deadline_extension: bool = False,
     max_extension_seconds: float = 7200,
+    marker_dir: Path | None = None,
+    session_id: str | None = None,
 ) -> SkillResult:
     """Shared subprocess execution for headless Claude sessions.
 
@@ -302,6 +304,10 @@ async def _execute_claude_headless(
     _result: SubprocessResult | None = None
     result: SubprocessResult
     skill_result: SkillResult
+
+    # NOTE: session_id is dispatch_id (DispatchIdentity UUID) at call time,
+    # NOT a post-run Claude Code session UUID
+    effective_marker_dir = marker_dir or (claude_code_project_dir(cwd) if cwd else None)
     while True:
         try:
             _result = await runner(
@@ -320,6 +326,8 @@ async def _execute_claude_headless(
                 on_pid_resolved=on_spawn,
                 enable_deadline_extension=enable_deadline_extension,
                 max_extension_seconds=max_extension_seconds,
+                marker_dir=effective_marker_dir,
+                session_id=session_id,
             )
         except Exception as exc:
             logger.error("headless_runner_crashed", exc_info=True)
@@ -822,6 +830,8 @@ class DefaultHeadlessExecutor:
         provider_fallback_env: dict[str, str] | None = None,
         provider_fallback_name: str = "",
         sentinel_contract: str = "",
+        marker_dir: Path | None = None,
+        session_id: str | None = None,
     ) -> SkillResult:
         cfg = self._ctx.config
         resolved_model = _resolve_model(model, cfg)
@@ -879,6 +889,10 @@ class DefaultHeadlessExecutor:
             else None
         )
 
+        effective_marker_dir: Path | None = marker_dir or (
+            claude_code_project_dir(cwd) if cwd else None
+        )
+
         return await _execute_claude_headless(
             spec,
             cwd,
@@ -903,4 +917,6 @@ class DefaultHeadlessExecutor:
             provider_fallback_name=provider_fallback_name,
             enable_deadline_extension=effective_deadline_ext,
             max_extension_seconds=effective_max_ext,
+            marker_dir=effective_marker_dir,
+            session_id=session_id,
         )

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -249,13 +249,15 @@ def test_headless_executor_protocol_dispatch_has_marker_params():
     import inspect
 
     from autoskillit.core import HeadlessExecutor
+    from autoskillit.execution.headless import DefaultHeadlessExecutor
 
-    sig = inspect.signature(HeadlessExecutor.dispatch_food_truck)
-    params = sig.parameters
-    assert "marker_dir" in params
-    assert params["marker_dir"].default is None
-    assert "session_id" in params
-    assert params["session_id"].default is None
+    for cls in (HeadlessExecutor, DefaultHeadlessExecutor):
+        sig = inspect.signature(cls.dispatch_food_truck)
+        params = sig.parameters
+        assert "marker_dir" in params, f"{cls.__name__} missing marker_dir"
+        assert params["marker_dir"].default is None, f"{cls.__name__}.marker_dir default != None"
+        assert "session_id" in params, f"{cls.__name__} missing session_id"
+        assert params["session_id"].default is None, f"{cls.__name__}.session_id default != None"
 
 
 # ── GateState mutation (REQ-PROTO-009) ────────────────────────────────────────

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -245,6 +245,19 @@ def test_default_headless_executor_satisfies_headless_executor():
     assert isinstance(DefaultHeadlessExecutor(MagicMock()), HeadlessExecutor)
 
 
+def test_headless_executor_protocol_dispatch_has_marker_params():
+    import inspect
+
+    from autoskillit.core import HeadlessExecutor
+
+    sig = inspect.signature(HeadlessExecutor.dispatch_food_truck)
+    params = sig.parameters
+    assert "marker_dir" in params
+    assert params["marker_dir"].default is None
+    assert "session_id" in params
+    assert params["session_id"].default is None
+
+
 # ── GateState mutation (REQ-PROTO-009) ────────────────────────────────────────
 
 

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -371,16 +371,3 @@ def test_default_executor_satisfies_protocol_with_dispatch(minimal_ctx) -> None:
 
     executor = DefaultHeadlessExecutor(minimal_ctx)
     assert isinstance(executor, HeadlessExecutor)
-
-
-def test_in_memory_executor_dispatch_accepts_marker_params():
-    import inspect
-
-    from tests.fakes import InMemoryHeadlessExecutor
-
-    sig = inspect.signature(InMemoryHeadlessExecutor.dispatch_food_truck)
-    params = sig.parameters
-    assert "marker_dir" in params
-    assert params["marker_dir"].default is None
-    assert "session_id" in params
-    assert params["session_id"].default is None

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -371,3 +371,16 @@ def test_default_executor_satisfies_protocol_with_dispatch(minimal_ctx) -> None:
 
     executor = DefaultHeadlessExecutor(minimal_ctx)
     assert isinstance(executor, HeadlessExecutor)
+
+
+def test_in_memory_executor_dispatch_accepts_marker_params():
+    import inspect
+
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    sig = inspect.signature(InMemoryHeadlessExecutor.dispatch_food_truck)
+    params = sig.parameters
+    assert "marker_dir" in params
+    assert params["marker_dir"].default is None
+    assert "session_id" in params
+    assert params["session_id"].default is None

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -346,3 +346,258 @@ def test_build_skill_result_provider_used_survives_budget_guard() -> None:
         provider_used="bedrock",
     )
     assert sr.provider.provider_used == "bedrock"
+
+
+# ── marker_dir / session_id forwarding tests ───────────────────────────────────
+
+
+def test_execute_claude_headless_accepts_marker_dir_and_session_id() -> None:
+    import inspect
+
+    from autoskillit.execution.headless import _execute_claude_headless
+
+    sig = inspect.signature(_execute_claude_headless)
+    params = sig.parameters
+    assert "marker_dir" in params
+    assert params["marker_dir"].default is None
+    assert params["marker_dir"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert "session_id" in params
+    assert params["session_id"].default is None
+    assert params["session_id"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_dispatch_food_truck_accepts_marker_dir_and_session_id() -> None:
+    import inspect
+
+    from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+    sig = inspect.signature(DefaultHeadlessExecutor.dispatch_food_truck)
+    params = sig.parameters
+    assert "marker_dir" in params
+    assert params["marker_dir"].default is None
+    assert params["marker_dir"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert "session_id" in params
+    assert params["session_id"].default is None
+    assert params["session_id"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+@pytest.mark.anyio
+async def test_dispatch_food_truck_forwards_marker_dir_and_session_id(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+
+    from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+    execute_kwargs: dict = {}
+
+    async def fake_execute(spec, cwd, ctx, **kwargs):
+        execute_kwargs.update(kwargs)
+        return SkillResult(
+            success=True,
+            result="ok",
+            session_id="s1",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._build_skill_result",
+        lambda *a, **kw: SkillResult(
+            success=True,
+            result="ok",
+            session_id="s1",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
+    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._compute_post_session_metrics",
+        lambda *a, **kw: object(),
+    )
+
+    executor = DefaultHeadlessExecutor(minimal_ctx)
+    marker = tmp_path / "markers"
+    await executor.dispatch_food_truck(
+        "prompt",
+        str(tmp_path),
+        completion_marker="%%DONE%%",
+        marker_dir=marker,
+        session_id="dispatch-uuid-123",
+    )
+
+    assert execute_kwargs["marker_dir"] == marker
+    assert execute_kwargs["session_id"] == "dispatch-uuid-123"
+
+
+@pytest.mark.anyio
+async def test_dispatch_food_truck_derives_marker_dir_from_cwd(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from pathlib import Path
+
+    from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+    execute_kwargs: dict = {}
+
+    async def fake_execute(spec, cwd, ctx, **kwargs):
+        execute_kwargs.update(kwargs)
+        return SkillResult(
+            success=True,
+            result="ok",
+            session_id="s1",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._build_skill_result",
+        lambda *a, **kw: SkillResult(
+            success=True,
+            result="ok",
+            session_id="s1",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
+    monkeypatch.setattr(
+        "autoskillit.execution.headless.claude_code_project_dir",
+        lambda cwd: Path("/derived/project"),
+    )
+    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._compute_post_session_metrics",
+        lambda *a, **kw: object(),
+    )
+
+    executor = DefaultHeadlessExecutor(minimal_ctx)
+    await executor.dispatch_food_truck(
+        "prompt",
+        str(tmp_path),
+        completion_marker="%%DONE%%",
+    )
+
+    assert execute_kwargs["marker_dir"] == Path("/derived/project")
+
+
+@pytest.mark.anyio
+async def test_dispatch_food_truck_marker_dir_none_when_cwd_falsy(
+    minimal_ctx, monkeypatch
+) -> None:
+    execute_kwargs: dict = {}
+
+    async def fake_execute(spec, cwd, ctx, **kwargs):
+        execute_kwargs.update(kwargs)
+        return SkillResult(
+            success=True,
+            result="ok",
+            session_id="s1",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._build_skill_result",
+        lambda *a, **kw: SkillResult(
+            success=True,
+            result="ok",
+            session_id="s1",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
+    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._compute_post_session_metrics",
+        lambda *a, **kw: object(),
+    )
+
+    from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+    executor = DefaultHeadlessExecutor(minimal_ctx)
+    await executor.dispatch_food_truck(
+        "prompt",
+        "",
+        completion_marker="%%DONE%%",
+    )
+
+    assert execute_kwargs["marker_dir"] is None
+
+
+@pytest.mark.anyio
+async def test_execute_claude_headless_forwards_marker_dir_to_runner(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from pathlib import Path
+
+    from autoskillit.execution.commands import ClaudeHeadlessCmd
+    from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
+    from tests.execution.conftest import _sr
+
+    spec = ClaudeHeadlessCmd(cmd=["echo", "test"], env={})
+    runner_kwargs: dict = {}
+
+    async def fake_runner(cmd, **kwargs):
+        runner_kwargs.update(kwargs)
+        return _sr()
+
+    minimal_ctx.runner = fake_runner
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._build_skill_result",
+        lambda *a, **kw: SkillResult(
+            success=True,
+            result="ok",
+            session_id="s1",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._compute_post_session_metrics",
+        lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
+    )
+    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
+
+    await _execute_claude_headless(
+        spec,
+        str(tmp_path),
+        minimal_ctx,
+        timeout=60,
+        stale_threshold=30,
+        marker_dir=Path("/custom/markers"),
+        session_id="sess-abc",
+    )
+
+    assert runner_kwargs["marker_dir"] == Path("/custom/markers")
+    assert runner_kwargs["session_id"] == "sess-abc"

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -404,20 +404,6 @@ async def test_dispatch_food_truck_forwards_marker_dir_and_session_id(
             stderr="",
         )
 
-    monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
-        lambda *a, **kw: SkillResult(
-            success=True,
-            result="ok",
-            session_id="s1",
-            subtype="success",
-            is_error=False,
-            exit_code=0,
-            needs_retry=False,
-            retry_reason=RetryReason.NONE,
-            stderr="",
-        ),
-    )
     monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
     monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
     monkeypatch.setattr(
@@ -463,20 +449,6 @@ async def test_dispatch_food_truck_derives_marker_dir_from_cwd(
             stderr="",
         )
 
-    monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
-        lambda *a, **kw: SkillResult(
-            success=True,
-            result="ok",
-            session_id="s1",
-            subtype="success",
-            is_error=False,
-            exit_code=0,
-            needs_retry=False,
-            retry_reason=RetryReason.NONE,
-            stderr="",
-        ),
-    )
     monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
     monkeypatch.setattr(
         "autoskillit.execution.headless.claude_code_project_dir",
@@ -518,20 +490,6 @@ async def test_dispatch_food_truck_marker_dir_none_when_cwd_falsy(
             stderr="",
         )
 
-    monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
-        lambda *a, **kw: SkillResult(
-            success=True,
-            result="ok",
-            session_id="s1",
-            subtype="success",
-            is_error=False,
-            exit_code=0,
-            needs_retry=False,
-            retry_reason=RetryReason.NONE,
-            stderr="",
-        ),
-    )
     monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
     monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
     monkeypatch.setattr(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -113,6 +113,8 @@ class DispatchFoodTruckCall:
     allowed_write_prefix: str = ""
     sentinel_contract: str = ""
     prior_completion_markers: Sequence[str] | None = None
+    marker_dir: Path | None = None
+    session_id: str | None = None
 
 
 _DEFAULT_SKILL_RESULT = SkillResult(
@@ -263,6 +265,8 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
                 allowed_write_prefix=allowed_write_prefix,
                 sentinel_contract=sentinel_contract,
                 prior_completion_markers=prior_completion_markers,
+                marker_dir=marker_dir,
+                session_id=session_id,
             )
         )
         if self._queue:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -236,6 +236,8 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         provider_fallback_name: str = "",
         sentinel_contract: str = "",
         prior_completion_markers: Sequence[str] | None = None,
+        marker_dir: Path | None = None,
+        session_id: str | None = None,
     ) -> SkillResult:
         self.dispatch_calls.append(
             DispatchFoodTruckCall(


### PR DESCRIPTION
## Summary

Add `marker_dir: Path | None = None` and `session_id: str | None = None` as keyword-only parameters to `_execute_claude_headless` and `dispatch_food_truck` in `src/autoskillit/execution/headless/__init__.py`. Derive `effective_marker_dir` at both call sites using the fallback expression `marker_dir or (claude_code_project_dir(cwd) if cwd else None)`. Forward both values through the full call chain: `dispatch_food_truck` → `_execute_claude_headless` → `runner(...)`. Update the `HeadlessExecutor` Protocol and `InMemoryHeadlessExecutor` fake to maintain type conformance. The `SubprocessRunner` Protocol and `run_managed_async` implementation already accept these parameters (added in P2), so no changes are needed below the `_execute_claude_headless` layer.

## Changed Files

### Modified (●):
- `src/autoskillit/core/types/_type_protocols_execution.py`
- `src/autoskillit/execution/headless/__init__.py`
- `tests/contracts/test_protocol_satisfaction.py`
- `tests/execution/test_headless_dispatch.py`
- `tests/execution/test_headless_provider_forwarding.py`
- `tests/fakes.py`

Closes #2304

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-211011-560367/.autoskillit/temp/make-plan/p3_a1_wire_marker_dir_session_id_plan_2026-05-09_211500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 74 | 8.4k | 376.0k | 54.5k | 69 | 37.0k | 4m 22s |
| verify | claude-opus-4-6 | 1 | 41 | 10.3k | 579.4k | 55.0k | 42 | 41.9k | 4m 15s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.6M | 12.9k | 1.2M | 29.1k | 102 | 89.2k | 4m 30s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 91.4k | 3.1k | 230.1k | 29.1k | 21 | 15.4k | 1m 9s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 58.4k | 1.8k | 230.1k | 29.1k | 17 | 15.1k | 44s |
| review_pr | claude-sonnet-4-6 | 3 | 280 | 102.7k | 1.4M | 82.1k | 126 | 192.8k | 22m 26s |
| resolve_review | claude-sonnet-4-6 | 2 | 522 | 34.8k | 3.8M | 94.6k | 155 | 118.7k | 17m 19s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 147 | 5.3k | 727.3k | 55.6k | 42 | 42.8k | 2m 16s |
| **Total** | | | 1.8M | 179.3k | 8.5M | 94.6k | | 553.0k | 57m 3s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 306 | 3806.9 | 291.5 | 42.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 77 | 49041.7 | 1542.0 | 451.7 |
| ci_conflict_fix | 1607 | 452.6 | 26.7 | 3.3 |
| **Total** | **1990** | 4250.8 | 277.9 | 90.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 2.2k | 27.8k | 1.3M | 112.3k | 17m 25s |
| claude-opus-4-6 | 1 | 41 | 10.3k | 579.4k | 41.9k | 4m 15s |
| MiniMax-M2.7-highspeed | 3 | 1.8M | 17.8k | 1.6M | 119.7k | 6m 23s |