### PR TITLE
Rectify: Vacuous Severity Enum Comparison Bug

### DIFF
--- a/tests/arch/_helpers.py
+++ b/tests/arch/_helpers.py
@@ -14,6 +14,7 @@ from tests.arch._rules import (
     _SENSITIVE_KEYWORDS,
     _STRENUM_COMPARE_EXEMPT_FILES,
     _STRENUM_FIELD_NAMES,
+    _STRENUM_SRC_COMPARE_EXEMPT_PATHS,
     RuleDescriptor,
     Violation,
     _rel,  # noqa: F401  # re-exported for test_layer_enforcement, test_subpackage_isolation
@@ -59,6 +60,13 @@ class ArchitectureViolationVisitor(ast.NodeVisitor):
         self._print_exempt = filepath.name in _PRINT_EXEMPT
         self._asyncio_pipe_exempt = filepath.name in _ASYNCIO_PIPE_EXEMPT
         self._broad_except_exempt = filepath.name in _BROAD_EXCEPT_EXEMPT
+        try:
+            rel = filepath.relative_to(SRC_ROOT)
+            self._strenum_src_compare_exempt = (
+                str(rel).replace("\\", "/") in _STRENUM_SRC_COMPARE_EXEMPT_PATHS
+            )
+        except ValueError:
+            self._strenum_src_compare_exempt = False
 
     def _add(self, node: ast.AST, rule: RuleDescriptor, message: str) -> None:
         self.violations.append(
@@ -203,8 +211,13 @@ class ArchitectureViolationVisitor(ast.NodeVisitor):
         Detects patterns like ``obj.severity == "ERROR"`` where ``severity`` is a known
         StrEnum field name but the comparator is a raw string constant (not an enum member).
         Comparisons against ``.value`` attribute accesses (e.g., ``f.severity.value == "error"``)
-        are exempt.
+        are exempt. Files in _STRENUM_SRC_COMPARE_EXEMPT_PATHS are fully exempt (Literal-typed
+        fields that share names with StrEnum fields).
         """
+        if self._strenum_src_compare_exempt:
+            self.generic_visit(node)
+            return
+
         # Only flag == and != operators
         if not isinstance(node.ops[0], (ast.Eq, ast.NotEq)):
             self.generic_visit(node)

--- a/tests/arch/_helpers.py
+++ b/tests/arch/_helpers.py
@@ -12,6 +12,7 @@ from tests.arch._rules import (
     _PRINT_EXEMPT,
     _RULE,
     _SENSITIVE_KEYWORDS,
+    _STRENUM_COMPARE_EXEMPT_FILES,
     _STRENUM_FIELD_NAMES,
     RuleDescriptor,
     Violation,
@@ -251,6 +252,8 @@ def _scan_strenum_compare(path: Path) -> list[Violation]:
     Unlike _scan(), this function is used for test files and uses a standalone
     AST walk that does not depend on the full ArchitectureViolationVisitor.
     """
+    if path.name in _STRENUM_COMPARE_EXEMPT_FILES:
+        return []
     source = path.read_text(encoding="utf-8")
     try:
         tree = ast.parse(source, filename=str(path))

--- a/tests/arch/_helpers.py
+++ b/tests/arch/_helpers.py
@@ -12,6 +12,7 @@ from tests.arch._rules import (
     _PRINT_EXEMPT,
     _RULE,
     _SENSITIVE_KEYWORDS,
+    _STRENUM_FIELD_NAMES,
     RuleDescriptor,
     Violation,
     _rel,  # noqa: F401  # re-exported for test_layer_enforcement, test_subpackage_isolation
@@ -195,6 +196,43 @@ class ArchitectureViolationVisitor(ast.NodeVisitor):
             )
         self.generic_visit(node)
 
+    def visit_Compare(self, node: ast.Compare) -> None:
+        """Rule ARCH-010: StrEnum fields must not be compared against raw string literals.
+
+        Detects patterns like ``obj.severity == "ERROR"`` where ``severity`` is a known
+        StrEnum field name but the comparator is a raw string constant (not an enum member).
+        Comparisons against ``.value`` attribute accesses (e.g., ``f.severity.value == "error"``)
+        are exempt.
+        """
+        # Only flag == and != operators
+        if not isinstance(node.ops[0], (ast.Eq, ast.NotEq)):
+            self.generic_visit(node)
+            return
+
+        # Check left side: must be an Attribute with a known StrEnum field name
+        if not isinstance(node.left, ast.Attribute):
+            self.generic_visit(node)
+            return
+
+        attr = node.left
+        if attr.attr not in _STRENUM_FIELD_NAMES:
+            self.generic_visit(node)
+            return
+
+        # Check that the comparator is a string constant (not a .value access)
+        for comparator in node.comparators:
+            # Exempt: comparison against .value attribute access (f.severity.value == "error")
+            if isinstance(comparator, ast.Attribute) and comparator.attr == "value":
+                continue
+            if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+                self._add(
+                    node,
+                    _RULE["ARCH-010"],
+                    f"StrEnum field {attr.attr!r} compared against raw string literal "
+                    f"{comparator.value!r} -- use the enum member instead",
+                )
+        self.generic_visit(node)
+
 
 def _scan(path: Path) -> list[Violation]:
     source = path.read_text(encoding="utf-8")
@@ -205,6 +243,48 @@ def _scan(path: Path) -> list[Violation]:
     visitor = ArchitectureViolationVisitor(filepath=path)
     visitor.visit(tree)
     return visitor.violations
+
+
+def _scan_strenum_compare(path: Path) -> list[Violation]:
+    """Scan a single file for ARCH-010 StrEnum-to-string comparison violations.
+
+    Unlike _scan(), this function is used for test files and uses a standalone
+    AST walk that does not depend on the full ArchitectureViolationVisitor.
+    """
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [Violation(path, exc.lineno or 0, 0, f"SyntaxError: {exc.msg}")]
+
+    violations: list[Violation] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        if not isinstance(node.ops[0], (ast.Eq, ast.NotEq)):
+            continue
+        if not isinstance(node.left, ast.Attribute):
+            continue
+        attr = node.left
+        if attr.attr not in _STRENUM_FIELD_NAMES:
+            continue
+        for comparator in node.comparators:
+            if isinstance(comparator, ast.Attribute) and comparator.attr == "value":
+                continue
+            if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+                violations.append(
+                    Violation(
+                        path,
+                        node.lineno,  # type: ignore[attr-defined]
+                        node.col_offset,  # type: ignore[attr-defined]
+                        f"StrEnum field {attr.attr!r} compared against raw string literal "
+                        f"{comparator.value!r} -- use the enum member instead",
+                        "ARCH-010",
+                        "development",
+                    )
+                )
+    return violations
 
 
 # ── Section B: Import analysis helpers ────────────────────────────────────────

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -119,6 +119,21 @@ _BROAD_EXCEPT_EXEMPT = frozenset(
 
 _ASYNCIO_PIPE_EXEMPT: frozenset[str] = frozenset({"process.py"})
 
+# ARCH-010: Known StrEnum field names that are compared against raw string literals.
+# Maps field name → enum class name for documentation purposes.
+# These are derived from dataclass/protocol definitions across the codebase.
+_STRENUM_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "severity",  # Severity
+        "status",  # ChannelBStatus, DispatchStatus
+        "outcome",  # SessionOutcome
+        "install_type",  # InstallType
+        "lifecycle",  # FeatureLifecycle
+        "session_type",  # SessionType
+        "dispatch_gate_type",  # DispatchGateType
+    }
+)
+
 # ARCH-007: Functions that check TerminationReason as sequential early-exit guards
 # (single-value checks), not as dispatch tables (>=2 values). Exempt from ARCH-007.
 _DISPATCH_TABLE_EXEMPT_FUNCTIONS = frozenset(
@@ -127,7 +142,7 @@ _DISPATCH_TABLE_EXEMPT_FUNCTIONS = frozenset(
     }
 )
 
-# ── RULES tuple — 9 entries ───────────────────────────────────────────────────
+# ── RULES tuple — 10 entries ──────────────────────────────────────────────────
 
 RULES: tuple[RuleDescriptor, ...] = (
     RuleDescriptor(
@@ -284,6 +299,25 @@ RULES: tuple[RuleDescriptor, ...] = (
         exemptions=frozenset(),
         severity="error",
         defense_standard="DS-009",
+    ),
+    RuleDescriptor(
+        rule_id="ARCH-010",
+        name="no-strenum-string-compare",
+        lens="development",
+        description=(
+            "StrEnum-typed attributes must not be compared against raw string literals; "
+            "use the enum member instead."
+        ),
+        rationale=(
+            "Python's StrEnum uses lowercase .value strings while member names are UPPERCASE. "
+            "Comparing a StrEnum field against a case-mismatched string literal always returns "
+            "False, creating vacuous assertions that silently pass regardless of actual state. "
+            "This rule enforces enum-member comparisons (f.severity == Severity.ERROR) which "
+            "are immune to case drift and checked by IDE autocompletion."
+        ),
+        exemptions=frozenset(),
+        severity="error",
+        defense_standard="DS-010",
     ),
 )
 

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -119,6 +119,17 @@ _BROAD_EXCEPT_EXEMPT = frozenset(
 
 _ASYNCIO_PIPE_EXEMPT: frozenset[str] = frozenset({"process.py"})
 
+# ARCH-010: Files exempt from the StrEnum-to-string comparison scan.
+# These files compare against fields typed as Literal[...], not actual StrEnums.
+# The same attribute names (e.g. "outcome", "status") appear in both Literal and
+# StrEnum contexts; the AST rule cannot distinguish them by field name alone.
+_STRENUM_COMPARE_EXEMPT_FILES: frozenset[str] = frozenset(
+    {
+        "test_result_parser.py",  # L3ParseResult.outcome: Literal[...], not SessionOutcome
+        "test_sidecar.py",  # IssueSidecarEntry.status: Literal["completed", "failed"], not StrEnum
+    }
+)
+
 # ARCH-010: Known StrEnum field names that are compared against raw string literals.
 # Maps field name → enum class name for documentation purposes.
 # These are derived from dataclass/protocol definitions across the codebase.

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -326,6 +326,11 @@ RULES: tuple[RuleDescriptor, ...] = (
             "This rule enforces enum-member comparisons (f.severity == Severity.ERROR) which "
             "are immune to case drift and checked by IDE autocompletion."
         ),
+        # ARCH-010 uses a standalone scanner (_scan_strenum_compare in _helpers.py)
+        # rather than the visitor-level exemptions= slot used by other rules.
+        # Reason: test-file scanning runs only this rule in isolation (avoiding the full
+        # ArchitectureViolationVisitor), so file-level exemptions are handled by
+        # _STRENUM_COMPARE_EXEMPT_FILES in _scan_strenum_compare directly.
         exemptions=frozenset(),
         severity="error",
         defense_standard="DS-010",

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -130,6 +130,19 @@ _STRENUM_COMPARE_EXEMPT_FILES: frozenset[str] = frozenset(
     }
 )
 
+# ARCH-010: Source files exempt from the visitor-level StrEnum comparison check.
+# Uses paths relative to src/autoskillit/ (forward slashes, platform-independent).
+# These source files compare Literal[...]-typed or plain-str fields that share names
+# with known StrEnum fields; the AST rule cannot distinguish by field name alone.
+_STRENUM_SRC_COMPARE_EXEMPT_PATHS: frozenset[str] = frozenset(
+    {
+        "cli/_validate.py",  # ValidationResult.status: plain str property, not a StrEnum
+        "execution/process/_process_monitor.py",  # psutil Connection.status: plain str
+        "fleet/_api.py",  # L3ParseResult.outcome: Literal[...], not SessionOutcome
+        "fleet/_checkpoint_bridge.py",  # IssueSidecarEntry.status: Literal[...], not StrEnum
+    }
+)
+
 # ARCH-010: Known StrEnum field names that are compared against raw string literals.
 # Maps field name → enum class name for documentation purposes.
 # These are derived from dataclass/protocol definitions across the codebase.

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -967,6 +967,7 @@ def test_arch010_accepts_non_strenum_field(tmp_path: Path) -> None:
 
 
 _TEST_FILES = sorted((Path(__file__).parent.parent).rglob("*.py"))
+_TEST_IDS = [str(f.relative_to(Path(__file__).parent.parent)) for f in _TEST_FILES]
 
 
 class TestArch010Enforcement:
@@ -975,13 +976,15 @@ class TestArch010Enforcement:
     @pytest.mark.parametrize(
         "test_file",
         _TEST_FILES,
-        ids=[str(f.relative_to(Path(__file__).parent.parent)) for f in _TEST_FILES],
+        ids=_TEST_IDS,
     )
     def test_no_strenum_string_compare_in_tests(self, test_file: Path) -> None:
         """ARCH-010: test files must not compare StrEnum fields against raw string literals."""
         # Exempt calibration snippets in test_ast_rules.py itself
         if test_file.name == "test_ast_rules.py":
-            return
+            pytest.skip(
+                "exempt: calibration snippets in this file are intentional ARCH-010 violations"
+            )
         violations = _scan_strenum_compare(test_file)
         assert not violations, (
             f"ARCH-010 violations in {test_file.relative_to(Path(__file__).parent.parent)}:\n"

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -1,4 +1,4 @@
-"""Architectural enforcement: AST-based visitor rules (ARCH-001 through ARCH-009).
+"""Architectural enforcement: AST-based visitor rules (ARCH-001 through ARCH-010).
 
 Rules enforced here (compile-time, no execution required):
   1. No print() calls in production code
@@ -10,6 +10,7 @@ Rules enforced here (compile-time, no execution required):
   7. Exhaustive TerminationReason dispatch (match/case + assert_never)
   8. No raw .pid attribute passed to start_linux_tracing()
   9. get_logger() result must be bound to variable named 'logger'
+ 10. StrEnum fields must not be compared against raw string literals
 
 Note: `import logging` and `logging.getLogger()` are enforced by ruff TID251
 at pre-commit time (see pyproject.toml [tool.ruff.lint.flake8-tidy-imports]).
@@ -33,6 +34,7 @@ from tests.arch._helpers import (
     _SOURCE_FILES,
     SRC_ROOT,
     _scan,
+    _scan_strenum_compare,
 )
 from tests.arch._rules import (
     _DISPATCH_TABLE_EXEMPT_FUNCTIONS,
@@ -906,3 +908,82 @@ def test_no_build_cmd_accepts_output_format_value_string() -> None:
                 f"{node.name} still accepts 'output_format_value' (raw string). "
                 f"Use 'output_format: OutputFormat' instead."
             )
+
+
+# ── ARCH-010: StrEnum-to-string comparison ────────────────────────────────────
+
+
+def test_arch010_detects_strenum_field_compared_to_uppercase_string(tmp_path: Path) -> None:
+    """ARCH-010 fires when a known StrEnum field is compared against a raw string literal."""
+    f = tmp_path / "bad.py"
+    f.write_text('result.status == "completion"\n')
+    violations = _scan(f)
+    arch010 = [v for v in violations if v.rule_id == "ARCH-010"]
+    assert arch010, (
+        f"Expected ARCH-010 violation for 'status == \"completion\"', got: {violations}"
+    )
+    assert "status" in arch010[0].message
+    assert '"completion"' in arch010[0].message
+
+
+def test_arch010_detects_severity_error_uppercase_string(tmp_path: Path) -> None:
+    """ARCH-010 fires for severity == "ERROR" (the original vacuous comparison bug)."""
+    f = tmp_path / "bad.py"
+    f.write_text('f.severity == "ERROR"\n')
+    violations = _scan(f)
+    arch010 = [v for v in violations if v.rule_id == "ARCH-010"]
+    assert arch010, f"Expected ARCH-010 violation for 'severity == \"ERROR\"', got: {violations}"
+    assert "severity" in arch010[0].message
+
+
+def test_arch010_accepts_enum_member_comparison(tmp_path: Path) -> None:
+    """ARCH-010 does NOT fire when comparing against an enum member (no raw string)."""
+    f = tmp_path / "good.py"
+    f.write_text("result.status == ChannelBStatus.COMPLETION\n")
+    violations = _scan(f)
+    arch010 = [v for v in violations if v.rule_id == "ARCH-010"]
+    assert not arch010, f"ARCH-010 should not fire for enum member comparison: {arch010}"
+
+
+def test_arch010_accepts_value_attribute_comparison(tmp_path: Path) -> None:
+    """ARCH-010 does NOT fire for f.severity.value == "error" (explicit .value access)."""
+    f = tmp_path / "ok.py"
+    f.write_text('f.severity.value == "error"\n')
+    violations = _scan(f)
+    arch010 = [v for v in violations if v.rule_id == "ARCH-010"]
+    assert not arch010, f"ARCH-010 should not fire for .value comparison: {arch010}"
+
+
+def test_arch010_accepts_non_strenum_field(tmp_path: Path) -> None:
+    """ARCH-010 does NOT fire for non-StrEnum fields."""
+    f = tmp_path / "ok.py"
+    f.write_text('result.name == "something"\n')
+    violations = _scan(f)
+    arch010 = [v for v in violations if v.rule_id == "ARCH-010"]
+    assert not arch010, f"ARCH-010 should not fire for non-StrEnum field: {arch010}"
+
+
+# ── ARCH-010 test-file parametrized sweep ──────────────────────────────────────
+
+
+_TEST_FILES = sorted((Path(__file__).parent.parent).rglob("*.py"))
+
+
+class TestArch010Enforcement:
+    """ARCH-010 enforcement for test files (covers the original bug location)."""
+
+    @pytest.mark.parametrize(
+        "test_file",
+        _TEST_FILES,
+        ids=[str(f.relative_to(Path(__file__).parent.parent)) for f in _TEST_FILES],
+    )
+    def test_no_strenum_string_compare_in_tests(self, test_file: Path) -> None:
+        """ARCH-010: test files must not compare StrEnum fields against raw string literals."""
+        # Exempt calibration snippets in test_ast_rules.py itself
+        if test_file.name == "test_ast_rules.py":
+            return
+        violations = _scan_strenum_compare(test_file)
+        assert not violations, (
+            f"ARCH-010 violations in {test_file.relative_to(Path(__file__).parent.parent)}:\n"
+            + "\n".join(f"  {v}" for v in violations)
+        )

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -923,7 +923,7 @@ def test_arch010_detects_strenum_field_compared_to_uppercase_string(tmp_path: Pa
         f"Expected ARCH-010 violation for 'status == \"completion\"', got: {violations}"
     )
     assert "status" in arch010[0].message
-    assert '"completion"' in arch010[0].message
+    assert "'completion'" in arch010[0].message
 
 
 def test_arch010_detects_severity_error_uppercase_string(tmp_path: Path) -> None:

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -981,7 +981,7 @@ class TestArch010Enforcement:
     def test_no_strenum_string_compare_in_tests(self, test_file: Path) -> None:
         """ARCH-010: test files must not compare StrEnum fields against raw string literals."""
         # Exempt calibration snippets in test_ast_rules.py itself
-        if test_file.name == "test_ast_rules.py":
+        if test_file.resolve() == Path(__file__).resolve():
             pytest.skip(
                 "exempt: calibration snippets in this file are intentional ARCH-010 violations"
             )

--- a/tests/arch/test_registry.py
+++ b/tests/arch/test_registry.py
@@ -45,7 +45,10 @@ def test_rule_descriptor_is_frozen_dataclass() -> None:
     assert rd.name == "test-rule"
     assert rd.lens == "operational"
     assert rd.exemptions == frozenset()
-    assert rd.severity == "error"
+    _expected_severity = "error"
+    assert (
+        rd.severity == _expected_severity
+    )  # plain str field, not StrEnum — use variable to avoid ARCH-010 false positive
     assert rd.defense_standard is None
     assert rd.adr_ref is None
     # Verify frozen (immutable)

--- a/tests/arch/test_registry.py
+++ b/tests/arch/test_registry.py
@@ -95,6 +95,7 @@ def test_rule_registry_completeness() -> None:
             "ARCH-007",
             "ARCH-008",
             "ARCH-009",
+            "ARCH-010",
         }
     )
     actual_ids = frozenset(rule_ids)

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -250,6 +250,19 @@ def test_severity_has_ok_member():
     assert set(Severity) == {Severity.OK, Severity.ERROR, Severity.WARNING, Severity.INFO}
 
 
+def test_severity_enum_not_equal_to_uppercase_string():
+    """Regression: StrEnum values are lowercase; uppercase comparison is always False.
+
+    ``f.severity == "ERROR"`` always returns False because Severity.ERROR.value
+    is ``"error"`` (lowercase), not ``"ERROR"``.
+    """
+    from autoskillit.core.types import Severity
+
+    assert Severity.ERROR != "ERROR"
+    assert Severity.ERROR == "error"
+    assert Severity.ERROR == Severity.ERROR
+
+
 def test_github_fetcher_protocol_has_label_methods():
     import inspect
 

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -82,7 +82,7 @@ class TestSessionLogMonitor:
             tg.start_soon(append_marker)
             tg.start_soon(_run_monitor)
 
-        assert monitor_result[0].status == "completion"
+        assert monitor_result[0].status == ChannelBStatus.COMPLETION
         assert monitor_result[0].session_id == "abc123"
 
     @pytest.mark.anyio
@@ -111,7 +111,7 @@ class TestSessionLogMonitor:
         )
         elapsed = time.monotonic() - start
 
-        assert result.status == "stale"
+        assert result.status == ChannelBStatus.STALE
         assert result.session_id == "abc123"
         assert elapsed < 1.0, f"Staleness should fire after ~0.2s, took {elapsed:.1f}s"
 
@@ -167,7 +167,7 @@ class TestSessionLogMonitor:
             tg.start_soon(_run_monitor)
 
         # Staleness should have fired AFTER the writing stopped, not during
-        assert monitor_result[0].status == "stale"
+        assert monitor_result[0].status == ChannelBStatus.STALE
 
     @pytest.mark.anyio
     async def test_monitor_ignores_marker_in_non_assistant_records(self, tmp_path):
@@ -239,7 +239,7 @@ class TestSessionLogMonitor:
                 f.write(assistant_record + "\n")
             # task group awaits _run_monitor to detect assistant record and complete
 
-        assert monitor_result[0].status == "completion"
+        assert monitor_result[0].status == ChannelBStatus.COMPLETION
 
     @pytest.mark.anyio
     async def test_monitor_realistic_jsonl_sequence(self, tmp_path):
@@ -323,7 +323,7 @@ class TestSessionLogMonitor:
                 f.write(assistant_record + "\n")
             # task group awaits _run_monitor to detect assistant record and complete
 
-        assert monitor_result[0].status == "completion"
+        assert monitor_result[0].status == ChannelBStatus.COMPLETION
 
 
 class TestSessionLogMonitorStaleSuppressionGate:
@@ -360,7 +360,7 @@ class TestSessionLogMonitorStaleSuppressionGate:
                     _phase1_poll=0.01,
                     _phase2_poll=0.05,
                 )
-        assert result.status == "stale"
+        assert result.status == ChannelBStatus.STALE
         assert call_count["n"] == 2
 
     @pytest.mark.anyio
@@ -379,7 +379,7 @@ class TestSessionLogMonitorStaleSuppressionGate:
                 _phase1_poll=0.01,
                 _phase2_poll=0.05,
             )
-        assert result.status == "stale"
+        assert result.status == ChannelBStatus.STALE
 
     @pytest.mark.anyio
     async def test_fires_stale_when_pid_is_none_regardless_of_tcp(self, tmp_path):
@@ -401,7 +401,7 @@ class TestSessionLogMonitorStaleSuppressionGate:
                     _phase1_poll=0.01,
                     _phase2_poll=0.05,
                 )
-        assert result.status == "stale"
+        assert result.status == ChannelBStatus.STALE
         mock_tcp.assert_not_called()
 
     @pytest.mark.anyio
@@ -793,7 +793,7 @@ class TestSessionLogMonitorSessionId:
             spawn_time=time.time() - 1,
         )
 
-        assert result.status == "completion"
+        assert result.status == ChannelBStatus.COMPLETION
         assert result.session_id == session_uuid
 
     @pytest.mark.anyio
@@ -822,7 +822,7 @@ class TestSessionLogMonitorSessionId:
             _phase2_poll=0.05,
         )
 
-        assert result.status == "stale"
+        assert result.status == ChannelBStatus.STALE
         assert result.session_id == session_uuid
 
     @pytest.mark.anyio
@@ -836,7 +836,7 @@ class TestSessionLogMonitorSessionId:
             _phase1_timeout=0.1,
         )
 
-        assert result.status == "stale"
+        assert result.status == ChannelBStatus.STALE
         assert result.session_id == ""
 
     @pytest.mark.anyio
@@ -938,7 +938,7 @@ class TestSessionIdBasedSelection:
             spawn_time=time.time() - 2,
             expected_session_id=session_a,
         )
-        assert result.status == "completion"
+        assert result.status == ChannelBStatus.COMPLETION
         assert result.session_id == session_a
 
     @pytest.mark.anyio
@@ -959,7 +959,7 @@ class TestSessionIdBasedSelection:
             spawn_time=time.time() - 2,
             expected_session_id="nonexistent-session-id",
         )
-        assert result.status == "completion"
+        assert result.status == ChannelBStatus.COMPLETION
         assert result.session_id == session_b
 
 

--- a/tests/recipe/conftest.py
+++ b/tests/recipe/conftest.py
@@ -7,7 +7,9 @@ from pathlib import Path
 import pytest
 import yaml
 
+from autoskillit.core.types import Severity
 from autoskillit.recipe.io import _parse_step, builtin_recipes_dir, load_recipe
+from autoskillit.recipe.registry import RuleFinding
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
 NO_AUTOSKILLIT_IMPORT = "no-autoskillit-import-in-skill-python-block"
@@ -34,6 +36,28 @@ KNOWN_VIOLATIONS_BY_RECIPE: dict[str, frozenset[str]] = {
 }
 
 KNOWN_PART_B_VIOLATIONS = frozenset().union(*KNOWN_VIOLATIONS_BY_RECIPE.values())
+
+
+def assert_no_rule_errors(
+    findings: list[RuleFinding],
+    *,
+    suppress: frozenset[str] = KNOWN_PART_B_VIOLATIONS,
+    context: str = "",
+) -> None:
+    """Assert that findings contain no non-suppressed ERROR-severity violations.
+
+    This helper encapsulates the canonical pattern::
+
+        [f for f in findings if f.severity == Severity.ERROR and f.rule not in suppress]
+
+    Using this helper instead of inline filters prevents the StrEnum comparison bug
+    where ``f.severity == "ERROR"`` always returns False (StrEnum values are lowercase).
+    """
+    errors = [f for f in findings if f.severity == Severity.ERROR and f.rule not in suppress]
+    assert not errors, (
+        f"Unexpected ERROR findings{f' in {context}' if context else ''}: "
+        f"{[(f.rule, f.step_name, f.message) for f in errors]}"
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -4,8 +4,10 @@ import importlib
 
 import pytest
 
+from autoskillit.core.types import Severity
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import run_semantic_rules
+from tests.recipe.conftest import assert_no_rule_errors
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -100,8 +102,19 @@ def test_planner_recipe_validate_routes_to_refine_on_fail(planner_recipe):
 
 def test_planner_recipe_validation_has_no_errors(planner_recipe):
     findings = run_semantic_rules(planner_recipe)
-    errors = [f for f in findings if f.severity == "ERROR"]
-    assert errors == [], f"Unexpected ERROR findings: {[f.rule for f in errors]}"
+    assert_no_rule_errors(findings, context="planner recipe")
+
+
+def test_severity_enum_not_equal_to_uppercase_string():
+    """Regression: StrEnum values are lowercase; uppercase comparison is always False.
+
+    This bug made ``test_planner_recipe_validation_has_no_errors`` vacuous:
+    ``f.severity == "ERROR"`` always returned False because Severity.ERROR.value
+    is ``"error"`` (lowercase), not ``"ERROR"``.
+    """
+    assert Severity.ERROR != "ERROR"
+    assert Severity.ERROR == "error"
+    assert Severity.ERROR == Severity.ERROR
 
 
 def test_planner_recipe_extract_domain_uses_positional_args(planner_recipe):

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -4,7 +4,6 @@ import importlib
 
 import pytest
 
-from autoskillit.core.types import Severity
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import run_semantic_rules
 from tests.recipe.conftest import assert_no_rule_errors
@@ -103,18 +102,6 @@ def test_planner_recipe_validate_routes_to_refine_on_fail(planner_recipe):
 def test_planner_recipe_validation_has_no_errors(planner_recipe):
     findings = run_semantic_rules(planner_recipe)
     assert_no_rule_errors(findings, context="planner recipe")
-
-
-def test_severity_enum_not_equal_to_uppercase_string():
-    """Regression: StrEnum values are lowercase; uppercase comparison is always False.
-
-    This bug made ``test_planner_recipe_validation_has_no_errors`` vacuous:
-    ``f.severity == "ERROR"`` always returned False because Severity.ERROR.value
-    is ``"error"`` (lowercase), not ``"ERROR"``.
-    """
-    assert Severity.ERROR != "ERROR"
-    assert Severity.ERROR == "error"
-    assert Severity.ERROR == Severity.ERROR
 
 
 def test_planner_recipe_extract_domain_uses_positional_args(planner_recipe):


### PR DESCRIPTION
## Summary

A StrEnum comparison trap makes `test_planner_recipe_validation_has_no_errors` vacuous — it always passes because `Severity.ERROR == "ERROR"` evaluates to `False` (the StrEnum value is `"error"`, lowercase). The architectural weakness is that no static analysis or AST rule prevents raw string literals from being compared against typed StrEnum fields, and no centralized assertion helper enforces the correct comparison pattern across 50+ recipe test files.

The proposed immunity adds two structural guarantees:
1. **ARCH-010 AST rule** — detects raw string comparisons against known StrEnum-typed attributes in test and source files, making this class of bug impossible to introduce without failing CI.
2. **Centralized `assert_no_rule_errors()` helper** — encapsulates the correct `Severity.ERROR` + `KNOWN_PART_B_VIOLATIONS` filter pattern, eliminating ad-hoc inline severity filtering.

## Requirements

Fix `test_planner_recipe_validation_has_no_errors` in `tests/recipe/test_planner_recipe.py` to use `Severity.ERROR` enum comparison instead of `"ERROR"` string comparison. Add ARCH-010 AST rule to detect StrEnum-to-string comparisons. Add centralized `assert_no_rule_errors()` helper in `tests/recipe/conftest.py`. Migrate fragile string comparisons in `test_process_session_log_monitor.py` to enum member comparisons.

## Changed Files

### Modified (●):
- tests/arch/_helpers.py
- tests/arch/_rules.py
- tests/arch/test_ast_rules.py
- tests/arch/test_registry.py
- tests/execution/test_process_session_log_monitor.py
- tests/recipe/conftest.py
- tests/recipe/test_planner_recipe.py

Closes #2368

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260510-143434-155655/.autoskillit/temp/rectify/rectify_vacuous_severity_enum_comparison_2026-05-10_143434.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 53 | 9.0k | 822.4k | 83.9k | 171 | 54.7k | 8m 42s |
| dry_walkthrough | claude-opus-4-6 | 1 | 48 | 13.5k | 1.8M | 77.9k | 104 | 65.1k | 6m 18s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.5M | 19.9k | 2.2M | 86.4k | 159 | 120.6k | 7m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 75.4k | 4.2k | 205.9k | 29.8k | 20 | 15.3k | 1m 33s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 56.3k | 1.5k | 235.7k | 29.8k | 16 | 15.2k | 45s |
| review_pr | claude-sonnet-4-6 | 3 | 272 | 104.1k | 1.4M | 86.8k | 114 | 241.6k | 26m 4s |
| resolve_review | claude-sonnet-4-6 | 3 | 717 | 52.7k | 4.4M | 73.0k | 227 | 174.0k | 28m 58s |
| ci_conflict_fix | claude-sonnet-4-6 | 2 | 328 | 16.6k | 1.8M | 65.3k | 88 | 74.9k | 6m 22s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 90.4k | 1.5k | 179.0k | 29.8k | 16 | 42.0k | 52s |
| resolve_ci | claude-sonnet-4-6 | 1 | 224 | 14.3k | 2.0M | 97.0k | 70 | 84.6k | 7m 11s |
| resolve_queue_merge_conflicts | claude-sonnet-4-6 | 1 | 259 | 16.1k | 1.3M | 56.7k | 67 | 43.8k | 5m 9s |
| **Total** | | | 3.7M | 253.4k | 16.3M | 97.0k | | 931.8k | 1h 39m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 267 | 8233.0 | 451.8 | 74.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 40 | 109883.1 | 4349.8 | 1318.0 |
| ci_conflict_fix | 25105 | 71.5 | 3.0 | 0.7 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 685 | 2965.7 | 123.5 | 20.8 |
| resolve_queue_merge_conflicts | 699 | 1838.2 | 62.6 | 23.0 |
| **Total** | **26796** | 606.8 | 34.8 | 9.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 4.4k | 28.8k | 2.0M | 195.2k | 34m 42s |
| claude-opus-4-6 | 1 | 35 | 23.2k | 994.7k | 62.6k | 10m 42s |
| MiniMax-M2.7-highspeed | 3 | 1.7M | 19.7k | 1.8M | 95.9k | 8m 16s |