### PR TITLE
[FIX] Disable Import Removal in ruff --fix (lint_after_edit_hook)

### DIFF
--- a/src/autoskillit/hooks/lint_after_edit_hook.py
+++ b/src/autoskillit/hooks/lint_after_edit_hook.py
@@ -74,7 +74,7 @@ def main() -> None:
 
     try:
         subprocess.run(
-            [ruff_cmd, "check", "--fix", file_path],
+            [ruff_cmd, "check", "--fix", "--ignore", "F4", file_path],
             capture_output=True,
             text=True,
             timeout=_TIMEOUT_S,

--- a/tests/hooks/test_lint_after_edit_hook.py
+++ b/tests/hooks/test_lint_after_edit_hook.py
@@ -238,6 +238,20 @@ class TestLintBehavior:
         assert LINT_AUTOFIX_TRIGGER in updated
         assert "re-read" in updated.lower()
 
+    def test_unused_import_not_removed(self, tmp_path, monkeypatch):
+        """F401 (unused import) must NOT be auto-fixed — import may be used in a later edit."""
+        f = tmp_path / "staged_import.py"
+        f.write_text("import asyncio\n\nx = 1\n")
+        out, code = _run_hook(
+            _build_event("Edit", str(f)),
+            headless=True,
+            skill_name="implement-worktree",
+            monkeypatch=monkeypatch,
+        )
+        assert code == 0
+        # The import must survive — ruff should NOT have removed it
+        assert "import asyncio" in f.read_text()
+
     def test_unfixable_error_reported(self, tmp_path, monkeypatch):
         f = tmp_path / "long_line.py"
         long_var = "a" * 200

--- a/tests/hooks/test_lint_after_edit_hook.py
+++ b/tests/hooks/test_lint_after_edit_hook.py
@@ -239,7 +239,7 @@ class TestLintBehavior:
         assert "re-read" in updated.lower()
 
     def test_unused_import_not_removed(self, tmp_path, monkeypatch):
-        """F401 (unused import) must NOT be auto-fixed — import may be used in a later edit."""
+        """F4xx import rules must NOT be auto-fixed — import may be used in a later edit."""
         f = tmp_path / "staged_import.py"
         f.write_text("import asyncio\n\nx = 1\n")
         out, code = _run_hook(


### PR DESCRIPTION
## Summary

Add `--ignore F4` to the `ruff check --fix` invocation in `lint_after_edit_hook.py` so that Pyflakes import-removal rules (F401 unused-import, F403 star-import, F811 redefinition) are never auto-fixed by the hook. This prevents the hook from removing imports that are added in one edit but consumed in a subsequent edit — the root cause of the 3-turn recovery loop observed in session 7ee05031.

## Requirements

## Problem

The `lint_after_edit_hook.py` PostToolUse hook runs `ruff check --fix` after every Edit/Write in headless sessions. This auto-fixes F401 (unused imports), which removes imports added in one edit before their usage is added in a subsequent edit.

In session 7ee05031 (#2332 resolve-review), the session added `import asyncio` in one Edit, the hook immediately removed it (F401), then the next Edit used `asyncio.CancelledError` — leaving the file with a missing import. This caused a 3-turn recovery loop (read → re-add import → re-run pre-commit).

## Proposed Change

Keep `ruff format` and `ruff check --fix` in the hook, but disable import-removal rules. Pass `--ignore F4` (or the broader F4 family) to the `ruff check --fix` invocation so ruff never removes imports automatically. Import cleanup should remain a pre-commit concern only, where the full file state is finalized.

The hook should still auto-fix basic formatting and safe lint fixes — just never removal of code.

## Evidence

- `src/autoskillit/hooks/lint_after_edit_hook.py` — runs `ruff check --fix` without rule exclusions
- Session 7ee05031: `import asyncio` added at L427, removed by hook, re-added at L456 after read-back at L452
- L432 hook notification warned about modification but session proceeded without verifying imports survived

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-103326-315772/.autoskillit/temp/make-plan/lint_after_edit_hook_disable_import_removal_plan_2026-05-10_103600.md`

Closes #2356

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 67 | 4.2k | 429.5k | 46.2k | 44 | 48.5k | 2m 37s |
| verify | claude-opus-4-6 | 1 | 26 | 2.5k | 250.2k | 41.6k | 27 | 28.6k | 2m 35s |
| implement* | MiniMax-M2.7 | 1 | 51.7k | 2.9k | 648.6k | 0 | 36 | 0 | 5m 23s |
| prepare_pr* | MiniMax-M2.7 | 1 | 40.7k | 2.2k | 186.5k | 0 | 16 | 0 | 1m 23s |
| compose_pr* | MiniMax-M2.7 | 1 | 41.7k | 2.7k | 357.4k | 0 | 30 | 34.0k | 2m 55s |
| review_pr | claude-opus-4-6 | 3 | 211 | 30.0k | 1.1M | 46.9k | 80 | 97.9k | 9m 35s |
| resolve_review | claude-opus-4-6 | 3 | 120 | 17.3k | 1.6M | 56.3k | 87 | 113.9k | 10m 36s |
| **Total** | | | 134.5k | 62.0k | 4.6M | 56.3k | | 322.9k | 35m 8s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 16 | 40540.0 | 0.0 | 182.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 821700.0 | 56957.5 | 8662.5 |
| **Total** | **18** | 254026.4 | 17939.8 | 3442.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 132 | 9.3k | 1.0M | 99.5k | 7m 14s |
| MiniMax-M2.7 | 3 | 134.1k | 7.8k | 1.2M | 34.0k | 9m 42s |