### PR TITLE
[FIX] Cross-Session JSONL Recovery for Resume Dispatches

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -802,11 +802,12 @@ async def _run_dispatch(
 
     jsonl_path = claude_code_log_path(str(tool_ctx.project_dir), skill_result.session_id or "")
 
+    extended_chain = prior_session_chain[:]
+    if prior_dispatched_session_id and prior_dispatched_session_id not in extended_chain:
+        extended_chain.append(prior_dispatched_session_id)
+
     additional_jsonl_paths: list[Path] = []
-    session_ids_for_jsonl = prior_session_chain[:]
-    if prior_dispatched_session_id and prior_dispatched_session_id not in session_ids_for_jsonl:
-        session_ids_for_jsonl.append(prior_dispatched_session_id)
-    for sid in session_ids_for_jsonl:
+    for sid in extended_chain:
         path = claude_code_log_path(str(tool_ctx.project_dir), sid)
         if path is not None:
             additional_jsonl_paths.append(path)
@@ -836,16 +837,10 @@ async def _run_dispatch(
         checkpoint=dispatch_checkpoint,
     )
 
-    accumulated_session_chain = prior_session_chain[:]
-    if (
-        prior_dispatched_session_id
-        and prior_dispatched_session_id not in accumulated_session_chain
-    ):
-        accumulated_session_chain.append(prior_dispatched_session_id)
-
     try:
         project_log_dir = str(claude_code_project_dir(str(tool_ctx.project_dir)))
     except OSError:
+        logger.warning("failed to resolve project log dir", exc_info=True)
         project_log_dir = ""
 
     record = DispatchRecord(
@@ -855,7 +850,7 @@ async def _run_dispatch(
         campaign_id=campaign_id,
         caller_session_id=caller_session_id,
         dispatched_session_id=skill_result.session_id,
-        session_chain=accumulated_session_chain,
+        session_chain=extended_chain,
         dispatched_session_log_dir=project_log_dir,
         dispatched_pid=_dispatched_pid[0] if _dispatched_pid else 0,
         reason=reason,

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -547,7 +547,7 @@ async def _run_dispatch(
                         prior_session_chain = list(d.session_chain)
                         prior_dispatched_session_id = d.dispatched_session_id
                         break
-        except Exception:
+        except (OSError, ValueError, KeyError, TypeError):
             logger.warning("failed to read prior session chain from state", exc_info=True)
     else:
         recipe_snapshot = {

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -535,8 +535,20 @@ async def _run_dispatch(
     dispatches_dir.mkdir(parents=True, exist_ok=True)
     campaign_id = tool_ctx.kitchen_id
 
+    prior_session_chain: list[str] = []
+    prior_dispatched_session_id = ""
     if resume_session_id and prior_dispatch_id:
         handle = DispatchStateHandle.open_continued(dispatches_dir, prior_dispatch_id)
+        try:
+            prior_state = read_state(handle.state_path)
+            if prior_state:
+                for d in prior_state.dispatches:
+                    if d.name == effective_name:
+                        prior_session_chain = list(d.session_chain)
+                        prior_dispatched_session_id = d.dispatched_session_id
+                        break
+        except Exception:
+            logger.warning("failed to read prior session chain from state", exc_info=True)
     else:
         recipe_snapshot = {
             "recipe_name": recipe_obj.name,
@@ -790,11 +802,21 @@ async def _run_dispatch(
 
     jsonl_path = claude_code_log_path(str(tool_ctx.project_dir), skill_result.session_id or "")
 
+    additional_jsonl_paths: list[Path] = []
+    session_ids_for_jsonl = prior_session_chain[:]
+    if prior_dispatched_session_id and prior_dispatched_session_id not in session_ids_for_jsonl:
+        session_ids_for_jsonl.append(prior_dispatched_session_id)
+    for sid in session_ids_for_jsonl:
+        path = claude_code_log_path(str(tool_ctx.project_dir), sid)
+        if path is not None:
+            additional_jsonl_paths.append(path)
+
     parsed = parse_l3_result_block(
         stdout=skill_result.result or "",
         expected_dispatch_id=dispatch_id,
         assistant_messages_path=jsonl_path,
         prior_dispatch_ids=prior_ids or None,
+        additional_jsonl_paths=additional_jsonl_paths or None,
     )
 
     sidecar_file = Path(dispatch_sidecar_path)
@@ -814,6 +836,18 @@ async def _run_dispatch(
         checkpoint=dispatch_checkpoint,
     )
 
+    accumulated_session_chain = prior_session_chain[:]
+    if (
+        prior_dispatched_session_id
+        and prior_dispatched_session_id not in accumulated_session_chain
+    ):
+        accumulated_session_chain.append(prior_dispatched_session_id)
+
+    try:
+        project_log_dir = str(claude_code_project_dir(str(tool_ctx.project_dir)))
+    except OSError:
+        project_log_dir = ""
+
     record = DispatchRecord(
         name=effective_name,
         status=final_status,
@@ -821,6 +855,8 @@ async def _run_dispatch(
         campaign_id=campaign_id,
         caller_session_id=caller_session_id,
         dispatched_session_id=skill_result.session_id,
+        session_chain=accumulated_session_chain,
+        dispatched_session_log_dir=project_log_dir,
         dispatched_pid=_dispatched_pid[0] if _dispatched_pid else 0,
         reason=reason,
         kill_reason=skill_result.retry_reason or "",

--- a/src/autoskillit/fleet/result_parser.py
+++ b/src/autoskillit/fleet/result_parser.py
@@ -209,6 +209,7 @@ def parse_l3_result_block(
             positions = _scan_for_sentinel(additional_text, open_sentinel, close_sentinel)
             if positions is not None:
                 open_pos, close_pos = positions
+                logger.debug("cross-session recovery matched %s", jsonl_path)
                 return _parse_body(
                     additional_text,
                     open_pos,

--- a/src/autoskillit/fleet/result_parser.py
+++ b/src/autoskillit/fleet/result_parser.py
@@ -25,7 +25,7 @@ class L3ParseResult:
     payload: dict | None
     raw_body: str | None
     parse_error: str | None
-    source: Literal["stdout", "assistant_messages_jsonl"]
+    source: Literal["stdout", "assistant_messages_jsonl", "additional_jsonl"]
 
 
 def _extract_text_from_jsonl(path: Path) -> str:
@@ -96,7 +96,7 @@ def _parse_body(
     open_pos: int,
     close_pos: int,
     open_sentinel: str,
-    source: Literal["stdout", "assistant_messages_jsonl"],
+    source: Literal["stdout", "assistant_messages_jsonl", "additional_jsonl"],
 ) -> L3ParseResult:
     """Extract body between sentinels and attempt JSON decode."""
     after_open = open_pos + len(open_sentinel)
@@ -214,7 +214,7 @@ def parse_l3_result_block(
                     open_pos,
                     close_pos,
                     open_sentinel,
-                    "assistant_messages_jsonl",
+                    "additional_jsonl",
                 )
 
     return L3ParseResult(

--- a/src/autoskillit/fleet/result_parser.py
+++ b/src/autoskillit/fleet/result_parser.py
@@ -145,6 +145,7 @@ def parse_l3_result_block(
     expected_dispatch_id: str,
     assistant_messages_path: Path | None = None,
     prior_dispatch_ids: Sequence[str] | None = None,
+    additional_jsonl_paths: Sequence[Path] | None = None,
 ) -> L3ParseResult:
     """Parse an L3 result block from food truck dispatch output.
 
@@ -154,6 +155,9 @@ def parse_l3_result_block(
     When prior_dispatch_ids is provided, additional fallback scans are performed
     for each prior ID after the primary and JSONL scans fail — this handles
     the resume case where the LLM may emit a sentinel keyed to an earlier ID.
+    When additional_jsonl_paths is provided, those files are scanned after all
+    other stages fail — this handles the resume case where the sentinel lives
+    in a prior session's JSONL file rather than the current session's file.
     """
     open_sentinel = f"---l3-result::{expected_dispatch_id}---"
     close_sentinel = f"---end-l3-result::{expected_dispatch_id}---"
@@ -195,6 +199,23 @@ def parse_l3_result_block(
                         prior_open,
                         "assistant_messages_jsonl",
                     )
+
+    # Stage 4: scan additional JSONL paths (cross-session recovery for resume)
+    if additional_jsonl_paths:
+        for jsonl_path in additional_jsonl_paths:
+            additional_text = _extract_text_from_jsonl(jsonl_path)
+            if not additional_text:
+                continue
+            positions = _scan_for_sentinel(additional_text, open_sentinel, close_sentinel)
+            if positions is not None:
+                open_pos, close_pos = positions
+                return _parse_body(
+                    additional_text,
+                    open_pos,
+                    close_pos,
+                    open_sentinel,
+                    "assistant_messages_jsonl",
+                )
 
     return L3ParseResult(
         outcome="no_sentinel",

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -477,6 +477,24 @@ def upsert_dispatch_record_by_name(state_path: Path, record: DispatchRecord) -> 
                         f"with {record.status!r} — "
                         f"use mark_dispatch_* state machine methods for valid transitions"
                     )
+                # FAILURE-to-FAILURE: snapshot prior failure diagnostics before overwrite
+                if (
+                    d.status == DispatchStatus.FAILURE
+                    and record.status == DispatchStatus.FAILURE
+                    and d.reason
+                ):
+                    snapshot: dict[str, Any] = {}
+                    for f in dataclasses.fields(d):
+                        if f.name in _RETRY_IDENTITY_FIELDS:
+                            continue
+                        val = getattr(d, f.name)
+                        if f.name == "status":
+                            snapshot[f.name] = str(val)
+                        elif isinstance(val, dict):
+                            snapshot[f.name] = dict(val)
+                        else:
+                            snapshot[f.name] = val
+                    record.attempt_history = [snapshot] + list(record.attempt_history)
                 m.state.dispatches[i] = record
                 m.mark_dirty()
                 return

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -492,6 +492,8 @@ def upsert_dispatch_record_by_name(state_path: Path, record: DispatchRecord) -> 
                             snapshot[f.name] = str(val)
                         elif isinstance(val, dict):
                             snapshot[f.name] = dict(val)
+                        elif isinstance(val, list):
+                            snapshot[f.name] = list(val)
                         else:
                             snapshot[f.name] = val
                     record.attempt_history = [snapshot] + list(record.attempt_history)

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -22,6 +22,7 @@ _RETRY_IDENTITY_FIELDS: frozenset[str] = frozenset(
         "campaign_id",
         "caller_session_id",
         "attempt_history",
+        "session_chain",
     }
 )
 
@@ -53,6 +54,7 @@ class DispatchRecord:
     campaign_id: str = ""
     caller_session_id: str = ""
     dispatched_session_id: str = ""
+    session_chain: list[str] = field(default_factory=list)
     dispatched_session_log_dir: str = ""
     dispatched_pid: int = 0
     dispatched_starttime_ticks: int = 0
@@ -75,6 +77,7 @@ class DispatchRecord:
             "campaign_id": self.campaign_id,
             "caller_session_id": self.caller_session_id,
             "dispatched_session_id": self.dispatched_session_id,
+            "session_chain": list(self.session_chain),
             "dispatched_session_log_dir": self.dispatched_session_log_dir,
             "dispatched_pid": self.dispatched_pid,
             "dispatched_starttime_ticks": self.dispatched_starttime_ticks,
@@ -105,6 +108,7 @@ class DispatchRecord:
                 or d.get("l3_session_id")
                 or d.get("l2_session_id", "")
             ),
+            session_chain=d.get("session_chain", []),
             dispatched_session_log_dir=(
                 d.get("dispatched_session_log_dir")
                 or d.get("l3_session_log_dir")

--- a/tests/fleet/test_dispatch_state_handle.py
+++ b/tests/fleet/test_dispatch_state_handle.py
@@ -258,3 +258,168 @@ class TestCaptureChainAcrossResumeBoundary:
 
             assert isinstance(result, DispatchCompleted), f"Unexpected result type: {type(result)}"
             assert result.dispatch_id == prior_id
+
+
+class TestSessionChainAccumulatesAcrossResume:
+    @pytest.mark.anyio
+    async def test_session_chain_accumulates_across_resume(self, tool_ctx, monkeypatch):
+        """session_chain accumulates prior dispatched_session_id on resume."""
+        from autoskillit.core import RetryReason, SkillResult
+        from autoskillit.fleet._api import _run_dispatch
+        from autoskillit.fleet.state import read_state
+        from tests.fleet._helpers import (
+            _no_sleep_quota_checker,
+            _noop_quota_refresher,
+            _setup_dispatch,
+        )
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+
+        dispatches_dir = tool_ctx.temp_dir / "dispatches"
+        campaign_id = tool_ctx.kitchen_id
+
+        prior_id = "prior-dispatch-abc123"
+        prior_state_path = dispatches_dir / f"{prior_id}.json"
+        write_initial_state(
+            prior_state_path,
+            campaign_id,
+            "camp",
+            "",
+            [DispatchRecord(name="test-recipe", dispatched_session_id="sess-original")],
+        )
+
+        tool_ctx.executor.push(
+            SkillResult(
+                success=True,
+                result="ok",
+                session_id="sess-resume-1",
+                subtype="success",
+                is_error=False,
+                exit_code=0,
+                needs_retry=False,
+                retry_reason=RetryReason.NONE,
+                stderr="",
+                token_usage=None,
+            )
+        )
+
+        from autoskillit.fleet.result_parser import L3ParseResult
+
+        def _fake_parse(*args, **kwargs):
+            return L3ParseResult(
+                outcome="completed_clean",
+                payload={"success": True},
+                raw_body=None,
+                parse_error=None,
+                source="stdout",
+            )
+
+        def _fake_classify(*args, **kwargs):
+            return (DispatchStatus.SUCCESS, None)
+
+        monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _fake_parse)
+        monkeypatch.setattr("autoskillit.fleet.classify_dispatch_outcome", _fake_classify)
+
+        result = await _run_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="do something",
+            ingredients=None,
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=lambda **_: "prompt",
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+            resume_session_id="sess-resume-1",
+            prior_dispatch_id=prior_id,
+        )
+
+        from autoskillit.fleet.state_types import DispatchRejected
+
+        if isinstance(result, DispatchRejected):
+            return
+
+        state = read_state(prior_state_path)
+        assert state is not None
+        disp = next(d for d in state.dispatches if d.dispatch_id == prior_id)
+        assert "sess-original" in disp.session_chain
+        assert disp.dispatched_session_id == "sess-resume-1"
+
+
+class TestDispatchedSessionLogDirPopulated:
+    @pytest.mark.anyio
+    async def test_dispatched_session_log_dir_populated(self, tool_ctx, monkeypatch):
+        """dispatched_session_log_dir is populated after _run_dispatch completes."""
+        from autoskillit.fleet import FleetSemaphore
+        from autoskillit.fleet._api import _run_dispatch
+        from autoskillit.fleet.state import read_state
+        from autoskillit.recipe.schema import Recipe, RecipeKind
+        from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+        from tests.fleet._helpers import (
+            _make_recipe_info,
+            _no_sleep_quota_checker,
+            _noop_quota_refresher,
+        )
+
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        recipe_name = "test-recipe-logdir"
+        repo = InMemoryRecipeRepository()
+        recipe_info = _make_recipe_info(recipe_name)
+        repo.add_recipe(recipe_name, recipe_info)
+        repo.add_full_recipe(
+            recipe_info.path,
+            Recipe(
+                name=recipe_name,
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={},
+                requires_packs=[],
+            ),
+        )
+        tool_ctx.recipes = repo
+        tool_ctx.executor = InMemoryHeadlessExecutor()
+
+        dispatches_dir = tool_ctx.temp_dir / "dispatches"
+        dispatches_dir.mkdir(parents=True, exist_ok=True)
+
+        from autoskillit.fleet.result_parser import L3ParseResult
+
+        def _fake_parse(*args, **kwargs):
+            return L3ParseResult(
+                outcome="completed_clean",
+                payload={"success": True},
+                raw_body=None,
+                parse_error=None,
+                source="stdout",
+            )
+
+        def _fake_classify(*args, **kwargs):
+            return (DispatchStatus.SUCCESS, None)
+
+        monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _fake_parse)
+        monkeypatch.setattr("autoskillit.fleet.classify_dispatch_outcome", _fake_classify)
+
+        result = await _run_dispatch(
+            tool_ctx=tool_ctx,
+            recipe=recipe_name,
+            task="do something",
+            ingredients=None,
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=lambda **_: "prompt",
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+
+        from autoskillit.fleet.state_types import DispatchRejected
+
+        if isinstance(result, DispatchRejected):
+            return
+
+        state_files = list(dispatches_dir.glob("*.json"))
+        assert len(state_files) == 1
+        state = read_state(state_files[0])
+        assert state is not None
+        assert len(state.dispatches) == 1
+        disp = state.dispatches[0]
+        assert disp.dispatched_session_log_dir != ""

--- a/tests/fleet/test_dispatch_state_handle.py
+++ b/tests/fleet/test_dispatch_state_handle.py
@@ -336,8 +336,7 @@ class TestSessionChainAccumulatesAcrossResume:
 
         from autoskillit.fleet.state_types import DispatchRejected
 
-        if isinstance(result, DispatchRejected):
-            return
+        assert not isinstance(result, DispatchRejected), f"Unexpected rejection: {result}"
 
         state = read_state(prior_state_path)
         assert state is not None
@@ -413,8 +412,7 @@ class TestDispatchedSessionLogDirPopulated:
 
         from autoskillit.fleet.state_types import DispatchRejected
 
-        if isinstance(result, DispatchRejected):
-            return
+        assert not isinstance(result, DispatchRejected), f"Unexpected rejection: {result}"
 
         state_files = list(dispatches_dir.glob("*.json"))
         assert len(state_files) == 1

--- a/tests/fleet/test_result_parser.py
+++ b/tests/fleet/test_result_parser.py
@@ -432,11 +432,11 @@ def test_parse_recovers_sentinel_from_additional_jsonl_paths(tmp_path: Path) -> 
     )
     assert result.outcome == "completed_clean"
     assert result.payload["summary"] == "from_original_session"
-    assert result.source == "assistant_messages_jsonl"
+    assert result.source == "additional_jsonl"
 
 
 def test_parse_additional_jsonl_paths_scanned_oldest_first(tmp_path: Path) -> None:
-    """Additional paths are scanned in order; _scan_for_sentinel returns the last sentinel in each file."""
+    """Additional paths are scanned in order; _scan_for_sentinel returns last sentinel."""
     older = make_jsonl_file(
         tmp_path,
         [

--- a/tests/fleet/test_result_parser.py
+++ b/tests/fleet/test_result_parser.py
@@ -30,9 +30,9 @@ def make_stdout(payload_json: str, dispatch_id: str = DISPATCH_ID) -> str:
     )
 
 
-def make_jsonl_file(tmp_path, messages: list[str]) -> Path:
+def make_jsonl_file(tmp_path, messages: list[str], filename: str = "session.jsonl") -> Path:
     """Write a JSONL file with type=assistant records containing given text."""
-    path: Path = tmp_path / "session.jsonl"
+    path: Path = tmp_path / filename
     lines = []
     for text in messages:
         record = {
@@ -411,3 +411,110 @@ def test_parse_prior_dispatch_ids_jsonl_fallback(tmp_path: Path) -> None:
     )
     assert result.outcome == "completed_clean"
     assert result.payload["summary"] == "from_jsonl"
+
+
+def test_parse_recovers_sentinel_from_additional_jsonl_paths(tmp_path: Path) -> None:
+    """Sentinel in additional_jsonl_paths (prior session) is recovered on primary miss."""
+    original_session_jsonl = make_jsonl_file(
+        tmp_path,
+        [
+            f"---l3-result::{DISPATCH_ID}---\n"
+            f'{{"success": true, "summary": "from_original_session"}}\n'
+            f"---end-l3-result::{DISPATCH_ID}---"
+        ],
+        "original_session.jsonl",
+    )
+    result = parse_l3_result_block(
+        stdout="no sentinel here",
+        expected_dispatch_id=DISPATCH_ID,
+        assistant_messages_path=tmp_path / "empty_session.jsonl",
+        additional_jsonl_paths=[original_session_jsonl],
+    )
+    assert result.outcome == "completed_clean"
+    assert result.payload["summary"] == "from_original_session"
+    assert result.source == "assistant_messages_jsonl"
+
+
+def test_parse_additional_jsonl_paths_scanned_oldest_first(tmp_path: Path) -> None:
+    """Additional paths are scanned in order; _scan_for_sentinel returns the last sentinel in each file."""
+    older = make_jsonl_file(
+        tmp_path,
+        [
+            f"---l3-result::{DISPATCH_ID}---\n"
+            f'{{"summary": "older"}}\n'
+            f"---end-l3-result::{DISPATCH_ID}---"
+        ],
+        "older.jsonl",
+    )
+    newer = make_jsonl_file(
+        tmp_path,
+        [
+            f"---l3-result::{DISPATCH_ID}---\n"
+            f'{{"summary": "newer"}}\n'
+            f"---end-l3-result::{DISPATCH_ID}---"
+        ],
+        "newer.jsonl",
+    )
+    result = parse_l3_result_block(
+        stdout="",
+        expected_dispatch_id=DISPATCH_ID,
+        additional_jsonl_paths=[older, newer],
+    )
+    # _scan_for_sentinel uses rfind, returning the LAST sentinel in each file.
+    # Files are scanned in order; first match wins (iteration order).
+    # older.jsonl is scanned first and returns "older".
+    assert result.outcome == "completed_clean"
+    assert result.payload["summary"] == "older"
+
+
+def test_parse_primary_jsonl_wins_over_additional(tmp_path: Path) -> None:
+    """When primary JSONL has the sentinel, additional paths are not consulted."""
+    primary_jsonl = make_jsonl_file(
+        tmp_path,
+        [
+            f"---l3-result::{DISPATCH_ID}---\n"
+            f'{{"summary": "primary"}}\n'
+            f"---end-l3-result::{DISPATCH_ID}---"
+        ],
+        "primary.jsonl",
+    )
+    additional_jsonl = make_jsonl_file(
+        tmp_path,
+        [
+            f"---l3-result::{DISPATCH_ID}---\n"
+            f'{{"summary": "additional"}}\n'
+            f"---end-l3-result::{DISPATCH_ID}---"
+        ],
+        "additional.jsonl",
+    )
+    result = parse_l3_result_block(
+        stdout="",
+        expected_dispatch_id=DISPATCH_ID,
+        assistant_messages_path=primary_jsonl,
+        additional_jsonl_paths=[additional_jsonl],
+    )
+    assert result.outcome == "completed_clean"
+    assert result.payload["summary"] == "primary"
+
+
+def test_parse_additional_jsonl_paths_nonexistent_skipped(tmp_path: Path) -> None:
+    """Non-existent additional paths are skipped without error."""
+    existing_jsonl = make_jsonl_file(
+        tmp_path,
+        [
+            f"---l3-result::{DISPATCH_ID}---\n"
+            f'{{"summary": "existing"}}\n'
+            f"---end-l3-result::{DISPATCH_ID}---"
+        ],
+        "existing.jsonl",
+    )
+    result = parse_l3_result_block(
+        stdout="",
+        expected_dispatch_id=DISPATCH_ID,
+        additional_jsonl_paths=[
+            tmp_path / "does_not_exist.jsonl",
+            existing_jsonl,
+        ],
+    )
+    assert result.outcome == "completed_clean"
+    assert result.payload["summary"] == "existing"

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -371,6 +371,8 @@ class TestClearDispatchFieldCoverage:
                 dirty_values[f.name] = 9999.0
             elif isinstance(default, dict):
                 dirty_values[f.name] = {"prompt_tokens": 500}
+            elif isinstance(default, list):
+                dirty_values[f.name] = ["sess-1", "sess-2"]
             elif default is None:
                 dirty_values[f.name] = "/dirty/path"
             elif isinstance(default, DispatchStatus):
@@ -420,6 +422,8 @@ class TestSnapshotCompleteness:
                 dirty_values[f.name] = 9999.0
             elif isinstance(default, dict):
                 dirty_values[f.name] = {"prompt_tokens": 500}
+            elif isinstance(default, list):
+                dirty_values[f.name] = ["sess-1", "sess-2"]
             elif default is None:
                 dirty_values[f.name] = "/dirty/path"
             elif isinstance(default, DispatchStatus):
@@ -466,6 +470,8 @@ class TestSnapshotCompleteness:
                 assert snapshot[key] == str(expected_val)
             elif isinstance(expected_val, dict):
                 assert snapshot[key] == dict(expected_val)
+            elif isinstance(expected_val, list):
+                assert snapshot[key] == list(expected_val)
             else:
                 assert snapshot[key] == expected_val, (
                     f"Snapshot[{key!r}] = {snapshot[key]!r}, expected {expected_val!r}"

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -1591,3 +1591,105 @@ class TestUpsertCannotOverwriteFailureWithSuccess:
             )
         assert "FAILURE" in str(exc_info.value)
         assert "run-implement" in str(exc_info.value)
+
+
+class TestUpsertFailureToFailureSnapshotsPrior:
+    """FAILURE-to-FAILURE overwrites must snapshot prior diagnostics to attempt_history."""
+
+    def test_upsert_failure_to_failure_snapshots_prior(self, tmp_path: Path) -> None:
+        """FAILURE record with non-empty reason is snapshotted before overwrite."""
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", [DispatchRecord(name="run-implement")])
+
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(
+                name="run-implement",
+                status=DispatchStatus.FAILURE,
+                reason="fleet_l3_parse_failed",
+                kill_reason="context_exhausted",
+            ),
+        )
+
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(
+                name="run-implement",
+                status=DispatchStatus.FAILURE,
+                reason="fleet_l3_no_result_block",
+            ),
+        )
+
+        state = read_state(sp)
+        assert state is not None
+        disp = next(d for d in state.dispatches if d.name == "run-implement")
+        assert len(disp.attempt_history) == 1
+        snapshot = disp.attempt_history[0]
+        assert snapshot["reason"] == "fleet_l3_parse_failed"
+        assert snapshot["kill_reason"] == "context_exhausted"
+        assert disp.status == DispatchStatus.FAILURE
+        assert disp.reason == "fleet_l3_no_result_block"
+
+    def test_upsert_failure_to_failure_no_snapshot_when_reason_empty(self, tmp_path: Path) -> None:
+        """No snapshot is taken when existing record has empty reason."""
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", [DispatchRecord(name="run-implement")])
+
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(
+                name="run-implement",
+                status=DispatchStatus.FAILURE,
+                reason="",
+            ),
+        )
+
+        upsert_dispatch_record_by_name(
+            sp,
+            DispatchRecord(
+                name="run-implement",
+                status=DispatchStatus.FAILURE,
+                reason="fleet_l3_no_result_block",
+            ),
+        )
+
+        state = read_state(sp)
+        assert state is not None
+        disp = next(d for d in state.dispatches if d.name == "run-implement")
+        assert len(disp.attempt_history) == 0
+
+    def test_upsert_failure_to_failure_preserves_existing_attempt_history(
+        self, tmp_path: Path
+    ) -> None:
+        """Pre-existing attempt_history is preserved when new snapshot is prepended."""
+        from autoskillit.fleet import upsert_dispatch_record_by_name
+
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", [DispatchRecord(name="run-implement")])
+
+        first_record = DispatchRecord(
+            name="run-implement",
+            status=DispatchStatus.FAILURE,
+            reason="first_failure",
+            attempt_history=[],
+        )
+        upsert_dispatch_record_by_name(sp, first_record)
+
+        second_record = DispatchRecord(
+            name="run-implement",
+            status=DispatchStatus.FAILURE,
+            reason="second_failure",
+            attempt_history=[{"dispatch_id": "prior-attempt", "status": "failure"}],
+        )
+        upsert_dispatch_record_by_name(sp, second_record)
+
+        state = read_state(sp)
+        assert state is not None
+        disp = next(d for d in state.dispatches if d.name == "run-implement")
+        assert len(disp.attempt_history) == 2
+        assert disp.attempt_history[0]["reason"] == "first_failure"
+        assert disp.attempt_history[1]["dispatch_id"] == "prior-attempt"

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -335,6 +335,7 @@ class TestDispatchRecordToDict:
             "campaign_id",
             "caller_session_id",
             "dispatched_session_id",
+            "session_chain",
             "dispatched_session_log_dir",
             "dispatched_pid",
             "dispatched_starttime_ticks",
@@ -460,6 +461,26 @@ class TestDispatchRecordSchemaV3:
         sp.write_text(json.dumps(v1_payload))
         state = read_state(sp)
         assert state is None
+
+
+class TestSessionChainFields:
+    def test_session_chain_in_to_dict(self) -> None:
+        """to_dict includes session_chain."""
+        d = DispatchRecord(name="d1", session_chain=["sess-a", "sess-b"])
+        result = d.to_dict()
+        assert "session_chain" in result
+        assert result["session_chain"] == ["sess-a", "sess-b"]
+
+    def test_session_chain_from_dict_missing_defaults_empty(self) -> None:
+        """from_dict handles missing session_chain (v4 compat)."""
+        d = DispatchRecord.from_dict({"name": "d1"})
+        assert d.session_chain == []
+
+    def test_session_chain_round_trips_through_to_dict(self) -> None:
+        """session_chain survives to_dict round-trip."""
+        d = DispatchRecord(name="d1", session_chain=["sess-first", "sess-second"])
+        roundtripped = DispatchRecord.from_dict(d.to_dict())
+        assert roundtripped.session_chain == ["sess-first", "sess-second"]
 
 
 class TestAttemptHistoryFields:


### PR DESCRIPTION
## Summary

When a fleet dispatch is resumed via `--resume <session_id>`, the resume session writes to its own JSONL file. The original session's JSONL (which contains the valid L3 sentinel) is never consulted by `parse_l3_result_block`. Additionally, `upsert_dispatch_record_by_name` overwrites the original FAILURE record (with rich diagnostic data) with the resume session's FAILURE record, permanently losing the original diagnostic.

**Root Cause:** `fleet/_api.py:792` computes the JSONL path exclusively from the current session ID. The prior session's JSONL is structurally unreachable. The `prior_dispatch_ids` fallback scans the wrong file.

**Fix:**
1. **Cross-session JSONL fallback:** Extend `parse_l3_result_block` with `additional_jsonl_paths` parameter to scan prior sessions' JSONL files when the primary scan returns `no_sentinel`.
2. **Session chain:** Add `session_chain` field to `DispatchRecord` to track all contributing session IDs across resume attempts.
3. **Snapshot gate:** In `upsert_dispatch_record_by_name`, snapshot prior FAILURE record to `attempt_history` before overwriting.
4. **Populate `dispatched_session_log_dir`:** Set the field when constructing the final `DispatchRecord`.

Closes #2400

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_cross_session_jsonl_recovery_2026-05-12_150832.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 4.0k | 11.3k | 741.6k | 86.4k | 138 | 62.7k | 9m 29s |
| dry_walkthrough | claude-opus-4-6 | 1 | 39 | 15.6k | 573.1k | 65.8k | 107 | 52.6k | 7m 57s |
| implement* | MiniMax-M2.7 | 1 | 7.5M | 68.0k | 12.9M | 29.2k | 426 | 29.2k | 30m 32s |
| prepare_pr* | MiniMax-M2.7 | 1 | 46.3k | 3.8k | 295.6k | 0 | 22 | 0 | 45s |
| compose_pr* | MiniMax-M2.7 | 1 | 49.7k | 1.6k | 201.3k | 29.2k | 16 | 15.3k | 53s |
| review_pr | claude-opus-4-6 | 3 | 84 | 85.6k | 1.8M | 96.0k | 97 | 227.6k | 21m 11s |
| resolve_review | claude-opus-4-6 | 2 | 128 | 28.4k | 3.8M | 80.2k | 166 | 113.0k | 18m 50s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 45 | 7.5k | 1.2M | 53.5k | 51 | 41.3k | 5m 36s |
| **Total** | | | 7.6M | 221.8k | 21.4M | 96.0k | | 541.6k | 1h 35m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 604 | 21314.5 | 48.3 | 112.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 64 | 27590.9 | 3555.8 | 1337.8 |
| resolve_review | 168 | 22376.9 | 672.9 | 168.9 |
| ci_conflict_fix | 301 | 3830.9 | 137.3 | 25.1 |
| **Total** | **1137** | 18789.7 | 476.4 | 195.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 4.0k | 11.3k | 741.6k | 62.7k | 9m 29s |
| claude-opus-4-6 | 1 | 39 | 15.6k | 573.1k | 52.6k | 7m 57s |
| MiniMax-M2.7 | 3 | 7.6M | 73.4k | 13.4M | 44.4k | 32m 10s |