### PR TITLE
[FEATURE] Cap Total Subagent Spawns at 9 in Investigate Skill

### DIFF
--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -79,6 +79,7 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 
 **ALWAYS:**
 - Use subagents for parallel exploration
+- Limit total subagent spawns to 9 across all batches (standard and deep mode). If the investigation requires more exploration vectors, consolidate related questions into fewer, broader subagent prompts rather than spawning additional agents.
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Write findings as a markdown report with unique name to `{{AUTOSKILLIT_TEMP}}/investigate/` directory (relative to the current working directory)
 - After writing the investigation report, emit the **absolute path** as a structured output

--- a/tests/skills/test_investigate_contracts.py
+++ b/tests/skills/test_investigate_contracts.py
@@ -172,3 +172,23 @@ def test_investigate_historical_step_reads_prior_diffs(step_35_section: str) -> 
         "or 'git log -p' so it can compare the prior fix approach against the current "
         "root cause"
     )
+
+
+def test_investigate_always_caps_subagent_spawns(skill_text: str) -> None:
+    """ALWAYS constraints must cap total subagent spawns at 9 across all batches."""
+    always_idx = skill_text.find("**ALWAYS:**")
+    assert always_idx != -1, "ALWAYS constraints block not found in investigate SKILL.md"
+    next_section_idx = skill_text.find("\n## ", always_idx)
+    always_block = (
+        skill_text[always_idx:next_section_idx]
+        if next_section_idx != -1
+        else skill_text[always_idx:]
+    )
+    has_numeric_cap = "9" in always_block
+    has_spawn_language = (
+        "subagent spawn" in always_block.lower() or "total subagent" in always_block.lower()
+    )
+    assert has_numeric_cap and has_spawn_language, (
+        "ALWAYS constraints must include a rule capping total subagent spawns at 9 "
+        "across all batches (standard and deep mode)"
+    )

--- a/tests/skills/test_investigate_contracts.py
+++ b/tests/skills/test_investigate_contracts.py
@@ -6,6 +6,8 @@ history scan, and conditional analysis between Step 3 (Synthesize) and
 Step 4 (Write Report).
 """
 
+import re
+
 import pytest
 
 
@@ -184,11 +186,14 @@ def test_investigate_always_caps_subagent_spawns(skill_text: str) -> None:
         if next_section_idx != -1
         else skill_text[always_idx:]
     )
-    has_numeric_cap = "9" in always_block
-    has_spawn_language = (
-        "subagent spawn" in always_block.lower() or "total subagent" in always_block.lower()
+    has_spawn_cap_nine = bool(
+        re.search(
+            r"(?:total\s+subagent\s+spawns|subagent\s+spawns).*?\b9\b"
+            r"|\b9\b.*?(?:total\s+subagent|subagent\s+spawn)",
+            always_block.lower(),
+        )
     )
-    assert has_numeric_cap and has_spawn_language, (
+    assert has_spawn_cap_nine, (
         "ALWAYS constraints must include a rule capping total subagent spawns at 9 "
         "across all batches (standard and deep mode)"
     )


### PR DESCRIPTION
## Summary

Add a single ALWAYS rule to `investigate/SKILL.md`'s Critical Constraints section capping total subagent spawns at 9 across all batches in both standard and deep mode. Add a contract test to verify the constraint is present and structurally correct.

## Requirements

## Problem

The investigate skill has no limit on how many subagents it can spawn. In session 168c9f5f (issue #2333), 11 subagents were launched across 4 batches, generating ~112KB of verbose output that saturated the 200K context window on Sonnet (peak: 172K tokens). The session never reached Step 4 (Write Report) — 0 write calls.

Historical investigate sessions peak at 58K–116K tokens. This session was a 2x outlier driven by uncapped agent count on a cross-cutting topic.

## Proposed Change

Add a rule to the investigate skill's SKILL.md capping total subagent spawns at 9 across all batches (standard and deep mode). Add the constraint to the **Critical Constraints** section as an ALWAYS rule:

> ALWAYS: Limit total subagent spawns to 9 across all batches (standard and deep mode). If the investigation requires more exploration vectors, consolidate related questions into fewer, broader subagent prompts rather than spawning additional agents.

## Evidence

- Session 168c9f5f: 11 agents, 4 batches, peak 172K, context_exhausted
- All successful investigate sessions: 58K–116K peak context
- The 4th batch (2 agents, 25KB output) pushed context past the point of no return — the session was already at ~140K before batch 4 fired

## Architecture Impact

This change adds a guardrail to the investigate skill to prevent excessive subagent spawning. The skill operates within its existing batch architecture; no new components are introduced.

## Changed Files

- `src/autoskillit/skills_extended/investigate/SKILL.md` — add ALWAYS rule
- `tests/skills/test_investigate_contracts.py` — add contract test

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260515-075836-503978/.autoskillit/temp/make-plan/cap_subagent_spawns_plan_2026-05-15_080202.md`

Closes #2357

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 147 | 8.3k | 699.2k | 67.6k | 71 | 56.3k | 4m 6s |
| verify | claude-sonnet-4-6 | 1 | 60 | 5.4k | 240.0k | 51.4k | 20 | 38.3k | 1m 44s |
| implement* | MiniMax-M2.7-highspeed | 1 | 169.1k | 2.7k | 319.2k | 34.3k | 24 | 32.7k | 1m 19s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 48.6k | 3.6k | 176.3k | 29.9k | 20 | 15.5k | 1m 12s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.2k | 1.4k | 206.1k | 29.9k | 14 | 15.4k | 41s |
| review_pr | claude-sonnet-4-6 | 4 | 576 | 36.4k | 1.4M | 43.9k | 120 | 123.5k | 9m 34s |
| resolve_review | claude-sonnet-4-6 | 1 | 165 | 11.0k | 901.9k | 56.8k | 51 | 43.9k | 4m 49s |
| **Total** | | | 265.8k | 68.9k | 4.0M | 67.6k | | 325.5k | 23m 27s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 21 | 15201.8 | 1558.0 | 130.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 69379.6 | 3374.8 | 843.7 |
| **Total** | **34** | 116939.7 | 9574.1 | 2025.3 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 207 | 13.7k | 939.2k | 94.6k | 5m 50s |
| MiniMax-M2.7-highspeed | 3 | 264.9k | 7.8k | 701.6k | 63.6k | 3m 11s |