### PR TITLE
Add structural loop guards to eliminate unbounded-cycle ERROR findings

### DIFF
--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -688,7 +688,6 @@
         }
       ],
       "on_failure": "check_repo_ci_event",
-      "skip_when_false": "inputs.open_pr",
       "optional_context_refs": [
         "review_loop_count",
         "review_verdict"
@@ -994,9 +993,34 @@
         "step_name": "pre_resolve_rebase"
       },
       "retries": 1,
-      "on_success": "diagnose_ci",
+      "on_success": "check_ci_rebase_loop",
       "on_failure": "release_issue_failure",
       "note": "Rebases the feature branch against integration head when resolve_ci emits already_green — the worktree was already clean because a sibling pipeline's fix already landed on integration. Pulling it in before re-running diagnose_ci gives the pipeline a real chance at emitting real_fix and reaching re_push.\n"
+    },
+    "check_ci_rebase_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_rebase_count }}",
+        "max_iterations": "3"
+      },
+      "capture": {
+        "ci_rebase_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "diagnose_ci"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "optional_context_refs": [
+        "ci_rebase_count"
+      ],
+      "note": "Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci cycle. Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green after 3 rebases, a structural issue requires human intervention.\n"
     },
     "re_push": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -653,7 +653,6 @@ steps:
         route: annotate_pr_diff
       - route: check_repo_ci_event
     on_failure: check_repo_ci_event
-    skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
       - review_verdict
@@ -951,13 +950,33 @@ steps:
         git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
       step_name: "pre_resolve_rebase"
     retries: 1
-    on_success: diagnose_ci
+    on_success: check_ci_rebase_loop
     on_failure: release_issue_failure
     note: >
       Rebases the feature branch against integration head when resolve_ci emits
       already_green — the worktree was already clean because a sibling pipeline's
       fix already landed on integration. Pulling it in before re-running diagnose_ci
       gives the pipeline a real chance at emitting real_fix and reaching re_push.
+
+  check_ci_rebase_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.ci_rebase_count }}"
+      max_iterations: "3"
+    capture:
+      ci_rebase_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: release_issue_failure
+      - route: diagnose_ci
+    on_failure: release_issue_failure
+    optional_context_refs:
+      - ci_rebase_count
+    note: >
+      Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci cycle.
+      Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green
+      after 3 rebases, a structural issue requires human intervention.
 
   re_push:
     tool: push_to_remote

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -691,7 +691,6 @@
         }
       ],
       "on_failure": "check_repo_ci_event",
-      "skip_when_false": "inputs.open_pr",
       "optional_context_refs": [
         "review_loop_count",
         "review_verdict"
@@ -1656,9 +1655,34 @@
         "step_name": "pre_resolve_rebase"
       },
       "retries": 1,
-      "on_success": "diagnose_ci",
+      "on_success": "check_ci_rebase_loop",
       "on_failure": "release_issue_failure",
       "note": "Rebases the feature branch against integration head when resolve_ci emits already_green — the worktree was already clean because a sibling pipeline's fix already landed on integration. Pulling it in before re-running diagnose_ci gives the pipeline a real chance at emitting real_fix and reaching re_push.\n"
+    },
+    "check_ci_rebase_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_rebase_count }}",
+        "max_iterations": "3"
+      },
+      "capture": {
+        "ci_rebase_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "diagnose_ci"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "optional_context_refs": [
+        "ci_rebase_count"
+      ],
+      "note": "Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci cycle. Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green after 3 rebases, a structural issue requires human intervention.\n"
     },
     "re_push": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -661,7 +661,6 @@ steps:
         route: annotate_pr_diff
       - route: check_repo_ci_event
     on_failure: check_repo_ci_event
-    skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
       - review_verdict
@@ -1532,13 +1531,33 @@ steps:
         git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
       step_name: "pre_resolve_rebase"
     retries: 1
-    on_success: diagnose_ci
+    on_success: check_ci_rebase_loop
     on_failure: release_issue_failure
     note: >
       Rebases the feature branch against integration head when resolve_ci emits
       already_green — the worktree was already clean because a sibling pipeline's
       fix already landed on integration. Pulling it in before re-running diagnose_ci
       gives the pipeline a real chance at emitting real_fix and reaching re_push.
+
+  check_ci_rebase_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.ci_rebase_count }}"
+      max_iterations: "3"
+    capture:
+      ci_rebase_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: release_issue_failure
+      - route: diagnose_ci
+    on_failure: release_issue_failure
+    optional_context_refs:
+      - ci_rebase_count
+    note: >
+      Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci cycle.
+      Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green
+      after 3 rebases, a structural issue requires human intervention.
 
   re_push:
     tool: push_to_remote

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -880,15 +880,15 @@
       "on_result": [
         {
           "when": "${{ result.verdict }} == 'real_fix'",
-          "route": "test"
+          "route": "check_test_fix_loop"
         },
         {
           "when": "${{ result.verdict }} == 'already_green'",
-          "route": "test"
+          "route": "check_test_fix_loop"
         },
         {
           "when": "${{ result.verdict }} == 'flake_suspected'",
-          "route": "test"
+          "route": "check_test_fix_loop"
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
@@ -903,7 +903,32 @@
       "retries": 3,
       "on_exhausted": "register_clone_failure",
       "on_context_limit": "register_clone_failure",
-      "note": "Fixes test failures without merging. Routes back to test for re-validation before the GitHub-API merge sequence. The base_branch with: key is present for contract compatibility only; the merge target is always the integration branch.\n"
+      "note": "Fixes test failures without merging. Routes back to check_test_fix_loop for iteration guard before re-validation before the GitHub-API merge sequence. The base_branch with: key is present for contract compatibility only; the merge target is always the integration branch.\n"
+    },
+    "check_test_fix_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.test_fix_loop_count }}",
+        "max_iterations": "3"
+      },
+      "capture": {
+        "test_fix_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "register_clone_failure"
+        },
+        {
+          "route": "test"
+        }
+      ],
+      "on_failure": "register_clone_failure",
+      "optional_context_refs": [
+        "test_fix_loop_count"
+      ],
+      "note": "Guards the test → fix → test cycle. Caps at 3 fix-retest iterations. If tests still fail after 3 fix attempts, escalates to clone failure.\n"
     },
     "next_part_or_next_pr": {
       "action": "route",
@@ -911,11 +936,36 @@
         "field": "next",
         "routes": {
           "more_parts": "verify",
-          "more_prs": "merge_pr",
+          "more_prs": "check_pr_merge_loop",
           "all_done": "push_batch_branch"
         }
       },
-      "note": "Routing step — no tool call. The agent evaluates what comes next: 1. If more plan_parts remain for the current PR → verify (next part). 2. If all parts done, advance current_pr_number. If more PRs remain → merge_pr. 3. If all PRs processed → push_batch_branch.\n"
+      "note": "Routing step — no tool call. The agent evaluates what comes next: 1. If more plan_parts remain for the current PR → verify (next part). 2. If all parts done, advance current_pr_number. If more PRs remain → check_pr_merge_loop. 3. If all PRs processed → push_batch_branch.\n"
+    },
+    "check_pr_merge_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.pr_merge_loop_count }}",
+        "max_iterations": "50"
+      },
+      "capture": {
+        "pr_merge_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "register_clone_failure"
+        },
+        {
+          "route": "merge_pr"
+        }
+      ],
+      "on_failure": "register_clone_failure",
+      "optional_context_refs": [
+        "pr_merge_loop_count"
+      ],
+      "note": "Guards the merge_pr → next_part_or_next_pr outer loop. The loop is data-bounded by the finite pr_order_file list; this provides a structural bound for the cycle validator. 50 iterations allows large batch runs.\n"
     },
     "push_batch_branch": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -945,6 +945,10 @@ steps:
       Guards the merge_pr → next_part_or_next_pr outer loop. The loop is
       data-bounded by the finite pr_order_file list; this provides a structural
       bound for the cycle validator. 50 iterations allows large batch runs.
+      Unlike retry loops (capped at 3–15 attempts), this cap is an outer
+      iteration over data items (PRs to merge), not a retry count — hence the
+      higher bound is safe: it tracks distinct work units, not repeated attempts
+      on the same operation.
 
   push_batch_branch:
     tool: push_to_remote

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -874,11 +874,11 @@ steps:
       fixes_applied: "${{ result.fixes_applied }}"
     on_result:
       - when: "${{ result.verdict }} == 'real_fix'"
-        route: test
+        route: check_test_fix_loop
       - when: "${{ result.verdict }} == 'already_green'"
-        route: test
+        route: check_test_fix_loop
       - when: "${{ result.verdict }} == 'flake_suspected'"
-        route: test
+        route: check_test_fix_loop
       - when: "${{ result.verdict }} == 'ci_only_failure'"
         route: register_clone_failure
       - when: "${{ result.verdict }} == 'no_test_infrastructure'"
@@ -888,10 +888,29 @@ steps:
     on_exhausted: register_clone_failure
     on_context_limit: register_clone_failure
     note: >
-      Fixes test failures without merging. Routes back to test for
-      re-validation before the GitHub-API merge sequence. The base_branch with:
-      key is present for contract compatibility only; the merge target is always
-      the integration branch.
+      Fixes test failures without merging. Routes back to check_test_fix_loop for
+      iteration guard before re-validation before the GitHub-API merge sequence.
+      The base_branch with: key is present for contract compatibility only; the
+      merge target is always the integration branch.
+
+  check_test_fix_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.test_fix_loop_count }}"
+      max_iterations: "3"
+    capture:
+      test_fix_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: register_clone_failure
+      - route: test
+    on_failure: register_clone_failure
+    optional_context_refs:
+      - test_fix_loop_count
+    note: >
+      Guards the test → fix → test cycle. Caps at 3 fix-retest iterations.
+      If tests still fail after 3 fix attempts, escalates to clone failure.
 
   next_part_or_next_pr:
     action: route
@@ -899,13 +918,33 @@ steps:
       field: next
       routes:
         more_parts: verify
-        more_prs: merge_pr
+        more_prs: check_pr_merge_loop
         all_done: push_batch_branch
     note: >
       Routing step — no tool call. The agent evaluates what comes next:
       1. If more plan_parts remain for the current PR → verify (next part).
-      2. If all parts done, advance current_pr_number. If more PRs remain → merge_pr.
+      2. If all parts done, advance current_pr_number. If more PRs remain → check_pr_merge_loop.
       3. If all PRs processed → push_batch_branch.
+
+  check_pr_merge_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.pr_merge_loop_count }}"
+      max_iterations: "50"
+    capture:
+      pr_merge_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: register_clone_failure
+      - route: merge_pr
+    on_failure: register_clone_failure
+    optional_context_refs:
+      - pr_merge_loop_count
+    note: >
+      Guards the merge_pr → next_part_or_next_pr outer loop. The loop is
+      data-bounded by the finite pr_order_file list; this provides a structural
+      bound for the cycle validator. 50 iterations allows large batch runs.
 
   push_batch_branch:
     tool: push_to_remote

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -409,9 +409,34 @@
         "output_dir": "${{ context.planner_dir }}"
       },
       "retries": 2,
-      "on_success": "validate",
+      "on_success": "check_refine_loop",
       "on_exhausted": "escalate_stop",
       "on_failure": "escalate_stop"
+    },
+    "check_refine_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.refine_loop_count }}",
+        "max_iterations": "5"
+      },
+      "capture": {
+        "refine_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "escalate_stop"
+        },
+        {
+          "route": "validate"
+        }
+      ],
+      "on_failure": "escalate_stop",
+      "optional_context_refs": [
+        "refine_loop_count"
+      ],
+      "note": "Guards the validate → check_verdict → refine cycle. Caps at 5 refinement iterations. If the plan still fails validation after 5 refinements, escalates to human.\n"
     },
     "compile": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -425,9 +425,29 @@ steps:
       cwd: "${{ inputs.source_dir }}"
       output_dir: "${{ context.planner_dir }}"
     retries: 2
-    on_success: validate
+    on_success: check_refine_loop
     on_exhausted: escalate_stop
     on_failure: escalate_stop
+
+  check_refine_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.refine_loop_count }}"
+      max_iterations: "5"
+    capture:
+      refine_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: escalate_stop
+      - route: validate
+    on_failure: escalate_stop
+    optional_context_refs:
+      - refine_loop_count
+    note: >
+      Guards the validate → check_verdict → refine cycle. Caps at 5 refinement
+      iterations. If the plan still fails validation after 5 refinements,
+      escalates to human.
 
   compile:
     tool: run_python

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -718,7 +718,6 @@
         }
       ],
       "on_failure": "check_repo_ci_event",
-      "skip_when_false": "inputs.open_pr",
       "optional_context_refs": [
         "review_loop_count",
         "review_verdict"
@@ -1683,9 +1682,34 @@
         "step_name": "pre_resolve_rebase"
       },
       "retries": 1,
-      "on_success": "diagnose_ci",
+      "on_success": "check_ci_rebase_loop",
       "on_failure": "release_issue_failure",
       "note": "Rebases the feature branch against integration head when resolve_ci emits already_green — the worktree was already clean because a sibling pipeline's fix already landed on integration. Pulling it in before re-running diagnose_ci gives the pipeline a real chance at emitting real_fix and reaching re_push.\n"
+    },
+    "check_ci_rebase_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_rebase_count }}",
+        "max_iterations": "3"
+      },
+      "capture": {
+        "ci_rebase_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "diagnose_ci"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "optional_context_refs": [
+        "ci_rebase_count"
+      ],
+      "note": "Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci cycle. Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green after 3 rebases, a structural issue requires human intervention.\n"
     },
     "re_push": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -663,7 +663,6 @@ steps:
         route: annotate_pr_diff
       - route: check_repo_ci_event
     on_failure: check_repo_ci_event
-    skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
       - review_verdict
@@ -1536,13 +1535,33 @@ steps:
         git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
       step_name: "pre_resolve_rebase"
     retries: 1
-    on_success: diagnose_ci
+    on_success: check_ci_rebase_loop
     on_failure: release_issue_failure
     note: >
       Rebases the feature branch against integration head when resolve_ci emits
       already_green — the worktree was already clean because a sibling pipeline's
       fix already landed on integration. Pulling it in before re-running diagnose_ci
       gives the pipeline a real chance at emitting real_fix and reaching re_push.
+
+  check_ci_rebase_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.ci_rebase_count }}"
+      max_iterations: "3"
+    capture:
+      ci_rebase_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: release_issue_failure
+      - route: diagnose_ci
+    on_failure: release_issue_failure
+    optional_context_refs:
+      - ci_rebase_count
+    note: >
+      Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci cycle.
+      Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green
+      after 3 rebases, a structural issue requires human intervention.
 
   re_push:
     tool: push_to_remote

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -274,13 +274,38 @@
       "on_result": [
         {
           "when": "remaining phases exist in context.group_files",
-          "route": "plan_phase"
+          "route": "check_phase_loop"
         },
         {
           "route": "audit_impl"
         }
       ],
-      "note": "Routing step. The agent evaluates remaining phases: 1. If more phases remain in group_files -> route to plan_phase. 2. If all phases complete -> route to audit_impl for completeness verification.\n"
+      "note": "Routing step. The agent evaluates remaining phases: 1. If more phases remain in group_files -> route to check_phase_loop. 2. If all phases complete -> route to audit_impl for completeness verification.\n"
+    },
+    "check_phase_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.phase_loop_count }}",
+        "max_iterations": "15"
+      },
+      "capture": {
+        "phase_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "audit_impl"
+        },
+        {
+          "route": "plan_phase"
+        }
+      ],
+      "on_failure": "audit_impl",
+      "optional_context_refs": [
+        "phase_loop_count"
+      ],
+      "note": "Guards the plan_phase → implement_phase → next_phase_or_experiment cycle. The loop is data-bounded by the finite group_files list; this provides a structural bound. 15 iterations allows complex multi-phase setups.\n"
     },
     "audit_impl": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -280,12 +280,32 @@ steps:
     action: route
     on_result:
       - when: "remaining phases exist in context.group_files"
-        route: plan_phase
+        route: check_phase_loop
       - route: audit_impl
     note: >
       Routing step. The agent evaluates remaining phases:
-      1. If more phases remain in group_files -> route to plan_phase.
+      1. If more phases remain in group_files -> route to check_phase_loop.
       2. If all phases complete -> route to audit_impl for completeness verification.
+
+  check_phase_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.phase_loop_count }}"
+      max_iterations: "15"
+    capture:
+      phase_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: audit_impl
+      - route: plan_phase
+    on_failure: audit_impl
+    optional_context_refs:
+      - phase_loop_count
+    note: >
+      Guards the plan_phase → implement_phase → next_phase_or_experiment cycle.
+      The loop is data-bounded by the finite group_files list; this provides a
+      structural bound. 15 iterations allows complex multi-phase setups.
 
   audit_impl:
     tool: run_skill

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -489,13 +489,38 @@
       "on_result": [
         {
           "when": "${{ result.next }} == more_phases",
-          "route": "plan_phase"
+          "route": "check_phase_loop"
         },
         {
           "route": "audit_impl"
         }
       ],
-      "note": "Routing step. The agent evaluates remaining phases: 1. If more phases remain in group_files -> route to plan_phase. 2. If all phases complete -> route to audit_impl for completeness verification.\n"
+      "note": "Routing step. The agent evaluates remaining phases: 1. If more phases remain in group_files -> route to check_phase_loop. 2. If all phases complete -> route to audit_impl for completeness verification.\n"
+    },
+    "check_phase_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.phase_loop_count }}",
+        "max_iterations": "15"
+      },
+      "capture": {
+        "phase_loop_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "audit_impl"
+        },
+        {
+          "route": "plan_phase"
+        }
+      ],
+      "on_failure": "audit_impl",
+      "optional_context_refs": [
+        "phase_loop_count"
+      ],
+      "note": "Guards the plan_phase → implement_phase → next_phase_or_experiment cycle. The loop is data-bounded by the finite group_files list; this provides a structural bound. 15 iterations allows complex multi-phase setups.\n"
     },
     "audit_impl": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -508,12 +508,32 @@ steps:
     action: route
     on_result:
       - when: "${{ result.next }} == more_phases"
-        route: plan_phase
+        route: check_phase_loop
       - route: audit_impl
     note: >
       Routing step. The agent evaluates remaining phases:
-      1. If more phases remain in group_files -> route to plan_phase.
+      1. If more phases remain in group_files -> route to check_phase_loop.
       2. If all phases complete -> route to audit_impl for completeness verification.
+
+  check_phase_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.phase_loop_count }}"
+      max_iterations: "15"
+    capture:
+      phase_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: audit_impl
+      - route: plan_phase
+    on_failure: audit_impl
+    optional_context_refs:
+      - phase_loop_count
+    note: >
+      Guards the plan_phase → implement_phase → next_phase_or_experiment cycle.
+      The loop is data-bounded by the finite group_files list; this provides a
+      structural bound. 15 iterations allows complex multi-phase setups.
 
   audit_impl:
     tool: run_skill

--- a/tests/recipe/conftest.py
+++ b/tests/recipe/conftest.py
@@ -17,7 +17,6 @@ KNOWN_PART_B_VIOLATIONS: frozenset[str] = frozenset(
     {
         NO_AUTOSKILLIT_IMPORT,
         "skill-result-routing-gap",
-        "unbounded-cycle",
     }
 )
 

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import structlog.testing
 
-from autoskillit.core import PACK_REGISTRY, SKILL_TOOLS
+from autoskillit.core import PACK_REGISTRY, SKILL_TOOLS, Severity
 from autoskillit.recipe._analysis import build_recipe_graph
 from autoskillit.recipe._skill_helpers import _get_skill_category_map
 from autoskillit.recipe.contracts import load_bundled_manifest, resolve_skill_name
@@ -36,7 +36,20 @@ for _dir in (builtin_recipes_dir(), PROJECT_ROOT / ".autoskillit" / "recipes"):
             if any(s.tool == "clone_repo" for s in _wf.steps.values()):
                 _ALL_CLONE_RECIPE_PATHS.append(_p)
 
-_CI_WATCH_CYCLE_STEPS = {"ci_watch", "handle_no_ci_runs", "check_ci_loop"}
+
+@pytest.mark.parametrize(
+    "recipe_yaml",
+    sorted(builtin_recipes_dir().glob("*.yaml")),
+    ids=lambda p: p.stem,
+)
+def test_no_unbounded_cycle_errors_in_bundled_recipes(recipe_yaml: Path) -> None:
+    """Every bundled recipe must have zero unbounded-cycle ERROR findings."""
+    recipe = load_recipe(recipe_yaml)
+    findings = run_semantic_rules(recipe)
+    errors = [f for f in findings if f.rule == "unbounded-cycle" and f.severity == Severity.ERROR]
+    assert errors == [], (
+        f"{recipe_yaml.stem}: {[f'{f.step_name}: {f.message[:80]}' for f in errors]}"
+    )
 
 
 def test_every_bundled_recipe_declares_requires_packs() -> None:
@@ -44,20 +57,6 @@ def test_every_bundled_recipe_declares_requires_packs() -> None:
     for path in sorted(builtin_recipes_dir().glob("*.yaml")):
         recipe = load_recipe(path)
         assert recipe.requires_packs, f"{path.name} does not declare requires_packs"
-
-
-@pytest.mark.parametrize("recipe_name", ["remediation", "implementation", "implementation-groups"])
-def test_bundled_recipe_no_unbounded_cycle_findings(recipe_name: str) -> None:
-    """Pipeline recipes must have zero unbounded-cycle findings for the ci_watch cycle."""
-    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
-    findings = run_semantic_rules(recipe)
-    ci_watch_cycle_findings = [
-        f for f in findings if f.rule == "unbounded-cycle" and f.step_name in _CI_WATCH_CYCLE_STEPS
-    ]
-    assert ci_watch_cycle_findings == [], (
-        f"{recipe_name} has unbounded-cycle findings for ci_watch cycle: "
-        + "; ".join(f.message for f in ci_watch_cycle_findings)
-    )
 
 
 def test_make_plan_contract_declares_plan_parts_output() -> None:

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -61,10 +61,11 @@ def test_check_ci_timed_out_loop_exists_with_correct_pattern(recipe) -> None:
 
 
 # T_IP_LOOP3
-def test_check_review_loop_has_skip_when_false_open_pr(recipe) -> None:
-    """check_review_loop must be skipped when inputs.open_pr is false."""
+def test_check_review_loop_has_no_skip_when_false(recipe) -> None:
+    """check_review_loop must NOT have skip_when_false — it was removed to eliminate bypass
+    edges that created unbounded-cycle ERROR findings via _build_step_graph."""
     step = recipe.steps["check_review_loop"]
-    assert step.skip_when_false == "inputs.open_pr"
+    assert step.skip_when_false is None
 
 
 # T_IP_LOOP4

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -62,8 +62,7 @@ def test_check_ci_timed_out_loop_exists_with_correct_pattern(recipe) -> None:
 
 # T_IP_LOOP3
 def test_check_review_loop_has_no_skip_when_false(recipe) -> None:
-    """check_review_loop must NOT have skip_when_false — it was removed to eliminate bypass
-    edges that created unbounded-cycle ERROR findings via _build_step_graph."""
+    """check_review_loop must NOT have skip_when_false."""
     step = recipe.steps["check_review_loop"]
     assert step.skip_when_false is None
 


### PR DESCRIPTION
## Summary

Fix 14 `unbounded-cycle` ERROR findings across 7 recipe files (6 distinct recipes) by applying two complementary strategies:

1. **Remove `skip_when_false` from `check_review_loop`** in 3 recipes (implementation, implementation-groups, remediation) — the `skip_when_false` on this step causes `_build_step_graph` to inject bypass edges from predecessors (`re_push_review`, `review_pr`) directly to targets (`annotate_pr_diff`), creating 2-step and 4-step cycle paths that circumvent the existing structural guard. Removing `skip_when_false` eliminates these bypass edges; the existing `check_review_loop` (a `run_python` step with `on_result` routing to `check_repo_ci_event` outside the cycle) then satisfies Check 1 of the `unbounded-cycle` rule and suppresses all 6 review cycle findings.

2. **Insert 8 new `check_loop_iteration` guard steps** across 6 recipes for the remaining 8 cycles that genuinely lack structural bounds.

3. **Remove `"unbounded-cycle"` from `KNOWN_PART_B_VIOLATIONS`** in `tests/recipe/conftest.py` — after all 14 ERRORs are resolved, this exemption is no longer needed.

## Changed Files

### New (★):
- `src/autoskillit/recipes/scripts/advance_queue_pr.sh`
- `src/autoskillit/recipes/scripts/create_artifact_branch.sh`
- `src/autoskillit/recipes/scripts/create_worktree.sh`
- `src/autoskillit/recipes/scripts/finalize_bundle.sh`
- `src/autoskillit/recipes/scripts/open_artifact_pr.sh`
- `src/autoskillit/recipes/scripts/push_branch.sh`
- `src/autoskillit/recipes/scripts/stage_bundle.sh`
- `src/autoskillit/recipes/scripts/tag_experiment_branch.sh`
- `tests/arch/test_skill_result_construction_guard.py`
- `tests/cli/test_doctor_fleet.py`
- `tests/contracts/test_download_data_contracts.py`
- `tests/contracts/test_figure_spec_contracts.py`
- `tests/core/test_plugin_cache.py`
- `tests/core/test_resolve_main_worktree.py`
- `tests/core/types/__init__.py`
- `tests/core/types/test_dispatch_identity.py`
- `tests/execution/test_api_error_signal_invariants.py`
- `tests/fleet/test_api_dispatch_marker.py`
- `tests/fleet/test_dispatch_identity_continuity.py`
- `tests/fleet/test_dispatch_state_handle.py`
- `tests/fleet/test_state_lock_contract.py`
- `tests/fleet/test_state_recovery.py`
- `tests/infra/test_ci_shard_config.py`
- `tests/infra/test_schema_read_convention.py`
- `tests/integration/test_fleet_concurrency.py`
- `tests/recipe/test_create_worktree_functional.py`
- `tests/recipe/test_create_worktree_script.py`
- `tests/recipe/test_research_audit_impl.py`
- `tests/recipe/test_research_download_data_step.py`
- `tests/recipe/test_skill_worktree_patterns.py`

### Modified (●):
- `src/autoskillit/recipes/implementation.yaml`
- `src/autoskillit/recipes/implementation-groups.yaml`
- `src/autoskillit/recipes/remediation.yaml`
- `src/autoskillit/recipes/merge-prs.yaml`
- `src/autoskillit/recipes/planner.yaml`
- `src/autoskillit/recipes/research-implement.yaml`
- `src/autoskillit/recipes/research.yaml`
- `tests/recipe/conftest.py`
- `tests/recipe/test_bundled_recipes_general.py`

Closes #2369

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260510-144313-500715/.autoskillit/temp/make-plan/unbounded-cycle-guard-steps-14-locations-across-6-recipes_plan_2026-05-10_190000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 94 | 43.0k | 1.5M | 107.9k | 142 | 101.3k | 20m 58s |
| verify | claude-opus-4-6 | 1 | 43 | 11.3k | 1.2M | 59.2k | 106 | 46.1k | 6m 17s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.7M | 15.1k | 1.4M | 78.8k | 132 | 66.3k | 9m 53s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 136.9k | 4.2k | 303.5k | 35.1k | 26 | 55.9k | 1m 40s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 40.9k | 2.2k | 176.1k | 29.8k | 14 | 15.2k | 49s |
| review_pr | claude-sonnet-4-6 | 3 | 408 | 93.0k | 1.8M | 97.0k | 119 | 210.2k | 20m 10s |
| resolve_review | claude-sonnet-4-6 | 2 | 486 | 28.5k | 2.7M | 69.0k | 146 | 100.7k | 18m 11s |
| **Total** | | | 1.9M | 197.3k | 9.1M | 107.9k | | 595.7k | 1h 18m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 459 | 3125.6 | 144.4 | 33.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 299501.8 | 11188.4 | 3171.6 |
| **Total** | **468** | 19339.3 | 1272.8 | 421.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 57 | 6.4k | 397.8k | 39.6k | 5m 57s |