### PR TITLE
[FIX] Add semantic verification tier (V10) to plan-experiment for database/literature accession verification

### DIFF
--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -61,6 +61,10 @@ incorporate the feedback before writing the plan.
 - Omit YAML frontmatter unless a V1–V4 ERROR is triggered — every plan must have frontmatter
 - Write frontmatter after the `# Experiment Plan:` heading — it always goes BEFORE
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Include database accession identifiers (GEO GSE*, SRA SRR*/SRP*, ENCODE ENCSR*, or
+  any external dataset identifier) in the data_manifest without first confirming their
+  existence via web search — accession patterns learned during training are frequently
+  hallucinated
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
@@ -135,6 +139,20 @@ information gaps and produce the best possible experiment plan.
 > download or generation, include the exact commands in the `acquisition` field.
 > For `literature` or `database` source types, describe the extraction or query
 > method in `acquisition` — download commands are not required.
+>
+> **Accession Verification (mandatory for database and literature source types):** For
+> every data_manifest entry with `source_type: database` or `source_type: literature`
+> that references a specific database accession (GEO GSE*, SRA SRR*/SRP*, ENCODE ENCSR*,
+> UniProt, PDB, or any external identifier) or a specific publication (DOI, PMID, author-
+> year citation), launch a web-search or web-fetch subagent to confirm:
+> (a) the accession/DOI resolves to an existing record,
+> (b) the organism, data type, or subject matter matches the plan's description, and
+> (c) the contributor/author attribution matches the plan's citation.
+> Record the confirmation URL in a `verification_url` field on the manifest entry.
+> If the accession cannot be confirmed, either remove the entry, switch to
+> `source_type: synthetic` with a generation plan, or flag the entry with
+> `verified: false` and a note explaining the verification failure. Never include
+> an unverified accession as accepted fact.
 
 **Subagent C — Environment Assessment:**
 > Determine whether the experiment can run with the project's existing
@@ -149,6 +167,8 @@ information gaps and produce the best possible experiment plan.
 - Research into how similar experiments have been designed elsewhere
 - Investigation of specific technical constraints or requirements
 - Any other research that improves the experiment plan
+- Web searches to verify database accession identifiers and literature citations
+  referenced in the data manifest — confirm each accession resolves and metadata matches
 
 **Breadth enforcement (when scope_directions.json is available):**
 Each direction with `must_cover: true` must be assessed for feasibility by at least
@@ -408,6 +428,14 @@ data_manifest:                        # REQUIRED — one entry per hypothesis (o
   #   acquisition: "extract values from published table"
   #   location: null
   #   verification: "values match published Table 2"
+  #   verification_url: "https://doi.org/10.1234/example.2023.table2"
+  # - hypothesis: [H5]
+  #   source_type: database
+  #   description: "ENCODE ChIP-seq for H3K27ac in HepG2"
+  #   acquisition: "query ENCODE REST API: /search/?type=Experiment&accession=ENCSR000EJD"
+  #   location: null
+  #   verification: "JSON response contains 'status': 'released'"
+  #   verification_url: "https://www.encodeproject.org/ENCSR000EJD/"
 
 experiment_slug: "{YYYY-MM-DD-slug}"  # optional, derived from directory layout
 ---
@@ -443,6 +471,7 @@ A list of data source entries, one per hypothesis (or shared across hypotheses).
 | `location` | no | Filesystem path where data will reside (null for in-script) |
 | `verification` | yes | How to confirm the data is present and valid |
 | `depends_on` | no | Prerequisite acquisition step (e.g., download before subset) |
+| `verification_url` | conditional | URL confirming accession existence (required for database/literature with external identifiers) |
 
 Apply these validation rules in order before writing the frontmatter:
 
@@ -480,9 +509,22 @@ V9: data_manifest completeness
     - Any entry with `source_type: literature` lacks a non-null `description` (must identify the source publication)
     NOTE: `literature` and `database` entries do NOT require `depends_on` or download commands.
     ERROR: "Data Manifest incomplete: {specific missing field or hypothesis}"
+
+V10: data_manifest semantic verification
+    ERROR if:
+    - Any entry with `source_type: database` references a specific accession identifier
+      (matching patterns like GSE*, SRR*, SRP*, ENCSR*, or any alphanumeric database ID)
+      AND lacks a `verification_url` field with a resolvable URL
+    - Any entry with `source_type: literature` references a specific publication
+      (DOI, PMID, or author-year citation) AND lacks a `verification_url` field
+    NOTE: Entries with `verified: false` explicitly set are exempt from this error
+      (they will appear as a V10 WARNING instead, alerting review-design to scrutinize).
+    WARNING if:
+    - Any database/literature entry has `verified: false` — flag for review-design attention
+    ERROR: "Unverified accession in data_manifest: {entry.description} has no verification_url"
 ```
 
-- ERRORs (V1–V4, V9): Stop frontmatter generation, append the error message to the plan
+- ERRORs (V1–V4, V9, V10): Stop frontmatter generation, append the error message to the plan
   prose under a `## Frontmatter Validation Errors` section, and save the plan WITHOUT
   a frontmatter block. Emit the `experiment_plan` token as usual.
 - WARNINGs (V5–V8): Continue; log each as a `# WARNING: ...` YAML comment on the

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -58,7 +58,7 @@ incorporate the feedback before writing the plan.
 - Leave success criteria vague — every criterion must be measurable
 - Omit the environment assessment — always explicitly state whether a custom
   environment is needed or not, and why
-- Omit YAML frontmatter unless a V1–V4 ERROR is triggered — every plan must have frontmatter
+- Omit YAML frontmatter unless a V1–V4, V9, V10 ERROR is triggered — every plan must have frontmatter
 - Write frontmatter after the `# Experiment Plan:` heading — it always goes BEFORE
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Include database accession identifiers (GEO GSE*, SRA SRR*/SRP*, ENCODE ENCSR*, or

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -75,9 +75,9 @@ incorporate the feedback before writing the plan.
 - Plan all artifacts into one self-contained `research/YYYY-MM-DD-{slug}/` folder
 - Include implementation phases that an implementer can follow step by step
 - Write YAML frontmatter between --- delimiters BEFORE the # Experiment Plan: heading
-- Apply all 9 validation rules before writing the frontmatter block
-- Log V1–V4, V9 ERRORs in a ## Frontmatter Validation Errors section instead of writing frontmatter
-- Log V5–V8 WARNINGs as # WARNING: ... YAML comments on the relevant field lines
+- Apply all 10 validation rules before writing the frontmatter block
+- Log V1–V4, V9, V10 ERRORs in a ## Frontmatter Validation Errors section instead of writing frontmatter
+- Log V5–V8, V10 WARNINGs as # WARNING: ... YAML comments on the relevant field lines
 
 ## Workflow
 
@@ -527,7 +527,7 @@ V10: data_manifest semantic verification
 - ERRORs (V1–V4, V9, V10): Stop frontmatter generation, append the error message to the plan
   prose under a `## Frontmatter Validation Errors` section, and save the plan WITHOUT
   a frontmatter block. Emit the `experiment_plan` token as usual.
-- WARNINGs (V5–V8): Continue; log each as a `# WARNING: ...` YAML comment on the
+- WARNINGs (V5–V8, V10): Continue; log each as a `# WARNING: ...` YAML comment on the
   relevant field line.
 
 Field requirements by experiment type:

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -187,7 +187,10 @@ def test_subagent_b_requires_accession_verification() -> None:
     )
     assert m, "Subagent B section not found in SKILL.md"
     subagent_b = m.group(0).lower()
-    assert "web" in subagent_b and ("search" in subagent_b or "fetch" in subagent_b), (
+    assert "web" in subagent_b, (
+        "Subagent B must mention web-based verification of database accessions"
+    )
+    assert "search" in subagent_b or "fetch" in subagent_b, (
         "Subagent B must mandate web search or web fetch to verify database accessions "
         "before including them in data_manifest"
     )

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -222,7 +222,7 @@ def test_additional_subagents_includes_accession_verification() -> None:
 
     text = SKILL_PATH.read_text()
     m = re.search(
-        r"\*\*Additional subagents.*?(?=\n\*\*Breadth enforcement|\n###|\n\*\*|## )",
+        r"\*\*Additional subagents.*?(?=\n\*\*Breadth enforcement|\n###|## )",
         text,
         re.DOTALL | re.IGNORECASE,
     )

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -26,7 +26,7 @@ def test_data_manifest_in_frontmatter_schema() -> None:
 
 def test_data_manifest_required_fields() -> None:
     text = SKILL_PATH.read_text()
-    after_manifest = text.lower().split("data_manifest")[1][:2000]
+    after_manifest = text.lower().split("### data_manifest")[1][:2000]
     for field in ("source_type", "acquisition", "verification", "hypothesis"):
         assert field in after_manifest, f"data_manifest missing field: {field}"
 
@@ -171,3 +171,90 @@ def test_v9_mentions_literature_and_database_source_types() -> None:
     v9_block = m.group(0)
     assert "literature" in v9_block.lower(), "V9 must mention literature source type"
     assert "database" in v9_block.lower(), "V9 must mention database source type"
+
+
+def test_subagent_b_requires_accession_verification() -> None:
+    """Subagent B instructions must mandate web-search verification of database accessions."""
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(
+        r"Subagent B.*?(?=\*\*Subagent C|\*\*Additional subagents)",
+        text,
+        re.DOTALL | re.IGNORECASE,
+    )
+    assert m, "Subagent B section not found in SKILL.md"
+    subagent_b = m.group(0).lower()
+    assert "web" in subagent_b and ("search" in subagent_b or "fetch" in subagent_b), (
+        "Subagent B must mandate web search or web fetch to verify database accessions "
+        "before including them in data_manifest"
+    )
+    assert "accession" in subagent_b or "identifier" in subagent_b, (
+        "Subagent B must reference accession or identifier verification"
+    )
+
+
+def test_v10_semantic_verification_rule_exists() -> None:
+    """V10 rule must enforce semantic verification of database/literature accessions."""
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(r"V10:.+?(?=\nV[0-9]+:|\n---|\n```|\Z)", text, re.DOTALL)
+    assert m, (
+        "V10 semantic verification rule not found in SKILL.md — "
+        "add a V10 rule requiring web-search confirmation of database/literature accessions"
+    )
+    v10_block = m.group(0).lower()
+    assert "verification" in v10_block or "verified" in v10_block or "confirm" in v10_block, (
+        "V10 must reference verification or confirmation of accessions"
+    )
+    assert "database" in v10_block, "V10 must cover database source_type entries"
+
+
+def test_plan_experiment_defines_all_validation_rules_including_v10() -> None:
+    """Validation rules must include V1 through V10."""
+    text = SKILL_PATH.read_text()
+    for i in range(1, 11):
+        assert f"V{i}:" in text, f"V{i} rule label not found in SKILL.md"
+
+
+def test_additional_subagents_includes_accession_verification() -> None:
+    """Additional subagents section must list accession/citation verification as a category."""
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(
+        r"\*\*Additional subagents.*?(?=\*\*Breadth enforcement|\n###|\n\*\*|## )",
+        text,
+        re.DOTALL | re.IGNORECASE,
+    )
+    assert m, "Additional subagents section not found in SKILL.md"
+    section = m.group(0).lower()
+    assert "accession" in section or "citation" in section or "identifier" in section, (
+        "Additional subagents must list accession/citation/identifier verification "
+        "as a sanctioned web-search category"
+    )
+
+
+def test_anti_fabrication_covers_accession_identifiers() -> None:
+    """NEVER block must explicitly cover fabrication of database accession identifiers."""
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(r"\*\*NEVER:\*\*.*?(?=\*\*ALWAYS:\*\*)", text, re.DOTALL)
+    assert m, "NEVER block not found in SKILL.md"
+    never_block = m.group(0).lower()
+    assert "accession" in never_block or "identifier" in never_block, (
+        "NEVER block must explicitly prohibit fabrication of database accession identifiers "
+        "or external dataset identifiers from training knowledge"
+    )
+
+
+def test_data_manifest_verification_url_field() -> None:
+    """data_manifest field definitions must include a verification_url field."""
+    text = SKILL_PATH.read_text()
+    lower = text.lower()
+    assert "verification_url" in lower or "verification_source" in lower, (
+        "data_manifest must include a verification_url or verification_source field "
+        "to record the URL used to confirm accession existence"
+    )

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -251,8 +251,10 @@ def test_anti_fabrication_covers_accession_identifiers() -> None:
 def test_data_manifest_verification_url_field() -> None:
     """data_manifest field definitions must include a verification_url field."""
     text = SKILL_PATH.read_text()
-    lower = text.lower()
-    assert "verification_url" in lower or "verification_source" in lower, (
-        "data_manifest must include a verification_url or verification_source field "
+    parts = text.lower().split("### data_manifest")
+    assert len(parts) > 1, "### data_manifest heading not found in SKILL.md"
+    after_manifest = parts[1][:3000]
+    assert "verification_url" in after_manifest, (
+        "data_manifest section must include a verification_url field "
         "to record the URL used to confirm accession existence"
     )

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -26,7 +26,9 @@ def test_data_manifest_in_frontmatter_schema() -> None:
 
 def test_data_manifest_required_fields() -> None:
     text = SKILL_PATH.read_text()
-    after_manifest = text.lower().split("### data_manifest")[1][:2000]
+    parts = text.lower().split("### data_manifest")
+    assert len(parts) > 1, "### data_manifest heading not found in SKILL.md"
+    after_manifest = parts[1][:2000]
     for field in ("source_type", "acquisition", "verification", "hypothesis"):
         assert field in after_manifest, f"data_manifest missing field: {field}"
 
@@ -211,20 +213,13 @@ def test_v10_semantic_verification_rule_exists() -> None:
     assert "database" in v10_block, "V10 must cover database source_type entries"
 
 
-def test_plan_experiment_defines_all_validation_rules_including_v10() -> None:
-    """Validation rules must include V1 through V10."""
-    text = SKILL_PATH.read_text()
-    for i in range(1, 11):
-        assert f"V{i}:" in text, f"V{i} rule label not found in SKILL.md"
-
-
 def test_additional_subagents_includes_accession_verification() -> None:
     """Additional subagents section must list accession/citation verification as a category."""
     import re
 
     text = SKILL_PATH.read_text()
     m = re.search(
-        r"\*\*Additional subagents.*?(?=\*\*Breadth enforcement|\n###|\n\*\*|## )",
+        r"\*\*Additional subagents.*?(?=\n\*\*Breadth enforcement|\n###|\n\*\*|## )",
         text,
         re.DOTALL | re.IGNORECASE,
     )

--- a/tests/skills/test_plan_experiment_schema_contracts.py
+++ b/tests/skills/test_plan_experiment_schema_contracts.py
@@ -55,9 +55,9 @@ def test_plan_experiment_documents_all_required_frontmatter_fields():
 
 
 def test_plan_experiment_defines_all_validation_rules():
-    """plan-experiment/SKILL.md must define all 9 validation rules V1–V9 as labeled entries."""
+    """plan-experiment/SKILL.md must define all 10 validation rules V1–V10 as labeled entries."""
     content = _read_skill_md("plan-experiment")
-    for rule_id in ["V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9"]:
+    for rule_id in ["V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9", "V10"]:
         assert f"{rule_id}:" in content, (
             f"plan-experiment/SKILL.md missing validation rule label {rule_id!r} "
             f"(expected '{rule_id}:' definition format)"


### PR DESCRIPTION
## Summary

The experiment pipeline lacks a semantic verification tier. Validation rules V1–V9 in plan-experiment are structural completeness checks (non-null fields, cardinality constraints). The review-design `data_acquisition` dimension checks plan quality (are acquisition steps present?). stage-data checks endpoint reachability (is the server up?). download-data checks execution success (did the file download?). No pipeline stage verifies that a claimed database accession actually exists — that the identifier resolves to a real entity whose metadata matches the plan's claims.

The proposed fix introduces a semantic verification tier: a new V10 rule requiring web-search confirmation of database and literature accessions, mandatory verification subagent instructions in Subagent B, an extension of the anti-fabrication pattern to cover accession identifiers, and an addition of a `verification_url` field to the data_manifest schema. Contract tests enforce that all components remain present and correctly worded.

## Requirements

## Problem

The experiment plan for campaign 8432a0e695784039 contains hallucinated and misattributed citations that entered the plan during plan-experiment's Subagent B (Data & Input Feasibility) phase. The plan was approved by review-design after 3 iterations, and download-data correctly returned FAIL when it could not resolve the placeholder accessions.

### Evidence: Verified Citation Failures

| Citation in Plan | Verification Result | Source |
|-----------------|-------------------|--------|
| "Bhatt 2024" / GSE273764 | GSE273764 **exists** but is **Shi et al.** (Crump/Gnedeva labs) — zebrafish & lizard inner ear, NOT mouse cochlear, NOT "Bhatt" | [GEO GSE273764](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE273764) |
| GSE22111 (Klisch 2011) | **Exists** but has only raw eland alignment files — no peak files deposited on GEO. PNAS supplementary Dataset S1 has binding site coordinates in Excel, not BED/narrowPeak. | [GEO GSE22111](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE22111) |
| "Lagnado 2025 eLife" scRNA-seq | **Does not exist.** Lagnado Lab (Sussex/MRC LMB) works on retinal circuits, not inner ear. No eLife paper matching this description from any "Lagnado" author. | [Lagnado Lab Publications](https://lagnadolab.com/publications/) |

### Root Cause

Plan-experiment's Subagent B does not mandate web-search confirmation of database accessions before including them in the plan. The "Additional subagents" section (SKILL.md lines 145–151) allows optional web searches but does not require accession verification.

### Proposed Fix

Require Subagent B (or a dedicated accession-validation subagent) to web-search-confirm every external database accession before including it in the plan:

1. For each `source_type: external` entry with a database accession (GEO, SRA, ENCODE, etc.), the planning phase must verify the accession exists via web search
2. If the accession cannot be confirmed, the entry must either use `source_type: literature` or explicitly flag as "unconfirmed"
3. Network failure during web search should produce a fallback: flag the entry as "unconfirmed"
4. Author attribution must be verified against the actual GEO contributor list

## Conflict Resolution Table

## Changed Files

### New (★):
None

### Modified (●):
- src/autoskillit/skills_extended/plan-experiment/SKILL.md
- src/autoskillit/recipes/contracts/bem-wrapper.yaml/json
- src/autoskillit/recipes/contracts/full-audit.yaml/json
- src/autoskillit/recipes/contracts/implement-findings.yaml/json
- src/autoskillit/recipes/contracts/implementation-groups.yaml/json
- src/autoskillit/recipes/contracts/implementation.yaml/json
- src/autoskillit/recipes/contracts/merge-prs.yaml/json
- src/autoskillit/recipes/contracts/planner.yaml/json
- src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml/json
- src/autoskillit/recipes/contracts/promote-to-main.yaml/json
- src/autoskillit/recipes/contracts/remediation.yaml/json
- src/autoskillit/recipes/contracts/research-archive.yaml/json
- src/autoskillit/recipes/contracts/research-campaign.yaml/json
- src/autoskillit/recipes/contracts/research-design.yaml/json
- src/autoskillit/recipes/contracts/research-implement.yaml/json
- src/autoskillit/recipes/contracts/research-review.yaml/json
- src/autoskillit/recipes/contracts/research.yaml/json
- tests/contracts/test_plan_experiment_contracts.py
- tests/skills/test_plan_experiment_schema_contracts.py

Closes #2386

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_accession_verification_gate_2026-05-11_210000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 59 | 8.6k | 519.5k | 90.3k | 181 | 50.2k | 8m 1s |
| rectify | claude-sonnet-4-6 | 1 | 52 | 11.0k | 751.0k | 75.9k | 102 | 53.7k | 6m 22s |
| dry_walkthrough | claude-opus-4-6 | 1 | 45 | 10.3k | 1.5M | 66.8k | 76 | 55.5k | 5m 18s |
| implement* | MiniMax-M2.7 | 1 | 69.7k | 12.1k | 2.6M | 21.4k | 104 | 0 | 8m 29s |
| prepare_pr* | MiniMax-M2.7 | 1 | 47.6k | 5.0k | 202.7k | 0 | 18 | 0 | 2m 22s |
| compose_pr* | MiniMax-M2.7 | 1 | 43.4k | 2.7k | 360.5k | 0 | 26 | 0 | 42s |
| review_pr | claude-opus-4-6 | 3 | 322 | 72.3k | 2.3M | 87.8k | 174 | 197.3k | 24m 0s |
| resolve_review | claude-opus-4-6 | 3 | 157 | 25.6k | 3.4M | 73.6k | 152 | 151.5k | 20m 47s |
| resolve_queue_merge_conflicts | claude-opus-4-6 | 1 | 49 | 8.7k | 1.3M | 55.0k | 46 | 41.7k | 3m 2s |
| **Total** | | | 161.3k | 156.3k | 12.9M | 90.3k | | 549.9k | 1h 19m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 201 | 12767.8 | 0.0 | 60.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 128 | 18286.8 | 1541.4 | 565.1 |
| resolve_review | 230 | 14752.8 | 658.6 | 111.4 |
| resolve_queue_merge_conflicts | 395 | 3381.2 | 105.6 | 22.0 |
| **Total** | **954** | 13550.8 | 576.4 | 163.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 111 | 19.6k | 1.3M | 103.9k | 14m 24s |
| claude-opus-4-6 | 1 | 45 | 10.3k | 1.5M | 55.5k | 5m 18s |
| MiniMax-M2.7 | 3 | 160.6k | 19.8k | 3.1M | 0 | 11m 34s |