### PR TITLE
Remove AskUserQuestion from campaign ingredient collection — use free-form conversation

### DIFF
--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -212,8 +212,8 @@ Do NOT re-dispatch from the full original issue list.
         _ing_section = (
             "\n## RECIPE INGREDIENTS — USE THESE EXACT NAMES\n\n"
             f"{ingredients_table}\n\n"
-            "Before dispatching, collect values for all required ingredients from the user "
-            "via AskUserQuestion. Do not dispatch until all required values are confirmed.\n"
+            "Before dispatching, ask the user conversationally for all required "
+            "ingredient values. Do not dispatch until all required values are confirmed.\n"
         )
 
     _first_action_section = ""
@@ -224,7 +224,7 @@ Do NOT re-dispatch from the full original issue list.
         _first_action_section = (
             "\nFIRST ACTION — before asking for any inputs:\n\n"
             f"1. {_display}\n\n"
-            "2. Collect ingredient values via AskUserQuestion.\n\n"
+            "2. Ask for required ingredient values and wait for the user's response.\n\n"
             "3. Proceed only after all required ingredient values are confirmed.\n"
         )
 

--- a/tests/cli/test_l3_orchestrator_prompt.py
+++ b/tests/cli/test_l3_orchestrator_prompt.py
@@ -480,9 +480,26 @@ class TestK15IngredientsTableInjection:
         prompt = _build(ingredients_table=None)
         assert "RECIPE INGREDIENTS" not in prompt
 
-    def test_ask_user_question_instruction_present(self) -> None:
+    def test_conversational_collection_instruction_present(self) -> None:
         prompt = _build(ingredients_table=self._TABLE)
-        assert "AskUserQuestion" in prompt
+        ing_start = prompt.index("RECIPE INGREDIENTS")
+        ing_end = (
+            prompt.index("FIRST ACTION")
+            if "FIRST ACTION" in prompt
+            else prompt.index("DISPATCH MANIFEST")
+        )
+        section = prompt[ing_start:ing_end]
+        assert "conversationally" in section
+        assert "AskUserQuestion" not in section
+
+    def test_no_ask_user_question_without_gate_dispatches(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        # Gate dispatches use AskUserQuestion; no gate dispatches should mean
+        # no AskUserQuestion in the ingredient/FIRST ACTION sections
+        ing_start = prompt.index("RECIPE INGREDIENTS")
+        ing_end = prompt.index("DISPATCH MANIFEST")
+        ingredient_and_first_action = prompt[ing_start:ing_end]
+        assert "AskUserQuestion" not in ingredient_and_first_action
 
     def test_ingredients_section_between_overview_and_manifest(self) -> None:
         prompt = _build(ingredients_table=self._TABLE)
@@ -530,12 +547,13 @@ class TestK16IngredientDisplayFirstAction:
         prompt = _build(ingredients_table=self._TABLE)
         assert prompt.index("FIRST ACTION") < prompt.index("DISPATCH MANIFEST")
 
-    def test_first_action_instructs_ask_user_question(self) -> None:
+    def test_first_action_instructs_conversational_collection(self) -> None:
         prompt = _build(ingredients_table=self._TABLE)
         first_action_idx = prompt.index("FIRST ACTION")
         dispatch_manifest_idx = prompt.index("DISPATCH MANIFEST")
         section = prompt[first_action_idx:dispatch_manifest_idx]
-        assert "AskUserQuestion" in section
+        assert "AskUserQuestion" not in section
+        assert "wait for the user" in section
 
 
 class TestResumeReasonInPrompt:

--- a/tests/cli/test_l3_orchestrator_prompt.py
+++ b/tests/cli/test_l3_orchestrator_prompt.py
@@ -494,10 +494,14 @@ class TestK15IngredientsTableInjection:
 
     def test_no_ask_user_question_without_gate_dispatches(self) -> None:
         prompt = _build(ingredients_table=self._TABLE)
-        # Gate dispatches use AskUserQuestion; no gate dispatches should mean
-        # no AskUserQuestion in the ingredient/FIRST ACTION sections
+        # Slice covers both the ingredient section and the FIRST ACTION section.
+        # Gate dispatches (which reference AskUserQuestion) appear in the DISPATCH
+        # MANIFEST section, outside this slice — so the assertion verifies no
+        # AskUserQuestion leaks into the pre-dispatch portion of the prompt.
         ing_start = prompt.index("RECIPE INGREDIENTS")
-        ing_end = prompt.index("DISPATCH MANIFEST")
+        ing_end = (
+            prompt.index("DISPATCH MANIFEST") if "DISPATCH MANIFEST" in prompt else len(prompt)
+        )
         ingredient_and_first_action = prompt[ing_start:ing_end]
         assert "AskUserQuestion" not in ingredient_and_first_action
 


### PR DESCRIPTION
## Summary

Replace `AskUserQuestion` tool calls with free-form conversational prompting for campaign ingredient collection. `AskUserQuestion` is a structured multiple-choice tool (requires `questions[]` array with `header`, `options`, `multiSelect`) that is architecturally unsuitable for collecting free-text values like file paths and research questions. The model guesses the parameter schema wrong, Claude Code's validator rejects it, and the session terminates with "User declined to answer questions."

**Scope of change:** Only the ingredient collection flow in the campaign prompt is affected. `AskUserQuestion` remains correct and necessary for:
- **Gate dispatches** (campaign prompt) — yes/no confirmation, which fits the multiple-choice format
- **Confirm steps** (orchestrator prompt) — same yes/no pattern
- **`--tools AskUserQuestion`** in `_session_launch.py` — still needed for the above use cases

Closes #2363

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-135022-607397/.autoskillit/temp/make-plan/remove_askuserquestion_campaign_ingredients_plan_2026-05-10_140600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.2k | 10.3k | 821.0k | 67.1k | 99 | 70.6k | 8m 28s |
| verify | claude-opus-4-6 | 1 | 31 | 4.5k | 495.3k | 49.4k | 47 | 36.3k | 2m 48s |
| implement* | MiniMax-M2.7-highspeed | 1 | 599.6k | 6.7k | 953.9k | 34.1k | 70 | 69.9k | 6m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 74.0k | 3.4k | 227.1k | 28.7k | 18 | 15.4k | 1m 26s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 81.6k | 2.8k | 255.9k | 28.7k | 22 | 15.2k | 1m 5s |
| review_pr | claude-sonnet-4-6 | 3 | 268 | 28.6k | 1.0M | 46.0k | 92 | 108.9k | 7m 48s |
| resolve_review | claude-sonnet-4-6 | 1 | 169 | 10.7k | 928.7k | 60.5k | 52 | 47.8k | 10m 16s |
| **Total** | | | 758.9k | 67.0k | 4.7M | 67.1k | | 364.0k | 38m 10s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 32 | 29810.2 | 2183.6 | 210.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 92867.2 | 4776.0 | 1069.7 |
| **Total** | **42** | 112634.8 | 8665.9 | 1595.7 |