### PR TITLE
Stale Cascade Path — infra/test_quota_check.py → hooks/test_quota_check.py

### DIFF
--- a/.autoskillit/test-source-map.json
+++ b/.autoskillit/test-source-map.json
@@ -649,7 +649,7 @@
     "tests/infra/test_hook_executability.py",
     "tests/infra/test_hook_settings.py",
     "tests/infra/test_pretty_output_integration.py",
-    "tests/infra/test_quota_check.py",
+    "tests/hooks/test_quota_check.py",
     "tests/migration/test_api.py",
     "tests/migration/test_engine.py",
     "tests/migration/test_loader.py",
@@ -874,7 +874,7 @@
     "tests/infra/test_open_kitchen_guard.py",
     "tests/infra/test_pretty_output.py",
     "tests/infra/test_pretty_output_integration.py",
-    "tests/infra/test_quota_check.py",
+    "tests/hooks/test_quota_check.py",
     "tests/infra/test_token_summary_appender.py",
     "tests/migration/test_engine.py",
     "tests/pipeline/test_gate.py",
@@ -1317,7 +1317,7 @@
     "tests/execution/test_session_log.py",
     "tests/execution/test_session_log_integration.py",
     "tests/franchise/test_franchise_e2e.py",
-    "tests/infra/test_quota_check.py",
+    "tests/hooks/test_quota_check.py",
     "tests/server/test_factory_recording.py",
     "tests/server/test_headless_session.py",
     "tests/server/test_lifespan.py",
@@ -1427,7 +1427,7 @@
   "src/autoskillit/hooks/_hook_settings.py": [
     "tests/execution/test_quota.py",
     "tests/infra/test_hook_settings.py",
-    "tests/infra/test_quota_check.py",
+    "tests/hooks/test_quota_check.py",
     "tests/infra/test_quota_post_check.py"
   ],
   "src/autoskillit/hooks/franchise_dispatch_guard.py": [
@@ -1451,7 +1451,7 @@
   ],
   "src/autoskillit/hooks/quota_guard.py": [
     "tests/execution/test_quota.py",
-    "tests/infra/test_quota_check.py"
+    "tests/hooks/test_quota_check.py"
   ],
   "src/autoskillit/hooks/quota_post_hook.py": [
     "tests/infra/test_quota_post_check.py"

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -287,7 +287,7 @@ MODULE_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
             "execution",
             "server",
             "cli",
-            "infra/test_quota_check.py",
+            "hooks/test_quota_check.py",
         }
     ),
     "linux_tracing": frozenset(

--- a/tests/infra/test_filter_activation.py
+++ b/tests/infra/test_filter_activation.py
@@ -84,6 +84,25 @@ def test_build_test_scope_returns_full_run_reason_for_bucket_a():
     assert result is FullRunReason.BUCKET_A
 
 
+def test_quota_check_not_in_infra() -> None:
+    """test_quota_check.py was moved to hooks/; assert no stale infra/ reference remains."""
+    assert not (REPO_ROOT / "tests/infra/test_quota_check.py").is_file()
+    assert (REPO_ROOT / "tests/hooks/test_quota_check.py").is_file()
+
+
+def test_source_map_quota_check_path_is_hooks() -> None:
+    """Committed source map must reference hooks/, not infra/, for test_quota_check.py."""
+    map_path = REPO_ROOT / ".autoskillit/test-source-map.json"
+    assert map_path.is_file(), "committed test-source-map.json must exist"
+    raw = map_path.read_text()
+    assert "tests/infra/test_quota_check.py" not in raw, (
+        "stale tests/infra/test_quota_check.py found in .autoskillit/test-source-map.json"
+    )
+    assert "tests/hooks/test_quota_check.py" in raw, (
+        "tests/hooks/test_quota_check.py not found in .autoskillit/test-source-map.json"
+    )
+
+
 def test_build_test_scope_returns_full_run_reason_for_unmapped():
     from tests._test_filter import FilterMode, FullRunReason, build_test_scope
 

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -241,6 +241,19 @@ class TestRecipeCascadeNarrowing:
         assert "test_fleet_cli.py" not in result_names
 
 
+def test_session_log_cascade_targets_hooks_quota_check() -> None:
+    """session_log cascade must point to hooks/ after test_quota_check.py was moved."""
+    from tests._test_filter import MODULE_CASCADE_EXECUTION
+
+    targets = MODULE_CASCADE_EXECUTION["session_log"]
+    assert "hooks/test_quota_check.py" in targets, (
+        "session_log cascade must include hooks/test_quota_check.py"
+    )
+    assert "infra/test_quota_check.py" not in targets, (
+        "stale infra/test_quota_check.py still present in session_log cascade"
+    )
+
+
 class TestServerFleetCascadeNarrowing:
     """REQ-FLEET-002: server cascade targets only fleet/test_pack_enforcement.py."""
 


### PR DESCRIPTION
## Summary

`test_quota_check.py` has been physically moved to `tests/hooks/test_quota_check.py`, but two artifacts still reference the old `tests/infra/` path:

1. **`tests/_test_filter.py` line 290** — `MODULE_CASCADE_EXECUTION["session_log"]` still contains `"infra/test_quota_check.py"`. When any `session_log`-tagged source file changes, the filter tries to include a non-existent file and silently drops the quota check tests.

2. **`.autoskillit/test-source-map.json`** — four occurrences of `"tests/infra/test_quota_check.py"` remain (lines 652, 877, 1320, 1430, 1454). The aggressive filter uses this committed oracle to narrow test scope; stale entries cause it to target a non-existent file, again dropping the quota check tests.

Both fixes are one-line (or one-string replace-all) edits. A new cascade-correctness test is added to prevent silent regression of this class of stale-path error.

Closes #2374

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260515-075836-287384/.autoskillit/temp/make-plan/stale_cascade_path_quota_check_plan_2026-05-15_080500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 121 | 13.6k | 515.2k | 51.5k | 78 | 39.0k | 7m 4s |
| verify | claude-sonnet-4-6 | 1 | 100 | 9.2k | 417.8k | 47.4k | 40 | 33.4k | 2m 27s |
| implement* | MiniMax-M2.7-highspeed | 1 | 321.8k | 5.0k | 518.1k | 28.8k | 53 | 42.6k | 2m 1s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 72.9k | 3.2k | 209.0k | 29.9k | 19 | 42.5k | 1m 20s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 55.4k | 1.7k | 236.0k | 29.9k | 16 | 15.4k | 43s |
| review_pr | claude-sonnet-4-6 | 4 | 432 | 52.0k | 2.0M | 53.9k | 154 | 148.6k | 13m 45s |
| resolve_review | claude-sonnet-4-6 | 1 | 149 | 9.3k | 697.5k | 50.9k | 41 | 37.0k | 3m 30s |
| **Total** | | | 450.9k | 94.0k | 4.6M | 53.9k | | 358.6k | 30m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 44 | 11775.3 | 968.3 | 113.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **44** | 104583.4 | 8149.2 | 2135.2 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 221 | 22.7k | 933.0k | 72.4k | 9m 31s |
| MiniMax-M2.7-highspeed | 3 | 450.1k | 9.9k | 963.2k | 100.5k | 4m 4s |