### PR TITLE
Rectify: Inline Script Bash Builtins False Positive — Missing Path-Safe Guards on Keyword Regexes

### DIFF
--- a/src/autoskillit/recipe/_git_helpers.py
+++ b/src/autoskillit/recipe/_git_helpers.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import regex as re
 
+from autoskillit.recipe._rule_helpers import cmd_keyword_pattern
+
 # Matches any line that contains a git command followed by a remote-aware verb.
 # Expanded from rules_skill_content.py to include push, merge-base, diff, ls-remote.
-_GIT_REMOTE_COMMAND_RE: re.Pattern[str] = re.compile(
-    r"\bgit\b.*?\b(?:fetch|rebase|log|show|rev-parse|push|merge-base|diff|ls-remote)\b"
+_GIT_REMOTE_COMMAND_RE: re.Pattern[str] = cmd_keyword_pattern(
+    r"git\b.*?(?:fetch|rebase|log|show|rev-parse|push|merge-base|diff|ls-remote)"
 )
 
 # Matches literal 'origin' not immediately preceded by $, {, or - (i.e., not a shell

--- a/src/autoskillit/recipe/_rule_helpers.py
+++ b/src/autoskillit/recipe/_rule_helpers.py
@@ -6,8 +6,8 @@ import regex as re
 
 from autoskillit.recipe._analysis import ValidationContext
 
-_PATH_SAFE_LOOKBEHIND = r"(?<![.a-zA-Z_/])"
-_PATH_SAFE_LOOKAHEAD = r"(?![.a-zA-Z_/])"
+_PATH_SAFE_LOOKBEHIND = r"(?<![.a-zA-Z0-9_/])"
+_PATH_SAFE_LOOKAHEAD = r"(?![.a-zA-Z0-9_/])"
 
 
 def cmd_keyword_pattern(
@@ -19,16 +19,17 @@ def cmd_keyword_pattern(
     """Build a keyword-matching regex with automatic path-safe guards.
 
     The returned pattern wraps the keyword alternation with:
-    - A negative lookbehind rejecting ``.``, letters, ``_``, ``/`` before the match
-    - A negative lookahead rejecting ``.``, letters, ``_``, ``/`` after the match
-      (unless disabled)
+    - A negative lookbehind rejecting ``.``, letters, digits, ``_``, ``/`` before the match
+    - A negative lookahead rejecting ``.``, letters, digits, ``_``, ``/`` after the match
+      (or ``(?!\\w)`` when lookahead=False for symmetric word-boundary semantics)
 
     Args:
         keywords: A regex alternation string (e.g., ``r"mapfile|declare|local|export"``).
         flags: Additional ``regex`` flags (e.g., ``re.VERBOSE``).
-        lookahead: Whether to add a trailing path-safe lookahead (default True).
+        lookahead: If True (default), adds path-safe lookahead. If False, uses ``(?!\\w)``
+            for symmetric word-boundary semantics without path-char filtering.
     """
-    tail = _PATH_SAFE_LOOKAHEAD if lookahead else r"\b"
+    tail = _PATH_SAFE_LOOKAHEAD if lookahead else r"(?!\w)"
     return re.compile(rf"{_PATH_SAFE_LOOKBEHIND}(?:{keywords}){tail}", flags)
 
 

--- a/src/autoskillit/recipe/_rule_helpers.py
+++ b/src/autoskillit/recipe/_rule_helpers.py
@@ -2,7 +2,34 @@
 
 from __future__ import annotations
 
+import regex as re
+
 from autoskillit.recipe._analysis import ValidationContext
+
+_PATH_SAFE_LOOKBEHIND = r"(?<![.a-zA-Z_/])"
+_PATH_SAFE_LOOKAHEAD = r"(?![.a-zA-Z_/])"
+
+
+def cmd_keyword_pattern(
+    keywords: str,
+    *,
+    flags: int = 0,
+    lookahead: bool = True,
+) -> re.Pattern[str]:
+    """Build a keyword-matching regex with automatic path-safe guards.
+
+    The returned pattern wraps the keyword alternation with:
+    - A negative lookbehind rejecting ``.``, letters, ``_``, ``/`` before the match
+    - A negative lookahead rejecting ``.``, letters, ``_``, ``/`` after the match
+      (unless disabled)
+
+    Args:
+        keywords: A regex alternation string (e.g., ``r"mapfile|declare|local|export"``).
+        flags: Additional ``regex`` flags (e.g., ``re.VERBOSE``).
+        lookahead: Whether to add a trailing path-safe lookahead (default True).
+    """
+    tail = _PATH_SAFE_LOOKAHEAD if lookahead else r"\b"
+    return re.compile(rf"{_PATH_SAFE_LOOKBEHIND}(?:{keywords}){tail}", flags)
 
 
 def _is_loop_guard_step(step_name: str, ctx: ValidationContext) -> bool:

--- a/src/autoskillit/recipe/rules/rules_inline_script.py
+++ b/src/autoskillit/recipe/rules/rules_inline_script.py
@@ -15,7 +15,7 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 _CONTROL_FLOW_RE = re.compile(
     r"""
-    (?<![.a-zA-Z_/])      # not preceded by word char or path separator
+    (?<![.a-zA-Z0-9_/])      # not preceded by word char, digit, or path separator
     (?:
         \bif\s+.*;\s*then\b |
         \bthen\b |

--- a/src/autoskillit/recipe/rules/rules_inline_script.py
+++ b/src/autoskillit/recipe/rules/rules_inline_script.py
@@ -6,6 +6,7 @@ import regex as re
 
 from autoskillit.core import Severity
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._rule_helpers import cmd_keyword_pattern
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 # ---------------------------------------------------------------------------
@@ -36,13 +37,13 @@ _JQ_BLOCK_RE = re.compile(
     re.DOTALL,
 )
 
-_BASH_BUILTINS_RE = re.compile(r"\b(?:mapfile|read\s+-r|declare|local|export)\b")
+_BASH_BUILTINS_RE = cmd_keyword_pattern(r"mapfile|read\s+-r|declare|local|export")
 
 _VAR_ASSIGN_RE = re.compile(r"^[A-Z_][A-Z0-9_]*=", re.MULTILINE)
 
 _AND_CHAIN_RE = re.compile(r"&&")
 
-_PYTHON3_C_RE = re.compile(r"\bpython3?\s+-c\b")
+_PYTHON3_C_RE = cmd_keyword_pattern(r"python3?\s+-c")
 
 
 def _strip_jq_blocks(cmd: str) -> str:

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -40,6 +40,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_protocol_names.py` | T5-T6: Protocol naming and DefaultSkillResolver export smoke tests |
 | `test_python_no_hardcoded_temp.py` | Architectural invariant: no literal `.autoskillit/temp` outside the whitelist |
 | `test_recipe_rule_registration.py` | REQ-RECIPE-001: every recipe/rules_*.py file must be imported by recipe/__init__.py |
+| `test_regex_guards.py` | Arch guard: keyword regexes in cmd-scanning rules must use path-safe lookbehind guards |
 | `test_regex_import.py` | Structural guard: src/ must use `import regex as re`, not bare `import re` (hooks/ exempt) |
 | `test_registry.py` | Symbolic rule registry tests (RuleDescriptor, RULES, Violation) |
 | `test_registry_key_casing.py` | Architectural invariant tests for registry key casing |

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -60,12 +60,10 @@ def _extract_re_compile_patterns(filepath: Path) -> list[tuple[str, str, int]]:
     compile_calls: dict[int, str] = {}
 
     for node in ast.walk(tree):
-        # Simple assignment: _FOO_RE = re.compile(...)
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and isinstance(node.value, ast.Call):
                     compile_calls[id(node.value)] = target.id
-        # Annotated assignment: _FOO_RE: re.Pattern[str] = re.compile(...)
         elif isinstance(node, ast.AnnAssign):
             if isinstance(node.target, ast.Name) and isinstance(node.value, ast.Call):
                 compile_calls[id(node.value)] = node.target.id
@@ -101,7 +99,6 @@ def test_cmd_keyword_regexes_use_path_safe_guards():
         for var_name, pattern, lineno in _extract_re_compile_patterns(filepath):
             if var_name in EXEMPT_PATTERNS:
                 continue
-            # If it uses a guard marker, it's safe
             if any(marker in pattern for marker in GUARD_MARKERS):
                 continue
             # If it uses bare \b without a guard, it's a violation

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -1,0 +1,112 @@
+"""Arch guard: keyword regexes in cmd-scanning rules must use path-safe guards.
+
+Enforces that all re.compile calls in cmd-scanning rule files either:
+  - Use cmd_keyword_pattern() (builder function), OR
+  - Contain (?<![.a-zA-Z_/]) (manual path-safe lookbehind), OR
+  - Are in the EXEMPT_PATTERNS frozenset (non-keyword patterns)
+
+This prevents regressions where a developer adds a bare \\b keyword regex
+that would false-positive on paths containing keyword-like substrings
+(e.g., .local matching 'local', /export/ matching 'export').
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from tests.arch._helpers import SRC_ROOT
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+# Files that scan cmd fields for keywords and must use path-safe patterns
+CMD_SCANNING_RULE_FILES = [
+    SRC_ROOT / "recipe" / "rules" / "rules_inline_script.py",
+    SRC_ROOT / "recipe" / "_git_helpers.py",
+]
+
+# Guard markers that indicate path-safe construction
+GUARD_MARKERS = frozenset(
+    {
+        "(?<![.a-zA-Z_/])",  # path-safe lookbehind (established pattern)
+        "cmd_keyword_pattern",  # builder function use
+    }
+)
+
+# Patterns that are exempt from the guard requirement (they don't match keywords)
+EXEMPT_PATTERNS = frozenset(
+    {
+        "_JQ_BLOCK_RE",  # strips jq blocks, not keyword matching
+        "_VAR_ASSIGN_RE",  # line-start anchored, not keyword matching
+        "_AND_CHAIN_RE",  # literal &&, not keyword matching
+        "_LITERAL_ORIGIN_RE",  # has its own context-safe lookbehind
+    }
+)
+
+
+def _extract_re_compile_patterns(filepath: Path) -> list[tuple[str, str, int]]:
+    """Return (variable_name, pattern_string, line_number) for each re.compile call."""
+    source = filepath.read_text()
+    tree = ast.parse(source)
+    results = []
+
+    # Map from re.compile Call nodes to their assigned variable names
+    compile_calls: dict[int, str] = {}
+
+    # First pass: find all Assign / AnnAssign nodes with a Call value and extract var names
+    for node in ast.walk(tree):
+        # Simple assignment: _FOO_RE = re.compile(...)
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and isinstance(node.value, ast.Call):
+                    compile_calls[id(node.value)] = target.id
+        # Annotated assignment: _FOO_RE: re.Pattern[str] = re.compile(...)
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and isinstance(node.value, ast.Call):
+                compile_calls[id(node.value)] = node.target.id
+
+    # Second pass: find all re.compile / regex.compile calls
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_re_compile = (
+            isinstance(func, ast.Attribute)
+            and func.attr == "compile"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in ("re", "regex")
+        )
+        if not is_re_compile:
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        if not isinstance(first_arg, ast.Constant) or not isinstance(first_arg.value, str):
+            continue
+
+        var_name = compile_calls.get(id(node), "<unknown>")
+        results.append((var_name, first_arg.value, node.lineno))
+
+    return results
+
+
+def test_cmd_keyword_regexes_use_path_safe_guards():
+    """All keyword-matching regexes in cmd-scanning rules must use path-safe guards."""
+    violations = []
+    for filepath in CMD_SCANNING_RULE_FILES:
+        for var_name, pattern, lineno in _extract_re_compile_patterns(filepath):
+            if var_name in EXEMPT_PATTERNS:
+                continue
+            # If it uses a guard marker, it's safe
+            if any(marker in pattern for marker in GUARD_MARKERS):
+                continue
+            # If it uses bare \b without a guard, it's a violation
+            if r"\b" in pattern:
+                rel_path = filepath.relative_to(SRC_ROOT.parent.parent)
+                violations.append(
+                    f"{rel_path}:{lineno} {var_name} uses \\b without path-safe guard"
+                )
+
+    assert violations == [], "Regex patterns missing path-safe guards:\n" + "\n".join(violations)

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -57,10 +57,8 @@ def _extract_re_compile_patterns(filepath: Path) -> list[tuple[str, str, int]]:
     tree = ast.parse(source)
     results = []
 
-    # Map from re.compile Call nodes to their assigned variable names
     compile_calls: dict[int, str] = {}
 
-    # First pass: find all Assign / AnnAssign nodes with a Call value and extract var names
     for node in ast.walk(tree):
         # Simple assignment: _FOO_RE = re.compile(...)
         if isinstance(node, ast.Assign):
@@ -72,7 +70,6 @@ def _extract_re_compile_patterns(filepath: Path) -> list[tuple[str, str, int]]:
             if isinstance(node.target, ast.Name) and isinstance(node.value, ast.Call):
                 compile_calls[id(node.value)] = node.target.id
 
-    # Second pass: find all re.compile / regex.compile calls
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -1,9 +1,13 @@
 """Arch guard: keyword regexes in cmd-scanning rules must use path-safe guards.
 
 Enforces that all re.compile calls in cmd-scanning rule files either:
-  - Use cmd_keyword_pattern() (builder function), OR
-  - Contain (?<![.a-zA-Z_/]) (manual path-safe lookbehind), OR
+  - Contain (?<![.a-zA-Z0-9_/]) (manual path-safe lookbehind), OR
+  - Contain (?![.a-zA-Z0-9_/]) (manual path-safe lookahead), OR
   - Are in the EXEMPT_PATTERNS frozenset (non-keyword patterns)
+
+Patterns built via cmd_keyword_pattern() are implicitly excluded from extraction:
+their first argument is an f-string (not an ast.Constant), so _extract_re_compile_patterns
+skips them. They do not need to appear in GUARD_MARKERS.
 
 This prevents regressions where a developer adds a bare \\b keyword regex
 that would false-positive on paths containing keyword-like substrings
@@ -27,11 +31,12 @@ CMD_SCANNING_RULE_FILES = [
     SRC_ROOT / "recipe" / "_git_helpers.py",
 ]
 
-# Guard markers that indicate path-safe construction
+# Guard markers that indicate path-safe construction.
+# cmd_keyword_pattern() callers are implicitly excluded from extraction (f-string first arg).
 GUARD_MARKERS = frozenset(
     {
-        "(?<![.a-zA-Z_/])",  # path-safe lookbehind (established pattern)
-        "cmd_keyword_pattern",  # builder function use
+        "(?<![.a-zA-Z0-9_/])",  # path-safe lookbehind
+        "(?![.a-zA-Z0-9_/])",  # path-safe lookahead
     }
 )
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -109,6 +109,7 @@ _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(
         "Lock",  # threading.Lock — safe module-level thread-safety primitive
         "version",
         "compile",
+        "cmd_keyword_pattern",  # recipe/_rule_helpers.py: regex factory returning compiled Pattern
         "object",
         "MappingProxyType",  # types.MappingProxyType — read-only view, no state
     }

--- a/tests/recipe/test_recipe_scripts.py
+++ b/tests/recipe/test_recipe_scripts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 
 import pytest
@@ -11,6 +10,7 @@ import pytest
 from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.io import builtin_recipes_dir, builtin_scripts_dir, load_recipe
 from autoskillit.recipe.validator import run_semantic_rules
+from tests.recipe.conftest import _make_workflow
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
@@ -100,21 +100,29 @@ def test_recipes_pass_inline_script_rule(recipe_name):
     )
 
 
-def test_recipes_pass_inline_script_rule_with_uv_tool_path(monkeypatch, tmp_path):
-    """Guard: inline-script rule must not false-positive on uv-tool-install paths."""
-    fake_pkg = tmp_path / ".local" / "share" / "uv" / "tools" / "autoskillit"
-    real_pkg = pkg_root()
-    shutil.copytree(real_pkg, fake_pkg, dirs_exist_ok=True)
-
-    import autoskillit.recipe.io as _rio
-
-    monkeypatch.setattr(_rio, "pkg_root", lambda: fake_pkg)
-
-    recipe = load_recipe(builtin_recipes_dir() / "research.yaml")
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "autoskillit init --path /home/user/.local/share/uv/tools/autoskillit",
+        "bash /home/user/.local/share/uv/tools/autoskillit/recipes/scripts/setup.sh",
+        "task install --dir /export/apps/autoskillit",
+    ],
+    ids=["uv-tool-local-path", "script-from-uv-tool-path", "export-dir-path"],
+)
+def test_inline_script_does_not_false_positive_on_keyword_in_path(cmd):
+    """Guard: inline-script rule must not false-positive on paths containing keyword substrings."""
+    recipe = _make_workflow(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": cmd},
+                "on_success": "END",
+            },
+            "END": {"action": "stop", "message": "Done"},
+        }
+    )
     findings = run_semantic_rules(recipe)
-    inline_findings = [
-        f for f in findings if f.rule in ("inline-script-in-cmd", "inline-python-in-cmd")
-    ]
-    assert inline_findings == [], (
-        f"research.yaml has inline script findings under uv-tool path: {inline_findings}"
+    assert not any(f.rule == "inline-script-in-cmd" for f in findings), (
+        f"False-positive on path-containing cmd '{cmd}': "
+        f"{[f for f in findings if f.rule == 'inline-script-in-cmd']}"
     )

--- a/tests/recipe/test_recipe_scripts.py
+++ b/tests/recipe/test_recipe_scripts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 
 import pytest
@@ -96,4 +97,24 @@ def test_recipes_pass_inline_script_rule(recipe_name):
     ]
     assert inline_findings == [], (
         f"Recipe {recipe_name} has inline script findings: {inline_findings}"
+    )
+
+
+def test_recipes_pass_inline_script_rule_with_uv_tool_path(monkeypatch, tmp_path):
+    """Guard: inline-script rule must not false-positive on uv-tool-install paths."""
+    fake_pkg = tmp_path / ".local" / "share" / "uv" / "tools" / "autoskillit"
+    real_pkg = pkg_root()
+    shutil.copytree(real_pkg, fake_pkg, dirs_exist_ok=True)
+
+    import autoskillit.recipe.io as _rio
+
+    monkeypatch.setattr(_rio, "pkg_root", lambda: fake_pkg)
+
+    recipe = load_recipe(builtin_recipes_dir() / "research.yaml")
+    findings = run_semantic_rules(recipe)
+    inline_findings = [
+        f for f in findings if f.rule in ("inline-script-in-cmd", "inline-python-in-cmd")
+    ]
+    assert inline_findings == [], (
+        f"research.yaml has inline script findings under uv-tool path: {inline_findings}"
     )

--- a/tests/recipe/test_rules_inline_script.py
+++ b/tests/recipe/test_rules_inline_script.py
@@ -84,19 +84,29 @@ def test_inline_script_fires_on_excessive_vars_and_chains():
     assert "inline-script-in-cmd" in codes
 
 
-def test_inline_script_fires_on_bash_builtins():
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "local varname=value",
+        "export VARNAME=value",
+        "declare -A mymap",
+        "mapfile -t lines < input.txt",
+        "read -r line < input.txt",
+    ],
+    ids=["local", "export", "declare", "mapfile", "read-r"],
+)
+def test_inline_script_fires_on_each_bash_builtin(cmd):
     recipe = _make_recipe(
         {
             "step_a": {
                 "tool": "run_cmd",
-                "with": {"cmd": 'declare -A map && map[key]=value && echo "${map[key]}"'},
+                "with": {"cmd": cmd},
                 "on_success": "END",
             }
         }
     )
     findings = run_semantic_rules(recipe)
-    codes = [f.rule for f in findings]
-    assert "inline-script-in-cmd" in codes
+    assert any(f.rule == "inline-script-in-cmd" for f in findings)
 
 
 def test_inline_script_error_on_control_flow():
@@ -235,6 +245,51 @@ def test_inline_script_ignores_non_run_cmd_steps():
             "step_a": {
                 "tool": "run_python",
                 "with": {"callable": "autoskillit.smoke_utils.check_loop_iteration"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "inline-script-in-cmd" for f in findings)
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # .local in uv tool install path
+        (
+            "bash /home/user/.local/share/uv/tools/autoskillit/"
+            "lib/python3.13/site-packages/autoskillit/recipes/scripts/create_worktree.sh arg1"
+        ),
+        # /usr/local/ standard path
+        "bash /usr/local/bin/my_script.sh arg1 arg2",
+        # /export/ as NFS mount point
+        "/export/home/user/scripts/run.sh",
+        # export embedded in path segment (not standalone)
+        "bash /opt/exported-tools/run.sh",
+        # local embedded in longer word
+        "bash /opt/localization/run.sh",
+        # declare in path
+        "/usr/lib/declare-tools/runner.sh",
+        # read in path
+        "/home/user/readability/run.sh",
+    ],
+    ids=[
+        "uv-tool-dotlocal",
+        "usr-local-bin",
+        "nfs-export-mount",
+        "export-in-compound-word",
+        "local-in-compound-word",
+        "declare-in-path",
+        "read-in-path",
+    ],
+)
+def test_inline_script_no_fire_on_path_containing_builtin_keyword(cmd):
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": cmd},
                 "on_success": "END",
             }
         }


### PR DESCRIPTION
## Summary

The `_BASH_BUILTINS_RE` regex in `rules_inline_script.py:39` uses bare `\b` word boundaries to detect bash builtins (`local`, `export`, `declare`, `mapfile`, `read -r`) in recipe `cmd` fields. After `{{AUTOSKILLIT_SCRIPTS}}` template expansion resolves to an absolute path containing `.local` (e.g., `~/.local/share/uv/tools/...`), the `\b` boundary matches at the `.`/`l` transition in `.local`, producing a false positive ERROR that blocks recipe validation.

The sibling `_CONTROL_FLOW_RE` (line 15) already has a `(?<![.a-zA-Z_/])` negative lookbehind that prevents this exact class of false positive — but `_BASH_BUILTINS_RE` was never given the same guard. This asymmetry has existed since the introducing commit (`75663905`, 2026-05-01).

**Architectural weakness:** There is no shared utility for constructing path-safe keyword regexes, no enforcement that cmd-scanning rules use path-safe guards, and no false-positive test infrastructure for path-containing cmd strings. Each rule author independently applies (or forgets) `\b` guards with ad-hoc lookbehinds.

**Proposed immunity:** A centralized `cmd_keyword_pattern()` builder in `_rule_helpers.py` that automatically applies path-safe lookbehind/lookahead guards, an arch test enforcing that all keyword regexes in cmd-scanning rules use path-safe construction, and parametrized false-positive test fixtures for path-containing cmd strings.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260510-154030-776085/.autoskillit/temp/rectify/rectify_inline_script_bash_builtins_false_positive_2026-05-10_160000.md`

Closes #2373

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 57 | 6.4k | 397.8k | 63.0k | 143 | 39.6k | 5m 57s |
| rectify | claude-sonnet-4-6 | 1 | 4.1k | 11.9k | 648.0k | 73.6k | 164 | 83.0k | 21m 3s |
| review | claude-sonnet-4-6 | 1 | 24 | 5.2k | 168.7k | 39.9k | 37 | 29.7k | 3m 58s |
| dry_walkthrough | claude-opus-4-6 | 1 | 35 | 23.2k | 994.7k | 75.6k | 81 | 62.6k | 10m 42s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.6M | 14.3k | 1.4M | 35.1k | 143 | 65.3k | 6m 9s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 95.5k | 3.9k | 235.8k | 29.8k | 19 | 15.4k | 1m 26s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.9k | 1.5k | 205.9k | 29.8k | 16 | 15.2k | 41s |
| review_pr | claude-sonnet-4-6 | 3 | 328 | 106.8k | 1.9M | 81.3k | 122 | 200.2k | 27m 52s |
| resolve_review | claude-sonnet-4-6 | 3 | 891 | 69.1k | 6.9M | 92.7k | 275 | 221.1k | 30m 0s |
| **Total** | | | 1.7M | 242.5k | 12.9M | 92.7k | | 732.0k | 1h 47m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 235 | 5975.8 | 277.7 | 60.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 80 | 86568.7 | 2763.8 | 864.1 |
| **Total** | **315** | 40873.8 | 2323.9 | 769.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 4.4k | 28.8k | 2.0M | 195.2k | 34m 42s |
| claude-opus-4-6 | 1 | 35 | 23.2k | 994.7k | 62.6k | 10m 42s |
| MiniMax-M2.7-highspeed | 3 | 1.7M | 19.7k | 1.8M | 95.9k | 8m 16s |