### PR TITLE
Rectify: Universal Sentinel Emission for All Terminal Stop Steps

### DIFF
--- a/.autoskillit/recipes/smoke-test.yaml
+++ b/.autoskillit/recipes/smoke-test.yaml
@@ -178,8 +178,12 @@ steps:
 
   done:
     action: stop
-    message: "Smoke test completed successfully — PR created and closed without merging."
+    message: >-
+      Smoke test completed successfully — PR created and closed without merging.
+      Emit the L3 result sentinel JSON block now.
 
   escalate:
     action: stop
-    message: "Smoke test failed — check step output for details."
+    message: >-
+      Smoke test failed — check step output for details.
+      Emit the L3 result sentinel JSON block now.

--- a/.autoskillit/recipes/smoke-test.yaml
+++ b/.autoskillit/recipes/smoke-test.yaml
@@ -180,10 +180,10 @@ steps:
     action: stop
     message: >-
       Smoke test completed successfully — PR created and closed without merging.
-      Emit the L3 result sentinel JSON block now.
+      Emit the L3 result sentinel JSON block now with success=true.
 
   escalate:
     action: stop
     message: >-
       Smoke test failed — check step output for details.
-      Emit the L3 result sentinel JSON block now.
+      Emit the L3 result sentinel JSON block now with success=false.

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -120,7 +120,9 @@ H3 — AUTO-ACCEPT CONFIRM STEPS:
 
 H3b — STOP STEP SEMANTICS:
   When you reach a step with action: "stop", the pipeline is TERMINATED.
-  Display the step's message in the sentinel block. Do NOT call any MCP tools.
+  Emit the L3 sentinel block with the step's message as the reason field.
+  Set success=true for completion terminals, success=false for failure/escalation terminals.
+  Do NOT call any MCP tools after a stop step.
   Do NOT attempt recovery, error reporting, or off-recipe actions after a stop step.
   A stop step is an INTENTIONAL terminus — the recipe author designed this as the endpoint.
 

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -11,8 +11,6 @@ from dataclasses import dataclass as _dc
 from pathlib import Path
 from typing import Any
 
-import regex as re
-
 from autoskillit.core import (
     LoadResult,
     RecipeSource,
@@ -35,6 +33,7 @@ from autoskillit.recipe._recipe_ingredients import (
     build_ingredient_rows,  # noqa: F401
     format_ingredients_table,
 )
+from autoskillit.recipe._rule_helpers import _SENTINEL_JSON_RE, _is_failure_sentinel_value
 from autoskillit.recipe.contracts import (
     check_contract_staleness,
     load_recipe_card,
@@ -69,8 +68,6 @@ from autoskillit.recipe.validator import (
 )
 
 logger = get_logger(__name__)
-
-_SENTINEL_JSON_RE = re.compile(r"[Ee]xample\s+sentinel:\s*(\{[^}]+\})", re.DOTALL)
 
 # ---------------------------------------------------------------------------
 # Stage timing helper
@@ -272,9 +269,9 @@ def _infer_stop_failure(name: str, message: str | None) -> bool:
             try:
                 parsed = json.loads(m.group(1))
                 if isinstance(parsed, dict) and "success" in parsed:
-                    val = parsed["success"]
-                    return val is False or (isinstance(val, str) and val.lower() == "false")
+                    return _is_failure_sentinel_value(parsed["success"])
             except (json.JSONDecodeError, ValueError):
+                logger.debug("sentinel_json_parse_failed", step=name, raw=m.group(1))
                 continue
     return "escalate" in name.lower() or "reject" in name.lower()
 

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import re
 import threading
 import time
 from collections.abc import Sequence
@@ -66,6 +68,8 @@ from autoskillit.recipe.validator import (
 )
 
 logger = get_logger(__name__)
+
+_SENTINEL_JSON_RE = re.compile(r"[Ee]xample\s+sentinel:\s*(\{[^}]+\})", re.DOTALL)
 
 # ---------------------------------------------------------------------------
 # Stage timing helper
@@ -257,6 +261,23 @@ def validate_from_path(
     }
 
 
+def _infer_stop_failure(name: str, message: str | None) -> bool:
+    """Determine whether a stop step represents a failure outcome.
+
+    Parses embedded sentinel JSON first; falls back to name-based heuristic.
+    """
+    if message:
+        for m in _SENTINEL_JSON_RE.finditer(message):
+            try:
+                parsed = json.loads(m.group(1))
+                if isinstance(parsed, dict) and "success" in parsed:
+                    val = parsed["success"]
+                    return val is False or (isinstance(val, str) and val.lower() == "false")
+            except (json.JSONDecodeError, ValueError):
+                continue
+    return "escalate" in name.lower() or "reject" in name.lower()
+
+
 def _build_stop_step_semantics(recipe: Recipe) -> str:
     stop_steps = {name: step for name, step in recipe.steps.items() if step.action == "stop"}
     if not stop_steps:
@@ -269,14 +290,7 @@ def _build_stop_step_semantics(recipe: Recipe) -> str:
         "- When routed to a stop step, emit the L3 sentinel block and TERMINATE.",
     ]
     for name, step in stop_steps.items():
-        is_failure = (
-            "escalate" in name.lower()
-            or "reject" in name.lower()
-            or (
-                step.message
-                and ("fail" in step.message.lower() or "error" in step.message.lower())
-            )
-        )
+        is_failure = _infer_stop_failure(name, step.message)
         success_val = "false" if is_failure else "true"
         lines.append(
             f"- For stop step '{name}': emit the L3 sentinel block with "

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -261,17 +261,27 @@ def _build_stop_step_semantics(recipe: Recipe) -> str:
     stop_steps = {name: step for name, step in recipe.steps.items() if step.action == "stop"}
     if not stop_steps:
         return ""
-    names = ", ".join(f"'{n}'" for n in stop_steps)
     lines = [
         "ACTION: STOP STEP SEMANTICS:",
-        f"- Steps {names} are terminal stop steps.",
-        "- When routed to a stop step, display its message and TERMINATE immediately.",
+        "- Stop steps are terminal — the pipeline ends when routed to them.",
         "- Do NOT call any MCP tools after a stop step.",
         "- Do NOT attempt recovery, error reporting, or off-recipe actions.",
-        "- A stop step is an INTENTIONAL terminus — the recipe author designed this as"
-        " the endpoint.",
+        "- When routed to a stop step, emit the L3 sentinel block and TERMINATE.",
     ]
     for name, step in stop_steps.items():
+        is_failure = (
+            "escalate" in name.lower()
+            or "reject" in name.lower()
+            or (
+                step.message
+                and ("fail" in step.message.lower() or "error" in step.message.lower())
+            )
+        )
+        success_val = "false" if is_failure else "true"
+        lines.append(
+            f"- For stop step '{name}': emit the L3 sentinel block with "
+            f"success={success_val} and reason=<step message>. Then TERMINATE."
+        )
         if step.message:
             lines.append(f"  Stop step '{name}' message: {step.message!r}")
     return "\n".join(lines)

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import threading
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass as _dc
 from pathlib import Path
 from typing import Any
+
+import regex as re
 
 from autoskillit.core import (
     LoadResult,

--- a/src/autoskillit/recipe/_rule_helpers.py
+++ b/src/autoskillit/recipe/_rule_helpers.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import regex as re
 
 from autoskillit.recipe._analysis import ValidationContext
+
+_SENTINEL_JSON_RE = re.compile(r"[Ee]xample\s+sentinel:\s*(\{[^}]+\})", re.DOTALL)
+
+
+def _is_failure_sentinel_value(val: Any) -> bool:
+    """Return True if *val* represents a failure sentinel success field."""
+    return val is False or (isinstance(val, str) and val.lower() == "false")
+
 
 _PATH_SAFE_LOOKBEHIND = r"(?<![.a-zA-Z0-9_/])"
 _PATH_SAFE_LOOKAHEAD = r"(?![.a-zA-Z0-9_/])"

--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -11,6 +11,7 @@ import regex as re
 
 from autoskillit.core import RECIPE_PACK_REGISTRY, DispatchGateType, Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._rule_helpers import _SENTINEL_JSON_RE, _is_failure_sentinel_value
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 from autoskillit.recipe.schema import CAMPAIGN_REF_RE, CampaignDispatch, RecipeKind
 
@@ -25,9 +26,6 @@ _KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 # dispatch task: field), so campaigns that rely on this injection pattern should not
 # be flagged for not explicitly forwarding them in the ingredients block.
 _AUTO_INJECTED_CAMPAIGN_INGREDIENTS: frozenset[str] = frozenset({"task"})
-
-
-_SENTINEL_JSON_RE = re.compile(r"[Ee]xample\s+sentinel:\s*(\{[^}]+\})", re.DOTALL)
 
 
 def _extract_sentinel_fields(recipe: Recipe) -> frozenset[str]:
@@ -660,11 +658,12 @@ def _extract_sentinel_fields_per_stop(recipe: Recipe) -> list[frozenset[str]]:
                 parsed = json.loads(match.group(1))
                 if isinstance(parsed, dict):
                     _sv = parsed.get("success")
-                    if _sv is False or (isinstance(_sv, str) and _sv.lower() == "false"):
+                    if _is_failure_sentinel_value(_sv):
                         is_failure_sentinel = True
                         break
                     fields.update(parsed.keys())
             except (json.JSONDecodeError, ValueError):
+                logger.debug("sentinel_json_parse_failed", step=step.name, raw=match.group(1))
                 continue
         if not is_failure_sentinel and fields:
             per_stop.append(frozenset(fields))

--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -659,7 +659,8 @@ def _extract_sentinel_fields_per_stop(recipe: Recipe) -> list[frozenset[str]]:
             try:
                 parsed = json.loads(match.group(1))
                 if isinstance(parsed, dict):
-                    if parsed.get("success") is False:
+                    _sv = parsed.get("success")
+                    if _sv is False or (isinstance(_sv, str) and _sv.lower() == "false"):
                         is_failure_sentinel = True
                         break
                     fields.update(parsed.keys())

--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -642,8 +642,10 @@ def _check_dispatch_capture_field_in_sentinel(ctx: ValidationContext) -> list[Ru
 def _extract_sentinel_fields_per_stop(recipe: Recipe) -> list[frozenset[str]]:
     """Extract field sets from each individual sentinel stop step.
 
-    Returns a list of frozensets, one per sentinel stop, rather than
-    the union. This enables per-path validation.
+    Returns a list of frozensets, one per success sentinel stop, rather than
+    the union. This enables per-path validation. Failure-terminal sentinels
+    (those whose example JSON contains ``"success": false``) are excluded
+    because failure paths do not produce captured result fields.
     """
     per_stop: list[frozenset[str]] = []
     for step in recipe.steps.values():
@@ -652,14 +654,18 @@ def _extract_sentinel_fields_per_stop(recipe: Recipe) -> list[frozenset[str]]:
         if "sentinel" not in step.message.lower():
             continue
         fields: set[str] = set()
+        is_failure_sentinel = False
         for match in _SENTINEL_JSON_RE.finditer(step.message):
             try:
                 parsed = json.loads(match.group(1))
                 if isinstance(parsed, dict):
+                    if parsed.get("success") is False:
+                        is_failure_sentinel = True
+                        break
                     fields.update(parsed.keys())
             except (json.JSONDecodeError, ValueError):
                 continue
-        if fields:
+        if not is_failure_sentinel and fields:
             per_stop.append(frozenset(fields))
     return per_stop
 

--- a/src/autoskillit/recipe/rules/rules_food_truck.py
+++ b/src/autoskillit/recipe/rules/rules_food_truck.py
@@ -7,29 +7,35 @@ from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 from autoskillit.recipe.schema import RecipeKind
 
+_DISPATCHABLE_KINDS = frozenset({RecipeKind.FOOD_TRUCK, RecipeKind.STANDARD})
+
 
 @semantic_rule(
-    name="food-truck-has-sentinel-stop",
-    description="Food-truck recipes must have a stop step referencing L3 sentinel",
+    name="all-dispatchable-stops-have-sentinel",
+    description="All stop steps in dispatchable recipes must instruct L3 sentinel emission",
     severity=Severity.ERROR,
 )
-def _check_food_truck_has_sentinel_stop(ctx: ValidationContext) -> list[RuleFinding]:
-    if ctx.recipe.kind != RecipeKind.FOOD_TRUCK:
+def _check_all_dispatchable_stops_have_sentinel(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind not in _DISPATCHABLE_KINDS:
         return []
+    findings: list[RuleFinding] = []
     for step_name, step in ctx.recipe.steps.items():
-        if step.action == "stop" and step.message and "sentinel" in step.message.lower():
-            return []
-    return [
-        RuleFinding(
-            rule="food-truck-has-sentinel-stop",
-            severity=Severity.ERROR,
-            step_name="(top-level)",
-            message=(
-                "Food-truck recipe has no stop step referencing L3 sentinel. "
-                "Food trucks must emit a sentinel JSON block on completion."
-            ),
-        )
-    ]
+        if step.action != "stop":
+            continue
+        if not step.message or "sentinel" not in step.message.lower():
+            findings.append(
+                RuleFinding(
+                    rule="all-dispatchable-stops-have-sentinel",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Stop step '{step_name}' does not reference L3 sentinel in its message. "
+                        "All stop steps in dispatchable recipes must instruct sentinel emission "
+                        "with the appropriate success/failure status."
+                    ),
+                )
+            )
+    return findings
 
 
 @semantic_rule(

--- a/src/autoskillit/recipes/bem-wrapper.json
+++ b/src/autoskillit/recipes/bem-wrapper.json
@@ -96,7 +96,7 @@
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "BEM wrapper failed — fallback execution map could not be written to disk. Human intervention required. Check {{AUTOSKILLIT_TEMP}} permissions and issue URLs in the ingredients."
+      "message": "BEM wrapper failed — fallback execution map could not be written to disk. Human intervention required. Check {{AUTOSKILLIT_TEMP}} permissions and issue URLs in the ingredients. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"BEM wrapper execution map write failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/bem-wrapper.yaml
@@ -102,3 +102,5 @@ steps:
       BEM wrapper failed — fallback execution map could not be written to disk.
       Human intervention required. Check {{AUTOSKILLIT_TEMP}} permissions and
       issue URLs in the ingredients.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "BEM wrapper execution map write failed"}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.619375+00:00",
+  "generated_at": "2026-05-12T04:39:28.885092+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.511308+00:00",
+  "generated_at": "2026-05-12T04:21:50.853721+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.113575+00:00",
-  "recipe_source_hash": "sha256:c4f6d0e0461f2cc59d5df1f41a04b83a649b215a48d91b3cdd361c2e00c89eba",
+  "generated_at": "2026-05-12T04:16:44.511308+00:00",
+  "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:03.934528+00:00",
+  "generated_at": "2026-05-12T06:41:48.028034+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.853721+00:00",
+  "generated_at": "2026-05-12T04:26:50.619375+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.028034+00:00",
+  "generated_at": "2026-05-12T07:06:15.706937+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.885092+00:00",
+  "generated_at": "2026-05-12T05:30:03.934528+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.853721+00:00'
+generated_at: '2026-05-12T04:26:50.619375+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.511308+00:00'
+generated_at: '2026-05-12T04:21:50.853721+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.028034+00:00'
+generated_at: '2026-05-12T07:06:15.706937+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:03.934528+00:00'
+generated_at: '2026-05-12T06:41:48.028034+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.619375+00:00'
+generated_at: '2026-05-12T04:39:28.885092+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.885092+00:00'
+generated_at: '2026-05-12T05:30:03.934528+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.113575+00:00'
-recipe_source_hash: sha256:c4f6d0e0461f2cc59d5df1f41a04b83a649b215a48d91b3cdd361c2e00c89eba
+generated_at: '2026-05-12T04:16:44.511308+00:00'
+recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:03.952759+00:00",
+  "generated_at": "2026-05-12T06:41:48.033967+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.520995+00:00",
+  "generated_at": "2026-05-12T04:21:50.859845+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.660414+00:00",
+  "generated_at": "2026-05-12T04:39:28.922632+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.033967+00:00",
+  "generated_at": "2026-05-12T07:06:15.712642+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.120326+00:00",
-  "recipe_source_hash": "sha256:279302789aaccfa1e4b8663bd8c9896b95af4ece9022f5c001959ac0f7e0b23a",
+  "generated_at": "2026-05-12T04:16:44.520995+00:00",
+  "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.922632+00:00",
+  "generated_at": "2026-05-12T05:30:03.952759+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.859845+00:00",
+  "generated_at": "2026-05-12T04:26:50.660414+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.859845+00:00'
+generated_at: '2026-05-12T04:26:50.660414+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.922632+00:00'
+generated_at: '2026-05-12T05:30:03.952759+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:03.952759+00:00'
+generated_at: '2026-05-12T06:41:48.033967+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.660414+00:00'
+generated_at: '2026-05-12T04:39:28.922632+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.520995+00:00'
+generated_at: '2026-05-12T04:21:50.859845+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.120326+00:00'
-recipe_source_hash: sha256:279302789aaccfa1e4b8663bd8c9896b95af4ece9022f5c001959ac0f7e0b23a
+generated_at: '2026-05-12T04:16:44.520995+00:00'
+recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.033967+00:00'
+generated_at: '2026-05-12T07:06:15.712642+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:03.958577+00:00",
+  "generated_at": "2026-05-12T06:41:48.039054+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.873139+00:00",
+  "generated_at": "2026-05-12T04:26:50.672951+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.928358+00:00",
+  "generated_at": "2026-05-12T05:30:03.958577+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.672951+00:00",
+  "generated_at": "2026-05-12T04:39:28.928358+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.125997+00:00",
-  "recipe_source_hash": "sha256:60df3c9aa757b621e8260129e48fd5459eb11e853ba98415f7cfc4bdcb81e4ed",
+  "generated_at": "2026-05-12T04:16:44.526510+00:00",
+  "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.039054+00:00",
+  "generated_at": "2026-05-12T07:06:15.718705+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.526510+00:00",
+  "generated_at": "2026-05-12T04:21:50.873139+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.873139+00:00'
+generated_at: '2026-05-12T04:26:50.672951+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.526510+00:00'
+generated_at: '2026-05-12T04:21:50.873139+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:03.958577+00:00'
+generated_at: '2026-05-12T06:41:48.039054+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.125997+00:00'
-recipe_source_hash: sha256:60df3c9aa757b621e8260129e48fd5459eb11e853ba98415f7cfc4bdcb81e4ed
+generated_at: '2026-05-12T04:16:44.526510+00:00'
+recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.928358+00:00'
+generated_at: '2026-05-12T05:30:03.958577+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.039054+00:00'
+generated_at: '2026-05-12T07:06:15.718705+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.672951+00:00'
+generated_at: '2026-05-12T04:39:28.928358+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.535950+00:00",
+  "generated_at": "2026-05-12T04:21:50.883247+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.136025+00:00",
-  "recipe_source_hash": "sha256:fa6b64288d101daa9e52bad391ddb2b7e8fcad8d8606214d23f4929f5a32d554",
+  "generated_at": "2026-05-12T04:16:44.535950+00:00",
+  "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.052567+00:00",
+  "generated_at": "2026-05-12T07:06:15.735200+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.692315+00:00",
+  "generated_at": "2026-05-12T04:39:28.938035+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:03.970104+00:00",
+  "generated_at": "2026-05-12T06:41:48.052567+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.938035+00:00",
+  "generated_at": "2026-05-12T05:30:03.970104+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.883247+00:00",
+  "generated_at": "2026-05-12T04:26:50.692315+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.692315+00:00'
+generated_at: '2026-05-12T04:39:28.938035+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:03.970104+00:00'
+generated_at: '2026-05-12T06:41:48.052567+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.535950+00:00'
+generated_at: '2026-05-12T04:21:50.883247+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.052567+00:00'
+generated_at: '2026-05-12T07:06:15.735200+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.938035+00:00'
+generated_at: '2026-05-12T05:30:03.970104+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.883247+00:00'
+generated_at: '2026-05-12T04:26:50.692315+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.136025+00:00'
-recipe_source_hash: sha256:fa6b64288d101daa9e52bad391ddb2b7e8fcad8d8606214d23f4929f5a32d554
+generated_at: '2026-05-12T04:16:44.535950+00:00'
+recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.550344+00:00",
+  "generated_at": "2026-05-12T04:21:50.899421+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.151587+00:00",
-  "recipe_source_hash": "sha256:488273bc4621762d2dcb2fd2b1c371befc47392f3616329f12d64394f2809466",
+  "generated_at": "2026-05-12T04:16:44.550344+00:00",
+  "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.066964+00:00",
+  "generated_at": "2026-05-12T07:06:15.749480+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.954290+00:00",
+  "generated_at": "2026-05-12T05:30:03.993537+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.899421+00:00",
+  "generated_at": "2026-05-12T04:26:50.718637+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.718637+00:00",
+  "generated_at": "2026-05-12T04:39:28.954290+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:03.993537+00:00",
+  "generated_at": "2026-05-12T06:41:48.066964+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.899421+00:00'
+generated_at: '2026-05-12T04:26:50.718637+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.550344+00:00'
+generated_at: '2026-05-12T04:21:50.899421+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.151587+00:00'
-recipe_source_hash: sha256:488273bc4621762d2dcb2fd2b1c371befc47392f3616329f12d64394f2809466
+generated_at: '2026-05-12T04:16:44.550344+00:00'
+recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.954290+00:00'
+generated_at: '2026-05-12T05:30:03.993537+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.718637+00:00'
+generated_at: '2026-05-12T04:39:28.954290+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.066964+00:00'
+generated_at: '2026-05-12T07:06:15.749480+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:03.993537+00:00'
+generated_at: '2026-05-12T06:41:48.066964+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.013953+00:00",
+  "generated_at": "2026-05-12T06:41:48.080277+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.564038+00:00",
+  "generated_at": "2026-05-12T04:21:50.914239+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.080277+00:00",
+  "generated_at": "2026-05-12T07:06:15.763125+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.968671+00:00",
+  "generated_at": "2026-05-12T05:30:04.013953+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.746272+00:00",
+  "generated_at": "2026-05-12T04:39:28.968671+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.914239+00:00",
+  "generated_at": "2026-05-12T04:26:50.746272+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.166319+00:00",
-  "recipe_source_hash": "sha256:8e46dcb1d749fbb395beacb197fc265d9da5a5b0e8626fbd4e0d67a5345a0ca8",
+  "generated_at": "2026-05-12T04:16:44.564038+00:00",
+  "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.968671+00:00'
+generated_at: '2026-05-12T05:30:04.013953+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.080277+00:00'
+generated_at: '2026-05-12T07:06:15.763125+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.564038+00:00'
+generated_at: '2026-05-12T04:21:50.914239+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.013953+00:00'
+generated_at: '2026-05-12T06:41:48.080277+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.166319+00:00'
-recipe_source_hash: sha256:8e46dcb1d749fbb395beacb197fc265d9da5a5b0e8626fbd4e0d67a5345a0ca8
+generated_at: '2026-05-12T04:16:44.564038+00:00'
+recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.914239+00:00'
+generated_at: '2026-05-12T04:26:50.746272+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.746272+00:00'
+generated_at: '2026-05-12T04:39:28.968671+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.978519+00:00",
+  "generated_at": "2026-05-12T05:30:04.025197+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.025197+00:00",
+  "generated_at": "2026-05-12T06:41:48.089368+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.768029+00:00",
+  "generated_at": "2026-05-12T04:39:28.978519+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.089368+00:00",
+  "generated_at": "2026-05-12T07:06:15.772951+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.924805+00:00",
+  "generated_at": "2026-05-12T04:26:50.768029+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.573786+00:00",
+  "generated_at": "2026-05-12T04:21:50.924805+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.176828+00:00",
-  "recipe_source_hash": "sha256:617abcd898b97ba2d6c3f51b3eb2613ce9c8a6dff71a1a9065b83e7ad24dba16",
+  "generated_at": "2026-05-12T04:16:44.573786+00:00",
+  "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.025197+00:00'
+generated_at: '2026-05-12T06:41:48.089368+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.978519+00:00'
+generated_at: '2026-05-12T05:30:04.025197+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.924805+00:00'
+generated_at: '2026-05-12T04:26:50.768029+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.089368+00:00'
+generated_at: '2026-05-12T07:06:15.772951+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.768029+00:00'
+generated_at: '2026-05-12T04:39:28.978519+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.176828+00:00'
-recipe_source_hash: sha256:617abcd898b97ba2d6c3f51b3eb2613ce9c8a6dff71a1a9065b83e7ad24dba16
+generated_at: '2026-05-12T04:16:44.573786+00:00'
+recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.573786+00:00'
+generated_at: '2026-05-12T04:21:50.924805+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.095351+00:00",
+  "generated_at": "2026-05-12T07:06:15.779187+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.931292+00:00",
+  "generated_at": "2026-05-12T04:26:50.780551+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.033024+00:00",
+  "generated_at": "2026-05-12T06:41:48.095351+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.780551+00:00",
+  "generated_at": "2026-05-12T04:39:28.985348+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.985348+00:00",
+  "generated_at": "2026-05-12T05:30:04.033024+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.183833+00:00",
-  "recipe_source_hash": "sha256:b6942fb601194a2fa8dac278c8319a291cafe3a844a7bb0995ba72cacb44174d",
+  "generated_at": "2026-05-12T04:16:44.579933+00:00",
+  "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.579933+00:00",
+  "generated_at": "2026-05-12T04:21:50.931292+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.931292+00:00'
+generated_at: '2026-05-12T04:26:50.780551+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.579933+00:00'
+generated_at: '2026-05-12T04:21:50.931292+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.183833+00:00'
-recipe_source_hash: sha256:b6942fb601194a2fa8dac278c8319a291cafe3a844a7bb0995ba72cacb44174d
+generated_at: '2026-05-12T04:16:44.579933+00:00'
+recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.985348+00:00'
+generated_at: '2026-05-12T05:30:04.033024+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.033024+00:00'
+generated_at: '2026-05-12T06:41:48.095351+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.095351+00:00'
+generated_at: '2026-05-12T07:06:15.779187+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.780551+00:00'
+generated_at: '2026-05-12T04:39:28.985348+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.998654+00:00",
+  "generated_at": "2026-05-12T04:26:50.893769+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.248603+00:00",
+  "generated_at": "2026-05-12T04:16:44.639187+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.639187+00:00",
+  "generated_at": "2026-05-12T04:21:50.998654+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.152787+00:00",
+  "generated_at": "2026-05-12T07:06:15.836868+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.052929+00:00",
+  "generated_at": "2026-05-12T05:30:04.108864+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.108864+00:00",
+  "generated_at": "2026-05-12T06:41:48.152787+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.893769+00:00",
+  "generated_at": "2026-05-12T04:39:29.052929+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.052929+00:00'
+generated_at: '2026-05-12T05:30:04.108864+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.152787+00:00'
+generated_at: '2026-05-12T07:06:15.836868+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.248603+00:00'
+generated_at: '2026-05-12T04:16:44.639187+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.639187+00:00'
+generated_at: '2026-05-12T04:21:50.998654+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.998654+00:00'
+generated_at: '2026-05-12T04:26:50.893769+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.893769+00:00'
+generated_at: '2026-05-12T04:39:29.052929+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.108864+00:00'
+generated_at: '2026-05-12T06:41:48.152787+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:28.994880+00:00",
+  "generated_at": "2026-05-12T05:30:04.046253+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.942158+00:00",
+  "generated_at": "2026-05-12T04:26:50.797173+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.046253+00:00",
+  "generated_at": "2026-05-12T06:41:48.104566+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.194076+00:00",
-  "recipe_source_hash": "sha256:1f2f5c7133bd520c9ec25386fe7fadf75c4608928a3b0de591cfb788f78ca1f8",
+  "generated_at": "2026-05-12T04:16:44.589010+00:00",
+  "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.797173+00:00",
+  "generated_at": "2026-05-12T04:39:28.994880+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.589010+00:00",
+  "generated_at": "2026-05-12T04:21:50.942158+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.104566+00:00",
+  "generated_at": "2026-05-12T07:06:15.788105+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:28.994880+00:00'
+generated_at: '2026-05-12T05:30:04.046253+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.194076+00:00'
-recipe_source_hash: sha256:1f2f5c7133bd520c9ec25386fe7fadf75c4608928a3b0de591cfb788f78ca1f8
+generated_at: '2026-05-12T04:16:44.589010+00:00'
+recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.104566+00:00'
+generated_at: '2026-05-12T07:06:15.788105+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.942158+00:00'
+generated_at: '2026-05-12T04:26:50.797173+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.046253+00:00'
+generated_at: '2026-05-12T06:41:48.104566+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.797173+00:00'
+generated_at: '2026-05-12T04:39:28.994880+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.589010+00:00'
+generated_at: '2026-05-12T04:21:50.942158+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.600392+00:00",
+  "generated_at": "2026-05-12T04:21:50.954530+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.059146+00:00",
+  "generated_at": "2026-05-12T06:41:48.115222+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.007208+00:00",
+  "generated_at": "2026-05-12T05:30:04.059146+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.206216+00:00",
-  "recipe_source_hash": "sha256:80f5de286ec555b43df482eeee47852952b99dea1be9a076f51a702b20044365",
+  "generated_at": "2026-05-12T04:16:44.600392+00:00",
+  "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.954530+00:00",
+  "generated_at": "2026-05-12T04:26:50.815622+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.815622+00:00",
+  "generated_at": "2026-05-12T04:39:29.007208+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.115222+00:00",
+  "generated_at": "2026-05-12T07:06:15.798906+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.600392+00:00'
+generated_at: '2026-05-12T04:21:50.954530+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.115222+00:00'
+generated_at: '2026-05-12T07:06:15.798906+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.954530+00:00'
+generated_at: '2026-05-12T04:26:50.815622+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.007208+00:00'
+generated_at: '2026-05-12T05:30:04.059146+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.059146+00:00'
+generated_at: '2026-05-12T06:41:48.115222+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.815622+00:00'
+generated_at: '2026-05-12T04:39:29.007208+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.206216+00:00'
-recipe_source_hash: sha256:80f5de286ec555b43df482eeee47852952b99dea1be9a076f51a702b20044365
+generated_at: '2026-05-12T04:16:44.600392+00:00'
+recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.113997+00:00",
+  "generated_at": "2026-05-12T06:41:48.158019+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.253500+00:00",
+  "generated_at": "2026-05-12T04:16:44.643977+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:51.004089+00:00",
+  "generated_at": "2026-05-12T04:26:50.904552+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.058608+00:00",
+  "generated_at": "2026-05-12T05:30:04.113997+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.158019+00:00",
+  "generated_at": "2026-05-12T07:06:15.841935+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.643977+00:00",
+  "generated_at": "2026-05-12T04:21:51.004089+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.904552+00:00",
+  "generated_at": "2026-05-12T04:39:29.058608+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.058608+00:00'
+generated_at: '2026-05-12T05:30:04.113997+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.643977+00:00'
+generated_at: '2026-05-12T04:21:51.004089+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.253500+00:00'
+generated_at: '2026-05-12T04:16:44.643977+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.904552+00:00'
+generated_at: '2026-05-12T04:39:29.058608+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.113997+00:00'
+generated_at: '2026-05-12T06:41:48.158019+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.158019+00:00'
+generated_at: '2026-05-12T07:06:15.841935+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:51.004089+00:00'
+generated_at: '2026-05-12T04:26:50.904552+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.825976+00:00",
+  "generated_at": "2026-05-12T04:39:29.013064+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.120265+00:00",
+  "generated_at": "2026-05-12T07:06:15.804301+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.013064+00:00",
+  "generated_at": "2026-05-12T05:30:04.069085+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.212821+00:00",
-  "recipe_source_hash": "sha256:dcd57563c3bb38164fbef5823246e9761d7cc43a51e80727487ecdd6b1d706de",
+  "generated_at": "2026-05-12T04:16:44.605777+00:00",
+  "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.960564+00:00",
+  "generated_at": "2026-05-12T04:26:50.825976+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.605777+00:00",
+  "generated_at": "2026-05-12T04:21:50.960564+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.069085+00:00",
+  "generated_at": "2026-05-12T06:41:48.120265+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.013064+00:00'
+generated_at: '2026-05-12T05:30:04.069085+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.069085+00:00'
+generated_at: '2026-05-12T06:41:48.120265+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.212821+00:00'
-recipe_source_hash: sha256:dcd57563c3bb38164fbef5823246e9761d7cc43a51e80727487ecdd6b1d706de
+generated_at: '2026-05-12T04:16:44.605777+00:00'
+recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.605777+00:00'
+generated_at: '2026-05-12T04:21:50.960564+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.825976+00:00'
+generated_at: '2026-05-12T04:39:29.013064+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.120265+00:00'
+generated_at: '2026-05-12T07:06:15.804301+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.960564+00:00'
+generated_at: '2026-05-12T04:26:50.825976+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.612290+00:00",
+  "generated_at": "2026-05-12T04:21:50.967780+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.078175+00:00",
+  "generated_at": "2026-05-12T06:41:48.126992+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.838644+00:00",
+  "generated_at": "2026-05-12T04:39:29.020470+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.219609+00:00",
-  "recipe_source_hash": "sha256:c09727853bb3aa07f9545c5056f0aadf4fbbbd71e93e684d7605518e0dcf2325",
+  "generated_at": "2026-05-12T04:16:44.612290+00:00",
+  "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.020470+00:00",
+  "generated_at": "2026-05-12T05:30:04.078175+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.126992+00:00",
+  "generated_at": "2026-05-12T07:06:15.810734+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.967780+00:00",
+  "generated_at": "2026-05-12T04:26:50.838644+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.126992+00:00'
+generated_at: '2026-05-12T07:06:15.810734+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.838644+00:00'
+generated_at: '2026-05-12T04:39:29.020470+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.078175+00:00'
+generated_at: '2026-05-12T06:41:48.126992+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.219609+00:00'
-recipe_source_hash: sha256:c09727853bb3aa07f9545c5056f0aadf4fbbbd71e93e684d7605518e0dcf2325
+generated_at: '2026-05-12T04:16:44.612290+00:00'
+recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.612290+00:00'
+generated_at: '2026-05-12T04:21:50.967780+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.020470+00:00'
+generated_at: '2026-05-12T05:30:04.078175+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.967780+00:00'
+generated_at: '2026-05-12T04:26:50.838644+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.619672+00:00",
+  "generated_at": "2026-05-12T04:21:50.975892+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.975892+00:00",
+  "generated_at": "2026-05-12T04:26:50.852175+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.134047+00:00",
+  "generated_at": "2026-05-12T07:06:15.818018+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.852175+00:00",
+  "generated_at": "2026-05-12T04:39:29.028364+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.087182+00:00",
+  "generated_at": "2026-05-12T06:41:48.134047+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.227124+00:00",
-  "recipe_source_hash": "sha256:66b02dd80508370eafbbcdc067628268660d60ce1062e4f60f115e75e76c0ad5",
+  "generated_at": "2026-05-12T04:16:44.619672+00:00",
+  "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.028364+00:00",
+  "generated_at": "2026-05-12T05:30:04.087182+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.028364+00:00'
+generated_at: '2026-05-12T05:30:04.087182+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.134047+00:00'
+generated_at: '2026-05-12T07:06:15.818018+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.975892+00:00'
+generated_at: '2026-05-12T04:26:50.852175+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.619672+00:00'
+generated_at: '2026-05-12T04:21:50.975892+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.087182+00:00'
+generated_at: '2026-05-12T06:41:48.134047+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.852175+00:00'
+generated_at: '2026-05-12T04:39:29.028364+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.227124+00:00'
-recipe_source_hash: sha256:66b02dd80508370eafbbcdc067628268660d60ce1062e4f60f115e75e76c0ad5
+generated_at: '2026-05-12T04:16:44.619672+00:00'
+recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T05:30:04.098055+00:00",
+  "generated_at": "2026-05-12T06:41:48.143220+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:26:50.869032+00:00",
+  "generated_at": "2026-05-12T04:39:29.038069+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:39:29.237306+00:00",
-  "recipe_source_hash": "sha256:cfaa7e407aba93238c259e5079bfde5f3d04ad9bb96f5b757d01454699e968ee",
+  "generated_at": "2026-05-12T04:16:44.628376+00:00",
+  "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:39:29.038069+00:00",
+  "generated_at": "2026-05-12T05:30:04.098055+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:50.987742+00:00",
+  "generated_at": "2026-05-12T04:26:50.869032+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T06:41:48.143220+00:00",
+  "generated_at": "2026-05-12T07:06:15.826934+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:16:44.628376+00:00",
+  "generated_at": "2026-05-12T04:21:50.987742+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:39:29.038069+00:00'
+generated_at: '2026-05-12T05:30:04.098055+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:26:50.869032+00:00'
+generated_at: '2026-05-12T04:39:29.038069+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:39:29.237306+00:00'
-recipe_source_hash: sha256:cfaa7e407aba93238c259e5079bfde5f3d04ad9bb96f5b757d01454699e968ee
+generated_at: '2026-05-12T04:16:44.628376+00:00'
+recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:16:44.628376+00:00'
+generated_at: '2026-05-12T04:21:50.987742+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T06:41:48.143220+00:00'
+generated_at: '2026-05-12T07:06:15.826934+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T05:30:04.098055+00:00'
+generated_at: '2026-05-12T06:41:48.143220+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:50.987742+00:00'
+generated_at: '2026-05-12T04:26:50.869032+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/full-audit.json
+++ b/src/autoskillit/recipes/full-audit.json
@@ -120,7 +120,7 @@
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Full audit pipeline failed — one or more audit chains could not complete. Check session logs and {{AUTOSKILLIT_TEMP}}/ directories for partial results. Individual chain failures are noted in the session output above."
+      "message": "Full audit pipeline failed — one or more audit chains could not complete. Check session logs and {{AUTOSKILLIT_TEMP}}/ directories for partial results. Individual chain failures are noted in the session output above. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"audit pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -195,3 +195,5 @@ steps:
       Full audit pipeline failed — one or more audit chains could not complete.
       Check session logs and {{AUTOSKILLIT_TEMP}}/ directories for partial results.
       Individual chain failures are noted in the session output above.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "audit pipeline failed"}

--- a/src/autoskillit/recipes/implement-findings.json
+++ b/src/autoskillit/recipes/implement-findings.json
@@ -170,11 +170,11 @@
     },
     "done": {
       "action": "stop",
-      "message": "implement-findings batch complete. All groups processed. See sidecar for per-issue outcomes."
+      "message": "implement-findings batch complete. All groups processed. See sidecar for per-issue outcomes. Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"implement-findings complete\"}"
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "implement-findings batch failed at setup. Manual investigation required. Check the step that routed here for root cause."
+      "message": "implement-findings batch failed at setup. Manual investigation required. Check the step that routed here for root cause. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"implement-findings batch failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/implement-findings.yaml
+++ b/src/autoskillit/recipes/implement-findings.yaml
@@ -226,9 +226,13 @@ steps:
     message: >-
       implement-findings batch complete. All groups processed.
       See sidecar for per-issue outcomes.
+      Emit the L3 result sentinel JSON block now with success=true.
+      Example sentinel: {"success": true, "reason": "implement-findings complete"}
 
   escalate_stop:
     action: stop
     message: >-
       implement-findings batch failed at setup. Manual investigation required.
       Check the step that routed here for root cause.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "implement-findings batch failed"}

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -923,7 +923,7 @@
     },
     "escalate_stop_no_ci": {
       "action": "stop",
-      "message": "CI safety net: statusCheckRollup returned no checks for PR ${{ context.pr_number }}. This typically means no workflow is configured to trigger on this branch pattern. Check .github/workflows/ trigger configuration. This is NOT a test failure — CI never started."
+      "message": "CI safety net: statusCheckRollup returned no checks for PR ${{ context.pr_number }}. This typically means no workflow is configured to trigger on this branch pattern. Check .github/workflows/ trigger configuration. This is NOT a test failure — CI never started. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"no CI checks configured\"}"
     },
     "diagnose_ci": {
       "tool": "run_skill",
@@ -1809,11 +1809,11 @@
     },
     "done": {
       "action": "stop",
-      "message": "Implementation pipeline complete. All groups/tasks have been planned, implemented, tested, and merged."
+      "message": "Implementation pipeline complete. All groups/tasks have been planned, implemented, tested, and merged. Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"implementation-groups complete\"}"
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Pipeline failed — human intervention needed. Check the worktree and plan for details."
+      "message": "Pipeline failed — human intervention needed. Check the worktree and plan for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"implementation-groups pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -886,6 +886,8 @@ steps:
       ${{ context.pr_number }}. This typically means no workflow is
       configured to trigger on this branch pattern. Check .github/workflows/
       trigger configuration. This is NOT a test failure — CI never started.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "no CI checks configured"}
 
   diagnose_ci:
     tool: run_skill
@@ -1689,9 +1691,15 @@ steps:
 
   done:
     action: stop
-    message: "Implementation pipeline complete. All groups/tasks have been planned, implemented, tested, and merged."
+    message: >-
+      Implementation pipeline complete. All groups/tasks have been planned, implemented, tested, and merged.
+      Emit the L3 result sentinel JSON block now with success=true.
+      Example sentinel: {"success": true, "reason": "implementation-groups complete"}
 
   escalate_stop:
     action: stop
-    message: "Pipeline failed — human intervention needed. Check the worktree and plan for details."
+    message: >-
+      Pipeline failed — human intervention needed. Check the worktree and plan for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "implementation-groups pipeline failed"}
 

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -926,7 +926,7 @@
     },
     "escalate_stop_no_ci": {
       "action": "stop",
-      "message": "CI safety net: statusCheckRollup returned no checks for PR ${{ context.pr_number }}. This typically means no workflow is configured to trigger on this branch pattern. Check .github/workflows/ trigger configuration. This is NOT a test failure — CI never started."
+      "message": "CI safety net: statusCheckRollup returned no checks for PR ${{ context.pr_number }}. This typically means no workflow is configured to trigger on this branch pattern. Check .github/workflows/ trigger configuration. This is NOT a test failure — CI never started. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"no CI checks configured\"}"
     },
     "check_repo_merge_state": {
       "tool": "check_repo_merge_state",
@@ -1812,11 +1812,11 @@
     },
     "done": {
       "action": "stop",
-      "message": "Implementation pipeline complete. All tasks have been planned, implemented, tested, and merged."
+      "message": "Implementation pipeline complete. All tasks have been planned, implemented, tested, and merged. Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"implementation complete\"}"
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Pipeline failed — human intervention needed. Check the worktree and plan for details."
+      "message": "Pipeline failed — human intervention needed. Check the worktree and plan for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"implementation pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -894,6 +894,8 @@ steps:
       ${{ context.pr_number }}. This typically means no workflow is
       configured to trigger on this branch pattern. Check .github/workflows/
       trigger configuration. This is NOT a test failure — CI never started.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "no CI checks configured"}
 
   check_repo_merge_state:
     tool: check_repo_merge_state
@@ -1697,9 +1699,15 @@ steps:
 
   done:
     action: stop
-    message: "Implementation pipeline complete. All tasks have been planned, implemented, tested, and merged."
+    message: >-
+      Implementation pipeline complete. All tasks have been planned, implemented, tested, and merged.
+      Emit the L3 result sentinel JSON block now with success=true.
+      Example sentinel: {"success": true, "reason": "implementation complete"}
 
   escalate_stop:
     action: stop
-    message: "Pipeline failed — human intervention needed. Check the worktree and plan for details."
+    message: >-
+      Pipeline failed — human intervention needed. Check the worktree and plan for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "implementation pipeline failed"}
 

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -1358,11 +1358,11 @@
     },
     "done": {
       "action": "stop",
-      "message": "PR consolidation complete."
+      "message": "PR consolidation complete. Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"merge complete\"}"
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Pipeline failed — human intervention needed. Check the integration branch and {{AUTOSKILLIT_TEMP}}/merge-prs/ for details.",
+      "message": "Pipeline failed — human intervention needed. Check the integration branch and {{AUTOSKILLIT_TEMP}}/merge-prs/ for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"merge-prs pipeline failed\"}",
       "note": "context.task may be null when reached via escalation_required=true from merge_pr (merge-pr does not set conflict_report_path on escalation paths). Do not rely on context.task being populated when handling this stop.\n"
     }
   }

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1329,11 +1329,17 @@ steps:
 
   done:
     action: stop
-    message: "PR consolidation complete."
+    message: >-
+      PR consolidation complete.
+      Emit the L3 result sentinel JSON block now with success=true.
+      Example sentinel: {"success": true, "reason": "merge complete"}
 
   escalate_stop:
     action: stop
-    message: "Pipeline failed — human intervention needed. Check the integration branch and {{AUTOSKILLIT_TEMP}}/merge-prs/ for details."
+    message: >-
+      Pipeline failed — human intervention needed. Check the integration branch and {{AUTOSKILLIT_TEMP}}/merge-prs/ for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "merge-prs pipeline failed"}
     note: >
       context.task may be null when reached via escalation_required=true from merge_pr
       (merge-pr does not set conflict_report_path on escalation paths). Do not rely on

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -452,11 +452,11 @@
     },
     "done": {
       "action": "stop",
-      "message": "Planning complete. Plan artifacts written to ${{ context.planner_dir }}/. Use compile output to create GitHub issues and milestones.\n"
+      "message": "Planning complete. Plan artifacts written to ${{ context.planner_dir }}/. Use compile output to create GitHub issues and milestones. Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"planning complete\"}"
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Planner pipeline failed — human intervention needed. Review the latest step output for details."
+      "message": "Planner pipeline failed — human intervention needed. Review the latest step output for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"planner pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -462,10 +462,15 @@ steps:
 
   done:
     action: stop
-    message: >
+    message: >-
       Planning complete. Plan artifacts written to ${{ context.planner_dir }}/.
       Use compile output to create GitHub issues and milestones.
+      Emit the L3 result sentinel JSON block now with success=true.
+      Example sentinel: {"success": true, "reason": "planning complete"}
 
   escalate_stop:
     action: stop
-    message: "Planner pipeline failed — human intervention needed. Review the latest step output for details."
+    message: >-
+      Planner pipeline failed — human intervention needed. Review the latest step output for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "planner pipeline failed"}

--- a/src/autoskillit/recipes/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.json
@@ -73,7 +73,7 @@
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Promotion failed — escalating for manual review."
+      "message": "Promotion failed — escalating for manual review. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"promotion failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.yaml
@@ -66,4 +66,7 @@ steps:
 
   escalate_stop:
     action: stop
-    message: "Promotion failed — escalating for manual review."
+    message: >-
+      Promotion failed — escalating for manual review.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "promotion failed"}

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -953,7 +953,7 @@
     },
     "escalate_stop_no_ci": {
       "action": "stop",
-      "message": "CI safety net: statusCheckRollup returned no checks for PR ${{ context.pr_number }}. This typically means no workflow is configured to trigger on this branch pattern. Check .github/workflows/ trigger configuration. This is NOT a test failure — CI never started."
+      "message": "CI safety net: statusCheckRollup returned no checks for PR ${{ context.pr_number }}. This typically means no workflow is configured to trigger on this branch pattern. Check .github/workflows/ trigger configuration. This is NOT a test failure — CI never started. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"no CI checks configured\"}"
     },
     "check_repo_merge_state": {
       "tool": "check_repo_merge_state",
@@ -1839,11 +1839,11 @@
     },
     "done": {
       "action": "stop",
-      "message": "Investigation complete. Fix implemented and PR opened."
+      "message": "Investigation complete. Fix implemented and PR opened. Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"remediation complete\"}"
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Human intervention needed. Review the latest output for details."
+      "message": "Human intervention needed. Review the latest output for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"remediation pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -896,6 +896,8 @@ steps:
       ${{ context.pr_number }}. This typically means no workflow is
       configured to trigger on this branch pattern. Check .github/workflows/
       trigger configuration. This is NOT a test failure — CI never started.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "no CI checks configured"}
 
   check_repo_merge_state:
     tool: check_repo_merge_state
@@ -1699,9 +1701,15 @@ steps:
 
   done:
     action: stop
-    message: "Investigation complete. Fix implemented and PR opened."
+    message: >-
+      Investigation complete. Fix implemented and PR opened.
+      Emit the L3 result sentinel JSON block now with success=true.
+      Example sentinel: {"success": true, "reason": "remediation complete"}
 
   escalate_stop:
     action: stop
-    message: "Human intervention needed. Review the latest output for details."
+    message: >-
+      Human intervention needed. Review the latest output for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "remediation pipeline failed"}
 

--- a/src/autoskillit/recipes/research-archive.json
+++ b/src/autoskillit/recipes/research-archive.json
@@ -133,7 +133,7 @@
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Research archival pipeline failed — human intervention needed. Check the latest step output for details."
+      "message": "Research archival pipeline failed — human intervention needed. Check the latest step output for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"research archival pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/research-archive.yaml
+++ b/src/autoskillit/recipes/research-archive.yaml
@@ -134,4 +134,7 @@ steps:
 
   escalate_stop:
     action: stop
-    message: "Research archival pipeline failed — human intervention needed. Check the latest step output for details."
+    message: >-
+      Research archival pipeline failed — human intervention needed. Check the latest step output for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "research archival pipeline failed"}

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -215,7 +215,7 @@
     },
     "design_rejected": {
       "action": "stop",
-      "message": "Research pipeline halted: experiment design rejected (verdict=STOP, resolution=failed). All stop-trigger findings are structural — revision cannot address the identified flaws. Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard.\n"
+      "message": "Research pipeline halted: experiment design rejected (verdict=STOP, resolution=failed). All stop-trigger findings are structural — revision cannot address the identified flaws. Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"experiment design rejected\"}\n"
     },
     "create_worktree": {
       "tool": "run_cmd",
@@ -242,7 +242,7 @@
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Research pipeline failed — human intervention needed. Check the latest step output for details."
+      "message": "Research pipeline failed — human intervention needed. Check the latest step output for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"research pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -193,6 +193,8 @@ steps:
       All stop-trigger findings are structural — revision cannot address the identified flaws.
       Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and
       {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "experiment design rejected"}
 
   create_worktree:
     tool: run_cmd
@@ -232,4 +234,7 @@ steps:
 
   escalate_stop:
     action: stop
-    message: "Research pipeline failed — human intervention needed. Check the latest step output for details."
+    message: >-
+      Research pipeline failed — human intervention needed. Check the latest step output for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "research pipeline failed"}

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -562,7 +562,7 @@
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Implementation pipeline failed — human intervention needed. Check the latest step output for details."
+      "message": "Implementation pipeline failed — human intervention needed. Check the latest step output for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"implementation pipeline failed\"}"
     },
     "implement_complete": {
       "action": "stop",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -527,7 +527,10 @@ steps:
   # --- Terminal Stops ---
   escalate_stop:
     action: stop
-    message: "Implementation pipeline failed — human intervention needed. Check the latest step output for details."
+    message: >-
+      Implementation pipeline failed — human intervention needed. Check the latest step output for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "implementation pipeline failed"}
 
   implement_complete:
     action: stop

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -488,7 +488,7 @@
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Review pipeline failed — human intervention needed. Check the latest step output for details."
+      "message": "Review pipeline failed — human intervention needed. Check the latest step output for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"review pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -477,4 +477,7 @@ steps:
 
   escalate_stop:
     action: stop
-    message: "Review pipeline failed — human intervention needed. Check the latest step output for details."
+    message: >-
+      Review pipeline failed — human intervention needed. Check the latest step output for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "review pipeline failed"}

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -246,7 +246,7 @@
     },
     "design_rejected": {
       "action": "stop",
-      "message": "Research pipeline halted: experiment design rejected (verdict=STOP, resolution=failed). All stop-trigger findings are structural — revision cannot address the identified flaws. Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard.\n"
+      "message": "Research pipeline halted: experiment design rejected (verdict=STOP, resolution=failed). All stop-trigger findings are structural — revision cannot address the identified flaws. Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"experiment design rejected\"}\n"
     },
     "create_worktree": {
       "tool": "run_cmd",
@@ -1202,11 +1202,11 @@
     },
     "research_complete": {
       "action": "stop",
-      "message": "Research complete. pr mode: report added to research/ folder and PR opened for review. local mode: bundle exported to {source_dir}/research-bundles/{slug}/ (context.local_bundle_path).\n"
+      "message": "Research complete. pr mode: report added to research/ folder and PR opened for review. local mode: bundle exported to {source_dir}/research-bundles/{slug}/ (context.local_bundle_path). Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"research complete\"}"
     },
     "escalate_stop": {
       "action": "stop",
-      "message": "Research pipeline failed — human intervention needed. Check the latest step output for details."
+      "message": "Research pipeline failed — human intervention needed. Check the latest step output for details. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"research pipeline failed\"}"
     }
   }
 }

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -262,6 +262,8 @@ steps:
       All stop-trigger findings are structural — revision cannot address the identified flaws.
       Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and
       {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "experiment design rejected"}
 
   # --- EXECUTION PHASE ---
   create_worktree:
@@ -1194,11 +1196,16 @@ steps:
 
   research_complete:
     action: stop
-    message: >
+    message: >-
       Research complete. pr mode: report added to research/ folder and PR opened for
       review. local mode: bundle exported to {source_dir}/research-bundles/{slug}/
       (context.local_bundle_path).
+      Emit the L3 result sentinel JSON block now with success=true.
+      Example sentinel: {"success": true, "reason": "research complete"}
 
   escalate_stop:
     action: stop
-    message: "Research pipeline failed — human intervention needed. Check the latest step output for details."
+    message: >-
+      Research pipeline failed — human intervention needed. Check the latest step output for details.
+      Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "research pipeline failed"}

--- a/tests/fleet/test_food_truck_prompt.py
+++ b/tests/fleet/test_food_truck_prompt.py
@@ -55,6 +55,29 @@ def test_fleet_prompt_contains_budget_exceeded_routing():
     assert "QUOTA BUDGET EXCEEDED" in prompt
 
 
+def test_h3b_stop_step_semantics_references_sentinel_and_success():
+    """H3b section of the fleet prompt must instruct the model to emit sentinel block with success field."""
+    prompt = _build_food_truck_prompt(
+        recipe="test-recipe",
+        task="Test task",
+        ingredients={},
+        mcp_prefix=DIRECT_PREFIX,
+        dispatch_id="test-dispatch",
+        campaign_id="test-campaign",
+        l3_timeout_sec=300,
+    )
+    h3b_start = prompt.find("H3b — STOP STEP SEMANTICS:")
+    h3c_start = prompt.find("H3c — ROUTE STEP SEMANTICS:")
+    assert h3b_start != -1, "H3b STOP STEP SEMANTICS section not found in prompt"
+    h3b_section = prompt[h3b_start:h3c_start] if h3c_start != -1 else prompt[h3b_start:]
+    assert "sentinel" in h3b_section.lower(), (
+        "H3b must reference 'sentinel' for stop step handling"
+    )
+    assert "success" in h3b_section.lower(), (
+        "H3b must instruct setting success field in sentinel block"
+    )
+
+
 def test_fleet_prompt_contains_missing_on_failure_sentinel():
     """The L2 fleet prompt must instruct the model to emit missing_on_failure sentinel."""
     prompt = _build_food_truck_prompt(

--- a/tests/fleet/test_food_truck_prompt.py
+++ b/tests/fleet/test_food_truck_prompt.py
@@ -56,7 +56,7 @@ def test_fleet_prompt_contains_budget_exceeded_routing():
 
 
 def test_h3b_stop_step_semantics_references_sentinel_and_success():
-    """H3b section of the fleet prompt must instruct the model to emit sentinel block with success field."""
+    """H3b must instruct sentinel block emission with success field."""
     prompt = _build_food_truck_prompt(
         recipe="test-recipe",
         task="Test task",

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -665,6 +665,25 @@ def test_orchestration_rules_include_stop_step_semantics():
     assert "done" in rules
 
 
+def test_build_stop_step_semantics_includes_sentinel_instruction():
+    """_build_stop_step_semantics() must inject sentinel emission instructions."""
+    from autoskillit.recipe._api import _build_stop_step_semantics
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={
+            "done": RecipeStep(action="stop", message="Pipeline complete."),
+            "escalate_stop": RecipeStep(action="stop", message="Escalated."),
+        },
+    )
+    sem = _build_stop_step_semantics(recipe)
+    assert "sentinel" in sem.lower(), (
+        "_build_stop_step_semantics must inject sentinel instructions"
+    )
+
+
 def test_build_ingredient_rows_resolved_overrides_literal_default():
     """T1: config-resolved value wins over a non-empty YAML literal default."""
     from autoskillit.recipe._api import build_ingredient_rows

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -682,6 +682,8 @@ def test_build_stop_step_semantics_includes_sentinel_instruction():
     assert "sentinel" in sem.lower(), (
         "_build_stop_step_semantics must inject sentinel instructions"
     )
+    assert "success=true" in sem, "Must include success=true for non-failure stop steps"
+    assert "success=false" in sem, "Must include success=false for failure stop steps"
 
 
 def test_build_ingredient_rows_resolved_overrides_literal_default():

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -725,12 +725,12 @@ def test_requires_packs_covers_all_default_disabled_skill_categories() -> None:
 
 
 def _dispatchable_recipe_names() -> list[str]:
-    from autoskillit.recipe.schema import RecipeKind
+    from autoskillit.recipe.rules.rules_food_truck import _DISPATCHABLE_KINDS
 
     names = []
     for yaml_file in sorted(builtin_recipes_dir().glob("*.yaml")):
         recipe = load_recipe(yaml_file)
-        if recipe.kind in {RecipeKind.FOOD_TRUCK, RecipeKind.STANDARD}:
+        if recipe.kind in _DISPATCHABLE_KINDS:
             names.append(recipe.name)
     return names
 

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -724,25 +724,18 @@ def test_requires_packs_covers_all_default_disabled_skill_categories() -> None:
         )
 
 
-@pytest.mark.parametrize(
-    "recipe_name",
-    [
-        "research-design",
-        "research-implement",
-        "research-review",
-        "research-archive",
-        "research",
-        "full-audit",
-        "bem-wrapper",
-        "promote-to-main-wrapper",
-        "planner",
-        "implement-findings",
-        "merge-prs",
-        "implementation",
-        "implementation-groups",
-        "remediation",
-    ],
-)
+def _dispatchable_recipe_names() -> list[str]:
+    from autoskillit.recipe.schema import RecipeKind
+
+    names = []
+    for yaml_file in sorted(builtin_recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(yaml_file)
+        if recipe.kind in {RecipeKind.FOOD_TRUCK, RecipeKind.STANDARD}:
+            names.append(recipe.name)
+    return names
+
+
+@pytest.mark.parametrize("recipe_name", _dispatchable_recipe_names())
 def test_recipe_all_stop_steps_have_sentinel_instructions(recipe_name: str) -> None:
     """Every stop step in bundled dispatchable recipes must include sentinel instructions."""
     recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -722,3 +722,33 @@ def test_requires_packs_covers_all_default_disabled_skill_categories() -> None:
             f"{path.name}: run_skill steps reference default-disabled packs {sorted(missing)} "
             f"but requires_packs={recipe.requires_packs!r} is missing them"
         )
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    [
+        "research-design",
+        "research-implement",
+        "research-review",
+        "research-archive",
+        "research",
+        "full-audit",
+        "bem-wrapper",
+        "promote-to-main-wrapper",
+        "planner",
+        "implement-findings",
+        "merge-prs",
+        "implementation",
+        "implementation-groups",
+        "remediation",
+    ],
+)
+def test_recipe_all_stop_steps_have_sentinel_instructions(recipe_name: str) -> None:
+    """Every stop step in every bundled dispatchable recipe must include sentinel emission instructions."""
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    for step_name, step in recipe.steps.items():
+        if step.action == "stop":
+            assert step.message, f"{recipe_name}.yaml step '{step_name}' must have a message"
+            assert "sentinel" in step.message.lower(), (
+                f"{recipe_name}.yaml step '{step_name}' must instruct L3 sentinel emission in its message"
+            )

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -744,11 +744,12 @@ def test_requires_packs_covers_all_default_disabled_skill_categories() -> None:
     ],
 )
 def test_recipe_all_stop_steps_have_sentinel_instructions(recipe_name: str) -> None:
-    """Every stop step in every bundled dispatchable recipe must include sentinel emission instructions."""
+    """Every stop step in bundled dispatchable recipes must include sentinel instructions."""
     recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
     for step_name, step in recipe.steps.items():
         if step.action == "stop":
             assert step.message, f"{recipe_name}.yaml step '{step_name}' must have a message"
             assert "sentinel" in step.message.lower(), (
-                f"{recipe_name}.yaml step '{step_name}' must instruct L3 sentinel emission in its message"
+                f"{recipe_name}.yaml step '{step_name}' must instruct "
+                f"L3 sentinel emission in its message"
             )

--- a/tests/recipe/test_rules_food_truck.py
+++ b/tests/recipe/test_rules_food_truck.py
@@ -160,7 +160,12 @@ def test_escalate_route_coverage_rule_passes_when_no_escalate_routes():
 
 def test_escalate_route_coverage_rule_skips_standard():
     """Standard recipe produces no findings for escalate-route-coverage rule."""
-    recipe = _standard_recipe()
+    recipe = Recipe(
+        name="standard-test",
+        description="standard recipe",
+        steps={"done": RecipeStep(action="stop", message="done")},
+        kitchen_rules=["NEVER"],
+    )
     found = _findings(recipe, "escalate-route-coverage")
     assert found == []
 

--- a/tests/recipe/test_rules_food_truck.py
+++ b/tests/recipe/test_rules_food_truck.py
@@ -25,16 +25,6 @@ def _food_truck_recipe(**kwargs: object) -> Recipe:
     return Recipe(**defaults)
 
 
-def _standard_recipe(**kwargs: object) -> Recipe:
-    return Recipe(
-        name="standard",
-        description="standard recipe",
-        steps={"done": RecipeStep(action="stop", message="done")},
-        kitchen_rules=["NEVER"],
-        **kwargs,
-    )
-
-
 def _findings(recipe: Recipe, rule: str, **ctx_kwargs: object) -> list:
     ctx = make_validation_context(recipe, **ctx_kwargs)
     return [f for f in run_semantic_rules(ctx) if f.rule == rule]

--- a/tests/recipe/test_rules_food_truck.py
+++ b/tests/recipe/test_rules_food_truck.py
@@ -35,7 +35,7 @@ def _findings(recipe: Recipe, rule: str, **ctx_kwargs: object) -> list:
 # ---------------------------------------------------------------------------
 
 
-def test_food_truck_has_sentinel_stop_rule_fires_on_missing_sentinel():
+def test_dispatchable_sentinel_rule_fires_on_missing_sentinel():
     """Dispatchable recipe with no sentinel in any stop message triggers a finding."""
     recipe = _food_truck_recipe(
         steps={"done": RecipeStep(action="stop", message="Promotion complete.")},
@@ -50,7 +50,7 @@ def test_food_truck_has_sentinel_stop_rule_fires_on_missing_sentinel():
 # ---------------------------------------------------------------------------
 
 
-def test_food_truck_has_sentinel_stop_rule_passes_when_present():
+def test_dispatchable_sentinel_rule_passes_when_present():
     """Food-truck recipe with sentinel in stop message produces no findings."""
     recipe = _food_truck_recipe(
         steps={
@@ -119,7 +119,7 @@ def test_food_truck_sentinel_rule_passes_when_all_stops_have_sentinel():
     assert found == [], "Rule must not fire when all stop steps have sentinel instructions"
 
 
-def test_food_truck_has_sentinel_stop_severity_is_error():
+def test_dispatchable_sentinel_rule_severity_is_error():
     """Guard: all-dispatchable-stops-have-sentinel must be ERROR, not WARNING."""
     from autoskillit.recipe.registry import _RULE_REGISTRY
 

--- a/tests/recipe/test_rules_food_truck.py
+++ b/tests/recipe/test_rules_food_truck.py
@@ -46,49 +46,97 @@ def _findings(recipe: Recipe, rule: str, **ctx_kwargs: object) -> list:
 
 
 def test_food_truck_has_sentinel_stop_rule_fires_on_missing_sentinel():
-    """food-truck recipe with no sentinel in stop message triggers a finding."""
+    """Dispatchable recipe with no sentinel in any stop message triggers a finding."""
     recipe = _food_truck_recipe(
         steps={"done": RecipeStep(action="stop", message="Promotion complete.")},
     )
-    found = _findings(recipe, "food-truck-has-sentinel-stop")
+    found = _findings(recipe, "all-dispatchable-stops-have-sentinel")
     assert found
     assert found[0].severity == Severity.ERROR
 
 
 # ---------------------------------------------------------------------------
-# T9: food-truck-has-sentinel-stop (passes when present)
+# T9: all-dispatchable-stops-have-sentinel (passes when present)
 # ---------------------------------------------------------------------------
 
 
 def test_food_truck_has_sentinel_stop_rule_passes_when_present():
-    """food-truck recipe with sentinel in stop message produces no findings."""
+    """Food-truck recipe with sentinel in stop message produces no findings."""
     recipe = _food_truck_recipe(
         steps={
             "done": RecipeStep(action="stop", message="Done. Emit your L3 sentinel JSON block.")
         },
     )
-    found = _findings(recipe, "food-truck-has-sentinel-stop")
+    found = _findings(recipe, "all-dispatchable-stops-have-sentinel")
     assert found == []
 
 
-# ---------------------------------------------------------------------------
-# T10: food-truck-has-sentinel-stop (skips standard)
-# ---------------------------------------------------------------------------
+def test_food_truck_sentinel_rule_fires_on_non_sentinel_stop_step():
+    """Multi-stop food-truck recipe: one sentinel stop, one plain stop -> fires for plain stop."""
+    recipe = _food_truck_recipe(
+        steps={
+            "done": RecipeStep(
+                action="stop",
+                message="Emit sentinel JSON block",
+            ),
+            "escalate_stop": RecipeStep(
+                action="stop",
+                message="This task cannot proceed.",
+            ),
+        },
+    )
+    found = _findings(recipe, "all-dispatchable-stops-have-sentinel")
+    assert found, "Rule must fire for stop step without sentinel in message"
+    escalate_findings = [f for f in found if f.step_name == "escalate_stop"]
+    assert escalate_findings, "Rule must produce a finding for escalate_stop specifically"
 
 
-def test_food_truck_has_sentinel_stop_rule_skips_standard():
-    """Standard recipe produces no findings for the food-truck sentinel rule."""
-    recipe = _standard_recipe()
-    found = _findings(recipe, "food-truck-has-sentinel-stop")
-    assert found == []
+def test_sentinel_rule_enforces_on_standard_dispatchable_recipe():
+    """Standard-kind dispatchable recipe with plain stop step triggers the sentinel rule."""
+    recipe = Recipe(
+        name="standard-test",
+        description="standard dispatchable recipe",
+        steps={
+            "done": RecipeStep(action="stop", message="done"),
+            "escalate_stop": RecipeStep(
+                action="stop",
+                message="Escalated.",
+            ),
+        },
+        kitchen_rules=["NEVER"],
+    )
+    found = _findings(recipe, "all-dispatchable-stops-have-sentinel")
+    assert found, "Standard recipe stop steps must have sentinel instructions"
+    escalate_findings = [f for f in found if f.step_name == "escalate_stop"]
+    assert escalate_findings, "Rule must fire for standard recipe's non-sentinel stop steps"
+
+
+def test_food_truck_sentinel_rule_passes_when_all_stops_have_sentinel():
+    """Multi-stop food-truck recipe where all stop steps mention sentinel -> no findings."""
+    recipe = _food_truck_recipe(
+        steps={
+            "done": RecipeStep(
+                action="stop",
+                message="Done. Emit your L3 sentinel JSON block.",
+            ),
+            "escalate_stop": RecipeStep(
+                action="stop",
+                message="Escalate. Emit L3 sentinel JSON block with success=false.",
+            ),
+        },
+    )
+    found = _findings(recipe, "all-dispatchable-stops-have-sentinel")
+    assert found == [], "Rule must not fire when all stop steps have sentinel instructions"
 
 
 def test_food_truck_has_sentinel_stop_severity_is_error():
-    """Guard: food-truck-has-sentinel-stop must be ERROR, not WARNING."""
+    """Guard: all-dispatchable-stops-have-sentinel must be ERROR, not WARNING."""
     from autoskillit.recipe.registry import _RULE_REGISTRY
 
-    rule = next((r for r in _RULE_REGISTRY if r.name == "food-truck-has-sentinel-stop"), None)
-    assert rule is not None, "Rule 'food-truck-has-sentinel-stop' not found in registry"
+    rule = next(
+        (r for r in _RULE_REGISTRY if r.name == "all-dispatchable-stops-have-sentinel"), None
+    )
+    assert rule is not None, "Rule 'all-dispatchable-stops-have-sentinel' not found in registry"
     assert rule.severity == Severity.ERROR
 
 

--- a/tests/recipe/test_sub_recipe_validation.py
+++ b/tests/recipe/test_sub_recipe_validation.py
@@ -190,10 +190,12 @@ def test_dual_validation_runs_standalone_and_combined(tmp_path: Path) -> None:
             on_failure: escalate
           finish:
             action: stop
-            message: Done.
+            message: >-
+              Pipeline finished. Emit the L3 result sentinel JSON block now.
           escalate:
             action: stop
-            message: Failed.
+            message: >-
+              Pipeline failed. Emit the L3 result sentinel JSON block now.
     """)
     (recipes_dir / "test-recipe.yaml").write_text(recipe_content)
 

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -203,7 +203,7 @@ class TestValidateRecipeTool:
             "    on_success: done\n"
             "  done:\n"
             "    action: stop\n"
-            '    message: "Done."\n'
+            '    message: "Done. Emit the L3 result sentinel JSON block now."\n'
         )
         result = json.loads(await validate_recipe(script_path=str(script)))
         assert result["valid"] is False

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -86,10 +86,10 @@ steps:
     on_failure: escalate
   done:
     action: stop
-    message: "Done."
+    message: "Done. Emit the L3 result sentinel JSON block now."
   escalate:
     action: stop
-    message: "Failed."
+    message: "Failed. Emit the L3 result sentinel JSON block now."
 kitchen_rules:
   - "Follow routing rules"
 """
@@ -123,7 +123,7 @@ class TestValidateRecipeTool:
             "    on_failure: escalate\n"
             "  done:\n"
             "    action: stop\n"
-            '    message: "Done."\n'
+            '    message: "Done. Emit the L3 result sentinel JSON block now."\n'
         )
         result = json.loads(await validate_recipe(script_path=str(script)))
         assert result["valid"] is True
@@ -180,7 +180,7 @@ class TestValidateRecipeTool:
             "    on_failure: done\n"
             "  done:\n"
             "    action: stop\n"
-            '    message: "Done."\n'
+            '    message: "Done. Emit the L3 result sentinel JSON block now."\n'
         )
         result = json.loads(await validate_recipe(script_path=str(script)))
         assert result["valid"] is True
@@ -241,7 +241,7 @@ class TestValidateRecipeTool:
             "    on_failure: escalate\n"
             "  done:\n"
             "    action: stop\n"
-            '    message: "Done."\n'
+            '    message: "Done. Emit the L3 result sentinel JSON block now."\n'
         )
         result = json.loads(await validate_recipe(script_path=str(script)))
         assert "findings" in result


### PR DESCRIPTION
## Summary

Failure-terminal stop steps (`escalate_stop`, `design_rejected`, `escalate_stop_no_ci`) across 13+ recipe YAML files lack sentinel emission instructions. Success terminals consistently include explicit sentinel JSON examples, but failure terminals contain only prose. A three-layer defense-in-depth fix makes the bug class structurally impossible: (1) `_build_stop_step_semantics()` now injects sentinel instructions for every stop step at prompt-build time, (2) the semantic rule `all-dispatchable-stops-have-sentinel` enforces universality across all dispatchable recipe kinds, and (3) H3b was strengthened to explicitly mention the `success` field.

Closes #2387

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_universal_failure_sentinel_2026-05-11_210500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 65 | 9.0k | 904.3k | 99.5k | 137 | 53.8k | 7m 32s |
| rectify | claude-sonnet-4-6 | 1 | 2.9k | 13.0k | 633.9k | 107.4k | 124 | 51.2k | 11m 14s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 1.4k | 12.3k | 1.2M | 77.0k | 135 | 63.8k | 7m 48s |
| implement* | MiniMax-M2.7 | 1 | 184.9k | 23.9k | 5.6M | 21.4k | 243 | 0 | 20m 25s |
| prepare_pr* | MiniMax-M2.7 | 1 | 48.2k | 4.2k | 303.7k | 0 | 23 | 0 | 2m 30s |
| compose_pr* | MiniMax-M2.7 | 1 | 48.1k | 2.9k | 621.5k | 0 | 37 | 0 | 2m 10s |
| review_pr | claude-opus-4-6 | 3 | 3.2k | 67.4k | 2.5M | 103.0k | 211 | 262.1k | 23m 5s |
| resolve_review | claude-opus-4-6 | 4 | 1.2k | 55.6k | 8.1M | 84.0k | 303 | 260.0k | 34m 11s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 49 | 12.7k | 1.6M | 72.4k | 63 | 60.8k | 4m 8s |
| diagnose_ci* | MiniMax-M2.7 | 1 | 48.1k | 4.0k | 540.1k | 29.3k | 36 | 41.6k | 3m 33s |
| resolve_ci | claude-opus-4-6 | 1 | 43 | 9.6k | 681.1k | 55.9k | 32 | 42.9k | 6m 12s |
| **Total** | | | 338.1k | 214.7k | 22.6M | 107.4k | | 836.2k | 2h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 489 | 11386.6 | 0.0 | 48.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 138 | 17849.6 | 1899.3 | 488.4 |
| resolve_review | 404 | 20071.5 | 643.5 | 137.7 |
| ci_conflict_fix | 410 | 3887.5 | 148.4 | 31.0 |
| diagnose_ci | 81 | 6668.2 | 513.4 | 49.8 |
| resolve_ci | 81 | 8408.6 | 529.9 | 118.6 |
| **Total** | **1603** | 14092.1 | 521.6 | 133.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 4.4k | 34.4k | 2.7M | 168.8k | 26m 35s |
| MiniMax-M2.7 | 3 | 281.3k | 30.9k | 6.5M | 0 | 25m 5s |
| claude-opus-4-6 | 1 | 74 | 16.5k | 3.5M | 87.7k | 11m 45s |