### PR TITLE
Scope Skill — Emit Structured Directions Manifest for Downstream Breadth Enforcement

### DIFF
--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1258,10 +1258,13 @@ skills:
     outputs:
     - name: scope_report
       type: file_path
+    - name: scope_directions
+      type: file_path
     expected_output_patterns:
     - "scope_report\\s*=\\s*/.+"
+    - "scope_directions\\s*=\\s*/.+"
     pattern_examples:
-    - "scope_report = /tmp/scope_report.md\n%%ORDER_UP%%"
+    - "scope_report = /tmp/scope_report.md\nscope_directions = /tmp/scope_directions.json\n%%ORDER_UP%%"
     write_behavior: always
 
   plan-experiment:
@@ -1269,6 +1272,9 @@ skills:
     - name: scope_report_path
       type: file_path
       required: true
+    - name: scope_directions_path
+      type: file_path
+      required: false
     - name: revision_guidance
       type: file_path
       required: false

--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -79,6 +79,7 @@
         "experiment_plan": "${{ result.experiment_plan }}",
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
         "scope_report": "${{ result.scope_report }}",
+        "scope_directions": "${{ result.scope_directions }}",
         "experiment_type": "${{ result.experiment_type }}"
       },
       "depends_on": []

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -87,6 +87,7 @@ dispatches:
       experiment_plan: "${{ result.experiment_plan }}"
       visualization_plan_path: "${{ result.visualization_plan_path }}"
       scope_report: "${{ result.scope_report }}"
+      scope_directions: "${{ result.scope_directions }}"
       experiment_type: "${{ result.experiment_type }}"
     depends_on: []
 

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -16,10 +16,15 @@
         {
           "name": "scope_report",
           "type": "file_path"
+        },
+        {
+          "name": "scope_directions",
+          "type": "file_path"
         }
       ],
       "expected_output_patterns": [
-        "scope_report\\s*=\\s*/.+"
+        "scope_report\\s*=\\s*/.+",
+        "scope_directions\\s*=\\s*/.+"
       ],
       "pattern_examples": [
         "scope_report = /tmp/scope_report.md\n%%ORDER_UP%%"
@@ -32,6 +37,12 @@
           "name": "scope_report_path",
           "type": "file_path",
           "required": true,
+          "recommended": false
+        },
+        {
+          "name": "scope_directions_path",
+          "type": "file_path",
+          "required": false,
           "recommended": false
         },
         {
@@ -830,7 +841,8 @@
         "research_question"
       ],
       "produced": [
-        "scope_report"
+        "scope_report",
+        "scope_directions"
       ]
     },
     {
@@ -842,6 +854,7 @@
         "output_mode",
         "review_design",
         "review_pr",
+        "scope_directions",
         "scope_report",
         "source_dir",
         "task"

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -27,7 +27,7 @@
         "scope_directions\\s*=\\s*/.+"
       ],
       "pattern_examples": [
-        "scope_report = /tmp/scope_report.md\n%%ORDER_UP%%"
+        "scope_report = /tmp/scope_report.md\nscope_directions = /tmp/scope_directions.json\n%%ORDER_UP%%"
       ],
       "write_behavior": "always"
     },

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -11,8 +11,11 @@ skills:
     outputs:
     - name: scope_report
       type: file_path
+    - name: scope_directions
+      type: file_path
     expected_output_patterns:
     - scope_report\s*=\s*/.+
+    - scope_directions\s*=\s*/.+
     pattern_examples:
     - 'scope_report = /tmp/scope_report.md
 
@@ -23,6 +26,10 @@ skills:
     - name: scope_report_path
       type: file_path
       required: true
+      recommended: false
+    - name: scope_directions_path
+      type: file_path
+      required: false
       recommended: false
     - name: revision_guidance
       type: file_path
@@ -698,6 +705,7 @@ dataflow:
   - research_question
   produced:
   - scope_report
+  - scope_directions
 - step: plan_experiment
   available:
   - audit_claims
@@ -706,6 +714,7 @@ dataflow:
   - output_mode
   - review_design
   - review_pr
+  - scope_directions
   - scope_report
   - source_dir
   - task

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -17,9 +17,10 @@ skills:
     - scope_report\s*=\s*/.+
     - scope_directions\s*=\s*/.+
     pattern_examples:
-    - 'scope_report = /tmp/scope_report.md
-
-      %%ORDER_UP%%'
+    - |-
+      scope_report = /tmp/scope_report.md
+      scope_directions = /tmp/scope_directions.json
+      %%ORDER_UP%%
     write_behavior: always
   plan-experiment:
     inputs:

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -47,7 +47,8 @@
         "step_name": "scope"
       },
       "capture": {
-        "scope_report": "${{ result.scope_report }}"
+        "scope_report": "${{ result.scope_report }}",
+        "scope_directions": "${{ result.scope_directions }}"
       },
       "on_success": "plan_experiment",
       "on_failure": "escalate_stop"
@@ -56,12 +57,13 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.revision_guidance }}",
+        "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.scope_directions }} ${{ context.revision_guidance }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_experiment"
       },
       "optional_context_refs": [
-        "revision_guidance"
+        "revision_guidance",
+        "scope_directions"
       ],
       "capture": {
         "experiment_plan": "${{ result.experiment_plan }}"
@@ -215,7 +217,7 @@
     },
     "design_complete": {
       "action": "stop",
-      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=${{ context.worktree_path }}, research_dir=${{ context.research_dir }}, research_dir_rel=${{ context.research_dir_rel }}. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\", \"research_dir_rel\": \"<rel>\"}"
+      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, scope_directions=<context.scope_directions>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=${{ context.worktree_path }}, research_dir=${{ context.research_dir }}, research_dir_rel=${{ context.research_dir_rel }}. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"scope_directions\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\", \"research_dir_rel\": \"<rel>\"}"
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -57,6 +57,7 @@ steps:
       step_name: scope
     capture:
       scope_report: "${{ result.scope_report }}"
+      scope_directions: "${{ result.scope_directions }}"
     on_success: plan_experiment
     on_failure: escalate_stop
 
@@ -64,10 +65,10 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.revision_guidance }}"
+      skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.scope_directions }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: plan_experiment
-    optional_context_refs: [revision_guidance]
+    optional_context_refs: [revision_guidance, scope_directions]
     capture:
       experiment_plan: "${{ result.experiment_plan }}"
     on_success: review_design
@@ -195,6 +196,7 @@ steps:
       Design phase complete. Emit the L3 result sentinel JSON block now.
       The sentinel must include the following fields from captured context:
       success=true, scope_report=<context.scope_report>,
+      scope_directions=<context.scope_directions>,
       experiment_plan=<context.experiment_plan>,
       visualization_plan_path=<context.visualization_plan_path>,
       report_plan_path=<context.report_plan_path>,
@@ -203,9 +205,9 @@ steps:
       research_dir=${{ context.research_dir }},
       research_dir_rel=${{ context.research_dir_rel }}.
       Example sentinel:
-      {"success": true, "scope_report": "<path>", "experiment_plan": "<path>",
-      "visualization_plan_path": "<path>", "report_plan_path": "<path>",
-      "experiment_type": "benchmark",
+      {"success": true, "scope_report": "<path>", "scope_directions": "<path>",
+      "experiment_plan": "<path>", "visualization_plan_path": "<path>",
+      "report_plan_path": "<path>", "experiment_type": "benchmark",
       "worktree_path": "<path>", "research_dir": "<path>",
       "research_dir_rel": "<rel>"}
 

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -74,7 +74,8 @@
         "step_name": "scope"
       },
       "capture": {
-        "scope_report": "${{ result.scope_report }}"
+        "scope_report": "${{ result.scope_report }}",
+        "scope_directions": "${{ result.scope_directions }}"
       },
       "on_success": "plan_experiment",
       "on_failure": "escalate_stop"
@@ -83,12 +84,13 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.revision_guidance }}",
+        "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.scope_directions }} ${{ context.revision_guidance }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_experiment"
       },
       "optional_context_refs": [
-        "revision_guidance"
+        "revision_guidance",
+        "scope_directions"
       ],
       "capture": {
         "experiment_plan": "${{ result.experiment_plan }}"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -123,6 +123,7 @@ steps:
       step_name: scope
     capture:
       scope_report: "${{ result.scope_report }}"
+      scope_directions: "${{ result.scope_directions }}"
     on_success: plan_experiment
     on_failure: escalate_stop
 
@@ -130,10 +131,10 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.revision_guidance }}"
+      skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.scope_directions }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: plan_experiment
-    optional_context_refs: [revision_guidance]
+    optional_context_refs: [revision_guidance, scope_directions]
     capture:
       experiment_plan: "${{ result.experiment_plan }}"
     on_success: review_design

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -40,7 +40,7 @@ one self-contained folder under `research/`.
 produced by `/autoskillit:scope`. Scan for the second path-like token. When present and
 the file exists, use its structured directions instead of extracting directions from the
 prose report. When absent or the file does not exist, fall back to extracting directions
-from the Proposed Investigation Directions section of the scope report (backward-compatible).
+from the Proposed Investigation Directions section of the scope report.
 
 `{revision_guidance}` — Optional. Absolute path to revision guidance produced by
 `/autoskillit:review-design` when verdict=REVISE. Scan for the third path-like token.

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -30,14 +30,20 @@ one self-contained folder under `research/`.
 
 ## Arguments
 
-/autoskillit:plan-experiment {scope_report_path} [{revision_guidance}]
+/autoskillit:plan-experiment {scope_report_path} [{scope_directions_path}] [{revision_guidance}]
 
 `{scope_report_path}` — Absolute path to the scope report produced by `/autoskillit:scope`
 (required). Scan tokens after the skill name for the first path-like token
 (starts with `/`, `./`, or `.autoskillit/`).
 
+`{scope_directions_path}` — Optional. Absolute path to the structured directions manifest
+produced by `/autoskillit:scope`. Scan for the second path-like token. When present and
+the file exists, use its structured directions instead of extracting directions from the
+prose report. When absent or the file does not exist, fall back to extracting directions
+from the Proposed Investigation Directions section of the scope report (backward-compatible).
+
 `{revision_guidance}` — Optional. Absolute path to revision guidance produced by
-`/autoskillit:review-design` when verdict=REVISE. Scan for the second path-like token.
+`/autoskillit:review-design` when verdict=REVISE. Scan for the third path-like token.
 When absent or empty (first pass), proceed normally. When present, read it and
 incorporate the feedback before writing the plan.
 
@@ -84,6 +90,14 @@ Detect and read inputs:
    `{revision_guidance}`. Extract all revision instructions — these take priority over
    your initial analysis in Step 2. Note which sections of the plan need rework.
    When absent or empty, omit this sub-step and proceed normally (first pass).
+3. If `{scope_directions_path}` is present and the file exists, read it as JSON.
+   Extract the `directions` array. Use these structured directions as the
+   authoritative list of investigation directions instead of parsing them from the
+   Markdown prose. Note which directions have `must_cover: true` — these are
+   mandatory and each must receive its own experimental design section in Step 3.
+   If the file is absent or does not exist, fall back to extracting directions
+   from the report's Proposed Investigation Directions section (no breadth
+   enforcement applies in this case).
 
 ### Step 2 — Explore Feasibility
 
@@ -133,10 +147,24 @@ information gaps and produce the best possible experiment plan.
 - Investigation of specific technical constraints or requirements
 - Any other research that improves the experiment plan
 
+**Breadth enforcement (when scope_directions.json is available):**
+Each direction with `must_cover: true` must be assessed for feasibility by at least
+one subagent. You may combine related must_cover directions into a single subagent
+if they share the same feasibility concerns, but every must_cover direction must be
+explicitly addressed in the feasibility findings.
+
 ### Step 3 — Write Experiment Plan
 
 Produce a structured experiment plan. The plan has two halves: the **research
 design** (what and why) and the **implementation plan** (how to build it).
+
+**Breadth enforcement (when scope_directions.json is available):**
+The experiment plan must include one clearly labeled design section per `must_cover: true`
+direction from `scope_directions.json`. If a must_cover direction is infeasible or
+redundant, you must include a **## Direction Dropped: {direction_id} — {title}** section
+with an explicit justification (minimum 2 sentences explaining why the direction was
+dropped and what evidence supports the decision). Silent omission of must_cover
+directions is prohibited.
 
 Choose a date-stamped slug for the experiment folder:
 `research/YYYY-MM-DD-{slug}/` where `{slug}` is a kebab-case summary of the

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -159,7 +159,7 @@ explicitly addressed in the feasibility findings.
 Produce a structured experiment plan. The plan has two halves: the **research
 design** (what and why) and the **implementation plan** (how to build it).
 
-**Breadth enforcement (when scope_directions.json is available):**
+**Breadth enforcement — plan sections (when scope_directions.json is available):**
 The experiment plan must include one clearly labeled design section per `must_cover: true`
 direction from `scope_directions.json`. If a must_cover direction is infeasible or
 redundant, you must include a **## Direction Dropped: {direction_id} — {title}** section

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -86,7 +86,7 @@ Detect and read inputs:
    - Proposed investigation directions
    - Success criteria hints
    - External research findings
-2. If a second path-like token is present and resolves to an existing file, read
+2. If a third path-like token is present and resolves to an existing file, read
    `{revision_guidance}`. Extract all revision instructions — these take priority over
    your initial analysis in Step 2. Note which sections of the plan need rework.
    When absent or empty, omit this sub-step and proceed normally (first pass).
@@ -95,9 +95,10 @@ Detect and read inputs:
    authoritative list of investigation directions instead of parsing them from the
    Markdown prose. Note which directions have `must_cover: true` — these are
    mandatory and each must receive its own experimental design section in Step 3.
-   If the file is absent or does not exist, fall back to extracting directions
+   If the file is absent, does not exist, cannot be parsed as valid JSON, or
+   lacks a non-empty `directions` array, fall back to extracting directions
    from the report's Proposed Investigation Directions section (no breadth
-   enforcement applies in this case).
+   enforcement applies in this case). Note the fallback reason in the plan.
 
 ### Step 2 — Explore Feasibility
 

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -86,11 +86,7 @@ Detect and read inputs:
    - Proposed investigation directions
    - Success criteria hints
    - External research findings
-2. If a third path-like token is present and resolves to an existing file, read
-   `{revision_guidance}`. Extract all revision instructions — these take priority over
-   your initial analysis in Step 2. Note which sections of the plan need rework.
-   When absent or empty, omit this sub-step and proceed normally (first pass).
-3. If `{scope_directions_path}` is present and the file exists, read it as JSON.
+2. If `{scope_directions_path}` is present and the file exists, read it as JSON.
    Extract the `directions` array. Use these structured directions as the
    authoritative list of investigation directions instead of parsing them from the
    Markdown prose. Note which directions have `must_cover: true` — these are
@@ -99,6 +95,10 @@ Detect and read inputs:
    lacks a non-empty `directions` array, fall back to extracting directions
    from the report's Proposed Investigation Directions section (no breadth
    enforcement applies in this case). Note the fallback reason in the plan.
+3. If a third path-like token is present and resolves to an existing file, read
+   `{revision_guidance}`. Extract all revision instructions — these take priority over
+   your initial analysis in Step 2. Note which sections of the plan need rework.
+   When absent or empty, omit this sub-step and proceed normally (first pass).
 
 ### Step 2 — Explore Feasibility
 

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -237,7 +237,7 @@ equal the number of entries where `must_cover == true`. At least one direction m
 
 ### Step 3 — Write Output
 
-Save both output files to `{{AUTOSKILLIT_TEMP}}/scope/`:
+Save both output files to `{{AUTOSKILLIT_TEMP}}/scope/` (relative to the current working directory):
 
 1. **Scope report:** `scope_{topic}_{YYYY-MM-DD_HHMMSS}.md`
    Where `{topic}` is a snake_case summary of the research question (max 40 chars).

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -208,14 +208,14 @@ file in `{{AUTOSKILLIT_TEMP}}/scope/` (the same directory as the scope report).
 
 **Field rules:**
 
-| Field | Type | Rules |
-|-------|------|-------|
-| `direction_id` | string | Sequential: D1, D2, D3, ... |
-| `title` | string | Short summary of the direction, max 80 characters |
-| `priority` | enum | `P0` (primary), `P1` (secondary), `P2` (exploratory) |
-| `must_cover` | boolean | `true` for P0 directions; `false` for P1/P2 |
-| `source_type` | enum | `computational`, `wet_lab`, `literature`, `hybrid` |
-| `feasibility_notes` | string | Brief assessment of feasibility, 1-2 sentences |
+| Field | Type | Constraints | Rules |
+|-------|------|-------------|-------|
+| `direction_id` | string | pattern: `^D\d+$` | Sequential: D1, D2, D3, ... |
+| `title` | string | maxLength: 80 | Short summary of the direction, max 80 characters |
+| `priority` | enum | values: `P0`, `P1`, `P2` | `P0` (primary), `P1` (secondary), `P2` (exploratory) |
+| `must_cover` | boolean | — | `true` for P0 directions; `false` for P1/P2 |
+| `source_type` | enum | values: `computational`, `wet_lab`, `literature`, `hybrid` | Classify the investigation approach |
+| `feasibility_notes` | string | — | Brief assessment of feasibility, 1-2 sentences |
 
 **Priority assignment rules:**
 - **P0 (primary):** Directions that directly address the core research question. These
@@ -232,10 +232,10 @@ file in `{{AUTOSKILLIT_TEMP}}/scope/` (the same directory as the scope report).
 - **hybrid:** Requires a combination of computational and experimental approaches
 
 **Validation:** `direction_count` must equal `len(directions)`. `must_cover_count` must
-equal the number of entries where `must_cover == true`. At least one direction must have
-`must_cover: true`. If any invariant is violated, correct the counts by recomputing them
-from the `directions` array before writing the file — do not emit a sidecar with stale
-or inconsistent count fields.
+equal the number of entries where `must_cover == true`. `must_cover_count` must be ≥ 1
+(at least one direction must have `must_cover: true`). If any invariant is violated,
+correct the counts by recomputing them from the `directions` array before writing the
+file — do not emit a sidecar with stale or inconsistent count fields.
 
 ### Step 3 — Write Output
 

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -178,15 +178,74 @@ threshold values or scoring standards are, and where they are defined. If no eva
 framework was found, omit this section entirely — do not emit an empty section.}
 ```
 
+### Step 2a — Extract Directions Manifest
+
+After writing the scope report, extract the investigation directions into a
+machine-readable JSON sidecar. Parse the **Proposed Investigation Directions**
+section of the report and produce a `scope_directions_{topic}_{YYYY-MM-DD_HHMMSS}.json`
+file in the same output directory.
+
+**Schema:**
+
+```json
+{
+  "research_question": "{the refined research question from the report}",
+  "generated_at": "{ISO-8601 timestamp}",
+  "direction_count": 3,
+  "must_cover_count": 2,
+  "directions": [
+    {
+      "direction_id": "D1",
+      "title": "Short description of the direction (max 80 chars)",
+      "priority": "P0",
+      "must_cover": true,
+      "source_type": "computational",
+      "feasibility_notes": "Brief feasibility assessment (1-2 sentences)"
+    }
+  ]
+}
+```
+
+**Field rules:**
+
+| Field | Type | Rules |
+|-------|------|-------|
+| `direction_id` | string | Sequential: D1, D2, D3, ... |
+| `title` | string | Short summary of the direction, max 80 characters |
+| `priority` | enum | `P0` (primary), `P1` (secondary), `P2` (exploratory) |
+| `must_cover` | boolean | `true` for P0 directions; `false` for P1/P2 |
+| `source_type` | enum | `computational`, `wet_lab`, `literature`, `hybrid` |
+| `feasibility_notes` | string | Brief assessment of feasibility, 1-2 sentences |
+
+**Priority assignment rules:**
+- **P0 (primary):** Directions that directly address the core research question. These
+  are the main investigation paths. At least one direction must be P0. Set `must_cover: true`.
+- **P1 (secondary):** Directions that support or complement the primary investigation
+  but are not essential. Set `must_cover: false`.
+- **P2 (exploratory):** Speculative or long-shot directions worth noting but not
+  requiring coverage. Set `must_cover: false`.
+
+**Source type classification:**
+- **computational:** Can be investigated entirely through computation (code, simulation, analysis)
+- **wet_lab:** Requires physical laboratory work (synthesis, assays, measurements)
+- **literature:** Can be resolved through literature review and meta-analysis
+- **hybrid:** Requires a combination of computational and experimental approaches
+
+**Validation:** `direction_count` must equal `len(directions)`. `must_cover_count` must
+equal the number of entries where `must_cover == true`. At least one direction must have
+`must_cover: true`.
+
 ### Step 3 — Write Output
 
-Save the scope report to:
-`{{AUTOSKILLIT_TEMP}}/scope/scope_{topic}_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Save both output files to `{{AUTOSKILLIT_TEMP}}/scope/`:
 
-Where `{topic}` is a snake_case summary of the research question (max 40 chars).
+1. **Scope report:** `scope_{topic}_{YYYY-MM-DD_HHMMSS}.md`
+   Where `{topic}` is a snake_case summary of the research question (max 40 chars).
 
-After saving, emit the structured output token as the very last line of your
-text output:
+2. **Directions manifest:** `scope_directions_{topic}_{YYYY-MM-DD_HHMMSS}.json`
+
+After saving both files, emit the structured output tokens as the last two lines
+of your text output, in this exact order:
 
 > **IMPORTANT:** Emit the structured output tokens as **literal plain text with no
 > markdown formatting on the token names**. Do not wrap token names in `**bold**`,
@@ -195,4 +254,5 @@ text output:
 
 ```
 scope_report = {absolute_path_to_scope_report}
+scope_directions = {absolute_path_to_scope_directions_json}
 ```

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -183,7 +183,7 @@ framework was found, omit this section entirely — do not emit an empty section
 After writing the scope report, extract the investigation directions into a
 machine-readable JSON sidecar. Parse the **Proposed Investigation Directions**
 section of the report and produce a `scope_directions_{topic}_{YYYY-MM-DD_HHMMSS}.json`
-file in the same output directory.
+file in `{{AUTOSKILLIT_TEMP}}/scope/` (the same directory as the scope report).
 
 **Schema:**
 
@@ -233,7 +233,9 @@ file in the same output directory.
 
 **Validation:** `direction_count` must equal `len(directions)`. `must_cover_count` must
 equal the number of entries where `must_cover == true`. At least one direction must have
-`must_cover: true`.
+`must_cover: true`. If any invariant is violated, correct the counts by recomputing them
+from the `directions` array before writing the file — do not emit a sidecar with stale
+or inconsistent count fields.
 
 ### Step 3 — Write Output
 

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -543,6 +543,7 @@ class TestOutputPathTokensDerivedFromContracts:
             "review_path",
             "revision_guidance",
             "scope_report",
+            "scope_directions",
             "summary_path",
             "triage_manifest",
             "triage_report",

--- a/tests/recipe/test_bundled_recipes_research.py
+++ b/tests/recipe/test_bundled_recipes_research.py
@@ -473,3 +473,6 @@ class TestResearchRecipeStructure:
         step = recipe.steps["stage_bundle"]
         assert step.on_success == "route_pr_or_local"
         assert step.on_failure == "route_pr_or_local"
+
+    def test_scope_captures_scope_directions(self, recipe) -> None:
+        assert "scope_directions" in recipe.steps["scope"].capture

--- a/tests/recipe/test_bundled_recipes_research.py
+++ b/tests/recipe/test_bundled_recipes_research.py
@@ -476,3 +476,6 @@ class TestResearchRecipeStructure:
 
     def test_scope_captures_scope_directions(self, recipe) -> None:
         assert "scope_directions" in recipe.steps["scope"].capture
+
+    def test_plan_experiment_optional_context_refs_includes_scope_directions(self, recipe) -> None:
+        assert "scope_directions" in recipe.steps["plan_experiment"].optional_context_refs

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -82,6 +82,9 @@ class TestResearchDesignRecipeStructure:
     def test_scope_captures_scope_report(self, recipe) -> None:
         assert "scope_report" in recipe.steps["scope"].capture
 
+    def test_scope_captures_scope_directions(self, recipe) -> None:
+        assert "scope_directions" in recipe.steps["scope"].capture
+
     def test_plan_experiment_routing(self, recipe) -> None:
         step = recipe.steps["plan_experiment"]
         assert step.on_success == "review_design"
@@ -92,6 +95,9 @@ class TestResearchDesignRecipeStructure:
 
     def test_plan_experiment_optional_context_refs(self, recipe) -> None:
         assert "revision_guidance" in recipe.steps["plan_experiment"].optional_context_refs
+
+    def test_plan_experiment_optional_context_refs_includes_scope_directions(self, recipe) -> None:
+        assert "scope_directions" in recipe.steps["plan_experiment"].optional_context_refs
 
     def test_review_design_skip_when_false(self, recipe) -> None:
         assert recipe.steps["review_design"].skip_when_false == "inputs.review_design"
@@ -220,6 +226,7 @@ class TestResearchDesignRecipeStructure:
         message = recipe.steps["design_complete"].message
         for field in (
             "scope_report",
+            "scope_directions",
             "experiment_plan",
             "visualization_plan_path",
             "report_plan_path",
@@ -230,6 +237,10 @@ class TestResearchDesignRecipeStructure:
             assert field in message, (
                 f"design_complete message must mention sentinel field: {field}"
             )
+
+    def test_design_complete_sentinel_includes_scope_directions(self, recipe) -> None:
+        msg = recipe.steps["design_complete"].message
+        assert "scope_directions" in msg
 
     def test_design_recipe_has_create_worktree_step(self, recipe) -> None:
         step = recipe.steps["create_worktree"]

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
@@ -94,10 +96,9 @@ class TestResearchDesignRecipeStructure:
         assert "experiment_plan" in recipe.steps["plan_experiment"].capture
 
     def test_plan_experiment_optional_context_refs(self, recipe) -> None:
-        assert "revision_guidance" in recipe.steps["plan_experiment"].optional_context_refs
-
-    def test_plan_experiment_optional_context_refs_includes_scope_directions(self, recipe) -> None:
-        assert "scope_directions" in recipe.steps["plan_experiment"].optional_context_refs
+        refs = recipe.steps["plan_experiment"].optional_context_refs
+        for field in ("revision_guidance", "scope_directions"):
+            assert field in refs, f"plan_experiment optional_context_refs must include: {field}"
 
     def test_review_design_skip_when_false(self, recipe) -> None:
         assert recipe.steps["review_design"].skip_when_false == "inputs.review_design"
@@ -240,7 +241,9 @@ class TestResearchDesignRecipeStructure:
 
     def test_design_complete_sentinel_includes_scope_directions(self, recipe) -> None:
         msg = recipe.steps["design_complete"].message
-        assert "scope_directions=<context.scope_directions>" in msg
+        assert re.search(r"scope_directions\s*=\s*<context\.scope_directions>", msg), (
+            "design_complete message must reference scope_directions via template syntax"
+        )
 
     def test_design_recipe_has_create_worktree_step(self, recipe) -> None:
         step = recipe.steps["create_worktree"]

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -240,7 +240,7 @@ class TestResearchDesignRecipeStructure:
 
     def test_design_complete_sentinel_includes_scope_directions(self, recipe) -> None:
         msg = recipe.steps["design_complete"].message
-        assert "scope_directions" in msg
+        assert "scope_directions=<context.scope_directions>" in msg
 
     def test_design_recipe_has_create_worktree_step(self, recipe) -> None:
         step = recipe.steps["create_worktree"]

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -415,6 +415,7 @@ def test_research_campaign_run_design_capture():
         "experiment_plan",
         "visualization_plan_path",
         "scope_report",
+        "scope_directions",
         "experiment_type",
     }
     for key, val in d.capture.items():

--- a/tests/recipe/test_research_campaign_structure.py
+++ b/tests/recipe/test_research_campaign_structure.py
@@ -118,6 +118,7 @@ def test_run_design_capture_keys(recipe: Recipe) -> None:
         "experiment_plan",
         "visualization_plan_path",
         "scope_report",
+        "scope_directions",
         "experiment_type",
     }
 

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -229,6 +229,7 @@ def test_output_path_tokens_synchronized() -> None:
             "recipe_path",
             # Research recipe skills (added in #504)
             "scope_report",
+            "scope_directions",
             "experiment_plan",
             "results_path",
             "report_path",


### PR DESCRIPTION
## Summary

Add a machine-readable `scope_directions.json` sidecar to the scope skill's output. The sidecar encodes each investigation direction with an ID, priority, `must_cover` flag, and `source_type` classification. A new output token `scope_directions` carries its path through recipe capture/context into plan-experiment, which reads the sidecar and enforces breadth: one experimental design per `must_cover: true` direction, with explicit justification required for any dropped direction.

Changes span six areas: (1) scope SKILL.md — new Step 2a to generate the sidecar, (2) plan-experiment SKILL.md — consume sidecar and enforce breadth, (3) skill_contracts.yaml — register the new token, (4) recipe YAML+JSON files — wire capture and context, (5) contracts/research.yaml — update dataflow, (6) test files — update frozenset fixtures and add wiring assertions.

Closes #2338

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-081809-192632/.autoskillit/temp/make-plan/scope_directions_manifest_plan_2026-05-10_082500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.0k | 15.6k | 1.3M | 117.9k | 176 | 74.6k | 13m 38s |
| verify | claude-sonnet-4-6 | 1 | 42 | 8.3k | 646.9k | 61.4k | 133 | 40.3k | 6m 12s |
| implement* | MiniMax-M2.7-highspeed | 1 | 4.8M | 22.6k | 2.3M | 34.1k | 186 | 69.7k | 9m 49s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 87.0k | 3.6k | 172.5k | 28.8k | 20 | 41.3k | 1m 9s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 45.9k | 1.2k | 198.4k | 28.8k | 15 | 15.2k | 45s |
| review_pr | claude-sonnet-4-6 | 3 | 778 | 93.7k | 1.3M | 82.3k | 98 | 202.2k | 23m 23s |
| resolve_review | claude-sonnet-4-6 | 3 | 1.2k | 78.3k | 11.2M | 129.6k | 340 | 253.6k | 35m 23s |
| **Total** | | | 4.9M | 223.4k | 17.1M | 129.6k | | 696.9k | 1h 30m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 78 | 143800.1 | 3251.5 | 1004.0 |
| **Total** | **78** | 219126.5 | 8935.2 | 2863.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 3.3k | 31.9k | 3.9M | 202.0k | 28m 22s |
| MiniMax-M2.7-highspeed | 3 | 4.9M | 27.4k | 2.7M | 126.2k | 11m 43s |