### PR TITLE
Research Recipes — Add download-data Step for Large External Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 134 bundled skills.
+tools and 135 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 52 MCP tools and 134 bundled skills.
+→ tests → PR → merge pipelines using 52 MCP tools and 135 bundled skills.
 
 ## Start here
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 134 bundled skills. Any new skill with an unguarded
+test that scans all 135 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 52 MCP tools and 134 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 52 MCP tools and 135 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
-The complete list of bundled skills (134 total: 3 in `src/autoskillit/skills/`,
-131 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+The complete list of bundled skills (135 total: 3 in `src/autoskillit/skills/`,
+132 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -37,7 +37,7 @@ Located under `src/autoskillit/skills_extended/`. Grouped by purpose:
 `generate-report`, `troubleshoot-experiment`
 
 ### Research and review
-`review-design`, `stage-data`, `setup-environment`, `bundle-local-report`, `reload-session`
+`review-design`, `stage-data`, `download-data`, `setup-environment`, `bundle-local-report`, `reload-session`
 
 ## Tier 3 — pipeline / automation
 

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 134 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 135 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -229,6 +229,7 @@ skills:
     - vis-lens-story-arc
     - plan-visualization
     - stage-data
+    - download-data
     - setup-environment
     - bundle-local-report
     # planner

--- a/src/autoskillit/recipe/_analysis_detectors.py
+++ b/src/autoskillit/recipe/_analysis_detectors.py
@@ -117,6 +117,7 @@ _OBSERVABILITY_CAPTURES: frozenset[tuple[str, str]] = frozenset(
         ("pr_url", "compose-pr"),
         ("html_path", "bundle-local-report"),
         ("resource_report", "stage-data"),
+        ("download_report", "download-data"),
         ("alignment_findings_path", "planner-validate-task-alignment"),
         ("review_approach_assessment_path", "planner-assess-review-approach"),
         # plan-visualization terminal handoff captures: emitted in food-truck sentinel,

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1341,7 +1341,7 @@ skills:
       type: file_path
     expected_output_patterns:
     - "verdict\\s*=\\s*(PASS|FAIL)"
-    - "download_report\\s*=\\s*/.+"
+    - "download_report\\s*=\\s*/.+/download-data/.+"
     pattern_examples:
     - "verdict = PASS\ndownload_report = /tmp/download-data/download_report_2026-05-10_120000.md\n%%ORDER_UP%%"
     write_behavior: always

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1329,6 +1329,23 @@ skills:
     - "verdict = PASS\nresource_report = /tmp/stage-data/resource_feasibility_2026-04-13_120000.md\n%%ORDER_UP%%"
     write_behavior: always
 
+  download-data:
+    inputs:
+    - name: experiment_plan
+      type: file_path
+      required: true
+    outputs:
+    - name: verdict
+      type: string
+    - name: download_report
+      type: file_path
+    expected_output_patterns:
+    - "verdict\\s*=\\s*(PASS|FAIL)"
+    - "download_report\\s*=\\s*/.+"
+    pattern_examples:
+    - "verdict = PASS\ndownload_report = /tmp/download-data/download_report_2026-05-10_120000.md\n%%ORDER_UP%%"
+    write_behavior: always
+
   setup-environment:
     inputs:
     - name: worktree_path

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1340,10 +1340,11 @@ skills:
     - name: download_report
       type: file_path
     expected_output_patterns:
-    - "verdict\\s*=\\s*(PASS|FAIL)"
-    - "download_report\\s*=\\s*/.+/download-data/.+"
+    - "verdict\\s*=\\s*(PASS|WARN|FAIL)"
+    - "download_report\\s*=\\s*\\S+/download-data/.+"
     pattern_examples:
     - "verdict = PASS\ndownload_report = /tmp/download-data/download_report_2026-05-10_120000.md\n%%ORDER_UP%%"
+    - "verdict = WARN\ndownload_report = /tmp/download-data/download_report_2026-05-10_120000.md\n%%ORDER_UP%%"
     write_behavior: always
 
   setup-environment:

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -102,6 +102,7 @@
         "field": "verdict",
         "routes": {
           "PASS": "decompose_phases",
+          "WARN": "decompose_phases",
           "FAIL": "escalate_stop"
         }
       },

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -74,13 +74,39 @@
       "on_result": {
         "field": "verdict",
         "routes": {
-          "PASS": "decompose_phases",
-          "WARN": "decompose_phases",
+          "PASS": "download_data",
+          "WARN": "download_data",
           "FAIL": "escalate_stop"
         }
       },
       "on_failure": "escalate_stop",
-      "note": "Pre-flight resource gate. Reads the experiment plan's data_manifest, checks available disk space and network connectivity for external/gitignored data entries, and creates the required directory structure in the worktree. PASS and WARN proceed to decompose_phases. FAIL escalates immediately with a detailed resource feasibility report rather than wasting compute on doomed downloads.\n"
+      "note": "Pre-flight resource gate. Reads the experiment plan's data_manifest, checks available disk space and network connectivity for external/gitignored data entries, and creates the required directory structure in the worktree. PASS and WARN proceed to download_data. FAIL escalates immediately with a detailed resource feasibility report rather than wasting compute on doomed downloads.\n"
+    },
+    "download_data": {
+      "tool": "run_skill",
+      "model": "",
+      "stale_threshold": 14400,
+      "idle_output_timeout": 0,
+      "retries": 1,
+      "on_exhausted": "escalate_stop",
+      "with": {
+        "skill_command": "/autoskillit:download-data ${{ inputs.experiment_plan }}",
+        "cwd": "${{ inputs.worktree_path }}",
+        "step_name": "download_data"
+      },
+      "capture": {
+        "verdict": "${{ result.verdict }}",
+        "download_report": "${{ result.download_report }}"
+      },
+      "on_result": {
+        "field": "verdict",
+        "routes": {
+          "PASS": "decompose_phases",
+          "FAIL": "escalate_stop"
+        }
+      },
+      "on_failure": "escalate_stop",
+      "note": "Downloads external and gitignored datasets declared in the experiment plan's data_manifest. Executes acquisition commands sequentially into the directories pre-created by stage_data. Uses a 4-hour stale threshold to accommodate multi-GB downloads. PASS proceeds to decompose_phases. FAIL escalates immediately.\n"
     },
     "decompose_phases": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -107,7 +107,7 @@
         }
       },
       "on_failure": "escalate_stop",
-      "note": "Downloads external and gitignored datasets declared in the experiment plan's data_manifest. Executes acquisition commands sequentially into the directories pre-created by stage_data. Uses a 4-hour stale threshold to accommodate multi-GB downloads. PASS proceeds to decompose_phases. FAIL escalates immediately.\n"
+      "note": "Downloads external and gitignored datasets declared in the experiment plan's data_manifest. Executes acquisition commands sequentially into the directories pre-created by stage_data. Uses a 4-hour stale threshold to accommodate multi-GB downloads. PASS and WARN proceed to decompose_phases. FAIL escalates immediately.\n"
     },
     "decompose_phases": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -80,17 +80,44 @@ steps:
     on_result:
       field: verdict
       routes:
-        PASS: decompose_phases
-        WARN: decompose_phases
+        PASS: download_data
+        WARN: download_data
         FAIL: escalate_stop
     on_failure: escalate_stop
     note: >
       Pre-flight resource gate. Reads the experiment plan's data_manifest, checks
       available disk space and network connectivity for external/gitignored data
       entries, and creates the required directory structure in the worktree. PASS
-      and WARN proceed to decompose_phases. FAIL escalates immediately with a
+      and WARN proceed to download_data. FAIL escalates immediately with a
       detailed resource feasibility report rather than wasting compute on doomed
       downloads.
+
+  download_data:
+    tool: run_skill
+    model: ""
+    stale_threshold: 14400
+    idle_output_timeout: 0
+    retries: 1
+    on_exhausted: escalate_stop
+    with:
+      skill_command: "/autoskillit:download-data ${{ inputs.experiment_plan }}"
+      cwd: "${{ inputs.worktree_path }}"
+      step_name: download_data
+    capture:
+      verdict: "${{ result.verdict }}"
+      download_report: "${{ result.download_report }}"
+    on_result:
+      field: verdict
+      routes:
+        PASS: decompose_phases
+        FAIL: escalate_stop
+    on_failure: escalate_stop
+    note: >
+      Downloads external and gitignored datasets declared in the experiment
+      plan's data_manifest. Executes acquisition commands sequentially into
+      the directories pre-created by stage_data. Uses a 4-hour stale threshold
+      to accommodate multi-GB downloads. PASS proceeds to decompose_phases.
+      FAIL escalates immediately.
 
   # --- Phase Iteration ---
   decompose_phases:

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -117,7 +117,7 @@ steps:
       Downloads external and gitignored datasets declared in the experiment
       plan's data_manifest. Executes acquisition commands sequentially into
       the directories pre-created by stage_data. Uses a 4-hour stale threshold
-      to accommodate multi-GB downloads. PASS proceeds to decompose_phases.
+      to accommodate multi-GB downloads. PASS and WARN proceed to decompose_phases.
       FAIL escalates immediately.
 
   # --- Phase Iteration ---

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -110,6 +110,7 @@ steps:
       field: verdict
       routes:
         PASS: decompose_phases
+        WARN: decompose_phases
         FAIL: escalate_stop
     on_failure: escalate_stop
     note: >

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -279,6 +279,7 @@
         "field": "verdict",
         "routes": {
           "PASS": "setup_environment",
+          "WARN": "setup_environment",
           "FAIL": "escalate_stop"
         }
       },

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -284,7 +284,7 @@
         }
       },
       "on_failure": "escalate_stop",
-      "note": "Downloads external and gitignored datasets declared in the experiment plan's data_manifest. Executes acquisition commands sequentially into the directories pre-created by stage_data. Uses a 4-hour stale threshold to accommodate multi-GB downloads. PASS proceeds to setup_environment. FAIL escalates immediately — partial downloads are not recoverable without re-running the full step.\n"
+      "note": "Downloads external and gitignored datasets declared in the experiment plan's data_manifest. Executes acquisition commands sequentially into the directories pre-created by stage_data. Uses a 4-hour stale threshold to accommodate multi-GB downloads. PASS and WARN proceed to setup_environment. FAIL escalates immediately — partial downloads are not recoverable without re-running the full step.\n"
     },
     "setup_environment": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -251,13 +251,39 @@
       "on_result": {
         "field": "verdict",
         "routes": {
-          "PASS": "setup_environment",
-          "WARN": "setup_environment",
+          "PASS": "download_data",
+          "WARN": "download_data",
           "FAIL": "escalate_stop"
         }
       },
       "on_failure": "escalate_stop",
-      "note": "Pre-flight resource gate. Reads the experiment plan's data_manifest, checks available disk space and network connectivity for external/gitignored data entries, and creates the required directory structure in the worktree. PASS and WARN proceed to setup_environment. FAIL escalates immediately with a detailed resource feasibility report rather than wasting compute on doomed downloads.\n"
+      "note": "Pre-flight resource gate. Reads the experiment plan's data_manifest, checks available disk space and network connectivity for external/gitignored data entries, and creates the required directory structure in the worktree. PASS and WARN proceed to download_data. FAIL escalates immediately with a detailed resource feasibility report rather than wasting compute on doomed downloads.\n"
+    },
+    "download_data": {
+      "tool": "run_skill",
+      "model": "",
+      "stale_threshold": 14400,
+      "idle_output_timeout": 0,
+      "retries": 1,
+      "on_exhausted": "escalate_stop",
+      "with": {
+        "skill_command": "/autoskillit:download-data ${{ context.experiment_plan }}",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "download_data"
+      },
+      "capture": {
+        "verdict": "${{ result.verdict }}",
+        "download_report": "${{ result.download_report }}"
+      },
+      "on_result": {
+        "field": "verdict",
+        "routes": {
+          "PASS": "setup_environment",
+          "FAIL": "escalate_stop"
+        }
+      },
+      "on_failure": "escalate_stop",
+      "note": "Downloads external and gitignored datasets declared in the experiment plan's data_manifest. Executes acquisition commands sequentially into the directories pre-created by stage_data. Uses a 4-hour stale threshold to accommodate multi-GB downloads. PASS proceeds to setup_environment. FAIL escalates immediately — partial downloads are not recoverable without re-running the full step.\n"
     },
     "setup_environment": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -297,6 +297,7 @@ steps:
       field: verdict
       routes:
         PASS: setup_environment
+        WARN: setup_environment
         FAIL: escalate_stop
     on_failure: escalate_stop
     note: >

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -304,7 +304,7 @@ steps:
       Downloads external and gitignored datasets declared in the experiment
       plan's data_manifest. Executes acquisition commands sequentially into
       the directories pre-created by stage_data. Uses a 4-hour stale threshold
-      to accommodate multi-GB downloads. PASS proceeds to setup_environment.
+      to accommodate multi-GB downloads. PASS and WARN proceed to setup_environment.
       FAIL escalates immediately — partial downloads are not recoverable
       without re-running the full step.
 

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -267,17 +267,45 @@ steps:
     on_result:
       field: verdict
       routes:
-        PASS: setup_environment
-        WARN: setup_environment
+        PASS: download_data
+        WARN: download_data
         FAIL: escalate_stop
     on_failure: escalate_stop
     note: >
       Pre-flight resource gate. Reads the experiment plan's data_manifest, checks
       available disk space and network connectivity for external/gitignored data
       entries, and creates the required directory structure in the worktree. PASS
-      and WARN proceed to setup_environment. FAIL escalates immediately with a
+      and WARN proceed to download_data. FAIL escalates immediately with a
       detailed resource feasibility report rather than wasting compute on doomed
       downloads.
+
+  download_data:
+    tool: run_skill
+    model: ""
+    stale_threshold: 14400
+    idle_output_timeout: 0
+    retries: 1
+    on_exhausted: escalate_stop
+    with:
+      skill_command: "/autoskillit:download-data ${{ context.experiment_plan }}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: download_data
+    capture:
+      verdict: "${{ result.verdict }}"
+      download_report: "${{ result.download_report }}"
+    on_result:
+      field: verdict
+      routes:
+        PASS: setup_environment
+        FAIL: escalate_stop
+    on_failure: escalate_stop
+    note: >
+      Downloads external and gitignored datasets declared in the experiment
+      plan's data_manifest. Executes acquisition commands sequentially into
+      the directories pre-created by stage_data. Uses a 4-hour stale threshold
+      to accommodate multi-GB downloads. PASS proceeds to setup_environment.
+      FAIL escalates immediately — partial downloads are not recoverable
+      without re-running the full step.
 
   setup_environment:
     tool: run_skill

--- a/src/autoskillit/skills_extended/download-data/SKILL.md
+++ b/src/autoskillit/skills_extended/download-data/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: download-data
+categories: [research]
+description: >
+  Download external and gitignored datasets declared in the experiment plan's
+  data_manifest. Executes acquisition commands sequentially into pre-created
+  directories, verifies each download, and emits a PASS/FAIL verdict.
+hooks:
+  PreToolUse:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: "echo '[SKILL: download-data] Downloading external datasets...'"
+          once: true
+---
+
+# Download Data Skill
+
+Download external and gitignored datasets declared in the experiment plan's
+`data_manifest` frontmatter section. Executes acquisition commands sequentially
+into the directories pre-created by `stage_data`, verifies each download, and
+emits a PASS/FAIL verdict. PASS proceeds to `setup_environment` (research.yaml)
+or `decompose_phases` (research-implement.yaml); FAIL escalates immediately.
+
+## When to Use
+
+- Invoked by the research recipe's `download_data` step between `stage_data`
+  and `setup_environment` (research.yaml) or `decompose_phases` (research-implement.yaml)
+- Whenever external or gitignored datasets need to be acquired before experiment execution
+
+## Arguments
+
+```
+/autoskillit:download-data <experiment_plan_path>
+```
+
+- `experiment_plan_path` — Absolute path to the experiment plan (positional).
+  Default: `$AUTOSKILLIT_TEMP/experiment-plan.md` in the current working directory.
+
+## Critical Constraints
+
+**NEVER:**
+- Modify the experiment plan or any source files
+- Run subagents in the background (`run_in_background: true` is prohibited)
+- Skip the `depends_on` command when it is specified for an entry
+- Proceed with a failed download without escalating
+- Write files outside `{{AUTOSKILLIT_TEMP}}/download-data/`
+
+**ALWAYS:**
+- Read the `data_manifest` frontmatter section of the experiment plan
+- Filter for `source_type: external` and `source_type: gitignored` entries only
+- Skip entries that lack an `acquisition` command (e.g., `source_type: literature`
+  or `source_type: database` entries without download commands)
+- Execute `depends_on` before `acquisition` for the same entry
+- Verify each download using the entry's `verification` criteria
+- Write the download report before emitting the verdict token
+- Use `model: "sonnet"` for all subagents
+
+## Workflow
+
+### Step 1 — Parse the Experiment Plan
+
+Read the experiment plan at the provided path (or default path). Parse the
+`data_manifest` YAML frontmatter section. Identify all entries where
+`source_type` is `"external"` or `"gitignored"`.
+
+### Step 2 — Short-Circuit for No-Downloads Plans
+
+If no `external` or `gitignored` entries with `acquisition` commands exist,
+emit `verdict = PASS` with a note that no external data downloads are required.
+Write a minimal download report and exit. This covers synthetic/fixture-only
+plans and plans with only `source_type: literature` or `source_type: database`
+entries that lack acquisition commands.
+
+### Step 3 — Execute Acquisition Commands Sequentially
+
+For each `external`/`gitignored` entry (respecting `depends_on` ordering):
+
+**a. Skip entries without acquisition commands** — Entries whose `source_type`
+is `literature` or `database` and lack an `acquisition` field are skipped.
+
+**b. Handle retry cleanup** — If this is a retry (the step's `retries: 1`
+triggers re-execution on failure), remove any partial output files at the
+entry's target location before proceeding to prevent partial-file corruption
+on re-download.
+
+**c. Execute `depends_on` if specified** — If the entry has a `depends_on`
+field, execute that command first in the worktree CWD.
+
+**d. Execute the acquisition command** — Run the `acquisition` command via Bash
+in the worktree CWD. Use no timeout on individual commands (the step-level
+`stale_threshold: 14400` provides the outer bound). Log stdout/stderr to:
+```
+{{AUTOSKILLIT_TEMP}}/download-data/download_{entry_index}_{timestamp}.log
+```
+
+**e. Verify the download** — After each command completes, run the `verification`
+check. Verification forms include:
+- checksum file comparison (`.md5`, `.sha256` sidecars)
+- minimum file size threshold
+- directory non-empty assertion
+- custom shell command specified in the entry's `verification` field
+
+### Step 4 — Assess Results
+
+Build a download results table:
+```
+| Entry | Source Type | Location | Status | Duration |
+| ...   | external    | data/geo/| OK     | 42m 18s  |
+| ...   | external    | data/rna/| FAILED | 12m 03s  |
+```
+
+- **PASS**: all entries succeeded
+- **FAIL**: any entry failed
+
+### Step 5 — Write the Download Report
+
+Save to:
+```
+{{AUTOSKILLIT_TEMP}}/download-data/download_report_{YYYY-MM-DD_HHMMSS}.md
+```
+
+Report structure:
+```markdown
+## Download Report
+**Date:** {timestamp}
+**Verdict:** PASS | FAIL
+
+### Download Results
+| Entry | Source Type | Location | Status | Duration |
+|-------|-------------|----------|--------|----------|
+...
+
+### Individual Logs
+- {entry}: {{AUTOSKILLIT_TEMP}}/download-data/download_{entry_index}_{timestamp}.log
+```
+
+### Step 6 — Emit Structured Output Tokens
+
+Emit structured output tokens as LITERAL PLAIN TEXT with NO markdown
+formatting on the token names. Do not wrap token names in `**bold**`,
+`*italic*`, or any other markdown. The adjudicator performs a regex match
+on the exact token name — decorators cause match failure.
+
+```
+verdict = PASS
+download_report = /absolute/path/to/download_report_{YYYY-MM-DD_HHMMSS}.md
+```
+
+## Output
+
+```
+verdict = PASS|FAIL
+download_report = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/download-data/download_report_{YYYY-MM-DD_HHMMSS}.md
+```

--- a/src/autoskillit/skills_extended/download-data/SKILL.md
+++ b/src/autoskillit/skills_extended/download-data/SKILL.md
@@ -45,6 +45,8 @@ or `decompose_phases` (research-implement.yaml); FAIL escalates immediately.
 - Skip the `depends_on` command when it is specified for an entry
 - Proceed with a failed download without escalating
 - Write files outside `{{AUTOSKILLIT_TEMP}}/download-data/`
+- Fabricate or hallucinate download results — only report actual command output
+- Attribute a missing or partial file to a completed download
 
 **ALWAYS:**
 - Read the `data_manifest` frontmatter section of the experiment plan
@@ -148,6 +150,9 @@ download_report = /absolute/path/to/download_report_{YYYY-MM-DD_HHMMSS}.md
 ```
 
 ## Output
+
+Include the completion marker from the ORCHESTRATION DIRECTIVE at the end of the
+structured output block.
 
 ```
 verdict = PASS|FAIL

--- a/src/autoskillit/skills_extended/download-data/SKILL.md
+++ b/src/autoskillit/skills_extended/download-data/SKILL.md
@@ -4,7 +4,7 @@ categories: [research]
 description: >
   Download external and gitignored datasets declared in the experiment plan's
   data_manifest. Executes acquisition commands sequentially into pre-created
-  directories, verifies each download, and emits a PASS/FAIL verdict.
+  directories, verifies each download, and emits a PASS/WARN/FAIL verdict.
 hooks:
   PreToolUse:
     - matcher: "*"
@@ -19,8 +19,9 @@ hooks:
 Download external and gitignored datasets declared in the experiment plan's
 `data_manifest` frontmatter section. Executes acquisition commands sequentially
 into the directories pre-created by `stage_data`, verifies each download, and
-emits a PASS/FAIL verdict. PASS proceeds to `setup_environment` (research.yaml)
-or `decompose_phases` (research-implement.yaml); FAIL escalates immediately.
+emits a PASS/WARN/FAIL verdict. PASS and WARN proceed to `setup_environment`
+(research.yaml) or `decompose_phases` (research-implement.yaml); FAIL escalates
+immediately.
 
 ## When to Use
 
@@ -35,7 +36,7 @@ or `decompose_phases` (research-implement.yaml); FAIL escalates immediately.
 ```
 
 - `experiment_plan_path` — Absolute path to the experiment plan (positional).
-  Default: `$AUTOSKILLIT_TEMP/experiment-plan.md` in the current working directory.
+  Default: `$AUTOSKILLIT_TEMP/experiment-plan.md`.
 
 ## Critical Constraints
 
@@ -90,8 +91,9 @@ on re-download.
 field, execute that command first in the worktree CWD.
 
 **d. Execute the acquisition command** — Run the `acquisition` command via Bash
-in the worktree CWD. Use no timeout on individual commands (the step-level
-`stale_threshold: 14400` provides the outer bound). Log stdout/stderr to:
+in the worktree CWD. Pass `timeout=14400000` (ms) to each Bash invocation to
+prevent the tool's 120 s default from killing multi-GB downloads; the step-level
+`stale_threshold: 14400` provides the outer bound. Log stdout/stderr to:
 ```
 {{AUTOSKILLIT_TEMP}}/download-data/download_{entry_index}_{timestamp}.log
 ```
@@ -112,8 +114,11 @@ Build a download results table:
 | ...   | external    | data/rna/| FAILED | 12m 03s  |
 ```
 
-- **PASS**: all entries succeeded
-- **FAIL**: any entry failed
+- **PASS**: all entries succeeded with no warnings
+- **WARN**: all entries completed but at least one triggered a recoverable condition
+  (e.g., a verification check passed after retry, or the directory is non-empty but
+  below the expected size threshold)
+- **FAIL**: any entry failed and could not be recovered
 
 ### Step 5 — Write the Download Report
 
@@ -126,7 +131,7 @@ Report structure:
 ```markdown
 ## Download Report
 **Date:** {timestamp}
-**Verdict:** PASS | FAIL
+**Verdict:** PASS | WARN | FAIL
 
 ### Download Results
 | Entry | Source Type | Location | Status | Duration |
@@ -145,7 +150,7 @@ formatting on the token names. Do not wrap token names in `**bold**`,
 on the exact token name — decorators cause match failure.
 
 ```
-verdict = PASS
+verdict = PASS|WARN|FAIL
 download_report = /absolute/path/to/download_report_{YYYY-MM-DD_HHMMSS}.md
 ```
 
@@ -155,6 +160,6 @@ Include the completion marker from the ORCHESTRATION DIRECTIVE at the end of the
 structured output block.
 
 ```
-verdict = PASS|FAIL
+verdict = PASS|WARN|FAIL
 download_report = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/download-data/download_report_{YYYY-MM-DD_HHMMSS}.md
 ```

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -27,7 +27,7 @@ compute on doomed downloads.
 ## When to Use
 
 - Invoked by the research recipe's `stage_data` step between `create_worktree`
-  and `decompose_phases`
+  and `download_data`
 - Whenever a pre-flight resource check is needed before data-intensive implementation
 
 ## Arguments

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -245,7 +245,7 @@ analyze-prs, arch-lens-c4-container, arch-lens-concurrency, arch-lens-data-linea
 arch-lens-development, arch-lens-error-resilience, arch-lens-module-dependency, arch-lens-operational,
 arch-lens-process-flow, arch-lens-repository-access, arch-lens-scenarios, arch-lens-security, arch-lens-state-lifecycle,
 audit-arch, audit-bugs, audit-claims, audit-cohesion, audit-defense-standards, audit-docs, audit-feature-gates, audit-friction, audit-impl, audit-review-decisions, audit-tests,
-build-execution-map, bundle-local-report, close-kitchen, collapse-issues, compose-pr, compose-research-pr, design-guards, diagnose-ci, dry-walkthrough, elaborate-phase,
+build-execution-map, bundle-local-report, close-kitchen, collapse-issues, compose-pr, compose-research-pr, design-guards, diagnose-ci, download-data, dry-walkthrough, elaborate-phase,
 enrich-issues, exp-lens-benchmark-representativeness, exp-lens-causal-assumptions, exp-lens-comparator-construction,
 exp-lens-error-budget, exp-lens-estimand-clarity, exp-lens-exploratory-confirmatory, exp-lens-fair-comparison,
 exp-lens-governance-risk, exp-lens-iterative-learning, exp-lens-measurement-validity, exp-lens-pipeline-integrity,

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -59,6 +59,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_sous_chef_routing.py` | Contract tests for the CONTEXT LIMIT ROUTING section in sous-chef SKILL.md |
 | `test_sous_chef_scheduling.py` | Contract tests for the PARALLEL STEP SCHEDULING section in sous-chef SKILL.md |
 | `test_stage_data_contracts.py` | Contract tests for stage-data SKILL.md — pre-flight resource feasibility gate |
+| `test_download_data_contracts.py` | Contract tests for download-data SKILL.md — external dataset acquisition step |
 | `test_sub_skill_refusal_contracts.py` | Cross-skill contract: every SKILL.md that invokes sub-skills must contain explicit refusal handling language |
 | `test_target_skill_invocability.py` | Contract: the target skill of a run_skill call must be invocable after session setup |
 | `test_token_summary_contracts.py` | Structural contracts for the token summary pipeline |

--- a/tests/contracts/test_download_data_contracts.py
+++ b/tests/contracts/test_download_data_contracts.py
@@ -37,72 +37,64 @@ def test_skill_categories_include_research(skill_text: str) -> None:
     assert any("research" in lines[j] for j in range(cats_idx, min(cats_idx + 5, len(lines))))
 
 
-def test_skill_md_has_output_section() -> None:
+def test_skill_md_has_output_section(skill_text: str) -> None:
     """SKILL.md must have an ## Output section."""
-    text = SKILL_PATH.read_text()
-    assert "## Output" in text
+    assert "## Output" in skill_text
 
 
-def test_skill_md_emits_verdict_token() -> None:
+def test_skill_md_emits_verdict_token(skill_text: str) -> None:
     """Output section must document verdict = PASS|FAIL."""
-    text = SKILL_PATH.read_text()
-    assert "verdict =" in text
-    assert "PASS" in text
-    assert "FAIL" in text
+    assert "verdict =" in skill_text
+    assert "PASS" in skill_text
+    assert "FAIL" in skill_text
 
 
-def test_skill_md_emits_download_report_token() -> None:
+def test_skill_md_emits_download_report_token(skill_text: str) -> None:
     """Output section must document download_report token."""
-    text = SKILL_PATH.read_text()
-    assert "download_report =" in text
+    assert "download_report =" in skill_text
 
 
-def test_skill_reads_data_manifest() -> None:
+def test_skill_reads_data_manifest(skill_text: str) -> None:
     """Skill must read data_manifest from the experiment plan."""
-    text = SKILL_PATH.read_text()
-    assert "data_manifest" in text
+    assert "data_manifest" in skill_text
 
 
-def test_skill_filters_external_and_gitignored() -> None:
+def test_skill_filters_external_and_gitignored(skill_text: str) -> None:
     """Skill must filter for source_type external and gitignored entries."""
-    text = SKILL_PATH.read_text().lower()
-    assert "external" in text
-    assert "gitignored" in text
+    lower = skill_text.lower()
+    assert "external" in lower
+    assert "gitignored" in lower
 
 
-def test_skill_executes_acquisition_commands() -> None:
+def test_skill_executes_acquisition_commands(skill_text: str) -> None:
     """Skill must execute acquisition commands."""
-    text = SKILL_PATH.read_text().lower()
-    assert "acquisition" in text
+    assert "acquisition" in skill_text.lower()
 
 
-def test_skill_respects_depends_on() -> None:
+def test_skill_respects_depends_on(skill_text: str) -> None:
     """Skill must respect depends_on ordering."""
-    text = SKILL_PATH.read_text().lower()
-    assert "depends_on" in text
+    assert "depends_on" in skill_text.lower()
 
 
-def test_skill_writes_download_report() -> None:
+def test_skill_writes_download_report(skill_text: str) -> None:
     """Skill must write a download report before emitting verdict."""
-    text = SKILL_PATH.read_text()
-    assert "download_report" in text
+    assert "download_report" in skill_text
 
 
-def test_skill_verifies_downloads() -> None:
+def test_skill_verifies_downloads(skill_text: str) -> None:
     """Skill must verify downloads after execution."""
-    text = SKILL_PATH.read_text().lower()
-    assert "verification" in text or "verify" in text
+    lower = skill_text.lower()
+    assert "verification" in lower or "verify" in lower
 
 
-def test_skill_has_stale_threshold_mention() -> None:
+def test_skill_has_stale_threshold_mention(skill_text: str) -> None:
     """Skill documentation must reference the stale_threshold context."""
-    text = SKILL_PATH.read_text().lower()
-    assert "stale" in text or "14400" in text
+    lower = skill_text.lower()
+    assert "stale" in lower or "14400" in lower
 
 
-def test_skill_categories_in_frontmatter() -> None:
+def test_skill_categories_in_frontmatter(skill_text: str) -> None:
     """Frontmatter must define categories before hooks block."""
-    text = SKILL_PATH.read_text()
-    cats_idx = text.find("categories:")
-    hooks_idx = text.find("hooks:")
+    cats_idx = skill_text.find("categories:")
+    hooks_idx = skill_text.find("hooks:")
     assert cats_idx != -1 and hooks_idx != -1 and cats_idx < hooks_idx

--- a/tests/contracts/test_download_data_contracts.py
+++ b/tests/contracts/test_download_data_contracts.py
@@ -34,7 +34,7 @@ def test_skill_categories_include_research(skill_text: str) -> None:
     lines = skill_text.splitlines()
     cats_idx = next((i for i, line in enumerate(lines) if "categories:" in line), None)
     assert cats_idx is not None, "categories: block not found in frontmatter"
-    assert any("research" in lines[j] for j in range(cats_idx + 1, min(cats_idx + 5, len(lines))))
+    assert any("research" in lines[j] for j in range(cats_idx, min(cats_idx + 5, len(lines))))
 
 
 def test_skill_md_has_output_section() -> None:

--- a/tests/contracts/test_download_data_contracts.py
+++ b/tests/contracts/test_download_data_contracts.py
@@ -24,17 +24,17 @@ def test_skill_md_exists() -> None:
     assert SKILL_PATH.exists()
 
 
-def test_skill_name_matches_directory() -> None:
+def test_skill_name_matches_directory(skill_text: str) -> None:
     """Frontmatter name field must be 'download-data'."""
-    text = SKILL_PATH.read_text()
-    assert "name: download-data" in text
+    assert "name: download-data" in skill_text
 
 
-def test_skill_categories_include_research() -> None:
+def test_skill_categories_include_research(skill_text: str) -> None:
     """Frontmatter categories must include 'research'."""
-    text = SKILL_PATH.read_text()
-    assert "categories:" in text
-    assert "research" in text
+    lines = skill_text.splitlines()
+    cats_idx = next((i for i, line in enumerate(lines) if "categories:" in line), None)
+    assert cats_idx is not None, "categories: block not found in frontmatter"
+    assert any("research" in lines[j] for j in range(cats_idx + 1, min(cats_idx + 5, len(lines))))
 
 
 def test_skill_md_has_output_section() -> None:
@@ -105,4 +105,4 @@ def test_skill_categories_in_frontmatter() -> None:
     text = SKILL_PATH.read_text()
     cats_idx = text.find("categories:")
     hooks_idx = text.find("hooks:")
-    assert cats_idx > 0 and cats_idx < hooks_idx
+    assert cats_idx != -1 and hooks_idx != -1 and cats_idx < hooks_idx

--- a/tests/contracts/test_download_data_contracts.py
+++ b/tests/contracts/test_download_data_contracts.py
@@ -1,0 +1,108 @@
+"""Contract tests for download-data SKILL.md — external dataset acquisition step."""
+
+from pathlib import Path
+
+import pytest
+
+SKILL_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "download-data"
+    / "SKILL.md"
+)
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_PATH.read_text()
+
+
+def test_skill_md_exists() -> None:
+    """download-data SKILL.md must exist at skills_extended/download-data/SKILL.md."""
+    assert SKILL_PATH.exists()
+
+
+def test_skill_name_matches_directory() -> None:
+    """Frontmatter name field must be 'download-data'."""
+    text = SKILL_PATH.read_text()
+    assert "name: download-data" in text
+
+
+def test_skill_categories_include_research() -> None:
+    """Frontmatter categories must include 'research'."""
+    text = SKILL_PATH.read_text()
+    assert "categories:" in text
+    assert "research" in text
+
+
+def test_skill_md_has_output_section() -> None:
+    """SKILL.md must have an ## Output section."""
+    text = SKILL_PATH.read_text()
+    assert "## Output" in text
+
+
+def test_skill_md_emits_verdict_token() -> None:
+    """Output section must document verdict = PASS|FAIL."""
+    text = SKILL_PATH.read_text()
+    assert "verdict =" in text
+    assert "PASS" in text
+    assert "FAIL" in text
+
+
+def test_skill_md_emits_download_report_token() -> None:
+    """Output section must document download_report token."""
+    text = SKILL_PATH.read_text()
+    assert "download_report =" in text
+
+
+def test_skill_reads_data_manifest() -> None:
+    """Skill must read data_manifest from the experiment plan."""
+    text = SKILL_PATH.read_text()
+    assert "data_manifest" in text
+
+
+def test_skill_filters_external_and_gitignored() -> None:
+    """Skill must filter for source_type external and gitignored entries."""
+    text = SKILL_PATH.read_text().lower()
+    assert "external" in text
+    assert "gitignored" in text
+
+
+def test_skill_executes_acquisition_commands() -> None:
+    """Skill must execute acquisition commands."""
+    text = SKILL_PATH.read_text().lower()
+    assert "acquisition" in text
+
+
+def test_skill_respects_depends_on() -> None:
+    """Skill must respect depends_on ordering."""
+    text = SKILL_PATH.read_text().lower()
+    assert "depends_on" in text
+
+
+def test_skill_writes_download_report() -> None:
+    """Skill must write a download report before emitting verdict."""
+    text = SKILL_PATH.read_text()
+    assert "download_report" in text
+
+
+def test_skill_verifies_downloads() -> None:
+    """Skill must verify downloads after execution."""
+    text = SKILL_PATH.read_text().lower()
+    assert "verification" in text or "verify" in text
+
+
+def test_skill_has_stale_threshold_mention() -> None:
+    """Skill documentation must reference the stale_threshold context."""
+    text = SKILL_PATH.read_text().lower()
+    assert "stale" in text or "14400" in text
+
+
+def test_skill_categories_in_frontmatter() -> None:
+    """Frontmatter must define categories before hooks block."""
+    text = SKILL_PATH.read_text()
+    cats_idx = text.find("categories:")
+    hooks_idx = text.find("hooks:")
+    assert cats_idx > 0 and cats_idx < hooks_idx

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -314,10 +314,10 @@ def test_docs_state_37_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 37)
 
 
-def test_skill_visibility_states_134_skills() -> None:
-    # 134 = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 131 extended.
-    # DefaultSkillResolver.list_all() returns 133 (excludes sous-chef from public surface).
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 134)
+def test_skill_visibility_states_135_skills() -> None:
+    # 135 = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 132 extended.
+    # DefaultSkillResolver.list_all() returns 134 (excludes sous-chef from public surface).
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 135)
 
 
 def test_safety_hooks_states_21_hooks() -> None:

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -576,6 +576,8 @@ class TestOutputPathTokensDerivedFromContracts:
             "env_report",
             # run-experiment group manifest output (multi-group awareness)
             "group_manifest",
+            # download-data skill output (research recipe download report)
+            "download_report",
         }
     )
 

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -576,7 +576,6 @@ class TestOutputPathTokensDerivedFromContracts:
             "env_report",
             # run-experiment group manifest output (multi-group awareness)
             "group_manifest",
-            # download-data skill output (research recipe download report)
             "download_report",
         }
     )

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -88,6 +88,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_research_review_recipe.py` | Tests for research-review sub-recipe structure |
 | `test_research_smoke_fixtures.py` | Smoke-test fixture constants and classification/structural validation for the research recipe |
 | `test_research_stage_data_step.py` | Tests for stage-data step in research recipes |
+| `test_research_download_data_step.py` | Tests for download-data step in research recipes |
 | `test_research_sub_recipes.py` | Tests for research sub-recipe YAML structure (design, implement, review, archive) |
 | `test_research_sub_recipe_rules.py` | Contract tests for research sub-recipe semantic rules and dataflow analysis |
 | `test_resolve_ci_routing_invariant.py` | Tests for CI routing invariant in resolve steps |

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -663,6 +663,7 @@ ALWAYS_WRITE_SKILLS = {
     "compose-research-pr",
     "design-guards",
     "diagnose-ci",
+    "download-data",
     "dry-walkthrough",
     "file-audit-issues",
     "generate-report",

--- a/tests/recipe/test_research_download_data_step.py
+++ b/tests/recipe/test_research_download_data_step.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.schema import Recipe
 from autoskillit.recipe.validator import validate_recipe_structure
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
@@ -13,95 +14,102 @@ RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 
 
 @pytest.fixture(scope="module")
-def recipe():
+def recipe() -> Recipe:
     return load_recipe(RESEARCH_RECIPE_PATH)
 
 
-def test_download_data_step_exists(recipe) -> None:
+def test_download_data_step_exists(recipe: Recipe) -> None:
     """research.yaml must include a download_data step."""
     assert "download_data" in recipe.steps
 
 
-def test_download_data_uses_run_skill_tool(recipe) -> None:
+def test_download_data_uses_run_skill_tool(recipe: Recipe) -> None:
     """download_data step must use the run_skill tool."""
     assert recipe.steps["download_data"].tool == "run_skill"
 
 
-def test_download_data_skill_command_references_download_data_skill(recipe) -> None:
+def test_download_data_skill_command_references_download_data_skill(recipe: Recipe) -> None:
     """download_data skill_command must reference the download-data skill."""
     step = recipe.steps["download_data"]
     assert "download-data" in step.with_args["skill_command"]
 
 
-def test_download_data_skill_command_passes_experiment_plan(recipe) -> None:
+def test_download_data_skill_command_passes_experiment_plan(recipe: Recipe) -> None:
     """download_data skill_command must reference experiment_plan."""
     step = recipe.steps["download_data"]
     assert "experiment_plan" in step.with_args["skill_command"]
 
 
-def test_download_data_cwd_is_worktree_path(recipe) -> None:
+def test_download_data_cwd_is_worktree_path(recipe: Recipe) -> None:
     """download_data cwd must reference context.worktree_path."""
     step = recipe.steps["download_data"]
     assert "worktree_path" in step.with_args.get("cwd", "")
 
 
-def test_download_data_captures_verdict(recipe) -> None:
+def test_download_data_captures_verdict(recipe: Recipe) -> None:
     """download_data must capture the verdict token."""
     step = recipe.steps["download_data"]
     assert "verdict" in step.capture
 
 
-def test_download_data_captures_download_report(recipe) -> None:
+def test_download_data_captures_download_report(recipe: Recipe) -> None:
     """download_data must capture the download_report token."""
     step = recipe.steps["download_data"]
     assert "download_report" in step.capture
 
 
-def test_download_data_pass_routes_to_setup_environment(recipe) -> None:
+def test_download_data_pass_routes_to_setup_environment(recipe: Recipe) -> None:
     """download_data PASS verdict must route to setup_environment."""
     step = recipe.steps["download_data"]
     assert step.on_result is not None
     assert step.on_result.routes["PASS"] == "setup_environment"
 
 
-def test_download_data_fail_routes_to_escalate_stop(recipe) -> None:
+def test_download_data_warn_routes_to_setup_environment(recipe: Recipe) -> None:
+    """download_data WARN verdict must route to setup_environment."""
+    step = recipe.steps["download_data"]
+    assert step.on_result is not None
+    assert step.on_result.routes["WARN"] == "setup_environment"
+
+
+def test_download_data_fail_routes_to_escalate_stop(recipe: Recipe) -> None:
     """download_data FAIL verdict must route to escalate_stop."""
     step = recipe.steps["download_data"]
     assert step.on_result is not None
     assert step.on_result.routes["FAIL"] == "escalate_stop"
 
 
-def test_download_data_on_failure_escalates(recipe) -> None:
+def test_download_data_on_failure_escalates(recipe: Recipe) -> None:
     """download_data on_failure must escalate_stop."""
     step = recipe.steps["download_data"]
     assert step.on_failure == "escalate_stop"
 
 
-def test_download_data_stale_threshold_is_14400(recipe) -> None:
+def test_download_data_stale_threshold_is_14400(recipe: Recipe) -> None:
     """download_data stale_threshold must be 14400 (4 hours)."""
     step = recipe.steps["download_data"]
     assert step.stale_threshold == 14400
 
 
-def test_download_data_idle_output_timeout_is_0(recipe) -> None:
+def test_download_data_idle_output_timeout_is_0(recipe: Recipe) -> None:
     """download_data idle_output_timeout must be 0 (disabled)."""
     step = recipe.steps["download_data"]
     assert step.idle_output_timeout == 0
 
 
-def test_download_data_retries_is_1(recipe) -> None:
+def test_download_data_retries_is_1(recipe: Recipe) -> None:
     """download_data retries must be 1."""
     step = recipe.steps["download_data"]
     assert step.retries == 1
 
 
-def test_download_data_on_exhausted_escalates(recipe) -> None:
+def test_download_data_on_exhausted_escalates(recipe: Recipe) -> None:
     """download_data on_exhausted must escalate_stop."""
     step = recipe.steps["download_data"]
     assert step.on_exhausted == "escalate_stop"
 
 
-def test_research_recipe_still_validates(recipe) -> None:
+def test_research_recipe_still_validates(recipe: Recipe) -> None:
     """research.yaml must pass structural validation after download_data is added."""
     errors = validate_recipe_structure(recipe)
     assert errors == [], f"Validation errors: {errors}"

--- a/tests/recipe/test_research_download_data_step.py
+++ b/tests/recipe/test_research_download_data_step.py
@@ -1,0 +1,107 @@
+"""Tests for download_data step wiring in the research recipe."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.validator import validate_recipe_structure
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
+
+
+@pytest.fixture(scope="module")
+def recipe():
+    return load_recipe(RESEARCH_RECIPE_PATH)
+
+
+def test_download_data_step_exists(recipe) -> None:
+    """research.yaml must include a download_data step."""
+    assert "download_data" in recipe.steps
+
+
+def test_download_data_uses_run_skill_tool(recipe) -> None:
+    """download_data step must use the run_skill tool."""
+    assert recipe.steps["download_data"].tool == "run_skill"
+
+
+def test_download_data_skill_command_references_download_data_skill(recipe) -> None:
+    """download_data skill_command must reference the download-data skill."""
+    step = recipe.steps["download_data"]
+    assert "download-data" in step.with_args["skill_command"]
+
+
+def test_download_data_skill_command_passes_experiment_plan(recipe) -> None:
+    """download_data skill_command must reference experiment_plan."""
+    step = recipe.steps["download_data"]
+    assert "experiment_plan" in step.with_args["skill_command"]
+
+
+def test_download_data_cwd_is_worktree_path(recipe) -> None:
+    """download_data cwd must reference context.worktree_path."""
+    step = recipe.steps["download_data"]
+    assert "worktree_path" in step.with_args.get("cwd", "")
+
+
+def test_download_data_captures_verdict(recipe) -> None:
+    """download_data must capture the verdict token."""
+    step = recipe.steps["download_data"]
+    assert "verdict" in step.capture
+
+
+def test_download_data_captures_download_report(recipe) -> None:
+    """download_data must capture the download_report token."""
+    step = recipe.steps["download_data"]
+    assert "download_report" in step.capture
+
+
+def test_download_data_pass_routes_to_setup_environment(recipe) -> None:
+    """download_data PASS verdict must route to setup_environment."""
+    step = recipe.steps["download_data"]
+    assert step.on_result is not None
+    assert step.on_result.routes["PASS"] == "setup_environment"
+
+
+def test_download_data_fail_routes_to_escalate_stop(recipe) -> None:
+    """download_data FAIL verdict must route to escalate_stop."""
+    step = recipe.steps["download_data"]
+    assert step.on_result is not None
+    assert step.on_result.routes["FAIL"] == "escalate_stop"
+
+
+def test_download_data_on_failure_escalates(recipe) -> None:
+    """download_data on_failure must escalate_stop."""
+    step = recipe.steps["download_data"]
+    assert step.on_failure == "escalate_stop"
+
+
+def test_download_data_stale_threshold_is_14400(recipe) -> None:
+    """download_data stale_threshold must be 14400 (4 hours)."""
+    step = recipe.steps["download_data"]
+    assert step.stale_threshold == 14400
+
+
+def test_download_data_idle_output_timeout_is_0(recipe) -> None:
+    """download_data idle_output_timeout must be 0 (disabled)."""
+    step = recipe.steps["download_data"]
+    assert step.idle_output_timeout == 0
+
+
+def test_download_data_retries_is_1(recipe) -> None:
+    """download_data retries must be 1."""
+    step = recipe.steps["download_data"]
+    assert step.retries == 1
+
+
+def test_download_data_on_exhausted_escalates(recipe) -> None:
+    """download_data on_exhausted must escalate_stop."""
+    step = recipe.steps["download_data"]
+    assert step.on_exhausted == "escalate_stop"
+
+
+def test_research_recipe_still_validates(recipe) -> None:
+    """research.yaml must pass structural validation after download_data is added."""
+    errors = validate_recipe_structure(recipe)
+    assert errors == [], f"Validation errors: {errors}"

--- a/tests/recipe/test_research_implement_recipe.py
+++ b/tests/recipe/test_research_implement_recipe.py
@@ -68,3 +68,49 @@ class TestResearchImplementRecipe:
         step = recipe.steps["run_retry_delay"]
         assert step.tool == "run_cmd"
         assert "sleep" in step.with_args.get("cmd", "")
+
+
+class TestResearchImplementDownloadData:
+    """Tests for download_data step in research-implement.yaml (T3)."""
+
+    @pytest.fixture(scope="module")
+    def recipe(self):
+        return load_recipe(builtin_recipes_dir() / "research-implement.yaml")
+
+    def test_download_data_step_exists(self, recipe) -> None:
+        """research-implement.yaml must include a download_data step."""
+        assert "download_data" in recipe.steps
+
+    def test_download_data_pass_routes_to_decompose_phases(self, recipe) -> None:
+        """download_data PASS verdict must route to decompose_phases."""
+        step = recipe.steps["download_data"]
+        assert step.on_result is not None
+        assert step.on_result.routes["PASS"] == "decompose_phases"
+
+    def test_download_data_fail_routes_to_escalate_stop(self, recipe) -> None:
+        """download_data FAIL verdict must route to escalate_stop."""
+        step = recipe.steps["download_data"]
+        assert step.on_result is not None
+        assert step.on_result.routes["FAIL"] == "escalate_stop"
+
+    def test_download_data_stale_threshold(self, recipe) -> None:
+        """download_data stale_threshold must be 14400 (4 hours)."""
+        step = recipe.steps["download_data"]
+        assert step.stale_threshold == 14400
+
+    def test_download_data_idle_output_timeout(self, recipe) -> None:
+        """download_data idle_output_timeout must be 0 (disabled)."""
+        step = recipe.steps["download_data"]
+        assert step.idle_output_timeout == 0
+
+    def test_stage_data_pass_routes_to_download_data(self, recipe) -> None:
+        """stage_data PASS verdict must route to download_data."""
+        step = recipe.steps["stage_data"]
+        assert step.on_result is not None
+        assert step.on_result.routes["PASS"] == "download_data"
+
+    def test_stage_data_warn_routes_to_download_data(self, recipe) -> None:
+        """stage_data WARN verdict must route to download_data."""
+        step = recipe.steps["stage_data"]
+        assert step.on_result is not None
+        assert step.on_result.routes["WARN"] == "download_data"

--- a/tests/recipe/test_research_implement_recipe.py
+++ b/tests/recipe/test_research_implement_recipe.py
@@ -73,7 +73,7 @@ class TestResearchImplementRecipe:
 class TestResearchImplementDownloadData:
     """Tests for download_data step in research-implement.yaml (T3)."""
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def recipe(self):
         return load_recipe(builtin_recipes_dir() / "research-implement.yaml")
 

--- a/tests/recipe/test_research_implement_recipe.py
+++ b/tests/recipe/test_research_implement_recipe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.schema import Recipe
 from autoskillit.recipe.validator import validate_recipe_structure
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
@@ -74,42 +75,48 @@ class TestResearchImplementDownloadData:
     """Tests for download_data step in research-implement.yaml (T3)."""
 
     @pytest.fixture(scope="class")
-    def recipe(self):
+    def recipe(self) -> Recipe:
         return load_recipe(builtin_recipes_dir() / "research-implement.yaml")
 
-    def test_download_data_step_exists(self, recipe) -> None:
+    def test_download_data_step_exists(self, recipe: Recipe) -> None:
         """research-implement.yaml must include a download_data step."""
         assert "download_data" in recipe.steps
 
-    def test_download_data_pass_routes_to_decompose_phases(self, recipe) -> None:
+    def test_download_data_pass_routes_to_decompose_phases(self, recipe: Recipe) -> None:
         """download_data PASS verdict must route to decompose_phases."""
         step = recipe.steps["download_data"]
         assert step.on_result is not None
         assert step.on_result.routes["PASS"] == "decompose_phases"
 
-    def test_download_data_fail_routes_to_escalate_stop(self, recipe) -> None:
+    def test_download_data_warn_routes_to_decompose_phases(self, recipe: Recipe) -> None:
+        """download_data WARN verdict must route to decompose_phases."""
+        step = recipe.steps["download_data"]
+        assert step.on_result is not None
+        assert step.on_result.routes["WARN"] == "decompose_phases"
+
+    def test_download_data_fail_routes_to_escalate_stop(self, recipe: Recipe) -> None:
         """download_data FAIL verdict must route to escalate_stop."""
         step = recipe.steps["download_data"]
         assert step.on_result is not None
         assert step.on_result.routes["FAIL"] == "escalate_stop"
 
-    def test_download_data_stale_threshold(self, recipe) -> None:
+    def test_download_data_stale_threshold(self, recipe: Recipe) -> None:
         """download_data stale_threshold must be 14400 (4 hours)."""
         step = recipe.steps["download_data"]
         assert step.stale_threshold == 14400
 
-    def test_download_data_idle_output_timeout(self, recipe) -> None:
+    def test_download_data_idle_output_timeout(self, recipe: Recipe) -> None:
         """download_data idle_output_timeout must be 0 (disabled)."""
         step = recipe.steps["download_data"]
         assert step.idle_output_timeout == 0
 
-    def test_stage_data_pass_routes_to_download_data(self, recipe) -> None:
+    def test_stage_data_pass_routes_to_download_data(self, recipe: Recipe) -> None:
         """stage_data PASS verdict must route to download_data."""
         step = recipe.steps["stage_data"]
         assert step.on_result is not None
         assert step.on_result.routes["PASS"] == "download_data"
 
-    def test_stage_data_warn_routes_to_download_data(self, recipe) -> None:
+    def test_stage_data_warn_routes_to_download_data(self, recipe: Recipe) -> None:
         """stage_data WARN verdict must route to download_data."""
         step = recipe.steps["stage_data"]
         assert step.on_result is not None

--- a/tests/recipe/test_research_stage_data_step.py
+++ b/tests/recipe/test_research_stage_data_step.py
@@ -55,18 +55,18 @@ def test_stage_data_captures_resource_report(recipe) -> None:
     assert "resource_report" in step.capture
 
 
-def test_stage_data_pass_routes_to_setup_environment(recipe) -> None:
-    """stage_data PASS verdict must route to setup_environment."""
+def test_stage_data_pass_routes_to_download_data(recipe) -> None:
+    """stage_data PASS verdict must route to download_data."""
     step = recipe.steps["stage_data"]
     assert step.on_result is not None
-    assert step.on_result.routes["PASS"] == "setup_environment"
+    assert step.on_result.routes["PASS"] == "download_data"
 
 
-def test_stage_data_warn_routes_to_setup_environment(recipe) -> None:
-    """stage_data WARN verdict must route to setup_environment."""
+def test_stage_data_warn_routes_to_download_data(recipe) -> None:
+    """stage_data WARN verdict must route to download_data."""
     step = recipe.steps["stage_data"]
     assert step.on_result is not None
-    assert step.on_result.routes["WARN"] == "setup_environment"
+    assert step.on_result.routes["WARN"] == "download_data"
 
 
 def test_stage_data_fail_does_not_route_to_decompose_phases(recipe) -> None:

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -274,7 +274,6 @@ def test_output_path_tokens_synchronized() -> None:
             "env_report",
             # run-experiment group manifest output (multi-group awareness)
             "group_manifest",
-            # download-data skill output (research recipe download report)
             "download_report",
         }
     )

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -274,6 +274,8 @@ def test_output_path_tokens_synchronized() -> None:
             "env_report",
             # run-experiment group manifest output (multi-group awareness)
             "group_manifest",
+            # download-data skill output (research recipe download report)
+            "download_report",
         }
     )
 


### PR DESCRIPTION
## Summary

Insert a `download_data` step into `research.yaml` and `research-implement.yaml` between `stage_data` and the subsequent step. The new step uses a dedicated `download-data` skill (invoked via `run_skill`) that reads the experiment plan's `data_manifest`, filters for `external`/`gitignored` entries, executes each `acquisition` command sequentially, and emits a PASS/FAIL verdict. The step uses `stale_threshold: 14400` (4 hours) and `idle_output_timeout: 0` to accommodate multi-hour downloads — fields only available on `run_skill` steps, which rules out a `run_cmd` approach.

## Requirements

- Insert a `download_data` step in `research.yaml` and `research-implement.yaml` between `stage_data` and `decompose_phases`
- Read Data Manifest entries with `source_type: external` or `gitignored`
- Execute each `acquisition` command sequentially into the pre-created directories
- Use `stale_threshold: 14400` (4 hours) and `idle_output_timeout: 0`
- Route PASS → `decompose_phases`, FAIL → `escalate_stop`

Closes #2331

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-013930-988274/.autoskillit/temp/make-plan/research_recipes_add_download_data_step_plan_2026-05-10_014600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 77 | 11.3k | 624.9k | 101.5k | 147 | 57.6k | 8m 9s |
| review | claude-sonnet-4-6 | 1 | 52 | 5.5k | 159.2k | 36.9k | 40 | 27.0k | 3m 38s |
| verify | claude-sonnet-4-6 | 1 | 688 | 6.2k | 335.8k | 76.1k | 103 | 37.6k | 7m 44s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.0M | 13.7k | 1.3M | 34.1k | 133 | 30.5k | 6m 27s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 89.4k | 4.3k | 227.1k | 28.7k | 22 | 15.2k | 1m 24s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 82.1k | 2.0k | 284.6k | 28.7k | 25 | 15.2k | 51s |
| review_pr | claude-sonnet-4-6 | 3 | 406 | 113.9k | 2.8M | 104.0k | 149 | 243.6k | 33m 15s |
| resolve_review | claude-sonnet-4-6 | 2 | 830 | 46.4k | 7.9M | 103.7k | 268 | 178.3k | 21m 37s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 2 | 207.9k | 2.5k | 403.0k | 28.8k | 32 | 82.0k | 1m 28s |
| resolve_ci | claude-sonnet-4-6 | 2 | 332 | 10.3k | 1.6M | 48.4k | 100 | 70.3k | 7m 38s |
| **Total** | | | 2.4M | 216.1k | 15.5M | 104.0k | | 757.3k | 1h 32m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 509 | 2547.0 | 59.9 | 26.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 4 | 697308.5 | 60893.2 | 28464.8 |
| resolve_review | 195 | 40262.9 | 914.4 | 238.2 |
| diagnose_ci | 4 | 100759.8 | 20508.2 | 622.0 |
| resolve_ci | 7 | 222740.7 | 10038.0 | 1471.9 |
| **Total** | **719** | 21600.5 | 1053.2 | 300.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 8 | 8.5k | 519.2k | 27.4M | 1.5M | 3h 8m |
| claude-opus-4-6 | 1 | 1.7k | 47.1k | 5.1M | 236.3k | 33m 58s |
| MiniMax-M2.7-highspeed | 5 | 16.8M | 151.8k | 12.7M | 570.5k | 1h 13m |