### PR TITLE
Relax V9 Acquisition Requirement and Add Comparative Research Types

### DIFF
--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -424,7 +424,7 @@ V1: benchmark/causal_inference/factorial_design/instrument_validation/single_sub
 V2: causal_inference/factorial_design → estimand.contrast is not null
     ERROR: "causal_inference/factorial_design requires estimand with treatment, outcome, and contrast fields"
 
-V3: !(exploratory | qualitative_interpretive) → statistical_plan present AND test not null
+V3: !(exploratory/qualitative_interpretive) → statistical_plan present AND test not null
     ERROR: "Non-exploratory/non-qualitative experiments require a statistical_plan; use {test: 'none'} to waive"
 
 V4: environment.type=custom → spec_path not null

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -460,7 +460,6 @@ V9: data_manifest completeness
   relevant field line.
 
 Field requirements by experiment type:
-
 | Field | benchmark | causal_inf | config_study | evid_synth | exploratory | fact_design | instr_valid | obs_corr | qual_interp | robust_audit | sim_model | single_subj |
 |-------|-----------|-----------|-------------|-----------|-------------|-----------|------------|---------|------------|-------------|----------|------------|
 | experiment_type | required | required | required | required | required | required | required | required | required | required | required | required |

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -118,6 +118,8 @@ information gaps and produce the best possible experiment plan.
 > must NOT assume the data will already be present — especially in worktrees where
 > gitignored directories are empty. If the directive specifies data that requires
 > download or generation, include the exact commands in the `acquisition` field.
+> For `literature` or `database` source types, describe the extraction or query
+> method in `acquisition` — download commands are not required.
 
 **Subagent C — Environment Assessment:**
 > Determine whether the experiment can run with the project's existing
@@ -315,7 +317,7 @@ complete experiment plan file with YAML frontmatter prepended before the
 
 ```
 ---
-experiment_type: {one of: benchmark, configuration_study, causal_inference, robustness_audit, exploratory}
+experiment_type: {one of: benchmark, causal_inference, configuration_study, evidence_synthesis, exploratory, factorial_design, instrument_validation, observational_correlational, qualitative_interpretive, robustness_audit, simulation_modeling, single_subject}
 
 estimand:
   treatment: "{the intervention}"     # RECOMMENDED; required when causal_inference
@@ -359,7 +361,7 @@ success_criteria:                     # REQUIRED
 
 data_manifest:                        # REQUIRED — one entry per hypothesis (or shared)
   - hypothesis: [H1, H2]             # which hypotheses consume this data
-    source_type: synthetic            # synthetic | fixture | external | gitignored
+    source_type: synthetic            # synthetic | fixture | external | gitignored | literature | database
     description: "Gaussian blobs, 10K-100K points"
     acquisition: "generate in-script via sklearn.datasets"
     location: null                    # null for in-script generation
@@ -371,6 +373,12 @@ data_manifest:                        # REQUIRED — one entry per hypothesis (o
   #   location: "temp/merfish_100k/"
   #   verification: "directory exists with >= 1 .parquet file, total size > 10MB"
   #   depends_on: "python tests/visual_eval/download_merfish.py"
+  # - hypothesis: [H1, H3]
+  #   source_type: literature
+  #   description: "Published expression data from Smith et al. 2023, Table 2"
+  #   acquisition: "extract values from published table"
+  #   location: null
+  #   verification: "values match published Table 2"
 
 experiment_slug: "{YYYY-MM-DD-slug}"  # optional, derived from directory layout
 ---
@@ -400,7 +408,7 @@ A list of data source entries, one per hypothesis (or shared across hypotheses).
 | Field | Required | Description |
 |-------|----------|-------------|
 | `hypothesis` | yes | List of hypothesis IDs that consume this data |
-| `source_type` | yes | One of: `synthetic`, `fixture`, `external`, `gitignored` |
+| `source_type` | yes | One of: `synthetic`, `fixture`, `external`, `gitignored`, `literature`, `database` |
 | `description` | yes | Human-readable description of the data |
 | `acquisition` | yes | Exact command or method to produce/retrieve the data |
 | `location` | no | Filesystem path where data will reside (null for in-script) |
@@ -410,14 +418,14 @@ A list of data source entries, one per hypothesis (or shared across hypotheses).
 Apply these validation rules in order before writing the frontmatter:
 
 ```
-V1: benchmark/causal_inference → len(baselines) >= 1 AND each baseline.version not empty
-    ERROR: "Benchmark/causal_inference experiments require at least one named baseline with a version"
+V1: benchmark/causal_inference/factorial_design/instrument_validation/single_subject → len(baselines) >= 1 AND each baseline.version not empty
+    ERROR: "This experiment type requires at least one named baseline with a version"
 
-V2: causal_inference → estimand.contrast is not null
-    ERROR: "causal_inference requires estimand with treatment, outcome, and contrast fields"
+V2: causal_inference/factorial_design → estimand.contrast is not null
+    ERROR: "causal_inference/factorial_design requires estimand with treatment, outcome, and contrast fields"
 
-V3: !exploratory → statistical_plan present AND test not null
-    ERROR: "Non-exploratory experiments require a statistical_plan; use {test: 'none'} to waive"
+V3: !(exploratory | qualitative_interpretive) → statistical_plan present AND test not null
+    ERROR: "Non-exploratory/non-qualitative experiments require a statistical_plan; use {test: 'none'} to waive"
 
 V4: environment.type=custom → spec_path not null
     ERROR: "Custom environment requires spec_path pointing to environment.yml"
@@ -439,6 +447,9 @@ V9: data_manifest completeness
     - Any hypothesis referenced in `success_criteria` has no entry in `data_manifest`
     - Any entry with `source_type: external` or `source_type: gitignored` lacks a non-null `location`
     - Any entry with `source_type: external` lacks a `depends_on` or explicit download command in `acquisition`
+    - Any entry with `source_type: database` lacks a non-null `acquisition` (must describe query method)
+    - Any entry with `source_type: literature` lacks a non-null `description` (must identify the source publication)
+    NOTE: `literature` and `database` entries do NOT require `depends_on` or download commands.
     ERROR: "Data Manifest incomplete: {specific missing field or hypothesis}"
 ```
 
@@ -450,17 +461,17 @@ V9: data_manifest completeness
 
 Field requirements by experiment type:
 
-| Field | benchmark | config_study | causal_inference | robustness_audit | exploratory |
-|-------|-----------|-------------|-----------------|-----------------|-------------|
-| experiment_type | required | required | required | required | required |
-| estimand | recommended | recommended | **required** | recommended | optional |
-| hypothesis_h0/h1 | required | required | required | required | required |
-| metrics | required | required | required | required | required |
-| baselines | **required** | optional | **required** | optional | optional |
-| statistical_plan | required | required | required | required | **waived** |
-| environment | required | required | required | required | required |
-| success_criteria | required | required | required | required | required |
-| data_manifest | required | required | required | required | required |
+| Field | benchmark | causal_inf | config_study | evid_synth | exploratory | fact_design | instr_valid | obs_corr | qual_interp | robust_audit | sim_model | single_subj |
+|-------|-----------|-----------|-------------|-----------|-------------|-----------|------------|---------|------------|-------------|----------|------------|
+| experiment_type | required | required | required | required | required | required | required | required | required | required | required | required |
+| estimand | recommended | **required** | recommended | optional | optional | **required** | recommended | recommended | optional | recommended | recommended | optional |
+| hypothesis_h0/h1 | required | required | required | optional | required | required | required | required | optional | required | required | required |
+| metrics | required | required | required | required | required | required | required | required | optional | required | required | required |
+| baselines | **required** | **required** | optional | optional | optional | **required** | **required** | optional | optional | optional | optional | **required** |
+| statistical_plan | required | required | required | required | **waived** | required | required | required | **waived** | required | required | required |
+| environment | required | required | required | required | required | required | required | required | required | required | required | required |
+| success_criteria | required | required | required | required | required | required | required | required | optional | required | required | required |
+| data_manifest | required | required | required | required | required | required | required | required | optional | required | required | required |
 
 ### Step 4 — Write Output
 

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -10,6 +10,13 @@ SKILL_PATH = (
     / "plan-experiment"
     / "SKILL.md"
 )
+EXPERIMENT_TYPES_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "recipes"
+    / "experiment-types"
+)
 
 
 def test_data_manifest_in_frontmatter_schema() -> None:
@@ -79,17 +86,11 @@ def test_plan_experiment_layout_includes_taskfile() -> None:
 
 
 def test_experiment_type_enum_lists_all_registry_types() -> None:
-    """All 12 experiment types from the registry appear in the template enum."""
+    """All experiment types from the registry appear in the template enum."""
     import re
 
-    EXPERIMENT_TYPES_DIR = (
-        Path(__file__).resolve().parent.parent.parent
-        / "src"
-        / "autoskillit"
-        / "recipes"
-        / "experiment-types"
-    )
     registry_types = {p.stem for p in EXPERIMENT_TYPES_DIR.glob("*.yaml")}
+    assert len(registry_types) > 0, "experiment-types registry dir is empty or missing"
     text = SKILL_PATH.read_text()
     m = re.search(r"experiment_type:\s*\{one of:\s*([^}]+)\}", text, re.IGNORECASE)
     assert m, "experiment_type enum not found in SKILL.md template"
@@ -115,14 +116,8 @@ def test_field_requirements_table_covers_all_registry_types() -> None:
     """Field requirements table has a column for every registry experiment type."""
     import re
 
-    EXPERIMENT_TYPES_DIR = (
-        Path(__file__).resolve().parent.parent.parent
-        / "src"
-        / "autoskillit"
-        / "recipes"
-        / "experiment-types"
-    )
     registry_types = {p.stem for p in EXPERIMENT_TYPES_DIR.glob("*.yaml")}
+    assert len(registry_types) > 0, "experiment-types registry dir is empty or missing"
     text = SKILL_PATH.read_text()
     m = re.search(
         r"Field requirements by experiment type:(.+?)(?:\n\n|\Z)", text, re.DOTALL | re.IGNORECASE

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -76,3 +76,103 @@ def test_plan_experiment_layout_includes_taskfile() -> None:
         "plan-experiment/SKILL.md Experiment Directory Layout must include Taskfile.yml "
         "with standardized build-env / run-experiment / test tasks"
     )
+
+
+def test_experiment_type_enum_lists_all_registry_types() -> None:
+    """All 12 experiment types from the registry appear in the template enum."""
+    import re
+
+    EXPERIMENT_TYPES_DIR = (
+        Path(__file__).resolve().parent.parent.parent
+        / "src"
+        / "autoskillit"
+        / "recipes"
+        / "experiment-types"
+    )
+    registry_types = {p.stem for p in EXPERIMENT_TYPES_DIR.glob("*.yaml")}
+    text = SKILL_PATH.read_text()
+    m = re.search(r"experiment_type:\s*\{one of:\s*([^}]+)\}", text, re.IGNORECASE)
+    assert m, "experiment_type enum not found in SKILL.md template"
+    enum_str = m.group(1)
+    enum_types = {t.strip() for t in enum_str.split(",")}
+    missing = registry_types - enum_types
+    assert not missing, f"experiment_type enum missing registry types: {missing}"
+
+
+def test_source_type_enum_includes_literature_and_database() -> None:
+    """source_type enum includes literature and database values."""
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(r"source_type:\s*synthetic\s*#\s*([^\n]+)", text, re.IGNORECASE)
+    assert m, "source_type enum comment not found in SKILL.md"
+    comment = m.group(1)
+    assert "literature" in comment, "source_type enum missing 'literature'"
+    assert "database" in comment, "source_type enum missing 'database'"
+
+
+def test_field_requirements_table_covers_all_registry_types() -> None:
+    """Field requirements table has a column for every registry experiment type."""
+    import re
+
+    EXPERIMENT_TYPES_DIR = (
+        Path(__file__).resolve().parent.parent.parent
+        / "src"
+        / "autoskillit"
+        / "recipes"
+        / "experiment-types"
+    )
+    registry_types = {p.stem for p in EXPERIMENT_TYPES_DIR.glob("*.yaml")}
+    text = SKILL_PATH.read_text()
+    m = re.search(
+        r"Field requirements by experiment type:(.+?)(?:\n\n|\Z)", text, re.DOTALL | re.IGNORECASE
+    )
+    assert m, "Field requirements table not found in SKILL.md"
+    table_block = m.group(1)
+    header_line = table_block.split("\n")[1]
+    col_tokens = [t.strip().rstrip("|") for t in header_line.split("|")]
+    col_tokens = [t for t in col_tokens if t]
+    abbrevs = {
+        "causal_inference": "causal_inf",
+        "configuration_study": "config_study",
+        "evidence_synthesis": "evid_synth",
+        "factorial_design": "fact_design",
+        "instrument_validation": "instr_valid",
+        "observational_correlational": "obs_corr",
+        "qualitative_interpretive": "qual_interp",
+        "robustness_audit": "robust_audit",
+        "simulation_modeling": "sim_model",
+        "single_subject": "single_subj",
+    }
+    covered = set(col_tokens[1:])
+    missing = []
+    for rtype in registry_types:
+        abbrev = abbrevs.get(rtype, rtype)
+        if abbrev not in covered:
+            missing.append(rtype)
+    assert not missing, f"Field requirements table missing columns for: {missing}"
+
+
+def test_v3_exempts_qualitative_interpretive() -> None:
+    """V3 exempts qualitative_interpretive from statistical_plan requirement."""
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(r"V3:\s*([^\n]+)", text)
+    assert m, "V3 rule not found in SKILL.md"
+    v3_line = m.group(1)
+    assert "qualitative" in v3_line.lower(), (
+        "V3 rule must exempt qualitative_interpretive from statistical_plan requirement"
+    )
+
+
+def test_v9_mentions_literature_and_database_source_types() -> None:
+    """V9 rule text mentions both literature and database source types."""
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
+    assert m, "V9 rule not found in SKILL.md"
+    v9_block = m.group(0)
+    assert "literature" in v9_block.lower(), "V9 must mention literature source type"
+    assert "database" in v9_block.lower(), "V9 must mention database source type"

--- a/tests/skills/test_plan_experiment_schema_contracts.py
+++ b/tests/skills/test_plan_experiment_schema_contracts.py
@@ -55,9 +55,9 @@ def test_plan_experiment_documents_all_required_frontmatter_fields():
 
 
 def test_plan_experiment_defines_all_validation_rules():
-    """plan-experiment/SKILL.md must define all 8 validation rules V1–V8 as labeled entries."""
+    """plan-experiment/SKILL.md must define all 9 validation rules V1–V9 as labeled entries."""
     content = _read_skill_md("plan-experiment")
-    for rule_id in ["V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8"]:
+    for rule_id in ["V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9"]:
         assert f"{rule_id}:" in content, (
             f"plan-experiment/SKILL.md missing validation rule label {rule_id!r} "
             f"(expected '{rule_id}:' definition format)"


### PR DESCRIPTION
## Summary

The plan-experiment SKILL.md has four structural defects that prevent the agent from selecting appropriate experiment types for broad research questions.

## Requirements

**From issue #2334 (with correction applied):**

The original fix request sought to:
- Make V9 a WARNING for `exploratory` experiments, or add `source_type: literature | database` that doesn't require `acquisition` commands
- Add new experiment_type(s) like `comparative_survey` with relaxed field requirements

**Correction from issue:** The `experiment_type` enum actually has 12 types, not 5. The SKILL.md template comment listing only 5 types is stale. The full registry includes `evidence_synthesis` and `qualitative_interpretive` which may already be suitable.

**Updated scope:**
1. Fix the stale SKILL.md template comment to enumerate all 12 types
2. Evaluate whether existing types (especially `evidence_synthesis`) have appropriate validation rules for broad research questions
3. Only add new types if existing ones are genuinely insufficient after evaluation

**Implementation steps in plan:**
- Update experiment_type enum comment (5 → 12 types)
- Add `literature` and `database` to source_type enum (4 → 6 types)
- Expand field requirements table (5 → 12 columns)
- Modify V3 to exempt `qualitative_interpretive`
- Modify V9 to handle `literature` and `database` source types with relaxed requirements
- Update V1 and V2 to reference new experiment types
- Add 5 new contract tests + update 1 existing test

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-081809-322389/.autoskillit/temp/make-plan/plan_experiment_relax_v9_plan_2026-05-10_082600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.8k | 14.9k | 944.9k | 64.5k | 113 | 51.3k | 8m 59s |
| review | claude-sonnet-4-6 | 1 | 1.5k | 6.3k | 159.0k | 37.2k | 45 | 27.5k | 3m 29s |
| verify | claude-opus-4-6 | 1 | 42 | 7.7k | 1.3M | 69.7k | 73 | 56.8k | 5m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 681.3k | 8.9k | 802.0k | 28.7k | 81 | 48.9k | 3m 40s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 73.5k | 4.4k | 198.4k | 28.8k | 20 | 15.3k | 1m 38s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 51.9k | 2.6k | 198.4k | 28.7k | 15 | 15.2k | 56s |
| review_pr | claude-sonnet-4-6 | 3 | 545 | 58.7k | 1.4M | 65.0k | 99 | 138.3k | 14m 18s |
| resolve_review | claude-sonnet-4-6 | 1 | 303 | 19.6k | 2.1M | 94.8k | 99 | 82.6k | 9m 27s |
| **Total** | | | 810.9k | 123.3k | 7.1M | 94.8k | | 435.8k | 47m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 155 | 5174.4 | 315.3 | 57.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 27 | 76460.8 | 3058.7 | 727.7 |
| **Total** | **182** | 38915.5 | 2394.4 | 677.3 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 3.5k | 31.1k | 2.0M | 126.4k | 17m 0s |
| claude-opus-4-6 | 1 | 42 | 7.7k | 1.3M | 56.8k | 5m 8s |
| MiniMax-M2.7-highspeed | 3 | 806.7k | 15.9k | 1.2M | 79.3k | 6m 14s |