### PR TITLE
Thread capture param through fleet prompt builder + Section 8 injection + tests

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -633,6 +633,7 @@ async def _run_dispatch(
         dispatch_id=dispatch_id,
         campaign_id=campaign_id,
         l3_timeout_sec=timeout_sec or 1800,
+        capture={k: e.from_ for k, e in capture.items()} if capture else None,
     )
 
     if tool_ctx.executor is None:

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -57,6 +57,7 @@ def _build_food_truck_prompt(
     dispatch_id: str,
     campaign_id: str,
     l3_timeout_sec: int,
+    capture: dict[str, str] | None = None,
 ) -> str:
     """Build the system prompt for an L2 food truck headless session.
 
@@ -65,12 +66,25 @@ def _build_food_truck_prompt(
     filtered sous-chef discipline, headless directives, routing/predicates,
     budget guidance, quota awareness, campaign task, ingredient values,
     and a sentinel-anchored result contract.
+
+    ``capture`` is an optional mapping of captured field names to their
+    descriptions, used to inject additional fields into the Section 8
+    sentinel format block.
     """
     dispatch_id_short = dispatch_id[:8]
     ingredients_json = json.dumps(ingredients)
     ingredients_pretty_json = json.dumps(ingredients, indent=2)
 
     admiral_block = _build_admiral_dispatch_block()
+
+    extra_fields_example = (
+        ", " + ", ".join(f'"capture_{k}": "<{k}_value>"' for k in capture) if capture else ""
+    )
+    extra_fields_docs = (
+        "\n" + "\n".join(f"- capture_{k}: captured value for {k}" for k in capture)
+        if capture
+        else ""
+    )
 
     return f"""\
 You are an L2 food truck orchestrator. Execute the recipe '{recipe}' autonomously.
@@ -262,7 +276,8 @@ as your final output. No other text after the sentinel.
 
 ```
 ---l3-result::{dispatch_id}---
-{{"success": <true|false>, "reason": "<completion_reason>", "summary": "<one_line_summary>"}}
+{{"success": <true|false>, "reason": "<completion_reason>", "summary": "<one_line_summary>"
+{extra_fields_example}}}
 ---end-l3-result::{dispatch_id}---
 %%L3_DONE::{dispatch_id_short}%%
 ```
@@ -271,7 +286,7 @@ Fields:
 - success: true if all mandatory steps completed without unresolved failures
 - reason: "completed", "failed", "quota_exhausted", "timeout",
   "open_kitchen_failed", "missing_on_failure"
-- summary: One-line description of what happened
+- summary: One-line description of what happened{extra_fields_docs}
 
 The sentinel markers ---l3-result::{dispatch_id}--- and ---end-l3-result::{dispatch_id}---
 are parsed by the fleet dispatcher. The %%L3_DONE::{dispatch_id_short}%% marker

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -80,6 +80,10 @@ def _build_food_truck_prompt(
     extra_fields_example = (
         ", " + ", ".join(f'"capture_{k}": "<{k}_value>"' for k in capture) if capture else ""
     )
+    sentinel_json_example = (
+        '{"success": <true|false>, "reason": "<completion_reason>",'
+        ' "summary": "<one_line_summary>"' + extra_fields_example + "}"
+    )
     extra_fields_docs = (
         "\n" + "\n".join(f"- capture_{k}: {v}" for k, v in capture.items()) if capture else ""
     )
@@ -274,8 +278,7 @@ as your final output. No other text after the sentinel.
 
 ```
 ---l3-result::{dispatch_id}---
-{{"success": <true|false>, "reason": "<completion_reason>", "summary": "<one_line_summary>"
-{extra_fields_example}}}
+{sentinel_json_example}
 ---end-l3-result::{dispatch_id}---
 %%L3_DONE::{dispatch_id_short}%%
 ```

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -81,9 +81,7 @@ def _build_food_truck_prompt(
         ", " + ", ".join(f'"capture_{k}": "<{k}_value>"' for k in capture) if capture else ""
     )
     extra_fields_docs = (
-        "\n" + "\n".join(f"- capture_{k}: captured value for {k}" for k in capture)
-        if capture
-        else ""
+        "\n" + "\n".join(f"- capture_{k}: {v}" for k, v in capture.items()) if capture else ""
     )
 
     return f"""\

--- a/tests/cli/test_food_truck_prompt.py
+++ b/tests/cli/test_food_truck_prompt.py
@@ -232,8 +232,8 @@ class TestSentinelFormat:
     @pytest.mark.parametrize(
         "capture_arg",
         [
-            {"worktree_path": "/repo"},
-            {"worktree_path": "/repo", "pr_url": "https://github.com/org/repo/pull/1"},
+            {"worktree_path": "${{ result.worktree_path }}"},
+            {"worktree_path": "${{ result.worktree_path }}", "pr_url": "${{ result.pr_url }}"},
         ],
         ids=["1-key", "2-key"],
     )
@@ -251,8 +251,9 @@ class TestSentinelFormat:
             capture=capture_arg,
         )
         section8 = prompt[prompt.index("--- SECTION 8") :]
-        for key in capture_arg:
+        for key, description in capture_arg.items():
             assert f"capture_{key}" in section8
+            assert description in section8
         assert '"success"' in section8
         assert '"reason"' in section8
 

--- a/tests/cli/test_food_truck_prompt.py
+++ b/tests/cli/test_food_truck_prompt.py
@@ -229,6 +229,52 @@ class TestSentinelFormat:
         assert '"success"' in prompt
         assert '"reason"' in prompt
 
+    @pytest.mark.parametrize(
+        "capture_arg",
+        [
+            {"worktree_path": "/repo"},
+            {"worktree_path": "/repo", "pr_url": "https://github.com/org/repo/pull/1"},
+        ],
+        ids=["1-key", "2-key"],
+    )
+    def test_sentinel_capture_fields_injected(self, capture_arg: dict[str, str]) -> None:
+        from autoskillit.fleet._prompts import _build_food_truck_prompt
+
+        prompt = _build_food_truck_prompt(
+            recipe=_RECIPE,
+            task=_TASK,
+            ingredients=_INGREDIENTS,
+            mcp_prefix=_MCP_PREFIX,
+            dispatch_id=_DISPATCH_ID,
+            campaign_id=_CAMPAIGN_ID,
+            l3_timeout_sec=_L3_TIMEOUT,
+            capture=capture_arg,
+        )
+        section8 = prompt[prompt.index("--- SECTION 8") :]
+        for key in capture_arg:
+            assert f"capture_{key}" in section8
+        assert '"success"' in section8
+        assert '"reason"' in section8
+
+    @pytest.mark.parametrize("capture_arg", [None, {}], ids=["none", "empty"])
+    def test_sentinel_section8_unchanged_when_capture_none(
+        self, capture_arg: dict[str, str] | None
+    ) -> None:
+        from autoskillit.fleet._prompts import _build_food_truck_prompt
+
+        prompt = _build_food_truck_prompt(
+            recipe=_RECIPE,
+            task=_TASK,
+            ingredients=_INGREDIENTS,
+            mcp_prefix=_MCP_PREFIX,
+            dispatch_id=_DISPATCH_ID,
+            campaign_id=_CAMPAIGN_ID,
+            l3_timeout_sec=_L3_TIMEOUT,
+            capture=capture_arg,
+        )
+        section8 = prompt[prompt.index("--- SECTION 8") :]
+        assert "capture_" not in section8
+
 
 # --- Group E-6: No First-Action Bootstrap ---
 


### PR DESCRIPTION
## Summary

Thread the `capture` parameter through the fleet prompt builder pipeline: extend `_build_food_truck_prompt` to accept an optional `capture` dict, inject capture field names into the Section 8 sentinel format block (JSON example + Fields list), wire `_run_dispatch` to pass `capture` through to the prompt builder, and add parametrized test coverage for both populated and absent capture paths.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.



## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-135446-539944/.autoskillit/temp/make-plan/p1_wp2_thread_capture_param_plan_2026-05-10_140200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 1.8k | 12.3k | 524.4k | 59.3k | 52 | 50.4k | 6m 44s |
| verify | claude-opus-4-6 | 1 | 40 | 8.8k | 588.2k | 62.4k | 50 | 49.4k | 4m 5s |
| implement* | MiniMax-M2.7-highspeed | 1 | 491.8k | 6.8k | 823.6k | 53.5k | 78 | 37.4k | 6m 47s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 98.4k | 2.8k | 255.9k | 28.7k | 20 | 15.4k | 1m 16s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 43.0k | 912 | 198.4k | 28.7k | 14 | 15.1k | 34s |
| review_pr | claude-sonnet-4-6 | 2 | 168 | 32.0k | 718.7k | 53.0k | 61 | 78.6k | 8m 43s |
| resolve_review | claude-sonnet-4-6 | 2 | 656 | 40.0k | 4.3M | 74.8k | 183 | 122.7k | 16m 30s |
| **Total** | | | 635.9k | 103.6k | 7.5M | 74.8k | | 369.0k | 44m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 66 | 12478.6 | 567.3 | 103.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 18 | 241433.9 | 6815.8 | 2220.9 |
| **Total** | **84** | 88749.5 | 4392.8 | 1233.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 6.3k | 18.4k | 1.1M | 65.3k | 13m 35s |