### PR TITLE
[FIX] Rectify: Capture Field Name Contract — Prompt Builder ↔ Extractor Alignment

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -151,6 +151,7 @@ from .types import BackgroundSupervisor as BackgroundSupervisor
 from .types import BareResume as BareResume
 from .types import CampaignProtector as CampaignProtector
 from .types import CAPTURE_VALID_VALUE_TYPES as CAPTURE_VALID_VALUE_TYPES
+from .types import resolve_payload_field as resolve_payload_field
 from .types import CaptureEntrySpec as CaptureEntrySpec
 from .types import CaptureValueTypeError as CaptureValueTypeError
 from .types import ChannelBStatus as ChannelBStatus

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -151,7 +151,6 @@ from .types import BackgroundSupervisor as BackgroundSupervisor
 from .types import BareResume as BareResume
 from .types import CampaignProtector as CampaignProtector
 from .types import CAPTURE_VALID_VALUE_TYPES as CAPTURE_VALID_VALUE_TYPES
-from .types import resolve_payload_field as resolve_payload_field
 from .types import CaptureEntrySpec as CaptureEntrySpec
 from .types import CaptureValueTypeError as CaptureValueTypeError
 from .types import ChannelBStatus as ChannelBStatus
@@ -244,6 +243,7 @@ from .types import assert_prompt_sentinel as assert_prompt_sentinel
 from .types import extract_path_arg as extract_path_arg
 from .types import extract_skill_name as extract_skill_name
 from .types import fleet_error as fleet_error
+from .types import resolve_payload_field as resolve_payload_field
 from .types import resolve_skill_name as resolve_skill_name
 from .types import resolve_target_skill as resolve_target_skill
 from .types import resume_spec_from_cli as resume_spec_from_cli

--- a/src/autoskillit/core/types/_type_capture.py
+++ b/src/autoskillit/core/types/_type_capture.py
@@ -5,6 +5,7 @@ Zero autoskillit imports outside this sub-package. IL-0 type contract.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 __all__ = [
@@ -13,8 +14,6 @@ __all__ = [
     "CaptureValueTypeError",
     "resolve_payload_field",
 ]
-
-import re
 
 _RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
 

--- a/src/autoskillit/core/types/_type_capture.py
+++ b/src/autoskillit/core/types/_type_capture.py
@@ -7,7 +7,32 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-__all__ = ["CAPTURE_VALID_VALUE_TYPES", "CaptureEntrySpec", "CaptureValueTypeError"]
+__all__ = [
+    "CAPTURE_VALID_VALUE_TYPES",
+    "CaptureEntrySpec",
+    "CaptureValueTypeError",
+    "resolve_payload_field",
+]
+
+import re
+
+_RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
+
+
+def resolve_payload_field(entry: CaptureEntrySpec) -> str | None:
+    """Extract the payload field name from a CaptureEntrySpec's ``from_`` template.
+
+    Parses the ``${{ result.<field_name> }}`` template string and returns the
+    bare field name. Returns ``None`` if the template does not match the expected
+    pattern.
+
+    This is the single source of truth for deriving the JSON field name that
+    L3 sessions should emit in the sentinel block and that the extractor
+    uses to look up values in the parsed payload.
+    """
+    m = _RESULT_REF_RE.match(entry.from_.strip())
+    return m.group(1) if m else None
+
 
 CAPTURE_VALID_VALUE_TYPES = frozenset({"path", "url", "string", "optional_string"})
 

--- a/src/autoskillit/core/types/_type_capture.py
+++ b/src/autoskillit/core/types/_type_capture.py
@@ -53,6 +53,8 @@ class CaptureEntrySpec:
     value_type: str = "string"
 
     def __post_init__(self) -> None:
+        if not self.from_ or not self.from_.strip():
+            raise ValueError("CaptureEntrySpec.from_ must be a non-empty string")
         if self.value_type not in _VALID_VALUE_TYPES:
             raise ValueError(
                 f"CaptureEntrySpec.value_type must be one of {sorted(_VALID_VALUE_TYPES)}, "

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -26,6 +26,7 @@ from autoskillit.core import (
     claude_code_log_path,
     claude_code_project_dir,
     get_logger,
+    resolve_payload_field,
     truncate_text,
     write_versioned_json,
 )
@@ -51,7 +52,6 @@ class CaptureCompletenessError(RuntimeError):
 
 
 _CAMPAIGN_REF_RE = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
-_RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
 
 
 def _validate_capture_value(key: str, value: str, declared_type: str) -> None:
@@ -120,10 +120,9 @@ def _extract_captures(
     result: dict[str, str] = {}
     expected_fields: list[str] = []
     for key, entry in capture_spec.items():
-        m = _RESULT_REF_RE.match(entry.from_.strip())
-        if m is None:
+        field_name = resolve_payload_field(entry)
+        if field_name is None:
             continue
-        field_name = m.group(1)
         expected_fields.append(field_name)
         if field_name in payload:
             value: object = payload[field_name]
@@ -633,7 +632,7 @@ async def _run_dispatch(
         dispatch_id=dispatch_id,
         campaign_id=campaign_id,
         l3_timeout_sec=timeout_sec or 1800,
-        capture={k: e.from_ for k, e in capture.items()} if capture else None,
+        capture=capture,
     )
 
     if tool_ctx.executor is None:

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -14,8 +14,10 @@ import regex as re
 from autoskillit.core import (
     ADMIRAL_DISPATCH_SECTIONS,
     ROUTING_AUTHORITY_CLAUSE,
+    CaptureEntrySpec,
     get_logger,
     pkg_root,
+    resolve_payload_field,
 )
 from autoskillit.hooks import (
     QUOTA_BUDGET_EXCEEDED_TRIGGER,
@@ -62,7 +64,7 @@ def _build_food_truck_prompt(
     dispatch_id: str,
     campaign_id: str,
     l3_timeout_sec: int,
-    capture: dict[str, str] | None = None,
+    capture: dict[str, CaptureEntrySpec] | None = None,
 ) -> str:
     """Build the system prompt for an L2 food truck headless session.
 
@@ -72,9 +74,8 @@ def _build_food_truck_prompt(
     budget guidance, quota awareness, campaign task, ingredient values,
     and a sentinel-anchored result contract.
 
-    ``capture`` is an optional mapping of captured field names to their
-    descriptions, used to inject additional fields into the Section 8
-    sentinel format block.
+    ``capture`` is an optional mapping of capture entry keys to their specs,
+    used to inject additional fields into the Section 8 sentinel format block.
     """
     dispatch_id_short = dispatch_id[:8]
     ingredients_json = json.dumps(ingredients)
@@ -82,15 +83,25 @@ def _build_food_truck_prompt(
 
     admiral_block = _build_admiral_dispatch_block()
 
+    capture_field_pairs: list[tuple[str, str, str]] = []
+    if capture:
+        for key, entry in capture.items():
+            field = resolve_payload_field(entry) or key
+            capture_field_pairs.append((key, field, entry.from_))
+
     extra_fields_example = (
-        ", " + ", ".join(f'"capture_{k}": "<{k}_value>"' for k in capture) if capture else ""
+        ", " + ", ".join(f'"{field}": "<{field}_value>"' for _, field, _ in capture_field_pairs)
+        if capture_field_pairs
+        else ""
     )
     sentinel_json_example = (
         '{"success": <true|false>, "reason": "<completion_reason>",'
         ' "summary": "<one_line_summary>"' + extra_fields_example + "}"
     )
     extra_fields_docs = (
-        "\n" + "\n".join(f"- capture_{k}: {v}" for k, v in capture.items()) if capture else ""
+        "\n" + "\n".join(f"- {field}: {from_}" for _, field, from_ in capture_field_pairs)
+        if capture_field_pairs
+        else ""
     )
 
     return f"""\

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.652371+00:00",
+  "generated_at": "2026-05-12T22:04:45.501321+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.501321+00:00",
+  "generated_at": "2026-05-12T22:08:59.988950+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:52.880325+00:00",
-  "recipe_source_hash": "sha256:c4f6d0e0461f2cc59d5df1f41a04b83a649b215a48d91b3cdd361c2e00c89eba",
+  "generated_at": "2026-05-12T21:54:49.652371+00:00",
+  "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/bem-wrapper.json
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:08:59.988950+00:00",
+  "generated_at": "2026-05-12T22:18:39.954684+00:00",
   "recipe_source_hash": "sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:08:59.988950+00:00'
+generated_at: '2026-05-12T22:18:39.954684+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.501321+00:00'
+generated_at: '2026-05-12T22:08:59.988950+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.652371+00:00'
+generated_at: '2026-05-12T22:04:45.501321+00:00'
 recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/bem-wrapper.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:52.880325+00:00'
-recipe_source_hash: sha256:c4f6d0e0461f2cc59d5df1f41a04b83a649b215a48d91b3cdd361c2e00c89eba
+generated_at: '2026-05-12T21:54:49.652371+00:00'
+recipe_source_hash: sha256:fede7009c6a067eddee74b5bea2826748d6f02ca729eb94a4d911f127a05da15
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.664876+00:00",
+  "generated_at": "2026-05-12T22:04:45.507721+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:08:59.994968+00:00",
+  "generated_at": "2026-05-12T22:18:39.964273+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.507721+00:00",
+  "generated_at": "2026-05-12T22:08:59.994968+00:00",
   "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:52.895716+00:00",
-  "recipe_source_hash": "sha256:279302789aaccfa1e4b8663bd8c9896b95af4ece9022f5c001959ac0f7e0b23a",
+  "generated_at": "2026-05-12T21:54:49.664876+00:00",
+  "recipe_source_hash": "sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.664876+00:00'
+generated_at: '2026-05-12T22:04:45.507721+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.507721+00:00'
+generated_at: '2026-05-12T22:08:59.994968+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:52.895716+00:00'
-recipe_source_hash: sha256:279302789aaccfa1e4b8663bd8c9896b95af4ece9022f5c001959ac0f7e0b23a
+generated_at: '2026-05-12T21:54:49.664876+00:00'
+recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:08:59.994968+00:00'
+generated_at: '2026-05-12T22:18:39.964273+00:00'
 recipe_source_hash: sha256:fd4ebb707ac39372dd3e8f3974d899f483120067c2116ae4bf8ebe40e7fafe87
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.517701+00:00",
+  "generated_at": "2026-05-12T22:09:00.006117+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.006117+00:00",
+  "generated_at": "2026-05-12T22:18:39.969977+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.670577+00:00",
+  "generated_at": "2026-05-12T22:04:45.517701+00:00",
   "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implement-findings.json
+++ b/src/autoskillit/recipes/contracts/implement-findings.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:52.911205+00:00",
-  "recipe_source_hash": "sha256:60df3c9aa757b621e8260129e48fd5459eb11e853ba98415f7cfc4bdcb81e4ed",
+  "generated_at": "2026-05-12T21:54:49.670577+00:00",
+  "recipe_source_hash": "sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.517701+00:00'
+generated_at: '2026-05-12T22:09:00.006117+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:52.911205+00:00'
-recipe_source_hash: sha256:60df3c9aa757b621e8260129e48fd5459eb11e853ba98415f7cfc4bdcb81e4ed
+generated_at: '2026-05-12T21:54:49.670577+00:00'
+recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.006117+00:00'
+generated_at: '2026-05-12T22:18:39.969977+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implement-findings.yaml
+++ b/src/autoskillit/recipes/contracts/implement-findings.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.670577+00:00'
+generated_at: '2026-05-12T22:04:45.517701+00:00'
 recipe_source_hash: sha256:59b2e744604634112bd794f7149bebc117a3399977c931ea37711713d16edd3c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.015727+00:00",
+  "generated_at": "2026-05-12T22:18:39.979049+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:52.922125+00:00",
-  "recipe_source_hash": "sha256:fa6b64288d101daa9e52bad391ddb2b7e8fcad8d8606214d23f4929f5a32d554",
+  "generated_at": "2026-05-12T21:54:49.679540+00:00",
+  "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.527047+00:00",
+  "generated_at": "2026-05-12T22:09:00.015727+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.679540+00:00",
+  "generated_at": "2026-05-12T22:04:45.527047+00:00",
   "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.015727+00:00'
+generated_at: '2026-05-12T22:18:39.979049+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.527047+00:00'
+generated_at: '2026-05-12T22:09:00.015727+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:52.922125+00:00'
-recipe_source_hash: sha256:fa6b64288d101daa9e52bad391ddb2b7e8fcad8d8606214d23f4929f5a32d554
+generated_at: '2026-05-12T21:54:49.679540+00:00'
+recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.679540+00:00'
+generated_at: '2026-05-12T22:04:45.527047+00:00'
 recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.031783+00:00",
+  "generated_at": "2026-05-12T22:18:39.993965+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.694327+00:00",
+  "generated_at": "2026-05-12T22:04:45.543029+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.543029+00:00",
+  "generated_at": "2026-05-12T22:09:00.031783+00:00",
   "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:52.947202+00:00",
-  "recipe_source_hash": "sha256:488273bc4621762d2dcb2fd2b1c371befc47392f3616329f12d64394f2809466",
+  "generated_at": "2026-05-12T21:54:49.694327+00:00",
+  "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.031783+00:00'
+generated_at: '2026-05-12T22:18:39.993965+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:52.947202+00:00'
-recipe_source_hash: sha256:488273bc4621762d2dcb2fd2b1c371befc47392f3616329f12d64394f2809466
+generated_at: '2026-05-12T21:54:49.694327+00:00'
+recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.543029+00:00'
+generated_at: '2026-05-12T22:09:00.031783+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.694327+00:00'
+generated_at: '2026-05-12T22:04:45.543029+00:00'
 recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.708478+00:00",
+  "generated_at": "2026-05-12T22:04:45.557188+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.046127+00:00",
+  "generated_at": "2026-05-12T22:18:40.008064+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:52.975829+00:00",
-  "recipe_source_hash": "sha256:8e46dcb1d749fbb395beacb197fc265d9da5a5b0e8626fbd4e0d67a5345a0ca8",
+  "generated_at": "2026-05-12T21:54:49.708478+00:00",
+  "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.557188+00:00",
+  "generated_at": "2026-05-12T22:09:00.046127+00:00",
   "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.557188+00:00'
+generated_at: '2026-05-12T22:09:00.046127+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.046127+00:00'
+generated_at: '2026-05-12T22:18:40.008064+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.708478+00:00'
+generated_at: '2026-05-12T22:04:45.557188+00:00'
 recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:52.975829+00:00'
-recipe_source_hash: sha256:8e46dcb1d749fbb395beacb197fc265d9da5a5b0e8626fbd4e0d67a5345a0ca8
+generated_at: '2026-05-12T21:54:49.708478+00:00'
+recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.056518+00:00",
+  "generated_at": "2026-05-12T22:18:40.019008+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.718053+00:00",
+  "generated_at": "2026-05-12T22:04:45.567051+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.567051+00:00",
+  "generated_at": "2026-05-12T22:09:00.056518+00:00",
   "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:53.004591+00:00",
-  "recipe_source_hash": "sha256:617abcd898b97ba2d6c3f51b3eb2613ce9c8a6dff71a1a9065b83e7ad24dba16",
+  "generated_at": "2026-05-12T21:54:49.718053+00:00",
+  "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.718053+00:00'
+generated_at: '2026-05-12T22:04:45.567051+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.056518+00:00'
+generated_at: '2026-05-12T22:18:40.019008+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.567051+00:00'
+generated_at: '2026-05-12T22:09:00.056518+00:00'
 recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:53.004591+00:00'
-recipe_source_hash: sha256:617abcd898b97ba2d6c3f51b3eb2613ce9c8a6dff71a1a9065b83e7ad24dba16
+generated_at: '2026-05-12T21:54:49.718053+00:00'
+recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:53.019594+00:00",
-  "recipe_source_hash": "sha256:b6942fb601194a2fa8dac278c8319a291cafe3a844a7bb0995ba72cacb44174d",
+  "generated_at": "2026-05-12T21:54:49.724485+00:00",
+  "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.063349+00:00",
+  "generated_at": "2026-05-12T22:18:40.025665+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.573589+00:00",
+  "generated_at": "2026-05-12T22:09:00.063349+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.724485+00:00",
+  "generated_at": "2026-05-12T22:04:45.573589+00:00",
   "recipe_source_hash": "sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.573589+00:00'
+generated_at: '2026-05-12T22:09:00.063349+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.063349+00:00'
+generated_at: '2026-05-12T22:18:40.025665+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:53.019594+00:00'
-recipe_source_hash: sha256:b6942fb601194a2fa8dac278c8319a291cafe3a844a7bb0995ba72cacb44174d
+generated_at: '2026-05-12T21:54:49.724485+00:00'
+recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main-wrapper.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.724485+00:00'
+generated_at: '2026-05-12T22:04:45.573589+00:00'
 recipe_source_hash: sha256:c7235a3a70f2489ac5cb5c44b0ee0f7c5da279dde9971feb8a29619eb3de9189
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.789333+00:00",
+  "generated_at": "2026-05-12T22:04:45.635749+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.635749+00:00",
+  "generated_at": "2026-05-12T22:09:00.125232+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.125232+00:00",
+  "generated_at": "2026-05-12T22:18:40.086646+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.json
+++ b/src/autoskillit/recipes/contracts/promote-to-main.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:53.108110+00:00",
+  "generated_at": "2026-05-12T21:54:49.789333+00:00",
   "recipe_source_hash": "sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:53.108110+00:00'
+generated_at: '2026-05-12T21:54:49.789333+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.789333+00:00'
+generated_at: '2026-05-12T22:04:45.635749+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.125232+00:00'
+generated_at: '2026-05-12T22:18:40.086646+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/promote-to-main.yaml
+++ b/src/autoskillit/recipes/contracts/promote-to-main.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.635749+00:00'
+generated_at: '2026-05-12T22:09:00.125232+00:00'
 recipe_source_hash: sha256:2cb20f84feece68dd5792dec580580a6260558c2c2fe28b328263636c1e3a0ba
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:53.035749+00:00",
-  "recipe_source_hash": "sha256:1f2f5c7133bd520c9ec25386fe7fadf75c4608928a3b0de591cfb788f78ca1f8",
+  "generated_at": "2026-05-12T21:54:49.733770+00:00",
+  "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.583086+00:00",
+  "generated_at": "2026-05-12T22:09:00.072612+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.733770+00:00",
+  "generated_at": "2026-05-12T22:04:45.583086+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.072612+00:00",
+  "generated_at": "2026-05-12T22:18:40.035162+00:00",
   "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.072612+00:00'
+generated_at: '2026-05-12T22:18:40.035162+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:53.035749+00:00'
-recipe_source_hash: sha256:1f2f5c7133bd520c9ec25386fe7fadf75c4608928a3b0de591cfb788f78ca1f8
+generated_at: '2026-05-12T21:54:49.733770+00:00'
+recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.733770+00:00'
+generated_at: '2026-05-12T22:04:45.583086+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.583086+00:00'
+generated_at: '2026-05-12T22:09:00.072612+00:00'
 recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.746083+00:00",
+  "generated_at": "2026-05-12T22:04:45.595240+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.595240+00:00",
+  "generated_at": "2026-05-12T22:09:00.085157+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.085157+00:00",
+  "generated_at": "2026-05-12T22:18:40.046845+00:00",
   "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-archive.json
+++ b/src/autoskillit/recipes/contracts/research-archive.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:53.054306+00:00",
-  "recipe_source_hash": "sha256:80f5de286ec555b43df482eeee47852952b99dea1be9a076f51a702b20044365",
+  "generated_at": "2026-05-12T21:54:49.746083+00:00",
+  "recipe_source_hash": "sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {},

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:53.054306+00:00'
-recipe_source_hash: sha256:80f5de286ec555b43df482eeee47852952b99dea1be9a076f51a702b20044365
+generated_at: '2026-05-12T21:54:49.746083+00:00'
+recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.595240+00:00'
+generated_at: '2026-05-12T22:09:00.085157+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.746083+00:00'
+generated_at: '2026-05-12T22:04:45.595240+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-archive.yaml
+++ b/src/autoskillit/recipes/contracts/research-archive.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.085157+00:00'
+generated_at: '2026-05-12T22:18:40.046845+00:00'
 recipe_source_hash: sha256:f148cd2ff61ff07d49b8dc718680691f6d35ebf523b93e201503a2c49c8c8ef6
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.794617+00:00",
+  "generated_at": "2026-05-12T22:04:45.641106+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.641106+00:00",
+  "generated_at": "2026-05-12T22:09:00.130794+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T04:21:53.113431+00:00",
+  "generated_at": "2026-05-12T21:54:49.794617+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.json
+++ b/src/autoskillit/recipes/contracts/research-campaign.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.130794+00:00",
+  "generated_at": "2026-05-12T22:18:40.092467+00:00",
   "recipe_source_hash": "sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.641106+00:00'
+generated_at: '2026-05-12T22:09:00.130794+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T04:21:53.113431+00:00'
+generated_at: '2026-05-12T21:54:49.794617+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.794617+00:00'
+generated_at: '2026-05-12T22:04:45.641106+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.130794+00:00'
+generated_at: '2026-05-12T22:18:40.092467+00:00'
 recipe_source_hash: sha256:4d31f0fab9dcae740c3f135055108e236e69b2db4904caaf48db5c0f8d0845c0
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:53.061009+00:00",
-  "recipe_source_hash": "sha256:dcd57563c3bb38164fbef5823246e9761d7cc43a51e80727487ecdd6b1d706de",
+  "generated_at": "2026-05-12T21:54:49.752273+00:00",
+  "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.600636+00:00",
+  "generated_at": "2026-05-12T22:09:00.090728+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.090728+00:00",
+  "generated_at": "2026-05-12T22:18:40.052021+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.json
+++ b/src/autoskillit/recipes/contracts/research-design.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.752273+00:00",
+  "generated_at": "2026-05-12T22:04:45.600636+00:00",
   "recipe_source_hash": "sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:53.061009+00:00'
-recipe_source_hash: sha256:dcd57563c3bb38164fbef5823246e9761d7cc43a51e80727487ecdd6b1d706de
+generated_at: '2026-05-12T21:54:49.752273+00:00'
+recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.090728+00:00'
+generated_at: '2026-05-12T22:18:40.052021+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.752273+00:00'
+generated_at: '2026-05-12T22:04:45.600636+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-design.yaml
+++ b/src/autoskillit/recipes/contracts/research-design.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.600636+00:00'
+generated_at: '2026-05-12T22:09:00.090728+00:00'
 recipe_source_hash: sha256:14a3be38df2920ea0bd5e375c9c5aa057dc04fc94305346c061fa28339fb7a35
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.097775+00:00",
+  "generated_at": "2026-05-12T22:18:40.059183+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.759437+00:00",
+  "generated_at": "2026-05-12T22:04:45.607493+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.607493+00:00",
+  "generated_at": "2026-05-12T22:09:00.097775+00:00",
   "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:53.073584+00:00",
-  "recipe_source_hash": "sha256:c09727853bb3aa07f9545c5056f0aadf4fbbbd71e93e684d7605518e0dcf2325",
+  "generated_at": "2026-05-12T21:54:49.759437+00:00",
+  "recipe_source_hash": "sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.607493+00:00'
+generated_at: '2026-05-12T22:09:00.097775+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.097775+00:00'
+generated_at: '2026-05-12T22:18:40.059183+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:53.073584+00:00'
-recipe_source_hash: sha256:c09727853bb3aa07f9545c5056f0aadf4fbbbd71e93e684d7605518e0dcf2325
+generated_at: '2026-05-12T21:54:49.759437+00:00'
+recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.759437+00:00'
+generated_at: '2026-05-12T22:04:45.607493+00:00'
 recipe_source_hash: sha256:60f971b50134e635d48bceade6c29cad91f9dc2d3e9dca631535eea108e8f420
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.105768+00:00",
+  "generated_at": "2026-05-12T22:18:40.066697+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.767401+00:00",
+  "generated_at": "2026-05-12T22:04:45.614871+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:53.081881+00:00",
-  "recipe_source_hash": "sha256:66b02dd80508370eafbbcdc067628268660d60ce1062e4f60f115e75e76c0ad5",
+  "generated_at": "2026-05-12T21:54:49.767401+00:00",
+  "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/research-review.json
+++ b/src/autoskillit/recipes/contracts/research-review.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.614871+00:00",
+  "generated_at": "2026-05-12T22:09:00.105768+00:00",
   "recipe_source_hash": "sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.614871+00:00'
+generated_at: '2026-05-12T22:09:00.105768+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.767401+00:00'
+generated_at: '2026-05-12T22:04:45.614871+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.105768+00:00'
+generated_at: '2026-05-12T22:18:40.066697+00:00'
 recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research-review.yaml
+++ b/src/autoskillit/recipes/contracts/research-review.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:53.081881+00:00'
-recipe_source_hash: sha256:66b02dd80508370eafbbcdc067628268660d60ce1062e4f60f115e75e76c0ad5
+generated_at: '2026-05-12T21:54:49.767401+00:00'
+recipe_source_hash: sha256:763f2a01bc230e1a48b0a91c1722c1a3d8fa7b881c61aa559408c0c2d61f408c
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:09:00.114982+00:00",
+  "generated_at": "2026-05-12T22:18:40.076058+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T21:54:49.777294+00:00",
+  "generated_at": "2026-05-12T22:04:45.624552+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-12T22:04:45.624552+00:00",
+  "generated_at": "2026-05-12T22:09:00.114982+00:00",
   "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},

--- a/src/autoskillit/recipes/contracts/research.json
+++ b/src/autoskillit/recipes/contracts/research.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-12T04:21:53.095024+00:00",
-  "recipe_source_hash": "sha256:cfaa7e407aba93238c259e5079bfde5f3d04ad9bb96f5b757d01454699e968ee",
+  "generated_at": "2026-05-12T21:54:49.777294+00:00",
+  "recipe_source_hash": "sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:09:00.114982+00:00'
+generated_at: '2026-05-12T22:18:40.076058+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T22:04:45.624552+00:00'
+generated_at: '2026-05-12T22:09:00.114982+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-05-12T04:21:53.095024+00:00'
-recipe_source_hash: sha256:cfaa7e407aba93238c259e5079bfde5f3d04ad9bb96f5b757d01454699e968ee
+generated_at: '2026-05-12T21:54:49.777294+00:00'
+recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-05-12T21:54:49.777294+00:00'
+generated_at: '2026-05-12T22:04:45.624552+00:00'
 recipe_source_hash: sha256:c2619036cbe9baff01ec0ca58da9dfe94995afc276b1e18c028403015ebfe792
 bundled_manifest_version: 0.1.0
 skill_hashes: {}

--- a/tests/cli/test_food_truck_prompt.py
+++ b/tests/cli/test_food_truck_prompt.py
@@ -9,7 +9,7 @@ import re
 
 import pytest
 
-from autoskillit.core.types import CaptureEntrySpec
+from autoskillit.core.types import CaptureEntrySpec, resolve_payload_field
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -258,7 +258,8 @@ class TestSentinelFormat:
         )
         section8 = prompt[prompt.index("--- SECTION 8") :]
         for entry in capture_arg.values():
-            field = entry.from_.split("result.")[1].strip().rstrip("}")
+            field = resolve_payload_field(entry)
+            assert field is not None
             assert f'"{field}"' in section8
             assert entry.from_ in section8
         assert '"success"' in section8

--- a/tests/cli/test_food_truck_prompt.py
+++ b/tests/cli/test_food_truck_prompt.py
@@ -236,10 +236,13 @@ class TestSentinelFormat:
         [
             {
                 "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
+            },
+            {
+                "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
                 "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
             },
         ],
-        ids=["2-key"],
+        ids=["1-key", "2-key"],
     )
     def test_sentinel_capture_fields_injected(
         self, capture_arg: dict[str, CaptureEntrySpec]

--- a/tests/cli/test_food_truck_prompt.py
+++ b/tests/cli/test_food_truck_prompt.py
@@ -9,6 +9,8 @@ import re
 
 import pytest
 
+from autoskillit.core.types import CaptureEntrySpec
+
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small, pytest.mark.feature("fleet")]
 
 # --- Fixtures ---
@@ -232,12 +234,16 @@ class TestSentinelFormat:
     @pytest.mark.parametrize(
         "capture_arg",
         [
-            {"worktree_path": "${{ result.worktree_path }}"},
-            {"worktree_path": "${{ result.worktree_path }}", "pr_url": "${{ result.pr_url }}"},
+            {
+                "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
+                "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
+            },
         ],
-        ids=["1-key", "2-key"],
+        ids=["2-key"],
     )
-    def test_sentinel_capture_fields_injected(self, capture_arg: dict[str, str]) -> None:
+    def test_sentinel_capture_fields_injected(
+        self, capture_arg: dict[str, CaptureEntrySpec]
+    ) -> None:
         from autoskillit.fleet._prompts import _build_food_truck_prompt
 
         prompt = _build_food_truck_prompt(
@@ -251,15 +257,16 @@ class TestSentinelFormat:
             capture=capture_arg,
         )
         section8 = prompt[prompt.index("--- SECTION 8") :]
-        for key, description in capture_arg.items():
-            assert f"capture_{key}" in section8
-            assert description in section8
+        for entry in capture_arg.values():
+            field = entry.from_.split("result.")[1].strip().rstrip("}")
+            assert f'"{field}"' in section8
+            assert entry.from_ in section8
         assert '"success"' in section8
         assert '"reason"' in section8
 
     @pytest.mark.parametrize("capture_arg", [None, {}], ids=["none", "empty"])
     def test_sentinel_section8_unchanged_when_capture_none(
-        self, capture_arg: dict[str, str] | None
+        self, capture_arg: dict[str, CaptureEntrySpec] | None
     ) -> None:
         from autoskillit.fleet._prompts import _build_food_truck_prompt
 

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -8,6 +8,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 |------|---------|
 | `__init__.py` | empty |
 | `test_add_dir_validation.py` | Tests for ValidatedAddDir and validate_add_dir |
+| `test_capture.py` | Tests for CaptureEntrySpec and resolve_payload_field |
 | `test_branch_guard.py` | Tests for core.branch_guard — protected-branch validation |
 | `test_claude_env.py` | Unit tests for build_claude_env() — IDE env scrubbing at the subprocess launch boundary |
 | `test_core.py` | Tests for the core/ sub-package foundation layer |

--- a/tests/core/test_capture.py
+++ b/tests/core/test_capture.py
@@ -1,0 +1,42 @@
+"""Tests for capture type contracts and resolve_payload_field."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types import CaptureEntrySpec, resolve_payload_field
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+class TestResolvePayloadField:
+    def test_basic_field_extraction(self) -> None:
+        entry = CaptureEntrySpec(from_="${{ result.worktree_path }}")
+        assert resolve_payload_field(entry) == "worktree_path"
+
+    def test_pr_url_field_extraction(self) -> None:
+        entry = CaptureEntrySpec(from_="${{ result.pr_url }}")
+        assert resolve_payload_field(entry) == "pr_url"
+
+    def test_hyphenated_field_name(self) -> None:
+        entry = CaptureEntrySpec(from_="${{ result.worktree-path }}")
+        assert resolve_payload_field(entry) == "worktree-path"
+
+    def test_non_result_template_returns_none(self) -> None:
+        entry = CaptureEntrySpec(from_="not a template")
+        assert resolve_payload_field(entry) is None
+
+    def test_whitespace_variations(self) -> None:
+        entry = CaptureEntrySpec(from_="${{result.worktree_path}}")
+        assert resolve_payload_field(entry) == "worktree_path"
+
+        entry = CaptureEntrySpec(from_="${{  result.worktree_path  }}")
+        assert resolve_payload_field(entry) == "worktree_path"
+
+    def test_bare_field_name_in_template(self) -> None:
+        entry = CaptureEntrySpec(from_="${{ result.field_name }}")
+        assert resolve_payload_field(entry) == "field_name"
+
+    def test_with_value_type(self) -> None:
+        entry = CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="path")
+        assert resolve_payload_field(entry) == "worktree_path"

--- a/tests/core/test_capture.py
+++ b/tests/core/test_capture.py
@@ -10,13 +10,17 @@ pytestmark = [pytest.mark.layer("core"), pytest.mark.small, pytest.mark.feature(
 
 
 class TestResolvePayloadField:
-    def test_basic_field_extraction(self) -> None:
-        entry = CaptureEntrySpec(from_="${{ result.worktree_path }}")
-        assert resolve_payload_field(entry) == "worktree_path"
-
-    def test_pr_url_field_extraction(self) -> None:
-        entry = CaptureEntrySpec(from_="${{ result.pr_url }}")
-        assert resolve_payload_field(entry) == "pr_url"
+    @pytest.mark.parametrize(
+        ("template", "expected"),
+        [
+            ("${{ result.worktree_path }}", "worktree_path"),
+            ("${{ result.pr_url }}", "pr_url"),
+            ("${{ result.field_name }}", "field_name"),
+        ],
+    )
+    def test_basic_field_extraction(self, template: str, expected: str) -> None:
+        entry = CaptureEntrySpec(from_=template)
+        assert resolve_payload_field(entry) == expected
 
     def test_hyphenated_field_name(self) -> None:
         entry = CaptureEntrySpec(from_="${{ result.worktree-path }}")
@@ -26,16 +30,16 @@ class TestResolvePayloadField:
         entry = CaptureEntrySpec(from_="not a template")
         assert resolve_payload_field(entry) is None
 
-    def test_whitespace_variations(self) -> None:
-        entry = CaptureEntrySpec(from_="${{result.worktree_path}}")
+    @pytest.mark.parametrize(
+        "template",
+        [
+            "${{result.worktree_path}}",
+            "${{  result.worktree_path  }}",
+        ],
+    )
+    def test_whitespace_variations(self, template: str) -> None:
+        entry = CaptureEntrySpec(from_=template)
         assert resolve_payload_field(entry) == "worktree_path"
-
-        entry = CaptureEntrySpec(from_="${{  result.worktree_path  }}")
-        assert resolve_payload_field(entry) == "worktree_path"
-
-    def test_bare_field_name_in_template(self) -> None:
-        entry = CaptureEntrySpec(from_="${{ result.field_name }}")
-        assert resolve_payload_field(entry) == "field_name"
 
     def test_with_value_type(self) -> None:
         entry = CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="path")

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -614,6 +614,101 @@ def test_extract_captures_raises_on_complete_capture_miss():
 
 
 # ---------------------------------------------------------------------------
+# Round-trip contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureFieldNameRoundTrip:
+    """Verify the prompt builder and extractor agree on payload field names."""
+
+    def test_prompt_example_fields_match_extractor_keys(self) -> None:
+        """Prompt builder produces bare field names; extractor looks for bare names."""
+        from autoskillit.core.types import CaptureEntrySpec
+        from autoskillit.fleet._prompts import _build_food_truck_prompt
+
+        capture_spec = {
+            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
+            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
+        }
+
+        prompt = _build_food_truck_prompt(
+            recipe="test-recipe",
+            task="implement feature X",
+            ingredients={"branch": "main"},
+            mcp_prefix="mcp__autoskillit__",
+            dispatch_id="abc12345deadbeef",
+            campaign_id="camp-001",
+            l3_timeout_sec=3600,
+            capture=capture_spec,
+        )
+
+        section8 = prompt[prompt.index("--- SECTION 8") :]
+
+        for key, entry in capture_spec.items():
+            field = entry.from_.split("result.")[1].strip().rstrip("}")
+            assert f'"{field}"' in section8, f"Bare field name {field!r} not in Section 8"
+            assert f"capture_{field}" not in section8, (
+                f"Prefix form capture_{field!r} found in Section 8 — extractor uses bare names"
+            )
+
+    def test_synthetic_payload_round_trip(self) -> None:
+        """Build synthetic L3 JSON using prompt field names; verify extractor finds all."""
+        from autoskillit.core.types import CaptureEntrySpec
+        from autoskillit.fleet._api import _extract_captures
+
+        capture_spec = {
+            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
+            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
+        }
+
+        synthetic_payload = {
+            "success": True,
+            "reason": "completed",
+            "summary": "done",
+            "worktree_path": "/home/user/worktrees/impl-feature-20260512",
+            "pr_url": "https://github.com/org/repo/pull/42",
+        }
+
+        result = _extract_captures(capture_spec, synthetic_payload)
+        assert result["worktree_path"] == "/home/user/worktrees/impl-feature-20260512"
+        assert result["pr_url"] == "https://github.com/org/repo/pull/42"
+
+    def test_hyphenated_field_name_round_trip(self) -> None:
+        """Field names with hyphens are handled correctly end-to-end."""
+        from autoskillit.core.types import CaptureEntrySpec
+        from autoskillit.fleet._api import _extract_captures
+        from autoskillit.fleet._prompts import _build_food_truck_prompt
+
+        capture_spec = {
+            "worktree-path": CaptureEntrySpec(from_="${{ result.worktree-path }}"),
+        }
+
+        prompt = _build_food_truck_prompt(
+            recipe="test-recipe",
+            task="implement feature X",
+            ingredients={"branch": "main"},
+            mcp_prefix="mcp__autoskillit__",
+            dispatch_id="abc12345deadbeef",
+            campaign_id="camp-001",
+            l3_timeout_sec=3600,
+            capture=capture_spec,
+        )
+
+        section8 = prompt[prompt.index("--- SECTION 8") :]
+        assert '"worktree-path"' in section8
+
+        synthetic_payload = {
+            "success": True,
+            "reason": "completed",
+            "summary": "done",
+            "worktree-path": "/home/user/worktree-path",
+        }
+
+        result = _extract_captures(capture_spec, synthetic_payload)
+        assert result["worktree-path"] == "/home/user/worktree-path"
+
+
+# ---------------------------------------------------------------------------
 # Typed capture contract tests (Step 1a–1d, 1g)
 # ---------------------------------------------------------------------------
 

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.types import CaptureEntrySpec
+from autoskillit.core.types import CaptureEntrySpec, resolve_payload_field
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -645,7 +645,8 @@ class TestCaptureFieldNameRoundTrip:
         section8 = prompt[prompt.index("--- SECTION 8") :]
 
         for key, entry in capture_spec.items():
-            field = entry.from_.split("result.")[1].strip().rstrip("}")
+            field = resolve_payload_field(entry)
+            assert field is not None
             assert f'"{field}"' in section8, f"Bare field name {field!r} not in Section 8"
             assert f"capture_{field}" not in section8, (
                 f"Prefix form capture_{field!r} found in Section 8 — extractor uses bare names"

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -649,7 +649,7 @@ class TestCaptureFieldNameRoundTrip:
             assert field is not None
             assert f'"{field}"' in section8, f"Bare field name {field!r} not in Section 8"
             assert f"capture_{field}" not in section8, (
-                f"Prefix form capture_{field!r} found in Section 8 — extractor uses bare names"
+                f"Prefix form capture_{field} found in Section 8 — extractor uses bare names"
             )
 
     def test_synthetic_payload_round_trip(self) -> None:


### PR DESCRIPTION
## Summary

The prompt builder (`_build_food_truck_prompt`) and the capture extractor (`_extract_captures`) disagreed on field naming for capture fields in the L3 sentinel JSON payload. The prompt builder was adding a `capture_` prefix to field names in the JSON example shown to L3 sessions, but the extractor was deriving bare field names from `CaptureEntrySpec.from_` templates. The L3 session followed the prompt's format instruction and emitted prefixed keys; the extractor looked for bare keys; the lookup always missed.

The fix introduces a **canonical field name resolver** (`resolve_payload_field`) shared by both the prompt builder and the extractor at IL-0 core, plus a **round-trip contract test** that verifies the prompt's JSON example produces payloads parseable by `_extract_captures`.

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_capture_field_name_contract_2026-05-12_144500.md`

## Changed Files

### New:
- `tests/core/test_capture.py`

### Modified:
- `src/autoskillit/core/__init__.pyi`
- `src/autoskillit/core/types/_type_capture.py`
- `src/autoskillit/fleet/_api.py`
- `src/autoskillit/fleet/_prompts.py`
- `src/autoskillit/recipes/contracts/` (14 contract YAML/JSON files — full-audit, bem-wrapper, implementation, implementation-groups, implement-findings, merge-prs, planner, promote-to-main, promote-to-main-wrapper, remediation, research, research-archive, research-campaign, research-design, research-implement, research-review)
- `tests/cli/test_food_truck_prompt.py`
- `tests/core/CLAUDE.md`
- `tests/fleet/test_campaign_capture.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-opus-4-6 | 1 | 1.5k | 9.0k | 546.8k | 67.2k | 59 | 59.2k | 5m 3s |
| dry_walkthrough | claude-opus-4-6 | 1 | 65 | 14.3k | 2.0M | 77.5k | 141 | 64.1k | 8m 12s |
| implement* | MiniMax-M2.7 | 1 | 81.7k | 12.9k | 2.4M | 22.5k | 101 | 0 | 3m 31s |
| prepare_pr* | MiniMax-M2.7 | 1 | 90.9k | 4.3k | 230.4k | 29.2k | 22 | 15.4k | 1m 46s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.4k | 1.4k | 262.1k | 0 | 16 | 0 | 27s |
| review_pr | claude-opus-4-6 | 3 | 188 | 64.6k | 1.2M | 78.4k | 101 | 190.6k | 18m 44s |
| resolve_review | claude-opus-4-6 | 2 | 116 | 20.4k | 3.9M | 82.4k | 129 | 120.8k | 14m 26s |
| **Total** | | | 213.9k | 127.0k | 10.5M | 82.4k | | 450.2k | 52m 12s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 341 | 6957.8 | 0.0 | 37.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 128 | 9188.9 | 1488.8 | 504.4 |
| resolve_review | 178 | 21744.3 | 678.8 | 114.8 |
| **Total** | **647** | 16216.1 | 695.8 | 196.3 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 1.6k | 29.0k | 3.8M | 172.9k | 22m 16s |
| MiniMax-M2.7 | 3 | 212.0k | 18.7k | 2.9M | 15.4k | 5m 46s |