### PR TITLE
Rectify: Campaign Dispatch Capture Contract System

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -148,6 +148,7 @@ from .types import AuditLog as AuditLog
 from .types import BackgroundSupervisor as BackgroundSupervisor
 from .types import BareResume as BareResume
 from .types import CampaignProtector as CampaignProtector
+from .types import CAPTURE_VALID_VALUE_TYPES as CAPTURE_VALID_VALUE_TYPES
 from .types import CaptureEntrySpec as CaptureEntrySpec
 from .types import CaptureValueTypeError as CaptureValueTypeError
 from .types import ChannelBStatus as ChannelBStatus

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -148,6 +148,8 @@ from .types import AuditLog as AuditLog
 from .types import BackgroundSupervisor as BackgroundSupervisor
 from .types import BareResume as BareResume
 from .types import CampaignProtector as CampaignProtector
+from .types import CaptureEntrySpec as CaptureEntrySpec
+from .types import CaptureValueTypeError as CaptureValueTypeError
 from .types import ChannelBStatus as ChannelBStatus
 from .types import ChannelConfirmation as ChannelConfirmation
 from .types import CIRunScope as CIRunScope

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -20,6 +20,7 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 | `_type_protocols_recipe.py` | Protocols: `RecipeRepository`, `MigrationService`, `DatabaseReader`, `ReadOnlyResolver` |
 | `_type_protocols_infra.py` | Protocols: `GateState`, `BackgroundSupervisor`, `FleetLock`, `QuotaRefreshTask`, `TokenFactory`, `CampaignProtector` |
 | `_type_checkpoint.py` | `SessionCheckpoint` frozen dataclass and `compute_remaining()` helper for session resume |
+| `_type_capture.py` | `CaptureEntrySpec` and `CaptureValueTypeError` for typed capture contract enforcement |
 | `_type_dispatch_identity.py` | `DispatchIdentity` frozen value object, `PromptContractError`, and `assert_prompt_sentinel` for sentinel contract enforcement |
 | `_type_helpers.py` | Text processing and skill-name extraction utilities |
 | `_type_resume.py` | `ResumeSpec` discriminated union: `NoResume | BareResume | NamedResume` |

--- a/src/autoskillit/core/types/__init__.py
+++ b/src/autoskillit/core/types/__init__.py
@@ -6,6 +6,8 @@ autoskillit.core (the package gateway) in production code — not from here.
 
 from __future__ import annotations
 
+from ._type_capture import *  # noqa: F401, F403
+from ._type_capture import __all__ as _capture_all
 from ._type_checkpoint import *  # noqa: F401, F403
 from ._type_checkpoint import __all__ as _checkpoint_all
 from ._type_constants import *  # noqa: F401, F403
@@ -45,6 +47,7 @@ __all__ = (
     _checkpoint_all
     + _constants_all
     + _dispatch_identity_all
+    + _capture_all
     + _enums_all
     + _figure_spec_all
     + _helpers_all

--- a/src/autoskillit/core/types/__init__.py
+++ b/src/autoskillit/core/types/__init__.py
@@ -44,10 +44,10 @@ from ._type_subprocess import *  # noqa: F401, F403
 from ._type_subprocess import __all__ as _subprocess_all
 
 __all__ = (
-    _checkpoint_all
+    _capture_all
+    + _checkpoint_all
     + _constants_all
     + _dispatch_identity_all
-    + _capture_all
     + _enums_all
     + _figure_spec_all
     + _helpers_all

--- a/src/autoskillit/core/types/_type_capture.py
+++ b/src/autoskillit/core/types/_type_capture.py
@@ -1,0 +1,51 @@
+"""Capture type contracts for the campaign dispatch capture chain.
+
+Zero autoskillit imports outside this sub-package. IL-0 type contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["CaptureEntrySpec", "CaptureValueTypeError"]
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureEntrySpec:
+    """A single capture entry with semantic type declaration.
+
+    Attributes:
+        from_: The ``${{ result.<field_name> }}`` template string — what was previously
+            the plain string value in the ``dict[str, str]`` capture spec.
+        value_type: One of ``path``, ``url``, ``string``, ``optional_string``.
+            Defaults to ``string`` for backward compatibility during migration.
+    """
+
+    from_: str
+    value_type: str = "string"
+
+
+class CaptureValueTypeError(ValueError):
+    """Raised when a captured value violates its declared type contract.
+
+    Attributes:
+        key: The capture entry key that failed validation.
+        value: The raw value that was provided.
+        declared_type: The ``value_type`` that was declared in ``CaptureEntrySpec``.
+        reason: Human-readable description of why validation failed.
+    """
+
+    def __init__(
+        self,
+        key: str,
+        value: str,
+        declared_type: str,
+        reason: str,
+    ) -> None:
+        self.key = key
+        self.value = value
+        self.declared_type = declared_type
+        self.reason = reason
+        super().__init__(
+            f"Capture entry {key!r} (declared type: {declared_type!r}) failed validation: {reason}"
+        )

--- a/src/autoskillit/core/types/_type_capture.py
+++ b/src/autoskillit/core/types/_type_capture.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 
 __all__ = ["CaptureEntrySpec", "CaptureValueTypeError"]
 
+_VALID_VALUE_TYPES = frozenset({"path", "url", "string", "optional_string"})
+
 
 @dataclass(frozen=True, slots=True)
 class CaptureEntrySpec:
@@ -23,6 +25,13 @@ class CaptureEntrySpec:
 
     from_: str
     value_type: str = "string"
+
+    def __post_init__(self) -> None:
+        if self.value_type not in _VALID_VALUE_TYPES:
+            raise ValueError(
+                f"CaptureEntrySpec.value_type must be one of {sorted(_VALID_VALUE_TYPES)}, "
+                f"got {self.value_type!r}"
+            )
 
 
 class CaptureValueTypeError(ValueError):

--- a/src/autoskillit/core/types/_type_capture.py
+++ b/src/autoskillit/core/types/_type_capture.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-__all__ = ["CaptureEntrySpec", "CaptureValueTypeError"]
+__all__ = ["CAPTURE_VALID_VALUE_TYPES", "CaptureEntrySpec", "CaptureValueTypeError"]
 
-_VALID_VALUE_TYPES = frozenset({"path", "url", "string", "optional_string"})
+CAPTURE_VALID_VALUE_TYPES = frozenset({"path", "url", "string", "optional_string"})
+
+_VALID_VALUE_TYPES = CAPTURE_VALID_VALUE_TYPES
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -54,7 +54,11 @@ from .state_recovery import (
     derive_orchestrator_resume_spec,
     has_blocking_dispatch,
 )
-from .state_types import FLEET_STATE_SCHEMA_VERSION, DispatchOutcome
+from .state_types import (
+    _INFRASTRUCTURE_FAILURE_REASONS,
+    FLEET_STATE_SCHEMA_VERSION,
+    DispatchOutcome,
+)
 from .summary import (
     CampaignParseResult,
     CampaignSummary,

--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -55,7 +55,7 @@ from .state_recovery import (
     has_blocking_dispatch,
 )
 from .state_types import (
-    _INFRASTRUCTURE_FAILURE_REASONS,
+    _INFRASTRUCTURE_FAILURE_REASONS,  # noqa: F401
     FLEET_STATE_SCHEMA_VERSION,
     DispatchOutcome,
 )

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -83,8 +83,14 @@ def _validate_capture_value(key: str, value: str, declared_type: str) -> None:
                 reason="string value must be non-empty",
             )
     elif declared_type == "url":
-        # URL type: non-empty values should look like URLs
-        if value and not (
+        if not value:
+            raise CaptureValueTypeError(
+                key=key,
+                value=value,
+                declared_type=declared_type,
+                reason="url value must be non-empty",
+            )
+        if not (
             value.startswith("http://")
             or value.startswith("https://")
             or value.startswith("file://")

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -16,6 +16,8 @@ import psutil
 import regex as re
 
 from autoskillit.core import (
+    CaptureEntrySpec,
+    CaptureValueTypeError,
     FleetErrorCode,
     InfraExitCategory,
     RetryReason,
@@ -52,28 +54,76 @@ _CAMPAIGN_REF_RE = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
 _RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
 
 
+def _validate_capture_value(key: str, value: str, declared_type: str) -> None:
+    """Validate a captured value against its declared type.
+
+    Raises CaptureValueTypeError if validation fails.
+    """
+    if declared_type == "path":
+        if not value:
+            raise CaptureValueTypeError(
+                key=key,
+                value=value,
+                declared_type=declared_type,
+                reason="path value must be non-empty",
+            )
+        if not Path(value).exists():
+            raise CaptureValueTypeError(
+                key=key,
+                value=value,
+                declared_type=declared_type,
+                reason=f"path does not exist: {value}",
+            )
+    elif declared_type == "string":
+        if not value:
+            raise CaptureValueTypeError(
+                key=key,
+                value=value,
+                declared_type=declared_type,
+                reason="string value must be non-empty",
+            )
+    elif declared_type == "url":
+        # URL type: non-empty values should look like URLs
+        if value and not (
+            value.startswith("http://")
+            or value.startswith("https://")
+            or value.startswith("file://")
+        ):
+            raise CaptureValueTypeError(
+                key=key,
+                value=value,
+                declared_type=declared_type,
+                reason=f"url value must start with http://, https://, or file://: {value!r}",
+            )
+    # optional_string: any value including empty string — no validation
+
+
 def _extract_captures(
-    capture_spec: dict[str, str],
+    capture_spec: dict[str, CaptureEntrySpec],
     payload: dict[str, object],
 ) -> dict[str, str]:
     """Extract captured values from an L3 result payload.
 
-    For each entry in `capture_spec` whose value matches ``${{ result.field }}``,
-    reads `payload[field]` and converts it to str. Missing payload keys are logged
-    as warnings. If the capture spec has entries but all fields are absent from the
-    payload, raises CaptureCompletenessError.
+    For each entry in `capture_spec`, reads `payload[field_name]` from the
+    ``from_`` template and validates it against the declared `value_type`.
+    Missing payload keys are logged as warnings. If the capture spec has
+    entries but all fields are absent from the payload, raises
+    CaptureCompletenessError. If a value fails type validation,
+    raises CaptureValueTypeError.
     """
     result: dict[str, str] = {}
     expected_fields: list[str] = []
-    for key, template in capture_spec.items():
-        m = _RESULT_REF_RE.match(template.strip())
+    for key, entry in capture_spec.items():
+        m = _RESULT_REF_RE.match(entry.from_.strip())
         if m is None:
             continue
         field_name = m.group(1)
         expected_fields.append(field_name)
         if field_name in payload:
-            value = payload[field_name]
-            result[key] = value if isinstance(value, str) else json.dumps(value, default=str)
+            value: object = payload[field_name]
+            str_value = value if isinstance(value, str) else json.dumps(value, default=str)
+            _validate_capture_value(key, str_value, entry.value_type)
+            result[key] = str_value
         else:
             logger.warning(
                 "capture_field_missing_from_payload",
@@ -96,7 +146,8 @@ def _interpolate_campaign_refs(
 ) -> dict[str, str]:
     """Resolve ``${{ campaign.key }}`` references in ingredient values.
 
-    Raises ValueError if a campaign reference cannot be resolved.
+    Raises ValueError if a campaign reference cannot be resolved or resolves to
+    an empty string (which may indicate an invalid capture from a prior dispatch).
     Non-campaign values are returned unchanged.
     """
     out: dict[str, str] = {}
@@ -110,7 +161,13 @@ def _interpolate_campaign_refs(
                     f"but '{ref}' has not been captured by any prior dispatch. "
                     f"Available: {sorted(captured)}"
                 )
-            return captured[ref]
+            resolved = captured[ref]
+            if resolved == "":
+                raise ValueError(
+                    f"Ingredient '{_k}' campaign ref '{ref}' resolved to empty string — "
+                    f"the capturing dispatch may have emitted an empty value"
+                )
+            return resolved
 
         out[k] = _CAMPAIGN_REF_RE.sub(_replace, v)
     return out
@@ -193,6 +250,17 @@ def _write_campaign_refusal(
         )
     except Exception:
         logger.warning("failed to record refusal to campaign state", exc_info=True)
+
+
+def _normalize_capture_spec(capture: dict[str, str] | None) -> dict[str, CaptureEntrySpec] | None:
+    """Convert YAML-format ``dict[str, str]`` capture spec to ``dict[str, CaptureEntrySpec]``.
+
+    The recipe YAML uses shorthand capture entries: ``{key: "${{ result.field }}"}``.
+    This converts them to the typed ``CaptureEntrySpec`` format used internally.
+    """
+    if capture is None:
+        return None
+    return {key: CaptureEntrySpec(from_=val) for key, val in capture.items()}
 
 
 async def _touch_dispatch_marker(
@@ -290,7 +358,7 @@ async def execute_dispatch(
             quota_checker=quota_checker,
             quota_refresher=quota_refresher,
             cache_invalidator=cache_invalidator,
-            capture=capture,
+            capture=_normalize_capture_spec(capture),
             resume_session_id=resume_session_id,
             resume_checkpoint=resume_checkpoint,
             idle_output_timeout=idle_output_timeout,
@@ -365,7 +433,7 @@ async def _run_dispatch(
     quota_checker: Callable[..., Any],
     quota_refresher: Callable[..., Any],
     cache_invalidator: Callable[[str], None] | None = None,
-    capture: dict[str, str] | None = None,
+    capture: dict[str, CaptureEntrySpec] | None = None,
     resume_session_id: str | None = None,
     resume_checkpoint: SessionCheckpoint | None = None,
     idle_output_timeout: int | None = None,

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -121,12 +121,12 @@ def _extract_captures(
         expected_fields.append(field_name)
         if field_name in payload:
             value: object = payload[field_name]
-            if not isinstance(value, str) and entry.value_type in ("path", "string", "url"):
+            if not isinstance(value, str) and entry.value_type == "path":
                 raise CaptureValueTypeError(
                     key=key,
                     value=repr(value),
                     declared_type=entry.value_type,
-                    reason=f"expected a string, got {type(value).__name__}",
+                    reason=f"expected a string path, got {type(value).__name__}",
                 )
             str_value = value if isinstance(value, str) else json.dumps(value, default=str)
             _validate_capture_value(key, str_value, entry.value_type)

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -7,7 +7,7 @@ import functools
 import json
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -121,6 +121,13 @@ def _extract_captures(
         expected_fields.append(field_name)
         if field_name in payload:
             value: object = payload[field_name]
+            if not isinstance(value, str) and entry.value_type in ("path", "string", "url"):
+                raise CaptureValueTypeError(
+                    key=key,
+                    value=repr(value),
+                    declared_type=entry.value_type,
+                    reason=f"expected a string, got {type(value).__name__}",
+                )
             str_value = value if isinstance(value, str) else json.dumps(value, default=str)
             _validate_capture_value(key, str_value, entry.value_type)
             result[key] = str_value
@@ -252,15 +259,21 @@ def _write_campaign_refusal(
         logger.warning("failed to record refusal to campaign state", exc_info=True)
 
 
-def _normalize_capture_spec(capture: dict[str, str] | None) -> dict[str, CaptureEntrySpec] | None:
+def _normalize_capture_spec(
+    capture: Mapping[str, str | CaptureEntrySpec] | None,
+) -> dict[str, CaptureEntrySpec] | None:
     """Convert YAML-format ``dict[str, str]`` capture spec to ``dict[str, CaptureEntrySpec]``.
 
     The recipe YAML uses shorthand capture entries: ``{key: "${{ result.field }}"}``.
     This converts them to the typed ``CaptureEntrySpec`` format used internally.
+    Already-typed ``CaptureEntrySpec`` values are passed through unchanged.
     """
     if capture is None:
         return None
-    return {key: CaptureEntrySpec(from_=val) for key, val in capture.items()}
+    return {
+        key: val if isinstance(val, CaptureEntrySpec) else CaptureEntrySpec(from_=val)
+        for key, val in capture.items()
+    }
 
 
 async def _touch_dispatch_marker(

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -456,24 +456,25 @@ def upsert_dispatch_record_by_name(state_path: Path, record: DispatchRecord) -> 
     state is unknown and _validate_transition enforcement is not appropriate.
     If the state file is missing or corrupted, this is a no-op.
 
-    Terminal-status protection: once a dispatch reaches a terminal status (SUCCESS,
-    FAILURE, etc.), it cannot be overwritten with any other terminal status via this
-    bypass path. Use mark_dispatch_* state machine methods for valid transitions.
+    Terminal-status protection: FAILURE→SUCCESS and SUCCESS→FAILURE overwrites are
+    blocked — terminal status transitions must go through mark_dispatch_* state machine
+    methods.
     """
     with CampaignStateMutator(state_path) as m:
         if m.state is None:
             return
         for i, d in enumerate(m.state.dispatches):
             if d.name == record.name:
-                # Terminal-status protection: reject any terminal→terminal overwrite
-                if (
-                    d.status in TERMINAL_DISPATCH_STATUSES
-                    and record.status in TERMINAL_DISPATCH_STATUSES
-                    and d.status != record.status
-                ):
+                # Block terminal-status overwrites in both directions
+                if d.status == DispatchStatus.FAILURE and record.status == DispatchStatus.SUCCESS:
                     raise ValueError(
-                        f"Cannot overwrite terminal dispatch {record.name!r} "
-                        f"(status: {d.status!r}) with {record.status!r} — "
+                        f"Cannot overwrite FAILURE dispatch {record.name!r} with SUCCESS — "
+                        f"use mark_dispatch_* state machine methods for valid transitions"
+                    )
+                if d.status == DispatchStatus.SUCCESS and record.status != DispatchStatus.SUCCESS:
+                    raise ValueError(
+                        f"Cannot overwrite SUCCESS dispatch {record.name!r} "
+                        f"with {record.status!r} — "
                         f"use mark_dispatch_* state machine methods for valid transitions"
                     )
                 m.state.dispatches[i] = record

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -456,18 +456,24 @@ def upsert_dispatch_record_by_name(state_path: Path, record: DispatchRecord) -> 
     state is unknown and _validate_transition enforcement is not appropriate.
     If the state file is missing or corrupted, this is a no-op.
 
-    Terminal-status protection: once a dispatch reaches FAILURE, it cannot be
-    silently overwritten with SUCCESS via this bypass path.
+    Terminal-status protection: once a dispatch reaches a terminal status (SUCCESS,
+    FAILURE, etc.), it cannot be overwritten with any other terminal status via this
+    bypass path. Use mark_dispatch_* state machine methods for valid transitions.
     """
     with CampaignStateMutator(state_path) as m:
         if m.state is None:
             return
         for i, d in enumerate(m.state.dispatches):
             if d.name == record.name:
-                # Terminal-status protection: reject SUCCESS overwriting FAILURE
-                if d.status == DispatchStatus.FAILURE and record.status == DispatchStatus.SUCCESS:
+                # Terminal-status protection: reject any terminal→terminal overwrite
+                if (
+                    d.status in TERMINAL_DISPATCH_STATUSES
+                    and record.status in TERMINAL_DISPATCH_STATUSES
+                    and d.status != record.status
+                ):
                     raise ValueError(
-                        f"Cannot overwrite FAILURE dispatch {record.name!r} with SUCCESS — "
+                        f"Cannot overwrite terminal dispatch {record.name!r} "
+                        f"(status: {d.status!r}) with {record.status!r} — "
                         f"use mark_dispatch_* state machine methods for valid transitions"
                     )
                 m.state.dispatches[i] = record

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -455,12 +455,21 @@ def upsert_dispatch_record_by_name(state_path: Path, record: DispatchRecord) -> 
     Intended for external writes (e.g. from result envelopes) where the prior
     state is unknown and _validate_transition enforcement is not appropriate.
     If the state file is missing or corrupted, this is a no-op.
+
+    Terminal-status protection: once a dispatch reaches FAILURE, it cannot be
+    silently overwritten with SUCCESS via this bypass path.
     """
     with CampaignStateMutator(state_path) as m:
         if m.state is None:
             return
         for i, d in enumerate(m.state.dispatches):
             if d.name == record.name:
+                # Terminal-status protection: reject SUCCESS overwriting FAILURE
+                if d.status == DispatchStatus.FAILURE and record.status == DispatchStatus.SUCCESS:
+                    raise ValueError(
+                        f"Cannot overwrite FAILURE dispatch {record.name!r} with SUCCESS — "
+                        f"use mark_dispatch_* state machine methods for valid transitions"
+                    )
                 m.state.dispatches[i] = record
                 m.mark_dirty()
                 return

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -414,7 +414,7 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
                 logger.warning(
                     "capture_spec_malformed_longform",
                     capture_name=key,
-                    dict_keys=sorted(val.keys()),
+                    present_fields=sorted(val),
                 )
     return result
 

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import (
+    CAPTURE_VALID_VALUE_TYPES,
     CORE_PACKS,
     CaptureEntrySpec,
     DispatchGateType,
@@ -38,7 +39,6 @@ logger = get_logger(__name__)
 
 _TEMP_PLACEHOLDER = "{{AUTOSKILLIT_TEMP}}"
 _SCRIPTS_PLACEHOLDER = "{{AUTOSKILLIT_SCRIPTS}}"
-_CAPTURE_VALID_VALUE_TYPES = frozenset({"path", "url", "string", "optional_string"})
 
 
 def substitute_temp_placeholder(text: str, temp_dir_relpath: str) -> str:
@@ -401,7 +401,7 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
             type_ = val.get("type")
             if isinstance(from_, str):
                 effective_type = type_ if isinstance(type_, str) else "string"
-                if effective_type not in _CAPTURE_VALID_VALUE_TYPES:
+                if effective_type not in CAPTURE_VALID_VALUE_TYPES:
                     logger.warning(
                         "capture_spec_unknown_type",
                         capture_name=key,

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -404,7 +404,7 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
                 if effective_type not in _CAPTURE_VALID_VALUE_TYPES:
                     logger.warning(
                         "capture_spec_unknown_type",
-                        capture_key=key,
+                        capture_name=key,
                         type_value=effective_type,
                         fallback="string",
                     )

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -414,7 +414,7 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
                 logger.warning(
                     "capture_spec_malformed_longform",
                     capture_name=key,
-                    keys=sorted(val.keys()),
+                    dict_keys=sorted(val.keys()),
                 )
     return result
 

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -38,6 +38,7 @@ logger = get_logger(__name__)
 
 _TEMP_PLACEHOLDER = "{{AUTOSKILLIT_TEMP}}"
 _SCRIPTS_PLACEHOLDER = "{{AUTOSKILLIT_SCRIPTS}}"
+_CAPTURE_VALID_VALUE_TYPES = frozenset({"path", "url", "string", "optional_string"})
 
 
 def substitute_temp_placeholder(text: str, temp_dir_relpath: str) -> str:
@@ -396,10 +397,19 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
             # Shorthand: string value is the from_ template
             result[key] = CaptureEntrySpec(from_=val, value_type="string")
         elif isinstance(val, dict):
-            from_ = val.get("from") if isinstance(val, dict) else None
-            type_ = val.get("type") if isinstance(val, dict) else None
+            from_ = val.get("from")
+            type_ = val.get("type")
             if isinstance(from_, str):
-                result[key] = CaptureEntrySpec(from_=from_, value_type=type_ or "string")
+                effective_type = type_ if isinstance(type_, str) else "string"
+                if effective_type not in _CAPTURE_VALID_VALUE_TYPES:
+                    logger.warning(
+                        "capture_spec_unknown_type",
+                        key=key,
+                        type_value=effective_type,
+                        fallback="string",
+                    )
+                    effective_type = "string"
+                result[key] = CaptureEntrySpec(from_=from_, value_type=effective_type)
         # Non-dict, non-string values are ignored
     return result
 

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -386,8 +386,8 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
     - Long-form: ``{key: {from: "${{ result.field }}", type: "path"}}``
       → ``CaptureEntrySpec(from_=..., value_type="path")``
 
-    Unknown YAML structures are silently ignored (treated as non-result-template
-    values that _extract_captures will skip).
+    Malformed long-form dicts (e.g. missing ``from`` key) emit a warning.
+    Non-dict, non-string values are silently skipped.
     """
     if not capture_raw or not isinstance(capture_raw, dict):
         return {}
@@ -410,7 +410,12 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
                     )
                     effective_type = "string"
                 result[key] = CaptureEntrySpec(from_=from_, value_type=effective_type)
-        # Non-dict, non-string values are ignored
+            else:
+                logger.warning(
+                    "capture_spec_malformed_longform",
+                    capture_name=key,
+                    keys=sorted(val.keys()),
+                )
     return result
 
 

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from autoskillit.core import (
     CORE_PACKS,
+    CaptureEntrySpec,
     DispatchGateType,
     LoadReport,
     LoadResult,
@@ -375,6 +376,34 @@ if _PARSE_RECIPE_HANDLED_FIELDS | _RECIPE_COMPUTED_FIELDS != frozenset(
     )
 
 
+def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
+    """Parse a YAML capture spec into ``dict[str, CaptureEntrySpec]``.
+
+    Accepts two YAML forms:
+    - Shorthand: ``{key: "${{ result.field }}"}`` →
+      ``CaptureEntrySpec(from_=..., value_type="string")``
+    - Long-form: ``{key: {from: "${{ result.field }}", type: "path"}}``
+      → ``CaptureEntrySpec(from_=..., value_type="path")``
+
+    Unknown YAML structures are silently ignored (treated as non-result-template
+    values that _extract_captures will skip).
+    """
+    if not capture_raw or not isinstance(capture_raw, dict):
+        return {}
+    result: dict[str, CaptureEntrySpec] = {}
+    for key, val in capture_raw.items():
+        if isinstance(val, str):
+            # Shorthand: string value is the from_ template
+            result[key] = CaptureEntrySpec(from_=val, value_type="string")
+        elif isinstance(val, dict):
+            from_ = val.get("from") if isinstance(val, dict) else None
+            type_ = val.get("type") if isinstance(val, dict) else None
+            if isinstance(from_, str):
+                result[key] = CaptureEntrySpec(from_=from_, value_type=type_ or "string")
+        # Non-dict, non-string values are ignored
+    return result
+
+
 def _parse_recipe(data: dict[str, Any]) -> Recipe:
     name = data.get("name", "")
     description = data.get("description", "")
@@ -454,7 +483,7 @@ def _parse_recipe(data: dict[str, Any]) -> Recipe:
                     task=d.get("task", ""),
                     ingredients=d.get("ingredients") or {},
                     depends_on=d.get("depends_on") or [],
-                    capture=d.get("capture") or {},
+                    capture=_parse_capture_spec(d.get("capture")),
                     gate=d_gate,
                     message=d.get("message") or None,
                 )

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -404,7 +404,7 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
                 if effective_type not in _CAPTURE_VALID_VALUE_TYPES:
                     logger.warning(
                         "capture_spec_unknown_type",
-                        key=key,
+                        capture_key=key,
                         type_value=effective_type,
                         fallback="string",
                     )

--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -582,15 +582,15 @@ def _check_dispatch_capture_value_references_result(ctx: ValidationContext) -> l
         return []
     findings = []
     for d in ctx.recipe.dispatches:
-        for key, val in d.capture.items():
-            if not _RESULT_TEMPLATE_RE.match(val.strip()):
+        for key, entry in d.capture.items():
+            if not _RESULT_TEMPLATE_RE.match(entry.from_.strip()):
                 findings.append(
                     RuleFinding(
                         rule="dispatch-capture-value-references-result",
                         severity=Severity.ERROR,
                         step_name="(top-level)",
                         message=(
-                            f"Dispatch {d.name!r} capture[{key!r}] value {val!r} must use "
+                            f"Dispatch {d.name!r} capture[{key!r}] value {entry.from_!r} must use "
                             "${{ result.<field_name> }} syntax."
                         ),
                     )
@@ -617,7 +617,7 @@ def _check_dispatch_capture_field_in_sentinel(ctx: ValidationContext) -> list[Ru
         if not sentinel_fields:
             continue
         for cap_key, cap_val in d.capture.items():
-            match = _RESULT_FIELD_RE.match(cap_val.strip())
+            match = _RESULT_FIELD_RE.match(cap_val.from_.strip())
             if not match:
                 continue
             field_name = match.group(1)
@@ -685,7 +685,7 @@ def _check_dispatch_capture_field_in_all_sentinels(
         if len(per_stop) < 2:
             continue
         for cap_key, cap_val in d.capture.items():
-            match = _RESULT_FIELD_RE.match(cap_val.strip())
+            match = _RESULT_FIELD_RE.match(cap_val.from_.strip())
             if not match:
                 continue
             field_name = match.group(1)

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -11,7 +11,13 @@ from typing import Final
 
 import regex as re
 
-from autoskillit.core import FEATURE_REGISTRY, RECIPE_PACK_TAGS, DispatchGateType, RecipeSource
+from autoskillit.core import (
+    FEATURE_REGISTRY,
+    RECIPE_PACK_TAGS,
+    CaptureEntrySpec,
+    DispatchGateType,
+    RecipeSource,
+)
 
 AUTOSKILLIT_VERSION_KEY: Final = "autoskillit_version"
 RECIPE_VERSION_KEY: Final = "recipe_version"
@@ -142,7 +148,7 @@ class CampaignDispatch:
         default_factory=dict
     )  # string-only: YAML pass-through key-value pairs, not structured RecipeIngredient objects
     depends_on: list[str] = field(default_factory=list)
-    capture: dict[str, str] = field(default_factory=dict)
+    capture: dict[str, CaptureEntrySpec] = field(default_factory=dict)
     gate: DispatchGateType | None = None
     message: str | None = None
 

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -141,7 +141,6 @@ async def dispatch_food_truck(
         continue_on_failure_str = os.environ.get("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
         if campaign_state_path_str and continue_on_failure_str.lower() != "true":
             from autoskillit.fleet import (  # noqa: PLC0415
-                _INFRASTRUCTURE_FAILURE_REASONS,
                 has_blocking_dispatch,
                 reset_blocking_dispatch,
             )
@@ -174,6 +173,7 @@ async def dispatch_food_truck(
 
         from autoskillit.core import SessionCheckpoint  # noqa: PLC0415
         from autoskillit.fleet import (  # noqa: PLC0415
+            _INFRASTRUCTURE_FAILURE_REASONS,
             DispatchCompleted,
             DispatchStatus,
             execute_dispatch,
@@ -230,7 +230,7 @@ async def dispatch_food_truck(
             campaign_state_path_str
             and continue_on_failure_str.lower() != "true"
             and isinstance(result, DispatchCompleted)
-            and result.dispatch_status != DispatchStatus.SUCCESS
+            and result.dispatch_status == DispatchStatus.FAILURE
             and result.reason not in _INFRASTRUCTURE_FAILURE_REASONS
             and not dispatch_name
         ):
@@ -239,6 +239,21 @@ async def dispatch_food_truck(
                 "Campaign halted: a prior dispatch failed and "
                 "continue_on_failure is false. "
                 "No further dispatches permitted.",
+            )
+
+        if (
+            campaign_state_path_str
+            and isinstance(result, DispatchCompleted)
+            and result.dispatch_status != DispatchStatus.SUCCESS
+            and (continue_on_failure_str.lower() == "true" or dispatch_name)
+        ):
+            logger.warning(
+                "dispatch_non_success_allowed_past_halt_gate",
+                dispatch_name=effective_name,
+                dispatch_status=result.dispatch_status,
+                reason=result.reason,
+                continue_on_failure=continue_on_failure_str,
+                has_dispatch_name=bool(dispatch_name),
             )
 
         return result.to_envelope()

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -141,6 +141,7 @@ async def dispatch_food_truck(
         continue_on_failure_str = os.environ.get("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
         if campaign_state_path_str and continue_on_failure_str.lower() != "true":
             from autoskillit.fleet import (  # noqa: PLC0415
+                _INFRASTRUCTURE_FAILURE_REASONS,
                 has_blocking_dispatch,
                 reset_blocking_dispatch,
             )
@@ -219,13 +220,19 @@ async def dispatch_food_truck(
                 result,
             )
 
-        # Post-dispatch halt: if continue_on_failure=false and the dispatch failed,
-        # return FLEET_CAMPAIGN_HALTED immediately — mirrors the pre-dispatch gate.
+        # Post-dispatch halt: if continue_on_failure=false and the dispatch failed
+        # (logic failure, not infrastructure), return FLEET_CAMPAIGN_HALTED immediately.
+        # Infrastructure failures (fleet_l3_no_result_block, fleet_quota_exhausted) do
+        # not halt — they are retriable at the L3 level without campaign-level impact.
+        # Also skip halt if dispatch_name was provided — the pre-dispatch gate already
+        # handled the reset case, and a retry of the blocking dispatch should proceed.
         if (
             campaign_state_path_str
             and continue_on_failure_str.lower() != "true"
             and isinstance(result, DispatchCompleted)
             and result.dispatch_status != DispatchStatus.SUCCESS
+            and result.reason not in _INFRASTRUCTURE_FAILURE_REASONS
+            and not dispatch_name
         ):
             return fleet_error(
                 FleetErrorCode.FLEET_CAMPAIGN_HALTED,

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -172,7 +172,11 @@ async def dispatch_food_truck(
                 )
 
         from autoskillit.core import SessionCheckpoint  # noqa: PLC0415
-        from autoskillit.fleet import DispatchCompleted, execute_dispatch  # noqa: PLC0415
+        from autoskillit.fleet import (  # noqa: PLC0415
+            DispatchCompleted,
+            DispatchStatus,
+            execute_dispatch,
+        )
         from autoskillit.server import _get_ctx
         from autoskillit.server._misc import (  # noqa: PLC0415
             _refresh_quota_cache,
@@ -213,6 +217,21 @@ async def dispatch_food_truck(
                 campaign_state_path_str,
                 effective_name,
                 result,
+            )
+
+        # Post-dispatch halt: if continue_on_failure=false and the dispatch failed,
+        # return FLEET_CAMPAIGN_HALTED immediately — mirrors the pre-dispatch gate.
+        if (
+            campaign_state_path_str
+            and continue_on_failure_str.lower() != "true"
+            and isinstance(result, DispatchCompleted)
+            and result.dispatch_status != DispatchStatus.SUCCESS
+        ):
+            return fleet_error(
+                FleetErrorCode.FLEET_CAMPAIGN_HALTED,
+                "Campaign halted: a prior dispatch failed and "
+                "continue_on_failure is false. "
+                "No further dispatches permitted.",
             )
 
         return result.to_envelope()

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -138,8 +138,10 @@ async def dispatch_food_truck(
             )
 
         campaign_state_path_str = os.environ.get("AUTOSKILLIT_CAMPAIGN_STATE_PATH")
-        continue_on_failure_str = os.environ.get("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
-        if campaign_state_path_str and continue_on_failure_str.lower() != "true":
+        continue_on_failure = (
+            os.environ.get("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false").lower() == "true"
+        )
+        if campaign_state_path_str and not continue_on_failure:
             from autoskillit.fleet import (  # noqa: PLC0415
                 has_blocking_dispatch,
                 reset_blocking_dispatch,
@@ -228,7 +230,7 @@ async def dispatch_food_truck(
         # handled the reset case, and a retry of the blocking dispatch should proceed.
         if (
             campaign_state_path_str
-            and continue_on_failure_str.lower() != "true"
+            and not continue_on_failure
             and isinstance(result, DispatchCompleted)
             and result.dispatch_status == DispatchStatus.FAILURE
             and result.reason not in _INFRASTRUCTURE_FAILURE_REASONS
@@ -245,14 +247,14 @@ async def dispatch_food_truck(
             campaign_state_path_str
             and isinstance(result, DispatchCompleted)
             and result.dispatch_status != DispatchStatus.SUCCESS
-            and (continue_on_failure_str.lower() == "true" or dispatch_name)
+            and (continue_on_failure or dispatch_name)
         ):
             logger.warning(
                 "dispatch_non_success_allowed_past_halt_gate",
                 dispatch_name=effective_name,
                 dispatch_status=result.dispatch_status,
                 reason=result.reason,
-                continue_on_failure=continue_on_failure_str,
+                continue_on_failure=continue_on_failure,
                 has_dispatch_name=bool(dispatch_name),
             )
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -802,7 +802,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 31,
         "execution": 18,
         "core": 20,
-        "core/types": 18,
+        "core/types": 19,
         "cli": 20,
         "hooks": 10,
         "pipeline": 12,

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -30,6 +30,7 @@ class TestCoreSubpackages:
             "_type_protocols_workspace",
             "_type_results_execution",
             "_type_figure_spec",
+            "_type_capture",
         }
         actual = {p.stem for p in (SRC / "core" / "types").glob("_type_*.py")}
         assert actual == expected

--- a/tests/cli/CLAUDE.md
+++ b/tests/cli/CLAUDE.md
@@ -62,6 +62,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_serve_sigterm.py` | Regression guard: serve() uses event-loop-routed signal handling (issue #745) |
 | `test_session_launch.py` | Tests for cli/_session_launch.py — _run_interactive_session contract |
 | `test_session_picker.py` | Tests for cli/_session_picker.py |
+| `test_signal_guard.py` | Tests for _fleet_signal_guard in cli/_fleet.py (Group J) |
 | `test_startup_budget.py` | Integration test: serve() must call anyio.run() within the startup timing budget |
 | `test_subprocess_env_contracts.py` | Structural contract: every subprocess.run(["autoskillit",...]) in CLI must inject AUTOSKILLIT_SKIP_STALE_CHECK |
 | `test_terminal.py` | Tests for cli/_terminal.py terminal_guard() context manager |

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 
 import anyio
@@ -27,11 +26,11 @@ async def test_marker_created_before_dispatch(tool_ctx, monkeypatch, tmp_path: P
     async def _asserting_dispatch(**_kw):
         found = list(marker_dir.glob("dispatch-in-progress--*.marker"))
         assert len(found) == 1, f"Expected 1 marker, found {len(found)}"
-        raise asyncio.CancelledError
+        raise RuntimeError("marker assertion complete")
 
     monkeypatch.setattr(tool_ctx.executor, "dispatch_food_truck", _asserting_dispatch)
 
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(RuntimeError, match="marker assertion complete"):
         await _run_dispatch(
             tool_ctx=tool_ctx,
             recipe="test-recipe",
@@ -117,7 +116,7 @@ async def test_heartbeat_refreshes_mtime(tmp_path: Path) -> None:
         tg.start_soon(_touch_dispatch_marker, marker_path, 0.05, trigger)
 
         async def _stop():
-            await anyio.sleep(0.25)
+            await anyio.sleep(1.0)
             trigger.set()
 
         tg.start_soon(_stop)

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -117,7 +117,7 @@ async def test_heartbeat_refreshes_mtime(tmp_path: Path) -> None:
         tg.start_soon(_touch_dispatch_marker, marker_path, 0.05, trigger)
 
         async def _stop():
-            await anyio.sleep(1.0)
+            await anyio.sleep(2.1)
             trigger.set()
 
         tg.start_soon(_stop)

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import anyio
@@ -26,11 +27,11 @@ async def test_marker_created_before_dispatch(tool_ctx, monkeypatch, tmp_path: P
     async def _asserting_dispatch(**_kw):
         found = list(marker_dir.glob("dispatch-in-progress--*.marker"))
         assert len(found) == 1, f"Expected 1 marker, found {len(found)}"
-        raise RuntimeError("marker assertion complete")
+        raise asyncio.CancelledError
 
     monkeypatch.setattr(tool_ctx.executor, "dispatch_food_truck", _asserting_dispatch)
 
-    with pytest.raises(RuntimeError, match="marker assertion complete"):
+    with pytest.raises(asyncio.CancelledError):
         await _run_dispatch(
             tool_ctx=tool_ctx,
             recipe="test-recipe",

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -270,22 +270,6 @@ def test_extract_research_partial_payload_skips_missing():
     assert "visualization_plan_path" not in result
 
 
-def test_extract_empty_string_path_is_captured():
-    """Empty-string capture for path type must be rejected (CaptureValueTypeError).
-
-    This test documents the NEW correct behavior. The old buggy behavior (accepting
-    empty strings for any capture type) is no longer valid.
-    """
-    from autoskillit.core.types import CaptureEntrySpec
-    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
-
-    capture_spec = {
-        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
-    }
-    with pytest.raises(CaptureValueTypeError):
-        _extract_captures(capture_spec, {"p": ""})
-
-
 def test_extract_research_capture_all_fields_combined():
     from autoskillit.fleet._api import _extract_captures
 
@@ -605,23 +589,14 @@ def test_extract_captures_raises_on_complete_capture_miss():
 # ---------------------------------------------------------------------------
 
 
-def _make_entry_spec(from_: str, value_type: str):
-    """Build a CaptureEntrySpec for testing."""
-    from autoskillit.core.types import CaptureEntrySpec
-
-    return CaptureEntrySpec(from_=from_, value_type=value_type)
-
-
 def test_extract_path_type_rejects_empty_string():
     """A path-type capture with an empty-string value must raise CaptureValueTypeError."""
-    from autoskillit.core.types import CaptureEntrySpec
+    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
 
     capture_spec = {
         "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
     }
     payload = {"p": ""}
-
-    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
 
     with pytest.raises(CaptureValueTypeError) as exc_info:
         _extract_captures(capture_spec, payload)
@@ -631,29 +606,25 @@ def test_extract_path_type_rejects_empty_string():
 
 def test_extract_optional_string_type_accepts_empty():
     """An optional_string-type capture with an empty-string value must be accepted."""
-    from autoskillit.core.types import CaptureEntrySpec
+    from autoskillit.fleet._api import _extract_captures
 
     capture_spec = {
         "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="optional_string"),
     }
     payload = {"pr_url": ""}
 
-    from autoskillit.fleet._api import _extract_captures
-
     result = _extract_captures(capture_spec, payload)
     assert result == {"pr_url": ""}
 
 
-def test_extract_path_type_rejects_nonexistent_path():
+def test_extract_path_type_rejects_nonexistent_path(tmp_path: Path):
     """A path-type capture with a non-existent path must raise CaptureValueTypeError."""
-    from autoskillit.core.types import CaptureEntrySpec
+    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
 
     capture_spec = {
         "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
     }
-    payload = {"p": "/tmp/does-not-exist-autoskillit-test-xyz"}
-
-    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
+    payload = {"p": str(tmp_path / "nonexistent")}
 
     with pytest.raises(CaptureValueTypeError) as exc_info:
         _extract_captures(capture_spec, payload)
@@ -671,4 +642,5 @@ def test_interpolate_rejects_empty_string_campaign_ref():
     with pytest.raises(ValueError) as exc_info:
         _interpolate_campaign_refs(ingredients, captured)
     msg = str(exc_info.value).lower()
-    assert "empty" in msg or "report_path" in msg
+    assert "empty" in msg
+    assert "report_path" in msg

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -604,6 +604,21 @@ def test_extract_path_type_rejects_empty_string():
     assert "p" in str(exc_info.value)
 
 
+def test_extract_url_type_rejects_empty_string():
+    """A url-type capture with an empty-string value must raise CaptureValueTypeError."""
+    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
+
+    capture_spec = {
+        "u": CaptureEntrySpec(from_="${{ result.u }}", value_type="url"),
+    }
+    payload = {"u": ""}
+
+    with pytest.raises(CaptureValueTypeError) as exc_info:
+        _extract_captures(capture_spec, payload)
+    assert exc_info.value.declared_type == "url"
+    assert "non-empty" in str(exc_info.value)
+
+
 def test_extract_optional_string_type_accepts_empty():
     """An optional_string-type capture with an empty-string value must be accepted."""
     from autoskillit.fleet._api import _extract_captures

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.core.types import CaptureEntrySpec
+
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+def _ce(from_: str, value_type: str = "string") -> CaptureEntrySpec:
+    """Shorthand to build a CaptureEntrySpec in tests."""
+    return CaptureEntrySpec(from_=from_, value_type=value_type)
 
 
 # ---------------------------------------------------------------------------
@@ -19,7 +26,7 @@ def test_extract_captures_from_payload():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"sources_manifest": "${{ result.sources_manifest }}"},
+        {"sources_manifest": _ce("${{ result.sources_manifest }}")},
         {"sources_manifest": "/tmp/sources.json", "extra": "ignored"},
     )
     assert result == {"sources_manifest": "/tmp/sources.json"}
@@ -30,7 +37,7 @@ def test_extract_captures_all_fields_missing_raises():
 
     with pytest.raises(CaptureCompletenessError):
         _extract_captures(
-            {"missing_key": "${{ result.missing_key }}"},
+            {"missing_key": _ce("${{ result.missing_key }}")},
             {"other": "value"},
         )
 
@@ -39,7 +46,7 @@ def test_extract_captures_non_result_template_skipped():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"a": "plain_string", "b": "${{ inputs.x }}"},
+        {"a": _ce("plain_string"), "b": _ce("${{ inputs.x }}")},
         {"plain_string": "val", "x": "val2"},
     )
     assert result == {}
@@ -49,7 +56,7 @@ def test_extract_captures_converts_value_to_str():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"count": "${{ result.count }}"},
+        {"count": _ce("${{ result.count }}")},
         {"count": 42},
     )
     assert result == {"count": "42"}
@@ -60,7 +67,7 @@ def test_extract_captures_list_value_uses_json_dumps():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"issue_urls": "${{ result.issue_urls }}"},
+        {"issue_urls": _ce("${{ result.issue_urls }}")},
         {
             "issue_urls": [
                 "https://github.com/org/repo/issues/1",
@@ -79,7 +86,7 @@ def test_extract_captures_dict_value_uses_json_dumps():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"meta": "${{ result.meta }}"},
+        {"meta": _ce("${{ result.meta }}")},
         {"meta": {"count": 3, "status": "ok"}},
     )
     assert json.loads(result["meta"]) == {"count": 3, "status": "ok"}
@@ -128,7 +135,7 @@ def test_extract_captures_bool_value_uses_json_dumps():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"flag": "${{ result.flag }}"},
+        {"flag": _ce("${{ result.flag }}")},
         {"flag": True},
     )
     assert result == {"flag": "true"}
@@ -139,7 +146,7 @@ def test_extract_captures_none_value_uses_json_dumps():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"val": "${{ result.val }}"},
+        {"val": _ce("${{ result.val }}")},
         {"val": None},
     )
     assert result == {"val": "null"}
@@ -150,7 +157,7 @@ def test_extract_captures_float_value_uses_json_dumps():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"pi": "${{ result.pi }}"},
+        {"pi": _ce("${{ result.pi }}")},
         {"pi": 3.14},
     )
     assert result == {"pi": "3.14"}
@@ -179,10 +186,10 @@ def test_extract_research_design_captures():
     from autoskillit.fleet._api import _extract_captures
 
     spec = {
-        "worktree_path": "${{ result.worktree_path }}",
-        "research_dir": "${{ result.research_dir }}",
-        "experiment_plan": "${{ result.experiment_plan }}",
-        "visualization_plan_path": "${{ result.visualization_plan_path }}",
+        "worktree_path": _ce("${{ result.worktree_path }}"),
+        "research_dir": _ce("${{ result.research_dir }}"),
+        "experiment_plan": _ce("${{ result.experiment_plan }}"),
+        "visualization_plan_path": _ce("${{ result.visualization_plan_path }}"),
     }
     payload = {
         "worktree_path": "/tmp/wt-123",
@@ -203,7 +210,7 @@ def test_extract_research_implement_capture():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"report_path": "${{ result.report_path }}"},
+        {"report_path": _ce("${{ result.report_path }}")},
         {"report_path": "/tmp/wt-123/report.md"},
     )
     assert result == {"report_path": "/tmp/wt-123/report.md"}
@@ -213,9 +220,9 @@ def test_extract_research_review_captures():
     from autoskillit.fleet._api import _extract_captures
 
     spec = {
-        "pr_url": "${{ result.pr_url }}",
-        "all_diagram_paths": "${{ result.all_diagram_paths }}",
-        "report_path_after_finalize": "${{ result.report_path_after_finalize }}",
+        "pr_url": _ce("${{ result.pr_url }}"),
+        "all_diagram_paths": _ce("${{ result.all_diagram_paths }}"),
+        "report_path_after_finalize": _ce("${{ result.report_path_after_finalize }}"),
     }
     payload = {
         "pr_url": "https://github.com/org/repo/pull/42",
@@ -234,7 +241,7 @@ def test_extract_research_review_all_diagram_paths_list():
     from autoskillit.fleet._api import _extract_captures
 
     result = _extract_captures(
-        {"all_diagram_paths": "${{ result.all_diagram_paths }}"},
+        {"all_diagram_paths": _ce("${{ result.all_diagram_paths }}")},
         {"all_diagram_paths": ["arch.png", "flow.png"]},
     )
     assert result == {"all_diagram_paths": '["arch.png", "flow.png"]'}
@@ -245,10 +252,10 @@ def test_extract_research_partial_payload_skips_missing():
     from autoskillit.fleet._api import _extract_captures
 
     spec = {
-        "worktree_path": "${{ result.worktree_path }}",
-        "research_dir": "${{ result.research_dir }}",
-        "experiment_plan": "${{ result.experiment_plan }}",
-        "visualization_plan_path": "${{ result.visualization_plan_path }}",
+        "worktree_path": _ce("${{ result.worktree_path }}"),
+        "research_dir": _ce("${{ result.research_dir }}"),
+        "experiment_plan": _ce("${{ result.experiment_plan }}"),
+        "visualization_plan_path": _ce("${{ result.visualization_plan_path }}"),
     }
     payload = {
         "worktree_path": "/tmp/wt-123",
@@ -264,26 +271,32 @@ def test_extract_research_partial_payload_skips_missing():
 
 
 def test_extract_empty_string_path_is_captured():
-    from autoskillit.fleet._api import _extract_captures
+    """Empty-string capture for path type must be rejected (CaptureValueTypeError).
 
-    result = _extract_captures(
-        {"p": "${{ result.p }}"},
-        {"p": ""},
-    )
-    assert result == {"p": ""}
+    This test documents the NEW correct behavior. The old buggy behavior (accepting
+    empty strings for any capture type) is no longer valid.
+    """
+    from autoskillit.core.types import CaptureEntrySpec
+    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
+
+    capture_spec = {
+        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
+    }
+    with pytest.raises(CaptureValueTypeError):
+        _extract_captures(capture_spec, {"p": ""})
 
 
 def test_extract_research_capture_all_fields_combined():
     from autoskillit.fleet._api import _extract_captures
 
     spec = {
-        "worktree_path": "${{ result.worktree_path }}",
-        "research_dir": "${{ result.research_dir }}",
-        "experiment_plan": "${{ result.experiment_plan }}",
-        "visualization_plan_path": "${{ result.visualization_plan_path }}",
-        "report_path": "${{ result.report_path }}",
-        "pr_url": "${{ result.pr_url }}",
-        "all_diagram_paths": "${{ result.all_diagram_paths }}",
+        "worktree_path": _ce("${{ result.worktree_path }}"),
+        "research_dir": _ce("${{ result.research_dir }}"),
+        "experiment_plan": _ce("${{ result.experiment_plan }}"),
+        "visualization_plan_path": _ce("${{ result.visualization_plan_path }}"),
+        "report_path": _ce("${{ result.report_path }}"),
+        "pr_url": _ce("${{ result.pr_url }}"),
+        "all_diagram_paths": _ce("${{ result.all_diagram_paths }}"),
     }
     payload = {
         "worktree_path": "/tmp/wt-123",
@@ -555,10 +568,10 @@ def test_extract_captures_logs_warning_for_missing_spec_keys():
     from autoskillit.fleet._api import _extract_captures
 
     capture_spec = {
-        "pr_url": "${{ result.pr_url }}",
-        "report_path": "${{ result.report_path }}",
+        "pr_url": _ce("${{ result.pr_url }}"),
+        "report_path": _ce("${{ result.report_path }}"),
     }
-    payload = {"pr_url": "https://github.com/..."}  # report_path absent
+    payload: dict[str, object] = {"pr_url": "https://github.com/..."}  # report_path absent
 
     with structlog.testing.capture_logs() as logs:
         result = _extract_captures(capture_spec, payload)
@@ -578,10 +591,84 @@ def test_extract_captures_raises_on_complete_capture_miss():
     from autoskillit.fleet._api import CaptureCompletenessError, _extract_captures
 
     capture_spec = {
-        "pr_url": "${{ result.pr_url }}",
-        "report_path": "${{ result.report_path }}",
+        "pr_url": _ce("${{ result.pr_url }}"),
+        "report_path": _ce("${{ result.report_path }}"),
     }
-    payload = {"success": True}  # No captured fields present at all
+    payload: dict[str, object] = {"success": True}  # No captured fields present at all
 
     with pytest.raises(CaptureCompletenessError):
         _extract_captures(capture_spec, payload)
+
+
+# ---------------------------------------------------------------------------
+# Typed capture contract tests (Step 1a–1d, 1g)
+# ---------------------------------------------------------------------------
+
+
+def _make_entry_spec(from_: str, value_type: str):
+    """Build a CaptureEntrySpec for testing."""
+    from autoskillit.core.types import CaptureEntrySpec
+
+    return CaptureEntrySpec(from_=from_, value_type=value_type)
+
+
+def test_extract_path_type_rejects_empty_string():
+    """A path-type capture with an empty-string value must raise CaptureValueTypeError."""
+    from autoskillit.core.types import CaptureEntrySpec
+
+    capture_spec = {
+        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
+    }
+    payload = {"p": ""}
+
+    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
+
+    with pytest.raises(CaptureValueTypeError) as exc_info:
+        _extract_captures(capture_spec, payload)
+    assert "path" in str(exc_info.value).lower()
+    assert "p" in str(exc_info.value)
+
+
+def test_extract_optional_string_type_accepts_empty():
+    """An optional_string-type capture with an empty-string value must be accepted."""
+    from autoskillit.core.types import CaptureEntrySpec
+
+    capture_spec = {
+        "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="optional_string"),
+    }
+    payload = {"pr_url": ""}
+
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(capture_spec, payload)
+    assert result == {"pr_url": ""}
+
+
+def test_extract_path_type_rejects_nonexistent_path():
+    """A path-type capture with a non-existent path must raise CaptureValueTypeError."""
+    from autoskillit.core.types import CaptureEntrySpec
+
+    capture_spec = {
+        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
+    }
+    payload = {"p": "/tmp/does-not-exist-autoskillit-test-xyz"}
+
+    from autoskillit.fleet._api import CaptureValueTypeError, _extract_captures
+
+    with pytest.raises(CaptureValueTypeError) as exc_info:
+        _extract_captures(capture_spec, payload)
+    msg = str(exc_info.value).lower()
+    assert "path" in msg or "exist" in msg
+
+
+def test_interpolate_rejects_empty_string_campaign_ref():
+    """_interpolate_campaign_refs must reject an empty-string captured value."""
+    from autoskillit.fleet._api import _interpolate_campaign_refs
+
+    ingredients = {"report_path": "${{ campaign.report_path }}"}
+    captured = {"report_path": ""}
+
+    with pytest.raises(ValueError) as exc_info:
+        _interpolate_campaign_refs(ingredients, captured)
+    msg = str(exc_info.value).lower()
+    assert "empty" in msg or "report_path" in msg

--- a/tests/fleet/test_dispatch_state_handle.py
+++ b/tests/fleet/test_dispatch_state_handle.py
@@ -58,6 +58,7 @@ class TestResumeWithoutPriorDispatchId:
 
     @pytest.mark.anyio
     async def test_resume_without_prior_dispatch_id_persists_captures(self, tool_ctx, monkeypatch):
+        from autoskillit.core.types import CaptureEntrySpec
         from autoskillit.fleet.result_parser import L3ParseResult
         from tests.fleet._helpers import (
             _no_sleep_quota_checker,
@@ -98,7 +99,7 @@ class TestResumeWithoutPriorDispatchId:
             quota_refresher=_noop_quota_refresher,
             resume_session_id="sess-123",
             prior_dispatch_id=None,
-            capture={"plan_path": "${{ result.plan_path }}"},
+            capture={"plan_path": CaptureEntrySpec(from_="${{ result.plan_path }}")},
         )
 
         dispatches_dir = tool_ctx.temp_dir / "dispatches"

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -1561,3 +1561,33 @@ class TestContinueOnFailureDoesNotResetFailureDispatches:
         assert state is not None
         a = next(d for d in state.dispatches if d.name == "A")
         assert a.status == DispatchStatus.PENDING
+
+
+class TestUpsertCannotOverwriteFailureWithSuccess:
+    """upsert_dispatch_record_by_name must reject overwriting FAILURE with SUCCESS."""
+
+    def test_upsert_cannot_overwrite_failure_with_success(self, tmp_path: Path) -> None:
+        """Overwriting a FAILURE dispatch record with SUCCESS must raise ValueError."""
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("run-implement"))
+
+        # Write an initial FAILURE record
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(
+                name="run-implement", status=DispatchStatus.FAILURE, reason="task-failed"
+            ),
+        )
+
+        # Attempting to overwrite with SUCCESS must raise
+        with pytest.raises(ValueError) as exc_info:
+            upsert_dispatch_record_by_name(
+                sp,
+                DispatchRecord(
+                    name="run-implement", status=DispatchStatus.SUCCESS, reason="all good"
+                ),
+            )
+        assert "FAILURE" in str(exc_info.value)
+        assert "run-implement" in str(exc_info.value)

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -418,7 +418,7 @@ def test_research_campaign_run_design_capture():
         "experiment_type",
     }
     for key, val in d.capture.items():
-        assert val == f"${{{{ result.{key} }}}}"
+        assert val.from_ == f"${{{{ result.{key} }}}}"
 
 
 def test_research_campaign_run_implement_ingredients():
@@ -456,8 +456,8 @@ def test_research_campaign_run_implement_capture():
     d = recipe.dispatches[1]
     assert d.name == "run-implement"
     assert set(d.capture.keys()) == {"report_path", "experiment_results"}
-    assert d.capture["report_path"] == "${{ result.report_path }}"
-    assert d.capture["experiment_results"] == "${{ result.experiment_results }}"
+    assert d.capture["report_path"].from_ == "${{ result.report_path }}"
+    assert d.capture["experiment_results"].from_ == "${{ result.experiment_results }}"
 
 
 def test_research_campaign_run_review_ingredients():
@@ -508,8 +508,10 @@ def test_research_campaign_run_review_capture():
     d = recipe.dispatches[2]
     assert d.name == "run-review"
     assert set(d.capture.keys()) == {"pr_url", "report_path_after_finalize"}
-    assert d.capture["pr_url"] == "${{ result.pr_url }}"
-    assert d.capture["report_path_after_finalize"] == "${{ result.report_path_after_finalize }}"
+    assert d.capture["pr_url"].from_ == "${{ result.pr_url }}"
+    assert (
+        d.capture["report_path_after_finalize"].from_ == "${{ result.report_path_after_finalize }}"
+    )
 
 
 def test_research_campaign_run_archive_ingredients():
@@ -568,7 +570,7 @@ def test_research_campaign_capture_values_reference_result():
             assert d.capture == {}, f"run-archive must have empty capture, got {d.capture!r}"
             continue
         for val in d.capture.values():
-            assert _RESULT_TEMPLATE_RE.match(val.strip()), (
+            assert _RESULT_TEMPLATE_RE.match(val.from_.strip()), (
                 f"Dispatch {d.name!r} capture value {val!r} does not reference result"
             )
 

--- a/tests/recipe/test_research_campaign_structure.py
+++ b/tests/recipe/test_research_campaign_structure.py
@@ -104,7 +104,7 @@ def test_run_design_has_non_empty_capture(recipe: Recipe) -> None:
     for key in d.capture:
         assert _IDENT_RE.match(key), f"Capture key {key!r} is not a valid identifier"
     for val in d.capture.values():
-        assert _RESULT_TMPL_RE.match(val.strip()), (
+        assert _RESULT_TMPL_RE.match(val.from_.strip()), (
             f"Capture value {val!r} does not match result template"
         )
 
@@ -129,7 +129,7 @@ def test_run_implement_has_non_empty_capture(recipe: Recipe) -> None:
     for key in d.capture:
         assert _IDENT_RE.match(key), f"Capture key {key!r} is not a valid identifier"
     for val in d.capture.values():
-        assert _RESULT_TMPL_RE.match(val.strip()), (
+        assert _RESULT_TMPL_RE.match(val.from_.strip()), (
             f"Capture value {val!r} does not match result template"
         )
 
@@ -147,7 +147,7 @@ def test_run_review_has_non_empty_capture(recipe: Recipe) -> None:
     for key in d.capture:
         assert _IDENT_RE.match(key), f"Capture key {key!r} is not a valid identifier"
     for val in d.capture.values():
-        assert _RESULT_TMPL_RE.match(val.strip()), (
+        assert _RESULT_TMPL_RE.match(val.from_.strip()), (
             f"Capture value {val!r} does not match result template"
         )
 

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -17,9 +17,9 @@ from autoskillit.recipe.schema import CampaignDispatch, Recipe, RecipeKind, Reci
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
-def _cap(from_: str) -> CaptureEntrySpec:
+def _cap(from_: str, value_type: str = "string") -> CaptureEntrySpec:
     """Shorthand to build a CaptureEntrySpec in tests."""
-    return CaptureEntrySpec(from_=from_)
+    return CaptureEntrySpec(from_=from_, value_type=value_type)
 
 
 def _standard_recipe(**kwargs: object) -> Recipe:

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -9,11 +9,17 @@ import yaml
 
 import autoskillit.recipe  # noqa: F401 -- triggers rule registration
 from autoskillit.core import Severity
+from autoskillit.core.types import CaptureEntrySpec
 from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import CampaignDispatch, Recipe, RecipeKind, RecipeStep
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _cap(from_: str) -> CaptureEntrySpec:
+    """Shorthand to build a CaptureEntrySpec in tests."""
+    return CaptureEntrySpec(from_=from_)
 
 
 def _standard_recipe(**kwargs: object) -> Recipe:
@@ -499,7 +505,7 @@ def test_capture_key_must_be_identifier():
                 name="phase-one",
                 recipe="implementation",
                 task="t",
-                capture={"bad-key": "${{ result.v }}"},
+                capture={"bad-key": _cap("${{ result.v }}")},
             )
         ]
     )
@@ -520,7 +526,7 @@ def test_capture_value_must_reference_result():
                 name="phase-one",
                 recipe="implementation",
                 task="t",
-                capture={"k": "not_a_template"},
+                capture={"k": _cap("not_a_template")},
             )
         ]
     )
@@ -568,7 +574,7 @@ def test_campaign_ingredient_ref_satisfied_by_ancestor():
                 name="phase-one",
                 recipe="implementation",
                 task="t",
-                capture={"x": "${{ result.x }}"},
+                capture={"x": _cap("${{ result.x }}")},
             ),
             CampaignDispatch(
                 name="phase-two",
@@ -595,7 +601,7 @@ def test_valid_capture_spec_passes():
                 name="phase-one",
                 recipe="implementation",
                 task="t",
-                capture={"out_file": "${{ result.out_file }}"},
+                capture={"out_file": _cap("${{ result.out_file }}")},
             )
         ]
     )
@@ -675,7 +681,7 @@ def test_gate_dispatch_no_capture_fires_when_capture_is_set():
                 name="gate-check",
                 gate="confirm",
                 message="Proceed?",
-                capture={"key": "${{ result.val }}"},
+                capture={"key": _cap("${{ result.val }}")},
             )
         ]
     )
@@ -1214,7 +1220,7 @@ def test_dispatch_capture_field_in_sentinel_fires_on_unknown_field(tmp_path: Pat
                 name="phase-one",
                 recipe="target-recipe",
                 task="do it",
-                capture={"bad_field": "${{ result.nonexistent_field }}"},
+                capture={"bad_field": _cap("${{ result.nonexistent_field }}")},
             ),
         ]
     )
@@ -1253,7 +1259,7 @@ def test_dispatch_capture_field_in_sentinel_passes_when_field_exists(tmp_path: P
                 name="phase-one",
                 recipe="target-recipe",
                 task="do it",
-                capture={"output_path": "${{ result.output_path }}"},
+                capture={"output_path": _cap("${{ result.output_path }}")},
             ),
         ]
     )
@@ -1291,7 +1297,7 @@ def test_dispatch_capture_field_in_sentinel_checks_any_sentinel(tmp_path: Path):
                 name="phase-one",
                 recipe="target-recipe",
                 task="do it",
-                capture={"alpha": "${{ result.alpha }}"},
+                capture={"alpha": _cap("${{ result.alpha }}")},
             ),
         ]
     )
@@ -1320,7 +1326,7 @@ def test_dispatch_capture_field_in_sentinel_skips_no_sentinel(tmp_path: Path):
                 name="phase-one",
                 recipe="target-recipe",
                 task="do it",
-                capture={"output_path": "${{ result.output_path }}"},
+                capture={"output_path": _cap("${{ result.output_path }}")},
             ),
         ]
     )
@@ -1381,7 +1387,7 @@ def test_dispatch_capture_field_in_sentinel_skips_unloadable_target(tmp_path: Pa
                 name="phase-one",
                 recipe="nonexistent-recipe",
                 task="do it",
-                capture={"output_path": "${{ result.output_path }}"},
+                capture={"output_path": _cap("${{ result.output_path }}")},
             ),
         ],
     )
@@ -1559,7 +1565,7 @@ def test_dispatch_capture_field_in_all_sentinels_fires_on_path_exclusive_field(t
                 name="phase-one",
                 recipe="dual-sentinel-target",
                 task="do it",
-                capture={"pr_url": "${{ result.pr_url }}"},
+                capture={"pr_url": _cap("${{ result.pr_url }}")},
             ),
         ]
     )

--- a/tests/server/test_tools_dispatch_halt.py
+++ b/tests/server/test_tools_dispatch_halt.py
@@ -218,8 +218,6 @@ class TestPostDispatchHaltOnFailure:
         """
         from unittest.mock import AsyncMock
 
-        from autoskillit.fleet import DispatchCompleted, DispatchStatus
-
         state_path = tmp_path / "campaign_state.json"
         monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(state_path))
         monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
@@ -227,26 +225,10 @@ class TestPostDispatchHaltOnFailure:
         # Write a FAILURE dispatch record into campaign state
         _write_campaign_state(state_path, [{"name": "run-design", "status": "failure"}])
 
-        execute_called = False
-
-        async def mock_execute_dispatch(**kwargs):
-            nonlocal execute_called
-            execute_called = True
-            return DispatchCompleted(
-                success=False,
-                dispatch_status=DispatchStatus.FAILURE,
-                dispatch_id="d2",
-                dispatched_session_id="sess-2",
-                reason="task-failed",
-                token_usage={},
-                l3_parse_source="stdout",
-                lifespan_started=True,
-                l3_payload=None,
-            )
-
+        mock_execute = AsyncMock()
         monkeypatch.setattr(
             "autoskillit.fleet.execute_dispatch",
-            AsyncMock(side_effect=mock_execute_dispatch),
+            mock_execute,
         )
 
         self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
@@ -257,9 +239,7 @@ class TestPostDispatchHaltOnFailure:
         # Must return FLEET_CAMPAIGN_HALTED immediately — execute_dispatch must NOT be called
         assert result["success"] is False
         assert result["error"] == "fleet_campaign_halted"
-        assert execute_called is False, (
-            "execute_dispatch was called even though campaign is halted after prior FAILURE"
-        )
+        mock_execute.assert_not_called()
 
     def _setup_standard_dispatch(self, tool_ctx, monkeypatch):
         """Wire tool_ctx for a standard dispatch."""

--- a/tests/server/test_tools_dispatch_halt.py
+++ b/tests/server/test_tools_dispatch_halt.py
@@ -201,6 +201,77 @@ class TestDispatchFoodTruckHaltEnforcement:
         tool_ctx.executor = InMemoryHeadlessExecutor()
 
 
+class TestPostDispatchHaltOnFailure:
+    """Post-dispatch halt: FAILURE result + continue_on_failure=false → FLEET_CAMPAIGN_HALTED."""
+
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_halts_after_failure_when_continue_on_failure_false(
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
+    ):
+        """After a dispatch returns FAILURE with continue_on_failure=false,
+        the next dispatch_food_truck call must return FLEET_CAMPAIGN_HALTED immediately,
+        before calling execute_dispatch.
+        """
+        from unittest.mock import AsyncMock
+
+        from autoskillit.fleet import DispatchCompleted, DispatchStatus
+
+        state_path = tmp_path / "campaign_state.json"
+        monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_STATE_PATH", str(state_path))
+        monkeypatch.setenv("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false")
+
+        # Write a FAILURE dispatch record into campaign state
+        _write_campaign_state(state_path, [{"name": "run-design", "status": "failure"}])
+
+        execute_called = False
+
+        async def mock_execute_dispatch(**kwargs):
+            nonlocal execute_called
+            execute_called = True
+            return DispatchCompleted(
+                success=False,
+                dispatch_status=DispatchStatus.FAILURE,
+                dispatch_id="d2",
+                dispatched_session_id="sess-2",
+                reason="task-failed",
+                token_usage={},
+                l3_parse_source="stdout",
+                lifespan_started=True,
+                l3_payload=None,
+            )
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.execute_dispatch",
+            AsyncMock(side_effect=mock_execute_dispatch),
+        )
+
+        self._setup_standard_dispatch(tool_ctx_kitchen_open, monkeypatch)
+        from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
+
+        result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
+
+        # Must return FLEET_CAMPAIGN_HALTED immediately — execute_dispatch must NOT be called
+        assert result["success"] is False
+        assert result["error"] == "fleet_campaign_halted"
+        assert execute_called is False, (
+            "execute_dispatch was called even though campaign is halted after prior FAILURE"
+        )
+
+    def _setup_standard_dispatch(self, tool_ctx, monkeypatch):
+        """Wire tool_ctx for a standard dispatch."""
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        repo = InMemoryRecipeRepository()
+        recipe_info = _make_recipe_info("test-recipe")
+        repo.add_recipe("test-recipe", recipe_info)
+        repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe"))
+        tool_ctx.recipes = repo
+        tool_ctx.executor = InMemoryHeadlessExecutor()
+
+
 class TestDispatchFoodTruckRetryOnFailure:
     @pytest.fixture(autouse=True)
     def _set_fleet_session(self, monkeypatch):


### PR DESCRIPTION
## Summary

The dispatch capture chain treats all captured string values as semantically equivalent with no schema typing or contract enforcement — empty strings, non-existent paths, and partially malformed payloads silently pass through because the system's only invariant is key presence, not value semantics. Additionally, `dispatch_food_truck` enforces `continue_on_failure` only pre-dispatch, not post-dispatch, leaving a window where a failed re-dispatch is not structurally halted.

The fix introduces a **Typed Capture Contract System**: extend the capture spec schema at the campaign YAML level to declare a `value_type` per captured entry (`path`, `url`, `string`, `optional_string`). Contracts are enforced at extraction time and interpolation time. A post-dispatch halt gate is added to `dispatch_food_truck` that mirrors the existing pre-dispatch gate. Together, these changes make the entire bug class impossible to reach — invalid captured values are rejected at the boundary closest to their origin, and every dispatch failure structurally halts the campaign before the L3 orchestrator can proceed.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260510-010134-279639/.autoskillit/temp/rectify/rectify_campaign_dispatch_captured_context_2026-05-10_011500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 9.9k | 11.3k | 504.9k | 104.6k | 216 | 54.2k | 9m 37s |
| rectify | claude-sonnet-4-6 | 1 | 103 | 17.8k | 483.3k | 111.9k | 111 | 52.2k | 10m 18s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 156 | 14.9k | 1.4M | 99.5k | 55 | 86.8k | 5m 15s |
| implement* | MiniMax-M2.7-highspeed | 1 | 20.4M | 66.0k | 6.5M | 90.3k | 528 | 815.5k | 42m 16s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 71.5k | 4.1k | 169.7k | 28.8k | 19 | 15.4k | 1m 17s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 51.8k | 1.5k | 198.5k | 28.8k | 19 | 15.2k | 42s |
| review_pr | claude-sonnet-4-6 | 3 | 263 | 117.7k | 2.2M | 117.3k | 220 | 275.4k | 38m 34s |
| resolve_review | claude-sonnet-4-6 | 4 | 934 | 109.1k | 19.8M | 174.6k | 501 | 389.1k | 1h 22m |
| **Total** | | | 20.5M | 342.4k | 31.3M | 174.6k | | 1.7M | 3h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 553 | 11825.2 | 1474.7 | 119.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 217 | 91291.8 | 1792.9 | 503.0 |
| **Total** | **770** | 40639.7 | 2212.7 | 444.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 8 | 11.2k | 836.3k | 46.6M | 2.4M | 4h 51m |
| claude-opus-4-6 | 1 | 1.7k | 47.1k | 5.1M | 236.3k | 33m 58s |
| MiniMax-M2.7-highspeed | 5 | 17.1M | 157.4k | 13.3M | 667.6k | 1h 16m |