### PR TITLE
Research Recipes — Add audit-impl Gate and Fix Silent Group Abandonment

### DIFF
--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -54,6 +54,10 @@
     "test_check_enabled": {
       "description": "When 'true' (the default), run test_check in the implementation phase. Set to 'false' for de novo worktrees without test infrastructure.\n",
       "default": "true"
+    },
+    "audit": {
+      "description": "When 'true' (the default), run audit-impl in the implementation phase to verify all decomposed phases have corresponding commits.",
+      "default": "true"
     }
   },
   "dispatches": [
@@ -92,7 +96,8 @@
         "base_branch": "${{ inputs.base_branch }}",
         "issue_url": "${{ inputs.issue_url }}",
         "output_mode": "${{ inputs.output_mode }}",
-        "test_check_enabled": "${{ inputs.test_check_enabled }}"
+        "test_check_enabled": "${{ inputs.test_check_enabled }}",
+        "audit": "${{ inputs.audit }}"
       },
       "capture": {
         "report_path": "${{ result.report_path }}",

--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -56,7 +56,7 @@
       "default": "true"
     },
     "audit": {
-      "description": "When 'true' (the default), run audit-impl in the implementation phase to verify all decomposed phases have corresponding commits.",
+      "description": "When 'true' (the default), run audit-impl after phase iteration to verify all decomposed phases have corresponding implementation commits. Catches silent group abandonment when context_limit fires mid-iteration.\n",
       "default": "true"
     }
   },

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -63,6 +63,11 @@ ingredients:
       When 'true' (the default), run test_check in the implementation phase.
       Set to 'false' for de novo worktrees without test infrastructure.
     default: "true"
+  audit:
+    description: >-
+      When 'true' (the default), run audit-impl in the implementation phase to
+      verify all decomposed phases have corresponding commits.
+    default: "true"
 
 dispatches:
   - name: run-design
@@ -97,6 +102,7 @@ dispatches:
       issue_url: "${{ inputs.issue_url }}"
       output_mode: "${{ inputs.output_mode }}"
       test_check_enabled: "${{ inputs.test_check_enabled }}"
+      audit: "${{ inputs.audit }}"
     capture:
       report_path: "${{ result.report_path }}"
       experiment_results: "${{ result.experiment_results }}"

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -64,9 +64,10 @@ ingredients:
       Set to 'false' for de novo worktrees without test infrastructure.
     default: "true"
   audit:
-    description: >-
-      When 'true' (the default), run audit-impl in the implementation phase to
-      verify all decomposed phases have corresponding commits.
+    description: >
+      When 'true' (the default), run audit-impl after phase iteration to verify
+      all decomposed phases have corresponding implementation commits.
+      Catches silent group abandonment when context_limit fires mid-iteration.
     default: "true"
 
 dispatches:

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -53,7 +53,7 @@
       "default": "true"
     },
     "audit": {
-      "description": "When 'true' (the default), run audit-impl after phase iteration to verify all decomposed phases have corresponding implementation commits.\n",
+      "description": "When 'true' (the default), run audit-impl after phase iteration to verify all decomposed phases have corresponding implementation commits. Catches silent group abandonment when context_limit fires mid-iteration.\n",
       "default": "true"
     }
   },
@@ -271,7 +271,7 @@
       "on_failure": "escalate_stop",
       "on_context_limit": "escalate_stop",
       "skip_when_false": "inputs.audit",
-      "note": "Post-implementation quality gate. Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO, escalates with a remediation report detailing which phases are missing.\n"
+      "note": "Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO, escalates with a remediation report detailing which phases are missing. If false (inputs.audit=false), skip directly to run_experiment.\n"
     },
     "run_experiment": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -51,11 +51,15 @@
     "test_check_enabled": {
       "description": "When 'true' (the default), run test_check after report generation. Set to 'false' for de novo worktrees without test infrastructure.\n",
       "default": "true"
+    },
+    "audit": {
+      "description": "When 'true' (the default), run audit-impl after phase iteration to verify all decomposed phases have corresponding implementation commits.\n",
+      "default": "true"
     }
   },
   "kitchen_rules": [
     "NEVER use native Claude Code tools from the orchestrator: Read, Grep, Glob, Edit, Write, Bash, Agent, WebFetch, WebSearch, NotebookEdit are ALL forbidden. All work is delegated through run_skill, run_cmd, run_python.\n",
-    "PHASE ITERATION: decompose_phases always runs. The agent maintains a phase queue from group_files. For each phase, run plan_phase then implement_phase. Advance to run_experiment when all phases complete.\n",
+    "PHASE ITERATION: decompose_phases always runs. The agent maintains a phase queue from group_files. For each phase, run plan_phase then implement_phase. When all phases complete (or on context exhaustion), route to audit_impl for implementation completeness verification before advancing to run_experiment.\n",
     "SENTINEL EMISSION: When reaching implement_complete, emit the L3 result sentinel JSON block exactly as instructed in the step message — include worktree_path, research_dir, report_path, and experiment_results (when available).\n"
   ],
   "steps": {
@@ -93,9 +97,23 @@
       "capture": {
         "group_files": "${{ result.group_files }}"
       },
-      "on_success": "plan_phase",
+      "on_success": "capture_impl_base",
       "on_failure": "escalate_stop",
       "note": "Decomposes the experiment plan into sequenced phases. Each phase becomes an independently plannable implementation unit. Typical decomposition: infrastructure/logging -> data generators -> plotting/analysis scripts -> experiment implementation.\n"
+    },
+    "capture_impl_base": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "git rev-parse HEAD",
+        "cwd": "${{ inputs.worktree_path }}",
+        "step_name": "capture_impl_base"
+      },
+      "capture": {
+        "impl_base_sha": "${{ result.stdout | trim }}"
+      },
+      "on_success": "plan_phase",
+      "on_failure": "escalate_stop",
+      "note": "Captures the worktree HEAD SHA before phase implementation begins. Used by audit_impl to diff pre-implementation state against post-implementation state, detecting phases that produced no commits.\n"
     },
     "plan_phase": {
       "tool": "run_skill",
@@ -132,9 +150,9 @@
       "retries": 0,
       "on_success": "next_phase_or_experiment",
       "on_failure": "troubleshoot_implement_failure",
-      "on_exhausted": "run_experiment",
-      "on_context_limit": "run_experiment",
-      "note": "Implements the current phase plan in an isolated worktree via implement-experiment. Context exhaustion is a normal termination — the worktree is intact and run_experiment picks up what was committed. Failures route to troubleshoot for classification before re-planning or escalation.\n"
+      "on_exhausted": "audit_impl",
+      "on_context_limit": "audit_impl",
+      "note": "Implements the current phase plan in an isolated worktree via implement-experiment. Context exhaustion routes to audit_impl for implementation completeness verification before proceeding to run_experiment. Failures route to troubleshoot for classification before re-planning or escalation.\n"
     },
     "troubleshoot_implement_failure": {
       "tool": "run_skill",
@@ -178,18 +196,18 @@
       "on_result": [
         {
           "when": "${{ result.max_exceeded }} == true",
-          "route": "run_experiment"
+          "route": "audit_impl"
         },
         {
           "route": "route_implement_retry_delay"
         }
       ],
-      "on_failure": "run_experiment",
+      "on_failure": "audit_impl",
       "optional_context_refs": [
         "implement_fix_count",
         "retry_delay"
       ],
-      "note": "Iteration guard for implement_phase → troubleshoot → plan_phase cycle. Caps fix-and-retry loops at 3 iterations. On exhaustion, skips to run_experiment with whatever implementation is committed.\n"
+      "note": "Iteration guard for implement_phase → troubleshoot → plan_phase cycle. Caps fix-and-retry loops at 3 iterations. On exhaustion, routes to audit_impl to verify implementation completeness before run_experiment.\n"
     },
     "route_implement_retry_delay": {
       "action": "route",
@@ -225,10 +243,35 @@
           "route": "plan_phase"
         },
         {
-          "route": "run_experiment"
+          "route": "audit_impl"
         }
       ],
-      "note": "Routing step. The agent evaluates remaining phases: 1. If more phases remain in group_files -> route to plan_phase. 2. If all phases complete -> route to run_experiment.\n"
+      "note": "Routing step. The agent evaluates remaining phases: 1. If more phases remain in group_files -> route to plan_phase. 2. If all phases complete -> route to audit_impl for completeness verification.\n"
+    },
+    "audit_impl": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}",
+        "cwd": "${{ inputs.worktree_path }}",
+        "step_name": "audit_impl"
+      },
+      "capture": {
+        "remediation_path": "${{ result.remediation_path }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.verdict }} == GO",
+          "route": "run_experiment"
+        },
+        {
+          "route": "escalate_stop"
+        }
+      ],
+      "on_failure": "escalate_stop",
+      "on_context_limit": "escalate_stop",
+      "skip_when_false": "inputs.audit",
+      "note": "Post-implementation quality gate. Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO, escalates with a remediation report detailing which phases are missing.\n"
     },
     "run_experiment": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -54,6 +54,7 @@ ingredients:
     description: >
       When 'true' (the default), run audit-impl after phase iteration to verify
       all decomposed phases have corresponding implementation commits.
+      Catches silent group abandonment when context_limit fires mid-iteration.
     default: "true"
 
 kitchen_rules:
@@ -269,12 +270,12 @@ steps:
     on_context_limit: escalate_stop
     skip_when_false: "inputs.audit"
     note: >
-      Post-implementation quality gate. Diffs impl_base_sha..HEAD and verifies
-      all decomposed phases from group_files have corresponding implementation
-      commits. Catches silent group abandonment when on_context_limit fires
-      mid-iteration — reports exactly which phases were completed vs. skipped.
-      On GO, proceeds to run_experiment. On NO GO, escalates with a remediation
-      report detailing which phases are missing.
+      Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files
+      have corresponding implementation commits. Catches silent group abandonment
+      when on_context_limit fires mid-iteration — reports exactly which phases
+      were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO,
+      escalates with a remediation report detailing which phases are missing.
+      If false (inputs.audit=false), skip directly to run_experiment.
 
   # --- Experiment + Report ---
   run_experiment:

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -50,6 +50,11 @@ ingredients:
       When 'true' (the default), run test_check after report generation.
       Set to 'false' for de novo worktrees without test infrastructure.
     default: "true"
+  audit:
+    description: >
+      When 'true' (the default), run audit-impl after phase iteration to verify
+      all decomposed phases have corresponding implementation commits.
+    default: "true"
 
 kitchen_rules:
   - >
@@ -59,7 +64,9 @@ kitchen_rules:
   - >
     PHASE ITERATION: decompose_phases always runs. The agent maintains
     a phase queue from group_files. For each phase, run plan_phase then
-    implement_phase. Advance to run_experiment when all phases complete.
+    implement_phase. When all phases complete (or on context exhaustion),
+    route to audit_impl for implementation completeness verification
+    before advancing to run_experiment.
   - >
     SENTINEL EMISSION: When reaching implement_complete, emit the L3 result
     sentinel JSON block exactly as instructed in the step message — include
@@ -102,13 +109,28 @@ steps:
       step_name: decompose
     capture:
       group_files: "${{ result.group_files }}"
-    on_success: plan_phase
+    on_success: capture_impl_base
     on_failure: escalate_stop
     note: >
       Decomposes the experiment plan into sequenced phases. Each phase
       becomes an independently plannable implementation unit. Typical
       decomposition: infrastructure/logging -> data generators ->
       plotting/analysis scripts -> experiment implementation.
+
+  capture_impl_base:
+    tool: run_cmd
+    with:
+      cmd: "git rev-parse HEAD"
+      cwd: "${{ inputs.worktree_path }}"
+      step_name: capture_impl_base
+    capture:
+      impl_base_sha: "${{ result.stdout | trim }}"
+    on_success: plan_phase
+    on_failure: escalate_stop
+    note: >
+      Captures the worktree HEAD SHA before phase implementation begins.
+      Used by audit_impl to diff pre-implementation state against post-implementation
+      state, detecting phases that produced no commits.
 
   plan_phase:
     tool: run_skill
@@ -146,13 +168,13 @@ steps:
     retries: 0
     on_success: next_phase_or_experiment
     on_failure: troubleshoot_implement_failure
-    on_exhausted: run_experiment
-    on_context_limit: run_experiment
+    on_exhausted: audit_impl
+    on_context_limit: audit_impl
     note: >
       Implements the current phase plan in an isolated worktree via implement-experiment.
-      Context exhaustion is a normal termination — the worktree is intact and
-      run_experiment picks up what was committed. Failures route to troubleshoot
-      for classification before re-planning or escalation.
+      Context exhaustion routes to audit_impl for implementation completeness verification
+      before proceeding to run_experiment. Failures route to troubleshoot for
+      classification before re-planning or escalation.
 
   troubleshoot_implement_failure:
     tool: run_skill
@@ -186,16 +208,16 @@ steps:
       implement_fix_count: "${{ result.next_iteration }}"
     on_result:
       - when: "${{ result.max_exceeded }} == true"
-        route: run_experiment
+        route: audit_impl
       - route: route_implement_retry_delay
-    on_failure: run_experiment
+    on_failure: audit_impl
     optional_context_refs:
       - implement_fix_count
       - retry_delay
     note: >
       Iteration guard for implement_phase → troubleshoot → plan_phase cycle.
-      Caps fix-and-retry loops at 3 iterations. On exhaustion, skips to
-      run_experiment with whatever implementation is committed.
+      Caps fix-and-retry loops at 3 iterations. On exhaustion, routes to
+      audit_impl to verify implementation completeness before run_experiment.
 
   route_implement_retry_delay:
     action: route
@@ -224,11 +246,35 @@ steps:
     on_result:
       - when: "remaining phases exist in context.group_files"
         route: plan_phase
-      - route: run_experiment
+      - route: audit_impl
     note: >
       Routing step. The agent evaluates remaining phases:
       1. If more phases remain in group_files -> route to plan_phase.
-      2. If all phases complete -> route to run_experiment.
+      2. If all phases complete -> route to audit_impl for completeness verification.
+
+  audit_impl:
+    tool: run_skill
+    model: ""
+    with:
+      skill_command: "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}"
+      cwd: "${{ inputs.worktree_path }}"
+      step_name: audit_impl
+    capture:
+      remediation_path: "${{ result.remediation_path }}"
+    on_result:
+      - when: "${{ result.verdict }} == GO"
+        route: run_experiment
+      - route: escalate_stop
+    on_failure: escalate_stop
+    on_context_limit: escalate_stop
+    skip_when_false: "inputs.audit"
+    note: >
+      Post-implementation quality gate. Diffs impl_base_sha..HEAD and verifies
+      all decomposed phases from group_files have corresponding implementation
+      commits. Catches silent group abandonment when on_context_limit fires
+      mid-iteration — reports exactly which phases were completed vs. skipped.
+      On GO, proceeds to run_experiment. On NO GO, escalates with a remediation
+      report detailing which phases are missing.
 
   # --- Experiment + Report ---
   run_experiment:

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -46,6 +46,10 @@
     "test_check_enabled": {
       "description": "When 'true' (the default), run test_check after report generation. Set to 'false' for de novo worktrees without test infrastructure.\n",
       "default": "true"
+    },
+    "audit": {
+      "description": "When 'true' (the default), run audit-impl after phase iteration to verify all decomposed phases have corresponding implementation commits. Catches silent group abandonment when context_limit fires mid-iteration.\n",
+      "default": "true"
     }
   },
   "kitchen_rules": [
@@ -55,7 +59,7 @@
     "Inconclusive results are valid findings, not failures.",
     "Route to on_failure when a step fails — do not investigate directly.",
     "DESIGN REVIEW LOOP: review_design validates the plan and may route back to plan_experiment with revision guidance. Bounded by check_design_review_loop (max 3 iterations). On exhaustion or failure, proceed to execution with the best available plan — do not stop. Exception: a STOP verdict triggers resolve_design_review, which triages each stop-trigger finding as ADDRESSABLE/STRUCTURAL/DISCUSS. If any are ADDRESSABLE or DISCUSS, revision guidance is generated and the plan loops back for revision (via revise_design). If all are STRUCTURAL, the pipeline halts at design_rejected (truly terminal — revision cannot address the flaws).\n",
-    "PHASE ITERATION: decompose_phases always runs. The agent maintains a phase queue from group_files. For each phase, run plan_phase then implement_phase. Advance to run_experiment when all phases complete.\n",
+    "PHASE ITERATION: decompose_phases always runs. The agent maintains a phase queue from group_files. For each phase, run plan_phase then implement_phase. When all phases complete (or on context exhaustion), route to audit_impl for implementation completeness verification before advancing to run_experiment.\n",
     "PERMANENT ARTIFACTS: create_worktree commits the experiment plan to research/ and supporting artifacts (scope report, design evaluation) to research/artifacts/. These are permanent records in the PR.\n",
     "ARCHIVAL PHASE: After all review and re-validation cycles complete, the pipeline extracts research/ into a clean artifact PR, tags the full experiment branch under archive/research/, and closes the original PR. Every archival step degrades gracefully — failures route to research_complete without blocking the pipeline.\n",
     "LOCAL MODE OUTPUT: In local mode, the finalized bundle (report.html, report.md, artifacts.tar.gz) is exported to {source_dir}/research-bundles/{date-slug}/. This directory is created only when output_mode=local and is not committed to git.\n"
@@ -295,9 +299,23 @@
       "capture": {
         "group_files": "${{ result.group_files }}"
       },
-      "on_success": "plan_phase",
+      "on_success": "capture_impl_base",
       "on_failure": "escalate_stop",
       "note": "Decomposes the experiment plan into sequenced phases. Each phase becomes an independently plannable implementation unit. Typical decomposition: infrastructure/logging -> data generators -> plotting/analysis scripts -> experiment implementation. ITERATION: The agent maintains a phase queue from group_files. For each phase, run plan_phase then implement_phase before advancing.\n"
+    },
+    "capture_impl_base": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "git rev-parse HEAD",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "capture_impl_base"
+      },
+      "capture": {
+        "impl_base_sha": "${{ result.stdout | trim }}"
+      },
+      "on_success": "plan_phase",
+      "on_failure": "escalate_stop",
+      "note": "Captures the worktree HEAD SHA before phase implementation begins. Used by audit_impl to diff pre-implementation state against post-implementation state, detecting phases that produced no commits.\n"
     },
     "plan_phase": {
       "tool": "run_skill",
@@ -334,9 +352,9 @@
       "retries": 0,
       "on_success": "next_phase_or_experiment",
       "on_failure": "troubleshoot_implement_failure",
-      "on_exhausted": "run_experiment",
-      "on_context_limit": "run_experiment",
-      "note": "Implements the current phase plan in an isolated worktree via implement-experiment. Context exhaustion is a normal termination — the worktree is intact and run_experiment picks up what was committed. Failures route to troubleshoot for classification before re-planning or escalation.\n"
+      "on_exhausted": "audit_impl",
+      "on_context_limit": "audit_impl",
+      "note": "Implements the current phase plan in an isolated worktree via implement-experiment. Context exhaustion routes to audit_impl for implementation completeness verification before proceeding to run_experiment. Failures route to troubleshoot for classification before re-planning or escalation.\n"
     },
     "troubleshoot_implement_failure": {
       "tool": "run_skill",
@@ -380,18 +398,18 @@
       "on_result": [
         {
           "when": "${{ result.max_exceeded }} == true",
-          "route": "run_experiment"
+          "route": "audit_impl"
         },
         {
           "route": "route_implement_retry_delay"
         }
       ],
-      "on_failure": "run_experiment",
+      "on_failure": "audit_impl",
       "optional_context_refs": [
         "implement_fix_count",
         "retry_delay"
       ],
-      "note": "Iteration guard for implement_phase → troubleshoot → plan_phase cycle. Caps fix-and-retry loops at 3 iterations. On exhaustion, skips to run_experiment with whatever implementation is committed.\n"
+      "note": "Iteration guard for implement_phase → troubleshoot → plan_phase cycle. Caps fix-and-retry loops at 3 iterations. On exhaustion, routes to audit_impl to verify implementation completeness before run_experiment.\n"
     },
     "route_implement_retry_delay": {
       "action": "route",
@@ -427,10 +445,35 @@
           "route": "plan_phase"
         },
         {
-          "route": "run_experiment"
+          "route": "audit_impl"
         }
       ],
-      "note": "Routing step. The agent evaluates remaining phases: 1. If more phases remain in group_files -> route to plan_phase. 2. If all phases complete -> route to run_experiment.\n"
+      "note": "Routing step. The agent evaluates remaining phases: 1. If more phases remain in group_files -> route to plan_phase. 2. If all phases complete -> route to audit_impl for completeness verification.\n"
+    },
+    "audit_impl": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.worktree_path }}",
+        "step_name": "audit_impl"
+      },
+      "capture": {
+        "remediation_path": "${{ result.remediation_path }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.verdict }} == GO",
+          "route": "run_experiment"
+        },
+        {
+          "route": "escalate_stop"
+        }
+      ],
+      "on_failure": "escalate_stop",
+      "on_context_limit": "escalate_stop",
+      "skip_when_false": "inputs.audit",
+      "note": "Post-implementation quality gate. Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO, escalates with a remediation report detailing which phases are missing.\n"
     },
     "run_experiment": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -473,7 +473,7 @@
       "on_failure": "escalate_stop",
       "on_context_limit": "escalate_stop",
       "skip_when_false": "inputs.audit",
-      "note": "Post-implementation quality gate. Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO, escalates with a remediation report detailing which phases are missing.\n"
+      "note": "Post-implementation quality gate. Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO, escalates with a remediation report detailing which phases are missing. If false (inputs.audit=false), skip directly to run_experiment.\n"
     },
     "run_experiment": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -490,7 +490,8 @@ steps:
       commits. Catches silent group abandonment when on_context_limit fires
       mid-iteration — reports exactly which phases were completed vs. skipped.
       On GO, proceeds to run_experiment. On NO GO, escalates with a remediation
-      report detailing which phases are missing.
+      report detailing which phases are missing. If false (inputs.audit=false),
+      skip directly to run_experiment.
 
   # --- EXPERIMENT + REPORT PHASE ---
   run_experiment:

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -65,6 +65,12 @@ ingredients:
       When 'true' (the default), run test_check after report generation.
       Set to 'false' for de novo worktrees without test infrastructure.
     default: "true"
+  audit:
+    description: >
+      When 'true' (the default), run audit-impl after phase iteration to verify
+      all decomposed phases have corresponding implementation commits. Catches
+      silent group abandonment when context_limit fires mid-iteration.
+    default: "true"
 
 kitchen_rules:
   - >
@@ -88,7 +94,9 @@ kitchen_rules:
   - >
     PHASE ITERATION: decompose_phases always runs. The agent maintains
     a phase queue from group_files. For each phase, run plan_phase then
-    implement_phase. Advance to run_experiment when all phases complete.
+    implement_phase. When all phases complete (or on context exhaustion),
+    route to audit_impl for implementation completeness verification
+    before advancing to run_experiment.
   - >
     PERMANENT ARTIFACTS: create_worktree commits the experiment plan
     to research/ and supporting artifacts (scope report, design evaluation)
@@ -315,7 +323,7 @@ steps:
       step_name: decompose
     capture:
       group_files: "${{ result.group_files }}"
-    on_success: plan_phase
+    on_success: capture_impl_base
     on_failure: escalate_stop
     note: >
       Decomposes the experiment plan into sequenced phases. Each phase
@@ -324,6 +332,21 @@ steps:
       plotting/analysis scripts -> experiment implementation.
       ITERATION: The agent maintains a phase queue from group_files.
       For each phase, run plan_phase then implement_phase before advancing.
+
+  capture_impl_base:
+    tool: run_cmd
+    with:
+      cmd: "git rev-parse HEAD"
+      cwd: "${{ context.worktree_path }}"
+      step_name: capture_impl_base
+    capture:
+      impl_base_sha: "${{ result.stdout | trim }}"
+    on_success: plan_phase
+    on_failure: escalate_stop
+    note: >
+      Captures the worktree HEAD SHA before phase implementation begins.
+      Used by audit_impl to diff pre-implementation state against post-implementation
+      state, detecting phases that produced no commits.
 
   plan_phase:
     tool: run_skill
@@ -361,13 +384,13 @@ steps:
     retries: 0
     on_success: next_phase_or_experiment
     on_failure: troubleshoot_implement_failure
-    on_exhausted: run_experiment
-    on_context_limit: run_experiment
+    on_exhausted: audit_impl
+    on_context_limit: audit_impl
     note: >
       Implements the current phase plan in an isolated worktree via implement-experiment.
-      Context exhaustion is a normal termination — the worktree is intact and
-      run_experiment picks up what was committed. Failures route to troubleshoot
-      for classification before re-planning or escalation.
+      Context exhaustion routes to audit_impl for implementation completeness verification
+      before proceeding to run_experiment. Failures route to troubleshoot for
+      classification before re-planning or escalation.
 
   troubleshoot_implement_failure:
     tool: run_skill
@@ -401,16 +424,16 @@ steps:
       implement_fix_count: "${{ result.next_iteration }}"
     on_result:
       - when: "${{ result.max_exceeded }} == true"
-        route: run_experiment
+        route: audit_impl
       - route: route_implement_retry_delay
-    on_failure: run_experiment
+    on_failure: audit_impl
     optional_context_refs:
       - implement_fix_count
       - retry_delay
     note: >
       Iteration guard for implement_phase → troubleshoot → plan_phase cycle.
-      Caps fix-and-retry loops at 3 iterations. On exhaustion, skips to
-      run_experiment with whatever implementation is committed.
+      Caps fix-and-retry loops at 3 iterations. On exhaustion, routes to
+      audit_impl to verify implementation completeness before run_experiment.
 
   route_implement_retry_delay:
     action: route
@@ -439,11 +462,35 @@ steps:
     on_result:
       - when: "${{ result.next }} == more_phases"
         route: plan_phase
-      - route: run_experiment
+      - route: audit_impl
     note: >
       Routing step. The agent evaluates remaining phases:
       1. If more phases remain in group_files -> route to plan_phase.
-      2. If all phases complete -> route to run_experiment.
+      2. If all phases complete -> route to audit_impl for completeness verification.
+
+  audit_impl:
+    tool: run_skill
+    model: ""
+    with:
+      skill_command: "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: audit_impl
+    capture:
+      remediation_path: "${{ result.remediation_path }}"
+    on_result:
+      - when: "${{ result.verdict }} == GO"
+        route: run_experiment
+      - route: escalate_stop
+    on_failure: escalate_stop
+    on_context_limit: escalate_stop
+    skip_when_false: "inputs.audit"
+    note: >
+      Post-implementation quality gate. Diffs impl_base_sha..HEAD and verifies
+      all decomposed phases from group_files have corresponding implementation
+      commits. Catches silent group abandonment when on_context_limit fires
+      mid-iteration — reports exactly which phases were completed vs. skipped.
+      On GO, proceeds to run_experiment. On NO GO, escalates with a remediation
+      report detailing which phases are missing.
 
   # --- EXPERIMENT + REPORT PHASE ---
   run_experiment:

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -77,6 +77,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_research_campaign.py` | Contract card assertions for the research-campaign recipe |
 | `test_repository.py` | Tests for DefaultRecipeRepository |
 | `test_research_archive_recipe.py` | Tests for research-archive sub-recipe structure |
+| `test_research_audit_impl.py` | Tests for audit_impl gate and capture_impl_base in research recipes |
 | `test_research_bundle_lifecycle.py` | Tests for research bundle lifecycle in recipes |
 | `test_research_context_tracking.py` | Tests for research context tracking in recipes |
 | `test_research_implement_recipe.py` | Tests for research-implement sub-recipe structure |

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -437,6 +437,7 @@ def test_research_campaign_run_implement_ingredients():
         "issue_url",
         "output_mode",
         "test_check_enabled",
+        "audit",
     }
     assert d.ingredients["task"] == "${{ inputs.task }}"
     assert d.ingredients["worktree_path"] == "${{ campaign.worktree_path }}"
@@ -448,6 +449,7 @@ def test_research_campaign_run_implement_ingredients():
     assert d.ingredients["issue_url"] == "${{ inputs.issue_url }}"
     assert d.ingredients["output_mode"] == "${{ inputs.output_mode }}"
     assert d.ingredients["test_check_enabled"] == "${{ inputs.test_check_enabled }}"
+    assert d.ingredients["audit"] == "${{ inputs.audit }}"
 
 
 def test_research_campaign_run_implement_capture():

--- a/tests/recipe/test_research_audit_impl.py
+++ b/tests/recipe/test_research_audit_impl.py
@@ -1,0 +1,250 @@
+"""Tests for audit_impl gate and capture_impl_base in research recipes."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.validator import validate_recipe_structure
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestResearchRecipeAuditImpl:
+    """Tests for research.yaml audit_impl and capture_impl_base steps."""
+
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        return load_recipe(builtin_recipes_dir() / "research.yaml")
+
+    def test_has_audit_ingredient_defaulting_true(self, recipe) -> None:
+        """research.yaml must declare an audit ingredient with default 'true'."""
+        assert "audit" in recipe.ingredients
+        assert recipe.ingredients["audit"].default == "true"
+
+    def test_has_audit_impl_step(self, recipe) -> None:
+        """research.yaml must contain the audit_impl step."""
+        assert "audit_impl" in recipe.steps
+
+    def test_audit_impl_skip_when_false(self, recipe) -> None:
+        """audit_impl must use skip_when_false: inputs.audit."""
+        step = recipe.steps["audit_impl"]
+        assert step.skip_when_false == "inputs.audit"
+
+    def test_audit_impl_on_context_limit_escalates(self, recipe) -> None:
+        """audit_impl on_context_limit must route to escalate_stop."""
+        step = recipe.steps["audit_impl"]
+        assert step.on_context_limit == "escalate_stop"
+
+    def test_audit_impl_on_failure_escalates(self, recipe) -> None:
+        """audit_impl on_failure must route to escalate_stop."""
+        step = recipe.steps["audit_impl"]
+        assert step.on_failure == "escalate_stop"
+
+    def test_audit_impl_uses_impl_base_sha(self, recipe) -> None:
+        """audit_impl skill_command must reference context.impl_base_sha."""
+        step = recipe.steps["audit_impl"]
+        skill_cmd = step.with_args.get("skill_command", "")
+        assert "context.impl_base_sha" in skill_cmd
+
+    def test_audit_impl_uses_group_files(self, recipe) -> None:
+        """audit_impl skill_command must reference context.group_files."""
+        step = recipe.steps["audit_impl"]
+        skill_cmd = step.with_args.get("skill_command", "")
+        assert "context.group_files" in skill_cmd
+
+    def test_audit_impl_go_routes_to_run_experiment(self, recipe) -> None:
+        """audit_impl on_result GO verdict must route to run_experiment."""
+        step = recipe.steps["audit_impl"]
+        assert step.on_result is not None
+        conditions = step.on_result.conditions
+        go_cond = next(
+            (c for c in conditions if c.when and "verdict" in c.when and "GO" in c.when), None
+        )
+        assert go_cond is not None, "audit_impl must have a GO verdict condition"
+        assert go_cond.route == "run_experiment"
+
+    def test_implement_phase_on_context_limit_routes_to_audit_impl(self, recipe) -> None:
+        """implement_phase on_context_limit must route to audit_impl."""
+        step = recipe.steps["implement_phase"]
+        assert step.on_context_limit == "audit_impl"
+
+    def test_implement_phase_on_exhausted_routes_to_audit_impl(self, recipe) -> None:
+        """implement_phase on_exhausted must route to audit_impl."""
+        step = recipe.steps["implement_phase"]
+        assert step.on_exhausted == "audit_impl"
+
+    def test_next_phase_or_experiment_fallback_routes_to_audit_impl(self, recipe) -> None:
+        """next_phase_or_experiment default route must be audit_impl."""
+        step = recipe.steps["next_phase_or_experiment"]
+        conditions = step.on_result.conditions
+        default_cond = next((c for c in conditions if c.when is None), None)
+        assert default_cond is not None, "next_phase_or_experiment must have a default route"
+        assert default_cond.route == "audit_impl"
+
+    def test_check_implement_fix_loop_max_exceeded_routes_to_audit_impl(self, recipe) -> None:
+        """check_implement_fix_loop max_exceeded condition must route to audit_impl."""
+        step = recipe.steps["check_implement_fix_loop"]
+        conditions = step.on_result.conditions
+        max_exceeded_cond = next(
+            (c for c in conditions if c.when and "max_exceeded" in c.when), None
+        )
+        assert max_exceeded_cond is not None, (
+            "check_implement_fix_loop must have a max_exceeded condition"
+        )
+        assert max_exceeded_cond.route == "audit_impl"
+
+    def test_check_implement_fix_loop_on_failure_routes_to_audit_impl(self, recipe) -> None:
+        """check_implement_fix_loop on_failure must route to audit_impl."""
+        step = recipe.steps["check_implement_fix_loop"]
+        assert step.on_failure == "audit_impl"
+
+    def test_has_capture_impl_base_step(self, recipe) -> None:
+        """research.yaml must contain the capture_impl_base step."""
+        assert "capture_impl_base" in recipe.steps
+
+    def test_capture_impl_base_on_success_routes_to_plan_phase(self, recipe) -> None:
+        """capture_impl_base on_success must route to plan_phase."""
+        step = recipe.steps["capture_impl_base"]
+        assert step.on_success == "plan_phase"
+
+    def test_decompose_phases_routes_to_capture_impl_base(self, recipe) -> None:
+        """decompose_phases on_success must route to capture_impl_base."""
+        step = recipe.steps["decompose_phases"]
+        assert step.on_success == "capture_impl_base"
+
+    def test_validates_clean(self, recipe) -> None:
+        """research.yaml must pass structural validation."""
+        errors = validate_recipe_structure(recipe)
+        assert errors == [], f"Validation errors: {errors}"
+
+
+class TestResearchImplementRecipeAuditImpl:
+    """Tests for research-implement.yaml audit_impl and capture_impl_base steps."""
+
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        return load_recipe(builtin_recipes_dir() / "research-implement.yaml")
+
+    def test_has_audit_ingredient_defaulting_true(self, recipe) -> None:
+        """research-implement.yaml must declare an audit ingredient with default 'true'."""
+        assert "audit" in recipe.ingredients
+        assert recipe.ingredients["audit"].default == "true"
+
+    def test_has_audit_impl_step(self, recipe) -> None:
+        """research-implement.yaml must contain the audit_impl step."""
+        assert "audit_impl" in recipe.steps
+
+    def test_audit_impl_skip_when_false(self, recipe) -> None:
+        """audit_impl must use skip_when_false: inputs.audit."""
+        step = recipe.steps["audit_impl"]
+        assert step.skip_when_false == "inputs.audit"
+
+    def test_audit_impl_on_context_limit_escalates(self, recipe) -> None:
+        """audit_impl on_context_limit must route to escalate_stop."""
+        step = recipe.steps["audit_impl"]
+        assert step.on_context_limit == "escalate_stop"
+
+    def test_audit_impl_on_failure_escalates(self, recipe) -> None:
+        """audit_impl on_failure must route to escalate_stop."""
+        step = recipe.steps["audit_impl"]
+        assert step.on_failure == "escalate_stop"
+
+    def test_audit_impl_uses_impl_base_sha(self, recipe) -> None:
+        """audit_impl skill_command must reference context.impl_base_sha."""
+        step = recipe.steps["audit_impl"]
+        skill_cmd = step.with_args.get("skill_command", "")
+        assert "context.impl_base_sha" in skill_cmd
+
+    def test_audit_impl_uses_group_files(self, recipe) -> None:
+        """audit_impl skill_command must reference context.group_files."""
+        step = recipe.steps["audit_impl"]
+        skill_cmd = step.with_args.get("skill_command", "")
+        assert "context.group_files" in skill_cmd
+
+    def test_audit_impl_go_routes_to_run_experiment(self, recipe) -> None:
+        """audit_impl on_result GO verdict must route to run_experiment."""
+        step = recipe.steps["audit_impl"]
+        assert step.on_result is not None
+        conditions = step.on_result.conditions
+        go_cond = next(
+            (c for c in conditions if c.when and "verdict" in c.when and "GO" in c.when), None
+        )
+        assert go_cond is not None, "audit_impl must have a GO verdict condition"
+        assert go_cond.route == "run_experiment"
+
+    def test_implement_phase_on_context_limit_routes_to_audit_impl(self, recipe) -> None:
+        """implement_phase on_context_limit must route to audit_impl."""
+        step = recipe.steps["implement_phase"]
+        assert step.on_context_limit == "audit_impl"
+
+    def test_implement_phase_on_exhausted_routes_to_audit_impl(self, recipe) -> None:
+        """implement_phase on_exhausted must route to audit_impl."""
+        step = recipe.steps["implement_phase"]
+        assert step.on_exhausted == "audit_impl"
+
+    def test_next_phase_or_experiment_fallback_routes_to_audit_impl(self, recipe) -> None:
+        """next_phase_or_experiment default route must be audit_impl."""
+        step = recipe.steps["next_phase_or_experiment"]
+        conditions = step.on_result.conditions
+        default_cond = next((c for c in conditions if c.when is None), None)
+        assert default_cond is not None, "next_phase_or_experiment must have a default route"
+        assert default_cond.route == "audit_impl"
+
+    def test_check_implement_fix_loop_max_exceeded_routes_to_audit_impl(self, recipe) -> None:
+        """check_implement_fix_loop max_exceeded condition must route to audit_impl."""
+        step = recipe.steps["check_implement_fix_loop"]
+        conditions = step.on_result.conditions
+        max_exceeded_cond = next(
+            (c for c in conditions if c.when and "max_exceeded" in c.when), None
+        )
+        assert max_exceeded_cond is not None, (
+            "check_implement_fix_loop must have a max_exceeded condition"
+        )
+        assert max_exceeded_cond.route == "audit_impl"
+
+    def test_check_implement_fix_loop_on_failure_routes_to_audit_impl(self, recipe) -> None:
+        """check_implement_fix_loop on_failure must route to audit_impl."""
+        step = recipe.steps["check_implement_fix_loop"]
+        assert step.on_failure == "audit_impl"
+
+    def test_has_capture_impl_base_step(self, recipe) -> None:
+        """research-implement.yaml must contain the capture_impl_base step."""
+        assert "capture_impl_base" in recipe.steps
+
+    def test_capture_impl_base_on_success_routes_to_plan_phase(self, recipe) -> None:
+        """capture_impl_base on_success must route to plan_phase."""
+        step = recipe.steps["capture_impl_base"]
+        assert step.on_success == "plan_phase"
+
+    def test_decompose_phases_routes_to_capture_impl_base(self, recipe) -> None:
+        """decompose_phases on_success must route to capture_impl_base."""
+        step = recipe.steps["decompose_phases"]
+        assert step.on_success == "capture_impl_base"
+
+    def test_validates_clean(self, recipe) -> None:
+        """research-implement.yaml must pass structural validation."""
+        errors = validate_recipe_structure(recipe)
+        assert errors == [], f"Validation errors: {errors}"
+
+
+class TestResearchCampaignAuditIngredient:
+    """Tests for audit ingredient in research-campaign.yaml."""
+
+    @pytest.fixture(scope="class")
+    def campaign(self):
+        return load_recipe(builtin_recipes_dir() / "campaigns" / "research-campaign.yaml")
+
+    def test_campaign_has_audit_ingredient(self, campaign) -> None:
+        """research-campaign.yaml must declare an audit ingredient."""
+        assert "audit" in campaign.ingredients
+
+    def test_campaign_audit_default_true(self, campaign) -> None:
+        """research-campaign.yaml audit ingredient must default to 'true'."""
+        assert campaign.ingredients["audit"].default == "true"
+
+    def test_campaign_passes_audit_to_run_implement(self, campaign) -> None:
+        """run-implement dispatch must pass audit: "${{ inputs.audit }}"."""
+        run_implement = next(d for d in campaign.dispatches if d.name == "run-implement")
+        assert "audit" in run_implement.ingredients
+        assert run_implement.ingredients["audit"] == "${{ inputs.audit }}"

--- a/tests/recipe/test_research_audit_impl.py
+++ b/tests/recipe/test_research_audit_impl.py
@@ -1,5 +1,3 @@
-"""Tests for audit_impl gate and capture_impl_base in research recipes."""
-
 from __future__ import annotations
 
 import pytest
@@ -53,9 +51,7 @@ class TestResearchRecipesAuditImpl:
         step = recipe.steps["audit_impl"]
         assert step.on_result is not None
         conditions = step.on_result.conditions
-        go_cond = next(
-            (c for c in conditions if c.when and "verdict" in c.when and "GO" in c.when), None
-        )
+        go_cond = next((c for c in conditions if c.when and "== GO" in c.when), None)
         assert go_cond is not None, "audit_impl must have a GO verdict condition"
         assert go_cond.route == "run_experiment"
 
@@ -82,7 +78,8 @@ class TestResearchRecipesAuditImpl:
         step = recipe.steps["check_implement_fix_loop"]
         conditions = step.on_result.conditions
         max_exceeded_cond = next(
-            (c for c in conditions if c.when and "max_exceeded" in c.when), None
+            (c for c in conditions if c.when and "max_exceeded" in c.when and "== true" in c.when),
+            None,
         )
         assert max_exceeded_cond is not None, (
             "check_implement_fix_loop must have a max_exceeded condition"

--- a/tests/recipe/test_research_audit_impl.py
+++ b/tests/recipe/test_research_audit_impl.py
@@ -10,24 +10,19 @@ from autoskillit.recipe.validator import validate_recipe_structure
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
-class TestResearchRecipeAuditImpl:
-    """Tests for research.yaml audit_impl and capture_impl_base steps."""
-
-    @pytest.fixture(scope="class")
-    def recipe(self):
-        return load_recipe(builtin_recipes_dir() / "research.yaml")
+class TestResearchRecipesAuditImpl:
+    @pytest.fixture(params=["research.yaml", "research-implement.yaml"])
+    def recipe(self, request):
+        return load_recipe(builtin_recipes_dir() / request.param)
 
     def test_has_audit_ingredient_defaulting_true(self, recipe) -> None:
-        """research.yaml must declare an audit ingredient with default 'true'."""
         assert "audit" in recipe.ingredients
         assert recipe.ingredients["audit"].default == "true"
 
     def test_has_audit_impl_step(self, recipe) -> None:
-        """research.yaml must contain the audit_impl step."""
         assert "audit_impl" in recipe.steps
 
     def test_audit_impl_skip_when_false(self, recipe) -> None:
-        """audit_impl must use skip_when_false: inputs.audit."""
         step = recipe.steps["audit_impl"]
         assert step.skip_when_false == "inputs.audit"
 
@@ -100,7 +95,6 @@ class TestResearchRecipeAuditImpl:
         assert step.on_failure == "audit_impl"
 
     def test_has_capture_impl_base_step(self, recipe) -> None:
-        """research.yaml must contain the capture_impl_base step."""
         assert "capture_impl_base" in recipe.steps
 
     def test_capture_impl_base_on_success_routes_to_plan_phase(self, recipe) -> None:
@@ -114,116 +108,6 @@ class TestResearchRecipeAuditImpl:
         assert step.on_success == "capture_impl_base"
 
     def test_validates_clean(self, recipe) -> None:
-        """research.yaml must pass structural validation."""
-        errors = validate_recipe_structure(recipe)
-        assert errors == [], f"Validation errors: {errors}"
-
-
-class TestResearchImplementRecipeAuditImpl:
-    """Tests for research-implement.yaml audit_impl and capture_impl_base steps."""
-
-    @pytest.fixture(scope="class")
-    def recipe(self):
-        return load_recipe(builtin_recipes_dir() / "research-implement.yaml")
-
-    def test_has_audit_ingredient_defaulting_true(self, recipe) -> None:
-        """research-implement.yaml must declare an audit ingredient with default 'true'."""
-        assert "audit" in recipe.ingredients
-        assert recipe.ingredients["audit"].default == "true"
-
-    def test_has_audit_impl_step(self, recipe) -> None:
-        """research-implement.yaml must contain the audit_impl step."""
-        assert "audit_impl" in recipe.steps
-
-    def test_audit_impl_skip_when_false(self, recipe) -> None:
-        """audit_impl must use skip_when_false: inputs.audit."""
-        step = recipe.steps["audit_impl"]
-        assert step.skip_when_false == "inputs.audit"
-
-    def test_audit_impl_on_context_limit_escalates(self, recipe) -> None:
-        """audit_impl on_context_limit must route to escalate_stop."""
-        step = recipe.steps["audit_impl"]
-        assert step.on_context_limit == "escalate_stop"
-
-    def test_audit_impl_on_failure_escalates(self, recipe) -> None:
-        """audit_impl on_failure must route to escalate_stop."""
-        step = recipe.steps["audit_impl"]
-        assert step.on_failure == "escalate_stop"
-
-    def test_audit_impl_uses_impl_base_sha(self, recipe) -> None:
-        """audit_impl skill_command must reference context.impl_base_sha."""
-        step = recipe.steps["audit_impl"]
-        skill_cmd = step.with_args.get("skill_command", "")
-        assert "context.impl_base_sha" in skill_cmd
-
-    def test_audit_impl_uses_group_files(self, recipe) -> None:
-        """audit_impl skill_command must reference context.group_files."""
-        step = recipe.steps["audit_impl"]
-        skill_cmd = step.with_args.get("skill_command", "")
-        assert "context.group_files" in skill_cmd
-
-    def test_audit_impl_go_routes_to_run_experiment(self, recipe) -> None:
-        """audit_impl on_result GO verdict must route to run_experiment."""
-        step = recipe.steps["audit_impl"]
-        assert step.on_result is not None
-        conditions = step.on_result.conditions
-        go_cond = next(
-            (c for c in conditions if c.when and "verdict" in c.when and "GO" in c.when), None
-        )
-        assert go_cond is not None, "audit_impl must have a GO verdict condition"
-        assert go_cond.route == "run_experiment"
-
-    def test_implement_phase_on_context_limit_routes_to_audit_impl(self, recipe) -> None:
-        """implement_phase on_context_limit must route to audit_impl."""
-        step = recipe.steps["implement_phase"]
-        assert step.on_context_limit == "audit_impl"
-
-    def test_implement_phase_on_exhausted_routes_to_audit_impl(self, recipe) -> None:
-        """implement_phase on_exhausted must route to audit_impl."""
-        step = recipe.steps["implement_phase"]
-        assert step.on_exhausted == "audit_impl"
-
-    def test_next_phase_or_experiment_fallback_routes_to_audit_impl(self, recipe) -> None:
-        """next_phase_or_experiment default route must be audit_impl."""
-        step = recipe.steps["next_phase_or_experiment"]
-        conditions = step.on_result.conditions
-        default_cond = next((c for c in conditions if c.when is None), None)
-        assert default_cond is not None, "next_phase_or_experiment must have a default route"
-        assert default_cond.route == "audit_impl"
-
-    def test_check_implement_fix_loop_max_exceeded_routes_to_audit_impl(self, recipe) -> None:
-        """check_implement_fix_loop max_exceeded condition must route to audit_impl."""
-        step = recipe.steps["check_implement_fix_loop"]
-        conditions = step.on_result.conditions
-        max_exceeded_cond = next(
-            (c for c in conditions if c.when and "max_exceeded" in c.when), None
-        )
-        assert max_exceeded_cond is not None, (
-            "check_implement_fix_loop must have a max_exceeded condition"
-        )
-        assert max_exceeded_cond.route == "audit_impl"
-
-    def test_check_implement_fix_loop_on_failure_routes_to_audit_impl(self, recipe) -> None:
-        """check_implement_fix_loop on_failure must route to audit_impl."""
-        step = recipe.steps["check_implement_fix_loop"]
-        assert step.on_failure == "audit_impl"
-
-    def test_has_capture_impl_base_step(self, recipe) -> None:
-        """research-implement.yaml must contain the capture_impl_base step."""
-        assert "capture_impl_base" in recipe.steps
-
-    def test_capture_impl_base_on_success_routes_to_plan_phase(self, recipe) -> None:
-        """capture_impl_base on_success must route to plan_phase."""
-        step = recipe.steps["capture_impl_base"]
-        assert step.on_success == "plan_phase"
-
-    def test_decompose_phases_routes_to_capture_impl_base(self, recipe) -> None:
-        """decompose_phases on_success must route to capture_impl_base."""
-        step = recipe.steps["decompose_phases"]
-        assert step.on_success == "capture_impl_base"
-
-    def test_validates_clean(self, recipe) -> None:
-        """research-implement.yaml must pass structural validation."""
         errors = validate_recipe_structure(recipe)
         assert errors == [], f"Validation errors: {errors}"
 

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -32,10 +32,10 @@ def test_implement_phase_failure_routes_to_troubleshoot(recipe):
     assert step.on_failure == "troubleshoot_implement_failure"
 
 
-def test_implement_phase_exhausted_routes_to_run_experiment(recipe):
-    """implement_phase on_exhausted must route to run_experiment (not escalate)."""
+def test_implement_phase_exhausted_routes_to_audit_impl(recipe):
+    """implement_phase on_exhausted must route to audit_impl."""
     step = recipe.steps["implement_phase"]
-    assert step.on_exhausted == "run_experiment"
+    assert step.on_exhausted == "audit_impl"
 
 
 def test_implement_phase_uses_implement_experiment(recipe):


### PR DESCRIPTION
## Summary

Add the `audit_impl` step to `research.yaml` and `research-implement.yaml` as a mandatory gate between phase iteration and `run_experiment`. All five routes that currently short-circuit to `run_experiment` (bypassing remaining phases) will be intercepted by `audit_impl`, which verifies that the implementation diff covers all decomposed phases. A new `capture_impl_base` step captures the pre-implementation HEAD SHA for the diff reference. The `audit` ingredient (defaulting to `"true"` for research recipes) gates the step, and `research-campaign.yaml` passes it through to the implement dispatch.

## Requirements


## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([decompose_phases])

    subgraph PreImpl ["★ Pre-Implementation Capture"]
        direction TB
        CAP["★ capture_impl_base<br/>━━━━━━━━━━<br/>git rev-parse HEAD<br/>captures impl_base_sha"]
    end

    subgraph PhaseLoop ["Phase Iteration Loop"]
        direction TB
        PP["plan_phase<br/>━━━━━━━━━━<br/>make-plan for current phase"]
        IP["● implement_phase<br/>━━━━━━━━━━<br/>implement-experiment"]
        TS["troubleshoot_implement_failure"]
        CL["● check_implement_fix_loop<br/>━━━━━━━━━━<br/>max_iterations: 3"]
        NP["● next_phase_or_experiment<br/>━━━━━━━━━━<br/>route: more phases?"]
    end

    subgraph AuditGate ["★ Audit Gate"]
        direction TB
        AI["★ audit_impl<br/>━━━━━━━━━━<br/>audit-impl skill<br/>skip_when_false: inputs.audit<br/>on_context_limit: escalate_stop"]
        DEC{"verdict?"}
    end

    subgraph Experiment ["Experiment Execution"]
        direction TB
        RE["run_experiment<br/>━━━━━━━━━━<br/>run-experiment skill"]
    end

    STOP([escalate_stop])

    START --> CAP
    CAP --> PP
    PP --> IP
    IP -->|"on_success"| NP
    IP -->|"on_failure"| TS
    TS --> CL
    NP -->|"more_phases"| PP

    IP -->|"on_context_limit"| AI
    IP -->|"on_exhausted"| AI
    NP -->|"all complete"| AI
    CL -->|"max_exceeded / on_failure"| AI

    AI --> DEC
    DEC -->|"GO"| RE
    DEC -->|"NO GO / error"| STOP

    class START,STOP terminal;
    class CAP newComponent;
    class PP,NP phase;
    class IP,TS,RE handler;
    class CL stateNode;
    class AI newComponent;
    class DEC detector;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Entry and exit points |
| Green | New Component | `capture_impl_base` and `audit_impl` (new steps) |
| Purple | Phase | Control flow and routing nodes |
| Orange | Handler | Execution steps (implement, troubleshoot, experiment) |
| Teal | State | Loop iteration guard |
| Red | Detector | Verdict decision gate |

### Module Dependency Diagram

```mermaid
classDiagram
    direction LR

    class research__yaml {
        + audit_impl: Step
        + capture_impl_base: Step
        + audit: Ingredient
    }

    class research__implement__yaml {
        + audit_impl: Step
        + capture_impl_base: Step
        + audit: Ingredient
    }

    class research__campaign__yaml {
        + audit: Ingredient
        + run-implement dispatch: includes audit
    }

    class audit__impl__py {
        + audit_impl(): verdict GO|NO_GO
    }

    class smoke__utils__py {
        + check_loop_iteration()
    }

    class test__research__audit__impl__py {
        + test_has_audit_ingredient_defaulting_true()
        + test_has_audit_impl_step()
        + test_audit_impl_skip_when_false()
        + test_audit_impl_on_context_limit_escalates()
        + test_audit_impl_on_failure_escalates()
        + test_audit_impl_uses_impl_base_sha()
        + test_audit_impl_uses_group_files()
        + test_audit_impl_go_routes_to_run_experiment()
        + test_implement_phase_on_context_limit_routes_to_audit_impl()
        + test_implement_phase_on_exhausted_routes_to_audit_impl()
        + test_next_phase_or_experiment_fallback_routes_to_audit_impl()
        + test_check_implement_fix_loop_max_exceeded_routes_to_audit_impl()
        + test_check_implement_fix_loop_on_failure_routes_to_audit_impl()
        + test_has_capture_impl_base_step()
        + test_capture_impl_base_on_success_routes_to_plan_phase()
        + test_decompose_phases_routes_to_capture_impl_base()
        + test_validates_clean()
        + test_campaign_has_audit_ingredient()
        + test_campaign_audit_default_true()
        + test_campaign_passes_audit_to_run_implement()
    }

    research__yaml --> audit__impl__py: audit_impl step
    research__implement__yaml --> audit__impl__py: audit_impl step
    research__campaign__yaml --> research__implement__yaml: passes audit ingredient
    research__yaml --> smoke__utils__py: check_loop_iteration
    research__implement__yaml --> smoke__utils__py: check_loop_iteration
    test__research__audit__impl__py --> research__yaml: fixture
    test__research__audit__impl__py --> research__implement__yaml: fixture
    test__research__audit__impl__py --> research__campaign__yaml: fixture

    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff
    classDef campaign fill:#0d47a1,stroke:#1976d2,stroke-width:2px,color:#fff
    classDef testFile fill:#bf360c,stroke:#ff8a65,stroke-width:2px,color:#fff

    class research__yaml newComponent
    class research__implement__yaml newComponent
    class research__campaign__yaml campaign
    class test__research__audit__impl__py testFile
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Green | New/Modified Recipe | Steps and ingredients added by this PR |
| Blue | Campaign | research-campaign.yaml changes |
| Orange | Test | New test file |

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef scenario fill:#01579b,stroke:#4fc3f7,stroke-width:2px,color:#fff;
    classDef outcome fill:#1b5e20,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef failure fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    SC1["Scenario 1: Normal phase iteration completes successfully"]
    SC2["Scenario 2: Context limit fires mid-iteration"]
    SC3["Scenario 3: Max fix-loop iterations exceeded"]
    SC4["Scenario 4: Audit is disabled (audit='false')"]

    SC1 --> OUT1["All phases complete → audit_impl → GO → run_experiment"]
    SC2 --> OUT2["Partial phases → audit_impl → NO GO → escalate_stop"]
    SC3 --> OUT3["3 failed fixes → audit_impl → NO GO → escalate_stop"]
    SC4 --> OUT4["audit_impl skipped → run_experiment directly"]

    class SC1,SC2,SC3,SC4 scenario;
    class OUT1,OUT4 outcome;
    class OUT2,OUT3 failure;
```

Closes #2330

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-013932-446110/.autoskillit/temp/make-plan/research_recipes_audit_impl_gate_plan_2026-05-10_014700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 80 | 19.8k | 1.4M | 86.7k | 111 | 73.7k | 9m 36s |
| verify | claude-opus-4-6 | 1 | 868 | 17.1k | 3.1M | 87.6k | 124 | 75.3k | 8m 50s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.0M | 18.9k | 2.1M | 28.8k | 181 | 123.8k | 15m 12s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 73.2k | 3.1k | 198.5k | 28.8k | 19 | 15.4k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 69.5k | 3.1k | 198.5k | 28.8k | 16 | 15.1k | 1m 8s |
| review_pr | claude-sonnet-4-6 | 3 | 663 | 99.7k | 1.5M | 91.3k | 108 | 221.6k | 24m 16s |
| resolve_review | claude-sonnet-4-6 | 2 | 678 | 51.7k | 6.3M | 109.0k | 213 | 176.2k | 20m 0s |
| **Total** | | | 3.1M | 213.6k | 14.8M | 109.0k | | 701.0k | 1h 20m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 539 | 3836.5 | 229.6 | 35.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 164 | 38541.1 | 1074.3 | 315.1 |
| **Total** | **703** | 21014.9 | 997.1 | 303.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 8 | 8.5k | 519.2k | 27.4M | 1.5M | 3h 8m |
| claude-opus-4-6 | 1 | 1.7k | 47.1k | 5.1M | 236.3k | 33m 58s |
| MiniMax-M2.7-highspeed | 5 | 16.9M | 154.9k | 12.9M | 585.6k | 1h 15m |