### PR TITLE
Rectify: V9 Placeholder Syntax Rejection + data_acquisition Template Gate — PART A ONLY

### DIFF
--- a/src/autoskillit/recipe/_skill_placeholder_parser.py
+++ b/src/autoskillit/recipe/_skill_placeholder_parser.py
@@ -58,3 +58,21 @@ def shell_vars_assigned(bash_blocks: list[str]) -> set[str]:
             assigned.add(m.group(1))
             assigned.add(m.group(1).lower())
     return assigned
+
+
+_VRULE_RE = re.compile(
+    r"^(V\d+):\s*.+?(?=^V\d+:|\n---|\Z)",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def extract_validation_rule_block(content: str, rule_label: str) -> str | None:
+    """Extract a named validation rule block (e.g., 'V9') from SKILL.md content.
+
+    Returns the full block text from 'V9: ...' to the next V-rule label,
+    a '---' separator, or end of string. Returns None if the label is not found.
+    """
+    for m in _VRULE_RE.finditer(content):
+        if m.group(1) == rule_label:
+            return m.group(0).strip()
+    return None

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -547,8 +547,8 @@ _EXECUTABLE_FIELD_SKILLS: frozenset[str] = frozenset(
 
 _CONTENT_VALIDITY_SIGNALS_RE = re.compile(
     r"unresolved.{0,20}placeholder|template.{0,20}syntax|placeholder.{0,20}reject"
-    r"|must not contain.{0,20}placeholder|reject.{0,20}template|\{[a-z]"
-    r"|must not contain|reject.{0,10}invalid",
+    r"|must not contain.{0,20}placeholder|reject.{0,20}template|\{[a-z_][a-z0-9_]*\}"
+    r"|reject.{0,10}invalid",
     re.IGNORECASE,
 )
 

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -546,7 +546,9 @@ _EXECUTABLE_FIELD_SKILLS: frozenset[str] = frozenset(
 )
 
 _CONTENT_VALIDITY_SIGNALS_RE = re.compile(
-    r"placeholder|template|unresolved|\{[a-z]|must not contain|reject|invalid",
+    r"unresolved.{0,20}placeholder|template.{0,20}syntax|placeholder.{0,20}reject"
+    r"|must not contain.{0,20}placeholder|reject.{0,20}template|\{[a-z]"
+    r"|must not contain|reject.{0,10}invalid",
     re.IGNORECASE,
 )
 

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe._git_helpers import _GIT_REMOTE_COMMAND_RE, _LITERAL_ORIGIN_RE
 from autoskillit.recipe._skill_placeholder_parser import (
+    _VRULE_RE,
     extract_bash_blocks,
     extract_bash_placeholders,
     extract_declared_ingredients,
@@ -535,4 +536,70 @@ def _check_transition_boundary_anti_confirmation(ctx: ValidationContext) -> list
                     ),
                 )
             )
+    return findings
+
+
+_EXECUTABLE_FIELD_SKILLS: frozenset[str] = frozenset(
+    {
+        "plan-experiment",
+    }
+)
+
+_CONTENT_VALIDITY_SIGNALS_RE = re.compile(
+    r"placeholder|template|unresolved|\{[a-z]|must not contain|reject|invalid",
+    re.IGNORECASE,
+)
+
+
+@semantic_rule(
+    name="executable-field-content-validity",
+    description=(
+        "Skills with validation rules for executable fields (acquisition, spec_path) "
+        "must include content-validity checks, not just presence checks. "
+        "Fires when a V-rule block mentions an executable field but contains no "
+        "placeholder/template rejection language."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_executable_field_content_validity(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        if not skill_cmd:
+            continue
+        skill_name = resolve_skill_name(skill_cmd)
+        if skill_name is None:
+            continue
+        if skill_name not in _EXECUTABLE_FIELD_SKILLS:
+            continue
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
+        if skill_md is None:
+            continue
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        for m in _VRULE_RE.finditer(content):
+            block = m.group(0)
+            block_lower = block.lower()
+            if "acquisition" not in block_lower and "spec_path" not in block_lower:
+                continue
+            if not _CONTENT_VALIDITY_SIGNALS_RE.search(block):
+                findings.append(
+                    RuleFinding(
+                        rule="executable-field-content-validity",
+                        severity=Severity.WARNING,
+                        step_name=step_name,
+                        message=(
+                            f"V-rule {m.group(1)} in {skill_name} mentions an executable "
+                            f"field but lacks content-validity criteria "
+                            f"(placeholder/template rejection language)."
+                        ),
+                    )
+                )
     return findings

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -505,6 +505,8 @@ V9: data_manifest completeness
     - Any hypothesis referenced in `success_criteria` has no entry in `data_manifest`
     - Any entry with `source_type: external` or `source_type: gitignored` lacks a non-null `location`
     - Any entry with `source_type: external` lacks a `depends_on` or explicit download command in `acquisition`
+    - Any entry with `source_type: external` or `source_type: gitignored` must not contain unresolved template placeholders in the `acquisition` value — specifically single-brace tokens like `{accession_id}` (shell brace expansions such as `{file1,file2}` are permitted), unexpanded `${VAR}` references, or unresolved `$(command)` substitutions
+    - Any entry with `source_type: gitignored` lacks an explicit, executable acquisition or generation command (descriptive prose such as "generate from upstream pipeline" is insufficient — download-data executes this field as a literal Bash command)
     - Any entry with `source_type: database` lacks a non-null `acquisition` (must describe query method)
     - Any entry with `source_type: literature` lacks a non-null `description` (must identify the source publication)
     NOTE: `literature` and `database` entries do NOT require `depends_on` or download commands.

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -457,9 +457,13 @@ Validates that the experiment plan includes a complete data acquisition strategy
    B must be listed before A (or the dependency chain must be acyclic).
 5. **Directive compliance**: If the research task directive specifies particular data,
    the `data_manifest` must include acquisition steps for that data.
+6. **Template syntax validation**: Every `acquisition` command string is free of unresolved
+   template placeholders (`{variable_name}`, `${VAR}`, `$(command)` tokens). An acquisition
+   command containing unresolved placeholders is not executable and is functionally equivalent
+   to a missing acquisition command.
 
 **Findings format:**
-- STOP if: a hypothesis has no data source at all, or directive-specified data has no acquisition step
+- STOP if: a hypothesis has no data source at all, or directive-specified data has no acquisition step, or an acquisition command contains unresolved template placeholders
 - REVISE if: an external source lacks verification criteria, or gitignored path handling is unclear
 
 #### `agent_implementability` — Agent Execution Feasibility

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -3,6 +3,8 @@
 import re
 from pathlib import Path
 
+from autoskillit.recipe._skill_placeholder_parser import extract_validation_rule_block
+
 SKILL_PATH = (
     Path(__file__).resolve().parent.parent.parent
     / "src"
@@ -172,9 +174,8 @@ def test_v9_mentions_literature_and_database_source_types() -> None:
     """V9 rule text mentions both literature and database source types."""
 
     text = SKILL_PATH.read_text()
-    m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
-    assert m, "V9 rule not found in SKILL.md"
-    v9_block = m.group(0)
+    v9_block = extract_validation_rule_block(text, "V9")
+    assert v9_block is not None, "V9 rule not found in SKILL.md"
     assert "literature" in v9_block.lower(), "V9 must mention literature source type"
     assert "database" in v9_block.lower(), "V9 must mention database source type"
 
@@ -275,9 +276,9 @@ def test_v9_rejects_unresolved_template_placeholders() -> None:
     """
 
     text = SKILL_PATH.read_text()
-    m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
-    assert m, "V9 rule block not found"
-    v9 = m.group(0).lower()
+    v9_block = extract_validation_rule_block(text, "V9")
+    assert v9_block is not None, "V9 rule block not found"
+    v9 = v9_block.lower()
     placeholder_signals = ["placeholder", "template", "unresolved", "brace expansion"]
     assert any(s in v9 for s in placeholder_signals), (
         "V9 must specify rejection of unresolved template/placeholder syntax in acquisition fields"
@@ -299,9 +300,9 @@ def test_v9_requires_gitignored_acquisition_command() -> None:
     """
 
     text = SKILL_PATH.read_text()
-    m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
-    assert m, "V9 rule block not found"
-    v9 = m.group(0).lower()
+    v9_block = extract_validation_rule_block(text, "V9")
+    assert v9_block is not None, "V9 rule block not found"
+    v9 = v9_block.lower()
     assert "gitignored" in v9, "V9 must address source_type: gitignored entries"
     lines = v9.split("\n")
     has_gitignored_acquisition_line = any(
@@ -321,9 +322,9 @@ def test_v9_and_data_acquisition_source_type_consistency() -> None:
     pe_text = SKILL_PATH.read_text()
     rd_text = REVIEW_DESIGN_SKILL_PATH.read_text()
 
-    v9_match = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", pe_text, re.DOTALL)
-    assert v9_match, "V9 block not found in plan-experiment"
-    v9 = v9_match.group(0).lower()
+    v9_block = extract_validation_rule_block(pe_text, "V9")
+    assert v9_block is not None, "V9 block not found in plan-experiment"
+    v9 = v9_block.lower()
 
     da_start = rd_text.lower().find("data_acquisition")
     assert da_start != -1, "data_acquisition not found in review-design"

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -267,12 +267,11 @@ def test_data_manifest_verification_url_field() -> None:
 def test_v9_rejects_unresolved_template_placeholders() -> None:
     """V9 must contain language rejecting {variable} template syntax in acquisition fields.
 
-    Current V9 has no placeholder-rejection language at all — it only checks for
-    presence (non-null) of fields, not for content validity. The error template
-    ``{specific missing field or hypothesis}`` on line 482 is an authoring-time
-    placeholder for the LLM, not a validation criterion about runtime placeholders.
-    This test asserts that V9 explicitly addresses unresolved template placeholders
-    as a rejection criterion.
+    V9 must go beyond presence-only checks (non-null fields) and enforce content
+    validity. The error template ``{specific missing field or hypothesis}`` in V9 is
+    an authoring-time placeholder for the LLM, not a validation criterion about
+    runtime placeholders. This test asserts that V9 explicitly addresses unresolved
+    template placeholders as a rejection criterion.
     """
 
     text = SKILL_PATH.read_text()
@@ -292,11 +291,11 @@ def test_v9_rejects_unresolved_template_placeholders() -> None:
 def test_v9_requires_gitignored_acquisition_command() -> None:
     """V9 must require gitignored entries to have an executable acquisition command.
 
-    Current V9 only requires gitignored entries to have a non-null `location` (line 477)
-    but does NOT require an acquisition command — despite download-data executing
-    `acquisition` for gitignored entries identically to external entries.
-    This test asserts that V9 has a dedicated bullet/clause requiring gitignored
-    entries to have an acquisition command, separate from the external-only clause.
+    V9 must require gitignored entries to have an acquisition command — not just a
+    non-null `location` — since download-data executes `acquisition` for gitignored
+    entries identically to external entries. This test asserts that V9 has a dedicated
+    bullet/clause requiring gitignored entries to have an acquisition command,
+    separate from the external-only clause.
     """
 
     text = SKILL_PATH.read_text()

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -1,5 +1,6 @@
 """Contract tests for plan-experiment SKILL.md — data provenance lifecycle."""
 
+import re
 from pathlib import Path
 
 SKILL_PATH = (
@@ -16,6 +17,14 @@ EXPERIMENT_TYPES_DIR = (
     / "autoskillit"
     / "recipes"
     / "experiment-types"
+)
+REVIEW_DESIGN_SKILL_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "review-design"
+    / "SKILL.md"
 )
 
 
@@ -89,7 +98,6 @@ def test_plan_experiment_layout_includes_taskfile() -> None:
 
 def test_experiment_type_enum_lists_all_registry_types() -> None:
     """All experiment types from the registry appear in the template enum."""
-    import re
 
     registry_types = {p.stem for p in EXPERIMENT_TYPES_DIR.glob("*.yaml")}
     assert len(registry_types) > 0, "experiment-types registry dir is empty or missing"
@@ -104,7 +112,6 @@ def test_experiment_type_enum_lists_all_registry_types() -> None:
 
 def test_source_type_enum_includes_literature_and_database() -> None:
     """source_type enum includes literature and database values."""
-    import re
 
     text = SKILL_PATH.read_text()
     m = re.search(r"source_type:\s*synthetic\s*#\s*([^\n]+)", text, re.IGNORECASE)
@@ -116,7 +123,6 @@ def test_source_type_enum_includes_literature_and_database() -> None:
 
 def test_field_requirements_table_covers_all_registry_types() -> None:
     """Field requirements table has a column for every registry experiment type."""
-    import re
 
     registry_types = {p.stem for p in EXPERIMENT_TYPES_DIR.glob("*.yaml")}
     assert len(registry_types) > 0, "experiment-types registry dir is empty or missing"
@@ -152,7 +158,6 @@ def test_field_requirements_table_covers_all_registry_types() -> None:
 
 def test_v3_exempts_qualitative_interpretive() -> None:
     """V3 exempts qualitative_interpretive from statistical_plan requirement."""
-    import re
 
     text = SKILL_PATH.read_text()
     m = re.search(r"V3:\s*([^\n]+)", text)
@@ -165,7 +170,6 @@ def test_v3_exempts_qualitative_interpretive() -> None:
 
 def test_v9_mentions_literature_and_database_source_types() -> None:
     """V9 rule text mentions both literature and database source types."""
-    import re
 
     text = SKILL_PATH.read_text()
     m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
@@ -270,7 +274,6 @@ def test_v9_rejects_unresolved_template_placeholders() -> None:
     This test asserts that V9 explicitly addresses unresolved template placeholders
     as a rejection criterion.
     """
-    import re
 
     text = SKILL_PATH.read_text()
     m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
@@ -295,7 +298,6 @@ def test_v9_requires_gitignored_acquisition_command() -> None:
     This test asserts that V9 has a dedicated bullet/clause requiring gitignored
     entries to have an acquisition command, separate from the external-only clause.
     """
-    import re
 
     text = SKILL_PATH.read_text()
     m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
@@ -312,4 +314,30 @@ def test_v9_requires_gitignored_acquisition_command() -> None:
     assert has_gitignored_acquisition_line, (
         "V9 must have a dedicated clause requiring gitignored entries to have an "
         "executable acquisition or generation command (not just a non-null location)"
+    )
+
+
+def test_v9_and_data_acquisition_source_type_consistency() -> None:
+    """V9 and data_acquisition must address the same source_type variants."""
+    pe_text = SKILL_PATH.read_text()
+    rd_text = REVIEW_DESIGN_SKILL_PATH.read_text()
+
+    v9_match = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", pe_text, re.DOTALL)
+    assert v9_match, "V9 block not found in plan-experiment"
+    v9 = v9_match.group(0).lower()
+
+    da_start = rd_text.lower().find("data_acquisition")
+    assert da_start != -1, "data_acquisition not found in review-design"
+    da = rd_text[da_start : da_start + 3000].lower()
+
+    for source_type in ("external", "gitignored"):
+        assert source_type in v9, f"V9 must address source_type: {source_type}"
+        assert source_type in da, f"data_acquisition must address source_type: {source_type}"
+
+    placeholder_signals = ["placeholder", "template", "unresolved", "{"]
+    assert any(s in v9 for s in placeholder_signals), (
+        "V9 must mention template/placeholder validation"
+    )
+    assert any(s in da for s in placeholder_signals), (
+        "data_acquisition must mention template/placeholder validation"
     )

--- a/tests/contracts/test_plan_experiment_contracts.py
+++ b/tests/contracts/test_plan_experiment_contracts.py
@@ -258,3 +258,58 @@ def test_data_manifest_verification_url_field() -> None:
         "data_manifest section must include a verification_url field "
         "to record the URL used to confirm accession existence"
     )
+
+
+def test_v9_rejects_unresolved_template_placeholders() -> None:
+    """V9 must contain language rejecting {variable} template syntax in acquisition fields.
+
+    Current V9 has no placeholder-rejection language at all — it only checks for
+    presence (non-null) of fields, not for content validity. The error template
+    ``{specific missing field or hypothesis}`` on line 482 is an authoring-time
+    placeholder for the LLM, not a validation criterion about runtime placeholders.
+    This test asserts that V9 explicitly addresses unresolved template placeholders
+    as a rejection criterion.
+    """
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
+    assert m, "V9 rule block not found"
+    v9 = m.group(0).lower()
+    placeholder_signals = ["placeholder", "template", "unresolved", "brace expansion"]
+    assert any(s in v9 for s in placeholder_signals), (
+        "V9 must specify rejection of unresolved template/placeholder syntax in acquisition fields"
+    )
+    reject_signals = ["must not contain", "not permitted", "reject", "must be"]
+    assert any(s in v9 for s in reject_signals), (
+        "V9 must specify a prohibition for placeholder syntax, not just mention it"
+    )
+
+
+def test_v9_requires_gitignored_acquisition_command() -> None:
+    """V9 must require gitignored entries to have an executable acquisition command.
+
+    Current V9 only requires gitignored entries to have a non-null `location` (line 477)
+    but does NOT require an acquisition command — despite download-data executing
+    `acquisition` for gitignored entries identically to external entries.
+    This test asserts that V9 has a dedicated bullet/clause requiring gitignored
+    entries to have an acquisition command, separate from the external-only clause.
+    """
+    import re
+
+    text = SKILL_PATH.read_text()
+    m = re.search(r"V9:.+?(?=\nV[0-9]+:|\n---|\Z)", text, re.DOTALL)
+    assert m, "V9 rule block not found"
+    v9 = m.group(0).lower()
+    assert "gitignored" in v9, "V9 must address source_type: gitignored entries"
+    lines = v9.split("\n")
+    has_gitignored_acquisition_line = any(
+        "gitignored" in line
+        and ("acquisition" in line or "generation" in line)
+        and "location" not in line
+        for line in lines
+    )
+    assert has_gitignored_acquisition_line, (
+        "V9 must have a dedicated clause requiring gitignored entries to have an "
+        "executable acquisition or generation command (not just a non-null location)"
+    )

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -158,6 +158,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_skill_emit_consistency.py` | Tests for skill emit consistency in recipe steps |
 | `test_skill_worktree_patterns.py` | Tests that SKILL.md files do not use fragile relative worktree path patterns |
 | `test_silent_type_convention.py` | Tests for silent-type-convention.md documentation |
+| `test_skill_placeholder_parser.py` | Tests for SKILL.md V-rule block extraction utilities |
 | `test_silent_type_flows.py` | Integration tests for silent-type convention flows (vis-lens out-of-scope path) |
 | `test_staleness_cache.py` | Tests for recipe staleness cache |
 | `test_sub_recipe_loading.py` | Tests for sub-recipe loading and composition |

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -883,3 +883,118 @@ def test_rules_pass_ctx_skill_resolver_to_resolve_skill_md(tmp_path: Path) -> No
     assert all(r is resolver for r in non_none), (
         "Expected every non-None resolver to be the exact instance from ctx"
     )
+
+
+# ---------------------------------------------------------------------------
+# executable-field-content-validity tests
+# ---------------------------------------------------------------------------
+
+_EXEC_RULE_ID = "executable-field-content-validity"
+
+
+def test_executable_field_content_validity_fires_for_missing_criteria(tmp_path: Path) -> None:
+    """Rule fires when a V-rule block mentions acquisition without content-validity language."""
+    skill_dir = tmp_path / "plan-experiment"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # plan-experiment
+
+            V9: data manifest completeness
+              ERROR if source_type: external lacks acquisition.
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("plan-experiment", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    assert _EXEC_RULE_ID in [f.rule for f in findings], (
+        "Rule must fire when V9 mentions acquisition but lacks content-validity criteria"
+    )
+
+
+def test_executable_field_content_validity_passes_when_criteria_present(tmp_path: Path) -> None:
+    """Rule does NOT fire when V9 mentions acquisition with content-validity language."""
+    skill_dir = tmp_path / "plan-experiment"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # plan-experiment
+
+            V9: data manifest completeness
+              ERROR if source_type: external lacks acquisition.
+              ERROR if acquisition contains placeholder tokens.
+              ERROR if acquisition contains unresolved template syntax.
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("plan-experiment", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    assert _EXEC_RULE_ID not in [f.rule for f in findings], (
+        "Rule must not fire when V9 contains placeholder/template rejection language"
+    )
+
+
+def test_executable_field_content_validity_ignores_non_executable_skills(tmp_path: Path) -> None:
+    """Rule does NOT fire for skills not in _EXECUTABLE_FIELD_SKILLS."""
+    skill_dir = tmp_path / "other-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # other-skill
+
+            V9: some rule
+              ERROR if field lacks acquisition.
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("other-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    assert _EXEC_RULE_ID not in [f.rule for f in findings], (
+        "Rule must not fire for skills not in _EXECUTABLE_FIELD_SKILLS"
+    )
+
+
+def test_executable_field_content_validity_checks_all_v_rules(tmp_path: Path) -> None:
+    """Rule checks all V-rules that mention executable fields, not just V9."""
+    skill_dir = tmp_path / "plan-experiment"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # plan-experiment
+
+            V1: first rule
+              ERROR if something is missing.
+
+            V7: intermediate rule
+              ERROR if spec_path is not provided.
+
+            V9: data manifest completeness
+              ERROR if acquisition is present.
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("plan-experiment", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    exec_findings = [f for f in findings if f.rule == _EXEC_RULE_ID]
+    # Both V7 (spec_path) and V9 (acquisition) should fire since neither
+    # has content-validity language
+    assert len(exec_findings) == 2, (
+        f"Expected 2 findings (V7 + V9), got {len(exec_findings)}: "
+        + "; ".join(f.message for f in exec_findings)
+    )

--- a/tests/recipe/test_skill_placeholder_parser.py
+++ b/tests/recipe/test_skill_placeholder_parser.py
@@ -1,0 +1,57 @@
+"""Tests for _skill_placeholder_parser validation rule block extractor."""
+
+import pytest
+
+from autoskillit.recipe._skill_placeholder_parser import extract_validation_rule_block
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_extract_validation_rule_block_returns_v9() -> None:
+    """extract_validation_rule_block must extract a named V-rule block from SKILL.md."""
+    sample = (
+        "V8: success criteria cross-reference\n"
+        "  WARNING if conclusive_positive does not reference a metric.\n\n"
+        "V9: data_manifest completeness\n"
+        "  ERROR if source_type: external lacks acquisition.\n"
+        "  ERROR if acquisition contains {placeholder} tokens.\n\n"
+        "---\n"
+    )
+    block = extract_validation_rule_block(sample, "V9")
+    assert block is not None
+    assert "data_manifest" in block
+    assert "{placeholder}" in block
+    assert "V8" not in block
+
+
+def test_extract_validation_rule_block_returns_none_for_missing() -> None:
+    """extract_validation_rule_block returns None for a missing rule."""
+    block = extract_validation_rule_block("V1: some rule\n", "V9")
+    assert block is None
+
+
+def test_extract_validation_rule_block_returns_first_v() -> None:
+    """Extract the first V-rule when requested."""
+    sample = "V1: first rule\n  ERROR on fail.\n\nV2: second rule\n  WARN on warn.\n"
+    block = extract_validation_rule_block(sample, "V1")
+    assert block is not None
+    assert "first rule" in block
+    assert "V2" not in block
+
+
+def test_extract_validation_rule_block_stops_at_separator() -> None:
+    """Block extraction stops at --- separator."""
+    sample = "V1: rule body\n\n---\n\nOther content that is not part of V1\n"
+    block = extract_validation_rule_block(sample, "V1")
+    assert block is not None
+    assert "Other content" not in block
+
+
+def test_extract_validation_rule_block_different_rule() -> None:
+    """Can extract V2 as well as V1."""
+    sample = "V1: first rule\nV2: second rule\nV3: third rule\n"
+    block = extract_validation_rule_block(sample, "V2")
+    assert block is not None
+    assert "V1" not in block
+    assert "V2" in block
+    assert "V3" not in block

--- a/tests/skills/test_review_design_guards.py
+++ b/tests/skills/test_review_design_guards.py
@@ -29,6 +29,58 @@ def test_data_acquisition_not_l_weight() -> None:
     raise AssertionError("data_acquisition must have M or H weight in at least one bundled type")
 
 
+def test_data_acquisition_rejects_template_syntax() -> None:
+    """data_acquisition dimension must specify a STOP for unresolved template tokens."""
+    text = SKILL_PATH.read_text()
+    da_start = text.lower().find("data_acquisition")
+    assert da_start != -1, "data_acquisition dimension not found"
+    da_section = text[da_start : da_start + 3000].lower()
+    placeholder_signals = ["{", "placeholder", "template", "unresolved"]
+    assert any(s in da_section for s in placeholder_signals), (
+        "data_acquisition must specify template/placeholder syntax validation"
+    )
+    assert "stop" in da_section, (
+        "data_acquisition must produce STOP for unresolvable template tokens"
+    )
+
+
+def test_data_acquisition_enumerates_sub_checks() -> None:
+    """data_acquisition must enumerate all named sub-checks in SKILL.md."""
+    text = SKILL_PATH.read_text()
+    da_start = text.lower().find("data_acquisition")
+    assert da_start != -1
+    da_section = text[da_start : da_start + 3000].lower()
+    required_checks = [
+        "hypothesis coverage",
+        "external source readiness",
+        "gitignored path handling",
+        "dependency ordering",
+        "directive compliance",
+    ]
+    for check in required_checks:
+        assert check in da_section, f"data_acquisition must enumerate sub-check: {check}"
+
+
+def test_data_acquisition_has_stop_findings() -> None:
+    """data_acquisition findings format must include STOP-severity criteria.
+
+    data_acquisition is an L4 dimension — its critical findings produce REVISE via
+    the global verdict logic (not STOP via stop_triggers, which is L1+red_team only).
+    But the dimension's own findings format must still specify STOP-severity criteria
+    so the LLM executing review-design can flag catastrophic data gaps at the
+    dimension level.
+    """
+    text = SKILL_PATH.read_text()
+    # Find the section heading (#### heading with backtick-wrapped dimension name)
+    da_start = text.find("#### `data_acquisition`")
+    assert da_start != -1, "data_acquisition dimension not found"
+    next_dim = text.find("####", da_start + 1)
+    da_section = text[da_start:next_dim].lower() if next_dim != -1 else text[da_start:].lower()
+    assert "stop" in da_section, (
+        "data_acquisition findings format must specify STOP-severity criteria"
+    )
+
+
 def test_agent_implementability_dimension_exists() -> None:
     text = SKILL_PATH.read_text()
     assert "agent_implementability" in text

--- a/tests/skills/test_review_design_guards.py
+++ b/tests/skills/test_review_design_guards.py
@@ -32,9 +32,10 @@ def test_data_acquisition_not_l_weight() -> None:
 def test_data_acquisition_rejects_template_syntax() -> None:
     """data_acquisition dimension must specify a STOP for unresolved template tokens."""
     text = SKILL_PATH.read_text()
-    da_start = text.lower().find("data_acquisition")
+    da_start = text.find("#### `data_acquisition`")
     assert da_start != -1, "data_acquisition dimension not found"
-    da_section = text[da_start : da_start + 3000].lower()
+    next_dim = text.find("####", da_start + 1)
+    da_section = text[da_start:next_dim].lower() if next_dim != -1 else text[da_start:].lower()
     placeholder_signals = ["{", "placeholder", "template", "unresolved"]
     assert any(s in da_section for s in placeholder_signals), (
         "data_acquisition must specify template/placeholder syntax validation"
@@ -47,9 +48,10 @@ def test_data_acquisition_rejects_template_syntax() -> None:
 def test_data_acquisition_enumerates_sub_checks() -> None:
     """data_acquisition must enumerate all named sub-checks in SKILL.md."""
     text = SKILL_PATH.read_text()
-    da_start = text.lower().find("data_acquisition")
+    da_start = text.find("#### `data_acquisition`")
     assert da_start != -1
-    da_section = text[da_start : da_start + 3000].lower()
+    next_dim = text.find("####", da_start + 1)
+    da_section = text[da_start:next_dim].lower() if next_dim != -1 else text[da_start:].lower()
     required_checks = [
         "hypothesis coverage",
         "external source readiness",


### PR DESCRIPTION
## Summary

The `acquisition` field in experiment plan `data_manifest` entries is authored as free text by the plan-experiment LLM agent, passed verbatim through create_worktree, and executed as a literal Bash command by download-data. Two validation gates — plan-experiment's V9 rule and review-design's `data_acquisition` dimension — check only that the field is non-null ("presence checks"), never that its content is a syntactically valid shell command free of unresolved template placeholders. Strings like `{confirmed_accession}` pass both gates and fail at runtime.

This plan adds content-validity clauses to both SKILL.md validation gates and enforces them with Pattern C contract tests (regex-extracted section assertions), replacing the current Pattern A coverage (raw keyword presence across the entire file). It also closes the V9 gitignored asymmetry where `external` entries require an explicit download command but `gitignored` entries do not — despite download-data processing both identically.

Part B will cover semantic rule infrastructure for automated V-rule content-validity enforcement and cross-source consistency between plan-experiment and review-design.

## Requirements

- V9 must explicitly reject unresolved template placeholders (`{variable}`, `${VAR}`, `$(cmd)`) in `acquisition` fields for `source_type: external` and `source_type: gitignored` entries
- V9 must require `source_type: gitignored` entries to have an executable `acquisition` command (not just a non-null location)
- `data_acquisition` dimension must specify STOP-severity criteria for acquisition commands containing unresolved template tokens
- Both additions must be covered by Pattern C contract tests

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_v9_placeholder_syntax_rejection_part_a_2026-05-11_204552.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 60 | 7.0k | 534.0k | 62.1k | 135 | 47.3k | 5m 39s |
| rectify | claude-sonnet-4-6 | 1 | 69 | 21.2k | 818.4k | 77.5k | 198 | 64.3k | 12m 24s |
| dry_walkthrough | claude-opus-4-6 | 2 | 91 | 30.1k | 3.0M | 76.3k | 203 | 122.7k | 17m 29s |
| implement* | MiniMax-M2.7 | 2 | 154.1k | 22.5k | 3.8M | 21.4k | 170 | 0 | 17m 25s |
| prepare_pr* | MiniMax-M2.7 | 1 | 57.9k | 6.1k | 203.5k | 29.1k | 22 | 41.7k | 2m 33s |
| compose_pr* | MiniMax-M2.7 | 1 | 74.4k | 2.2k | 283.5k | 0 | 23 | 0 | 3m 32s |
| review_pr | claude-opus-4-6 | 3 | 4.8k | 86.5k | 1.8M | 92.6k | 171 | 247.3k | 29m 1s |
| resolve_review | claude-opus-4-6 | 2 | 118 | 29.4k | 3.3M | 84.5k | 128 | 123.4k | 16m 43s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 45 | 6.8k | 1.1M | 55.2k | 48 | 43.5k | 2m 32s |
| resolve_queue_merge_conflicts | claude-opus-4-6 | 1 | 36 | 7.6k | 747.7k | 57.2k | 31 | 44.2k | 2m 35s |
| **Total** | | | 291.6k | 219.5k | 15.6M | 92.6k | | 734.4k | 1h 49m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 543 | 6947.5 | 0.0 | 41.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 64 | 27587.3 | 3863.5 | 1351.9 |
| resolve_review | 192 | 17383.9 | 642.9 | 153.3 |
| ci_conflict_fix | 395 | 2902.0 | 110.2 | 17.3 |
| resolve_queue_merge_conflicts | 153 | 4886.8 | 288.7 | 49.7 |
| **Total** | **1347** | 11611.0 | 545.2 | 162.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 129 | 28.2k | 1.4M | 111.7k | 18m 4s |
| claude-opus-4-6 | 1 | 91 | 30.1k | 3.0M | 122.7k | 17m 29s |
| MiniMax-M2.7 | 3 | 286.3k | 30.8k | 4.3M | 41.7k | 23m 30s |