### PR TITLE
Canonical resolve_kitchen_id() eliminates cross-session capture orphaning

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -63,6 +63,7 @@ from .runtime.kitchen_state import find_caller_session_id as find_caller_session
 from .runtime.kitchen_state import get_state_dir as get_state_dir
 from .runtime.kitchen_state import is_marker_fresh as is_marker_fresh
 from .runtime.kitchen_state import read_marker as read_marker
+from .runtime.kitchen_state import resolve_kitchen_id as resolve_kitchen_id
 from .runtime.kitchen_state import sweep_stale_markers as sweep_stale_markers
 from .runtime.readiness import cleanup_readiness_sentinel as cleanup_readiness_sentinel
 from .runtime.readiness import readiness_sentinel_path as readiness_sentinel_path

--- a/src/autoskillit/core/runtime/__init__.py
+++ b/src/autoskillit/core/runtime/__init__.py
@@ -14,6 +14,7 @@ from .kitchen_state import (
     is_marker_fresh,
     marker_path,
     read_marker,
+    resolve_kitchen_id,
     sweep_stale_markers,
     write_marker,
 )
@@ -47,6 +48,7 @@ __all__ = [
     "provenance_path",
     "read_boot_id",
     "read_marker",
+    "resolve_kitchen_id",
     "read_provenance_for_session",
     "read_registry",
     "read_starttime_ticks",

--- a/src/autoskillit/core/runtime/kitchen_state.py
+++ b/src/autoskillit/core/runtime/kitchen_state.py
@@ -13,6 +13,7 @@ import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from uuid import uuid4
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,6 +140,16 @@ def sweep_stale_markers(ttl_hours: int = 24) -> int:
             except OSError:
                 pass
     return deleted
+
+
+def resolve_kitchen_id() -> str:
+    """Resolve kitchen identity: inherit campaign ID from environment, or mint fresh.
+
+    This is the SOLE legal assignment source for ctx.kitchen_id. All boot paths
+    and open_kitchen must call this function. The AST guard
+    test_kitchen_id_only_assigned_via_resolve_kitchen_id enforces this constraint.
+    """
+    return os.environ.get("AUTOSKILLIT_CAMPAIGN_ID") or str(uuid4())
 
 
 def find_caller_session_id(project_dir: Path | None = None) -> str:

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -23,6 +23,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from autoskillit.core import (
+    CAMPAIGN_ID_ENV_VAR,
     SessionType,
     cleanup_readiness_sentinel,
     get_logger,
@@ -32,6 +33,19 @@ from autoskillit.execution import RecordingSubprocessRunner
 from autoskillit.server._state import _get_ctx_or_none, deferred_initialize
 
 logger = get_logger(__name__)
+
+
+def resolve_kitchen_id() -> str:
+    """Resolve kitchen identity: inherit campaign ID from environment, or mint fresh.
+
+    This is the SOLE legal assignment source for ctx.kitchen_id. All boot paths
+    and open_kitchen must call this function. The AST guard
+    test_kitchen_id_only_assigned_via_resolve_kitchen_id enforces this constraint.
+    """
+    import os
+    from uuid import uuid4
+
+    return os.environ.get(CAMPAIGN_ID_ENV_VAR) or str(uuid4())
 
 
 def run_startup_drift_check() -> None:
@@ -153,18 +167,7 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
     is open before any tool call arrives. Fails open: any step failure is
     logged as a warning and does not abort gate activation.
     """
-    import os as _os
-    from uuid import uuid4
-
-    from autoskillit.core import register_active_kitchen
-    from autoskillit.pipeline import create_background_task
-    from autoskillit.server._misc import (
-        _prime_quota_cache,
-        _quota_refresh_loop,
-    )
-    from autoskillit.server.tools.tools_kitchen import _write_hook_config
-
-    ctx.kitchen_id = str(uuid4())
+    ctx.kitchen_id = resolve_kitchen_id()
     ctx.active_recipe_packs = frozenset()
     ctx.active_recipe_features = frozenset()
     if ctx.gate is None:
@@ -174,8 +177,11 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
     logger.info("fleet_auto_gate_boot", gate_state="open", kitchen_id=ctx.kitchen_id)
 
     try:
-        from autoskillit.core import _collect_disabled_feature_tags
+        from autoskillit.core import _collect_disabled_feature_tags, register_active_kitchen
+        from autoskillit.pipeline import create_background_task
         from autoskillit.server import mcp as _mcp
+        from autoskillit.server._misc import _prime_quota_cache, _quota_refresh_loop
+        from autoskillit.server.tools.tools_kitchen import _write_hook_config
 
         _features = ctx.config.features if ctx.config is not None else {}
         _exp_enabled = ctx.config.experimental_enabled if ctx.config is not None else False
@@ -203,7 +209,7 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
         logger.warning("fleet_auto_gate_boot_quota_refresh_failed", exc_info=True)
 
     try:
-        register_active_kitchen(ctx.kitchen_id, _os.getpid(), str(ctx.project_dir))
+        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
         logger.warning("fleet_auto_gate_boot_registry_failed", exc_info=True)
 
@@ -215,10 +221,7 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
     AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS is set. No-ops for interactive
     ORCHESTRATOR sessions (open_kitchen handles the gate there).
     """
-    from uuid import uuid4
-
     from autoskillit.core import (
-        CAMPAIGN_ID_ENV_VAR,
         FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
         HEADLESS_ENV_VAR,
         register_active_kitchen,
@@ -237,7 +240,7 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         return
 
     _packs = frozenset(p.strip() for p in _raw_tags.split(",") if p.strip())
-    ctx.kitchen_id = os.environ.get(CAMPAIGN_ID_ENV_VAR) or str(uuid4())
+    ctx.kitchen_id = resolve_kitchen_id()
     ctx.active_recipe_packs = _packs
     ctx.active_recipe_features = frozenset()
 

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -21,6 +21,7 @@ import os
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
+from uuid import uuid4
 
 from autoskillit.core import (
     CAMPAIGN_ID_ENV_VAR,
@@ -42,7 +43,6 @@ def resolve_kitchen_id() -> str:
     and open_kitchen must call this function. The AST guard
     test_kitchen_id_only_assigned_via_resolve_kitchen_id enforces this constraint.
     """
-    from uuid import uuid4
 
     return os.environ.get(CAMPAIGN_ID_ENV_VAR) or str(uuid4())
 

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -42,7 +42,6 @@ def resolve_kitchen_id() -> str:
     and open_kitchen must call this function. The AST guard
     test_kitchen_id_only_assigned_via_resolve_kitchen_id enforces this constraint.
     """
-    import os
     from uuid import uuid4
 
     return os.environ.get(CAMPAIGN_ID_ENV_VAR) or str(uuid4())

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -21,30 +21,18 @@ import os
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
-from uuid import uuid4
 
 from autoskillit.core import (
-    CAMPAIGN_ID_ENV_VAR,
     SessionType,
     cleanup_readiness_sentinel,
     get_logger,
+    resolve_kitchen_id,
     write_readiness_sentinel,
 )
 from autoskillit.execution import RecordingSubprocessRunner
 from autoskillit.server._state import _get_ctx_or_none, deferred_initialize
 
 logger = get_logger(__name__)
-
-
-def resolve_kitchen_id() -> str:
-    """Resolve kitchen identity: inherit campaign ID from environment, or mint fresh.
-
-    This is the SOLE legal assignment source for ctx.kitchen_id. All boot paths
-    and open_kitchen must call this function. The AST guard
-    test_kitchen_id_only_assigned_via_resolve_kitchen_id enforces this constraint.
-    """
-
-    return os.environ.get(CAMPAIGN_ID_ENV_VAR) or str(uuid4())
 
 
 def run_startup_drift_check() -> None:

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -7,7 +7,6 @@ import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
-from uuid import uuid4
 
 if TYPE_CHECKING:
     from autoskillit.config.settings import QuotaGuardConfig
@@ -123,7 +122,9 @@ async def _open_kitchen_handler() -> str | None:
 
     ctx = _get_ctx()
     ctx.gate.enable()
-    ctx.kitchen_id = os.environ.get("AUTOSKILLIT_CAMPAIGN_ID") or str(uuid4())
+    from autoskillit.server._lifespan import resolve_kitchen_id  # noqa: PLC0415
+
+    ctx.kitchen_id = resolve_kitchen_id()
     ctx.active_recipe_packs = frozenset()
     ctx.active_recipe_features = frozenset()
     logger.info("open_kitchen", gate_state="open", kitchen_id=ctx.kitchen_id)

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -23,6 +23,7 @@ from autoskillit.core import (
     find_latest_session_id,
     get_logger,
     pkg_root,
+    resolve_kitchen_id,
 )
 from autoskillit.pipeline import create_background_task
 from autoskillit.server import mcp
@@ -122,8 +123,6 @@ async def _open_kitchen_handler() -> str | None:
 
     ctx = _get_ctx()
     ctx.gate.enable()
-    from autoskillit.server._lifespan import resolve_kitchen_id  # noqa: PLC0415
-
     ctx.kitchen_id = resolve_kitchen_id()
     ctx.active_recipe_packs = frozenset()
     ctx.active_recipe_features = frozenset()

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -33,6 +33,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_import_linter_contracts.py` | Tests verifying import-linter contract documentation (REQ-ARCH-007) |
 | `test_import_paths.py` | Structural import-path compliance tests (REQ-IMP-001, REQ-IMP-002) |
 | `test_kitchen_guard_scoping.py` | Architectural enforcement: any_kitchen_open call-site scoping and test helper isolation |
+| `test_kitchen_id_assignment.py` | AST guard: ctx.kitchen_id assignment only via resolve_kitchen_id() |
 | `test_layer_enforcement.py` | MCP tool registry + import layer contracts + cross-package rules |
 | `test_layer_markers.py` | Enforce pytestmark layer markers on all in-scope test files |
 | `test_never_raises_contracts.py` | Structural enforcement of 'Never raises' docstring contracts in server/ |

--- a/tests/arch/test_kitchen_id_assignment.py
+++ b/tests/arch/test_kitchen_id_assignment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from pathlib import Path
 
 import pytest
 
@@ -20,45 +21,35 @@ def test_kitchen_id_only_assigned_via_resolve_kitchen_id():
         "src/autoskillit/server/tools/tools_kitchen.py",
     )
 
+    canonical_assign_linenos: set[str] = set()
+
     for file_path in src:
-        full_path = pytest.importorskip("pathlib").Path(__file__).parent.parent.parent / file_path
+        full_path = Path(__file__).parent.parent.parent / file_path
         tree = ast.parse(full_path.read_text(), filename=file_path)
 
-        resolve_kitchen_id_body: set[int] = set()
-        canonical_assign_linenos: set[int] = set()
-
         for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == "resolve_kitchen_id":
-                for child in ast.walk(node):
-                    if isinstance(child, ast.Assign):
-                        for target in child.targets:
-                            resolve_kitchen_id_body.add(child.lineno)
-
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    is_kitchen_id_attr = (
-                        isinstance(target, ast.Attribute) and target.attr == "kitchen_id"
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if not (isinstance(target, ast.Attribute) and target.attr == "kitchen_id"):
+                    continue
+                if isinstance(node.value, ast.Call):
+                    if getattr(node.value.func, "id", None) == "resolve_kitchen_id":
+                        canonical_assign_linenos.add(f"{file_path}:{node.lineno}")
+                        continue
+                    rhs = ast.unparse(node.value)
+                    pytest.fail(
+                        f"{file_path}:{node.lineno}: "
+                        f"ctx.kitchen_id assignment uses "
+                        f"{rhs}, not resolve_kitchen_id()"
                     )
-                    if is_kitchen_id_attr:
-                        is_resolve_kitchen_id_scope = any(
-                            n.lineno in resolve_kitchen_id_body
-                            for n in ast.walk(node)
-                            if isinstance(n, ast.Assign) and n.targets[0] == target
-                        )
-                        if not is_resolve_kitchen_id_scope:
-                            if isinstance(node.value, ast.Call):
-                                if getattr(node.value.func, "id", None) == "resolve_kitchen_id":
-                                    canonical_assign_linenos.add(node.lineno)
-                                else:
-                                    rhs = ast.unparse(node.value)
-                                    pytest.fail(
-                                        f"{file_path}:{node.lineno}: "
-                                        f"ctx.kitchen_id assignment uses "
-                                        f"{rhs}, not resolve_kitchen_id()"
-                                    )
-                            else:
-                                pytest.fail(
-                                    f"{file_path}:{node.lineno}: "
-                                    f"ctx.kitchen_id assignment is not via resolve_kitchen_id()"
-                                )
+                else:
+                    pytest.fail(
+                        f"{file_path}:{node.lineno}: "
+                        f"ctx.kitchen_id assignment is not via resolve_kitchen_id()"
+                    )
+
+    assert canonical_assign_linenos, (
+        "No ctx.kitchen_id = resolve_kitchen_id() assignments found in scanned files — "
+        "guard is vacuous"
+    )

--- a/tests/arch/test_kitchen_id_assignment.py
+++ b/tests/arch/test_kitchen_id_assignment.py
@@ -51,10 +51,11 @@ def test_kitchen_id_only_assigned_via_resolve_kitchen_id():
                                 if getattr(node.value.func, "id", None) == "resolve_kitchen_id":
                                     canonical_assign_linenos.add(node.lineno)
                                 else:
+                                    rhs = ast.unparse(node.value)
                                     pytest.fail(
                                         f"{file_path}:{node.lineno}: "
-                                        f"ctx.kitchen_id assignment uses {ast.unparse(node.value)}, "
-                                        f"not resolve_kitchen_id()"
+                                        f"ctx.kitchen_id assignment uses "
+                                        f"{rhs}, not resolve_kitchen_id()"
                                     )
                             else:
                                 pytest.fail(

--- a/tests/arch/test_kitchen_id_assignment.py
+++ b/tests/arch/test_kitchen_id_assignment.py
@@ -1,0 +1,63 @@
+"""AST structural guard: kitchen_id assignment is only via resolve_kitchen_id()."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def test_kitchen_id_only_assigned_via_resolve_kitchen_id():
+    """No code outside resolve_kitchen_id() may assign ctx.kitchen_id directly.
+
+    This prevents future boot paths from diverging by replicating the assignment logic.
+    All boot-path handlers must call resolve_kitchen_id() for kitchen_id assignment.
+    """
+    src = (
+        "src/autoskillit/server/_lifespan.py",
+        "src/autoskillit/server/tools/tools_kitchen.py",
+    )
+
+    for file_path in src:
+        full_path = pytest.importorskip("pathlib").Path(__file__).parent.parent.parent / file_path
+        tree = ast.parse(full_path.read_text(), filename=file_path)
+
+        resolve_kitchen_id_body: set[int] = set()
+        canonical_assign_linenos: set[int] = set()
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "resolve_kitchen_id":
+                for child in ast.walk(node):
+                    if isinstance(child, ast.Assign):
+                        for target in child.targets:
+                            resolve_kitchen_id_body.add(child.lineno)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    is_kitchen_id_attr = (
+                        isinstance(target, ast.Attribute) and target.attr == "kitchen_id"
+                    )
+                    if is_kitchen_id_attr:
+                        is_resolve_kitchen_id_scope = any(
+                            n.lineno in resolve_kitchen_id_body
+                            for n in ast.walk(node)
+                            if isinstance(n, ast.Assign) and n.targets[0] == target
+                        )
+                        if not is_resolve_kitchen_id_scope:
+                            if isinstance(node.value, ast.Call):
+                                if getattr(node.value.func, "id", None) == "resolve_kitchen_id":
+                                    canonical_assign_linenos.add(node.lineno)
+                                else:
+                                    pytest.fail(
+                                        f"{file_path}:{node.lineno}: "
+                                        f"ctx.kitchen_id assignment uses {ast.unparse(node.value)}, "
+                                        f"not resolve_kitchen_id()"
+                                    )
+                            else:
+                                pytest.fail(
+                                    f"{file_path}:{node.lineno}: "
+                                    f"ctx.kitchen_id assignment is not via resolve_kitchen_id()"
+                                )

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -784,3 +784,55 @@ def test_interpolate_rejects_empty_string_campaign_ref():
     msg = str(exc_info.value).lower()
     assert "empty" in msg
     assert "report_path" in msg
+
+
+# ---------------------------------------------------------------------------
+# Cross-session capture orphaning tests
+# ---------------------------------------------------------------------------
+
+
+def _make_success_state(state_path, campaign_id, captures):
+    """Helper: create a state file with one SUCCESS dispatch and captured values."""
+    from autoskillit.fleet.state import write_captured_values, write_initial_state
+    from autoskillit.fleet.state_types import DispatchRecord, DispatchStatus
+
+    dispatch = DispatchRecord(
+        name="test-dispatch-1",
+        status=DispatchStatus.SUCCESS,
+    )
+    write_initial_state(
+        state_path,
+        campaign_id=campaign_id,
+        campaign_name="test-campaign",
+        manifest_path="manifest.yaml",
+        dispatches=[dispatch],
+    )
+    write_captured_values(state_path, captures)
+
+
+def test_captures_from_prior_session_visible_with_same_campaign_id(tmp_path):
+    """Captures written under campaign_id X must be readable when kitchen_id == X."""
+    from autoskillit.fleet.state import read_all_campaign_captures
+
+    dispatches_dir = tmp_path / "dispatches"
+    dispatches_dir.mkdir()
+
+    state_path_1 = dispatches_dir / "dispatch_001.json"
+    _make_success_state(state_path_1, "campaign-original", {"output_url": "https://example.com"})
+
+    result = read_all_campaign_captures(dispatches_dir, "campaign-original")
+    assert result == {"output_url": "https://example.com"}
+
+
+def test_captures_from_prior_session_invisible_with_different_campaign_id(tmp_path):
+    """Different campaign_id = invisible captures (orphaned by namespace mismatch)."""
+    from autoskillit.fleet.state import read_all_campaign_captures
+
+    dispatches_dir = tmp_path / "dispatches"
+    dispatches_dir.mkdir()
+
+    state_path_1 = dispatches_dir / "dispatch_001.json"
+    _make_success_state(state_path_1, "kitchen-uuid-A", {"output_url": "https://example.com"})
+
+    result = read_all_campaign_captures(dispatches_dir, "kitchen-uuid-B")
+    assert result == {}  # orphaned — this is the bug we're preventing

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -115,10 +115,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # staleness_cache.py — cache dict
     ("src/autoskillit/recipe/staleness_cache.py", 67),
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
-    ("src/autoskillit/server/_lifespan.py", 75),
+    ("src/autoskillit/server/_lifespan.py", 63),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools/tools_kitchen.py", 111),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 556),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 112),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 555),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 495),
     # tools_github.py — bug report dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -115,7 +115,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # staleness_cache.py — cache dict
     ("src/autoskillit/recipe/staleness_cache.py", 67),
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
-    ("src/autoskillit/server/_lifespan.py", 76),
+    ("src/autoskillit/server/_lifespan.py", 75),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools/tools_kitchen.py", 111),
     ("src/autoskillit/server/tools/tools_kitchen.py", 556),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -115,10 +115,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # staleness_cache.py — cache dict
     ("src/autoskillit/recipe/staleness_cache.py", 67),
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
-    ("src/autoskillit/server/_lifespan.py", 62),
+    ("src/autoskillit/server/_lifespan.py", 76),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools/tools_kitchen.py", 112),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 555),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 111),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 556),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 495),
     # tools_github.py — bug report dict

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -333,29 +333,6 @@ class TestFleetAutoGateBoot:
         )
 
     @pytest.mark.anyio
-    async def test_fleet_auto_gate_boot_inherits_campaign_id_from_env(self, tool_ctx, monkeypatch):
-        """Fleet boot path must read AUTOSKILLIT_CAMPAIGN_ID when present."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        from autoskillit.pipeline.gate import DefaultGateState
-        from autoskillit.server._lifespan import _fleet_auto_gate_boot
-
-        monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_ID", "test-campaign-abc123")
-        tool_ctx.gate = DefaultGateState(enabled=False)
-        tool_ctx.quota_refresh_task = None
-
-        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
-            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch(
-                    "autoskillit.pipeline.create_background_task",
-                    return_value=MagicMock(),
-                ):
-                    with patch("autoskillit.core.register_active_kitchen"):
-                        await _fleet_auto_gate_boot(tool_ctx)
-
-        assert tool_ctx.kitchen_id == "test-campaign-abc123"
-
-    @pytest.mark.anyio
     @pytest.mark.parametrize(
         "boot_fn_name",
         ["_fleet_auto_gate_boot", "_food_truck_auto_gate_boot"],

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -332,6 +332,64 @@ class TestFleetAutoGateBoot:
             tool_ctx.kitchen_id, os.getpid(), str(tool_ctx.project_dir)
         )
 
+    @pytest.mark.anyio
+    async def test_fleet_auto_gate_boot_inherits_campaign_id_from_env(self, tool_ctx, monkeypatch):
+        """Fleet boot path must read AUTOSKILLIT_CAMPAIGN_ID when present."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _fleet_auto_gate_boot
+
+        monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_ID", "test-campaign-abc123")
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task",
+                    return_value=MagicMock(),
+                ):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        await _fleet_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.kitchen_id == "test-campaign-abc123"
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "boot_fn_name",
+        ["_fleet_auto_gate_boot", "_food_truck_auto_gate_boot"],
+    )
+    async def test_boot_paths_inherit_campaign_id(self, boot_fn_name, tool_ctx, monkeypatch):
+        """All boot paths must resolve kitchen_id via resolve_kitchen_id()."""
+        import importlib
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.core import CAMPAIGN_ID_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+
+        expected_id = f"test-campaign-{boot_fn_name}"
+        monkeypatch.setenv(CAMPAIGN_ID_ENV_VAR, expected_id)
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core")
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+
+        boot_fn = getattr(
+            importlib.import_module("autoskillit.server._lifespan"),
+            boot_fn_name,
+        )
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task",
+                    return_value=MagicMock(),
+                ):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        await boot_fn(tool_ctx)
+
+        assert tool_ctx.kitchen_id == expected_id
+
 
 @pytest.mark.feature("fleet")
 class TestFleetAutoGateBootProjectDir:


### PR DESCRIPTION
## Summary

The investigation identified that `kitchen_id` was independently assigned across three boot paths with no shared contract: `_fleet_auto_gate_boot` minted a fresh UUID (ignoring the `AUTOSKILLIT_CAMPAIGN_ID` env var), while `_food_truck_auto_gate_boot` and `_open_kitchen_handler` correctly read it. This caused fleet campaign retry sessions to write captured values under a different namespace than the original campaign, permanently orphaning them.

The fix extracts `kitchen_id` resolution into a single canonical function `resolve_kitchen_id()` that reads `AUTOSKILLIT_CAMPAIGN_ID` from the environment or falls back to `str(uuid4())`. All three boot paths now call this function. An AST structural guard (`test_kitchen_id_only_assigned_via_resolve_kitchen_id`) enforces that no boot path can assign `ctx.kitchen_id` directly. New tests cover the env-var inheritance for all boot paths and the cross-session capture visibility scenario.

## Requirements

### REQ-OOB-001: Campaign state adoption mechanism
Provide a mechanism to adopt captured values from a retry campaign into the original campaign state. Options:
- A CLI command or MCP tool: `adopt_dispatch_result(source_kitchen_id, target_kitchen_id, dispatch_name)` that copies the successful dispatch's state (including `captured_values`) from the source to the target campaign
- Automatic: when `dispatch_food_truck` detects a prior failed dispatch for the same `dispatch_name` under a different `campaign_id` (same `dispatches_dir`), link the result back

### REQ-OOB-002: Campaign resume should preserve kitchen_id
When the fleet campaign system resumes a failed campaign, it should reuse the original `kitchen_id` rather than generating a new one. This requires threading the original `AUTOSKILLIT_CAMPAIGN_ID` through the resume path in `cli/fleet/_fleet_session.py`.

### REQ-OOB-003: Diagnostic logging for orphaned captures
Log a WARNING when `write_captured_values` writes captures under a `kitchen_id` that differs from any existing campaign state files in the same `dispatches_dir` with matching `dispatch_name`. This helps detect orphaning at the time it occurs rather than downstream when interpolation fails.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260513-053825-172781/.autoskillit/temp/rectify/rectify_oob_campaign_retry_orphaned_captures_2026-05-13_053825.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 2.5k | 12.1k | 1.0M | 93.9k | 348 | 61.1k | 10m 50s |
| rectify | claude-sonnet-4-6 | 1 | 2.8k | 12.9k | 881.4k | 97.5k | 137 | 68.0k | 6m 27s |
| dry_walkthrough | claude-opus-4-6 | 1 | 1.1k | 18.4k | 1.8M | 77.7k | 148 | 66.3k | 8m 59s |
| implement* | MiniMax-M2.7 | 1 | 119.5k | 10.9k | 2.7M | 28.8k | 88 | 42.4k | 9m 52s |
| prepare_pr* | MiniMax-M2.7 | 1 | 55.4k | 3.5k | 356.7k | 0 | 25 | 0 | 1m 49s |
| compose_pr* | MiniMax-M2.7 | 1 | 41.0k | 1.9k | 299.4k | 28.8k | 22 | 41.1k | 1m 7s |
| review_pr | claude-opus-4-6 | 4 | 1.3k | 146.5k | 1.9M | 94.3k | 126 | 284.5k | 33m 8s |
| resolve_review | claude-opus-4-6 | 4 | 917 | 60.9k | 5.8M | 84.5k | 243 | 249.3k | 31m 39s |
| **Total** | | | 224.5k | 267.1k | 14.8M | 97.5k | | 812.7k | 1h 43m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 218 | 12410.6 | 194.3 | 50.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 130 | 44730.1 | 1918.0 | 468.4 |
| **Total** | **348** | 42610.9 | 2335.3 | 767.5 |