### PR TITLE
P3-A4: Create test_api_dispatch_marker.py with marker lifecycle tests

### DIFF
--- a/tests/fleet/CLAUDE.md
+++ b/tests/fleet/CLAUDE.md
@@ -10,6 +10,7 @@ Fleet campaign dispatch, state persistence, and sidecar tests.
 | `_helpers.py` | Shared helpers for tests/fleet/ test modules |
 | `conftest.py` | Shared fixtures for tests/fleet/ |
 | `test_api.py` | Tests for fleet._api module (Group J) |
+| `test_api_dispatch_marker.py` | Tests for _run_dispatch marker lifecycle and _touch_dispatch_marker heartbeat |
 | `test_campaign_capture.py` | Tests for campaign capture extraction and ingredient interpolation (Group J) |
 | `test_checkpoint_bridge.py` | Tests for checkpoint_from_sidecar converting IssueSidecarEntry to SessionCheckpoint |
 | `test_dispatch_failure_semantics.py` | Group F: Timeout + No-Result-Block failure semantics for fleet dispatch |

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -98,7 +98,7 @@ async def test_marker_deleted_after_exception(tool_ctx, monkeypatch, tmp_path: P
             quota_checker=_no_sleep_quota_checker,
             quota_refresher=_noop_quota_refresher,
         )
-    except RuntimeError:
+    except* RuntimeError:
         pass
 
     remaining = list(marker_dir.glob("dispatch-in-progress-*.marker"))

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -67,7 +67,7 @@ async def test_marker_deleted_after_success(tool_ctx, monkeypatch, tmp_path: Pat
         quota_refresher=_noop_quota_refresher,
     )
 
-    remaining = list(marker_dir.glob("dispatch-in-progress-*.marker"))
+    remaining = list(marker_dir.glob("dispatch-in-progress--*.marker"))
     assert remaining == [], f"Expected no marker files, found {remaining}"
 
 
@@ -101,7 +101,7 @@ async def test_marker_deleted_after_exception(tool_ctx, monkeypatch, tmp_path: P
     except* RuntimeError:
         pass
 
-    remaining = list(marker_dir.glob("dispatch-in-progress-*.marker"))
+    remaining = list(marker_dir.glob("dispatch-in-progress--*.marker"))
     assert remaining == [], f"Expected no marker files after exception, found {remaining}"
 
 

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -117,7 +117,7 @@ async def test_heartbeat_refreshes_mtime(tmp_path: Path) -> None:
         tg.start_soon(_touch_dispatch_marker, marker_path, 0.05, trigger)
 
         async def _stop():
-            await anyio.sleep(0.12)
+            await anyio.sleep(0.25)
             trigger.set()
 
         tg.start_soon(_stop)

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -98,7 +98,7 @@ async def test_marker_deleted_after_exception(tool_ctx, monkeypatch, tmp_path: P
             quota_checker=_no_sleep_quota_checker,
             quota_refresher=_noop_quota_refresher,
         )
-    except BaseException:
+    except RuntimeError:
         pass
 
     remaining = list(marker_dir.glob("dispatch-in-progress-*.marker"))

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -1,0 +1,156 @@
+"""Tests for _run_dispatch marker lifecycle and _touch_dispatch_marker heartbeat."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import anyio
+import pytest
+
+from autoskillit.fleet._api import _run_dispatch, _touch_dispatch_marker
+from tests.fleet._helpers import _no_sleep_quota_checker, _noop_quota_refresher, _setup_dispatch
+
+pytestmark = [pytest.mark.layer("fleet"), pytest.mark.medium, pytest.mark.feature("fleet")]
+
+
+@pytest.mark.anyio
+async def test_marker_created_before_dispatch(tool_ctx, monkeypatch, tmp_path: Path) -> None:
+    _setup_dispatch(tool_ctx, monkeypatch)
+    marker_dir = tmp_path / "marker_dir"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.claude_code_project_dir",
+        lambda _cwd: marker_dir,
+    )
+
+    async def _asserting_dispatch(**_kw):
+        found = list(marker_dir.glob("dispatch-in-progress--*.marker"))
+        assert len(found) == 1, f"Expected 1 marker, found {len(found)}"
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(tool_ctx.executor, "dispatch_food_truck", _asserting_dispatch)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="t",
+            ingredients=None,
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=lambda **kw: "prompt",
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+
+
+@pytest.mark.anyio
+async def test_marker_deleted_after_success(tool_ctx, monkeypatch, tmp_path: Path) -> None:
+    _setup_dispatch(tool_ctx, monkeypatch)
+    marker_dir = tmp_path / "claude"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.claude_code_project_dir",
+        lambda _cwd: marker_dir,
+    )
+
+    await _run_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="test-recipe",
+        task="t",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        prompt_builder=lambda **kw: "prompt",
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    remaining = list(marker_dir.glob("dispatch-in-progress-*.marker"))
+    assert remaining == [], f"Expected no marker files, found {remaining}"
+
+
+@pytest.mark.anyio
+async def test_marker_deleted_after_exception(tool_ctx, monkeypatch, tmp_path: Path) -> None:
+    _setup_dispatch(tool_ctx, monkeypatch)
+    marker_dir = tmp_path / "claude"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.claude_code_project_dir",
+        lambda _cwd: marker_dir,
+    )
+
+    async def _raise_runtime_error(**_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(tool_ctx.executor, "dispatch_food_truck", _raise_runtime_error)
+
+    try:
+        await _run_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="t",
+            ingredients=None,
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=lambda **kw: "prompt",
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+    except BaseException:
+        pass
+
+    remaining = list(marker_dir.glob("dispatch-in-progress-*.marker"))
+    assert remaining == [], f"Expected no marker files after exception, found {remaining}"
+
+
+@pytest.mark.anyio
+async def test_heartbeat_refreshes_mtime(tmp_path: Path) -> None:
+    marker_path = tmp_path / "dispatch-in-progress-test.marker"
+    marker_path.write_text("{}")
+    initial_mtime = marker_path.stat().st_mtime
+
+    trigger = anyio.Event()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_touch_dispatch_marker, marker_path, 0.05, trigger)
+
+        async def _stop():
+            await anyio.sleep(0.12)
+            trigger.set()
+
+        tg.start_soon(_stop)
+
+    final_mtime = marker_path.stat().st_mtime
+    assert final_mtime > initial_mtime, "heartbeat must advance marker mtime"
+
+
+@pytest.mark.anyio
+async def test_marker_not_written_when_cwd_unavailable(
+    tool_ctx, monkeypatch, tmp_path: Path
+) -> None:
+    _setup_dispatch(tool_ctx, monkeypatch)
+
+    def _raise_oserror(_cwd: str) -> Path:
+        raise OSError("simulated failure")
+
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.claude_code_project_dir",
+        _raise_oserror,
+    )
+
+    await _run_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="test-recipe",
+        task="t",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        prompt_builder=lambda **kw: "prompt",
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    assert len(tool_ctx.executor.dispatch_calls) == 1
+    assert list(tmp_path.rglob("*.marker")) == []


### PR DESCRIPTION
## Summary

Create `tests/fleet/test_api_dispatch_marker.py` — a new test module containing five async tests that exercise the dispatch marker lifecycle in `_run_dispatch` and the `_touch_dispatch_marker` heartbeat coroutine. Each test validates one invariant: marker existence before dispatch, cleanup after success, cleanup after exception, heartbeat mtime advancement, and graceful degradation when `claude_code_project_dir` raises OSError.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

Closes #2306

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-005020-533103/.autoskillit/temp/make-plan/P3-A4_create_test_api_dispatch_marker_plan_2026-05-10_010600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 83 | 11.1k | 878.3k | 63.0k | 61 | 68.2k | 5m 10s |
| verify | claude-opus-4-6 | 1 | 33 | 7.1k | 655.4k | 55.9k | 46 | 42.8k | 4m 2s |
| implement* | MiniMax-M2.7-highspeed | 1 | 984.2k | 11.9k | 753.3k | 34.1k | 76 | 66.6k | 4m 42s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 74.9k | 2.5k | 198.5k | 28.8k | 17 | 15.4k | 1m 10s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 92.6k | 3.5k | 256.1k | 28.8k | 20 | 15.1k | 1m 16s |
| review_pr | claude-sonnet-4-6 | 3 | 324 | 48.4k | 1.5M | 58.7k | 111 | 126.6k | 11m 57s |
| resolve_review | claude-sonnet-4-6 | 2 | 402 | 27.6k | 2.4M | 68.3k | 118 | 101.7k | 11m 38s |
| **Total** | | | 1.2M | 112.2k | 6.6M | 68.3k | | 436.4k | 39m 58s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 157 | 4798.3 | 424.4 | 75.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 297492.9 | 12714.9 | 3452.0 |
| **Total** | **165** | 40115.5 | 2645.0 | 679.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 7 | 7.1k | 384.0k | 18.5M | 1.0M | 2h 10m |
| claude-opus-4-6 | 1 | 113 | 23.8k | 1.7M | 123.4k | 17m 23s |
| MiniMax-M2.7-highspeed | 5 | 11.6M | 109.7k | 8.6M | 370.4k | 48m 47s |