### PR TITLE
Rectify: Diagnostic Lens Dataflow Immunity

### DIFF
--- a/src/autoskillit/recipe/_analysis_bfs.py
+++ b/src/autoskillit/recipe/_analysis_bfs.py
@@ -42,6 +42,11 @@ def _build_capture_origin_map(recipe: Recipe) -> dict[str, str]:
                 keys = RESULT_CAPTURE_RE.findall(cap_expr)
                 if len(keys) == 1:
                     origin[cap_var] = keys[0]
+        for cap_var, cap_expr in (step.capture_list or {}).items():
+            if isinstance(cap_expr, str):
+                keys = RESULT_CAPTURE_RE.findall(cap_expr)
+                if len(keys) == 1:
+                    origin[cap_var] = keys[0]
     return origin
 
 

--- a/src/autoskillit/recipe/_analysis_detectors.py
+++ b/src/autoskillit/recipe/_analysis_detectors.py
@@ -142,7 +142,7 @@ def _is_observability_capture(cap_key: str, step_name: str, step: RecipeStep) ->
     # merge_worktree cleanup_succeeded: matched by tool name + capture value,
     # not skill_command (merge_worktree is a direct tool, not a skill).
     if step.tool == "merge_worktree" and "result.cleanup_succeeded" in str(
-        step.capture.get(cap_key, "") or step.capture_list.get(cap_key, "")
+        (step.capture or {}).get(cap_key, "") or (step.capture_list or {}).get(cap_key, "")
     ):
         return True
 

--- a/src/autoskillit/recipe/_analysis_detectors.py
+++ b/src/autoskillit/recipe/_analysis_detectors.py
@@ -42,6 +42,8 @@ def _detect_ref_invalidations(recipe: Recipe, graph: dict[str, set[str]]) -> lis
     for step_name, step in recipe.steps.items():
         for cap_var in step.capture or {}:
             var_recapture_steps.setdefault(cap_var, set()).add(step_name)
+        for cap_var in step.capture_list or {}:
+            var_recapture_steps.setdefault(cap_var, set()).add(step_name)
 
     warnings: list[DataFlowWarning] = []
 
@@ -140,7 +142,7 @@ def _is_observability_capture(cap_key: str, step_name: str, step: RecipeStep) ->
     # merge_worktree cleanup_succeeded: matched by tool name + capture value,
     # not skill_command (merge_worktree is a direct tool, not a skill).
     if step.tool == "merge_worktree" and "result.cleanup_succeeded" in str(
-        step.capture.get(cap_key, "")
+        step.capture.get(cap_key, "") or step.capture_list.get(cap_key, "")
     ):
         return True
 
@@ -162,7 +164,7 @@ def _detect_dead_outputs(recipe: Recipe, graph: dict[str, set[str]]) -> list[Dat
     warnings: list[DataFlowWarning] = []
 
     for step_name, step in recipe.steps.items():
-        if not step.capture:
+        if not step.capture and not step.capture_list:
             continue
 
         # BFS: collect all steps reachable from this step
@@ -189,15 +191,18 @@ def _detect_dead_outputs(recipe: Recipe, graph: dict[str, set[str]]) -> list[Dat
         # as structural consumption of captured variables.
         if step.on_result:
             # Legacy field routing: field name matches a captured key
-            if step.on_result.field in step.capture:
+            if step.on_result.field in (step.capture or {}) or step.on_result.field in (
+                step.capture_list or {}
+            ):
                 consumed.add(step.on_result.field)
             # Predicate condition routing — conditions gate on step result;
             # treat all captured vars as structurally consumed.
             if step.on_result.conditions:
-                consumed.update(step.capture.keys())
+                consumed.update((step.capture or {}).keys())
+                consumed.update((step.capture_list or {}).keys())
 
         # Flag captured vars not consumed on any path
-        for cap_key in step.capture:
+        for cap_key in list(step.capture or {}) + list(step.capture_list or {}):
             if cap_key not in consumed:
                 if _is_observability_capture(cap_key, step_name, step):
                     continue
@@ -222,7 +227,7 @@ def _detect_implicit_handoffs(recipe: Recipe) -> list[DataFlowWarning]:
     warnings: list[DataFlowWarning] = []
 
     for step_name, step in recipe.steps.items():
-        if step.tool in SKILL_TOOLS and not step.capture:
+        if step.tool in SKILL_TOOLS and not step.capture and not step.capture_list:
             warnings.append(
                 DataFlowWarning(
                     code="IMPLICIT_HANDOFF",

--- a/src/autoskillit/recipe/rules/rules_actions.py
+++ b/src/autoskillit/recipe/rules/rules_actions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from autoskillit.core import Severity, get_logger
+from autoskillit.core import SKILL_TOOLS, Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 from autoskillit.recipe.schema import RecipeKind
@@ -124,4 +124,46 @@ def _check_route_step_requires_on_result(ctx: ValidationContext) -> list[RuleFin
                     ),
                 )
             )
+    return findings
+
+
+_SILENT_FAILURE_INDICATIVE_PHRASES = frozenset({"partial", "acceptable", "continue"})
+
+
+@semantic_rule(
+    name="silent-failure-skill-step",
+    description=(
+        "A run_skill step routes both success and failure to the same target, "
+        "making failures invisible. If failure is intentional (partial results are "
+        "acceptable), add a note explaining this so the pattern is distinguishable "
+        "from an oversight."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_silent_failure_skill_step(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool not in SKILL_TOOLS:
+            continue
+        if step.on_success is None or step.on_failure is None:
+            continue
+        if step.on_success != step.on_failure:
+            continue
+        note = (step.note or "").lower()
+        if any(phrase in note for phrase in _SILENT_FAILURE_INDICATIVE_PHRASES):
+            continue
+        findings.append(
+            RuleFinding(
+                rule="silent-failure-skill-step",
+                severity=Severity.WARNING,
+                step_name=step_name,
+                message=(
+                    f"Step '{step_name}' routes both success and failure to "
+                    f"'{step.on_success}'. Failure is therefore silent. "
+                    f"If this is intentional (partial results are acceptable), "
+                    f"add a note explaining why — e.g., 'Partial results are acceptable.' — "
+                    f"so the pattern is distinguishable from an oversight."
+                ),
+            )
+        )
     return findings

--- a/src/autoskillit/recipe/rules/rules_actions.py
+++ b/src/autoskillit/recipe/rules/rules_actions.py
@@ -127,7 +127,7 @@ def _check_route_step_requires_on_result(ctx: ValidationContext) -> list[RuleFin
     return findings
 
 
-_SILENT_FAILURE_INDICATIVE_PHRASES = frozenset({"partial", "acceptable", "continue"})
+_SILENT_FAILURE_INDICATIVE_PHRASES = frozenset({"partial", "acceptable"})
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/rules/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow.py
@@ -655,9 +655,9 @@ def _check_downstream_context_completeness(ctx: ValidationContext) -> list[RuleF
                     )
 
         if step.capture or step.capture_list:
-            for ctx_var in step.capture:
+            for ctx_var in step.capture or {}:
                 produced_context.add(ctx_var)
-            for ctx_var in step.capture_list:
+            for ctx_var in step.capture_list or {}:
                 produced_context.add(ctx_var)
 
     return findings

--- a/src/autoskillit/recipe/rules/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow.py
@@ -373,7 +373,9 @@ def _check_merge_cleanup_captured(ctx: ValidationContext) -> list[RuleFinding]:
         if step.tool != "merge_worktree":
             continue
         # Check whether any capture value references cleanup_succeeded
-        captures_cleanup = any("result.cleanup_succeeded" in str(v) for v in step.capture.values())
+        captures_cleanup = any(
+            "result.cleanup_succeeded" in str(v) for v in (step.capture or {}).values()
+        ) or any("result.cleanup_succeeded" in str(v) for v in (step.capture_list or {}).values())
         if not captures_cleanup:
             findings.append(
                 RuleFinding(
@@ -643,8 +645,10 @@ def _check_downstream_context_completeness(ctx: ValidationContext) -> list[RuleF
                         )
                     )
 
-        if step.capture:
-            for ctx_var in step.capture:
+        if step.capture or step.capture_list:
+            for ctx_var in step.capture or {}:
+                produced_context.add(ctx_var)
+            for ctx_var in step.capture_list or {}:
                 produced_context.add(ctx_var)
 
     return findings

--- a/src/autoskillit/recipe/rules/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow.py
@@ -209,17 +209,26 @@ def _check_python_capture_output_coverage(ctx: ValidationContext) -> list[RuleFi
     severity=Severity.ERROR,
 )
 def _check_dead_output(ctx: ValidationContext) -> list[RuleFinding]:
-    """Error when any captured context variable is never consumed downstream."""
-    return [
-        RuleFinding(
-            rule="dead-output",
-            severity=Severity.ERROR,
-            step_name=w.step_name,
-            message=w.message,
+    """Error when a capture variable is never consumed downstream; warning for capture_list."""
+    findings: list[RuleFinding] = []
+    for w in ctx.dataflow.warnings:
+        if w.code != "DEAD_OUTPUT":
+            continue
+        step = ctx.recipe.steps.get(w.step_name)
+        is_capture_list_only = (
+            step is not None
+            and w.field in (step.capture_list or {})
+            and w.field not in (step.capture or {})
         )
-        for w in ctx.dataflow.warnings
-        if w.code == "DEAD_OUTPUT"
-    ]
+        findings.append(
+            RuleFinding(
+                rule="dead-output",
+                severity=Severity.WARNING if is_capture_list_only else Severity.ERROR,
+                step_name=w.step_name,
+                message=w.message,
+            )
+        )
+    return findings
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/rules/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow.py
@@ -655,9 +655,9 @@ def _check_downstream_context_completeness(ctx: ValidationContext) -> list[RuleF
                     )
 
         if step.capture or step.capture_list:
-            for ctx_var in step.capture or {}:
+            for ctx_var in step.capture:
                 produced_context.add(ctx_var)
-            for ctx_var in step.capture_list or {}:
+            for ctx_var in step.capture_list:
                 produced_context.add(ctx_var)
 
     return findings

--- a/src/autoskillit/recipe/rules/rules_worktree.py
+++ b/src/autoskillit/recipe/rules/rules_worktree.py
@@ -294,7 +294,7 @@ def _check_capture_list_requires_retries_zero(ctx: ValidationContext) -> list[Ru
                     step_name=step_name,
                     message=(
                         f"Step '{step_name}' uses capture_list (accumulated across "
-                        f"lens iterations) but has retries: {step.retries}. Each retry "
+                        f"pipeline iterations) but has retries: {step.retries}. Each retry "
                         f"re-initializes the list, producing duplicate entries. "
                         f"Set retries: 0 and use on_context_limit routing to resume "
                         f"in the existing worktree."

--- a/src/autoskillit/recipe/rules/rules_worktree.py
+++ b/src/autoskillit/recipe/rules/rules_worktree.py
@@ -272,3 +272,33 @@ def _check_superseded_input_after_capture(ctx: ValidationContext) -> list[RuleFi
                 superseded_keys.update(step.capture.keys())
 
     return findings
+
+
+@semantic_rule(
+    name="capture-list-requires-retries-zero",
+    description=(
+        "capture_list steps must set retries: 0. "
+        "Each retry re-initializes the accumulated list, producing duplicates."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_capture_list_requires_retries_zero(ctx: ValidationContext) -> list[RuleFinding]:
+    wf = ctx.recipe
+    findings: list[RuleFinding] = []
+    for step_name, step in wf.steps.items():
+        if step.capture_list and step.retries > 0:
+            findings.append(
+                RuleFinding(
+                    rule="capture-list-requires-retries-zero",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' uses capture_list (accumulated across "
+                        f"lens iterations) but has retries: {step.retries}. Each retry "
+                        f"re-initializes the list, producing duplicate entries. "
+                        f"Set retries: 0 and use on_context_limit routing to resume "
+                        f"in the existing worktree."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -121,7 +121,7 @@ class RecipeStep:
         default_factory=list
     )  # Captured output names used for informational propagation, not flow control
 
-    def __post_init(self) -> None:
+    def __post_init__(self) -> None:
         if self.capture_list and self.retries > 0:
             raise ValueError(
                 f"Step '{self.name}' uses capture_list (accumulated list items across "

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -121,6 +121,14 @@ class RecipeStep:
         default_factory=list
     )  # Captured output names used for informational propagation, not flow control
 
+    def __post_init(self) -> None:
+        if self.capture_list and self.retries > 0:
+            raise ValueError(
+                f"Step '{self.name}' uses capture_list (accumulated list items across "
+                f"retries) but has retries: {self.retries}. Each retry re-initializes "
+                f"the list, producing duplicates. Set retries: 0."
+            )
+
 
 @dataclass(frozen=True, slots=True)
 class RecipeBlock:

--- a/src/autoskillit/recipes/contracts/full-audit.json
+++ b/src/autoskillit/recipes/contracts/full-audit.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:6baf8ef42831ae08726a47aa03c34547206a6cea1c72363a2af705951788a115",
+  "recipe_source_hash": "sha256:153373f9673d7f7f17d5dce1e252681e1517f1deccc23c9bf8cdf6d9648cd1e3",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/full-audit.yaml
+++ b/src/autoskillit/recipes/contracts/full-audit.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:6baf8ef42831ae08726a47aa03c34547206a6cea1c72363a2af705951788a115
+recipe_source_hash: sha256:153373f9673d7f7f17d5dce1e252681e1517f1deccc23c9bf8cdf6d9648cd1e3
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:f1c1eaa5dd4ac236833330f96cdc4bb22da640c9ab2a6ed657b160005ee878eb",
+  "recipe_source_hash": "sha256:69bf5a8c0aa2391a9ff92c57acfa88a498d940f9e89368dd93cc43cecf52e250",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967",
+  "recipe_source_hash": "sha256:f1c1eaa5dd4ac236833330f96cdc4bb22da640c9ab2a6ed657b160005ee878eb",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:801962e147b99de96962540aec399272ae4ebc6387f4c1eb3fa4987d5bc67967
+recipe_source_hash: sha256:f1c1eaa5dd4ac236833330f96cdc4bb22da640c9ab2a6ed657b160005ee878eb
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:f1c1eaa5dd4ac236833330f96cdc4bb22da640c9ab2a6ed657b160005ee878eb
+recipe_source_hash: sha256:69bf5a8c0aa2391a9ff92c57acfa88a498d940f9e89368dd93cc43cecf52e250
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:9f55ab7e4dec1f9d263e1739e304271e6c8a41458560f1f227c434ef8e41a644",
+  "recipe_source_hash": "sha256:4378d5fc307ec62c67bbd583a6e5da395eff873fddf5c1da496072eaae236465",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba",
+  "recipe_source_hash": "sha256:9f55ab7e4dec1f9d263e1739e304271e6c8a41458560f1f227c434ef8e41a644",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:9f55ab7e4dec1f9d263e1739e304271e6c8a41458560f1f227c434ef8e41a644
+recipe_source_hash: sha256:4378d5fc307ec62c67bbd583a6e5da395eff873fddf5c1da496072eaae236465
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:fdefa05168fbe84515fd69e809c749530ae256d9f466bc9eb30581de00339fba
+recipe_source_hash: sha256:9f55ab7e4dec1f9d263e1739e304271e6c8a41458560f1f227c434ef8e41a644
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d",
+  "recipe_source_hash": "sha256:11c2e1be8d396ecd02fd9c24de70af8b58c42133b25faa6ca027c3344a09f51f",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:03c8c78fc1104a43d83cc9973f1e80cb25f7ac00cc260c43332caaa796b9354d
+recipe_source_hash: sha256:11c2e1be8d396ecd02fd9c24de70af8b58c42133b25faa6ca027c3344a09f51f
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af",
+  "recipe_source_hash": "sha256:01932623ed3af6c63f5034f5063b8df7d93a06045141330400f580e15e327773",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:2dff6326ac3abe263a39f73b8386cebc204b56e62a6cfab8f1f647fc5427a7af
+recipe_source_hash: sha256:01932623ed3af6c63f5034f5063b8df7d93a06045141330400f580e15e327773
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085",
+  "recipe_source_hash": "sha256:a58ec1d6299d469f5d92c2dd5e765d44b0dace87c8ac0d6d1abb1ba536c02ab2",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:a58ec1d6299d469f5d92c2dd5e765d44b0dace87c8ac0d6d1abb1ba536c02ab2",
+  "recipe_source_hash": "sha256:c8e3b2498c8b22f7723349fb3c1491ef3c8e3860725f5d1737817b716b84fa25",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:a58ec1d6299d469f5d92c2dd5e765d44b0dace87c8ac0d6d1abb1ba536c02ab2
+recipe_source_hash: sha256:c8e3b2498c8b22f7723349fb3c1491ef3c8e3860725f5d1737817b716b84fa25
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:6d5d7855169fa90defcf4d70a329881d222e315086e225286766ff091ae26085
+recipe_source_hash: sha256:a58ec1d6299d469f5d92c2dd5e765d44b0dace87c8ac0d6d1abb1ba536c02ab2
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:

--- a/src/autoskillit/recipes/full-audit.json
+++ b/src/autoskillit/recipes/full-audit.json
@@ -74,7 +74,7 @@
       },
       "on_success": "validate_audits",
       "on_failure": "escalate_stop",
-      "retries": 1,
+      "retries": 0,
       "on_exhausted": "escalate_stop"
     },
     "validate_audits": {
@@ -92,7 +92,7 @@
       },
       "on_success": "create_issues",
       "on_failure": "escalate_stop",
-      "retries": 1,
+      "retries": 0,
       "on_exhausted": "escalate_stop"
     },
     "create_issues": {

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -115,7 +115,7 @@ steps:
       audit_report_paths: "${{ result.audit_report_path }}"
     on_success: validate_audits
     on_failure: escalate_stop
-    retries: 1
+    retries: 0
     on_exhausted: escalate_stop
 
   validate_audits:
@@ -158,7 +158,7 @@ steps:
       validated_report_paths: "${{ result.validated_report_path }}"
     on_success: create_issues
     on_failure: escalate_stop
-    retries: 1
+    retries: 0
     on_exhausted: escalate_stop
 
   create_issues:

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -172,6 +172,7 @@
       "capture_list": {
         "plan_parts": "${{ result.plan_parts }}"
       },
+      "retries": 0,
       "on_success": "review",
       "on_failure": "release_issue_failure",
       "note": "Produces plan in {{AUTOSKILLIT_TEMP}}/make-plan/. Glob plan_dir for *_part_*.md or single plan file. plan_parts context key contains the full ordered list of part files (sorted alphabetically). For a single-part plan, plan_parts has one entry equal to plan_path. GROUPS MODE: Replace the skill_command task with the current group's file path from context.group_files extracted from the group step's capture — do NOT read the file; pass the path directly to the skill. REMEDIATION MODE: context.remediation_path is available when the orchestrator re-enters plan from the remediate step; pass it inline in the skill_command rather than as a named with: key. ACCUMULATION: After each plan step execution in groups mode, the agent MUST append the captured plan_path to context.all_plan_paths using a comma separator instead of letting the capture block overwrite the accumulated value. For multi-group runs, the accumulated value looks like \"/path/groupA_plan.md,/path/groupB_plan.md\". ISSUE CONTEXT: If inputs.issue_url is a non-empty string, pass it to the skill so the make-plan skill can call fetch_github_issue internally to get full issue content: \"/autoskillit:make-plan {group_path}\\n\\nGitHub Issue: {inputs.issue_url}\"\n"

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -506,6 +506,7 @@
       "capture_list": {
         "all_diagram_paths": "${{ result.diagram_path }}"
       },
+      "retries": 0,
       "on_success": "compose_pr",
       "on_failure": "compose_pr",
       "on_context_limit": "compose_pr",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -176,6 +176,7 @@ steps:
       all_plan_paths: "${{ result.plan_path }}"
     capture_list:
       plan_parts: "${{ result.plan_parts }}"
+    retries: 0
     on_success: review
     on_failure: release_issue_failure
     note: >

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -476,6 +476,7 @@ steps:
       step_name: "run_arch_lenses"
     capture_list:
       all_diagram_paths: "${{ result.diagram_path }}"
+    retries: 0
     on_success: compose_pr
     on_failure: compose_pr
     on_context_limit: compose_pr

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -166,6 +166,7 @@
       "capture_list": {
         "plan_parts": "${{ result.plan_parts }}"
       },
+      "retries": 0,
       "on_success": "review",
       "on_failure": "release_issue_failure",
       "note": "Produces plan in {{AUTOSKILLIT_TEMP}}/make-plan/. Glob plan_dir for *_part_*.md or single plan file. plan_parts context key contains the full ordered list of part files (sorted alphabetically). For a single-part plan, plan_parts has one entry equal to plan_path. REMEDIATION MODE: context.remediation_path is available when the orchestrator re-enters plan from the remediate step; pass it inline in the skill_command rather than as a named with: key. ACCUMULATION: all_plan_paths accumulates across any re-entries to the plan step (e.g. remediation). For a single-pass run, all_plan_paths equals plan_path (the capture block handles this automatically). ISSUE CONTEXT: If inputs.issue_url is a non-empty string, append it to the skill_command so the make-plan skill can detect and fetch the issue itself: \"/autoskillit:make-plan {task}\\n\\nGitHub Issue: {inputs.issue_url}\" The skill detects the URL pattern and calls fetch_github_issue internally.\n"

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -496,6 +496,7 @@
       "capture_list": {
         "all_diagram_paths": "${{ result.diagram_path }}"
       },
+      "retries": 0,
       "on_success": "compose_pr",
       "on_failure": "compose_pr",
       "on_context_limit": "compose_pr",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -469,6 +469,7 @@ steps:
       step_name: "run_arch_lenses"
     capture_list:
       all_diagram_paths: "${{ result.diagram_path }}"
+    retries: 0
     on_success: compose_pr
     on_failure: compose_pr
     on_context_limit: compose_pr

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -178,6 +178,7 @@ steps:
       all_plan_paths: "${{ result.plan_path }}"
     capture_list:
       plan_parts: "${{ result.plan_parts }}"
+    retries: 0
     on_success: review
     on_failure: release_issue_failure
     note: >

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -338,7 +338,7 @@
         }
       ],
       "on_failure": "register_clone_failure",
-      "retries": 1,
+      "retries": 0,
       "on_exhausted": "register_clone_failure",
       "note": "Resolves git-level rebase conflicts between the ejected PR's branch and the current base_branch HEAD. Uses the same resolve-merge-conflicts skill as the classic path's integration conflict resolution.\n"
     },
@@ -568,7 +568,7 @@
         }
       ],
       "on_failure": "register_clone_failure",
-      "retries": 1,
+      "retries": 0,
       "on_exhausted": "enqueue_current_pr",
       "note": "Resolves git-level rebase conflicts between the next PR's branch and the current base_branch HEAD. Similar to resolve_ejected_conflicts but operates proactively before queue submission. Unresolvable conflicts (escalation_required=true) hard-stop at register_clone_failure. Retry exhaustion falls through to enqueue_current_pr — speculative rebase failure must not abort the current PR's queue cycle.\n"
     },
@@ -713,6 +713,7 @@
         "plan_parts": "${{ result.plan_parts }}",
         "all_plan_paths": "${{ result.plan_path }}"
       },
+      "retries": 0,
       "on_success": "verify",
       "on_failure": "register_clone_failure",
       "note": "Glob plan_dir for *_part_*.md or single plan file. Sort alphabetically into plan_parts[]. For a single-part plan, plan_parts has one entry equal to plan_path. PRIMARY PATH: context.task = conflict_report_path from merge_pr. REMEDIATION MODE: context.remediation_path is set when re-entering from the remediate step; pass it inline in the skill_command instead of context.task.\n"
@@ -1120,6 +1121,7 @@
           "route": "force_push_and_wait_mergeability"
         }
       ],
+      "retries": 0,
       "on_failure": "register_clone_failure",
       "note": "Automated conflict resolution when the integration PR is CONFLICTING (REQ-MERGE-003). Rebases context.batch_branch onto inputs.base_branch and resolves merge conflicts. Single attempt only — no retries — to prevent looping on unresolvable conflicts. On failure, escalates to register_clone_failure with diagnostics (REQ-MERGE-004).\n"
     },

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -360,7 +360,7 @@ steps:
         route: register_clone_failure
       - route: push_ejected_fix
     on_failure: register_clone_failure
-    retries: 1
+    retries: 0
     on_exhausted: register_clone_failure
     note: >
       Resolves git-level rebase conflicts between the ejected PR's branch and the
@@ -547,7 +547,7 @@ steps:
         route: register_clone_failure
       - route: push_rebased_next_pr
     on_failure: register_clone_failure
-    retries: 1
+    retries: 0
     on_exhausted: enqueue_current_pr
     note: >
       Resolves git-level rebase conflicts between the next PR's branch and the current
@@ -694,6 +694,7 @@ steps:
     capture_list:
       plan_parts: "${{ result.plan_parts }}"
       all_plan_paths: "${{ result.plan_path }}"
+    retries: 0
     on_success: verify
     on_failure: register_clone_failure
     note: >
@@ -1102,6 +1103,7 @@ steps:
       - when: "${{ result.escalation_required }} == true"
         route: register_clone_failure
       - route: force_push_and_wait_mergeability
+    retries: 0
     on_failure: register_clone_failure
     note: >
       Automated conflict resolution when the integration PR is CONFLICTING (REQ-MERGE-003).

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -129,6 +129,7 @@
       "capture_list": {
         "elab_result_path": "${{ result.elab_result_path }}"
       },
+      "retries": 0,
       "on_success": "merge_phases",
       "on_failure": "escalate_stop",
       "note": "PARALLEL DISPATCH: context.phase_ids contains comma-separated phase IDs (e.g. \"P1,P2,P3\"). For each phase_id, substitute it into the {phase_id} placeholder in skill_command and issue one run_skill call. Run ALL elaborations in parallel (all run_skill calls in a single message). Accumulate each elab_result_path value via capture_list.\n"
@@ -189,6 +190,7 @@
       "capture_list": {
         "phase_assignments_result_dir": "${{ result.phase_assignments_result_dir }}"
       },
+      "retries": 0,
       "on_success": "merge_assignments",
       "on_failure": "escalate_stop",
       "note": "PARALLEL DISPATCH: context.assignment_context_paths contains comma-separated paths to per-phase context files. For each context_path, substitute it into the {context_path} placeholder in skill_command and issue one run_skill call. Run ALL elaborations in parallel. Accumulate results via capture_list.\n"
@@ -221,6 +223,7 @@
       "capture_list": {
         "phase_refined_path": "${{ result.phase_refined_path }}"
       },
+      "retries": 0,
       "on_success": "merge_refined_assignments",
       "on_failure": "escalate_stop",
       "note": "PARALLEL DISPATCH: context.refine_context_paths contains comma-separated paths to per-phase context files produced by merge_tier_results. For each context_path, substitute it into the {context_path} placeholder and issue one run_skill call. Run ALL refinements in parallel. Accumulate results via capture_list.\n"
@@ -263,6 +266,7 @@
       "capture_list": {
         "phase_wps_result_dir": "${{ result.phase_wps_result_dir }}"
       },
+      "retries": 0,
       "on_success": "finalize_wp_manifest",
       "on_failure": "escalate_stop",
       "note": "SEQUENTIAL DISPATCH: context.wp_context_paths contains comma-separated paths to per-phase WP context files. For each context_path, substitute it into the {context_path} placeholder in skill_command and issue one run_skill call. Wait for each elaboration to complete before starting the next. Accumulate results via capture_list.\n"

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -136,6 +136,7 @@ steps:
       dispatch_items: "${{ context.phase_ids }}"
     capture_list:
       elab_result_path: "${{ result.elab_result_path }}"
+    retries: 0
     on_success: merge_phases
     on_failure: escalate_stop
     note: >
@@ -195,6 +196,7 @@ steps:
       dispatch_items: "${{ context.assignment_context_paths }}"
     capture_list:
       phase_assignments_result_dir: "${{ result.phase_assignments_result_dir }}"
+    retries: 0
     on_success: merge_assignments
     on_failure: escalate_stop
     note: >
@@ -227,6 +229,7 @@ steps:
       dispatch_items: "${{ context.refine_context_paths }}"
     capture_list:
       phase_refined_path: "${{ result.phase_refined_path }}"
+    retries: 0
     on_success: merge_refined_assignments
     on_failure: escalate_stop
     note: >
@@ -270,6 +273,7 @@ steps:
       dispatch_items: "${{ context.wp_context_paths }}"
     capture_list:
       phase_wps_result_dir: "${{ result.phase_wps_result_dir }}"
+    retries: 0
     on_success: finalize_wp_manifest
     on_failure: escalate_stop
     note: >

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -184,6 +184,7 @@
       "capture_list": {
         "plan_parts": "${{ result.plan_parts }}"
       },
+      "retries": 0,
       "on_success": "review",
       "on_failure": "release_issue_failure",
       "note": "Glob plan_dir for *_part_*.md or single plan file. Sort alphabetically into plan_parts[].\n"
@@ -415,6 +416,7 @@
       "capture_list": {
         "plan_parts": "${{ result.plan_parts }}"
       },
+      "retries": 0,
       "on_success": "dry_walkthrough",
       "on_failure": "release_issue_failure"
     },

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -536,6 +536,7 @@
       "capture_list": {
         "all_diagram_paths": "${{ result.diagram_path }}"
       },
+      "retries": 0,
       "on_success": "compose_pr",
       "on_failure": "compose_pr",
       "on_context_limit": "compose_pr",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -486,6 +486,7 @@ steps:
       step_name: "run_arch_lenses"
     capture_list:
       all_diagram_paths: "${{ result.diagram_path }}"
+    retries: 0
     on_success: compose_pr
     on_failure: compose_pr
     on_context_limit: compose_pr

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -198,6 +198,7 @@ steps:
       plan_path: "${{ result.plan_path }}"
     capture_list:
       plan_parts: "${{ result.plan_parts }}"
+    retries: 0
     on_success: review
     on_failure: release_issue_failure
     note: >
@@ -379,6 +380,7 @@ steps:
       plan_path: "${{ result.plan_path }}"
     capture_list:
       plan_parts: "${{ result.plan_parts }}"
+    retries: 0
     on_success: dry_walkthrough
     on_failure: release_issue_failure
 

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -150,6 +150,7 @@
       "capture_list": {
         "plan_parts": "${{ result.plan_parts }}"
       },
+      "retries": 0,
       "on_success": "implement_phase",
       "on_failure": "escalate_stop",
       "note": "Plans the current setup phase. Replace ${{ context.group_files }} in the skill_command with the FIRST REMAINING phase file path from the list — do NOT pass the entire list. Pass the path directly to the skill (do not read it). Glob plan_dir for *_part_*.md or single plan file. ITERATION: After each implement_phase cycle, advance to the next entry in context.group_files for the following plan_phase iteration. REMEDIATION MODE: context.remediation_path is available when the orchestrator re-enters plan_phase from the remediate step via check_audit_retry_loop; pass it inline in the skill_command rather than as a named with: key.\n"

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -164,6 +164,7 @@ steps:
       phase_plan_path: "${{ result.plan_path }}"
     capture_list:
       plan_parts: "${{ result.plan_parts }}"
+    retries: 0
     on_success: implement_phase
     on_failure: escalate_stop
     note: >

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -128,6 +128,7 @@
       "capture_list": {
         "all_diagram_paths": "${{ result.diagram_path }}"
       },
+      "retries": 0,
       "on_success": "stage_bundle",
       "on_failure": "stage_bundle"
     },

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -119,6 +119,7 @@ steps:
       step_name: run_experiment_lenses
     capture_list:
       all_diagram_paths: "${{ result.diagram_path }}"
+    retries: 0
     on_success: stage_bundle
     on_failure: stage_bundle
 

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -382,6 +382,7 @@
       "capture_list": {
         "plan_parts": "${{ result.plan_parts }}"
       },
+      "retries": 0,
       "on_success": "implement_phase",
       "on_failure": "escalate_stop",
       "note": "Plans the current setup phase. Replace ${{ context.group_files }} in the skill_command with the FIRST REMAINING phase file path from the list — do NOT pass the entire list. Pass the path directly to the skill (do not read it). Glob plan_dir for *_part_*.md or single plan file. ITERATION: After each implement_phase cycle, advance to the next entry in context.group_files for the following plan_phase iteration.\n"

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -836,6 +836,7 @@
       "capture_list": {
         "all_diagram_paths": "${{ result.diagram_path }}"
       },
+      "retries": 0,
       "on_success": "stage_bundle",
       "on_failure": "stage_bundle",
       "note": "LENS ITERATION: context.selected_lenses contains comma-separated lens slugs (e.g. \"fair-comparison,estimand-clarity\"). context.lens_context_paths contains the corresponding comma-separated context file paths. For each lens slug, run:\n  /autoskillit:exp-lens-{slug} {matching_context_path} ${{ context.experiment_plan }}\nRun all selected lenses in parallel (multiple run_skill calls in a single assistant message). Accumulate each diagram_path value into context.all_diagram_paths using comma separation via capture_list. If a lens fails, continue with remaining lenses — partial diagrams are acceptable (compose_research_pr handles empty lists).\n"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -795,6 +795,7 @@ steps:
       step_name: run_experiment_lenses
     capture_list:
       all_diagram_paths: "${{ result.diagram_path }}"
+    retries: 0
     on_success: stage_bundle
     on_failure: stage_bundle
     note: >

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -410,6 +410,7 @@ steps:
       phase_plan_path: "${{ result.plan_path }}"
     capture_list:
       plan_parts: "${{ result.plan_parts }}"
+    retries: 0
     on_success: implement_phase
     on_failure: escalate_stop
     note: >

--- a/src/autoskillit/recipes/scripts/finalize_bundle.sh
+++ b/src/autoskillit/recipes/scripts/finalize_bundle.sh
@@ -34,17 +34,19 @@ if [ ${#TAR_ITEMS[@]} -gt 0 ]; then
 fi
 
 if [ -f "${RESEARCH_DIR}/artifacts.tar.gz" ] && [ -f "${RESEARCH_DIR}/${REPORT_FILE}" ]; then
-    MANIFEST=$(tar tzf "${RESEARCH_DIR}/artifacts.tar.gz" | sort)
-    {
-        echo ""
-        echo "## Archive Manifest"
-        echo ""
-        echo "Contents of \`artifacts.tar.gz\`:"
-        echo ""
-        echo '```'
-        echo "${MANIFEST}"
-        echo '```'
-    } >> "${RESEARCH_DIR}/${REPORT_FILE}"
+    if ! grep -q '## Archive Manifest' "${RESEARCH_DIR}/${REPORT_FILE}" 2>/dev/null; then
+        MANIFEST=$(tar tzf "${RESEARCH_DIR}/artifacts.tar.gz" | sort)
+        {
+            echo ""
+            echo "## Archive Manifest"
+            echo ""
+            echo "Contents of \`artifacts.tar.gz\`:"
+            echo ""
+            echo '```'
+            echo "${MANIFEST}"
+            echo '```'
+        } >> "${RESEARCH_DIR}/${REPORT_FILE}"
+    fi
 fi
 
 [ -f "${RESEARCH_DIR}/artifacts.tar.gz" ] || \

--- a/src/autoskillit/recipes/scripts/stage_bundle.sh
+++ b/src/autoskillit/recipes/scripts/stage_bundle.sh
@@ -22,4 +22,9 @@ for f in "${WT_TEMP}"/make-groups/*.yaml; do [ -f "$f" ] && cp "$f" "${RESEARCH_
 for f in "${WT_TEMP}"/make-plan/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-plans/"; done
 for f in "${WT_TEMP}"/exp-lens-*/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/images/"; done
 
+SCRIPT_SRC="${RESEARCH_DIR}/scripts"
+if [ -d "${SCRIPT_SRC}" ]; then
+    for f in "${SCRIPT_SRC}"/*; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/scripts/"; done
+fi
+
 echo "stage_bundle=done"

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -59,6 +59,29 @@ def test_every_bundled_recipe_declares_requires_packs() -> None:
         assert recipe.requires_packs, f"{path.name} does not declare requires_packs"
 
 
+@pytest.mark.parametrize(
+    "recipe_yaml",
+    sorted(builtin_recipes_dir().glob("*.yaml")),
+    ids=lambda p: p.stem,
+)
+def test_bundled_recipes_capture_list_retries_zero(recipe_yaml: Path) -> None:
+    """Every bundled recipe must have zero capture-list-requires-retries-zero ERROR findings.
+
+    Steps using capture_list must set retries: 0 to prevent retry-induced duplication
+    of accumulated list items.
+    """
+    recipe = load_recipe(recipe_yaml)
+    findings = run_semantic_rules(recipe)
+    errors = [
+        f
+        for f in findings
+        if f.rule == "capture-list-requires-retries-zero" and f.severity == Severity.ERROR
+    ]
+    assert errors == [], (
+        f"{recipe_yaml.stem}: {[f'{f.step_name}: {f.message[:80]}' for f in errors]}"
+    )
+
+
 def test_make_plan_contract_declares_plan_parts_output() -> None:
     """D4: make-plan contract must declare plan_parts as an output."""
     manifest = load_bundled_manifest()

--- a/tests/recipe/test_io_schema_fields.py
+++ b/tests/recipe/test_io_schema_fields.py
@@ -73,6 +73,7 @@ def test_recipe_step_accepts_capture_list_field() -> None:
         with_args={"skill_command": "/autoskillit:make-plan inputs.task"},
         capture={"plan_path": "${{ result.plan_path }}"},
         capture_list={"plan_parts": "${{ result.plan_parts }}"},
+        retries=0,
         on_success="verify",
     )
     assert step.capture_list == {"plan_parts": "${{ result.plan_parts }}"}
@@ -98,6 +99,7 @@ def test_recipe_yaml_with_capture_list_parses(tmp_path: Path) -> None:
                 "with": {"skill_command": "/autoskillit:make-plan inputs.task"},
                 "capture": {"plan_path": "${{ result.plan_path }}"},
                 "capture_list": {"plan_parts": "${{ result.plan_parts }}"},
+                "retries": 0,
                 "on_success": "done",
             },
             "done": {"action": "stop", "message": "Done"},
@@ -123,6 +125,7 @@ def test_iter_steps_with_context_includes_capture_list_keys() -> None:
                 with_args={"skill_command": "/autoskillit:make-plan t"},
                 capture={"plan_path": "${{ result.plan_path }}"},
                 capture_list={"plan_parts": "${{ result.plan_parts }}"},
+                retries=0,
                 on_success="verify",
             ),
             "verify": RecipeStep(

--- a/tests/recipe/test_merge_prs_queue_pmp.py
+++ b/tests/recipe/test_merge_prs_queue_pmp.py
@@ -291,7 +291,7 @@ def test_merge_prs_resolve_proactive_conflicts_routing(pmp_recipe) -> None:
     assert success_route == "push_rebased_next_pr"
 
 
-def test_merge_prs_resolve_proactive_conflicts_has_retries(pmp_recipe) -> None:
+def test_merge_prs_resolve_proactive_conflicts_retries_zero(pmp_recipe) -> None:
     step = pmp_recipe.steps["resolve_proactive_rebase_conflicts"]
     assert step.retries == 0
     assert step.on_exhausted == "enqueue_current_pr"

--- a/tests/recipe/test_merge_prs_queue_pmp.py
+++ b/tests/recipe/test_merge_prs_queue_pmp.py
@@ -293,7 +293,7 @@ def test_merge_prs_resolve_proactive_conflicts_routing(pmp_recipe) -> None:
 
 def test_merge_prs_resolve_proactive_conflicts_has_retries(pmp_recipe) -> None:
     step = pmp_recipe.steps["resolve_proactive_rebase_conflicts"]
-    assert step.retries == 1
+    assert step.retries == 0
     assert step.on_exhausted == "enqueue_current_pr"
 
 

--- a/tests/recipe/test_research_bundle_lifecycle.py
+++ b/tests/recipe/test_research_bundle_lifecycle.py
@@ -100,6 +100,7 @@ def test_re_push_research_on_success_routes_to_finalize_bundle_render(recipe):
     )
 
 
+@pytest.mark.medium
 def test_finalize_bundle_script_manifest_idempotent(tmp_path):
     """finalize_bundle.sh must not append ## Archive Manifest more than once.
 

--- a/tests/recipe/test_research_bundle_lifecycle.py
+++ b/tests/recipe/test_research_bundle_lifecycle.py
@@ -112,6 +112,7 @@ def test_finalize_bundle_script_manifest_idempotent(tmp_path):
     worktree_path.mkdir()
 
     (research_dir / "report.md").write_text("# Research Report\n\nSome content.\n")
+    (research_dir / "data.csv").write_text("col1,col2\nval1,val2\n")
 
     script_path = (
         Path(__file__).parent.parent.parent

--- a/tests/recipe/test_research_bundle_lifecycle.py
+++ b/tests/recipe/test_research_bundle_lifecycle.py
@@ -1,3 +1,6 @@
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
@@ -94,4 +97,44 @@ def test_re_push_research_on_success_routes_to_finalize_bundle_render(recipe):
     step = recipe.steps["re_push_research"]
     assert step.on_success == "finalize_bundle_render", (
         "re_push_research.on_success must be finalize_bundle_render"
+    )
+
+
+def test_finalize_bundle_script_manifest_idempotent(tmp_path):
+    """finalize_bundle.sh must not append ## Archive Manifest more than once.
+
+    The idempotency guard checks for existing '## Archive Manifest' before appending,
+    so re-running the script produces the manifest section exactly once.
+    """
+    research_dir = tmp_path / "research"
+    research_dir.mkdir()
+    worktree_path = tmp_path / "worktree"
+    worktree_path.mkdir()
+
+    (research_dir / "report.md").write_text("# Research Report\n\nSome content.\n")
+
+    script_path = (
+        Path(__file__).parent.parent.parent
+        / "src/autoskillit/recipes/scripts"
+        / "finalize_bundle.sh"
+    )
+
+    def run_finalize():
+        result = subprocess.run(
+            [str(script_path), "local", str(research_dir), str(worktree_path)],
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    r1 = run_finalize()
+    assert r1.returncode == 0, f"first run failed: {r1.stderr}"
+
+    r2 = run_finalize()
+    assert r2.returncode == 0, f"second run failed: {r2.stderr}"
+
+    report_content = (research_dir / "report.md").read_text()
+    assert report_content.count("## Archive Manifest") == 1, (
+        "## Archive Manifest must appear exactly once after two script runs; "
+        f"found {report_content.count('## Archive Manifest')}"
     )

--- a/tests/recipe/test_rules_actions.py
+++ b/tests/recipe/test_rules_actions.py
@@ -114,3 +114,81 @@ class TestStopStepMessageQuality:
         )
         findings = [f for f in run_semantic_rules(recipe) if f.rule == "stop-step-message-quality"]
         assert len(findings) == 0
+
+
+class TestSilentFailureSkillStep:
+    """Tests for the silent-failure-skill-step rule."""
+
+    def test_skill_step_same_success_failure_routes_fires_warning(self):
+        """run_skill with identical on_success and on_failure routes must fire WARNING."""
+        recipe = _make_recipe(
+            {
+                "lens": {
+                    "tool": "run_skill",
+                    "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                    "on_success": "bundle",
+                    "on_failure": "bundle",
+                },
+                "bundle": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "silent-failure-skill-step"]
+        assert len(findings) == 1, f"Expected silent-failure-skill-step WARNING, got: {findings}"
+        assert findings[0].severity == Severity.WARNING
+        assert findings[0].step_name == "lens"
+
+    def test_skill_step_with_note_about_partial_results_is_clean(self):
+        """run_skill with note containing 'partial' or 'acceptable' must NOT fire."""
+        recipe = _make_recipe(
+            {
+                "lens": {
+                    "tool": "run_skill",
+                    "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                    "on_success": "bundle",
+                    "on_failure": "bundle",
+                    "note": "Partial results are acceptable.",
+                },
+                "bundle": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "silent-failure-skill-step"]
+        assert findings == [], (
+            f"silent-failure-skill-step must not fire when note explains partial results: {findings}"
+        )
+
+    def test_skill_step_different_success_failure_is_clean(self):
+        """run_skill with different on_success and on_failure routes must NOT fire."""
+        recipe = _make_recipe(
+            {
+                "lens": {
+                    "tool": "run_skill",
+                    "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                    "on_success": "bundle",
+                    "on_failure": "escalate",
+                },
+                "bundle": {"action": "stop", "message": "Done."},
+                "escalate": {"action": "stop", "message": "Failed."},
+            }
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "silent-failure-skill-step"]
+        assert findings == [], (
+            f"silent-failure-skill-step must not fire for different routes: {findings}"
+        )
+
+    def test_run_cmd_not_flagged(self):
+        """run_cmd (non-skill) step with identical success/failure routes must NOT fire."""
+        recipe = _make_recipe(
+            {
+                "cmd": {
+                    "tool": "run_cmd",
+                    "with": {"cmd": "echo hello"},
+                    "on_success": "done",
+                    "on_failure": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "silent-failure-skill-step"]
+        assert findings == [], (
+            f"silent-failure-skill-step is skill-specific and must not fire for run_cmd: {findings}"
+        )

--- a/tests/recipe/test_rules_actions.py
+++ b/tests/recipe/test_rules_actions.py
@@ -153,7 +153,8 @@ class TestSilentFailureSkillStep:
         )
         findings = [f for f in run_semantic_rules(recipe) if f.rule == "silent-failure-skill-step"]
         assert findings == [], (
-            f"silent-failure-skill-step must not fire when note explains partial results: {findings}"
+            "silent-failure-skill-step must not fire when note explains"
+            f" partial results: {findings}"
         )
 
     def test_skill_step_different_success_failure_is_clean(self):
@@ -190,5 +191,6 @@ class TestSilentFailureSkillStep:
         )
         findings = [f for f in run_semantic_rules(recipe) if f.rule == "silent-failure-skill-step"]
         assert findings == [], (
-            f"silent-failure-skill-step is skill-specific and must not fire for run_cmd: {findings}"
+            "silent-failure-skill-step is skill-specific and must not"
+            f" fire for run_cmd: {findings}"
         )

--- a/tests/recipe/test_rules_actions.py
+++ b/tests/recipe/test_rules_actions.py
@@ -125,7 +125,7 @@ class TestSilentFailureSkillStep:
             {
                 "lens": {
                     "tool": "run_skill",
-                    "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                    "with_args": {"skill_command": "/autoskillit:exp-lens-diagram test"},
                     "on_success": "bundle",
                     "on_failure": "bundle",
                 },
@@ -143,7 +143,7 @@ class TestSilentFailureSkillStep:
             {
                 "lens": {
                     "tool": "run_skill",
-                    "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                    "with_args": {"skill_command": "/autoskillit:exp-lens-diagram test"},
                     "on_success": "bundle",
                     "on_failure": "bundle",
                     "note": "Partial results are acceptable.",
@@ -162,7 +162,7 @@ class TestSilentFailureSkillStep:
             {
                 "lens": {
                     "tool": "run_skill",
-                    "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                    "with_args": {"skill_command": "/autoskillit:exp-lens-diagram test"},
                     "on_success": "bundle",
                     "on_failure": "escalate",
                 },
@@ -181,7 +181,7 @@ class TestSilentFailureSkillStep:
             {
                 "cmd": {
                     "tool": "run_cmd",
-                    "with": {"cmd": "echo hello"},
+                    "with_args": {"cmd": "echo hello"},
                     "on_success": "done",
                     "on_failure": "done",
                 },

--- a/tests/recipe/test_rules_clone.py
+++ b/tests/recipe/test_rules_clone.py
@@ -65,6 +65,7 @@ def test_make_plan_with_plan_parts_capture_passes() -> None:
                     "cwd": "/tmp",
                 },
                 capture_list={"plan_parts": "${result.plan_parts}"},
+                retries=0,
             )
         }
     )

--- a/tests/recipe/test_rules_dataflow_capture.py
+++ b/tests/recipe/test_rules_dataflow_capture.py
@@ -455,7 +455,9 @@ class TestDownstreamContextCompletenessRule:
             "consume": {
                 "tool": "run_skill",
                 "with": {
-                    "skill_command": "/autoskillit:prepare-research-pr ${{ context.all_diagram_paths }}"
+                    "skill_command": (
+                        "/autoskillit:prepare-research-pr ${{ context.all_diagram_paths }}"
+                    )
                 },
                 "on_success": "done",
             },
@@ -484,7 +486,11 @@ class TestDownstreamContextCompletenessRule:
             "consume": {
                 "tool": "run_skill",
                 "with": {
-                    "skill_command": "/autoskillit:prepare-research-pr ${{ context.all_diagram_paths }} ${{ context.missing_var }}"
+                    "skill_command": (
+                        "/autoskillit:prepare-research-pr"
+                        " ${{ context.all_diagram_paths }}"
+                        " ${{ context.missing_var }}"
+                    )
                 },
                 "on_success": "done",
             },

--- a/tests/recipe/test_rules_dataflow_capture.py
+++ b/tests/recipe/test_rules_dataflow_capture.py
@@ -440,3 +440,58 @@ class TestDownstreamContextCompletenessRule:
             f for f in findings if f.rule == "downstream-context-gap" and f.step_name == "consume"
         ]
         assert gap == [], f"downstream-context-gap must not fire for recipe input context: {gap}"
+
+    def test_dc5_capture_list_keys_registered_as_produced_context(self) -> None:
+        """T_DC5: downstream-context-gap does NOT fire when a downstream step references
+        a context variable produced by a prior step's capture_list block."""
+        steps = {
+            "produce": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                "on_success": "consume",
+            },
+            "consume": {
+                "tool": "run_skill",
+                "with": {
+                    "skill_command": "/autoskillit:prepare-research-pr ${{ context.all_diagram_paths }}"
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        gap = [
+            f for f in findings if f.rule == "downstream-context-gap" and f.step_name == "consume"
+        ]
+        assert gap == [], (
+            f"downstream-context-gap must not fire for capture_list-produced context: {gap}"
+        )
+
+    def test_dc6_capture_list_does_not_silence_missing_var_gap(self) -> None:
+        """T_DC6: downstream-context-gap still fires for truly unwired context vars even
+        when the recipe also uses capture_list elsewhere."""
+        steps = {
+            "produce": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                "on_success": "consume",
+            },
+            "consume": {
+                "tool": "run_skill",
+                "with": {
+                    "skill_command": "/autoskillit:prepare-research-pr ${{ context.all_diagram_paths }} ${{ context.missing_var }}"
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        gap = [
+            f for f in findings if f.rule == "downstream-context-gap" and f.step_name == "consume"
+        ]
+        assert len(gap) == 1, f"expected exactly 1 gap for missing_var, got {gap}"
+        assert "missing_var" in gap[0].message

--- a/tests/recipe/test_rules_dataflow_capture.py
+++ b/tests/recipe/test_rules_dataflow_capture.py
@@ -449,6 +449,7 @@ class TestDownstreamContextCompletenessRule:
                 "tool": "run_skill",
                 "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
                 "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                "retries": 0,
                 "on_success": "consume",
             },
             "consume": {
@@ -477,6 +478,7 @@ class TestDownstreamContextCompletenessRule:
                 "tool": "run_skill",
                 "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
                 "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                "retries": 0,
                 "on_success": "consume",
             },
             "consume": {

--- a/tests/recipe/test_rules_multipart_iteration.py
+++ b/tests/recipe/test_rules_multipart_iteration.py
@@ -162,6 +162,7 @@ def compliant_multipart_recipe_with_list() -> Recipe:
                 with_args={"skill_command": "/autoskillit:make-plan inputs.task"},
                 capture={"plan_path": "${{ result.plan_path }}"},
                 capture_list={"plan_parts": "${{ result.plan_parts }}"},
+                retries=0,
                 note="Glob plan_dir for *_part_*.md or single plan file. Sort into plan_parts[].",
                 on_success="done",
             ),

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -939,11 +939,6 @@ def test_superseded_input_in_skill_command_fires_error() -> None:
     ), f"Expected superseded-input-after-capture ERROR for skill_command ref, got: {findings}"
 
 
-# ---------------------------------------------------------------------------
-# capture-list-requires-retries-zero tests
-# ---------------------------------------------------------------------------
-
-
 class TestCaptureListRequiresRetriesZero:
     """Tests for the capture-list-requires-retries-zero rule."""
 

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -948,7 +948,12 @@ class TestCaptureListRequiresRetriesZero:
     """Tests for the capture-list-requires-retries-zero rule."""
 
     def test_capture_list_with_default_retries_fires_error(self) -> None:
-        """capture_list with no retries field (defaults to 3) must emit ERROR."""
+        """Validator fires ERROR when capture_list step has retries > 0.
+
+        Built with retries=0 to pass __post_init__, then mutated to retries=3
+        via direct assignment (RecipeStep is not frozen) to simulate a step
+        that bypassed the schema guard.
+        """
         step = RecipeStep(
             name="lens",
             tool="run_skill",

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -949,16 +949,20 @@ class TestCaptureListRequiresRetriesZero:
 
     def test_capture_list_with_default_retries_fires_error(self) -> None:
         """capture_list with no retries field (defaults to 3) must emit ERROR."""
-        steps = {
-            "lens": {
-                "tool": "run_skill",
-                "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
-                "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
-                "on_success": "done",
-            },
-            "done": {"action": "stop", "message": "Done."},
-        }
-        recipe = _make_workflow(steps)
+        step = RecipeStep(
+            name="lens",
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:exp-lens-diagram test"},
+            capture_list={"all_diagram_paths": "${{ result.diagram_path }}"},
+            retries=0,
+            on_success="done",
+        )
+        step.retries = 3  # simulate missing retries: field (defaults to 3)
+        recipe = Recipe(
+            name="test",
+            description="test",
+            steps={"lens": step, "done": RecipeStep(action="stop", message="Done.")},
+        )
         findings = run_semantic_rules(recipe)
         errors = [f for f in findings if f.severity == Severity.ERROR]
         assert any(
@@ -987,17 +991,20 @@ class TestCaptureListRequiresRetriesZero:
 
     def test_capture_list_with_retries_explicit_fires_error(self) -> None:
         """capture_list with retries: 1 (explicit non-zero) must emit ERROR."""
-        steps = {
-            "audits": {
-                "tool": "run_skill",
-                "with": {"skill_command": "/autoskillit:audit-friction"},
-                "capture_list": {"audit_report_paths": "${{ result.audit_report_path }}"},
-                "retries": 1,
-                "on_success": "done",
-            },
-            "done": {"action": "stop", "message": "Done."},
-        }
-        recipe = _make_workflow(steps)
+        step = RecipeStep(
+            name="audits",
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:audit-friction"},
+            capture_list={"audit_report_paths": "${{ result.audit_report_path }}"},
+            retries=0,
+            on_success="done",
+        )
+        step.retries = 1  # simulate explicit non-zero retries
+        recipe = Recipe(
+            name="test",
+            description="test",
+            steps={"audits": step, "done": RecipeStep(action="stop", message="Done.")},
+        )
         findings = run_semantic_rules(recipe)
         errors = [f for f in findings if f.severity == Severity.ERROR]
         assert any(

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -937,3 +937,110 @@ def test_superseded_input_in_skill_command_fires_error() -> None:
     assert any(
         f.rule == "superseded-input-after-capture" and f.step_name == "audit" for f in errors
     ), f"Expected superseded-input-after-capture ERROR for skill_command ref, got: {findings}"
+
+
+# ---------------------------------------------------------------------------
+# capture-list-requires-retries-zero tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureListRequiresRetriesZero:
+    """Tests for the capture-list-requires-retries-zero rule."""
+
+    def test_capture_list_with_default_retries_fires_error(self) -> None:
+        """capture_list with no retries field (defaults to 3) must emit ERROR."""
+        steps = {
+            "lens": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.severity == Severity.ERROR]
+        assert any(
+            f.rule == "capture-list-requires-retries-zero" and f.step_name == "lens"
+            for f in errors
+        ), f"Expected capture-list-requires-retries-zero ERROR, got: {findings}"
+
+    def test_capture_list_with_retries_zero_is_clean(self) -> None:
+        """capture_list with retries: 0 must NOT emit capture-list-requires-retries-zero."""
+        steps = {
+            "lens": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                "retries": 0,
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        rule_findings = [f for f in findings if f.rule == "capture-list-requires-retries-zero"]
+        assert rule_findings == [], (
+            f"capture-list-requires-retries-zero must not fire for retries:0, got: {rule_findings}"
+        )
+
+    def test_capture_list_with_retries_explicit_fires_error(self) -> None:
+        """capture_list with retries: 1 (explicit non-zero) must emit ERROR."""
+        steps = {
+            "audits": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:audit-friction"},
+                "capture_list": {"audit_report_paths": "${{ result.audit_report_path }}"},
+                "retries": 1,
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.severity == Severity.ERROR]
+        assert any(
+            f.rule == "capture-list-requires-retries-zero" and f.step_name == "audits"
+            for f in errors
+        ), f"Expected capture-list-requires-retries-zero ERROR for retries:1, got: {findings}"
+
+    def test_capture_not_capture_list_with_retries_is_clean(self) -> None:
+        """capture (not capture_list) with retries: 3 must NOT emit the capture_list rule."""
+        steps = {
+            "impl": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:implement-worktree-no-merge plan"},
+                "capture": {"worktree_path": "${{ result.worktree_path }}"},
+                "retries": 3,
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        rule_findings = [f for f in findings if f.rule == "capture-list-requires-retries-zero"]
+        assert rule_findings == [], (
+            "capture-list-requires-retries-zero is capture_list-specific and must not "
+            f"fire for regular capture with retries, got: {rule_findings}"
+        )
+
+    def test_empty_capture_list_with_retries_is_clean(self) -> None:
+        """capture_list: {} with retries: 3 must NOT emit the rule (empty = no accumulation)."""
+        steps = {
+            "step": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:some-skill"},
+                "capture_list": {},
+                "retries": 3,
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        rule_findings = [f for f in findings if f.rule == "capture-list-requires-retries-zero"]
+        assert rule_findings == [], (
+            "capture-list-requires-retries-zero must not fire for empty capture_list, "
+            f"got: {rule_findings}"
+        )

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -957,7 +957,7 @@ class TestCaptureListRequiresRetriesZero:
             retries=0,
             on_success="done",
         )
-        step.retries = 3  # simulate missing retries: field (defaults to 3)
+        step.retries = 3  # bypass __post_init__ guard: built with retries=0, mutated to non-zero
         recipe = Recipe(
             name="test",
             description="test",

--- a/tests/recipe/test_schema.py
+++ b/tests/recipe/test_schema.py
@@ -88,6 +88,38 @@ def test_recipe_step_retries_zero() -> None:
     assert step.retries == 0
 
 
+def test_recipe_step_capture_list_with_retries_raises() -> None:
+    """RecipeStep must raise ValueError when capture_list is non-empty and retries > 0."""
+    from autoskillit.recipe.schema import RecipeStep
+
+    with pytest.raises(ValueError, match="retries"):
+        RecipeStep(
+            capture_list={"all_diagram_paths": "${{ result.diagram_path }}"},
+            retries=3,
+        )
+
+
+def test_recipe_step_capture_list_retries_zero_ok() -> None:
+    """RecipeStep with capture_list and retries=0 must not raise."""
+    from autoskillit.recipe.schema import RecipeStep
+
+    step = RecipeStep(
+        capture_list={"all_diagram_paths": "${{ result.diagram_path }}"},
+        retries=0,
+    )
+    assert step.capture_list == {"all_diagram_paths": "${{ result.diagram_path }}"}
+    assert step.retries == 0
+
+
+def test_recipe_step_empty_capture_list_with_retries_ok() -> None:
+    """RecipeStep with empty capture_list and retries=3 must not raise."""
+    from autoskillit.recipe.schema import RecipeStep
+
+    step = RecipeStep(capture_list={}, retries=3)
+    assert step.capture_list == {}
+    assert step.retries == 3
+
+
 def test_recipe_step_has_on_exhausted_field() -> None:
     """RecipeStep must have an on_exhausted field defaulting to 'escalate'."""
     from autoskillit.recipe.schema import RecipeStep

--- a/tests/recipe/test_validator_dataflow.py
+++ b/tests/recipe/test_validator_dataflow.py
@@ -73,6 +73,53 @@ class TestDataFlowQuality:
         assert dead[0].step_name == "impl"
         assert dead[0].field == "worktree_path"
 
+    # DFQ2b
+    def test_dead_output_detected_for_capture_list(self) -> None:
+        """capture_list orphan vars must be flagged as DEAD_OUTPUT."""
+        wf = self._make_recipe(
+            {
+                "lens": {
+                    "tool": "run_skill",
+                    "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                    "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                    "on_success": "finish",
+                },
+                "finish": {"action": "stop", "message": "Done"},
+            }
+        )
+        report = analyze_dataflow(wf)
+        dead = [w for w in report.warnings if w.code == "DEAD_OUTPUT"]
+        assert len(dead) == 1, f"expected 1 dead output for orphan capture_list var, got {dead}"
+        assert dead[0].step_name == "lens"
+        assert dead[0].field == "all_diagram_paths"
+
+    # DFQ2c
+    def test_consumed_capture_list_not_flagged(self) -> None:
+        """capture_list vars consumed downstream must NOT be flagged as DEAD_OUTPUT."""
+        wf = self._make_recipe(
+            {
+                "lens": {
+                    "tool": "run_skill",
+                    "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
+                    "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                    "on_success": "bundle",
+                },
+                "bundle": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": (
+                            "/autoskillit:prepare-research-pr ${{ context.all_diagram_paths }}"
+                        ),
+                    },
+                    "on_success": "finish",
+                },
+                "finish": {"action": "stop", "message": "Done"},
+            }
+        )
+        report = analyze_dataflow(wf)
+        dead = [w for w in report.warnings if w.code == "DEAD_OUTPUT"]
+        assert len(dead) == 0, f"expected 0 dead outputs for consumed capture_list var, got {dead}"
+
     # DFQ3
     def test_consumed_output_not_flagged(self) -> None:
         wf = self._make_recipe(

--- a/tests/recipe/test_validator_dataflow.py
+++ b/tests/recipe/test_validator_dataflow.py
@@ -82,6 +82,7 @@ class TestDataFlowQuality:
                     "tool": "run_skill",
                     "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
                     "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                    "retries": 0,
                     "on_success": "finish",
                 },
                 "finish": {"action": "stop", "message": "Done"},
@@ -102,6 +103,7 @@ class TestDataFlowQuality:
                     "tool": "run_skill",
                     "with": {"skill_command": "/autoskillit:exp-lens-diagram test"},
                     "capture_list": {"all_diagram_paths": "${{ result.diagram_path }}"},
+                    "retries": 0,
                     "on_success": "bundle",
                 },
                 "bundle": {


### PR DESCRIPTION
## Summary

The recipe validation system has a structural blind spot: `capture_list` variables are invisible to the BFS dataflow analyzer, the `downstream-context-gap` rule, and the dead-output detector. This means an entire class of dataflow bugs — where accumulated outputs are produced but never consumed, or consumed but never produced — passes validation silently. Additionally, no semantic rule enforces `retries: 0` on `capture_list` steps, allowing retry-induced duplication across 5 recipes and 7 steps. The fix is to make the dataflow analyzer and schema aware of `capture_list`, add two new semantic rules, and harden the shell scripts that operate on lens outputs.

Part B will cover the pipeline ordering fix (integrating lens textual output into the report via a `re_integrate_lenses` step) and the renderer enhancement to process textual analysis alongside Mermaid blocks.

## Requirements

- REQ-REV-001: Diagnostic lens outputs (causal assumptions, estimand clarity) MUST be incorporated as sections in the final report, not stored as standalone files in `artifacts/images/`
- REQ-REV-002: Mermaid diagram content from lenses MUST be rendered (SVG/PNG or inline Mermaid in HTML) — not left as raw markdown
- REQ-REV-003: Each diagnostic lens MUST run exactly once per review phase — deduplication by lens name, not timestamp
- REQ-REV-004: `bundle-local-report` failure MUST be surfaced as a warning in the report rather than silently falling back to emergency export
- REQ-REV-005: The archive step MUST package implementation scripts into `artifacts/scripts/` in the tarball
- REQ-REV-006: The archive manifest section MUST appear exactly once in the report

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260515-081231-952920/.autoskillit/temp/rectify/rectify_diagnostic_lens_dataflow_immunity_2026-05-15_082900.md`

Closes #2418

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 62 | 9.4k | 791.3k | 113.5k | 326 | 55.9k | 7m 20s |
| rectify | claude-sonnet-4-6 | 1 | 6.0k | 12.7k | 794.2k | 80.4k | 143 | 65.4k | 6m 14s |
| dry_walkthrough | claude-opus-4-6 | 1 | 49 | 13.1k | 1.8M | 76.2k | 164 | 61.9k | 9m 57s |
| implement* | MiniMax-M2.7-highspeed | 1 | 5.9M | 31.3k | 2.9M | 101.9k | 251 | 273.8k | 12m 25s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 189.0k | 4.9k | 385.3k | 29.9k | 26 | 15.7k | 1m 40s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 65.4k | 1.8k | 236.0k | 29.9k | 18 | 15.4k | 47s |
| review_pr | claude-sonnet-4-6 | 5 | 2.0k | 167.2k | 5.0M | 109.3k | 299 | 463.8k | 47m 45s |
| resolve_review | claude-sonnet-4-6 | 5 | 1.1k | 86.6k | 6.8M | 96.7k | 387 | 321.8k | 43m 49s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 341 | 14.9k | 2.1M | 68.6k | 96 | 54.8k | 5m 28s |
| resolve_queue_merge_conflicts | claude-sonnet-4-6 | 1 | 268 | 21.9k | 2.0M | 91.1k | 96 | 78.0k | 6m 39s |
| **Total** | | | 6.2M | 363.8k | 22.9M | 113.5k | | 1.4M | 2h 22m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 549 | 5311.2 | 498.7 | 57.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 31 | 219420.6 | 10381.3 | 2792.1 |
| ci_conflict_fix | 327 | 6372.2 | 167.5 | 45.5 |
| resolve_queue_merge_conflicts | 1069 | 1849.9 | 72.9 | 20.5 |
| **Total** | **1976** | 11576.3 | 711.8 | 184.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 6.7k | 90.0k | 10.7M | 281.0k | 41m 25s |
| claude-opus-4-6 | 1 | 49 | 13.1k | 1.8M | 61.9k | 9m 57s |
| MiniMax-M2.7-highspeed | 3 | 6.2M | 38.0k | 3.5M | 304.8k | 14m 53s |