### PR TITLE
Add Remediation Retry Loop for audit-impl NO GO Verdicts

### DIFF
--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -683,9 +683,72 @@
       "positional_mapping": true
     },
     {
+      "step": "remediate",
+      "available": [
+        "audit",
+        "base_branch",
+        "download_report",
+        "experiment_plan",
+        "group_files",
+        "impl_base_sha",
+        "implement_fix_count",
+        "is_fixable",
+        "issue_url",
+        "output_mode",
+        "phase_loop_count",
+        "phase_plan_path",
+        "remediation_path",
+        "research_dir",
+        "research_dir_rel",
+        "resource_report",
+        "retry_delay",
+        "source_dir",
+        "task",
+        "test_check_enabled",
+        "verdict",
+        "visualization_plan_path",
+        "worktree_path"
+      ],
+      "required": [],
+      "produced": []
+    },
+    {
+      "step": "check_audit_retry_loop",
+      "available": [
+        "audit",
+        "base_branch",
+        "download_report",
+        "experiment_plan",
+        "group_files",
+        "impl_base_sha",
+        "implement_fix_count",
+        "is_fixable",
+        "issue_url",
+        "output_mode",
+        "phase_loop_count",
+        "phase_plan_path",
+        "remediation_path",
+        "research_dir",
+        "research_dir_rel",
+        "resource_report",
+        "retry_delay",
+        "source_dir",
+        "task",
+        "test_check_enabled",
+        "verdict",
+        "visualization_plan_path",
+        "worktree_path"
+      ],
+      "required": [],
+      "produced": [
+        "audit_retry_count"
+      ]
+    },
+    {
       "step": "run_experiment",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -717,6 +780,7 @@
       "step": "troubleshoot_run_failure",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -751,6 +815,7 @@
       "step": "route_run_failure",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -783,6 +848,7 @@
       "step": "adjust_experiment",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -818,6 +884,7 @@
       "step": "check_run_fix_loop",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -852,6 +919,7 @@
       "step": "route_run_retry_delay",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -885,6 +953,7 @@
       "step": "run_retry_delay",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -918,6 +987,7 @@
       "step": "ensure_results",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -953,6 +1023,7 @@
       "step": "generate_report",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -989,6 +1060,7 @@
       "step": "generate_report_inconclusive",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -1026,6 +1098,7 @@
       "step": "test",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -1060,6 +1133,7 @@
       "step": "fix_tests",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -1098,6 +1172,7 @@
       "step": "retest",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -1133,6 +1208,7 @@
       "step": "push_branch",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -1168,6 +1244,7 @@
       "step": "escalate_stop",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",
@@ -1203,6 +1280,7 @@
       "step": "implement_complete",
       "available": [
         "audit",
+        "audit_retry_count",
         "base_branch",
         "download_report",
         "experiment_plan",

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -545,9 +545,65 @@ dataflow:
   produced:
   - remediation_path
   positional_mapping: true
+- step: remediate
+  available:
+  - audit
+  - base_branch
+  - download_report
+  - experiment_plan
+  - group_files
+  - impl_base_sha
+  - implement_fix_count
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_loop_count
+  - phase_plan_path
+  - remediation_path
+  - research_dir
+  - research_dir_rel
+  - resource_report
+  - retry_delay
+  - source_dir
+  - task
+  - test_check_enabled
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: check_audit_retry_loop
+  available:
+  - audit
+  - base_branch
+  - download_report
+  - experiment_plan
+  - group_files
+  - impl_base_sha
+  - implement_fix_count
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_loop_count
+  - phase_plan_path
+  - remediation_path
+  - research_dir
+  - research_dir_rel
+  - resource_report
+  - retry_delay
+  - source_dir
+  - task
+  - test_check_enabled
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - audit_retry_count
 - step: run_experiment
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -575,6 +631,7 @@ dataflow:
 - step: troubleshoot_run_failure
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -605,6 +662,7 @@ dataflow:
 - step: route_run_failure
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -634,6 +692,7 @@ dataflow:
 - step: adjust_experiment
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -665,6 +724,7 @@ dataflow:
 - step: check_run_fix_loop
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -695,6 +755,7 @@ dataflow:
 - step: route_run_retry_delay
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -725,6 +786,7 @@ dataflow:
 - step: run_retry_delay
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -755,6 +817,7 @@ dataflow:
 - step: ensure_results
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -786,6 +849,7 @@ dataflow:
 - step: generate_report
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -818,6 +882,7 @@ dataflow:
 - step: generate_report_inconclusive
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -851,6 +916,7 @@ dataflow:
 - step: test
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -882,6 +948,7 @@ dataflow:
 - step: fix_tests
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -916,6 +983,7 @@ dataflow:
 - step: retest
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -948,6 +1016,7 @@ dataflow:
 - step: push_branch
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -980,6 +1049,7 @@ dataflow:
 - step: escalate_stop
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan
@@ -1012,6 +1082,7 @@ dataflow:
 - step: implement_complete
   available:
   - audit
+  - audit_retry_count
   - base_branch
   - download_report
   - experiment_plan

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -152,7 +152,7 @@
       },
       "on_success": "implement_phase",
       "on_failure": "escalate_stop",
-      "note": "Plans the current setup phase. Replace ${{ context.group_files }} in the skill_command with the FIRST REMAINING phase file path from the list — do NOT pass the entire list. Pass the path directly to the skill (do not read it). Glob plan_dir for *_part_*.md or single plan file. ITERATION: After each implement_phase cycle, advance to the next entry in context.group_files for the following plan_phase iteration.\n"
+      "note": "Plans the current setup phase. Replace ${{ context.group_files }} in the skill_command with the FIRST REMAINING phase file path from the list — do NOT pass the entire list. Pass the path directly to the skill (do not read it). Glob plan_dir for *_part_*.md or single plan file. ITERATION: After each implement_phase cycle, advance to the next entry in context.group_files for the following plan_phase iteration. REMEDIATION MODE: context.remediation_path is available when the orchestrator re-enters plan_phase from the remediate step via check_audit_retry_loop; pass it inline in the skill_command rather than as a named with: key.\n"
     },
     "implement_phase": {
       "tool": "run_skill",
@@ -310,13 +310,50 @@
           "route": "run_experiment"
         },
         {
+          "when": "result.error",
           "route": "escalate_stop"
+        },
+        {
+          "route": "remediate"
         }
       ],
       "on_failure": "escalate_stop",
       "on_context_limit": "escalate_stop",
       "skip_when_false": "inputs.audit",
-      "note": "Diffs base_branch...HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO, escalates with a remediation report detailing which phases are missing. If false (inputs.audit=false), skip directly to run_experiment.\n"
+      "note": "Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On error, escalates immediately. On NO GO, routes to remediate which re-enters plan_phase via check_audit_retry_loop (max 2 cycles). If false (inputs.audit=false), skip directly to run_experiment.\n"
+    },
+    "remediate": {
+      "action": "route",
+      "with": {
+        "remediation_path": "${{ context.remediation_path }}"
+      },
+      "on_success": "check_audit_retry_loop",
+      "note": "Pure routing step carrying the remediation file path from audit_impl's capture into the retry cycle. The remediation_path contains the list of missing phases identified by audit-impl.\n"
+    },
+    "check_audit_retry_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.audit_retry_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "audit_retry_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "escalate_stop"
+        },
+        {
+          "route": "plan_phase"
+        }
+      ],
+      "on_failure": "escalate_stop",
+      "optional_context_refs": [
+        "audit_retry_count"
+      ],
+      "note": "Guards the audit_impl → remediate → plan_phase remediation cycle. Allows up to 2 remediation attempts before escalating. This prevents unbounded re-planning when audit_impl repeatedly returns NO GO.\n"
     },
     "run_experiment": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -173,6 +173,9 @@ steps:
       Glob plan_dir for *_part_*.md or single plan file.
       ITERATION: After each implement_phase cycle, advance to the next entry in
       context.group_files for the following plan_phase iteration.
+      REMEDIATION MODE: context.remediation_path is available when the orchestrator
+      re-enters plan_phase from the remediate step via check_audit_retry_loop;
+      pass it inline in the skill_command rather than as a named with: key.
 
   implement_phase:
     tool: run_skill
@@ -304,7 +307,9 @@ steps:
     on_result:
       - when: "${{ result.verdict }} == GO"
         route: run_experiment
-      - route: escalate_stop
+      - when: "result.error"
+        route: escalate_stop
+      - route: remediate
     on_failure: escalate_stop
     on_context_limit: escalate_stop
     skip_when_false: "inputs.audit"
@@ -312,9 +317,40 @@ steps:
       Diffs base_branch...HEAD and verifies all decomposed phases from group_files
       have corresponding implementation commits. Catches silent group abandonment
       when on_context_limit fires mid-iteration — reports exactly which phases
-      were completed vs. skipped. On GO, proceeds to run_experiment. On NO GO,
-      escalates with a remediation report detailing which phases are missing.
+      were completed vs. skipped. On GO, proceeds to run_experiment. On error,
+      escalates immediately. On NO GO, routes to remediate which re-enters
+      plan_phase via check_audit_retry_loop (max 2 cycles).
       If false (inputs.audit=false), skip directly to run_experiment.
+
+  remediate:
+    action: route
+    with:
+      remediation_path: "${{ context.remediation_path }}"
+    on_success: check_audit_retry_loop
+    note: >
+      Pure routing step carrying the remediation file path from audit_impl's
+      capture into the retry cycle. The remediation_path contains the list of
+      missing phases identified by audit-impl.
+
+  check_audit_retry_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.audit_retry_count }}"
+      max_iterations: "2"
+    capture:
+      audit_retry_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: escalate_stop
+      - route: plan_phase
+    on_failure: escalate_stop
+    optional_context_refs:
+      - audit_retry_count
+    note: >
+      Guards the audit_impl → remediate → plan_phase remediation cycle.
+      Allows up to 2 remediation attempts before escalating. This prevents
+      unbounded re-planning when audit_impl repeatedly returns NO GO.
 
   # --- Experiment + Report ---
   run_experiment:

--- a/tests/recipe/test_research_audit_impl.py
+++ b/tests/recipe/test_research_audit_impl.py
@@ -152,6 +152,71 @@ class TestResearchRecipesAuditImpl:
         assert errors == [], f"Validation errors: {errors}"
 
 
+class TestResearchImplementRemediationLoop:
+    """Tests for the audit_impl → remediate → plan_phase retry cycle."""
+
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        return load_recipe(builtin_recipes_dir() / "research-implement.yaml")
+
+    def test_audit_impl_nogo_routes_to_remediate(self, recipe) -> None:
+        step = recipe.steps["audit_impl"]
+        conditions = step.on_result.conditions
+        default_cond = next((c for c in conditions if c.when is None), None)
+        assert default_cond is not None
+        assert default_cond.route == "remediate"
+
+    def test_audit_impl_error_routes_to_escalate_stop(self, recipe) -> None:
+        step = recipe.steps["audit_impl"]
+        conditions = step.on_result.conditions
+        error_cond = next((c for c in conditions if c.when and "result.error" in c.when), None)
+        assert error_cond is not None
+        assert error_cond.route == "escalate_stop"
+
+    def test_has_remediate_step(self, recipe) -> None:
+        assert "remediate" in recipe.steps
+        assert recipe.steps["remediate"].action == "route"
+
+    def test_remediate_carries_remediation_path(self, recipe) -> None:
+        step = recipe.steps["remediate"]
+        assert "remediation_path" in step.with_args
+        assert "context.remediation_path" in step.with_args["remediation_path"]
+
+    def test_remediate_routes_to_check_audit_retry_loop(self, recipe) -> None:
+        step = recipe.steps["remediate"]
+        assert step.on_success == "check_audit_retry_loop"
+
+    def test_has_check_audit_retry_loop_step(self, recipe) -> None:
+        step = recipe.steps["check_audit_retry_loop"]
+        assert step.tool == "run_python"
+        assert step.with_args["callable"] == "autoskillit.smoke_utils.check_loop_iteration"
+
+    def test_check_audit_retry_loop_max_iterations(self, recipe) -> None:
+        step = recipe.steps["check_audit_retry_loop"]
+        assert step.with_args["max_iterations"] == "2"
+
+    def test_check_audit_retry_loop_max_exceeded_routes_to_escalate_stop(self, recipe) -> None:
+        step = recipe.steps["check_audit_retry_loop"]
+        conditions = step.on_result.conditions
+        max_cond = next(
+            (c for c in conditions if c.when and "max_exceeded" in c.when and "== true" in c.when),
+            None,
+        )
+        assert max_cond is not None
+        assert max_cond.route == "escalate_stop"
+
+    def test_check_audit_retry_loop_default_routes_to_plan_phase(self, recipe) -> None:
+        step = recipe.steps["check_audit_retry_loop"]
+        conditions = step.on_result.conditions
+        default_cond = next((c for c in conditions if c.when is None), None)
+        assert default_cond is not None
+        assert default_cond.route == "plan_phase"
+
+    def test_check_audit_retry_loop_on_failure_escalates(self, recipe) -> None:
+        step = recipe.steps["check_audit_retry_loop"]
+        assert step.on_failure == "escalate_stop"
+
+
 class TestResearchCampaignAuditIngredient:
     """Tests for audit ingredient in research-campaign.yaml."""
 


### PR DESCRIPTION
## Summary

`research-implement.yaml` routes all non-GO `audit_impl` verdicts to `escalate_stop` (terminal halt), unlike `implementation.yaml` which routes NO GO to a `remediate` → `plan` re-implementation cycle. The `remediation_path` is captured but never consumed — dead context.

This plan adds three elements to `research-implement.yaml`:
1. A `remediate` routing step mirroring `implementation.yaml:427-431`
2. A `check_audit_retry_loop` guard step using `check_loop_iteration` with `max_iterations: "2"` to prevent unbounded cycles
3. Updated `audit_impl` `on_result` routing to distinguish GO / error / NO GO

## Requirements

### REQ-REM-001: Add `remediate` step to `research-implement.yaml`

Add a `remediate` action step (mirroring `implementation.yaml:427-432`) that:
- Receives `context.remediation_path` from the `audit_impl` capture
- Routes to `plan_phase` to re-enter the plan → implement → audit cycle

### REQ-REM-002: Update `audit_impl` on_result routing

Change the `audit_impl` step's `on_result` to:
```yaml
on_result:
  - when: "${{ result.verdict }} == GO"
    route: run_experiment
  - when: "result.error"
    route: escalate_stop
  - route: remediate
```

### REQ-REM-003: Bound the remediation cycle

Add a `max_audit_retries` or equivalent bound (e.g., 2 cycles) to prevent unbounded remediation loops, consistent with the existing unbounded-cycle guards (#2369).

## Problem

`research-implement.yaml` routes all non-GO `audit_impl` verdicts to `escalate_stop` (terminal halt), unlike `implementation.yaml` and `remediation.yaml` which both route NO GO to a `remediate` → `plan` re-implementation cycle. The remediation file is captured (`remediation_path`) but nothing consumes it — it is dead context.

### Observed in campaign `6c314d56b6dd4866`

After `audit-impl` returned NO GO with 3 missing items (inconclusive_zone test case, ATAC count matrix fixture, report.md dry-run), the pipeline halted immediately instead of entering a remediation cycle. The remediation file was written to `/home/talon/projects/worktrees/research-20260513-044828/.autoskillit/temp/audit-impl/remediation_atoh1_sensory_fate_evo_2026-05-13_120000.md` but was never consumed.

### Code comparison

**`research-implement.yaml:319-322`** (broken — no remediation):
```yaml
on_result:
  - when: "${{ result.verdict }} == GO"
    route: run_experiment
  - route: escalate_stop    # ALL non-GO → terminal halt
on_failure: escalate_stop
```

**`implementation.yaml:407-420`** (correct — has remediation cycle):
```yaml
on_result:
  - when: "${{ result.verdict }} == GO"
    route: push
  - when: "result.error"
    route: escalate_stop
  - route: remediate          # NO GO → remediate → plan cycle
```

`implementation.yaml` has a `remediate` step (line 427) that routes `context.remediation_path` back to the `plan` step, creating a full re-plan → implement → test → audit cycle. `research-implement.yaml` has no equivalent.

### Design intent

The `audit-impl` SKILL.md (Step 5) explicitly states on NO GO: "MERGE BLOCKED — feed remediation file to `/autoskillit:retry-worktree` or `/autoskillit:implement-worktree-no-merge`". The skill expects a consumer for its remediation output.

PR #2353 ("Research Recipes — Add audit-impl Gate and Fix Silent Group Abandonment") introduced `audit_impl` to `research-implement.yaml` but focused on detection (group abandonment) rather than recovery. The remediation routing was never wired up.

## Affected files

- `src/autoskillit/recipes/research-implement.yaml` (lines 310-332)

## Investigation reference

`investigation_research_campaign_dispatch_failure_no_retry_2026-05-13_180000.md`

Closes #2409

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260513-053940-683866/.autoskillit/temp/make-plan/research_implement_remediation_retry_loop_plan_2026-05-13_180000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 67 | 11.5k | 1.1M | 80.4k | 79 | 60.6k | 6m 39s |
| verify | claude-sonnet-4-6 | 1 | 37 | 10.0k | 500.4k | 72.5k | 103 | 60.6k | 5m 57s |
| implement* | MiniMax-M2.7 | 1 | 113.9k | 9.7k | 1.8M | 21.1k | 84 | 0 | 8m 7s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.0k | 3.5k | 190.5k | 25.9k | 18 | 8.1k | 3m 25s |
| compose_pr* | MiniMax-M2.7 | 1 | 40.9k | 2.7k | 344.9k | 0 | 22 | 0 | 1m 7s |
| review_pr | claude-sonnet-4-6 | 3 | 125 | 50.1k | 1.6M | 67.6k | 180 | 157.9k | 19m 42s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 34 | 9.2k | 879.8k | 80.3k | 34 | 66.9k | 3m 32s |
| **Total** | | | 198.1k | 96.6k | 6.3M | 80.4k | | 354.1k | 48m 32s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 301 | 5837.3 | 0.0 | 32.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| ci_conflict_fix | 456 | 1929.5 | 146.7 | 20.2 |
| **Total** | **757** | 8366.9 | 467.8 | 127.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 67 | 11.5k | 1.1M | 60.6k | 6m 39s |
| claude-sonnet-4-6 | 1 | 37 | 10.0k | 500.4k | 60.6k | 5m 57s |
| MiniMax-M2.7 | 3 | 197.8k | 15.9k | 2.3M | 8.1k | 12m 39s |