### PR TITLE
Direction-Selection Gate Between Scope and Plan-Experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 135 bundled skills.
+tools and 136 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 52 MCP tools and 135 bundled skills.
+→ tests → PR → merge pipelines using 52 MCP tools and 136 bundled skills.
 
 ## Start here
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 135 bundled skills. Any new skill with an unguarded
+test that scans all 136 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 52 MCP tools and 135 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 52 MCP tools and 136 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
-The complete list of bundled skills (135 total: 3 in `src/autoskillit/skills/`,
-132 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+The complete list of bundled skills (136 total: 3 in `src/autoskillit/skills/`,
+133 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -33,7 +33,7 @@ Located under `src/autoskillit/skills_extended/`. Grouped by purpose:
 `process-issues`, `make-campaign`
 
 ### Experiment family
-`scope`, `plan-experiment`, `implement-experiment`, `run-experiment`,
+`scope`, `select-directions`, `plan-experiment`, `implement-experiment`, `run-experiment`,
 `generate-report`, `troubleshoot-experiment`
 
 ### Research and review

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 135 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 136 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -208,6 +208,7 @@ skills:
     - prepare-issue
     - process-issues
     - scope
+    - select-directions
     - plan-experiment
     - implement-experiment
     - run-experiment

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1267,6 +1267,26 @@ skills:
     - "scope_report = /tmp/scope_report.md\nscope_directions = /tmp/scope_directions.json\n%%ORDER_UP%%"
     write_behavior: always
 
+  select-directions:
+    inputs:
+    - name: scope_report_path
+      type: file_path
+      required: false
+    - name: scope_directions_path
+      type: file_path
+      required: true
+    - name: min_breadth
+      type: string
+      required: false
+    outputs:
+    - name: selected_directions
+      type: file_path
+    expected_output_patterns:
+    - "selected_directions\\s*=\\s*/.+"
+    pattern_examples:
+    - "selected_directions = /tmp/selected_directions.json\n%%ORDER_UP%%"
+    write_behavior: always
+
   plan-experiment:
     inputs:
     - name: scope_report_path

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1269,12 +1269,12 @@ skills:
 
   select-directions:
     inputs:
-    - name: scope_report_path
-      type: file_path
-      required: false
     - name: scope_directions_path
       type: file_path
       required: true
+    - name: scope_report_path
+      type: file_path
+      required: false
     - name: min_breadth
       type: string
       required: false

--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -61,7 +61,7 @@
       "default": "true"
     },
     "min_breadth": {
-      "description": "Minimum number of directions to select when scope reports 3 or more directions. Enforced by the select_directions step in the design phase.\n",
+      "description": "Minimum number of directions to select when scope reports 3 or more directions. Enforced by the select_directions step in the design phase. Set to 0 to disable breadth enforcement.\n",
       "default": "2"
     }
   },

--- a/src/autoskillit/recipes/campaigns/research-campaign.json
+++ b/src/autoskillit/recipes/campaigns/research-campaign.json
@@ -59,6 +59,10 @@
     "audit": {
       "description": "When 'true' (the default), run audit-impl after phase iteration to verify all decomposed phases have corresponding implementation commits. Catches silent group abandonment when context_limit fires mid-iteration.\n",
       "default": "true"
+    },
+    "min_breadth": {
+      "description": "Minimum number of directions to select when scope reports 3 or more directions. Enforced by the select_directions step in the design phase.\n",
+      "default": "2"
     }
   },
   "dispatches": [
@@ -71,7 +75,8 @@
         "issue_url": "${{ inputs.issue_url }}",
         "source_dir": "${{ inputs.source_dir }}",
         "base_branch": "${{ inputs.base_branch }}",
-        "review_design": "${{ inputs.review_design }}"
+        "review_design": "${{ inputs.review_design }}",
+        "min_breadth": "${{ inputs.min_breadth }}"
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}",
@@ -80,6 +85,7 @@
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
         "scope_report": "${{ result.scope_report }}",
         "scope_directions": "${{ result.scope_directions }}",
+        "selected_directions": "${{ result.selected_directions }}",
         "experiment_type": "${{ result.experiment_type }}"
       },
       "depends_on": []

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -70,6 +70,11 @@ ingredients:
       all decomposed phases have corresponding implementation commits.
       Catches silent group abandonment when context_limit fires mid-iteration.
     default: "true"
+  min_breadth:
+    description: >
+      Minimum number of directions to select when scope reports 3 or more directions.
+      Enforced by the select_directions step in the design phase.
+    default: "2"
 
 dispatches:
   - name: run-design
@@ -81,6 +86,7 @@ dispatches:
       source_dir: "${{ inputs.source_dir }}"
       base_branch: "${{ inputs.base_branch }}"
       review_design: "${{ inputs.review_design }}"
+      min_breadth: "${{ inputs.min_breadth }}"
     capture:
       worktree_path: "${{ result.worktree_path }}"
       research_dir_rel: "${{ result.research_dir_rel }}"
@@ -88,6 +94,7 @@ dispatches:
       visualization_plan_path: "${{ result.visualization_plan_path }}"
       scope_report: "${{ result.scope_report }}"
       scope_directions: "${{ result.scope_directions }}"
+      selected_directions: "${{ result.selected_directions }}"
       experiment_type: "${{ result.experiment_type }}"
     depends_on: []
 

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -74,6 +74,7 @@ ingredients:
     description: >
       Minimum number of directions to select when scope reports 3 or more directions.
       Enforced by the select_directions step in the design phase.
+      Set to 0 to disable breadth enforcement.
     default: "2"
 
 dispatches:

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -31,6 +31,10 @@
     "issue_url": {
       "description": "Optional URL to an existing GitHub issue describing the research goal. Provided as context to scope and plan_experiment.\n",
       "required": false
+    },
+    "min_breadth": {
+      "description": "Minimum number of directions to select when scope reports 3 or more directions. Enforced by the select_directions step. Set to 0 to disable breadth enforcement.\n",
+      "default": "2"
     }
   },
   "kitchen_rules": [
@@ -50,6 +54,20 @@
         "scope_report": "${{ result.scope_report }}",
         "scope_directions": "${{ result.scope_directions }}"
       },
+      "on_success": "select_directions",
+      "on_failure": "escalate_stop"
+    },
+    "select_directions": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:select-directions ${{ context.scope_directions }} ${{ context.scope_report }} ${{ inputs.min_breadth }}",
+        "cwd": "${{ inputs.source_dir }}",
+        "step_name": "select_directions"
+      },
+      "capture": {
+        "selected_directions": "${{ result.selected_directions }}"
+      },
       "on_success": "plan_experiment",
       "on_failure": "escalate_stop"
     },
@@ -57,13 +75,13 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.scope_directions }} ${{ context.revision_guidance }}",
+        "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.selected_directions }} ${{ context.revision_guidance }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_experiment"
       },
       "optional_context_refs": [
         "revision_guidance",
-        "scope_directions"
+        "selected_directions"
       ],
       "capture": {
         "experiment_plan": "${{ result.experiment_plan }}"
@@ -217,7 +235,7 @@
     },
     "design_complete": {
       "action": "stop",
-      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, scope_directions=<context.scope_directions>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=${{ context.worktree_path }}, research_dir=${{ context.research_dir }}, research_dir_rel=${{ context.research_dir_rel }}. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"scope_directions\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\", \"research_dir_rel\": \"<rel>\"}"
+      "message": "Design phase complete. Emit the L3 result sentinel JSON block now. The sentinel must include the following fields from captured context: success=true, scope_report=<context.scope_report>, scope_directions=<context.scope_directions>, selected_directions=<context.selected_directions>, experiment_plan=<context.experiment_plan>, visualization_plan_path=<context.visualization_plan_path>, report_plan_path=<context.report_plan_path>, experiment_type=<context.experiment_type>, worktree_path=${{ context.worktree_path }}, research_dir=${{ context.research_dir }}, research_dir_rel=${{ context.research_dir_rel }}. Example sentinel: {\"success\": true, \"scope_report\": \"<path>\", \"scope_directions\": \"<path>\", \"selected_directions\": \"<path>\", \"experiment_plan\": \"<path>\", \"visualization_plan_path\": \"<path>\", \"report_plan_path\": \"<path>\", \"experiment_type\": \"benchmark\", \"worktree_path\": \"<path>\", \"research_dir\": \"<path>\", \"research_dir_rel\": \"<rel>\"}"
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -36,6 +36,11 @@ ingredients:
       Optional URL to an existing GitHub issue describing the research goal.
       Provided as context to scope and plan_experiment.
     required: false
+  min_breadth:
+    description: >
+      Minimum number of directions to select when scope reports 3 or more directions.
+      Enforced by the select_directions step. Set to 0 to disable breadth enforcement.
+    default: "2"
 
 kitchen_rules:
   - >
@@ -58,6 +63,18 @@ steps:
     capture:
       scope_report: "${{ result.scope_report }}"
       scope_directions: "${{ result.scope_directions }}"
+    on_success: select_directions
+    on_failure: escalate_stop
+
+  select_directions:
+    tool: run_skill
+    model: ""
+    with:
+      skill_command: "/autoskillit:select-directions ${{ context.scope_directions }} ${{ context.scope_report }} ${{ inputs.min_breadth }}"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: select_directions
+    capture:
+      selected_directions: "${{ result.selected_directions }}"
     on_success: plan_experiment
     on_failure: escalate_stop
 
@@ -65,10 +82,10 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.scope_directions }} ${{ context.revision_guidance }}"
+      skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.selected_directions }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: plan_experiment
-    optional_context_refs: [revision_guidance, scope_directions]
+    optional_context_refs: [revision_guidance, selected_directions]
     capture:
       experiment_plan: "${{ result.experiment_plan }}"
     on_success: review_design
@@ -197,6 +214,7 @@ steps:
       The sentinel must include the following fields from captured context:
       success=true, scope_report=<context.scope_report>,
       scope_directions=<context.scope_directions>,
+      selected_directions=<context.selected_directions>,
       experiment_plan=<context.experiment_plan>,
       visualization_plan_path=<context.visualization_plan_path>,
       report_plan_path=<context.report_plan_path>,
@@ -206,10 +224,10 @@ steps:
       research_dir_rel=${{ context.research_dir_rel }}.
       Example sentinel:
       {"success": true, "scope_report": "<path>", "scope_directions": "<path>",
-      "experiment_plan": "<path>", "visualization_plan_path": "<path>",
-      "report_plan_path": "<path>", "experiment_type": "benchmark",
-      "worktree_path": "<path>", "research_dir": "<path>",
-      "research_dir_rel": "<rel>"}
+      "selected_directions": "<path>", "experiment_plan": "<path>",
+      "visualization_plan_path": "<path>", "report_plan_path": "<path>",
+      "experiment_type": "benchmark", "worktree_path": "<path>",
+      "research_dir": "<path>", "research_dir_rel": "<rel>"}
 
   escalate_stop:
     action: stop

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -50,6 +50,10 @@
     "audit": {
       "description": "When 'true' (the default), run audit-impl after phase iteration to verify all decomposed phases have corresponding implementation commits. Catches silent group abandonment when context_limit fires mid-iteration.\n",
       "default": "true"
+    },
+    "min_breadth": {
+      "description": "Minimum number of directions to select when scope reports 3 or more directions. Enforced by the select_directions step. Set to 0 to disable breadth enforcement.\n",
+      "default": "2"
     }
   },
   "kitchen_rules": [
@@ -77,6 +81,20 @@
         "scope_report": "${{ result.scope_report }}",
         "scope_directions": "${{ result.scope_directions }}"
       },
+      "on_success": "select_directions",
+      "on_failure": "escalate_stop"
+    },
+    "select_directions": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:select-directions ${{ context.scope_directions }} ${{ context.scope_report }} ${{ inputs.min_breadth }}",
+        "cwd": "${{ inputs.source_dir }}",
+        "step_name": "select_directions"
+      },
+      "capture": {
+        "selected_directions": "${{ result.selected_directions }}"
+      },
       "on_success": "plan_experiment",
       "on_failure": "escalate_stop"
     },
@@ -84,13 +102,13 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.scope_directions }} ${{ context.revision_guidance }}",
+        "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.selected_directions }} ${{ context.revision_guidance }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_experiment"
       },
       "optional_context_refs": [
         "revision_guidance",
-        "scope_directions"
+        "selected_directions"
       ],
       "capture": {
         "experiment_plan": "${{ result.experiment_plan }}"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -71,6 +71,11 @@ ingredients:
       all decomposed phases have corresponding implementation commits. Catches
       silent group abandonment when context_limit fires mid-iteration.
     default: "true"
+  min_breadth:
+    description: >
+      Minimum number of directions to select when scope reports 3 or more directions.
+      Enforced by the select_directions step. Set to 0 to disable breadth enforcement.
+    default: "2"
 
 kitchen_rules:
   - >
@@ -124,6 +129,18 @@ steps:
     capture:
       scope_report: "${{ result.scope_report }}"
       scope_directions: "${{ result.scope_directions }}"
+    on_success: select_directions
+    on_failure: escalate_stop
+
+  select_directions:
+    tool: run_skill
+    model: ""
+    with:
+      skill_command: "/autoskillit:select-directions ${{ context.scope_directions }} ${{ context.scope_report }} ${{ inputs.min_breadth }}"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: select_directions
+    capture:
+      selected_directions: "${{ result.selected_directions }}"
     on_success: plan_experiment
     on_failure: escalate_stop
 
@@ -131,10 +148,10 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.scope_directions }} ${{ context.revision_guidance }}"
+      skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.selected_directions }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: plan_experiment
-    optional_context_refs: [revision_guidance, scope_directions]
+    optional_context_refs: [revision_guidance, selected_directions]
     capture:
       experiment_plan: "${{ result.experiment_plan }}"
     on_success: review_design

--- a/src/autoskillit/skills_extended/select-directions/SKILL.md
+++ b/src/autoskillit/skills_extended/select-directions/SKILL.md
@@ -155,7 +155,8 @@ selected_directions = {absolute_path_to_json}
 ## Output Location
 
 ```
-{{AUTOSKILLIT_TEMP}}/select-directions/selected_directions_{topic}_{timestamp}.json (relative to the current working directory)
+{{AUTOSKILLIT_TEMP}}/select-directions/selected_directions_{topic}_{timestamp}.json
+({{AUTOSKILLIT_TEMP}} resolves to an absolute path, independent of the current working directory)
 ```
 
 ## Output Fields (for recipe capture)

--- a/src/autoskillit/skills_extended/select-directions/SKILL.md
+++ b/src/autoskillit/skills_extended/select-directions/SKILL.md
@@ -90,7 +90,7 @@ Validate:
 
 Auto-select using this algorithm:
 1. Select all `must_cover: true` directions (P0)
-2. If selected count < min_breadth AND direction_count ≥ 3, add P1 directions in order until threshold met
+2. If selected count < min_breadth AND direction_count ≥ 3, add P1 directions in order until threshold met (set `must_cover: true` on each P1 direction added)
 3. Emit justification: "Auto-selected {N} directions: all P0 ({list}) + {M} P1 ({list}) to meet min_breadth={min_breadth}"
 
 ### Step 5: Write Output JSON

--- a/src/autoskillit/skills_extended/select-directions/SKILL.md
+++ b/src/autoskillit/skills_extended/select-directions/SKILL.md
@@ -121,6 +121,15 @@ Write `selected_directions_{topic}_{timestamp}.json` with this structure:
       "source_type": "...",
       "feasibility_notes": "...",
       "selection_justification": "..."
+    },
+    {
+      "direction_id": "D2",
+      "title": "...",
+      "priority": "P1",
+      "must_cover": true,
+      "source_type": "...",
+      "feasibility_notes": "...",
+      "selection_justification": "selected to meet min_breadth threshold"
     }
   ],
   "dropped_directions": [

--- a/src/autoskillit/skills_extended/select-directions/SKILL.md
+++ b/src/autoskillit/skills_extended/select-directions/SKILL.md
@@ -108,7 +108,7 @@ Write `selected_directions_{topic}_{timestamp}.json` with this structure:
   "generated_at": "<from original manifest>",
   "selected_at": "<ISO-8601 timestamp>",
   "selection_mode": "interactive|headless",
-  "direction_count": <count of selected>,
+  "selected_direction_count": <count of selected>,
   "must_cover_count": <count of selected with must_cover=true>,
   "original_direction_count": <from original manifest>,
   "min_breadth_applied": <threshold used>,

--- a/src/autoskillit/skills_extended/select-directions/SKILL.md
+++ b/src/autoskillit/skills_extended/select-directions/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: select-directions
+categories: [research]
+description: >
+  Direction-selection gate: parse scope directions manifest, present for
+  selection (human or agent), enforce breadth, output filtered directions.
+hooks:
+  PreToolUse:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: "echo '[SKILL: select-directions] Starting direction selection gate...'"
+          once: true
+---
+
+# Select Directions Skill
+
+Direction-selection gate between scope and plan_experiment. Parses the structured
+directions manifest emitted by scope, presents directions for human selection (interactive)
+or auto-selects P0/must_cover directions (headless), enforces a configurable minimum
+breadth threshold, and outputs a filtered selected_directions JSON file.
+
+## When to Use
+
+- Immediately after `scope` and before `plan_experiment` in research.yaml and research-design.yaml
+- Invoked automatically by the recipe engine via `run_skill`
+
+## Critical Constraints
+
+**NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+- Bypass the direction selection step — every direction must be explicitly selected or dropped with justification
+- Modify the original `scope_directions` JSON file
+- Pass through silently if `scope_directions_path` is missing or unparseable — STOP with an error
+
+**ALWAYS:**
+- Preserve all must_cover: true directions regardless of selection mode
+- Output a valid selected_directions JSON file to `{{AUTOSKILLIT_TEMP}}/select-directions/`
+- Emit the `selected_directions = {absolute_path}` token at the end of output
+
+## Arguments
+
+`{scope_directions_path} [scope_report_path] [min_breadth]`
+
+- `scope_directions_path` (position 1, required): absolute path to the scope_directions JSON manifest
+- `scope_report_path` (position 2, optional): absolute path to scope_report.md for display context
+- `min_breadth` (position 3, optional): minimum directions to select when ≥3 available (default: "2")
+
+## Workflow
+
+### Step 1: Parse Inputs
+
+Read `scope_directions_path` (position 1) as JSON. Extract:
+- `research_question`
+- `generated_at`
+- `directions` array
+
+Parse `min_breadth` from position 3 arguments (default to "2" if not provided).
+
+### Step 2: Detect Mode
+
+Run:
+```bash
+echo "${AUTOSKILLIT_HEADLESS:-0}"
+```
+- `"1"` → headless mode (auto-select)
+- `"0"` or empty → interactive mode (AskUserQuestion)
+
+### Step 3: Format Directions Table
+
+Display all directions as a numbered table:
+
+```
+| # | ID | Title | Priority | Must Cover | Source Type | Feasibility |
+|---|----|----|---------|------------|-------------|-------------|
+| 1 | D1 | ... | P0 | yes | computational | ... |
+```
+
+### Step 4a: Interactive Mode — AskUserQuestion
+
+Use AskUserQuestion to ask:
+> "Select directions to pursue (comma-separated IDs, e.g. D1,D3). Minimum {min_breadth} required when {direction_count} directions are available."
+
+Validate:
+- All specified IDs exist in the manifest
+- Selection count ≥ min_breadth when direction_count ≥ 3
+- If validation fails, re-prompt once with error message
+
+### Step 4b: Headless Mode — Auto-select
+
+Auto-select using this algorithm:
+1. Select all `must_cover: true` directions (P0)
+2. If selected count < min_breadth AND direction_count ≥ 3, add P1 directions in order until threshold met
+3. Emit justification: "Auto-selected {N} directions: all P0 ({list}) + {M} P1 ({list}) to meet min_breadth={min_breadth}"
+
+### Step 5: Write Output JSON
+
+Ensure output directory exists:
+```bash
+mkdir -p "{{AUTOSKILLIT_TEMP}}/select-directions/"
+```
+
+Write `selected_directions_{topic}_{timestamp}.json` with this structure:
+
+```json
+{
+  "research_question": "<from original manifest>",
+  "generated_at": "<from original manifest>",
+  "selected_at": "<ISO-8601 timestamp>",
+  "selection_mode": "interactive|headless",
+  "direction_count": <count of selected>,
+  "must_cover_count": <count of selected with must_cover=true>,
+  "original_direction_count": <from original manifest>,
+  "min_breadth_applied": <threshold used>,
+  "directions": [
+    {
+      "direction_id": "D1",
+      "title": "...",
+      "priority": "P0",
+      "must_cover": true,
+      "source_type": "...",
+      "feasibility_notes": "...",
+      "selection_justification": "..."
+    }
+  ],
+  "dropped_directions": [
+    {
+      "direction_id": "D3",
+      "title": "...",
+      "drop_justification": "..."
+    }
+  ]
+}
+```
+
+Note: All selected directions have `must_cover: true` regardless of original priority —
+this enforces that `plan-experiment`'s breadth enforcement covers every selected direction.
+
+### Step 6: Emit Output Token
+
+Print as the final lines of output:
+```
+selected_directions = {absolute_path_to_json}
+```
+
+## Output Location
+
+```
+{{AUTOSKILLIT_TEMP}}/select-directions/selected_directions_{topic}_{timestamp}.json (relative to the current working directory)
+```
+
+## Output Fields (for recipe capture)
+
+- `selected_directions` — absolute path to the selected_directions JSON file

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -255,7 +255,7 @@ file-audit-issues, implement-experiment, implement-worktree, implement-worktree-
 make-campaign, make-experiment-diag, make-groups, make-plan, make-req, merge-pr, mermaid, migrate-recipes, open-integration-pr,
 open-kitchen, pipeline-summary, plan-experiment, plan-visualization, planner-analyze, planner-assess-review-approach, planner-consolidate-wps, planner-elaborate-assignments, planner-elaborate-phase, planner-elaborate-wps, planner-extract-domain, planner-generate-phases, planner-reconcile-deps, planner-refine, planner-refine-assignments, planner-refine-phases, planner-refine-wps, planner-validate-task-alignment, prepare-issue, prepare-pr, prepare-research-pr, process-issues, promote-to-main, rectify, reload-session, report-bug,
 resolve-claims-review, resolve-design-review, resolve-failures, resolve-merge-conflicts, resolve-research-review, resolve-review, retry-worktree, review-approach, review-design, review-pr, review-research-pr, run-experiment,
-scope, setup-environment, setup-project, smoke-task, stage-data, triage-issues, troubleshoot-experiment,
+scope, select-directions, setup-environment, setup-project, smoke-task, stage-data, triage-issues, troubleshoot-experiment,
 validate-audit, validate-review-decisions, validate-test-audit, verify-diag,
 vis-lens-always-on, vis-lens-antipattern, vis-lens-caption-annot, vis-lens-chart-select,
 vis-lens-color-access, vis-lens-methodology-norms, vis-lens-figure-table, vis-lens-multi-compare,

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -314,10 +314,10 @@ def test_docs_state_37_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 37)
 
 
-def test_skill_visibility_states_135_skills() -> None:
-    # 135 = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 132 extended.
-    # DefaultSkillResolver.list_all() returns 134 (excludes sous-chef from public surface).
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 135)
+def test_skill_visibility_states_136_skills() -> None:
+    # 136 = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 133 extended.
+    # DefaultSkillResolver.list_all() returns 135 (excludes sous-chef from public surface).
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 136)
 
 
 def test_safety_hooks_states_21_hooks() -> None:

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -544,6 +544,7 @@ class TestOutputPathTokensDerivedFromContracts:
             "revision_guidance",
             "scope_report",
             "scope_directions",
+            "selected_directions",
             "summary_path",
             "triage_manifest",
             "triage_report",

--- a/tests/recipe/test_bundled_recipes_research.py
+++ b/tests/recipe/test_bundled_recipes_research.py
@@ -477,5 +477,38 @@ class TestResearchRecipeStructure:
     def test_scope_captures_scope_directions(self, recipe) -> None:
         assert "scope_directions" in recipe.steps["scope"].capture
 
-    def test_plan_experiment_optional_context_refs_includes_scope_directions(self, recipe) -> None:
-        assert "scope_directions" in recipe.steps["plan_experiment"].optional_context_refs
+    # --- select_directions gate tests ---
+
+    def test_research_has_select_directions_step(self, recipe) -> None:
+        assert "select_directions" in recipe.steps
+
+    def test_scope_routes_to_select_directions(self, recipe) -> None:
+        assert recipe.steps["scope"].on_success == "select_directions"
+
+    def test_select_directions_routes_to_plan_experiment(self, recipe) -> None:
+        assert recipe.steps["select_directions"].on_success == "plan_experiment"
+
+    def test_select_directions_captures_selected_directions(self, recipe) -> None:
+        assert "selected_directions" in recipe.steps["select_directions"].capture
+
+    def test_select_directions_on_failure_routes_to_escalate(self, recipe) -> None:
+        assert recipe.steps["select_directions"].on_failure == "escalate_stop"
+
+    def test_plan_experiment_skill_command_uses_selected_directions(self, recipe) -> None:
+        cmd = recipe.steps["plan_experiment"].with_args.get("skill_command", "")
+        assert "selected_directions" in cmd
+
+    def test_plan_experiment_skill_command_no_longer_uses_scope_directions(self, recipe) -> None:
+        cmd = recipe.steps["plan_experiment"].with_args.get("skill_command", "")
+        assert "scope_directions" not in cmd
+
+    def test_research_has_min_breadth_ingredient(self, recipe) -> None:
+        assert "min_breadth" in recipe.ingredients
+        assert recipe.ingredients["min_breadth"].default == "2"
+        assert recipe.ingredients["min_breadth"].required is False
+
+    def test_plan_experiment_optional_context_refs_includes_selected_directions(
+        self, recipe
+    ) -> None:
+        assert "selected_directions" in recipe.steps["plan_experiment"].optional_context_refs
+        assert "scope_directions" not in recipe.steps["plan_experiment"].optional_context_refs

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -35,7 +35,7 @@ class TestResearchDesignRecipeStructure:
         assert recipe.requires_packs == ["research", "vis-lens"]
 
     def test_ingredient_count(self, recipe) -> None:
-        assert len(recipe.ingredients) == 5
+        assert len(recipe.ingredients) == 6
 
     def test_task_ingredient_required(self, recipe) -> None:
         assert "task" in recipe.ingredients
@@ -58,11 +58,12 @@ class TestResearchDesignRecipeStructure:
         assert recipe.ingredients["issue_url"].required is False
 
     def test_step_count(self, recipe) -> None:
-        assert len(recipe.steps) == 11
+        assert len(recipe.steps) == 12
 
     def test_step_names(self, recipe) -> None:
         expected = {
             "scope",
+            "select_directions",
             "plan_experiment",
             "review_design",
             "plan_visualization",
@@ -78,7 +79,7 @@ class TestResearchDesignRecipeStructure:
 
     def test_scope_routing(self, recipe) -> None:
         step = recipe.steps["scope"]
-        assert step.on_success == "plan_experiment"
+        assert step.on_success == "select_directions"
         assert step.on_failure == "escalate_stop"
 
     def test_scope_captures_scope_report(self, recipe) -> None:
@@ -97,7 +98,7 @@ class TestResearchDesignRecipeStructure:
 
     def test_plan_experiment_optional_context_refs(self, recipe) -> None:
         refs = recipe.steps["plan_experiment"].optional_context_refs
-        for field in ("revision_guidance", "scope_directions"):
+        for field in ("revision_guidance", "selected_directions"):
             assert field in refs, f"plan_experiment optional_context_refs must include: {field}"
 
     def test_review_design_skip_when_false(self, recipe) -> None:
@@ -228,6 +229,7 @@ class TestResearchDesignRecipeStructure:
         for field in (
             "scope_report",
             "scope_directions",
+            "selected_directions",
             "experiment_plan",
             "visualization_plan_path",
             "report_plan_path",
@@ -238,6 +240,28 @@ class TestResearchDesignRecipeStructure:
             assert field in message, (
                 f"design_complete message must mention sentinel field: {field}"
             )
+
+    def test_design_has_select_directions_step(self, recipe) -> None:
+        assert "select_directions" in recipe.steps
+
+    def test_design_scope_routes_to_select_directions(self, recipe) -> None:
+        assert recipe.steps["scope"].on_success == "select_directions"
+
+    def test_design_select_directions_routes_to_plan_experiment(self, recipe) -> None:
+        assert recipe.steps["select_directions"].on_success == "plan_experiment"
+
+    def test_design_select_directions_captures_selected_directions(self, recipe) -> None:
+        assert "selected_directions" in recipe.steps["select_directions"].capture
+
+    def test_design_complete_sentinel_includes_selected_directions(self, recipe) -> None:
+        msg = recipe.steps["design_complete"].message
+        assert re.search(r"selected_directions\s*=\s*<context\.selected_directions>", msg), (
+            "design_complete message must reference selected_directions via template syntax"
+        )
+
+    def test_design_has_min_breadth_ingredient(self, recipe) -> None:
+        assert "min_breadth" in recipe.ingredients
+        assert recipe.ingredients["min_breadth"].default == "2"
 
     def test_design_complete_sentinel_includes_scope_directions(self, recipe) -> None:
         msg = recipe.steps["design_complete"].message

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -416,6 +416,7 @@ def test_research_campaign_run_design_capture():
         "visualization_plan_path",
         "scope_report",
         "scope_directions",
+        "selected_directions",
         "experiment_type",
     }
     for key, val in d.capture.items():

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -693,6 +693,7 @@ ALWAYS_WRITE_SKILLS = {
     "review-design",
     "run-experiment",
     "scope",
+    "select-directions",
     "setup-environment",
     "stage-data",
     "troubleshoot-experiment",

--- a/tests/recipe/test_research_campaign_structure.py
+++ b/tests/recipe/test_research_campaign_structure.py
@@ -119,8 +119,15 @@ def test_run_design_capture_keys(recipe: Recipe) -> None:
         "visualization_plan_path",
         "scope_report",
         "scope_directions",
+        "selected_directions",
         "experiment_type",
     }
+
+
+def test_campaign_design_captures_selected_directions(recipe: Recipe) -> None:
+    d = _dispatch_by_name(recipe, "run-design")
+    assert d is not None
+    assert "selected_directions" in d.capture
 
 
 def test_run_implement_has_non_empty_capture(recipe: Recipe) -> None:

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -276,6 +276,7 @@ def test_output_path_tokens_synchronized() -> None:
             # run-experiment group manifest output (multi-group awareness)
             "group_manifest",
             "download_report",
+            "selected_directions",
         }
     )
 


### PR DESCRIPTION
## Summary

Insert a `select_directions` recipe step between `scope` and `plan_experiment` in `research.yaml`, `research-design.yaml`, and `campaigns/research-campaign.yaml`. The step is powered by a new `select-directions` skill that reads the structured directions manifest emitted by scope (commit 686791be), presents directions for human selection (interactive) or auto-selects P0/must_cover directions with justification (headless), enforces a configurable minimum breadth threshold, and outputs a filtered `selected_directions` JSON file that replaces `scope_directions` as the input to `plan-experiment`. This eliminates autonomous direction picking by plan-experiment — the agent can no longer silently ignore directions.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-103511-449921/.autoskillit/temp/make-plan/direction_selection_gate_plan_2026-05-10_103800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 78 | 18.4k | 750.0k | 115.9k | 173 | 73.2k | 14m 54s |
| verify | claude-opus-4-6 | 1 | 2.7k | 13.4k | 2.9M | 102.2k | 132 | 95.6k | 9m 1s |
| implement* | MiniMax-M2.7-highspeed | 1 | 6.7M | 28.2k | 2.9M | 34.0k | 301 | 187.8k | 23m 14s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 90.1k | 3.5k | 201.3k | 28.8k | 20 | 41.3k | 1m 14s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 54.7k | 1.3k | 227.1k | 28.8k | 16 | 15.2k | 38s |
| review_pr | claude-sonnet-4-6 | 3 | 292 | 98.4k | 1.6M | 88.8k | 112 | 218.7k | 22m 54s |
| resolve_review | claude-sonnet-4-6 | 2 | 566 | 39.6k | 4.0M | 84.5k | 222 | 129.1k | 26m 35s |
| **Total** | | | 6.9M | 202.9k | 12.5M | 115.9k | | 760.8k | 1h 38m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 238 | 12100.4 | 789.1 | 118.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 25 | 158957.8 | 5162.2 | 1585.8 |
| **Total** | **263** | 47617.2 | 2892.7 | 771.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 244 | 23.0k | 1.5M | 113.6k | 23m 58s |
| claude-opus-4-6 | 1 | 2.7k | 13.4k | 2.9M | 95.6k | 9m 1s |
| MiniMax-M2.7-highspeed | 3 | 6.9M | 33.1k | 3.3M | 244.3k | 25m 6s |