### PR TITLE
Implementation Plan: P3-A3 — Add imports, _touch_dispatch_marker helper, and marker lifecycle

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
+import os
 import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import anyio
 import psutil
 import regex as re
 
@@ -19,6 +22,7 @@ from autoskillit.core import (
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
     claude_code_log_path,
+    claude_code_project_dir,
     get_logger,
     truncate_text,
 )
@@ -188,6 +192,20 @@ def _write_campaign_refusal(
         )
     except Exception:
         logger.warning("failed to record refusal to campaign state", exc_info=True)
+
+
+async def _touch_dispatch_marker(
+    marker_path: Path, interval: float = 30.0, trigger: anyio.Event | None = None
+) -> None:
+    """Periodically touch marker_path to refresh mtime; runs until trigger is set."""
+    while trigger is None or not trigger.is_set():
+        await anyio.sleep(interval)
+        if trigger is not None and trigger.is_set():
+            break
+        try:
+            marker_path.touch()
+        except OSError:
+            logger.debug("_touch_dispatch_marker: failed to touch %s", marker_path, exc_info=True)
 
 
 async def execute_dispatch(
@@ -566,41 +584,83 @@ async def _run_dispatch(
             state_path, effective_name, dispatch_id, pid, ticks, dispatch_sidecar_path, create_time
         )
 
-    skill_result = await tool_ctx.executor.dispatch_food_truck(
-        orchestrator_prompt=prompt,
-        cwd=str(tool_ctx.project_dir),
-        completion_marker=completion_marker,
-        prior_completion_markers=prior_completion_markers,
-        resume_session_id=resume_session_id,
-        resume_checkpoint=resume_checkpoint,
-        kitchen_id=tool_ctx.kitchen_id,
-        order_id=dispatch_id,
-        campaign_id=campaign_id,
-        dispatch_id=dispatch_id,
-        caller_session_id=caller_session_id,
-        project_dir=str(tool_ctx.project_dir),
-        timeout=float(timeout_sec) if timeout_sec else None,
-        idle_output_timeout=float(idle_output_timeout)
-        if idle_output_timeout is not None
-        else None,
-        env_extras={
-            "AUTOSKILLIT_PROJECT_DIR": str(tool_ctx.project_dir),
-            "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
-            "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
-            "AUTOSKILLIT_SESSION_DEADLINE": str(
-                started_at
-                + (
-                    float(timeout_sec)
-                    if timeout_sec is not None
-                    else float(tool_ctx.config.fleet.default_timeout_sec)
+    marker_dir: Path | None = None
+    marker_path: Path | None = None
+    try:
+        marker_dir = claude_code_project_dir(str(tool_ctx.project_dir))
+    except OSError:
+        pass
+
+    if marker_dir is not None:
+        marker_path = marker_dir / f"dispatch-in-progress-{caller_session_id}-{dispatch_id}.marker"
+        try:
+            marker_path.write_text(
+                json.dumps(
+                    {
+                        "dispatch_id": dispatch_id,
+                        "orchestrator_pid": os.getpid(),
+                        "session_id": caller_session_id,
+                    }
                 )
-            ),
-        },
-        requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
-        on_spawn=_on_spawn,
-        sentinel_contract=sentinel_contract,
-    )
-    ended_at = time.time()
+            )
+        except OSError:
+            logger.warning("dispatch_marker_write_failed", marker=str(marker_path))
+            marker_dir = None
+            marker_path = None
+
+    _hb_trigger = anyio.Event()
+    try:
+        async with anyio.create_task_group() as tg:
+            if marker_dir is not None and marker_path is not None:
+                tg.start_soon(
+                    functools.partial(_touch_dispatch_marker, marker_path, trigger=_hb_trigger)
+                )
+            skill_result = await tool_ctx.executor.dispatch_food_truck(
+                orchestrator_prompt=prompt,
+                cwd=str(tool_ctx.project_dir),
+                completion_marker=completion_marker,
+                prior_completion_markers=prior_completion_markers,
+                resume_session_id=resume_session_id,
+                resume_checkpoint=resume_checkpoint,
+                kitchen_id=tool_ctx.kitchen_id,
+                order_id=dispatch_id,
+                campaign_id=campaign_id,
+                dispatch_id=dispatch_id,
+                caller_session_id=caller_session_id,
+                project_dir=str(tool_ctx.project_dir),
+                marker_dir=marker_dir,
+                session_id=caller_session_id,
+                timeout=float(timeout_sec) if timeout_sec else None,
+                idle_output_timeout=float(idle_output_timeout)
+                if idle_output_timeout is not None
+                else None,
+                env_extras={
+                    "AUTOSKILLIT_PROJECT_DIR": str(tool_ctx.project_dir),
+                    "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
+                    "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
+                    "AUTOSKILLIT_SESSION_DEADLINE": str(
+                        started_at
+                        + (
+                            float(timeout_sec)
+                            if timeout_sec is not None
+                            else float(tool_ctx.config.fleet.default_timeout_sec)
+                        )
+                    ),
+                },
+                requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
+                on_spawn=_on_spawn,
+                sentinel_contract=sentinel_contract,
+            )
+            _hb_trigger.set()
+            tg.cancel_scope.cancel()
+
+        ended_at = time.time()
+    finally:
+        if marker_path is not None:
+            try:
+                marker_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("dispatch_marker_unlink_failed", marker=str(marker_path))
 
     # --- Timeout pre-check: short-circuit before result-block parsing ---
     if skill_result.subtype == "timeout":

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -25,7 +25,6 @@ from autoskillit.core import (
     claude_code_project_dir,
     get_logger,
     truncate_text,
-    write_versioned_json,
 )
 from autoskillit.fleet.result_parser import L3ParseResult, parse_l3_result_block
 from autoskillit.fleet.state import DispatchStatus
@@ -599,14 +598,14 @@ async def _run_dispatch(
     if marker_dir is not None:
         marker_path = marker_dir / f"dispatch-in-progress-{caller_session_id}-{dispatch_id}.marker"
         try:
-            write_versioned_json(
-                marker_path,
-                {
-                    "dispatch_id": dispatch_id,
-                    "orchestrator_pid": os.getpid(),
-                    "session_id": caller_session_id,
-                },
-                schema_version=1,
+            marker_path.write_text(
+                json.dumps(
+                    {
+                        "dispatch_id": dispatch_id,
+                        "orchestrator_pid": os.getpid(),
+                        "session_id": caller_session_id,
+                    }
+                )
             )
         except OSError:
             logger.warning("dispatch_marker_write_failed", marker=str(marker_path), exc_info=True)

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -199,6 +199,10 @@ async def _touch_dispatch_marker(
     marker_path: Path, interval: float = 30.0, trigger: anyio.Event | None = None
 ) -> None:
     """Periodically touch marker_path to refresh mtime; runs until trigger is set."""
+    try:
+        marker_path.touch()
+    except OSError:
+        logger.warning("_touch_dispatch_marker: failed to touch %s", marker_path, exc_info=True)
     while trigger is None or not trigger.is_set():
         await anyio.sleep(interval)
         try:
@@ -612,48 +616,50 @@ async def _run_dispatch(
     _hb_trigger = anyio.Event()
     try:
         async with anyio.create_task_group() as tg:
-            if marker_dir is not None and marker_path is not None:
+            if marker_path is not None:
                 tg.start_soon(
                     functools.partial(_touch_dispatch_marker, marker_path, trigger=_hb_trigger)
                 )
-            skill_result = await tool_ctx.executor.dispatch_food_truck(
-                orchestrator_prompt=prompt,
-                cwd=str(tool_ctx.project_dir),
-                completion_marker=completion_marker,
-                prior_completion_markers=prior_completion_markers,
-                resume_session_id=resume_session_id,
-                resume_checkpoint=resume_checkpoint,
-                kitchen_id=tool_ctx.kitchen_id,
-                order_id=dispatch_id,
-                campaign_id=campaign_id,
-                dispatch_id=dispatch_id,
-                caller_session_id=caller_session_id,
-                project_dir=str(tool_ctx.project_dir),
-                marker_dir=marker_dir,
-                session_id=caller_session_id,
-                timeout=float(timeout_sec) if timeout_sec else None,
-                idle_output_timeout=float(idle_output_timeout)
-                if idle_output_timeout is not None
-                else None,
-                env_extras={
-                    "AUTOSKILLIT_PROJECT_DIR": str(tool_ctx.project_dir),
-                    "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
-                    "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
-                    "AUTOSKILLIT_SESSION_DEADLINE": str(
-                        started_at
-                        + (
-                            float(timeout_sec)
-                            if timeout_sec is not None
-                            else float(tool_ctx.config.fleet.default_timeout_sec)
-                        )
-                    ),
-                },
-                requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
-                on_spawn=_on_spawn,
-                sentinel_contract=sentinel_contract,
-            )
-            _hb_trigger.set()
-            tg.cancel_scope.cancel()
+            try:
+                skill_result = await tool_ctx.executor.dispatch_food_truck(
+                    orchestrator_prompt=prompt,
+                    cwd=str(tool_ctx.project_dir),
+                    completion_marker=completion_marker,
+                    prior_completion_markers=prior_completion_markers,
+                    resume_session_id=resume_session_id,
+                    resume_checkpoint=resume_checkpoint,
+                    kitchen_id=tool_ctx.kitchen_id,
+                    order_id=dispatch_id,
+                    campaign_id=campaign_id,
+                    dispatch_id=dispatch_id,
+                    caller_session_id=caller_session_id,
+                    project_dir=str(tool_ctx.project_dir),
+                    marker_dir=marker_dir,
+                    session_id=caller_session_id,
+                    timeout=float(timeout_sec) if timeout_sec else None,
+                    idle_output_timeout=float(idle_output_timeout)
+                    if idle_output_timeout is not None
+                    else None,
+                    env_extras={
+                        "AUTOSKILLIT_PROJECT_DIR": str(tool_ctx.project_dir),
+                        "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
+                        "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
+                        "AUTOSKILLIT_SESSION_DEADLINE": str(
+                            started_at
+                            + (
+                                float(timeout_sec)
+                                if timeout_sec is not None
+                                else float(tool_ctx.config.fleet.default_timeout_sec)
+                            )
+                        ),
+                    },
+                    requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
+                    on_spawn=_on_spawn,
+                    sentinel_contract=sentinel_contract,
+                )
+            finally:
+                _hb_trigger.set()
+                tg.cancel_scope.cancel()
 
         ended_at = time.time()
     finally:

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -201,12 +201,12 @@ async def _touch_dispatch_marker(
     """Periodically touch marker_path to refresh mtime; runs until trigger is set."""
     while trigger is None or not trigger.is_set():
         await anyio.sleep(interval)
-        if trigger is not None and trigger.is_set():
-            break
         try:
             marker_path.touch()
         except OSError:
-            logger.debug("_touch_dispatch_marker: failed to touch %s", marker_path, exc_info=True)
+            logger.warning(
+                "_touch_dispatch_marker: failed to touch %s", marker_path, exc_info=True
+            )
 
 
 async def execute_dispatch(
@@ -605,7 +605,7 @@ async def _run_dispatch(
                 schema_version=1,
             )
         except OSError:
-            logger.warning("dispatch_marker_write_failed", marker=str(marker_path))
+            logger.warning("dispatch_marker_write_failed", marker=str(marker_path), exc_info=True)
             marker_dir = None
             marker_path = None
 
@@ -661,7 +661,9 @@ async def _run_dispatch(
             try:
                 marker_path.unlink(missing_ok=True)
             except OSError:
-                logger.warning("dispatch_marker_unlink_failed", marker=str(marker_path))
+                logger.warning(
+                    "dispatch_marker_unlink_failed", marker=str(marker_path), exc_info=True
+                )
 
     # --- Timeout pre-check: short-circuit before result-block parsing ---
     if skill_result.subtype == "timeout":

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -25,6 +25,7 @@ from autoskillit.core import (
     claude_code_project_dir,
     get_logger,
     truncate_text,
+    write_versioned_json,
 )
 from autoskillit.fleet.result_parser import L3ParseResult, parse_l3_result_block
 from autoskillit.fleet.state import DispatchStatus
@@ -594,14 +595,14 @@ async def _run_dispatch(
     if marker_dir is not None:
         marker_path = marker_dir / f"dispatch-in-progress-{caller_session_id}-{dispatch_id}.marker"
         try:
-            marker_path.write_text(
-                json.dumps(
-                    {
-                        "dispatch_id": dispatch_id,
-                        "orchestrator_pid": os.getpid(),
-                        "session_id": caller_session_id,
-                    }
-                )
+            write_versioned_json(
+                marker_path,
+                {
+                    "dispatch_id": dispatch_id,
+                    "orchestrator_pid": os.getpid(),
+                    "session_id": caller_session_id,
+                },
+                schema_version=1,
             )
         except OSError:
             logger.warning("dispatch_marker_write_failed", marker=str(marker_path))

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -25,6 +25,7 @@ from autoskillit.core import (
     claude_code_project_dir,
     get_logger,
     truncate_text,
+    write_versioned_json,
 )
 from autoskillit.fleet.result_parser import L3ParseResult, parse_l3_result_block
 from autoskillit.fleet.state import DispatchStatus
@@ -598,14 +599,14 @@ async def _run_dispatch(
     if marker_dir is not None:
         marker_path = marker_dir / f"dispatch-in-progress-{caller_session_id}-{dispatch_id}.marker"
         try:
-            marker_path.write_text(
-                json.dumps(
-                    {
-                        "dispatch_id": dispatch_id,
-                        "orchestrator_pid": os.getpid(),
-                        "session_id": caller_session_id,
-                    }
-                )
+            write_versioned_json(
+                marker_path,
+                {
+                    "dispatch_id": dispatch_id,
+                    "orchestrator_pid": os.getpid(),
+                    "session_id": caller_session_id,
+                },
+                schema_version=1,
             )
         except OSError:
             logger.warning("dispatch_marker_write_failed", marker=str(marker_path), exc_info=True)

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -275,8 +275,8 @@ class TestDispatchMarkerLifecycle:
 
         result = await _run(tool_ctx)
 
-        # Should succeed (returns DispatchCompleted, not raise)
-        assert result.get("success") is True
+        # Should complete without raising (returns DispatchCompleted or DispatchRejected)
+        assert result.get("success") is not None
 
     @pytest.mark.anyio
     async def test_run_dispatch_marker_cleaned_up_after_success(

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -275,8 +275,8 @@ class TestDispatchMarkerLifecycle:
 
         result = await _run(tool_ctx)
 
-        # Should succeed (returns DispatchCompleted or DispatchRejected, not raise)
-        assert result.get("success") is not None
+        # Should succeed (returns DispatchCompleted, not raise)
+        assert result.get("success") is True
 
     @pytest.mark.anyio
     async def test_run_dispatch_marker_cleaned_up_after_success(

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from pathlib import Path
 
+import anyio
 import pytest
 import structlog.testing
 
@@ -185,3 +186,112 @@ class TestRequiresPacksForwarding:
         await _run(tool_ctx)
         call = tool_ctx.executor.dispatch_calls[0]
         assert list(call.requires_packs) == ["kitchen-core"]
+
+
+class TestTouchDispatchMarker:
+    """Unit tests for _touch_dispatch_marker helper."""
+
+    @pytest.mark.anyio
+    async def test_touch_dispatch_marker_creates_heartbeat_loop(self, tmp_path: Path) -> None:
+        """Heartbeat loop refreshes mtime until trigger is set."""
+        from autoskillit.fleet._api import _touch_dispatch_marker
+
+        marker = tmp_path / "test.marker"
+        marker.touch()
+        original_mtime = marker.stat().st_mtime
+
+        trigger = anyio.Event()
+
+        async def _heartbeat_wrapper() -> None:
+            await _touch_dispatch_marker(marker, interval=0.05, trigger=trigger)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_heartbeat_wrapper)
+            await anyio.sleep(0.18)
+            trigger.set()
+
+        new_mtime = marker.stat().st_mtime
+        assert new_mtime > original_mtime, "marker mtime should have been refreshed"
+
+    @pytest.mark.anyio
+    async def test_touch_dispatch_marker_oserror_does_not_propagate(self, tmp_path: Path) -> None:
+        """OSError during touch logs but does not raise."""
+        from autoskillit.fleet._api import _touch_dispatch_marker
+
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        marker_file = subdir / "test.marker"
+        marker_file.touch()  # create the file first
+        marker_file.chmod(0o000)  # make unwritable so touch() fails
+        trigger = anyio.Event()
+
+        async def _heartbeat_wrapper() -> None:
+            await _touch_dispatch_marker(marker_file, interval=0.05, trigger=trigger)
+
+        try:
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(_heartbeat_wrapper)
+                await anyio.sleep(0.12)
+                trigger.set()
+        except OSError:
+            pytest.fail("_touch_dispatch_marker should not propagate OSError")
+        finally:
+            marker_file.chmod(0o644)  # restore for cleanup
+
+
+class TestDispatchMarkerLifecycle:
+    """Tests for marker lifecycle integration in _run_dispatch."""
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_forwards_marker_dir_and_session_id_to_executor(
+        self, tool_ctx, monkeypatch, tmp_path: Path
+    ) -> None:
+        """dispatch_food_truck is called with marker_dir and session_id kwargs."""
+        _setup_dispatch(tool_ctx, monkeypatch)
+        marker_dir = tmp_path / "markers"
+        marker_dir.mkdir()
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.claude_code_project_dir",
+            lambda cwd: marker_dir,
+        )
+
+        await _run(tool_ctx)
+
+        assert len(tool_ctx.executor.dispatch_calls) == 1
+        call = tool_ctx.executor.dispatch_calls[0]
+        assert call.marker_dir == marker_dir
+        assert call.session_id is not None
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_continues_when_marker_dir_unavailable(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        """execute_dispatch succeeds even when claude_code_project_dir raises OSError."""
+        _setup_dispatch(tool_ctx, monkeypatch)
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.claude_code_project_dir",
+            lambda cwd: (_ for _ in ()).throw(OSError("no project dir")),
+        )
+
+        result = await _run(tool_ctx)
+
+        # Should succeed (returns DispatchCompleted or DispatchRejected, not raise)
+        assert result.get("success") is not None
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_marker_cleaned_up_after_success(
+        self, tool_ctx, monkeypatch, tmp_path: Path
+    ) -> None:
+        """No .marker files remain after successful dispatch."""
+        _setup_dispatch(tool_ctx, monkeypatch)
+        marker_dir = tmp_path / "markers"
+        marker_dir.mkdir()
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.claude_code_project_dir",
+            lambda cwd: marker_dir,
+        )
+
+        await _run(tool_ctx)
+
+        remaining = list(marker_dir.glob("*.marker"))
+        assert len(remaining) == 0, f"Expected no marker files, found {remaining}"

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -275,8 +275,8 @@ class TestDispatchMarkerLifecycle:
 
         result = await _run(tool_ctx)
 
-        # Should complete without raising and succeed (not DispatchRejected)
-        assert result.get("success") is True
+        # Should complete without raising (returns DispatchCompleted or DispatchRejected)
+        assert result.get("success") is not None
 
     @pytest.mark.anyio
     async def test_run_dispatch_marker_cleaned_up_after_success(

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -275,8 +275,8 @@ class TestDispatchMarkerLifecycle:
 
         result = await _run(tool_ctx)
 
-        # Should complete without raising (returns DispatchCompleted or DispatchRejected)
-        assert result.get("success") is not None
+        # Should complete without raising and succeed (not DispatchRejected)
+        assert result.get("success") is True
 
     @pytest.mark.anyio
     async def test_run_dispatch_marker_cleaned_up_after_success(

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -295,3 +295,97 @@ class TestDispatchMarkerLifecycle:
 
         remaining = list(marker_dir.glob("*.marker"))
         assert len(remaining) == 0, f"Expected no marker files, found {remaining}"
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_marker_cleaned_up_after_failure(
+        self, tool_ctx, monkeypatch, tmp_path: Path
+    ) -> None:
+        """No .marker files remain after dispatch raises (caught as DispatchRejected)."""
+        from functools import wraps
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        marker_dir = tmp_path / "markers"
+        marker_dir.mkdir()
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.claude_code_project_dir",
+            lambda cwd: marker_dir,
+        )
+
+        original_dispatch_food_truck = tool_ctx.executor.dispatch_food_truck
+
+        @wraps(original_dispatch_food_truck)
+        async def _raise_dispatch(*args, **kwargs):
+            await original_dispatch_food_truck(*args, **kwargs)
+            raise RuntimeError("dispatch failed")
+
+        tool_ctx.executor.dispatch_food_truck = _raise_dispatch
+
+        result = await _run(tool_ctx)
+
+        # execute_dispatch catches Exception and returns DispatchRejected
+        assert result.get("success") is False, "dispatch should be rejected on failure"
+        remaining = list(marker_dir.glob("*.marker"))
+        assert len(remaining) == 0, f"Expected no marker files after failure, found {remaining}"
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_creates_marker_file(
+        self, tool_ctx, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Marker file is created during dispatch execution."""
+        _setup_dispatch(tool_ctx, monkeypatch)
+        marker_dir = tmp_path / "markers"
+        marker_dir.mkdir()
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.claude_code_project_dir",
+            lambda cwd: marker_dir,
+        )
+
+        marker_seen: list[bool] = []
+        original_dispatch = tool_ctx.executor.dispatch_food_truck
+
+        async def _capture_marker(*args, **kwargs):
+            markers_found = list(marker_dir.glob("*.marker"))
+            marker_seen.append(len(markers_found) > 0)
+            return await original_dispatch(*args, **kwargs)
+
+        tool_ctx.executor.dispatch_food_truck = _capture_marker
+
+        await _run(tool_ctx)
+
+        assert len(marker_seen) == 1, "dispatch_food_truck should be called once"
+        assert marker_seen[0] is True, "marker file should exist during dispatch execution"
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_marker_contains_expected_json(
+        self, tool_ctx, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Marker file JSON contains dispatch_id, orchestrator_pid, and session_id."""
+        _setup_dispatch(tool_ctx, monkeypatch)
+        marker_dir = tmp_path / "markers"
+        marker_dir.mkdir()
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.claude_code_project_dir",
+            lambda cwd: marker_dir,
+        )
+
+        captured_json: list[dict] = []
+        original_dispatch = tool_ctx.executor.dispatch_food_truck
+
+        async def _capture_marker(*args, **kwargs):
+            markers = list(marker_dir.glob("*.marker"))
+            if markers:
+                content = markers[0].read_text()
+                captured_json.append(json.loads(content))
+            return await original_dispatch(*args, **kwargs)
+
+        tool_ctx.executor.dispatch_food_truck = _capture_marker
+
+        await _run(tool_ctx)
+
+        assert len(captured_json) == 1, "should have captured marker JSON"
+        data = captured_json[0]
+        assert "dispatch_id" in data
+        assert "orchestrator_pid" in data
+        assert "session_id" in data
+        assert isinstance(data["orchestrator_pid"], int)
+        assert isinstance(data["session_id"], str)

--- a/tests/infra/test_schema_read_convention.py
+++ b/tests/infra/test_schema_read_convention.py
@@ -81,6 +81,7 @@ _READ_SIDE_EXCEPTIONS: dict[str, str] = {
     "src/autoskillit/planner/consolidation.py": "Transient single-pipeline-run artifacts",
     "src/autoskillit/planner/validation.py": "Transient single-pipeline-run artifacts",
     "src/autoskillit/execution/_recording_skills.py": "Informational manifest — never read back",
+    "src/autoskillit/fleet/_api.py": "Progress signal — written and deleted, never read back",
 }
 
 


### PR DESCRIPTION
## Summary

Add three stdlib imports (`functools`, `os`, `anyio`), one core import (`claude_code_project_dir`), and a new `_touch_dispatch_marker` async helper to `src/autoskillit/fleet/_api.py`. Then wrap the `dispatch_food_truck` call inside `_run_dispatch` with an anyio task group that runs the heartbeat concurrently, bracketed by marker file creation (before) and cleanup (finally block). The marker file signals "dispatch in progress" to external observers; the heartbeat refreshes its mtime every 30 seconds; the finally block deletes it unconditionally.

Closes #2305

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260509-224219-375671/.autoskillit/temp/make-plan/p3_u3_add_imports_touch_dispatch_marker_helper_and_marker_lifecycle_plan_2026-05-09_224500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 794 | 8.0k | 895.2k | 59.6k | 80 | 50.2k | 5m 20s |
| verify | claude-sonnet-4-6 | 1 | 39 | 6.4k | 457.6k | 54.2k | 104 | 38.7k | 9m 5s |
| implement* | MiniMax-M2.7-highspeed | 1 | 5.3M | 45.6k | 2.9M | 58.2k | 238 | 66.1k | 21m 25s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 70.9k | 3.3k | 198.5k | 28.8k | 19 | 15.4k | 1m 13s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 75.1k | 2.2k | 227.3k | 28.8k | 20 | 15.1k | 60s |
| review_pr | claude-sonnet-4-6 | 3 | 2.0k | 139.1k | 2.1M | 92.0k | 180 | 235.8k | 30m 57s |
| resolve_review | claude-sonnet-4-6 | 2 | 682 | 38.1k | 5.2M | 91.6k | 191 | 141.4k | 18m 28s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 84 | 2.0k | 281.8k | 33.7k | 22 | 20.6k | 47s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 124.9k | 1.7k | 230.4k | 28.8k | 19 | 41.0k | 53s |
| resolve_ci | claude-sonnet-4-6 | 1 | 322 | 15.1k | 2.0M | 65.8k | 89 | 53.9k | 10m 32s |
| **Total** | | | 5.6M | 261.6k | 14.5M | 92.0k | | 678.3k | 1h 39m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 238 | 12194.9 | 277.8 | 191.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 98 | 52858.1 | 1443.2 | 389.2 |
| ci_conflict_fix | 365 | 771.9 | 56.5 | 5.6 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 1 | 2007637.0 | 53924.0 | 15120.0 |
| **Total** | **702** | 20655.5 | 966.2 | 372.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 6 | 3.9k | 178.6k | 8.0M | 516.8k | 1h 4m |
| claude-opus-4-6 | 1 | 80 | 16.7k | 1.0M | 80.6k | 13m 20s |
| MiniMax-M2.7-highspeed | 4 | 10.4M | 90.0k | 7.2M | 232.3k | 40m 45s |