### PR TITLE
Narrow Over-Broad Test Cascade Entries for Execution and Recipe Layers

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -532,6 +532,10 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "cli",
         }
     ),
+    # skills/test_skill_output_compliance.py is intentionally absent: headless and process
+    # subpackages carry it via SUBPKG_CASCADE_EXECUTION. The fallthrough path covers
+    # execution modules that are not headless/process, so skills compliance testing is
+    # out of scope for generic execution changes.
     "execution": frozenset(
         {
             "execution",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -307,11 +307,38 @@ MODULE_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
             "cli/test_reload_loop.py",
         }
     ),
-    # headless and process are NOT listed — they fall through to cascade_map["execution"]
 }
 
 SUBPKG_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
     "merge_queue": frozenset({"execution"}),
+    "headless": frozenset(
+        {
+            "execution",
+            "core",
+            "workspace",
+            "migration",
+            "server",
+            "cli",
+            "infra/test_pretty_output_hook_infra.py",
+            "skills/test_skill_output_compliance.py",
+            "_llm_triage",
+            "smoke_utils",
+        }
+    ),
+    "process": frozenset(
+        {
+            "execution",
+            "core",
+            "workspace",
+            "migration",
+            "server",
+            "cli",
+            "infra/test_pretty_output_hook_infra.py",
+            "skills/test_skill_output_compliance.py",
+            "_llm_triage",
+            "smoke_utils",
+        }
+    ),
 }
 
 MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
@@ -513,8 +540,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "migration",
             "server",
             "cli",
-            "infra",
-            "skills",
+            "infra/test_pretty_output_hook_infra.py",
             "_llm_triage",
             "smoke_utils",
         }
@@ -547,7 +573,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "recipe",
             "_llm_triage",
             "core",
-            "hooks",
+            "hooks/test_recipe_contract_freshness.py",
             "migration",
             # Server file-level entries (9 of 52 import autoskillit.recipe):
             "server/test_factory.py",
@@ -1242,7 +1268,7 @@ def build_test_scope(
                     else:
                         test_dirs.update(
                             cascade_map["execution"]
-                        )  # fail-open: headless, process, unknown
+                        )  # fail-open: unknown execution modules
             elif pkg == "recipe" and mode == FilterMode.CONSERVATIVE:
                 stem = Path(f).stem
                 if stem in MODULE_CASCADE_RECIPE:

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -229,6 +229,7 @@ class TestBuildTestScope:
             "docs",
         ]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)
+        (tests_root / "infra" / "test_pretty_output_hook_infra.py").touch()
 
         result = build_test_scope(
             changed_files={"src/autoskillit/execution/headless.py"},
@@ -236,7 +237,7 @@ class TestBuildTestScope:
             tests_root=tests_root,
         )
         assert result is not None
-        dir_names = {p.name for p in result}
+        result_names = {p.name for p in result}
         for expected in [
             "execution",
             "core",
@@ -244,10 +245,13 @@ class TestBuildTestScope:
             "migration",
             "server",
             "cli",
-            "infra",
-            "skills",
         ]:
-            assert expected in dir_names, f"{expected} missing from cascade"
+            assert expected in result_names, f"{expected} missing from cascade"
+        assert "test_pretty_output_hook_infra.py" in result_names, (
+            "infra file missing from cascade"
+        )
+        assert "infra" not in result_names, "whole infra/ dir should not be in cascade"
+        assert "skills" not in result_names, "skills/ dir should not be in execution layer cascade"
 
     def test_scope_l2_recipe_conservative(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"
@@ -263,6 +267,7 @@ class TestBuildTestScope:
             "migration/test_api.py",
             "migration/test_engine.py",
             "hooks/test_recipe_write_advisor.py",
+            "hooks/test_recipe_contract_freshness.py",
             "infra/test_pretty_output_recipe.py",
             "skills/test_planner_skill_contracts.py",
             "skills/test_skill_placeholder_contracts.py",
@@ -293,14 +298,14 @@ class TestBuildTestScope:
             "test_zero_write_detection.py",
             "test_pretty_output_recipe.py",
             "test_skill_placeholder_contracts.py",
-            # hooks/test_recipe_write_advisor.py is covered by the directory-level "hooks" entry
-            "hooks",
+            "test_recipe_contract_freshness.py",
             "core",
             "migration",
         ]:
             assert expected in result_names, f"{expected} missing"
         for absent in [
             "execution",
+            "hooks",
             "infra",
             "skills",
             "server",

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -240,6 +240,24 @@ class TestRecipeCascadeNarrowing:
             assert fname in result_names, f"{fname!r} missing from recipe cascade result"
         assert "test_fleet_cli.py" not in result_names
 
+    def test_recipe_layer_uses_hooks_file_not_dir(self, tmp_path: Path) -> None:
+        """recipe/__init__.py change → hooks/test_recipe_contract_freshness.py in scope; hooks/ dir NOT."""
+        tests_root = tmp_path / "tests"
+        hooks_dir = tests_root / "hooks"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        (hooks_dir / "test_recipe_contract_freshness.py").touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/recipe/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        path_names = {p.name for p in result}
+        assert "test_recipe_contract_freshness.py" in path_names, (
+            "recipe layer must include hooks/test_recipe_contract_freshness.py"
+        )
+        assert "hooks" not in path_names, "recipe layer must not include the entire hooks/ dir"
+
 
 class TestServerFleetCascadeNarrowing:
     """REQ-FLEET-002: server cascade targets only fleet/test_pack_enforcement.py."""

--- a/tests/test_test_filter_execution_cascade.py
+++ b/tests/test_test_filter_execution_cascade.py
@@ -178,6 +178,76 @@ class TestBuildTestScopeExecutionCascade:
                 f"AGGRESSIVE mode should not widen execution cascade to {excluded}"
             )
 
+    def test_headless_includes_skills_compliance_test(self, tmp_path: Path) -> None:
+        """headless.py change → skills compliance file; skills/ dir excluded."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        (tests_root / "skills" / "test_skill_output_compliance.py").touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/headless/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        paths = {p for p in result}
+        path_names = {p.name for p in paths}
+        assert any(p.name == "test_skill_output_compliance.py" for p in paths), (
+            "headless change must include test_skill_output_compliance.py"
+        )
+        assert "skills" not in path_names, (
+            "headless change must NOT include the entire skills/ dir"
+        )
+
+    def test_process_includes_skills_compliance_test(self, tmp_path: Path) -> None:
+        """process/*.py change → skills compliance file; skills/ dir excluded."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        (tests_root / "skills" / "test_skill_output_compliance.py").touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/process/runner.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        paths = {p for p in result}
+        path_names = {p.name for p in paths}
+        assert any(p.name == "test_skill_output_compliance.py" for p in paths)
+        assert "skills" not in path_names
+
+    def test_other_execution_module_excludes_skills(self, tmp_path: Path) -> None:
+        """anomaly_detection.py change → no skills/ path (neither dir nor compliance file)."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        (tests_root / "skills" / "test_skill_output_compliance.py").touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/anomaly_detection.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        paths = {p for p in result}
+        path_names = {p.name for p in paths}
+        assert "skills" not in path_names
+        assert not any(p.name == "test_skill_output_compliance.py" for p in paths)
+
+    def test_execution_fallthrough_uses_infra_file_not_dir(self, tmp_path: Path) -> None:
+        """Execution-layer fallthrough uses infra file-level entry, not whole infra/ dir.
+
+        Uses execution/__init__.py: its stem (__init__) is absent from MODULE_CASCADE_EXECUTION
+        and the file is not inside a subdirectory covered by SUBPKG_CASCADE_EXECUTION, so it
+        truly falls through to LAYER_CASCADE_CONSERVATIVE["execution"].
+        """
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        (tests_root / "infra" / "test_pretty_output_hook_infra.py").touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        path_names = {p.name for p in result}
+        assert "infra" not in path_names, "execution layer fallthrough must not include infra/ dir"
+        assert "test_pretty_output_hook_infra.py" in path_names, (
+            "execution layer fallthrough must include infra/test_pretty_output_hook_infra.py"
+        )
+
 
 class TestClosureExecutionNarrowCascade:
     """__init__.py closure expansion for execution package."""
@@ -386,3 +456,15 @@ class TestSubpkgCascadeExecution:
         """SUBPKG_CASCADE_EXECUTION is importable and contains 'merge_queue' key."""
         assert "merge_queue" in SUBPKG_CASCADE_EXECUTION
         assert SUBPKG_CASCADE_EXECUTION["merge_queue"] == frozenset({"execution"})
+
+
+def test_headless_and_process_in_subpkg_cascade() -> None:
+    """headless and process must be explicit entries in SUBPKG_CASCADE_EXECUTION.
+
+    Files inside execution/headless/ and execution/process/ are detected by
+    _file_to_execution_subpkg(), which returns the directory name. The router
+    checks SUBPKG_CASCADE_EXECUTION first — MODULE_CASCADE_EXECUTION (stem-keyed)
+    is never reached for subpackage files.
+    """
+    assert "headless" in SUBPKG_CASCADE_EXECUTION, "headless must have explicit cascade entry"
+    assert "process" in SUBPKG_CASCADE_EXECUTION, "process must have explicit cascade entry"

--- a/tests/test_test_filter_execution_cascade.py
+++ b/tests/test_test_filter_execution_cascade.py
@@ -182,6 +182,7 @@ class TestBuildTestScopeExecutionCascade:
         """headless.py change → skills compliance file; skills/ dir excluded."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         (tests_root / "skills" / "test_skill_output_compliance.py").touch()
+        (tests_root / "infra" / "test_pretty_output_hook_infra.py").touch()
         result = build_test_scope(
             changed_files={"src/autoskillit/execution/headless/__init__.py"},
             mode=FilterMode.CONSERVATIVE,
@@ -193,6 +194,9 @@ class TestBuildTestScopeExecutionCascade:
         assert any(p.name == "test_skill_output_compliance.py" for p in paths), (
             "headless change must include test_skill_output_compliance.py"
         )
+        assert any(p.name == "test_pretty_output_hook_infra.py" for p in paths), (
+            "headless change must include infra/test_pretty_output_hook_infra.py"
+        )
         assert "skills" not in path_names, (
             "headless change must NOT include the entire skills/ dir"
         )
@@ -201,6 +205,7 @@ class TestBuildTestScopeExecutionCascade:
         """process/*.py change → skills compliance file; skills/ dir excluded."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         (tests_root / "skills" / "test_skill_output_compliance.py").touch()
+        (tests_root / "infra" / "test_pretty_output_hook_infra.py").touch()
         result = build_test_scope(
             changed_files={"src/autoskillit/execution/process/runner.py"},
             mode=FilterMode.CONSERVATIVE,
@@ -210,6 +215,9 @@ class TestBuildTestScopeExecutionCascade:
         paths = {p for p in result}
         path_names = {p.name for p in paths}
         assert any(p.name == "test_skill_output_compliance.py" for p in paths)
+        assert any(p.name == "test_pretty_output_hook_infra.py" for p in paths), (
+            "process change must include infra/test_pretty_output_hook_infra.py"
+        )
         assert "skills" not in path_names
 
     def test_other_execution_module_excludes_skills(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Three entries in `tests/_test_filter.py` pull in entire test directories when only one or two
files in each directory actually import from the relevant source packages. This plan narrows
those entries to file-level precision, reducing unnecessary test runs without losing coverage.

| Entry | Current | Proposed |
|-------|---------|----------|
| `LAYER_CASCADE_CONSERVATIVE["execution"]` → infra | `"infra"` (47 files) | `"infra/test_pretty_output_hook_infra.py"` |
| `LAYER_CASCADE_CONSERVATIVE["execution"]` → skills | `"skills"` (62 files) | removed from layer; added to new `headless`/`process` SUBPKG entries |
| `LAYER_CASCADE_CONSERVATIVE["recipe"]` → hooks | `"hooks"` (18 files) | `"hooks/test_recipe_contract_freshness.py"` |

Closes #2375

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260515-075837-986443/.autoskillit/temp/make-plan/narrow_cascade_entries_plan_2026-05-15_080000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 131 | 18.8k | 557.1k | 56.3k | 55 | 47.9k | 7m 21s |
| verify | claude-sonnet-4-6 | 1 | 324 | 44.5k | 2.9M | 102.6k | 103 | 88.7k | 14m 7s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.3M | 18.4k | 1.3M | 28.8k | 101 | 46.3k | 9m 14s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 113.2k | 3.2k | 325.5k | 29.9k | 24 | 15.5k | 1m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 67.4k | 1.6k | 206.1k | 29.9k | 16 | 15.4k | 48s |
| review_pr | claude-sonnet-4-6 | 3 | 350 | 56.8k | 1.6M | 61.1k | 112 | 135.5k | 13m 35s |
| resolve_review | claude-sonnet-4-6 | 1 | 205 | 13.6k | 1.2M | 67.0k | 62 | 53.4k | 4m 42s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 65.5k | 1.9k | 149.3k | 29.9k | 13 | 42.3k | 45s |
| resolve_ci | claude-sonnet-4-6 | 1 | 255 | 16.1k | 1.7M | 73.3k | 74 | 59.2k | 5m 56s |
| **Total** | | | 1.6M | 174.8k | 10.0M | 102.6k | | 504.2k | 57m 53s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 136 | 9714.4 | 340.5 | 135.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 103721.8 | 4453.1 | 1132.5 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 17 | 98416.8 | 3480.5 | 947.0 |
| **Total** | **165** | 60830.0 | 3055.6 | 1059.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 455 | 63.3k | 3.5M | 136.6k | 21m 28s |
| MiniMax-M2.7-highspeed | 3 | 1.5M | 23.1k | 1.9M | 77.2k | 11m 24s |