### PR TITLE
Rectify: Cross-Worktree Path Coherence in Campaign Dispatch

### DIFF
--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -582,7 +582,8 @@ def read_all_campaign_captures(
             dispatches = data.get("dispatches", [])
             all_success = all(d.get("status") == DispatchStatus.SUCCESS for d in dispatches)
             if all_success and dispatches:
-                entries.append((data.get("started_at", 0.0), caps))
+                started = data.get("started_at")
+                entries.append((float(started) if started is not None else 0.0, caps))
         except (KeyError, TypeError) as exc:
             logger.warning("read_all_campaign_captures: skipping %s: %s", path, exc)
             continue

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -568,6 +568,7 @@ def read_all_campaign_captures(
     result: dict[str, str] = {}
     if not dispatches_dir.is_dir():
         return result
+    entries: list[tuple[float, dict[str, str]]] = []
     for path in dispatches_dir.glob("*.json"):
         data = read_versioned_json(path, FLEET_STATE_SCHEMA_VERSION, logger=logger)
         if data is None:
@@ -581,10 +582,13 @@ def read_all_campaign_captures(
             dispatches = data.get("dispatches", [])
             all_success = all(d.get("status") == DispatchStatus.SUCCESS for d in dispatches)
             if all_success and dispatches:
-                result.update(caps)
+                entries.append((data.get("started_at", 0.0), caps))
         except (KeyError, TypeError) as exc:
             logger.warning("read_all_campaign_captures: skipping %s: %s", path, exc)
             continue
+    entries.sort(key=lambda e: e[0])
+    for _, caps in entries:
+        result.update(caps)
     return result
 
 

--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -882,6 +882,80 @@ def _check_gate_dispatch_no_recipe(ctx: ValidationContext) -> list[RuleFinding]:
 
 
 @semantic_rule(
+    name="campaign-path-coherence",
+    description=(
+        "Detects dispatches that invoke worktree-creating recipes "
+        "without re-capturing worktree_path"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_campaign_path_coherence(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings: list[RuleFinding] = []
+    for d in ctx.recipe.dispatches:
+        if d.gate:
+            continue
+        target = _load_dispatch_target(d, ctx.project_dir)
+        if target is None:
+            continue
+        for step in target.steps.values():
+            if step.capture and "worktree_path" in step.capture:
+                if "worktree_path" not in d.capture:
+                    findings.append(
+                        RuleFinding(
+                            rule="campaign-path-coherence",
+                            severity=Severity.ERROR,
+                            step_name="(top-level)",
+                            message=(
+                                f"Dispatch '{d.name}' invokes recipe '{d.recipe}' which "
+                                f"captures worktree_path at step '{step.name}', but the "
+                                f"dispatch does not re-capture worktree_path. Downstream "
+                                f"dispatches will receive a stale worktree path."
+                            ),
+                        )
+                    )
+                break
+    return findings
+
+
+@semantic_rule(
+    name="campaign-path-type-enforce",
+    description=(
+        "Validates that worktree_relative_path ingredients have "
+        "a corresponding worktree_path anchor"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_campaign_path_type_enforce(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings: list[RuleFinding] = []
+    for d in ctx.recipe.dispatches:
+        if d.gate:
+            continue
+        target = _load_dispatch_target(d, ctx.project_dir)
+        if target is None:
+            continue
+        for key, ing in target.ingredients.items():
+            if getattr(ing, "type", None) == "worktree_relative_path":
+                if "worktree_path" not in d.ingredients:
+                    findings.append(
+                        RuleFinding(
+                            rule="campaign-path-type-enforce",
+                            severity=Severity.ERROR,
+                            step_name="(top-level)",
+                            message=(
+                                f"Dispatch '{d.name}' provides ingredient '{key}' "
+                                f"(type: worktree_relative_path) without a corresponding "
+                                f"worktree_path anchor."
+                            ),
+                        )
+                    )
+    return findings
+
+
+@semantic_rule(
     name="gate-dispatch-no-capture",
     description="A gate dispatch must not specify capture",
     severity=Severity.ERROR,

--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -75,7 +75,6 @@
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}",
-        "research_dir": "${{ result.research_dir }}",
         "research_dir_rel": "${{ result.research_dir_rel }}",
         "experiment_plan": "${{ result.experiment_plan }}",
         "visualization_plan_path": "${{ result.visualization_plan_path }}",

--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -23,7 +23,8 @@
     },
     "source_dir": {
       "description": "Path to the project root",
-      "required": true
+      "required": true,
+      "type": "absolute_path"
     },
     "issue_url": {
       "description": "Optional URL to an existing GitHub issue describing the research goal. Provided as context to scope and plan_experiment.",
@@ -75,6 +76,7 @@
       "capture": {
         "worktree_path": "${{ result.worktree_path }}",
         "research_dir": "${{ result.research_dir }}",
+        "research_dir_rel": "${{ result.research_dir_rel }}",
         "experiment_plan": "${{ result.experiment_plan }}",
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
         "scope_report": "${{ result.scope_report }}",
@@ -89,7 +91,8 @@
       "ingredients": {
         "task": "${{ inputs.task }}",
         "worktree_path": "${{ campaign.worktree_path }}",
-        "research_dir": "${{ campaign.research_dir }}",
+        "research_dir": "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}",
+        "research_dir_rel": "${{ campaign.research_dir_rel }}",
         "experiment_plan": "${{ campaign.experiment_plan }}",
         "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
         "source_dir": "${{ inputs.source_dir }}",
@@ -100,6 +103,7 @@
         "audit": "${{ inputs.audit }}"
       },
       "capture": {
+        "worktree_path": "${{ result.worktree_path }}",
         "report_path": "${{ result.report_path }}",
         "experiment_results": "${{ result.experiment_results }}"
       },
@@ -117,7 +121,7 @@
         "experiment_type": "${{ campaign.experiment_type }}",
         "scope_report": "${{ campaign.scope_report }}",
         "worktree_path": "${{ campaign.worktree_path }}",
-        "research_dir": "${{ campaign.research_dir }}",
+        "research_dir": "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}",
         "experiment_plan": "${{ campaign.experiment_plan }}",
         "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
         "report_path": "${{ campaign.report_path }}",
@@ -143,7 +147,7 @@
       "ingredients": {
         "base_branch": "${{ inputs.base_branch }}",
         "worktree_path": "${{ campaign.worktree_path }}",
-        "research_dir": "${{ campaign.research_dir }}",
+        "research_dir": "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}",
         "pr_url": "${{ campaign.pr_url }}"
       },
       "capture": {},

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -83,7 +83,6 @@ dispatches:
       review_design: "${{ inputs.review_design }}"
     capture:
       worktree_path: "${{ result.worktree_path }}"
-      research_dir: "${{ result.research_dir }}"
       research_dir_rel: "${{ result.research_dir_rel }}"
       experiment_plan: "${{ result.experiment_plan }}"
       visualization_plan_path: "${{ result.visualization_plan_path }}"

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -27,6 +27,7 @@ ingredients:
   source_dir:
     description: Path to the project root
     required: true
+    type: absolute_path
   issue_url:
     description: >-
       Optional URL to an existing GitHub issue describing the research goal.
@@ -83,6 +84,7 @@ dispatches:
     capture:
       worktree_path: "${{ result.worktree_path }}"
       research_dir: "${{ result.research_dir }}"
+      research_dir_rel: "${{ result.research_dir_rel }}"
       experiment_plan: "${{ result.experiment_plan }}"
       visualization_plan_path: "${{ result.visualization_plan_path }}"
       scope_report: "${{ result.scope_report }}"
@@ -95,7 +97,8 @@ dispatches:
     ingredients:
       task: "${{ inputs.task }}"
       worktree_path: "${{ campaign.worktree_path }}"
-      research_dir: "${{ campaign.research_dir }}"
+      research_dir: "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}"
+      research_dir_rel: "${{ campaign.research_dir_rel }}"
       experiment_plan: "${{ campaign.experiment_plan }}"
       visualization_plan_path: "${{ campaign.visualization_plan_path }}"
       source_dir: "${{ inputs.source_dir }}"
@@ -105,6 +108,7 @@ dispatches:
       test_check_enabled: "${{ inputs.test_check_enabled }}"
       audit: "${{ inputs.audit }}"
     capture:
+      worktree_path: "${{ result.worktree_path }}"
       report_path: "${{ result.report_path }}"
       experiment_results: "${{ result.experiment_results }}"
     depends_on:
@@ -119,7 +123,7 @@ dispatches:
       experiment_type: "${{ campaign.experiment_type }}"
       scope_report: "${{ campaign.scope_report }}"
       worktree_path: "${{ campaign.worktree_path }}"
-      research_dir: "${{ campaign.research_dir }}"
+      research_dir: "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}"
       experiment_plan: "${{ campaign.experiment_plan }}"
       visualization_plan_path: "${{ campaign.visualization_plan_path }}"
       report_path: "${{ campaign.report_path }}"
@@ -141,7 +145,7 @@ dispatches:
     ingredients:
       base_branch: "${{ inputs.base_branch }}"
       worktree_path: "${{ campaign.worktree_path }}"
-      research_dir: "${{ campaign.research_dir }}"
+      research_dir: "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}"
       pr_url: "${{ campaign.pr_url }}"
     capture: {}
     depends_on:

--- a/src/autoskillit/recipes/research-archive.json
+++ b/src/autoskillit/recipes/research-archive.json
@@ -15,12 +15,14 @@
     "worktree_path": {
       "description": "Path to the pre-created worktree (passed by campaign dispatch)",
       "required": true,
-      "hidden": true
+      "hidden": true,
+      "type": "absolute_path"
     },
     "research_dir": {
       "description": "Path to the research/ directory in the worktree",
       "required": true,
-      "hidden": true
+      "hidden": true,
+      "type": "absolute_path"
     },
     "pr_url": {
       "description": "URL of the original experiment PR (passed by campaign dispatch)",

--- a/src/autoskillit/recipes/research-archive.yaml
+++ b/src/autoskillit/recipes/research-archive.yaml
@@ -18,10 +18,12 @@ ingredients:
     description: Path to the pre-created worktree (passed by campaign dispatch)
     required: true
     hidden: true
+    type: absolute_path
   research_dir:
     description: Path to the research/ directory in the worktree
     required: true
     hidden: true
+    type: absolute_path
   pr_url:
     description: URL of the original experiment PR (passed by campaign dispatch)
     required: true

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -203,7 +203,8 @@
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}",
-        "research_dir": "${{ result.research_dir }}"
+        "research_dir": "${{ result.research_dir }}",
+        "research_dir_rel": "${{ result.research_dir_rel }}"
       },
       "optional_context_refs": [
         "evaluation_dashboard",
@@ -214,7 +215,7 @@
     },
     "design_complete": {
       "action": "stop",
-      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=${{ context.worktree_path }}, research_dir=${{ context.research_dir }}. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\"}"
+      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=${{ context.worktree_path }}, research_dir=${{ context.research_dir }}, research_dir_rel=${{ context.research_dir_rel }}. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\", \"research_dir_rel\": \"<rel>\"}"
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -184,6 +184,7 @@ steps:
     capture:
       worktree_path: "${{ result.worktree_path }}"
       research_dir: "${{ result.research_dir }}"
+      research_dir_rel: "${{ result.research_dir_rel }}"
     optional_context_refs: [evaluation_dashboard, visualization_plan_trace_path]
     on_success: design_complete
     on_failure: escalate_stop
@@ -199,12 +200,14 @@ steps:
       report_plan_path=<context.report_plan_path>,
       experiment_type=<context.experiment_type>,
       worktree_path=${{ context.worktree_path }},
-      research_dir=${{ context.research_dir }}.
+      research_dir=${{ context.research_dir }},
+      research_dir_rel=${{ context.research_dir_rel }}.
       Example sentinel:
       {"success": true, "scope_report": "<path>", "experiment_plan": "<path>",
       "visualization_plan_path": "<path>", "report_plan_path": "<path>",
       "experiment_type": "benchmark",
-      "worktree_path": "<path>", "research_dir": "<path>"}
+      "worktree_path": "<path>", "research_dir": "<path>",
+      "research_dir_rel": "<rel>"}
 
   escalate_stop:
     action: stop

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -33,11 +33,18 @@
     },
     "worktree_path": {
       "description": "Path to the pre-created worktree (passed by campaign dispatch)",
-      "required": true
+      "required": true,
+      "type": "absolute_path"
+    },
+    "research_dir_rel": {
+      "description": "Repo-relative path to the research directory (e.g. research/2026-05-10-slug)",
+      "required": true,
+      "type": "worktree_relative_path"
     },
     "research_dir": {
-      "description": "Path to the research/ directory in the worktree",
-      "required": true
+      "description": "Path to the research/ directory in the worktree (reconstructed from anchor + rel)",
+      "required": true,
+      "type": "absolute_path"
     },
     "experiment_plan": {
       "description": "Path to the experiment plan file (passed by campaign dispatch)",
@@ -534,7 +541,7 @@
     },
     "implement_complete": {
       "action": "stop",
-      "message": "Implementation phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields: success=true, worktree_path=${{ context.worktree_path }}, research_dir=${{ inputs.research_dir }}, report_path=${{ context.report_path }}, experiment_results=${{ context.experiment_results }}. Example sentinel: {\"success\": true, \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\", \"report_path\": \"<path>\", \"experiment_results\": \"<path>\"}"
+      "message": "Implementation phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields: success=true, worktree_path=${{ context.worktree_path }}, research_dir_rel=${{ inputs.research_dir_rel }}, research_dir=${{ inputs.research_dir }}, report_path=${{ context.report_path }}, experiment_results=${{ context.experiment_results }}. Example sentinel: {\"success\": true, \"worktree_path\": \"<path>\", \"research_dir_rel\": \"<rel>\", \"research_dir\": \"<path>\", \"report_path\": \"<path>\", \"experiment_results\": \"<path>\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -35,9 +35,15 @@ ingredients:
   worktree_path:
     description: Path to the pre-created worktree (passed by campaign dispatch)
     required: true
-  research_dir:
-    description: Path to the research/ directory in the worktree
+    type: absolute_path
+  research_dir_rel:
+    description: "Repo-relative path to the research directory (e.g. research/2026-05-10-slug)"
     required: true
+    type: worktree_relative_path
+  research_dir:
+    description: Path to the research/ directory in the worktree (reconstructed from anchor + rel)
+    required: true
+    type: absolute_path
   experiment_plan:
     description: Path to the experiment plan file (passed by campaign dispatch)
     required: true
@@ -509,9 +515,10 @@ steps:
       Implementation phase complete. Emit the L3 result sentinel JSON block now.
       The sentinel must include the following fields:
       success=true, worktree_path=${{ context.worktree_path }},
+      research_dir_rel=${{ inputs.research_dir_rel }},
       research_dir=${{ inputs.research_dir }},
       report_path=${{ context.report_path }},
       experiment_results=${{ context.experiment_results }}.
       Example sentinel:
-      {"success": true, "worktree_path": "<path>", "research_dir": "<path>",
-      "report_path": "<path>", "experiment_results": "<path>"}
+      {"success": true, "worktree_path": "<path>", "research_dir_rel": "<rel>",
+      "research_dir": "<path>", "report_path": "<path>", "experiment_results": "<path>"}

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -44,23 +44,28 @@
     },
     "worktree_path": {
       "description": "Path to the pre-created worktree (passed by campaign dispatch)",
-      "required": true
+      "required": true,
+      "type": "absolute_path"
     },
     "research_dir": {
       "description": "Path to the research/ directory in the worktree",
-      "required": true
+      "required": true,
+      "type": "absolute_path"
     },
     "report_path": {
       "description": "Path to the generated research report",
-      "required": true
+      "required": true,
+      "type": "absolute_path"
     },
     "experiment_plan": {
       "description": "Path to the experiment plan file",
-      "required": true
+      "required": true,
+      "type": "absolute_path"
     },
     "experiment_results": {
       "description": "Path to the experiment results file",
-      "required": true
+      "required": true,
+      "type": "absolute_path"
     },
     "experiment_type": {
       "description": "Type of experiment (e.g. benchmark, comparison)",

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -47,18 +47,23 @@ ingredients:
   worktree_path:
     description: Path to the pre-created worktree (passed by campaign dispatch)
     required: true
+    type: absolute_path
   research_dir:
     description: Path to the research/ directory in the worktree
     required: true
+    type: absolute_path
   report_path:
     description: Path to the generated research report
     required: true
+    type: absolute_path
   experiment_plan:
     description: Path to the experiment plan file
     required: true
+    type: absolute_path
   experiment_results:
     description: Path to the experiment results file
     required: true
+    type: absolute_path
   experiment_type:
     description: Type of experiment (e.g. benchmark, comparison)
     required: true

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -234,7 +234,8 @@
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}",
-        "research_dir": "${{ result.research_dir }}"
+        "research_dir": "${{ result.research_dir }}",
+        "research_dir_rel": "${{ result.research_dir_rel }}"
       },
       "on_success": "stage_data",
       "on_failure": "escalate_stop",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -234,8 +234,7 @@
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}",
-        "research_dir": "${{ result.research_dir }}",
-        "research_dir_rel": "${{ result.research_dir_rel }}"
+        "research_dir": "${{ result.research_dir }}"
       },
       "on_success": "stage_data",
       "on_failure": "escalate_stop",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -254,7 +254,6 @@ steps:
     capture:
       worktree_path: "${{ result.worktree_path }}"
       research_dir: "${{ result.research_dir }}"
-      research_dir_rel: "${{ result.research_dir_rel }}"
     on_success: stage_data
     on_failure: escalate_stop
     note: >

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -254,6 +254,7 @@ steps:
     capture:
       worktree_path: "${{ result.worktree_path }}"
       research_dir: "${{ result.research_dir }}"
+      research_dir_rel: "${{ result.research_dir_rel }}"
     on_success: stage_data
     on_failure: escalate_stop
     note: >

--- a/src/autoskillit/recipes/scripts/create_worktree.sh
+++ b/src/autoskillit/recipes/scripts/create_worktree.sh
@@ -84,3 +84,4 @@ cd "${RESOLVED}" && git add research/ && git commit -m "Add experiment plan and 
 
 echo "research_dir=${RESEARCH_DIR}"
 echo "worktree_path=${RESOLVED}"
+echo "research_dir_rel=research/$(date +%Y-%m-%d)-${SLUG:-experiment}"

--- a/src/autoskillit/recipes/scripts/create_worktree.sh
+++ b/src/autoskillit/recipes/scripts/create_worktree.sh
@@ -84,4 +84,8 @@ cd "${RESOLVED}" && git add research/ && git commit -m "Add experiment plan and 
 
 echo "research_dir=${RESEARCH_DIR}"
 echo "worktree_path=${RESOLVED}"
-echo "research_dir_rel=${RESEARCH_DIR#"${RESOLVED}/"}"
+RESEARCH_DIR_REL="${RESEARCH_DIR#"${RESOLVED}/"}"
+case "${RESEARCH_DIR_REL}" in
+  /*) echo "error: research_dir_rel is absolute — prefix strip failed" >&2; exit 1;;
+esac
+echo "research_dir_rel=${RESEARCH_DIR_REL}"

--- a/src/autoskillit/recipes/scripts/create_worktree.sh
+++ b/src/autoskillit/recipes/scripts/create_worktree.sh
@@ -84,4 +84,4 @@ cd "${RESOLVED}" && git add research/ && git commit -m "Add experiment plan and 
 
 echo "research_dir=${RESEARCH_DIR}"
 echo "worktree_path=${RESOLVED}"
-echo "research_dir_rel=research/$(date +%Y-%m-%d)-${SLUG:-experiment}"
+echo "research_dir_rel=${RESEARCH_DIR#"${RESOLVED}/"}"

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -297,6 +297,38 @@ def test_extract_research_capture_all_fields_combined():
     assert result["all_diagram_paths"] == '["a.png", "b.png"]'
 
 
+def test_relative_path_capture_and_reconstruction():
+    """Repo-relative path values survive capture → interpolation
+    and produce correct absolute paths when joined with worktree_path."""
+    from autoskillit.fleet._api import _extract_captures, _interpolate_campaign_refs
+
+    spec = {
+        "worktree_path": "${{ result.worktree_path }}",
+        "research_dir_rel": "${{ result.research_dir_rel }}",
+    }
+    payload = {
+        "worktree_path": "/tmp/wt-A",
+        "research_dir_rel": "research/2026-05-10-test",
+        "research_dir": "/tmp/wt-A/research/2026-05-10-test",
+    }
+    captured = _extract_captures(spec, payload)
+    assert captured == {
+        "worktree_path": "/tmp/wt-A",
+        "research_dir_rel": "research/2026-05-10-test",
+    }
+
+    # Simulate implement phase updating the anchor to a new worktree
+    new_anchor = {**captured, "worktree_path": "/tmp/wt-B"}
+    interpolated = _interpolate_campaign_refs(
+        {"research_dir": "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}"},
+        new_anchor,
+    )
+    assert interpolated["research_dir"] == "/tmp/wt-B/research/2026-05-10-test"
+    assert not interpolated["research_dir"].startswith("/tmp/wt-A"), (
+        "research_dir must be reconstructed from new anchor, not the stale design worktree"
+    )
+
+
 def test_interpolate_campaign_worktree_and_report_path():
     from autoskillit.fleet._api import _interpolate_campaign_refs
 

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -324,9 +324,6 @@ def test_relative_path_capture_and_reconstruction():
         new_anchor,
     )
     assert interpolated["research_dir"] == "/tmp/wt-B/research/2026-05-10-test"
-    assert not interpolated["research_dir"].startswith("/tmp/wt-A"), (
-        "research_dir must be reconstructed from new anchor, not the stale design worktree"
-    )
 
 
 def test_interpolate_campaign_worktree_and_report_path():

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -303,8 +303,8 @@ def test_relative_path_capture_and_reconstruction():
     from autoskillit.fleet._api import _extract_captures, _interpolate_campaign_refs
 
     spec = {
-        "worktree_path": "${{ result.worktree_path }}",
-        "research_dir_rel": "${{ result.research_dir_rel }}",
+        "worktree_path": _ce("${{ result.worktree_path }}"),
+        "research_dir_rel": _ce("${{ result.research_dir_rel }}"),
     }
     payload = {
         "worktree_path": "/tmp/wt-A",

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -714,9 +714,11 @@ async def test_cross_phase_paths_are_coherent_when_implement_creates_new_worktre
     # The anchor must be updated to the implement worktree
     assert impl_captures["worktree_path"] == "/tmp/wt-B"
     assert impl_captures["report_path"] == "/tmp/wt-B/report.md"
-    # research_dir_rel remains stable across worktree transitions
+    # research_dir_rel is not in the implement capture spec — the campaign-level
+    # anchor persists unchanged (tested via run-review ingredient interpolation below)
     assert "research_dir_rel" not in impl_captures
-    # stale research_dir from implement payload must not leak into captures
+    # research_dir is excluded from capture spec by design: the campaign reconstructs
+    # it from worktree_path + research_dir_rel rather than capturing an absolute path
     assert "research_dir" not in impl_captures
 
     # Step 3: run-review — receives reconstructed research_dir from updated anchor + relative

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -534,3 +534,238 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     assert captured_during_archive["pr_url"] == "https://github.com/example/repo/pull/123"
     assert captured_during_archive["worktree_path"] == "/tmp/wt/proj"
     assert captured_during_archive["research_dir"] == "/tmp/wt/proj/.research"
+
+
+@pytest.mark.anyio
+async def test_cross_phase_paths_are_coherent_when_implement_creates_new_worktree(
+    tool_ctx,
+    monkeypatch,
+):
+    """Verify that run-review receives paths all rooted in the same worktree,
+    even when run-implement creates a new worktree internally.
+
+    Design phase emits: worktree_path=/tmp/wt-A, research_dir_rel=research/2026-05-10-test
+    Implement phase emits: worktree_path=/tmp/wt-B (NEW), report_path=/tmp/wt-B/report.md
+    Assert: run-review receives research_dir reconstructed to /tmp/wt-B/research/2026-05-10-test
+    """
+    from autoskillit.fleet._api import execute_dispatch
+    from autoskillit.fleet.result_parser import L3ParseResult
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+    from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+    from ._helpers import (
+        _make_recipe_info,
+        _no_sleep_quota_checker,
+        _noop_quota_refresher,
+    )
+
+    campaign_path = builtin_recipes_dir() / "campaigns" / "research-campaign.yaml"
+    campaign = load_recipe(campaign_path)
+
+    from autoskillit.fleet import FleetSemaphore
+
+    repo = InMemoryRecipeRepository()
+    for dispatch in campaign.dispatches:
+        recipe_path = builtin_recipes_dir() / f"{dispatch.recipe}.yaml"
+        actual_recipe = load_recipe(recipe_path)
+        info = _make_recipe_info(dispatch.recipe)
+        repo.add_recipe(dispatch.recipe, info)
+        repo.add_full_recipe(info.path, actual_recipe)
+
+    tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=4)
+    tool_ctx.recipes = repo
+    tool_ctx.executor = InMemoryHeadlessExecutor()
+
+    # Step 1: run-design — emits design worktree (/tmp/wt-A) and relative research path
+    def _make_design_result(**_):
+        return L3ParseResult(
+            outcome="completed_clean",
+            payload={
+                "success": True,
+                "worktree_path": "/tmp/wt-A",
+                "research_dir": "/tmp/wt-A/research/2026-05-10-test",
+                "research_dir_rel": "research/2026-05-10-test",
+                "experiment_plan": "/tmp/wt-A/research/2026-05-10-test/plan.md",
+                "visualization_plan_path": "/tmp/wt-A/research/2026-05-10-test/vis.md",
+                "scope_report": "/tmp/wt-A/research/2026-05-10-test/scope.md",
+                "experiment_type": "observational",
+            },
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        )
+
+    monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _make_design_result)
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-design",
+        task="Design the research",
+        ingredients={
+            "task": "do it",
+            "issue_url": "",
+            "source_dir": "",
+            "base_branch": "main",
+            "review_design": "false",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={
+            "worktree_path": "${{ result.worktree_path }}",
+            "research_dir": "${{ result.research_dir }}",
+            "research_dir_rel": "${{ result.research_dir_rel }}",
+            "experiment_plan": "${{ result.experiment_plan }}",
+            "visualization_plan_path": "${{ result.visualization_plan_path }}",
+            "scope_report": "${{ result.scope_report }}",
+            "experiment_type": "${{ result.experiment_type }}",
+        },
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    result = json.loads(raw.to_envelope())
+    assert result["success"] is True, f"run-design failed: {result}"
+
+    state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    design_state = json.loads(state_files[0].read_text())
+    design_captures = design_state.get("captured_values", {})
+
+    assert design_captures["worktree_path"] == "/tmp/wt-A"
+    assert design_captures["research_dir_rel"] == "research/2026-05-10-test"
+
+    # Step 2: run-implement — internally creates NEW worktree (/tmp/wt-B) and emits it
+    # The campaign re-captures worktree_path to update the anchor
+    def _make_implement_result(**_):
+        return L3ParseResult(
+            outcome="completed_clean",
+            payload={
+                "success": True,
+                "worktree_path": "/tmp/wt-B",
+                "research_dir": "/tmp/wt-A/research/2026-05-10-test",
+                "report_path": "/tmp/wt-B/report.md",
+                "experiment_results": "/tmp/wt-B/results.json",
+            },
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        )
+
+    monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _make_implement_result)
+
+    captured_implement_ingredients: dict = {}
+
+    def _implement_prompt_builder(**kwargs):
+        captured_implement_ingredients.update(kwargs.get("ingredients", {}))
+        return "prompt"
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-implement",
+        task="Implement the research",
+        ingredients={
+            "task": "do it",
+            "worktree_path": "${{ campaign.worktree_path }}",
+            "research_dir": "${{ campaign.research_dir }}",
+            "research_dir_rel": "${{ campaign.research_dir_rel }}",
+            "experiment_plan": "${{ campaign.experiment_plan }}",
+            "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
+            "source_dir": "",
+            "base_branch": "main",
+            "issue_url": "",
+            "output_mode": "pr",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={
+            "worktree_path": "${{ result.worktree_path }}",
+            "report_path": "${{ result.report_path }}",
+            "experiment_results": "${{ result.experiment_results }}",
+        },
+        prompt_builder=_implement_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    result = json.loads(raw.to_envelope())
+    assert result["success"] is True, f"run-implement failed: {result}"
+
+    # After implement, campaign.worktree_path should be /tmp/wt-B (updated anchor)
+    state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    impl_state = next(
+        (
+            f
+            for f in state_files
+            if json.loads(f.read_text()).get("campaign_name") == "research-implement"
+        ),
+        None,
+    )
+    impl_data = json.loads(impl_state.read_text())
+    impl_captures = impl_data.get("captured_values", {})
+
+    # The anchor must be updated to the implement worktree
+    assert impl_captures["worktree_path"] == "/tmp/wt-B"
+    assert impl_captures["report_path"] == "/tmp/wt-B/report.md"
+    # research_dir_rel remains stable across worktree transitions
+    assert "research_dir_rel" not in impl_captures
+
+    # Step 3: run-review — receives reconstructed research_dir from updated anchor + relative
+    def _make_review_result(**_):
+        return L3ParseResult(
+            outcome="completed_clean",
+            payload={
+                "success": True,
+                "pr_url": "https://github.com/example/repo/pull/123",
+                "report_path_after_finalize": "/tmp/wt-B/final-report.md",
+            },
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        )
+
+    monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _make_review_result)
+
+    captured_review_ingredients: dict = {}
+
+    def _review_prompt_builder(**kwargs):
+        captured_review_ingredients.update(kwargs.get("ingredients", {}))
+        return "prompt"
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="research-review",
+        task="Review and open PR",
+        ingredients={
+            "task": "do it",
+            "experiment_results": "${{ campaign.experiment_results }}",
+            "experiment_type": "${{ campaign.experiment_type }}",
+            "scope_report": "${{ campaign.scope_report }}",
+            "worktree_path": "${{ campaign.worktree_path }}",
+            "research_dir": "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}",
+            "experiment_plan": "${{ campaign.experiment_plan }}",
+            "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
+            "report_path": "${{ campaign.report_path }}",
+            "source_dir": "",
+            "base_branch": "main",
+            "issue_url": "",
+            "output_mode": "pr",
+            "review_pr": "true",
+            "audit_claims": "false",
+        },
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={
+            "pr_url": "${{ result.pr_url }}",
+            "report_path_after_finalize": "${{ result.report_path_after_finalize }}",
+        },
+        prompt_builder=_review_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    result = json.loads(raw.to_envelope())
+    assert result["success"] is True, f"run-review failed: {result}"
+
+    # All paths must be coherent — rooted in the same worktree (/tmp/wt-B)
+    assert captured_review_ingredients["worktree_path"] == "/tmp/wt-B"
+    # reconstruction: /tmp/wt-B + research/2026-05-10-test
+    assert captured_review_ingredients["research_dir"] == "/tmp/wt-B/research/2026-05-10-test"
+    assert captured_review_ingredients["report_path"] == "/tmp/wt-B/report.md"
+    assert captured_review_ingredients["experiment_results"] == "/tmp/wt-B/results.json"

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -53,6 +53,7 @@ def _setup_research_campaign(tool_ctx):
             ingredients={
                 "worktree_path": RecipeIngredient(description="Path to worktree"),
                 "research_dir": RecipeIngredient(description="Path to research dir"),
+                "research_dir_rel": RecipeIngredient(description="Repo-relative research dir"),
             },
         ),
     )
@@ -282,6 +283,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
                 "success": True,
                 "worktree_path": "/tmp/wt/proj",
                 "research_dir": "/tmp/wt/proj/.research",
+                "research_dir_rel": ".research",
                 "experiment_plan": "/tmp/wt/proj/.research/plan.md",
                 "visualization_plan_path": "/tmp/wt/proj/.research/vis.md",
                 "scope_report": "/tmp/wt/proj/.research/scope.md",
@@ -316,6 +318,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
         capture={
             "worktree_path": "${{ result.worktree_path }}",
             "research_dir": "${{ result.research_dir }}",
+            "research_dir_rel": "${{ result.research_dir_rel }}",
             "experiment_plan": "${{ result.experiment_plan }}",
             "visualization_plan_path": "${{ result.visualization_plan_path }}",
             "scope_report": "${{ result.scope_report }}",
@@ -336,6 +339,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
 
     assert accumulated["worktree_path"] == "/tmp/wt/proj"
     assert accumulated["research_dir"] == "/tmp/wt/proj/.research"
+    assert accumulated["research_dir_rel"] == ".research"
     assert accumulated["experiment_plan"] == "/tmp/wt/proj/.research/plan.md"
     assert accumulated["experiment_type"] == "observational"
 
@@ -345,6 +349,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
             outcome="completed_clean",
             payload={
                 "success": True,
+                "worktree_path": "/tmp/wt/proj",
                 "report_path": "/tmp/wt/proj/.research/report.md",
                 "experiment_results": "/tmp/wt/proj/.research/results.json",
             },
@@ -368,7 +373,8 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
         ingredients={
             "task": "do it",
             "worktree_path": "${{ campaign.worktree_path }}",
-            "research_dir": "${{ campaign.research_dir }}",
+            "research_dir": "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}",
+            "research_dir_rel": "${{ campaign.research_dir_rel }}",
             "experiment_plan": "${{ campaign.experiment_plan }}",
             "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
             "source_dir": "",
@@ -379,6 +385,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
         dispatch_name=None,
         timeout_sec=None,
         capture={
+            "worktree_path": "${{ result.worktree_path }}",
             "report_path": "${{ result.report_path }}",
             "experiment_results": "${{ result.experiment_results }}",
         },
@@ -392,6 +399,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     # Verify implement resolved all campaign refs from design captures
     assert captured_during_implement["worktree_path"] == "/tmp/wt/proj"
     assert captured_during_implement["research_dir"] == "/tmp/wt/proj/.research"
+    assert captured_during_implement["research_dir_rel"] == ".research"
     assert captured_during_implement["experiment_plan"] == "/tmp/wt/proj/.research/plan.md"
     assert captured_during_implement["visualization_plan_path"] == "/tmp/wt/proj/.research/vis.md"
 
@@ -409,6 +417,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     impl_data = json.loads(impl_state.read_text())
     accumulated.update(impl_data.get("captured_values", {}))
 
+    assert accumulated["worktree_path"] == "/tmp/wt/proj"
     assert accumulated["report_path"] == "/tmp/wt/proj/.research/report.md"
     assert accumulated["experiment_results"] == "/tmp/wt/proj/.research/results.json"
 
@@ -444,7 +453,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
             "experiment_type": "${{ campaign.experiment_type }}",
             "scope_report": "${{ campaign.scope_report }}",
             "worktree_path": "${{ campaign.worktree_path }}",
-            "research_dir": "${{ campaign.research_dir }}",
+            "research_dir": "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}",
             "experiment_plan": "${{ campaign.experiment_plan }}",
             "visualization_plan_path": "${{ campaign.visualization_plan_path }}",
             "report_path": "${{ campaign.report_path }}",
@@ -473,6 +482,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
     assert captured_during_review["experiment_type"] == "observational"
     assert captured_during_review["scope_report"] == "/tmp/wt/proj/.research/scope.md"
     assert captured_during_review["worktree_path"] == "/tmp/wt/proj"
+    assert captured_during_review["research_dir"] == "/tmp/wt/proj/.research"
     assert captured_during_review["report_path"] == "/tmp/wt/proj/.research/report.md"
 
     # Update accumulated captures
@@ -517,7 +527,7 @@ async def test_full_four_step_chain_verifies_complete_data_lineage(tool_ctx, mon
         ingredients={
             "base_branch": "main",
             "worktree_path": "${{ campaign.worktree_path }}",
-            "research_dir": "${{ campaign.research_dir }}",
+            "research_dir": "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}",
             "pr_url": "${{ campaign.pr_url }}",
         },
         dispatch_name=None,

--- a/tests/fleet/test_research_campaign_dispatch.py
+++ b/tests/fleet/test_research_campaign_dispatch.py
@@ -716,6 +716,8 @@ async def test_cross_phase_paths_are_coherent_when_implement_creates_new_worktre
     assert impl_captures["report_path"] == "/tmp/wt-B/report.md"
     # research_dir_rel remains stable across worktree transitions
     assert "research_dir_rel" not in impl_captures
+    # stale research_dir from implement payload must not leak into captures
+    assert "research_dir" not in impl_captures
 
     # Step 3: run-review — receives reconstructed research_dir from updated anchor + relative
     def _make_review_result(**_):

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -34,6 +34,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_contract_verdict_output_required.py` | Contract: verdict output is required in recipe step |
 | `test_contracts.py` | Contract tests for recipe schema and recipe step contracts |
 | `test_contracts_block_fingerprint.py` | Tests for block fingerprint contract |
+| `test_create_worktree_script.py` | Tests for create_worktree.sh script |
 | `test_diagnose_ci_subtype_output.py` | Tests for CI subtype diagnosis output |
 | `test_registry_types.py` | Tests for `RuleDef` and `BlockRuleDef` frozen dataclasses |
 | `test_diagrams.py` | Tests for recipe flow diagram generation and staleness detection |

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -412,6 +412,7 @@ def test_research_campaign_run_design_capture():
     assert set(d.capture.keys()) == {
         "worktree_path",
         "research_dir",
+        "research_dir_rel",
         "experiment_plan",
         "visualization_plan_path",
         "scope_report",
@@ -430,6 +431,7 @@ def test_research_campaign_run_implement_ingredients():
         "task",
         "worktree_path",
         "research_dir",
+        "research_dir_rel",
         "experiment_plan",
         "visualization_plan_path",
         "source_dir",
@@ -441,7 +443,11 @@ def test_research_campaign_run_implement_ingredients():
     }
     assert d.ingredients["task"] == "${{ inputs.task }}"
     assert d.ingredients["worktree_path"] == "${{ campaign.worktree_path }}"
-    assert d.ingredients["research_dir"] == "${{ campaign.research_dir }}"
+    assert (
+        d.ingredients["research_dir"]
+        == "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}"
+    )
+    assert d.ingredients["research_dir_rel"] == "${{ campaign.research_dir_rel }}"
     assert d.ingredients["experiment_plan"] == "${{ campaign.experiment_plan }}"
     assert d.ingredients["visualization_plan_path"] == "${{ campaign.visualization_plan_path }}"
     assert d.ingredients["source_dir"] == "${{ inputs.source_dir }}"
@@ -457,7 +463,8 @@ def test_research_campaign_run_implement_capture():
     recipe = load_recipe(path)
     d = recipe.dispatches[1]
     assert d.name == "run-implement"
-    assert set(d.capture.keys()) == {"report_path", "experiment_results"}
+    assert set(d.capture.keys()) == {"worktree_path", "report_path", "experiment_results"}
+    assert d.capture["worktree_path"].from_ == "${{ result.worktree_path }}"
     assert d.capture["report_path"].from_ == "${{ result.report_path }}"
     assert d.capture["experiment_results"].from_ == "${{ result.experiment_results }}"
 
@@ -491,12 +498,15 @@ def test_research_campaign_run_review_ingredients():
     assert d.ingredients["output_mode"] == "${{ inputs.output_mode }}"
     assert d.ingredients["review_pr"] == "${{ inputs.review_pr }}"
     assert d.ingredients["audit_claims"] == "${{ inputs.audit_claims }}"
+    assert (
+        d.ingredients["research_dir"]
+        == "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}"
+    )
     for key in [
         "experiment_results",
         "experiment_type",
         "scope_report",
         "worktree_path",
-        "research_dir",
         "experiment_plan",
         "visualization_plan_path",
         "report_path",
@@ -528,10 +538,12 @@ def test_research_campaign_run_archive_ingredients():
         "pr_url",
     }
     assert d.ingredients["base_branch"] == "${{ inputs.base_branch }}"
-    for key in d.ingredients:
-        if key == "base_branch":
-            continue
-        assert d.ingredients[key] == f"${{{{ campaign.{key} }}}}"
+    assert d.ingredients["worktree_path"] == "${{ campaign.worktree_path }}"
+    assert d.ingredients["pr_url"] == "${{ campaign.pr_url }}"
+    assert (
+        d.ingredients["research_dir"]
+        == "${{ campaign.worktree_path }}/${{ campaign.research_dir_rel }}"
+    )
 
 
 def test_research_campaign_no_campaign_refs_in_run_design():

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -411,7 +411,6 @@ def test_research_campaign_run_design_capture():
     assert d.name == "run-design"
     assert set(d.capture.keys()) == {
         "worktree_path",
-        "research_dir",
         "research_dir_rel",
         "experiment_plan",
         "visualization_plan_path",

--- a/tests/recipe/test_create_worktree_script.py
+++ b/tests/recipe/test_create_worktree_script.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 
 import pytest
@@ -62,8 +63,5 @@ def test_create_worktree_emits_research_dir_rel(tmp_path):
         f"stdout must contain 'research_dir_rel=research/...' line. Got:\n{stdout}"
     )
     # The rel path should follow pattern: research/YYYY-MM-DD-test-task
-    import re
-
     rel_match = re.search(r"research_dir_rel=(research/[\d-]+-[\w-]+)", stdout)
     assert rel_match, f"Could not find research_dir_rel pattern in stdout:\n{stdout}"
-    assert result.returncode == 0

--- a/tests/recipe/test_create_worktree_script.py
+++ b/tests/recipe/test_create_worktree_script.py
@@ -1,0 +1,69 @@
+"""Tests for create_worktree.sh script."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_create_worktree_emits_research_dir_rel(tmp_path):
+    """create_worktree.sh must emit research_dir_rel alongside research_dir."""
+    from autoskillit.recipe.io import builtin_recipes_dir
+
+    script_path = builtin_recipes_dir() / "scripts" / "create_worktree.sh"
+    if not script_path.exists():
+        pytest.skip("create_worktree.sh not found")
+
+    # Create a minimal git repo as the source directory
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=source_dir, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=source_dir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=source_dir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=source_dir,
+        check=True,
+    )
+
+    # Create a minimal experiment plan file
+    plan_dir = tmp_path / "plans"
+    plan_dir.mkdir()
+    experiment_plan = plan_dir / "experiment-plan.md"
+    experiment_plan.write_text("# Experiment Plan\n\nTest experiment.")
+
+    # Run create_worktree.sh
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_path),
+            str(source_dir),
+            "test-task",
+            str(experiment_plan),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+    stdout = result.stdout
+    assert "research_dir_rel=research/" in stdout, (
+        f"stdout must contain 'research_dir_rel=research/...' line. Got:\n{stdout}"
+    )
+    # The rel path should follow pattern: research/YYYY-MM-DD-test-task
+    import re
+
+    rel_match = re.search(r"research_dir_rel=(research/[\d-]+-[\w-]+)", stdout)
+    assert rel_match, f"Could not find research_dir_rel pattern in stdout:\n{stdout}"
+    assert result.returncode == 0

--- a/tests/recipe/test_research_campaign_rules.py
+++ b/tests/recipe/test_research_campaign_rules.py
@@ -149,9 +149,9 @@ def test_dispatch_capture_field_in_all_sentinels_contract_passes(validation_ctx)
     )
 
 
-def test_campaign_path_coherence_rule_flags_missing_worktree_recapture(validation_ctx) -> None:
-    """A dispatch that invokes a recipe with implement_phase (worktree-creating)
-    must re-capture worktree_path, or the rule emits an error."""
+def test_campaign_path_coherence_rule_passes_on_valid_campaign(validation_ctx) -> None:
+    """The bundled research-campaign.yaml correctly re-captures worktree_path,
+    so the coherence rule should not fire."""
     findings = run_semantic_rules(validation_ctx)
     matched = [f for f in findings if f.rule == "campaign-path-coherence"]
     assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)

--- a/tests/recipe/test_research_campaign_rules.py
+++ b/tests/recipe/test_research_campaign_rules.py
@@ -147,3 +147,145 @@ def test_dispatch_capture_field_in_all_sentinels_contract_passes(validation_ctx)
     assert all_sentinel_findings == [], (
         f"Per-path sentinel validation failures: {all_sentinel_findings}"
     )
+
+
+def test_campaign_path_coherence_rule_flags_missing_worktree_recapture(validation_ctx) -> None:
+    """A dispatch that invokes a recipe with implement_phase (worktree-creating)
+    must re-capture worktree_path, or the rule emits an error."""
+    findings = run_semantic_rules(validation_ctx)
+    matched = [f for f in findings if f.rule == "campaign-path-coherence"]
+    assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)
+
+
+def test_campaign_path_type_enforce_rule_passes(validation_ctx) -> None:
+    """All worktree_relative_path ingredients must have a corresponding worktree_path anchor."""
+    findings = run_semantic_rules(validation_ctx)
+    matched = [f for f in findings if f.rule == "campaign-path-type-enforce"]
+    assert not matched, "; ".join(f"{f.rule}: {f.message}" for f in matched)
+
+
+def test_campaign_path_coherence_rule_detects_missing_recapture() -> None:
+    """Construct a campaign YAML where a dispatch invokes implement-experiment
+    (which captures worktree_path) but does NOT re-capture worktree_path itself.
+    The rule should emit an error."""
+    import tempfile
+    from pathlib import Path
+
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.io import load_recipe
+
+    # Create a minimal campaign YAML where run-implement does NOT re-capture worktree_path
+    bad_yaml = """
+name: bad-campaign
+description: test
+kind: campaign
+recipe_version: "1.0.0"
+requires_recipe_packs:
+  - research-family
+allowed_recipes:
+  - research-implement
+
+dispatches:
+  - name: run-design
+    recipe: research-design
+    task: "Design the research"
+    ingredients:
+      task: "${{ inputs.task }}"
+    capture:
+      worktree_path: "${{ result.worktree_path }}"
+      research_dir_rel: "${{ result.research_dir_rel }}"
+    depends_on: []
+
+  - name: run-implement
+    recipe: research-implement
+    task: "Implement the research"
+    ingredients:
+      worktree_path: "${{ campaign.worktree_path }}"
+    capture:
+      report_path: "${{ result.report_path }}"
+    depends_on:
+      - run-design
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        campaign_file = tmp_path / "test-campaign.yaml"
+        campaign_file.write_text(bad_yaml)
+
+        recipe = load_recipe(campaign_file)
+        ctx = make_validation_context(
+            recipe,
+            available_recipes=frozenset({"research-design", "research-implement"}),
+            project_dir=tmp_path,
+        )
+        findings = run_semantic_rules(ctx)
+        coherence_findings = [f for f in findings if f.rule == "campaign-path-coherence"]
+        assert coherence_findings, (
+            "campaign-path-coherence rule should have emitted an error for "
+            "run-implement dispatch that invokes research-implement (which captures "
+            "worktree_path at implement_phase) but does not re-capture worktree_path"
+        )
+
+
+def test_campaign_path_type_enforce_rule_detects_missing_anchor() -> None:
+    """A dispatch that provides a worktree_relative_path ingredient without
+    a corresponding worktree_path anchor should emit an error."""
+    import tempfile
+    from pathlib import Path
+
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.io import load_recipe
+
+    bad_yaml = """
+name: bad-campaign
+description: test
+kind: campaign
+recipe_version: "1.0.0"
+requires_recipe_packs:
+  - research-family
+allowed_recipes:
+  - research-implement
+
+ingredients:
+  research_dir_rel:
+    description: "Repo-relative path to research dir"
+    required: true
+    type: worktree_relative_path
+
+dispatches:
+  - name: run-design
+    recipe: research-design
+    task: "Design the research"
+    ingredients:
+      task: "${{ inputs.task }}"
+    capture:
+      worktree_path: "${{ result.worktree_path }}"
+      research_dir_rel: "${{ result.research_dir_rel }}"
+    depends_on: []
+
+  - name: run-implement
+    recipe: research-implement
+    task: "Implement the research"
+    ingredients:
+      research_dir_rel: "${{ campaign.research_dir_rel }}"
+    capture: {}
+    depends_on:
+      - run-design
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        campaign_file = tmp_path / "test-campaign.yaml"
+        campaign_file.write_text(bad_yaml)
+
+        recipe = load_recipe(campaign_file)
+        ctx = make_validation_context(
+            recipe,
+            available_recipes=frozenset({"research-design", "research-implement"}),
+            project_dir=tmp_path,
+        )
+        findings = run_semantic_rules(ctx)
+        type_findings = [f for f in findings if f.rule == "campaign-path-type-enforce"]
+        assert type_findings, (
+            "campaign-path-type-enforce rule should have emitted an error for "
+            "run-implement dispatch that provides research_dir_rel (type: "
+            "worktree_relative_path) without a corresponding worktree_path anchor"
+        )

--- a/tests/recipe/test_research_campaign_structure.py
+++ b/tests/recipe/test_research_campaign_structure.py
@@ -114,7 +114,6 @@ def test_run_design_capture_keys(recipe: Recipe) -> None:
     assert d is not None
     assert set(d.capture.keys()) == {
         "worktree_path",
-        "research_dir",
         "research_dir_rel",
         "experiment_plan",
         "visualization_plan_path",

--- a/tests/recipe/test_research_campaign_structure.py
+++ b/tests/recipe/test_research_campaign_structure.py
@@ -115,6 +115,7 @@ def test_run_design_capture_keys(recipe: Recipe) -> None:
     assert set(d.capture.keys()) == {
         "worktree_path",
         "research_dir",
+        "research_dir_rel",
         "experiment_plan",
         "visualization_plan_path",
         "scope_report",
@@ -137,7 +138,7 @@ def test_run_implement_has_non_empty_capture(recipe: Recipe) -> None:
 def test_run_implement_capture_keys(recipe: Recipe) -> None:
     d = _dispatch_by_name(recipe, "run-implement")
     assert d is not None
-    assert set(d.capture.keys()) == {"report_path", "experiment_results"}
+    assert set(d.capture.keys()) == {"worktree_path", "report_path", "experiment_results"}
 
 
 def test_run_review_has_non_empty_capture(recipe: Recipe) -> None:


### PR DESCRIPTION
## Summary

Campaign dispatches propagate absolute filesystem paths as opaque strings through `${{ campaign.* }}` references. When a mid-campaign phase creates a new worktree (as `implement-experiment` does unconditionally), absolute paths captured from earlier phases become invalid — they reference a different filesystem tree. The architecture lacked any mechanism to detect or prevent this class of cross-boundary path divergence.

This fix separates path values into an absolute anchor (`worktree_path`) and repo-relative suffixes, adds type annotations on path ingredients, and introduces a semantic rule (`campaign-path-coherence`) that statically detects when a dispatch's capture block fails to re-anchor paths after a worktree-creating step.

## Requirements

Post-mortem from research-campaign run `973264238ab2444a`. The design phase captured `research_dir` from its own worktree. The implement phase was told to emit `research_dir=${{ inputs.research_dir }}` verbatim — which is the DESIGN worktree path, not the implement worktree path. Review dispatches then received the wrong path.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260510-054053-666024/.autoskillit/temp/rectify/rectify_research_dir_worktree_reconciliation_2026-05-10_060000.md`

## Changed Files

**New:**
- `tests/recipe/test_create_worktree_script.py`

**Modified:**
- `src/autoskillit/fleet/state.py`
- `src/autoskillit/recipe/rules/rules_campaign.py`
- `src/autoskillit/recipes/campaigns/research-campaign.json`
- `src/autoskillit/recipes/campaigns/research-campaign.yaml`
- `src/autoskillit/recipes/research-archive.json`
- `src/autoskillit/recipes/research-archive.yaml`
- `src/autoskillit/recipes/research-design.json`
- `src/autoskillit/recipes/research-design.yaml`
- `src/autoskillit/recipes/research-implement.json`
- `src/autoskillit/recipes/research-implement.yaml`
- `src/autoskillit/recipes/research-review.json`
- `src/autoskillit/recipes/research-review.yaml`
- `src/autoskillit/recipes/scripts/create_worktree.sh`
- `tests/fleet/test_campaign_capture.py`
- `tests/fleet/test_research_campaign_dispatch.py`
- `tests/recipe/CLAUDE.md`
- `tests/recipe/test_campaign_loader.py`
- `tests/recipe/test_research_campaign_rules.py`
- `tests/recipe/test_research_campaign_structure.py`

Closes #2333

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 65 | 12.4k | 957.9k | 116.0k | 263 | 72.7k | 8m 12s |
| rectify | claude-sonnet-4-6 | 1 | 47 | 10.7k | 425.4k | 98.1k | 162 | 59.2k | 9m 39s |
| dry_walkthrough | claude-opus-4-6 | 1 | 47 | 15.1k | 1.4M | 66.1k | 136 | 53.0k | 10m 52s |
| implement* | MiniMax-M2.7 | 1 | 128.5k | 25.8k | 7.0M | 0 | 157 | 0 | 16m 4s |
| prepare_pr* | MiniMax-M2.7 | 1 | 44.9k | 2.9k | 210.0k | 0 | 17 | 34.0k | 1m 44s |
| compose_pr* | MiniMax-M2.7 | 1 | 38.6k | 1.8k | 298.5k | 25.9k | 22 | 8.1k | 1m 10s |
| review_pr | claude-opus-4-6 | 3 | 117 | 106.6k | 2.2M | 115.8k | 199 | 282.9k | 35m 36s |
| resolve_review | claude-opus-4-6 | 3 | 184 | 43.2k | 4.0M | 93.3k | 212 | 202.7k | 22m 23s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 41 | 4.9k | 1.2M | 67.6k | 37 | 54.3k | 2m 32s |
| diagnose_ci* | MiniMax-M2.7 | 1 | 39.5k | 1.8k | 223.3k | 0 | 16 | 0 | 1m 35s |
| resolve_ci | claude-opus-4-6 | 1 | 47 | 5.3k | 829.6k | 54.4k | 38 | 42.5k | 9m 37s |
| **Total** | | | 252.1k | 230.4k | 18.8M | 116.0k | | 809.4k | 1h 59m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 592 | 11841.8 | 0.0 | 43.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 36 | 112131.2 | 5631.1 | 1201.3 |
| ci_conflict_fix | 633 | 1822.3 | 85.8 | 7.7 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 4 | 207392.0 | 10614.8 | 1324.2 |
| **Total** | **1265** | 14822.2 | 639.8 | 182.2 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 112 | 23.1k | 1.4M | 131.9k | 17m 51s |
| claude-opus-4-6 | 2 | 155 | 48.0k | 6.9M | 164.2k | 23m 48s |
| MiniMax-M2.7 | 3 | 212.1k | 30.5k | 7.5M | 42.1k | 18m 59s |