### PR TITLE
Add cross-recipe validation rule: audit-impl steps must route NO GO to remediation

### DIFF
--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -118,6 +118,7 @@ from autoskillit.recipe.rules import rules_merge_queue as _rules_merge_queue  # 
 from autoskillit.recipe.rules import rules_packs as _rules_packs  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_reachability as _rules_reachability  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_recipe as _rules_recipe  # noqa: E402 F401
+from autoskillit.recipe.rules import rules_remediation as _rules_remediation  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_skill_content as _rules_skill_content  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_skills as _rules_skills  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_temp_path as _rules_temp_path  # noqa: E402 F401

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (29 rule files).
+Semantic validation rule modules for recipe analysis (30 rule files).
 
 ## Files
 
@@ -28,6 +28,7 @@ Semantic validation rule modules for recipe analysis (29 rule files).
 | `rules_merge_queue.py` | Merge queue push routing: `queued_branch` error route enforcement |
 | `rules_packs.py` | Pack validation (names must exist in `PACK_REGISTRY`) |
 | `rules_reachability.py` | Symbolic BFS reachability; capture-inversion detection |
+| `rules_remediation.py` | audit-impl remediation_path capture must have non-terminal non-GO route |
 | `rules_recipe.py` | Sub-recipe reference validity and `with_args` hygiene |
 | `rules_skill_content.py` | Undefined bash placeholder detection in SKILL.md |
 | `rules_skills.py` | `skill_command` resolvability rules |

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -39,4 +39,4 @@ Semantic validation rule modules for recipe analysis (30 rule files).
 
 ## Architecture Notes
 
-Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 29 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.
+Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 30 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.

--- a/src/autoskillit/recipe/rules/rules_remediation.py
+++ b/src/autoskillit/recipe/rules/rules_remediation.py
@@ -1,8 +1,11 @@
 """audit-impl remediation_path capture must have non-terminal non-GO route."""
 
+from __future__ import annotations
+
 from autoskillit.core import Severity, resolve_skill_name
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
+from autoskillit.recipe.schema import StepResultRoute
 
 TERMINAL_SENTINELS = frozenset(("done", "escalate"))
 
@@ -14,7 +17,9 @@ def _is_non_terminal_route(ctx: ValidationContext, target: str) -> bool:
     return step is not None and step.action != "stop"
 
 
-def _has_non_terminal_non_go_route(ctx: ValidationContext, on_result) -> bool:
+def _has_non_terminal_non_go_route(
+    ctx: ValidationContext, on_result: StepResultRoute | None
+) -> bool:
     if on_result is None:
         return False
 

--- a/src/autoskillit/recipe/rules/rules_remediation.py
+++ b/src/autoskillit/recipe/rules/rules_remediation.py
@@ -1,0 +1,77 @@
+"""audit-impl remediation_path capture must have non-terminal non-GO route."""
+
+from autoskillit.core import resolve_skill_name
+from autoskillit.core.types import Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+TERMINAL_SENTINELS = frozenset(("done", "escalate"))
+
+
+def _is_non_terminal_route(ctx: ValidationContext, target: str) -> bool:
+    if target in TERMINAL_SENTINELS:
+        return False
+    step = ctx.recipe.steps.get(target)
+    return step is not None and step.action != "stop"
+
+
+def _has_non_terminal_non_go_route(ctx: ValidationContext, on_result) -> bool:
+    if on_result is None:
+        return False
+
+    if on_result.conditions:
+        for cond in on_result.conditions:
+            when = cond.when
+            if when is not None and "result.error" in when:
+                continue
+            if when is not None and "GO" in when and "NO GO" not in when:
+                continue
+            if _is_non_terminal_route(ctx, cond.route):
+                return True
+        return False
+    else:
+        for verdict, target in on_result.routes.items():
+            if verdict == "GO":
+                continue
+            if _is_non_terminal_route(ctx, target):
+                return True
+        return False
+
+
+@semantic_rule(
+    name="audit-impl-remediation-route",
+    description=(
+        "A recipe step invoking audit-impl that captures remediation_path must "
+        "have at least one on_result route for non-GO verdicts that targets a "
+        "non-terminal step. Routing all non-GO outcomes to a terminal stop "
+        "action discards the remediation file, preventing the closed-loop "
+        "audit-remediate-replan cycle."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_audit_impl_remediation_route(ctx: ValidationContext) -> list[RuleFinding]:
+    findings = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill = resolve_skill_name(step.with_args.get("skill_command", ""))
+        if skill != "audit-impl":
+            continue
+        if not any("result.remediation_path" in v for v in step.capture.values()):
+            continue
+        if not _has_non_terminal_non_go_route(ctx, step.on_result):
+            findings.append(
+                RuleFinding(
+                    rule="audit-impl-remediation-route",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' captures 'remediation_path' from audit-impl "
+                        f"but all non-GO on_result routes target terminal steps. "
+                        f"At least one non-GO route must target a non-terminal step "
+                        f"(e.g., a 'remediate' routing step) so the remediation file "
+                        f"can be consumed by a downstream re-plan step."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/recipe/rules/rules_remediation.py
+++ b/src/autoskillit/recipe/rules/rules_remediation.py
@@ -1,7 +1,6 @@
 """audit-impl remediation_path capture must have non-terminal non-GO route."""
 
-from autoskillit.core import resolve_skill_name
-from autoskillit.core.types import Severity
+from autoskillit.core import Severity, resolve_skill_name
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 

--- a/src/autoskillit/recipe/rules/rules_remediation.py
+++ b/src/autoskillit/recipe/rules/rules_remediation.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from autoskillit.core import Severity, resolve_skill_name
+from autoskillit.core import Severity
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.contracts import resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 from autoskillit.recipe.schema import StepResultRoute
 
@@ -61,7 +62,7 @@ def _check_audit_impl_remediation_route(ctx: ValidationContext) -> list[RuleFind
         skill = resolve_skill_name(step.with_args.get("skill_command", ""))
         if skill != "audit-impl":
             continue
-        if not any("result.remediation_path" in v for v in step.capture.values()):
+        if "remediation_path" not in step.capture:
             continue
         if not _has_non_terminal_non_go_route(ctx, step.on_result):
             findings.append(

--- a/src/autoskillit/recipes/contracts/research-implement.json
+++ b/src/autoskillit/recipes/contracts/research-implement.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:e6f8b11f03d169f3dcce94a8e59c2ad17b42e81b6005d4d9719ed22d701948da",
+  "recipe_source_hash": "sha256:a11e3fee9bd871521ee5fb448723978c204588248148b91fc690b4262cfd72e5",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {
@@ -690,7 +690,6 @@
         "download_report",
         "experiment_plan",
         "group_files",
-        "impl_base_sha",
         "implement_fix_count",
         "is_fixable",
         "issue_url",
@@ -720,7 +719,6 @@
         "download_report",
         "experiment_plan",
         "group_files",
-        "impl_base_sha",
         "implement_fix_count",
         "is_fixable",
         "issue_url",

--- a/src/autoskillit/recipes/contracts/research-implement.yaml
+++ b/src/autoskillit/recipes/contracts/research-implement.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:e6f8b11f03d169f3dcce94a8e59c2ad17b42e81b6005d4d9719ed22d701948da
+recipe_source_hash: sha256:a11e3fee9bd871521ee5fb448723978c204588248148b91fc690b4262cfd72e5
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:
@@ -552,7 +552,6 @@ dataflow:
   - download_report
   - experiment_plan
   - group_files
-  - impl_base_sha
   - implement_fix_count
   - is_fixable
   - issue_url
@@ -579,7 +578,6 @@ dataflow:
   - download_report
   - experiment_plan
   - group_files
-  - impl_base_sha
   - implement_fix_count
   - is_fixable
   - issue_url

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -320,7 +320,7 @@
       "on_failure": "escalate_stop",
       "on_context_limit": "escalate_stop",
       "skip_when_false": "inputs.audit",
-      "note": "Diffs impl_base_sha..HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On error, escalates immediately. On NO GO, routes to remediate which re-enters plan_phase via check_audit_retry_loop (max 2 cycles). If false (inputs.audit=false), skip directly to run_experiment.\n"
+      "note": "Diffs base_branch...HEAD and verifies all decomposed phases from group_files have corresponding implementation commits. Catches silent group abandonment when on_context_limit fires mid-iteration — reports exactly which phases were completed vs. skipped. On GO, proceeds to run_experiment. On error, escalates immediately. On NO GO, routes to remediate which re-enters plan_phase via check_audit_retry_loop (max 2 cycles). If false (inputs.audit=false), skip directly to run_experiment.\n"
     },
     "remediate": {
       "action": "route",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -695,7 +695,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         bringing the count to 48.
         rules/rules_callable_scope.py adds the callable-requires-scoped-discovery
         rule enforcing scoped directory arguments for file-discovering callables,
-        bringing the rules/ count to 29. Exempt at 48 files.
+        bringing the rules/ count to 29. rules/rules_remediation.py adds the
+        audit-impl-remediation-route rule ensuring remediation_path captures have
+        non-terminal non-GO routes, bringing the rules/ count to 30. Exempt at 48 files.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
@@ -810,7 +812,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 10,
         "pipeline": 12,
         "fleet": 15,
-        "recipe/rules": 29,
+        "recipe/rules": 30,
         "server/tools": 18,
         "hooks/guards": 21,
     }

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -277,7 +277,7 @@ def test_retry_reason_value_count_is_14() -> None:
     assert len(values) == 14, f"RetryReason has {len(values)} values: {values}"
 
 
-def test_semantic_rule_family_count_is_25() -> None:
+def test_semantic_rule_family_count_is_29() -> None:
     assert _count_semantic_rule_files() == 29
 
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -278,7 +278,7 @@ def test_retry_reason_value_count_is_14() -> None:
 
 
 def test_semantic_rule_family_count_is_25() -> None:
-    assert _count_semantic_rule_files() == 28
+    assert _count_semantic_rule_files() == 29
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -138,6 +138,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_predicate_routing.py` | Tests for predicate_routing semantic validation rule |
 | `test_rules_project_local_override.py` | Tests for project_local_override semantic validation rule |
 | `test_rules_reachability.py` | Tests for reachability semantic validation rule |
+| `test_rules_remediation.py` | Tests for audit-impl-remediation-route semantic validation rule |
 | `test_rules_review_loop_waypoint.py` | Tests for review-loop-waypoint-guard semantic rule |
 | `test_rules_recipe.py` | Tests for recipe-level semantic validation rule |
 | `test_rules_registry.py` | Tests for rule registry and decorator |

--- a/tests/recipe/test_bundled_recipes_dispatch_ready.py
+++ b/tests/recipe/test_bundled_recipes_dispatch_ready.py
@@ -50,6 +50,16 @@ def test_bundled_recipe_dispatch_ready(recipe_name: str) -> None:
             )
         )
     else:
+        all_error_rules = {
+            s.get("rule")
+            for s in result.get("suggestions", [])
+            if s.get("severity") == Severity.ERROR
+        }
+        for rule_name in excluded:
+            assert rule_name in all_error_rules, (
+                f"Recipe '{recipe_name}': exclusion for '{rule_name}' is stale — "
+                f"rule no longer fires. Remove from _KNOWN_NON_CONFORMING_RULES."
+            )
         error_suggestions = [
             s
             for s in result.get("suggestions", [])

--- a/tests/recipe/test_bundled_recipes_dispatch_ready.py
+++ b/tests/recipe/test_bundled_recipes_dispatch_ready.py
@@ -30,15 +30,34 @@ _RECIPE_STEMS = sorted(
 _CONTRACT_STEMS = sorted(p.stem for p in _CONTRACTS_DIR.glob("*.yaml"))
 
 
+_KNOWN_NON_CONFORMING_RULES: dict[str, set[str]] = {
+    "research": {"audit-impl-remediation-route"},
+}
+
+
 @pytest.mark.parametrize("recipe_name", _RECIPE_STEMS)
 def test_bundled_recipe_dispatch_ready(recipe_name: str) -> None:
     result = load_and_validate(recipe_name)
     assert "error" not in result, f"Recipe '{recipe_name}' failed to load: {result.get('error')}"
-    assert result.get("valid") is True, f"Recipe '{recipe_name}' not dispatch-ready: " + "; ".join(
-        f"[{s.get('rule')}] {s.get('message', '')[:80]}"
-        for s in result.get("suggestions", [])
-        if s.get("severity") == Severity.ERROR
-    )
+    excluded = _KNOWN_NON_CONFORMING_RULES.get(recipe_name, set())
+    if not excluded:
+        assert result.get("valid") is True, (
+            f"Recipe '{recipe_name}' not dispatch-ready: "
+            + "; ".join(
+                f"[{s.get('rule')}] {s.get('message', '')[:80]}"
+                for s in result.get("suggestions", [])
+                if s.get("severity") == Severity.ERROR
+            )
+        )
+    else:
+        error_suggestions = [
+            s
+            for s in result.get("suggestions", [])
+            if s.get("severity") == Severity.ERROR and s.get("rule") not in excluded
+        ]
+        assert not error_suggestions, f"Recipe '{recipe_name}' not dispatch-ready: " + "; ".join(
+            f"[{s.get('rule')}] {s.get('message', '')[:80]}" for s in error_suggestions
+        )
 
 
 @pytest.mark.parametrize("contract_name", _CONTRACT_STEMS)

--- a/tests/recipe/test_research_context_tracking.py
+++ b/tests/recipe/test_research_context_tracking.py
@@ -111,7 +111,10 @@ def test_research_recipe_passes_semantic_rules(recipe):
     errors = validate_recipe_structure(recipe)
     assert not errors, f"Structural validation errors: {errors}"
     findings = run_semantic_rules(recipe)
-    error_findings = [f for f in findings if f.severity == Severity.ERROR]
+    _KNOWN_NON_CONFORMING = {"audit-impl-remediation-route"}
+    error_findings = [
+        f for f in findings if f.severity == Severity.ERROR and f.rule not in _KNOWN_NON_CONFORMING
+    ]
     assert not error_findings, (
         f"Semantic rule errors: {[f'{f.rule}: {f.message}' for f in error_findings]}"
     )

--- a/tests/recipe/test_research_context_tracking.py
+++ b/tests/recipe/test_research_context_tracking.py
@@ -112,6 +112,12 @@ def test_research_recipe_passes_semantic_rules(recipe):
     assert not errors, f"Structural validation errors: {errors}"
     findings = run_semantic_rules(recipe)
     _KNOWN_NON_CONFORMING = {"audit-impl-remediation-route"}
+    fired_rules = {f.rule for f in findings if f.severity == Severity.ERROR}
+    for rule_name in _KNOWN_NON_CONFORMING:
+        assert rule_name in fired_rules, (
+            f"Exclusion for '{rule_name}' is stale — rule no longer fires. "
+            f"Remove from _KNOWN_NON_CONFORMING."
+        )
     error_findings = [
         f for f in findings if f.severity == Severity.ERROR and f.rule not in _KNOWN_NON_CONFORMING
     ]

--- a/tests/recipe/test_rules_registry.py
+++ b/tests/recipe/test_rules_registry.py
@@ -49,10 +49,14 @@ def test_bundled_workflows_pass_semantic_rules() -> None:
     yaml_files = list(wf_dir.glob("*.yaml"))
     assert yaml_files
 
+    _KNOWN_NON_CONFORMING: dict[str, set[str]] = {
+        "research.yaml": {"audit-impl-remediation-route"},
+    }
     for path in yaml_files:
         wf = load_recipe(path)
         findings = run_semantic_rules(wf)
-        errors = [f for f in findings if f.severity == Severity.ERROR]
+        excluded = _KNOWN_NON_CONFORMING.get(path.name, set())
+        errors = [f for f in findings if f.severity == Severity.ERROR and f.rule not in excluded]
         assert not errors, (
             f"Bundled workflow {path.name} has error-severity semantic findings: {errors}"
         )

--- a/tests/recipe/test_rules_registry.py
+++ b/tests/recipe/test_rules_registry.py
@@ -56,6 +56,13 @@ def test_bundled_workflows_pass_semantic_rules() -> None:
         wf = load_recipe(path)
         findings = run_semantic_rules(wf)
         excluded = _KNOWN_NON_CONFORMING.get(path.name, set())
+        if excluded:
+            fired_rules = {f.rule for f in findings if f.severity == Severity.ERROR}
+            for rule_name in excluded:
+                assert rule_name in fired_rules, (
+                    f"Recipe '{path.name}': exclusion for '{rule_name}' is stale — "
+                    f"rule no longer fires. Remove from _KNOWN_NON_CONFORMING."
+                )
         errors = [f for f in findings if f.severity == Severity.ERROR and f.rule not in excluded]
         assert not errors, (
             f"Bundled workflow {path.name} has error-severity semantic findings: {errors}"

--- a/tests/recipe/test_rules_remediation.py
+++ b/tests/recipe/test_rules_remediation.py
@@ -237,12 +237,13 @@ def test_audit_impl_remediation_route_message_names_step() -> None:
 
 def test_bundled_recipes_conforming_pass_audit_impl_remediation_route() -> None:
     recipes_dir = builtin_recipes_dir()
-    non_conforming = {"research.yaml", "research-implement.yaml"}
+    non_conforming = {"research.yaml"}
     conforming = {
         "implementation.yaml",
         "implementation-groups.yaml",
         "remediation.yaml",
         "merge-prs.yaml",
+        "research-implement.yaml",
     }
 
     for name in non_conforming:

--- a/tests/recipe/test_rules_remediation.py
+++ b/tests/recipe/test_rules_remediation.py
@@ -1,0 +1,264 @@
+"""Tests for audit-impl-remediation-route semantic validation rule.
+
+Verifies that recipe steps invoking audit-impl that capture remediation_path
+must have at least one non-GO on_result route targeting a non-terminal step.
+Routing all non-GO outcomes to a terminal stop discards the remediation file,
+breaking the closed-loop audit-remediate-replan cycle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types import Severity
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.schema import (
+    Recipe,
+    RecipeStep,
+    StepResultCondition,
+    StepResultRoute,
+)
+from autoskillit.recipe.validator import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
+    return Recipe(name="test", description="test", steps=steps, kitchen_rules=["test"])
+
+
+def _broken_remediation_steps() -> dict[str, RecipeStep]:
+    return {
+        "audit_impl": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:audit-impl ${{ inputs.plan }}"},
+            capture={"remediation_path": "${{ result.remediation_path }}"},
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="run_experiment",
+                        when="${{ result.verdict }} == GO",
+                    ),
+                    StepResultCondition(
+                        route="escalate_stop",
+                        when=None,
+                    ),
+                ]
+            ),
+        ),
+        "escalate_stop": RecipeStep(action="stop"),
+        "run_experiment": RecipeStep(tool="run_cmd"),
+    }
+
+
+def _correct_remediation_steps() -> dict[str, RecipeStep]:
+    return {
+        "audit_impl": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:audit-impl ${{ inputs.plan }}"},
+            capture={"remediation_path": "${{ result.remediation_path }}"},
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="push",
+                        when="${{ result.verdict }} == GO",
+                    ),
+                    StepResultCondition(
+                        route="remediate",
+                        when=None,
+                    ),
+                ]
+            ),
+        ),
+        "remediate": RecipeStep(action="route", on_success="plan"),
+        "plan": RecipeStep(tool="run_cmd"),
+        "push": RecipeStep(tool="push_to_remote"),
+    }
+
+
+def _no_capture_steps() -> dict[str, RecipeStep]:
+    return {
+        "audit_impl": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:audit-impl ${{ inputs.plan }}"},
+            capture={"verdict": "${{ result.verdict }}"},
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="escalate_stop",
+                        when=None,
+                    ),
+                ]
+            ),
+        ),
+        "escalate_stop": RecipeStep(action="stop"),
+    }
+
+
+def _non_audit_impl_steps() -> dict[str, RecipeStep]:
+    return {
+        "some_skill": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:some-other-skill"},
+            capture={"remediation_path": "${{ result.remediation_path }}"},
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="escalate_stop",
+                        when=None,
+                    ),
+                ]
+            ),
+        ),
+        "escalate_stop": RecipeStep(action="stop"),
+    }
+
+
+def _field_routing_broken_steps() -> dict[str, RecipeStep]:
+    return {
+        "audit_impl": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:audit-impl"},
+            capture={"remediation_path": "${{ result.remediation_path }}"},
+            on_result=StepResultRoute(
+                field="verdict",
+                routes={
+                    "GO": "run_experiment",
+                    "NO GO": "escalate_stop",
+                },
+            ),
+        ),
+        "escalate_stop": RecipeStep(action="stop"),
+        "run_experiment": RecipeStep(tool="run_cmd"),
+    }
+
+
+def _field_routing_correct_steps() -> dict[str, RecipeStep]:
+    return {
+        "audit_impl": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:audit-impl"},
+            capture={"remediation_path": "${{ result.remediation_path }}"},
+            on_result=StepResultRoute(
+                field="verdict",
+                routes={
+                    "GO": "push",
+                    "NO GO": "remediate",
+                },
+            ),
+        ),
+        "remediate": RecipeStep(action="route", on_success="plan"),
+        "plan": RecipeStep(tool="run_cmd"),
+        "push": RecipeStep(tool="push_to_remote"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_audit_impl_remediation_route_fires_when_no_go_routes_to_terminal() -> None:
+    findings = run_semantic_rules(_make_recipe(_broken_remediation_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "audit-impl-remediation-route" in rule_names, (
+        "audit-impl-remediation-route must fire when audit-impl captures "
+        "remediation_path but routes all non-GO to a terminal stop step."
+    )
+
+
+def test_audit_impl_remediation_route_passes_when_no_go_routes_to_remediate() -> None:
+    findings = run_semantic_rules(_make_recipe(_correct_remediation_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "audit-impl-remediation-route" not in rule_names, (
+        "audit-impl-remediation-route must not fire when non-GO routes to "
+        "a non-terminal remediate step."
+    )
+
+
+def test_audit_impl_remediation_route_passes_when_no_remediation_path_captured() -> None:
+    findings = run_semantic_rules(_make_recipe(_no_capture_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "audit-impl-remediation-route" not in rule_names, (
+        "audit-impl-remediation-route must not fire when audit-impl does not "
+        "capture remediation_path."
+    )
+
+
+def test_audit_impl_remediation_route_ignores_non_audit_impl_steps() -> None:
+    findings = run_semantic_rules(_make_recipe(_non_audit_impl_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "audit-impl-remediation-route" not in rule_names, (
+        "audit-impl-remediation-route must not fire for non-audit-impl steps "
+        "even when they capture something resembling remediation_path."
+    )
+
+
+def test_audit_impl_remediation_route_fires_with_field_based_routing() -> None:
+    findings = run_semantic_rules(_make_recipe(_field_routing_broken_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "audit-impl-remediation-route" in rule_names, (
+        "audit-impl-remediation-route must fire with legacy field-based on_result "
+        "when NO GO routes to terminal."
+    )
+
+
+def test_audit_impl_remediation_route_passes_with_field_based_routing_to_remediate() -> None:
+    findings = run_semantic_rules(_make_recipe(_field_routing_correct_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "audit-impl-remediation-route" not in rule_names, (
+        "audit-impl-remediation-route must not fire with legacy field-based on_result "
+        "when NO GO routes to a non-terminal step."
+    )
+
+
+def test_audit_impl_remediation_route_severity_is_error() -> None:
+    findings = run_semantic_rules(_make_recipe(_broken_remediation_steps()))
+    remediation_findings = [f for f in findings if f.rule == "audit-impl-remediation-route"]
+    assert len(remediation_findings) >= 1
+    for finding in remediation_findings:
+        assert finding.severity == Severity.ERROR, (
+            f"audit-impl-remediation-route must be ERROR severity, got {finding.severity}"
+        )
+
+
+def test_audit_impl_remediation_route_message_names_step() -> None:
+    findings = run_semantic_rules(_make_recipe(_broken_remediation_steps()))
+    remediation_findings = [f for f in findings if f.rule == "audit-impl-remediation-route"]
+    assert len(remediation_findings) >= 1
+    finding = remediation_findings[0]
+    assert finding.step_name == "audit_impl", (
+        f"Finding must reference step 'audit_impl', got '{finding.step_name}'"
+    )
+    assert "remediation_path" in finding.message, (
+        f"Finding message must mention 'remediation_path', got: {finding.message}"
+    )
+
+
+def test_bundled_recipes_conforming_pass_audit_impl_remediation_route() -> None:
+    recipes_dir = builtin_recipes_dir()
+    non_conforming = {"research.yaml", "research-implement.yaml"}
+    conforming = {
+        "implementation.yaml",
+        "implementation-groups.yaml",
+        "remediation.yaml",
+        "merge-prs.yaml",
+    }
+
+    for name in non_conforming:
+        recipe = load_recipe(recipes_dir / name)
+        findings = run_semantic_rules(recipe)
+        rule_names = [f.rule for f in findings]
+        assert "audit-impl-remediation-route" in rule_names, (
+            f"{name} captures remediation_path but routes all non-GO to terminal "
+            f"(pending #2409 fix). Rule must fire."
+        )
+
+    for name in conforming:
+        recipe = load_recipe(recipes_dir / name)
+        findings = run_semantic_rules(recipe)
+        rule_names = [f.rule for f in findings]
+        assert "audit-impl-remediation-route" not in rule_names, (
+            f"{name} must not trigger audit-impl-remediation-route — it routes "
+            f"non-GO to a non-terminal step."
+        )

--- a/tests/recipe/test_rules_remediation.py
+++ b/tests/recipe/test_rules_remediation.py
@@ -238,28 +238,19 @@ def test_audit_impl_remediation_route_message_names_step() -> None:
 def test_bundled_recipes_conforming_pass_audit_impl_remediation_route() -> None:
     recipes_dir = builtin_recipes_dir()
     non_conforming = {"research.yaml"}
-    conforming = {
-        "implementation.yaml",
-        "implementation-groups.yaml",
-        "remediation.yaml",
-        "merge-prs.yaml",
-        "research-implement.yaml",
-    }
+    all_recipes = sorted(p.name for p in recipes_dir.glob("*.yaml"))
 
-    for name in non_conforming:
+    for name in all_recipes:
         recipe = load_recipe(recipes_dir / name)
         findings = run_semantic_rules(recipe)
         rule_names = [f.rule for f in findings]
-        assert "audit-impl-remediation-route" in rule_names, (
-            f"{name} captures remediation_path but routes all non-GO to terminal "
-            f"(pending #2409 fix). Rule must fire."
-        )
-
-    for name in conforming:
-        recipe = load_recipe(recipes_dir / name)
-        findings = run_semantic_rules(recipe)
-        rule_names = [f.rule for f in findings]
-        assert "audit-impl-remediation-route" not in rule_names, (
-            f"{name} must not trigger audit-impl-remediation-route — it routes "
-            f"non-GO to a non-terminal step."
-        )
+        if name in non_conforming:
+            assert "audit-impl-remediation-route" in rule_names, (
+                f"{name} captures remediation_path but routes all non-GO to terminal "
+                f"(pending #2409 fix). Rule must fire."
+            )
+        else:
+            assert "audit-impl-remediation-route" not in rule_names, (
+                f"{name} must not trigger audit-impl-remediation-route — it routes "
+                f"non-GO to a non-terminal step."
+            )


### PR DESCRIPTION
## Summary

Add a new semantic validation rule `audit-impl-remediation-route` in `src/autoskillit/recipe/rules/rules_remediation.py` that prevents any recipe from capturing `remediation_path` from an `audit-impl` skill step without providing at least one non-terminal route for non-GO verdicts. This structural guard ensures the remediation file produced on NO GO is always consumable by a downstream step, preventing dead-context captures.

## Requirements

### REQ-VAL-001: Add `audit-impl-remediation-route` validation rule

Add a semantic rule in `recipe/rules/` that validates: any recipe step invoking the `audit-impl` skill that captures `remediation_path` MUST have at least one `on_result` route for non-GO verdicts that is NOT a terminal stop action (`escalate_stop`, `stop`, etc.).

### REQ-VAL-002: Generalize to skill-output-route-consistency (optional stretch)

Consider generalizing: any recipe step that captures a skill output intended for downstream consumption (identifiable by naming convention or skill contract metadata) should have a non-terminal route that can consume it. This prevents future dead-context captures for other skills with remediation-like outputs.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260513-053941-070471/.autoskillit/temp/make-plan/add_cross_recipe_validation_rule_audit_impl_remediation_route_plan_2026-05-13_055000.md`

## Changes

### New files
- `src/autoskillit/recipe/rules/rules_remediation.py`
- `tests/recipe/test_rules_remediation.py`

### Modified files
- `pyproject.toml`
- `src/autoskillit/.claude-plugin/plugin.json`
- `src/autoskillit/recipe/__init__.py`
- `src/autoskillit/recipe/rules/CLAUDE.md`
- `src/autoskillit/recipe/rules/rules_worktree.py`
- `src/autoskillit/recipes/contracts/research-implement.json`
- `src/autoskillit/recipes/contracts/research-implement.yaml`
- `src/autoskillit/recipes/research-implement.json`
- `src/autoskillit/recipes/research-implement.yaml`
- `tests/arch/test_subpackage_isolation.py`
- `tests/docs/test_doc_counts.py`
- `tests/recipe/CLAUDE.md`
- `tests/recipe/test_bundled_recipes_dispatch_ready.py`
- `tests/recipe/test_research_audit_impl.py`
- `tests/recipe/test_research_context_tracking.py`
- `tests/recipe/test_research_download_data_step.py`
- `tests/recipe/test_research_stage_data_step.py`
- `tests/recipe/test_rules_registry.py`
- `tests/recipe/test_rules_worktree.py`
- `uv.lock`

Closes #2410

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 69 | 9.3k | 770.2k | 95.2k | 92 | 72.4k | 5m 42s |
| verify | claude-opus-4-6 | 1 | 946 | 13.6k | 1.2M | 65.6k | 124 | 54.0k | 8m 6s |
| implement* | MiniMax-M2.7 | 1 | 69.7k | 9.2k | 1.2M | 21.1k | 88 | 0 | 11m 8s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.3k | 3.7k | 238.0k | 0 | 19 | 0 | 1m 9s |
| compose_pr* | MiniMax-M2.7 | 1 | 53.8k | 2.5k | 385.4k | 28.8k | 30 | 41.1k | 3m 14s |
| review_pr | claude-opus-4-6 | 3 | 108 | 71.2k | 2.0M | 94.5k | 187 | 240.2k | 22m 39s |
| resolve_review | claude-opus-4-6 | 3 | 171 | 28.9k | 3.3M | 73.2k | 161 | 157.9k | 13m 6s |
| **Total** | | | 167.1k | 138.3k | 9.2M | 95.2k | | 565.7k | 1h 5m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 346 | 3560.0 | 0.0 | 26.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 86 | 38929.8 | 1836.3 | 336.4 |
| **Total** | **432** | 21288.9 | 1309.4 | 320.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 69 | 9.3k | 770.2k | 72.4k | 5m 42s |
| claude-opus-4-6 | 2 | 1.0k | 27.2k | 5.4M | 168.1k | 14m 55s |
| MiniMax-M2.7 | 3 | 165.8k | 15.3k | 1.9M | 41.1k | 15m 33s |