### PR TITLE
Rectify: Planner ID Contract Enforcement Layer

### DIFF
--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -9,11 +9,13 @@ from typing import TypedDict
 from autoskillit.core import atomic_write, write_versioned_json
 from autoskillit.planner._sort_utils import _natural_sort_key
 from autoskillit.planner.schema import (
+    _ASSIGN_ID_RE,
     ASSIGN_RESULT_FILE_RE,
     PHASE_RESULT_FILE_RE,
     WP_RESULT_FILE_RE,
     RunDirResult,
     TaskResolutionResult,
+    make_canonical_assignment_id,
     validate_assignment_result,
     validate_phase_result,
     validate_refined_assignments,
@@ -284,11 +286,17 @@ def expand_assignments(
         for idx, a in enumerate(previews, start=1):
             if isinstance(a, dict):
                 aid = a.get("id", "")
-                if not aid:
-                    aid = f"{phase_id}-A{idx}"
+                if not aid or not _ASSIGN_ID_RE.match(aid):
+                    aid = make_canonical_assignment_id(phase_id, idx)
                 assignment_ids.append(aid)
             else:
-                assignment_ids.append(str(a))
+                assignment_ids.append(make_canonical_assignment_id(phase_id, idx))
+        for aid in assignment_ids:
+            if not _ASSIGN_ID_RE.match(aid):
+                raise ValueError(
+                    f"Assignment ID {aid!r} in phase {phase_id} does not match "
+                    f"canonical format {_ASSIGN_ID_RE.pattern}"
+                )
         assignment_names = [a.get("name", "") if isinstance(a, dict) else str(a) for a in previews]
         metadata = {
             "assignment_count": len(previews),

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -9,7 +9,7 @@ from typing import TypedDict
 from autoskillit.core import atomic_write, write_versioned_json
 from autoskillit.planner._sort_utils import _natural_sort_key
 from autoskillit.planner.schema import (
-    _ASSIGN_ID_RE,
+    ASSIGN_ID_RE,
     ASSIGN_RESULT_FILE_RE,
     PHASE_RESULT_FILE_RE,
     WP_RESULT_FILE_RE,
@@ -286,17 +286,11 @@ def expand_assignments(
         for idx, a in enumerate(previews, start=1):
             if isinstance(a, dict):
                 aid = a.get("id", "")
-                if not aid or not _ASSIGN_ID_RE.match(aid):
+                if not aid or not ASSIGN_ID_RE.match(aid):
                     aid = make_canonical_assignment_id(phase_id, idx)
                 assignment_ids.append(aid)
             else:
                 assignment_ids.append(make_canonical_assignment_id(phase_id, idx))
-        for aid in assignment_ids:
-            if not _ASSIGN_ID_RE.match(aid):
-                raise ValueError(
-                    f"Assignment ID {aid!r} in phase {phase_id} does not match "
-                    f"canonical format {_ASSIGN_ID_RE.pattern}"
-                )
         assignment_names = [a.get("name", "") if isinstance(a, dict) else str(a) for a in previews]
         metadata = {
             "assignment_count": len(previews),

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -132,7 +132,8 @@ def _write_refine_contexts(
         if missing:
             raise ValueError(
                 f"Phases {sorted(missing)} have no merged assignments — "
-                f"all result files may have been filtered out"
+                f"expected={sorted(expected_phase_ids)}, "
+                f"found={sorted(phase_groups)}"
             )
 
     contexts_dir = planner_dir / "refine_contexts"
@@ -242,8 +243,10 @@ def merge_tier_results(
         excluded = [f for f in all_files if not tier_re.match(f.name)]
         if excluded:
             names = [f.name for f in excluded]
+            display = names[:10]
+            suffix = f" and {len(names) - 10} more" if len(names) > 10 else ""
             raise ValueError(
-                f"Result files in {results_dir} excluded by {tier_re.pattern}: {names}. "
+                f"Result files in {results_dir} excluded by {tier_re.pattern}: {display}{suffix}. "
                 f"This indicates non-canonical IDs were generated upstream."
             )
         paths = [f for f in all_files if tier_re.match(f.name)]
@@ -270,7 +273,12 @@ def merge_tier_results(
         expected_phase_ids: frozenset[str] | None = None
         manifest_path = Path(results_dir) / "phase_assignment_manifest.json"
         if manifest_path.exists():
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Corrupted phase_assignment_manifest.json at {manifest_path}: {exc}"
+                ) from exc
             expected_phase_ids = frozenset(
                 item["id"] for item in manifest.get("items", []) if item.get("id")
             )

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -114,6 +114,7 @@ def _write_refine_contexts(
     planner_dir: Path,
     assignments: list[dict[str, Any]],
     task_file_path: str,
+    expected_phase_ids: frozenset[str] | None = None,
 ) -> list[str]:
     phase_groups: dict[str, list[dict[str, Any]]] = {}
     for assignment in assignments:
@@ -124,6 +125,14 @@ def _write_refine_contexts(
             logger.warning(
                 "Assignment %r has no phase_id — skipped from refine contexts",
                 assignment.get("id", "<unknown>"),
+            )
+
+    if expected_phase_ids is not None:
+        missing = expected_phase_ids - frozenset(phase_groups)
+        if missing:
+            raise ValueError(
+                f"Phases {sorted(missing)} have no merged assignments — "
+                f"all result files may have been filtered out"
             )
 
     contexts_dir = planner_dir / "refine_contexts"
@@ -228,11 +237,18 @@ def merge_tier_results(
     **kwargs: Any,
 ) -> dict[str, Any]:
     tier_re = _TIER_FILE_RE.get(key)
-    paths = sorted(
-        f
-        for f in Path(results_dir).glob("*_result.json")
-        if tier_re is None or tier_re.match(f.name)
-    )
+    all_files = sorted(Path(results_dir).glob("*_result.json"))
+    if tier_re is not None:
+        excluded = [f for f in all_files if not tier_re.match(f.name)]
+        if excluded:
+            names = [f.name for f in excluded]
+            raise ValueError(
+                f"Result files in {results_dir} excluded by {tier_re.pattern}: {names}. "
+                f"This indicates non-canonical IDs were generated upstream."
+            )
+        paths = [f for f in all_files if tier_re.match(f.name)]
+    else:
+        paths = all_files
     if not paths:
         raise ValueError(f"No *_result.json files found in {results_dir}")
     result = merge_files(
@@ -251,7 +267,16 @@ def merge_tier_results(
                 output_path,
             )
         planner_dir = Path(output_path).parent
-        context_paths = _write_refine_contexts(planner_dir, assignments, task_file_path)
+        expected_phase_ids: frozenset[str] | None = None
+        manifest_path = Path(results_dir) / "phase_assignment_manifest.json"
+        if manifest_path.exists():
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            expected_phase_ids = frozenset(
+                item["id"] for item in manifest.get("items", []) if item.get("id")
+            )
+        context_paths = _write_refine_contexts(
+            planner_dir, assignments, task_file_path, expected_phase_ids=expected_phase_ids
+        )
         result["refine_context_paths"] = ",".join(context_paths)
     return result
 

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -279,9 +279,12 @@ def merge_tier_results(
                 raise ValueError(
                     f"Corrupted phase_assignment_manifest.json at {manifest_path}: {exc}"
                 ) from exc
-            expected_phase_ids = frozenset(
-                item["id"] for item in manifest.get("items", []) if item.get("id")
-            )
+            manifest_items = manifest.get("items", [])
+            if any(not item.get("id") for item in manifest_items):
+                raise ValueError(
+                    f"Manifest item has missing or empty 'id' field at {manifest_path}"
+                )
+            expected_phase_ids = frozenset(item["id"] for item in manifest_items)
         context_paths = _write_refine_contexts(
             planner_dir, assignments, task_file_path, expected_phase_ids=expected_phase_ids
         )

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -258,7 +258,9 @@ def validate_wp_result(
 
     wp_id = result["id"]
     if not _WP_ID_RE.match(wp_id):
-        raise ValueError(f"WP id {wp_id!r} does not match expected PX-AY-WPZ format")
+        raise ValueError(
+            f"validate_wp_result: WP id {wp_id!r} does not match expected PX-AY-WPZ format"
+        )
 
     if not allow_stub:
         count = len(result.get("deliverables", []))
@@ -292,7 +294,9 @@ def resolve_wp_id(wp: dict[str, Any], assign_id: str) -> str:
     wp_id = wp.get("id", "")
     if wp_id:
         if not _WP_ID_RE.match(wp_id):
-            raise ValueError(f"WP id {wp_id!r} does not match expected PX-AY-WPZ format")
+            raise ValueError(
+                f"resolve_wp_id: WP id {wp_id!r} does not match expected PX-AY-WPZ format"
+            )
         return wp_id
     id_suffix = wp.get("id_suffix", "")
     if id_suffix:

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -152,6 +152,7 @@ class ValidationFinding(TypedDict):
 
 _PHASE_ID_RE = re.compile(r"^P\d+$")
 _ASSIGN_ID_RE = re.compile(r"^P\d+-A\d+$")
+ASSIGN_ID_RE = _ASSIGN_ID_RE
 _WP_ID_RE = re.compile(r"^P\d+-A\d+-WP\d+$")
 
 

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -154,6 +154,18 @@ _PHASE_ID_RE = re.compile(r"^P\d+$")
 _ASSIGN_ID_RE = re.compile(r"^P\d+-A\d+$")
 _WP_ID_RE = re.compile(r"^P\d+-A\d+-WP\d+$")
 
+
+def make_canonical_assignment_id(phase_id: str, index: int) -> str:
+    """Generate a canonical assignment ID and validate it."""
+    aid = f"{phase_id}-A{index}"
+    if not _ASSIGN_ID_RE.match(aid):
+        raise ValueError(
+            f"Cannot construct canonical assignment ID from phase_id={phase_id!r}, "
+            f"index={index}: result {aid!r} does not match {_ASSIGN_ID_RE.pattern}"
+        )
+    return aid
+
+
 PHASE_RESULT_FILE_RE = re.compile(r"^P\d+_result\.json$")
 ASSIGN_RESULT_FILE_RE = re.compile(r"^P\d+-A\d+_result\.json$")
 WP_RESULT_FILE_RE = re.compile(r"^P\d+-A\d+-WP\d+_result\.json$")
@@ -245,10 +257,7 @@ def validate_wp_result(
 
     wp_id = result["id"]
     if not _WP_ID_RE.match(wp_id):
-        warnings.warn(
-            f"WP id {wp_id!r} does not match expected PX-AY-WPZ format",
-            stacklevel=2,
-        )
+        raise ValueError(f"WP id {wp_id!r} does not match expected PX-AY-WPZ format")
 
     if not allow_stub:
         count = len(result.get("deliverables", []))
@@ -281,10 +290,18 @@ def _reject_empty_string_ids(data: dict[str, Any], context: str) -> None:
 def resolve_wp_id(wp: dict[str, Any], assign_id: str) -> str:
     wp_id = wp.get("id", "")
     if wp_id:
+        if not _WP_ID_RE.match(wp_id):
+            raise ValueError(f"WP id {wp_id!r} does not match expected PX-AY-WPZ format")
         return wp_id
     id_suffix = wp.get("id_suffix", "")
     if id_suffix:
-        return f"{assign_id}-{id_suffix}"
+        resolved = f"{assign_id}-{id_suffix}"
+        if not _WP_ID_RE.match(resolved):
+            raise ValueError(
+                f"Resolved WP id {resolved!r} (from assign_id={assign_id!r}, "
+                f"id_suffix={id_suffix!r}) does not match expected PX-AY-WPZ format"
+            )
+        return resolved
     raise ValueError(f"Work package in assignment {assign_id!r} has neither 'id' nor 'id_suffix'")
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -151,7 +151,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 308),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 255),
+    ("src/autoskillit/planner/manifests.py", 257),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc.py", 445),
 }

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -289,7 +289,7 @@ class TestCompilePlanEdgeCases:
             {"id": "BADID", "name": "Bad", "deliverables": ["x.py"]},
         )
 
-        with pytest.raises(ValueError, match="Invalid WP id format"):
+        with pytest.raises(RuntimeError, match="does not match expected PX-AY-WPZ format"):
             compile_plan(str(tmp_path), write_task_file(tmp_path, "t"), "s")
 
 

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -891,20 +891,18 @@ def test_merge_refined_assignments_writes_to_planner_dir(tmp_path):
 
 
 def test_merge_tier_results_skips_non_assignment_files(tmp_path):
-    """Sentinel files in assignments/ must not be included in merge output."""
+    """Canonical assignment files are merged; non-canonical files raise an error instead."""
     from tests.planner.conftest import make_assignment_result
 
     assign_dir = tmp_path / "assignments"
     assign_dir.mkdir()
     out = tmp_path / "combined.json"
 
+    # Only canonical assignment files — non-canonical files (e.g. phase files in
+    # assignments dir) now cause merge_tier_results to raise instead of silently skipping
     write_json(
         assign_dir / "P1-A1_result.json",
         make_assignment_result(1, 1),
-    )
-    write_json(
-        assign_dir / "P1_result.json",
-        {"id": "P1", "status": "complete", "assignment_count": 1, "failed_count": 0},
     )
 
     task_file = write_task_file(tmp_path)
@@ -913,7 +911,6 @@ def test_merge_tier_results_skips_non_assignment_files(tmp_path):
     merged = json.loads(out.read_text())
     ids = [a["id"] for a in merged["assignments"]]
     assert "P1-A1" in ids
-    assert "P1" not in ids
 
 
 def test_merge_files_produces_indented_output(tmp_path: Path) -> None:
@@ -924,3 +921,54 @@ def test_merge_files_produces_indented_output(tmp_path: Path) -> None:
     raw = out.read_text(encoding="utf-8")
     lines = raw.strip().splitlines()
     assert len(lines) > 1, "merge_files output must be multi-line (indented)"
+
+
+# --- ID Contract Enforcement Tests (1d, 1e) ---
+
+
+def test_merge_tier_results_raises_on_excluded_assignment_files(tmp_path: Path) -> None:
+    """Test 1d: excluded files cause merge_tier_results to raise instead of silent drop."""
+    from tests.planner.conftest import make_assignment_result, write_json
+
+    results_dir = tmp_path / "assignments"
+    results_dir.mkdir()
+
+    # Write one canonical result file and one non-canonical that matches *_result.json
+    # but NOT ASSIGN_RESULT_FILE_RE (e.g., P1_result.json instead of P1-A1_result.json)
+    write_json(results_dir / "P1-A1_result.json", make_assignment_result(1, 1))
+    # This file matches *_result.json but NOT ASSIGN_RESULT_FILE_RE (missing -A{num})
+    write_json(
+        results_dir / "P1_result.json",
+        {"id": "P1", "name": "Phase 1", "ordering": 1, "goal": "x", "scope": []},
+    )
+
+    out = tmp_path / "combined.json"
+
+    with pytest.raises(ValueError, match="excluded"):
+        merge_tier_results(str(results_dir), str(out), "assignments")
+
+
+def test_write_refine_contexts_detects_missing_expected_phases(tmp_path: Path) -> None:
+    """Test 1e: _write_refine_contexts raises when an expected phase has zero assignments."""
+    from autoskillit.planner.merge import _write_refine_contexts
+
+    # Phase P1 and P2 are expected, but only P1 has assignments
+    assignments = [
+        {
+            "id": "P1-A1",
+            "phase_id": "P1",
+            "name": "Auth",
+            "goal": "Auth goal",
+            "technical_approach": "JWT",
+            "proposed_work_packages": [],
+        },
+    ]
+    expected_phase_ids = frozenset({"P1", "P2", "P3"})
+
+    with pytest.raises(ValueError, match="P2|P3"):
+        _write_refine_contexts(
+            tmp_path,
+            assignments,
+            task_file_path="",
+            expected_phase_ids=expected_phase_ids,
+        )

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -890,16 +890,14 @@ def test_merge_refined_assignments_writes_to_planner_dir(tmp_path):
     assert expected.exists()
 
 
-def test_merge_tier_results_skips_non_assignment_files(tmp_path):
-    """Canonical assignment files are merged; non-canonical files raise an error instead."""
+def test_merge_tier_results_merges_canonical_assignment_files(tmp_path):
+    """Canonical assignment files are merged into combined output successfully."""
     from tests.planner.conftest import make_assignment_result
 
     assign_dir = tmp_path / "assignments"
     assign_dir.mkdir()
     out = tmp_path / "combined.json"
 
-    # Only canonical assignment files — non-canonical files (e.g. phase files in
-    # assignments dir) now cause merge_tier_results to raise instead of silently skipping
     write_json(
         assign_dir / "P1-A1_result.json",
         make_assignment_result(1, 1),
@@ -965,7 +963,7 @@ def test_write_refine_contexts_detects_missing_expected_phases(tmp_path: Path) -
     ]
     expected_phase_ids = frozenset({"P1", "P2", "P3"})
 
-    with pytest.raises(ValueError, match="P2|P3"):
+    with pytest.raises(ValueError, match=r"P[23].*have no merged assignments"):
         _write_refine_contexts(
             tmp_path,
             assignments,

--- a/tests/planner/test_pipeline_integration.py
+++ b/tests/planner/test_pipeline_integration.py
@@ -217,3 +217,62 @@ def test_pipeline_factory_fixtures_are_schema_compliant(tmp_path: Path) -> None:
 
     milestones = json.loads((tmp_path / "milestones.json").read_text())
     assert milestones["milestones"][0]["name_slug"] == "schema-alignment"
+
+
+# ---------------------------------------------------------------------------
+# ID Contract Enforcement Tests (1f)
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_expand_through_merge_end_to_end(tmp_path: Path) -> None:
+    """Test 1f: WP-prefix plain-string previews survive expand→merge pipeline."""
+    from autoskillit.planner import expand_assignments, merge_tier_results
+    from tests.planner.conftest import make_assignment_result, write_json
+
+    # Create a refined_plan with plain-string previews (including WP-style prefixes)
+    write_json(
+        tmp_path / "refined_plan.json",
+        {
+            "phases": [
+                {
+                    "id": "P1",
+                    "name": "Foundation",
+                    "ordering": 1,
+                    "assignments_preview": ["WP-1: Define Backend", "WP-2: Implement API"],
+                },
+                {
+                    "id": "P2",
+                    "name": "Application",
+                    "ordering": 2,
+                    "assignments_preview": ["WP-3: Build UI"],
+                },
+            ]
+        },
+    )
+
+    # expand_assignments should normalize to canonical IDs
+    expand_assignments(str(tmp_path / "refined_plan.json"), str(tmp_path))
+
+    # Write canonical assignment result files using the IDs expand_assignments would produce
+    write_json(
+        tmp_path / "assignments" / "P1-A1_result.json",
+        make_assignment_result(1, 1, name="Define Backend"),
+    )
+    write_json(
+        tmp_path / "assignments" / "P1-A2_result.json",
+        make_assignment_result(1, 2, name="Implement API"),
+    )
+    write_json(
+        tmp_path / "assignments" / "P2-A1_result.json",
+        make_assignment_result(2, 1, name="Build UI"),
+    )
+
+    # merge_tier_results should find all three files — no silent drops
+    out = tmp_path / "merged.json"
+    merge_tier_results(str(tmp_path / "assignments"), str(out), "assignments")
+
+    merged = json.loads(out.read_text())
+    ids = {a["id"] for a in merged["assignments"]}
+    assert ids == {"P1-A1", "P1-A2", "P2-A1"}, (
+        f"All three canonical assignment IDs must survive merge, got {ids}"
+    )

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -666,9 +666,9 @@ def test_expand_assignments_normalizes_dict_with_noncanonical_id(tmp_path: Path)
 def test_expand_assignments_post_generation_all_ids_match_regex(
     tmp_path: Path, preview_input: list, expected_ids: list[str]
 ) -> None:
-    """Test 1c: every generated assignment ID matches _ASSIGN_ID_RE."""
+    """Test 1c: every generated assignment ID matches ASSIGN_ID_RE."""
     from autoskillit.planner.manifests import expand_assignments
-    from autoskillit.planner.schema import _ASSIGN_ID_RE
+    from autoskillit.planner.schema import ASSIGN_ID_RE
 
     refined = tmp_path / "refined_plan.json"
     refined.write_text(
@@ -690,7 +690,7 @@ def test_expand_assignments_post_generation_all_ids_match_regex(
     assignment_ids = manifest["items"][0]["metadata"]["assignment_ids"]
     assert assignment_ids == expected_ids, f"Expected {expected_ids}, got {assignment_ids}"
     for aid in assignment_ids:
-        assert _ASSIGN_ID_RE.match(aid), (
+        assert ASSIGN_ID_RE.match(aid), (
             f"Assignment ID {aid!r} does not match canonical format ^P\\d+-A\\d+$"
         )
 

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -570,3 +570,145 @@ def test_expand_wps_includes_task_file_path_in_context(tmp_path: Path) -> None:
         assert "task_file_path" in context, "Context file must include task_file_path field"
         assert context["task_file_path"] == str(task_file)
         assert "task" not in context, "Context file must not include inline task text"
+
+
+# --- ID Contract Enforcement Tests (1a, 1b, 1c, 1g) ---
+
+
+def test_expand_assignments_normalizes_plain_string_previews(tmp_path: Path) -> None:
+    """Test 1a: plain-string previews are normalized to canonical P{N}-A{M} IDs."""
+    from autoskillit.planner.manifests import expand_assignments
+
+    refined = tmp_path / "refined_plan.json"
+    refined.write_text(
+        json.dumps(
+            {
+                "phases": [
+                    {
+                        "id": "P3",
+                        "name": "Phase 3",
+                        "ordering": 3,
+                        "assignments_preview": ["WP-1: Define Backend", "WP-2: Implement API"],
+                    },
+                ]
+            }
+        )
+    )
+    result = expand_assignments(str(refined), str(tmp_path))
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assignment_ids = manifest["items"][0]["metadata"]["assignment_ids"]
+    assignment_names = manifest["items"][0]["metadata"]["assignment_names"]
+    assert assignment_ids == ["P3-A1", "P3-A2"], (
+        f"Expected canonical IDs ['P3-A1', 'P3-A2'], got {assignment_ids}"
+    )
+    assert assignment_names == ["WP-1: Define Backend", "WP-2: Implement API"], (
+        f"Raw string names should be preserved in assignment_names, got {assignment_names}"
+    )
+
+
+def test_expand_assignments_normalizes_dict_with_noncanonical_id(tmp_path: Path) -> None:
+    """Test 1b: dict previews with non-canonical id are normalized to canonical format."""
+    from autoskillit.planner.manifests import expand_assignments
+
+    refined = tmp_path / "refined_plan.json"
+    refined.write_text(
+        json.dumps(
+            {
+                "phases": [
+                    {
+                        "id": "P1",
+                        "name": "Phase 1",
+                        "ordering": 1,
+                        "assignments_preview": [{"id": "setup-infra", "name": "Setup Infra"}],
+                    },
+                ]
+            }
+        )
+    )
+    result = expand_assignments(str(refined), str(tmp_path))
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assignment_ids = manifest["items"][0]["metadata"]["assignment_ids"]
+    assert assignment_ids == ["P1-A1"], (
+        f"Expected canonical ['P1-A1'], got {assignment_ids} — non-canonical must be normalized"
+    )
+
+
+@pytest.mark.parametrize(
+    "preview_input,expected_ids",
+    [
+        # Plain strings with WP-style prefixes
+        (
+            ["WP-1: Task A", "WP-2: Task B"],
+            ["P1-A1", "P1-A2"],
+        ),
+        # Dicts with canonical IDs
+        (
+            [{"id": "P1-A1", "name": "A"}, {"id": "P1-A2", "name": "B"}],
+            ["P1-A1", "P1-A2"],
+        ),
+        # Dicts without IDs
+        (
+            [{"name": "First"}, {"name": "Second"}],
+            ["P1-A1", "P1-A2"],
+        ),
+        # Mixed: dict with canonical id + plain string
+        (
+            [{"id": "P1-A1", "name": "First"}, "Task B"],
+            ["P1-A1", "P1-A2"],
+        ),
+        # Dict with non-canonical id
+        (
+            [{"id": "setup-task", "name": "Setup"}],
+            ["P1-A1"],
+        ),
+    ],
+)
+def test_expand_assignments_post_generation_all_ids_match_regex(
+    tmp_path: Path, preview_input: list, expected_ids: list[str]
+) -> None:
+    """Test 1c: every generated assignment ID matches _ASSIGN_ID_RE."""
+    from autoskillit.planner.manifests import expand_assignments
+    from autoskillit.planner.schema import _ASSIGN_ID_RE
+
+    refined = tmp_path / "refined_plan.json"
+    refined.write_text(
+        json.dumps(
+            {
+                "phases": [
+                    {
+                        "id": "P1",
+                        "name": "Phase 1",
+                        "ordering": 1,
+                        "assignments_preview": preview_input,
+                    },
+                ]
+            }
+        )
+    )
+    result = expand_assignments(str(refined), str(tmp_path))
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assignment_ids = manifest["items"][0]["metadata"]["assignment_ids"]
+    assert assignment_ids == expected_ids, f"Expected {expected_ids}, got {assignment_ids}"
+    for aid in assignment_ids:
+        assert _ASSIGN_ID_RE.match(aid), (
+            f"Assignment ID {aid!r} does not match canonical format ^P\\d+-A\\d+$"
+        )
+
+
+def test_validate_refined_plan_accepts_non_empty_plain_string_preview(tmp_path: Path) -> None:
+    """Test 1g: validate_refined_plan accepts plain-string entries that are non-empty strings."""
+    from autoskillit.planner.schema import validate_refined_plan
+
+    data = {
+        "phases": [
+            {
+                "id": "P1",
+                "name": "Phase 1",
+                "ordering": 1,
+                "assignments_preview": ["WP-1: Task A", {"id": "P1-A2", "name": "Task B"}],
+            },
+        ]
+    }
+    # Should not raise — plain strings are valid previews
+    result = validate_refined_plan(data)
+    assert result["phases"][0]["assignments_preview"] == data["phases"][0]["assignments_preview"]

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -343,6 +343,25 @@ def test_tier_filename_regexes_match_expected_patterns() -> None:
         assert not WP_RESULT_FILE_RE.match(name)
 
 
+# ---------------------------------------------------------------------------
+# ID Contract Enforcement Tests (1h)
+# ---------------------------------------------------------------------------
+
+
+def test_wp_id_validation_raises_on_noncanonical(tmp_path: Path) -> None:
+    """Test 1h: validate_wp_result raises (not warns) for non-canonical WP IDs."""
+    from autoskillit.planner.schema import validate_wp_result
+
+    data = {
+        "id": "WP-1: Define Backend",
+        "name": "Backend Definition",
+        "goal": "Define the backend API",
+        "deliverables": ["api.yaml"],
+    }
+    with pytest.raises(ValueError, match="does not match expected"):
+        validate_wp_result(data)
+
+
 def test_refine_wps_skill_md_no_prefix_derivation_instruction() -> None:
     """planner-refine-wps SKILL.md must not instruct derivation from id prefix."""
     skill_md = Path("src/autoskillit/skills_extended/planner-refine-wps/SKILL.md")


### PR DESCRIPTION
## Summary

The planner pipeline has a systemic architectural weakness: three ID-format regexes (`_PHASE_ID_RE`, `_ASSIGN_ID_RE`, `_WP_ID_RE`) are defined in `schema.py` but are either unused or produce only warnings at validation time, while the corresponding file-filter regexes (`PHASE_RESULT_FILE_RE`, `ASSIGN_RESULT_FILE_RE`, `WP_RESULT_FILE_RE`) are hard gates that silently discard non-matching results. This creates a "leaky source, silent sink" pattern: ID generation sites produce IDs with no format enforcement, and downstream file filters silently drop non-conforming results with no error, warning, or telemetry. The architectural fix is a **centralized ID contract enforcement layer** that makes malformed IDs structurally impossible to propagate past generation boundaries, and makes silent drops structurally impossible at filter boundaries.

## Requirements

1. **Normalize assignment IDs in `expand_assignments`** (`manifests.py:284-291`): When processing plain-string previews, extract the prefix and renormalize to `{phase_id}-A{idx}` regardless of upstream prefix. This enforces the contract at the generation boundary.

2. **Add a validation gate** after `expand_assignments` that verifies all generated `assignment_ids` match `_ASSIGN_ID_RE` (`^P\d+-A\d+$`) and fails fast instead of silently dropping data downstream.

3. Optionally broaden `ASSIGN_RESULT_FILE_RE` to accept `WP` suffixes as a defense-in-depth measure.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260515-203723-521113/.autoskillit/temp/rectify/rectify_planner_id_contract_enforcement_2026-05-15_210500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 51 | 7.9k | 541.2k | 59.8k | 111 | 85.0k | 4m 50s |
| rectify | claude-opus-4-6 | 1 | 50 | 11.5k | 577.0k | 59.4k | 54 | 43.1k | 4m 55s |
| dry_walkthrough | claude-opus-4-6 | 1 | 52 | 15.6k | 1.3M | 62.8k | 87 | 48.2k | 7m 23s |
| implement* | MiniMax-M2.7-highspeed | 1 | 5.0M | 27.3k | 2.5M | 94.2k | 220 | 165.9k | 14m 33s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 97.9k | 4.6k | 209.7k | 29.9k | 25 | 42.7k | 1m 30s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 89.9k | 1.7k | 326.6k | 30.0k | 23 | 15.4k | 52s |
| review_pr | claude-sonnet-4-6 | 3 | 558 | 119.8k | 2.2M | 95.7k | 169 | 222.6k | 30m 41s |
| resolve_review | claude-sonnet-4-6 | 3 | 977 | 67.0k | 7.0M | 87.0k | 301 | 196.4k | 25m 37s |
| **Total** | | | 5.2M | 255.5k | 14.6M | 95.7k | | 819.4k | 1h 30m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 360 | 6911.4 | 460.9 | 75.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 56 | 124784.6 | 3507.3 | 1197.2 |
| **Total** | **416** | 35209.3 | 1969.7 | 614.1 |