### PR TITLE
Rectify: Planner Validate/Refine Loop — Zero-Progress Detection and Cycle-Breaking

### DIFF
--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 import regex as re
 
@@ -149,6 +149,9 @@ class ValidationFinding(TypedDict):
     message: str
     severity: Literal["error", "warning"]
     check: str
+    cycle_size: NotRequired[int]
+    cycle_nodes: NotRequired[list[str]]
+    cycle_edges: NotRequired[list[list[str]]]
 
 
 _PHASE_ID_RE = re.compile(r"^P\d+$")

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -204,11 +204,46 @@ def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[ValidationFinding]:
 
     if len(sorted_nodes) < len(wp_results):
         cycle_nodes = [n for n in wp_results if n not in set(sorted_nodes)]
+        # Decompose cycle: Kahn's algorithm leaves cycle nodes with in-degree > 0
+        # Reconstruct in-degree state at detection time to identify cycle edges
+        in_degree_end: dict[str, int] = {}
+        for wp_id in wp_results:
+            in_degree_end[wp_id] = 0
+        for wp_id, wp in wp_results.items():
+            for dep in wp.get("depends_on", []):
+                if (
+                    dep in wp_results
+                    and dep not in set(sorted_nodes)
+                    and wp_id not in set(sorted_nodes)
+                ):
+                    in_degree_end[wp_id] += 1
+
+        remaining = [n for n in wp_results if n not in set(sorted_nodes)]
+        if len(remaining) == 2:
+            # 2-node mutual cycle: both nodes have in-degree > 0 from each other
+            a, b = sorted(remaining)
+            # Check if a depends on b and b depends on a
+            a_deps = set(wp_results.get(a, {}).get("depends_on", []))
+            b_deps = set(wp_results.get(b, {}).get("depends_on", []))
+            if b in a_deps and a in b_deps:
+                return [
+                    {
+                        "message": f"Cycle detected among WPs: {a}, {b}",
+                        "severity": "error",
+                        "check": "dag_acyclic",
+                        "cycle_size": 2,
+                        "cycle_nodes": [a, b],
+                        "cycle_edges": [[a, b], [b, a]],
+                    }
+                ]
+        # 3+ nodes or non-mutual 2-node: report without edges
         return [
             {
                 "message": f"Cycle detected among WPs: {', '.join(sorted(cycle_nodes))}",
                 "severity": "error",
                 "check": "dag_acyclic",
+                "cycle_size": len(cycle_nodes),
+                "cycle_nodes": cycle_nodes,
             }
         ]
     return []

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -205,9 +205,8 @@ def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[ValidationFinding]:
     if len(sorted_nodes) < len(wp_results):
         cycle_nodes = [n for n in wp_results if n not in set(sorted_nodes)]
 
-        remaining = [n for n in wp_results if n not in set(sorted_nodes)]
-        if len(remaining) == 2:
-            a, b = sorted(remaining)
+        if len(cycle_nodes) == 2:
+            a, b = sorted(cycle_nodes)
             a_deps = set(wp_results.get(a, {}).get("depends_on", []))
             b_deps = set(wp_results.get(b, {}).get("depends_on", []))
             if b in a_deps and a in b_deps:

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -204,25 +204,10 @@ def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[ValidationFinding]:
 
     if len(sorted_nodes) < len(wp_results):
         cycle_nodes = [n for n in wp_results if n not in set(sorted_nodes)]
-        # Decompose cycle: Kahn's algorithm leaves cycle nodes with in-degree > 0
-        # Reconstruct in-degree state at detection time to identify cycle edges
-        in_degree_end: dict[str, int] = {}
-        for wp_id in wp_results:
-            in_degree_end[wp_id] = 0
-        for wp_id, wp in wp_results.items():
-            for dep in wp.get("depends_on", []):
-                if (
-                    dep in wp_results
-                    and dep not in set(sorted_nodes)
-                    and wp_id not in set(sorted_nodes)
-                ):
-                    in_degree_end[wp_id] += 1
 
         remaining = [n for n in wp_results if n not in set(sorted_nodes)]
         if len(remaining) == 2:
-            # 2-node mutual cycle: both nodes have in-degree > 0 from each other
             a, b = sorted(remaining)
-            # Check if a depends on b and b depends on a
             a_deps = set(wp_results.get(a, {}).get("depends_on", []))
             b_deps = set(wp_results.get(b, {}).get("depends_on", []))
             if b in a_deps and a in b_deps:
@@ -236,7 +221,10 @@ def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[ValidationFinding]:
                         "cycle_edges": [[a, b], [b, a]],
                     }
                 ]
-        # 3+ nodes or non-mutual 2-node: report without edges
+        # 3+ node or non-mutual 2-node cycles omit cycle_edges — key absence is the
+        # contract signal for planner-refine to escalate rather than auto-fix (see
+        # planner-refine SKILL.md: "If finding contains cycle_size: 3 or higher (or no
+        # cycle_edges): Escalate as CRITICAL").
         return [
             {
                 "message": f"Cycle detected among WPs: {', '.join(sorted(cycle_nodes))}",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -113,6 +113,7 @@ from autoskillit.recipe.rules import rules_graph as _rules_graph  # noqa: E402 F
 from autoskillit.recipe.rules import rules_inline_script as _rules_inline_script  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_inputs as _rules_inputs  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_isolation as _rules_isolation  # noqa: E402 F401
+from autoskillit.recipe.rules import rules_loop_progress as _rules_loop_progress  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_merge as _rules_merge  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_merge_queue as _rules_merge_queue  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_packs as _rules_packs  # noqa: E402 F401

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -31,6 +31,7 @@ Semantic validation rule modules for recipe analysis (31 rule files).
 | `rules_remediation.py` | audit-impl remediation_path capture must have non-terminal non-GO route |
 | `rules_recipe.py` | Sub-recipe reference validity and `with_args` hygiene |
 | `rules_route_gate.py` | Route gate shared-stop detection; fallback and primary path convergence |
+| `rules_loop_progress.py` | Loop progress tracking: run_skill steps in cycles must capture declared outputs |
 | `rules_skill_content.py` | Undefined bash placeholder detection in SKILL.md |
 | `rules_skills.py` | `skill_command` resolvability rules |
 | `rules_temp_path.py` | Rejects bare `{{AUTOSKILLIT_TEMP}}/` without scope prefix |

--- a/src/autoskillit/recipe/rules/rules_loop_progress.py
+++ b/src/autoskillit/recipe/rules/rules_loop_progress.py
@@ -1,0 +1,111 @@
+"""Semantic validation rules — loop progress tracking enforcement."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from autoskillit.recipe.schema import RecipeStep
+
+from autoskillit.core import (
+    SKILL_TOOLS,
+    Severity,
+    get_logger,
+    resolve_skill_name,
+)
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.contracts import (
+    get_skill_contract,
+    load_bundled_manifest,
+)
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+logger = get_logger(__name__)
+
+
+def _find_cycle_members(
+    graph: dict[str, set[str]], recipe_steps: Mapping[str, RecipeStep]
+) -> list[frozenset[str]]:
+    """Find all sets of steps that participate in a routing cycle.
+
+    Uses DFS back-edge detection (same pattern as _check_unbounded_cycles).
+    Returns a list of frozensets of step names that form cycles.
+    """
+    visited: set[str] = set()
+    rec_stack: set[str] = set()
+    cycles: list[frozenset[str]] = []
+
+    def dfs(node: str, path: list[str]) -> None:
+        visited.add(node)
+        rec_stack.add(node)
+        for neighbor in sorted(graph.get(node, set())):
+            if neighbor not in recipe_steps:
+                continue
+            if neighbor not in visited:
+                dfs(neighbor, path + [neighbor])
+            elif neighbor in rec_stack:
+                if neighbor in path:
+                    cycle_steps = path[path.index(neighbor) :]
+                else:
+                    cycle_steps = path
+                cycles.append(frozenset(cycle_steps))
+        rec_stack.discard(node)
+
+    for step_name in recipe_steps:
+        if step_name not in visited:
+            dfs(step_name, [step_name])
+
+    return cycles
+
+
+@semantic_rule(
+    name="loop-body-uncaptured-output",
+    description=("run_skill steps inside routing cycles must capture declared outputs"),
+    severity=Severity.ERROR,
+)
+def _check_loop_body_capture(ctx: ValidationContext) -> list[RuleFinding]:
+    """Flag run_skill steps in cycles that have no capture block despite declared outputs."""
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+    recipe_steps = ctx.recipe.steps
+
+    cycle_sets = _find_cycle_members(ctx.step_graph, recipe_steps)
+
+    for cycle_set in cycle_sets:
+        for step_name in cycle_set:
+            step = recipe_steps.get(step_name)
+            if step is None:
+                continue
+            if step.tool not in SKILL_TOOLS:
+                continue
+
+            skill_cmd = step.with_args.get("skill_command", "")
+            name = resolve_skill_name(skill_cmd)
+            if not name:
+                continue
+
+            contract = get_skill_contract(name, manifest)
+            if not contract:
+                continue
+
+            if not contract.outputs:
+                continue
+
+            if step.capture is None or len(step.capture) == 0:
+                cycle_list = sorted(cycle_set)
+                findings.append(
+                    RuleFinding(
+                        rule="loop-body-uncaptured-output",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Step '{step_name}' in loop [{'→'.join(cycle_list)}] "
+                            f"invokes skill '{name}' with declared outputs "
+                            f"{[o.name for o in contract.outputs]} "
+                            f"but has no capture: block"
+                        ),
+                    )
+                )
+
+    return findings

--- a/src/autoskillit/recipe/rules/rules_loop_progress.py
+++ b/src/autoskillit/recipe/rules/rules_loop_progress.py
@@ -44,12 +44,8 @@ def _find_cycle_members(
                 continue
             if neighbor not in visited:
                 dfs(neighbor, path + [neighbor])
-            elif neighbor in rec_stack:
-                if neighbor in path:
-                    cycle_steps = path[path.index(neighbor) :]
-                else:
-                    cycle_steps = path
-                cycles.append(frozenset(cycle_steps))
+            elif neighbor in rec_stack and neighbor in path:
+                cycles.append(frozenset(path[path.index(neighbor) :]))
         rec_stack.discard(node)
 
     for step_name in recipe_steps:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2016,7 +2016,14 @@ skills:
     outputs: []
   planner-refine:
     inputs: []
-    outputs: []
+    outputs:
+      - name: issues_fixed
+        type: string
+      - name: refinement_complete
+        type: string
+    pattern_examples:
+      - "refinement_complete = true\nissues_fixed = 3"
+    write_behavior: always
   planner-refine-phases:
     inputs:
       - name: combined_plan_path
@@ -2222,6 +2229,29 @@ callable_contracts:
     - name: next_iteration
       type: str
     - name: max_exceeded
+      type: str
+  autoskillit.smoke_utils.check_loop_with_progress:
+    inputs:
+    - name: current_iteration
+      type: str
+      required: false
+    - name: max_iterations
+      type: str
+      required: false
+    - name: issues_fixed_count
+      type: str
+      required: false
+    - name: prev_issues_fixed_count
+      type: str
+      required: false
+    outputs:
+    - name: next_iteration
+      type: str
+    - name: max_exceeded
+      type: str
+    - name: zero_progress
+      type: str
+    - name: prev_issues_fixed_count
       type: str
   autoskillit.smoke_utils.check_review_loop:
     inputs:

--- a/src/autoskillit/recipes/contracts/planner.json
+++ b/src/autoskillit/recipes/contracts/planner.json
@@ -1,5 +1,5 @@
 {
-  "recipe_source_hash": "sha256:01932623ed3af6c63f5034f5063b8df7d93a06045141330400f580e15e327773",
+  "recipe_source_hash": "sha256:17ffec6676f0d038086ac0b23e94add65edce5e0a68178ea8287c33517aeff61",
   "bundled_manifest_version": "0.1.0",
   "skill_hashes": {},
   "skills": {
@@ -330,9 +330,21 @@
     },
     "planner-refine": {
       "inputs": [],
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "issues_fixed",
+          "type": "string"
+        },
+        {
+          "name": "refinement_complete",
+          "type": "string"
+        }
+      ],
       "expected_output_patterns": [],
-      "pattern_examples": []
+      "pattern_examples": [
+        "refinement_complete = true\nissues_fixed = 3"
+      ],
+      "write_behavior": "always"
     }
   },
   "dataflow": [
@@ -917,7 +929,9 @@
         "wp_context_paths"
       ],
       "required": [],
-      "produced": [],
+      "produced": [
+        "issues_fixed_count"
+      ],
       "positional_args": 1
     },
     {
@@ -928,6 +942,7 @@
         "combined_phases_path",
         "combined_wps_path",
         "consolidated_wps_path",
+        "issues_fixed_count",
         "phase_ids",
         "phase_manifest_path",
         "plan_snapshot_path",
@@ -947,7 +962,8 @@
       ],
       "required": [],
       "produced": [
-        "refine_loop_count"
+        "refine_loop_count",
+        "prev_issues_fixed_count"
       ]
     },
     {
@@ -958,11 +974,13 @@
         "combined_phases_path",
         "combined_wps_path",
         "consolidated_wps_path",
+        "issues_fixed_count",
         "phase_ids",
         "phase_manifest_path",
         "plan_snapshot_path",
         "planner_assess_review_approach",
         "planner_dir",
+        "prev_issues_fixed_count",
         "refine_context_paths",
         "refine_loop_count",
         "refined_assignments_path",
@@ -987,11 +1005,13 @@
         "combined_phases_path",
         "combined_wps_path",
         "consolidated_wps_path",
+        "issues_fixed_count",
         "phase_ids",
         "phase_manifest_path",
         "plan_snapshot_path",
         "planner_assess_review_approach",
         "planner_dir",
+        "prev_issues_fixed_count",
         "refine_context_paths",
         "refine_loop_count",
         "refined_assignments_path",
@@ -1016,11 +1036,13 @@
         "combined_phases_path",
         "combined_wps_path",
         "consolidated_wps_path",
+        "issues_fixed_count",
         "phase_ids",
         "phase_manifest_path",
         "plan_snapshot_path",
         "planner_assess_review_approach",
         "planner_dir",
+        "prev_issues_fixed_count",
         "refine_context_paths",
         "refine_loop_count",
         "refined_assignments_path",

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,4 +1,4 @@
-recipe_source_hash: sha256:01932623ed3af6c63f5034f5063b8df7d93a06045141330400f580e15e327773
+recipe_source_hash: sha256:17ffec6676f0d038086ac0b23e94add65edce5e0a68178ea8287c33517aeff61
 bundled_manifest_version: 0.1.0
 skill_hashes: {}
 skills:
@@ -232,9 +232,17 @@ skills:
     write_behavior: always
   planner-refine:
     inputs: []
-    outputs: []
+    outputs:
+    - name: issues_fixed
+      type: string
+    - name: refinement_complete
+      type: string
     expected_output_patterns: []
-    pattern_examples: []
+    pattern_examples:
+    - 'refinement_complete = true
+
+      issues_fixed = 3'
+    write_behavior: always
 dataflow:
 - step: init
   available:
@@ -721,7 +729,8 @@ dataflow:
   - verdict
   - wp_context_paths
   required: []
-  produced: []
+  produced:
+  - issues_fixed_count
   positional_args: 1
 - step: check_refine_loop
   available:
@@ -730,6 +739,7 @@ dataflow:
   - combined_phases_path
   - combined_wps_path
   - consolidated_wps_path
+  - issues_fixed_count
   - phase_ids
   - phase_manifest_path
   - plan_snapshot_path
@@ -749,6 +759,7 @@ dataflow:
   required: []
   produced:
   - refine_loop_count
+  - prev_issues_fixed_count
 - step: compile
   available:
   - alignment_findings_path
@@ -756,11 +767,13 @@ dataflow:
   - combined_phases_path
   - combined_wps_path
   - consolidated_wps_path
+  - issues_fixed_count
   - phase_ids
   - phase_manifest_path
   - plan_snapshot_path
   - planner_assess_review_approach
   - planner_dir
+  - prev_issues_fixed_count
   - refine_context_paths
   - refine_loop_count
   - refined_assignments_path
@@ -782,11 +795,13 @@ dataflow:
   - combined_phases_path
   - combined_wps_path
   - consolidated_wps_path
+  - issues_fixed_count
   - phase_ids
   - phase_manifest_path
   - plan_snapshot_path
   - planner_assess_review_approach
   - planner_dir
+  - prev_issues_fixed_count
   - refine_context_paths
   - refine_loop_count
   - refined_assignments_path
@@ -808,11 +823,13 @@ dataflow:
   - combined_phases_path
   - combined_wps_path
   - consolidated_wps_path
+  - issues_fixed_count
   - phase_ids
   - phase_manifest_path
   - plan_snapshot_path
   - planner_assess_review_approach
   - planner_dir
+  - prev_issues_fixed_count
   - refine_context_paths
   - refine_loop_count
   - refined_assignments_path

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -412,6 +412,9 @@
         "cwd": "${{ inputs.source_dir }}",
         "output_dir": "${{ context.planner_dir }}"
       },
+      "capture": {
+        "issues_fixed_count": "${{ result.issues_fixed }}"
+      },
       "retries": 2,
       "on_success": "check_refine_loop",
       "on_exhausted": "escalate_stop",
@@ -420,14 +423,21 @@
     "check_refine_loop": {
       "tool": "run_python",
       "with": {
-        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "callable": "autoskillit.smoke_utils.check_loop_with_progress",
         "current_iteration": "${{ context.refine_loop_count }}",
-        "max_iterations": "5"
+        "max_iterations": "5",
+        "issues_fixed_count": "${{ context.issues_fixed_count }}",
+        "prev_issues_fixed_count": "${{ context.prev_issues_fixed_count }}"
       },
       "capture": {
-        "refine_loop_count": "${{ result.next_iteration }}"
+        "refine_loop_count": "${{ result.next_iteration }}",
+        "prev_issues_fixed_count": "${{ result.prev_issues_fixed_count }}"
       },
       "on_result": [
+        {
+          "when": "${{ result.zero_progress }} == true",
+          "route": "escalate_stop"
+        },
         {
           "when": "${{ result.max_exceeded }} == true",
           "route": "escalate_stop"
@@ -438,9 +448,10 @@
       ],
       "on_failure": "escalate_stop",
       "optional_context_refs": [
-        "refine_loop_count"
-      ],
-      "note": "Guards the validate → check_verdict → refine cycle. Caps at 5 refinement iterations. If the plan still fails validation after 5 refinements, escalates to human.\n"
+        "refine_loop_count",
+        "issues_fixed_count",
+        "prev_issues_fixed_count"
+      ]
     },
     "compile": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -428,6 +428,8 @@ steps:
         ${{ context.planner_dir }}
       cwd: "${{ inputs.source_dir }}"
       output_dir: "${{ context.planner_dir }}"
+    capture:
+      issues_fixed_count: "${{ result.issues_fixed }}"
     retries: 2
     on_success: check_refine_loop
     on_exhausted: escalate_stop
@@ -436,22 +438,25 @@ steps:
   check_refine_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      callable: "autoskillit.smoke_utils.check_loop_with_progress"
       current_iteration: "${{ context.refine_loop_count }}"
       max_iterations: "5"
+      issues_fixed_count: "${{ context.issues_fixed_count }}"
+      prev_issues_fixed_count: "${{ context.prev_issues_fixed_count }}"
     capture:
       refine_loop_count: "${{ result.next_iteration }}"
+      prev_issues_fixed_count: "${{ result.prev_issues_fixed_count }}"
     on_result:
+      - when: "${{ result.zero_progress }} == true"
+        route: escalate_stop
       - when: "${{ result.max_exceeded }} == true"
         route: escalate_stop
       - route: validate
     on_failure: escalate_stop
     optional_context_refs:
       - refine_loop_count
-    note: >
-      Guards the validate → check_verdict → refine cycle. Caps at 5 refinement
-      iterations. If the plan still fails validation after 5 refinements,
-      escalates to human.
+      - issues_fixed_count
+      - prev_issues_fixed_count
 
   compile:
     tool: run_python

--- a/src/autoskillit/skills_extended/planner-refine/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine/SKILL.md
@@ -135,15 +135,16 @@ Manual inspection of wp_manifest.json required.
 ```
 Write this to stdout. Do NOT attempt ID renaming.
 
-**DAG cycles** — escalate:
-- Findings matching `Cycle detected among WPs: ...` indicate a circular dependency in the
-  WP graph. Resolving cycles requires semantic understanding of the plan structure.
-```
-CRITICAL: Cannot auto-fix DAG cycle:
-- {finding text}
-Manual restructuring of depends_on relationships required.
-```
-Write this to stdout. Do NOT attempt cycle-breaking.
+**DAG cycles** — break 2-node mutual cycles; escalate larger:
+- If finding contains `cycle_size: 2` and `cycle_edges`:
+  - Identify the two WP IDs and their mutual dependency edges
+  - Remove the `depends_on` entry from the **higher-numbered WP** (lexicographic sort
+    of WP IDs — e.g., P1-A1-WP2 > P1-A1-WP1, so remove P1-A1-WP1 from P1-A1-WP2's deps)
+  - Update the WP's `_result.json` and `dep_graph.json` if it exists
+  - Count this toward `issues_fixed`
+- If finding contains `cycle_size: 3` or higher (or no `cycle_edges`):
+  - Escalate as CRITICAL (same as before)
+  - Do NOT attempt cycle-breaking for 3+ node cycles
 
 ### Step 4: Write corrected artifacts
 

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -224,6 +224,45 @@ def check_loop_iteration(
     }
 
 
+def check_loop_with_progress(
+    current_iteration: str = "",
+    max_iterations: str = "5",
+    issues_fixed_count: str = "",
+    prev_issues_fixed_count: str = "",
+) -> dict[str, str]:
+    """Progress-aware loop iteration guard.
+
+    Extends check_loop_iteration with zero-progress detection: if
+    issues_fixed_count == "0" for two consecutive iterations (current and
+    previous), returns zero_progress="true" for early-exit routing.
+    """
+    current_iteration = current_iteration or ""
+    max_iterations = max_iterations or ""
+    issues_fixed_count = issues_fixed_count or ""
+    prev_issues_fixed_count = prev_issues_fixed_count or ""
+
+    try:
+        iteration = int(current_iteration.strip()) if current_iteration.strip() else 0
+    except ValueError as exc:
+        raise ValueError(f"current_iteration must be numeric, got: {current_iteration!r}") from exc
+    next_iteration = iteration + 1
+    try:
+        max_iter = int(max_iterations.strip()) if max_iterations.strip() else 5
+    except ValueError as exc:
+        raise ValueError(f"max_iterations must be numeric, got: {max_iterations!r}") from exc
+
+    current_fixed = issues_fixed_count.strip()
+    prev_fixed = prev_issues_fixed_count.strip()
+    zero_progress = current_fixed == "0" and prev_fixed == "0"
+
+    return {
+        "next_iteration": str(next_iteration),
+        "max_exceeded": "true" if next_iteration >= max_iter else "false",
+        "zero_progress": "true" if zero_progress else "false",
+        "prev_issues_fixed_count": current_fixed,
+    }
+
+
 def patch_pr_token_summary(
     pr_url: str,
     cwd: str = "",

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -236,11 +236,6 @@ def check_loop_with_progress(
     issues_fixed_count == "0" for two consecutive iterations (current and
     previous), returns zero_progress="true" for early-exit routing.
     """
-    current_iteration = current_iteration or ""
-    max_iterations = max_iterations or ""
-    issues_fixed_count = issues_fixed_count or ""
-    prev_issues_fixed_count = prev_issues_fixed_count or ""
-
     try:
         iteration = int(current_iteration.strip()) if current_iteration.strip() else 0
     except ValueError as exc:

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -251,8 +251,11 @@ def check_loop_with_progress(
     except ValueError as exc:
         raise ValueError(f"max_iterations must be numeric, got: {max_iterations!r}") from exc
 
-    current_fixed = issues_fixed_count.strip()
+    current_fixed = issues_fixed_count.strip() or "0"
     prev_fixed = prev_issues_fixed_count.strip()
+    # Normalize current (missing capture → "0") but not prev: prev is legitimately ""
+    # on iteration 1, and normalizing it would trigger a false zero_progress on the first
+    # call with no prior value.
     zero_progress = current_fixed == "0" and prev_fixed == "0"
 
     return {

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -697,7 +697,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         rule enforcing scoped directory arguments for file-discovering callables,
         bringing the rules/ count to 29. rules/rules_remediation.py adds the
         audit-impl-remediation-route rule ensuring remediation_path captures have
-        non-terminal non-GO routes, bringing the rules/ count to 30. Exempt at 48 files.
+        non-terminal non-GO routes, bringing the rules/ count to 30.
+        rules/rules_loop_progress.py adds the loop-body-uncaptured-output rule
+        ensuring run_skill steps inside routing cycles capture declared outputs,
+        bringing the rules/ count to 31. Exempt at 48 files.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
@@ -812,7 +815,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 10,
         "pipeline": 12,
         "fleet": 15,
-        "recipe/rules": 31,
+        "recipe/rules": 32,
         "server/tools": 18,
         "hooks/guards": 22,
     }

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -277,7 +277,7 @@ def test_retry_reason_value_count_is_14() -> None:
     assert len(values) == 14, f"RetryReason has {len(values)} values: {values}"
 
 
-def test_semantic_rule_family_count_is_30() -> None:
+def test_semantic_rule_family_count_is_31() -> None:
     assert _count_semantic_rule_files() == 31
 
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -278,7 +278,7 @@ def test_retry_reason_value_count_is_14() -> None:
 
 
 def test_semantic_rule_family_count_is_30() -> None:
-    assert _count_semantic_rule_files() == 30
+    assert _count_semantic_rule_files() == 31
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -142,12 +142,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils.py — partitions, ranges, diff metrics, queue, enriched handoff
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 126),
-    # Lines 143 and 420 are list-payload write sites (dual membership: also in list_sites
+    # Lines 143 and 415 are list-payload write sites (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches
     # them because it cannot distinguish list vs dict return types — intentional.
     ("src/autoskillit/smoke_utils.py", 143),
-    ("src/autoskillit/smoke_utils.py", 420),
-    ("src/autoskillit/smoke_utils.py", 468),
+    ("src/autoskillit/smoke_utils.py", 415),
+    ("src/autoskillit/smoke_utils.py", 463),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 308),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
@@ -215,7 +215,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 143),
-            ("src/autoskillit/smoke_utils.py", 420),
+            ("src/autoskillit/smoke_utils.py", 415),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -142,12 +142,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils.py — partitions, ranges, diff metrics, queue, enriched handoff
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 126),
-    # Lines 143 and 378 are list-payload write sites (dual membership: also in list_sites
+    # Lines 143 and 417 are list-payload write sites (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches
     # them because it cannot distinguish list vs dict return types — intentional.
     ("src/autoskillit/smoke_utils.py", 143),
-    ("src/autoskillit/smoke_utils.py", 378),
-    ("src/autoskillit/smoke_utils.py", 426),
+    ("src/autoskillit/smoke_utils.py", 417),
+    ("src/autoskillit/smoke_utils.py", 465),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 308),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
@@ -215,7 +215,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 143),
-            ("src/autoskillit/smoke_utils.py", 378),
+            ("src/autoskillit/smoke_utils.py", 417),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -142,12 +142,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils.py — partitions, ranges, diff metrics, queue, enriched handoff
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 126),
-    # Lines 143 and 417 are list-payload write sites (dual membership: also in list_sites
+    # Lines 143 and 420 are list-payload write sites (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches
     # them because it cannot distinguish list vs dict return types — intentional.
     ("src/autoskillit/smoke_utils.py", 143),
-    ("src/autoskillit/smoke_utils.py", 417),
-    ("src/autoskillit/smoke_utils.py", 465),
+    ("src/autoskillit/smoke_utils.py", 420),
+    ("src/autoskillit/smoke_utils.py", 468),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 308),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
@@ -215,7 +215,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 143),
-            ("src/autoskillit/smoke_utils.py", 417),
+            ("src/autoskillit/smoke_utils.py", 420),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -9,6 +9,7 @@ import pytest
 
 from autoskillit.planner.schema import DELIVERABLE_BOUNDS
 from autoskillit.planner.validation import (
+    _check_dag_acyclic,
     _check_duplicate_deliverables,
     _check_sizing_bounds,
     _iter_tier_files,
@@ -727,3 +728,39 @@ def test_validate_plan_raises_on_non_canonical_wp_file(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="excluded"):
         validate_plan(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# DAG cycle decomposition tests
+# ---------------------------------------------------------------------------
+
+
+def test_check_dag_acyclic_decomposes_2_node_cycle() -> None:
+    """2-node mutual cycles are reported with cycle_size=2 and edges."""
+    wp_results = {
+        "P1-A1-WP1": {"depends_on": ["P1-A1-WP2"]},
+        "P1-A1-WP2": {"depends_on": ["P1-A1-WP1"]},
+        "P1-A1-WP3": {"depends_on": []},
+    }
+    findings = _check_dag_acyclic(wp_results)
+    assert len(findings) == 1
+    assert findings[0]["cycle_size"] == 2
+    assert set(findings[0]["cycle_nodes"]) == {"P1-A1-WP1", "P1-A1-WP2"}
+    assert set(map(tuple, findings[0]["cycle_edges"])) == {
+        ("P1-A1-WP1", "P1-A1-WP2"),
+        ("P1-A1-WP2", "P1-A1-WP1"),
+    }
+
+
+def test_check_dag_acyclic_3_node_cycle_no_edges() -> None:
+    """3+ node cycles report cycle_size and cycle_nodes but no edges (not safe to auto-fix)."""
+    wp_results = {
+        "P1-A1-WP1": {"depends_on": ["P1-A1-WP3"]},
+        "P1-A1-WP2": {"depends_on": ["P1-A1-WP1"]},
+        "P1-A1-WP3": {"depends_on": ["P1-A1-WP2"]},
+    }
+    findings = _check_dag_acyclic(wp_results)
+    assert len(findings) == 1
+    assert findings[0]["cycle_size"] == 3
+    assert set(findings[0]["cycle_nodes"]) == {"P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"}
+    assert "cycle_edges" not in findings[0]

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -141,6 +141,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_remediation.py` | Tests for audit-impl-remediation-route semantic validation rule |
 | `test_rules_review_loop_waypoint.py` | Tests for review-loop-waypoint-guard semantic rule |
 | `test_rules_route_gate.py` | Tests for route-gate-shared-stop semantic validation rule |
+| `test_rules_loop_progress.py` | Tests for loop-body-uncaptured-output semantic validation rule |
 | `test_rules_recipe.py` | Tests for recipe-level semantic validation rule |
 | `test_rules_registry.py` | Tests for rule registry and decorator |
 | `test_rules_shadowed_input.py` | Tests for shadowed_input semantic validation rule |
@@ -157,6 +158,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_weak_constraint.py` | Tests for weak_constraint semantic validation rule |
 | `test_rules_worktree.py` | Tests for worktree semantic validation rule |
 | `test_schema.py` | Tests for Recipe, RecipeStep, and DataFlowWarning schema |
+| `test_skill_contract_completeness.py` | Tests for SKILL.md to skill_contracts.yaml output completeness |
 | `test_skill_emit_consistency.py` | Tests for skill emit consistency in recipe steps |
 | `test_skill_worktree_patterns.py` | Tests that SKILL.md files do not use fragile relative worktree path patterns |
 | `test_silent_type_convention.py` | Tests for silent-type-convention.md documentation |

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -770,6 +770,7 @@ ALWAYS_WRITE_SKILLS = {
     "planner-elaborate-phase",
     "planner-elaborate-wps",
     "planner-generate-phases",
+    "planner-refine",
     "planner-refine-assignments",
     "planner-refine-phases",
     "planner-refine-wps",

--- a/tests/recipe/test_rules_loop_progress.py
+++ b/tests/recipe/test_rules_loop_progress.py
@@ -1,0 +1,197 @@
+"""Tests for recipe/rules_loop_progress.py semantic rules."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import Severity
+from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.schema import Recipe, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
+    """Minimal recipe factory for loop_progress rules tests."""
+    return Recipe(
+        name="test-loop-progress",
+        description="Test recipe for loop progress rules.",
+        version="0.2.0",
+        kitchen_rules=["test"],
+        steps=steps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# loop-body-uncaptured-output
+# ---------------------------------------------------------------------------
+
+
+def test_rule_fires_when_skill_in_cycle_has_no_capture(monkeypatch) -> None:
+    """Rule fires ERROR when a run_skill step in a cycle has no capture despite declared outputs."""
+    # Mock manifest with a skill that has outputs
+    mock_manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [{"name": "issues_fixed", "type": "string"}],
+            }
+        },
+    }
+    import autoskillit.recipe.rules.rules_loop_progress as _rlp
+
+    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: mock_manifest)
+
+    recipe = _make_recipe(
+        {
+            "validate": RecipeStep(
+                tool="run_cmd", with_args={"cmd": "echo validate"}, on_success="check_verdict"
+            ),
+            "check_verdict": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo check"},
+                on_success="refine",
+            ),
+            "refine": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:test-skill"},
+                on_success="check_loop",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo loop"},
+                on_success="validate",
+            ),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    loop_findings = [f for f in findings if f.rule == "loop-body-uncaptured-output"]
+    assert len(loop_findings) == 1
+    assert loop_findings[0].severity == Severity.ERROR
+    assert loop_findings[0].step_name == "refine"
+
+
+def test_rule_no_fire_when_skill_in_cycle_has_capture(monkeypatch) -> None:
+    """Rule does NOT fire when a run_skill step in a cycle has a capture block."""
+    mock_manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [{"name": "issues_fixed", "type": "string"}],
+            }
+        },
+    }
+    import autoskillit.recipe.rules.rules_loop_progress as _rlp
+
+    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: mock_manifest)
+
+    recipe = _make_recipe(
+        {
+            "validate": RecipeStep(
+                tool="run_cmd", with_args={"cmd": "echo validate"}, on_success="check_verdict"
+            ),
+            "check_verdict": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo check"},
+                on_success="refine",
+            ),
+            "refine": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:test-skill"},
+                capture={"count": "${{ result.issues_fixed }}"},
+                on_success="check_loop",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo loop"},
+                on_success="validate",
+            ),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    loop_findings = [f for f in findings if f.rule == "loop-body-uncaptured-output"]
+    assert len(loop_findings) == 0
+
+
+def test_rule_no_fire_when_skill_has_no_outputs(monkeypatch) -> None:
+    """Rule does NOT fire when a run_skill step has empty outputs declaration."""
+    mock_manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [],
+            }
+        },
+    }
+    import autoskillit.recipe.rules.rules_loop_progress as _rlp
+
+    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: mock_manifest)
+
+    recipe = _make_recipe(
+        {
+            "validate": RecipeStep(
+                tool="run_cmd", with_args={"cmd": "echo validate"}, on_success="refine"
+            ),
+            "refine": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:test-skill"},
+                on_success="check_loop",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo loop"},
+                on_success="validate",
+            ),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    loop_findings = [f for f in findings if f.rule == "loop-body-uncaptured-output"]
+    assert len(loop_findings) == 0
+
+
+def test_rule_no_fire_for_non_skill_tool_in_cycle(monkeypatch) -> None:
+    """Rule does NOT fire for run_cmd steps in cycles (only run_skill)."""
+    mock_manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [{"name": "issues_fixed", "type": "string"}],
+            }
+        },
+    }
+    import autoskillit.recipe.rules.rules_loop_progress as _rlp
+
+    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: mock_manifest)
+
+    recipe = _make_recipe(
+        {
+            "a": RecipeStep(tool="run_cmd", with_args={"cmd": "echo a"}, on_success="b"),
+            "b": RecipeStep(tool="run_cmd", with_args={"cmd": "echo b"}, on_success="a"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    loop_findings = [f for f in findings if f.rule == "loop-body-uncaptured-output"]
+    assert len(loop_findings) == 0
+
+
+def test_planner_refine_capture_compliant() -> None:
+    """planner-refine step in planner.yaml now has capture, so rule must NOT fire for it."""
+    from pathlib import Path
+
+    from autoskillit.recipe.io import load_recipe
+
+    recipe_path = Path("src/autoskillit/recipes/planner.yaml")
+    recipe = load_recipe(recipe_path)
+
+    # The rule should not fire for the refine step since it now has capture
+    findings = run_semantic_rules(recipe)
+    loop_findings = [f for f in findings if f.rule == "loop-body-uncaptured-output"]
+    refine_findings = [f for f in loop_findings if f.step_name == "refine"]
+    assert len(refine_findings) == 0, (
+        f"loop-body-uncaptured-output fired for 'refine' step: "
+        f"{[f.message for f in refine_findings]}"
+    )

--- a/tests/recipe/test_rules_loop_progress.py
+++ b/tests/recipe/test_rules_loop_progress.py
@@ -184,7 +184,9 @@ def test_planner_refine_capture_compliant() -> None:
 
     from autoskillit.recipe.io import load_recipe
 
-    recipe_path = Path("src/autoskillit/recipes/planner.yaml")
+    recipe_path = (
+        Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipes" / "planner.yaml"
+    )
     recipe = load_recipe(recipe_path)
 
     # The rule should not fire for the refine step since it now has capture

--- a/tests/recipe/test_rules_loop_progress.py
+++ b/tests/recipe/test_rules_loop_progress.py
@@ -4,11 +4,22 @@ from __future__ import annotations
 
 import pytest
 
+import autoskillit.recipe.rules.rules_loop_progress as _rlp
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_MOCK_MANIFEST = {
+    "version": "0.1.0",
+    "skills": {
+        "test-skill": {
+            "inputs": [],
+            "outputs": [{"name": "issues_fixed", "type": "string"}],
+        }
+    },
+}
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
@@ -28,20 +39,8 @@ def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
 
 
 def test_rule_fires_when_skill_in_cycle_has_no_capture(monkeypatch) -> None:
-    """Rule fires ERROR when a run_skill step in a cycle has no capture despite declared outputs."""
-    # Mock manifest with a skill that has outputs
-    mock_manifest = {
-        "version": "0.1.0",
-        "skills": {
-            "test-skill": {
-                "inputs": [],
-                "outputs": [{"name": "issues_fixed", "type": "string"}],
-            }
-        },
-    }
-    import autoskillit.recipe.rules.rules_loop_progress as _rlp
-
-    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: mock_manifest)
+    """Rule fires ERROR when run_skill step in a cycle has no capture despite declared outputs."""
+    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: _MOCK_MANIFEST)
 
     recipe = _make_recipe(
         {
@@ -74,18 +73,7 @@ def test_rule_fires_when_skill_in_cycle_has_no_capture(monkeypatch) -> None:
 
 def test_rule_no_fire_when_skill_in_cycle_has_capture(monkeypatch) -> None:
     """Rule does NOT fire when a run_skill step in a cycle has a capture block."""
-    mock_manifest = {
-        "version": "0.1.0",
-        "skills": {
-            "test-skill": {
-                "inputs": [],
-                "outputs": [{"name": "issues_fixed", "type": "string"}],
-            }
-        },
-    }
-    import autoskillit.recipe.rules.rules_loop_progress as _rlp
-
-    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: mock_manifest)
+    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: _MOCK_MANIFEST)
 
     recipe = _make_recipe(
         {
@@ -126,7 +114,6 @@ def test_rule_no_fire_when_skill_has_no_outputs(monkeypatch) -> None:
             }
         },
     }
-    import autoskillit.recipe.rules.rules_loop_progress as _rlp
 
     monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: mock_manifest)
 
@@ -154,18 +141,7 @@ def test_rule_no_fire_when_skill_has_no_outputs(monkeypatch) -> None:
 
 def test_rule_no_fire_for_non_skill_tool_in_cycle(monkeypatch) -> None:
     """Rule does NOT fire for run_cmd steps in cycles (only run_skill)."""
-    mock_manifest = {
-        "version": "0.1.0",
-        "skills": {
-            "test-skill": {
-                "inputs": [],
-                "outputs": [{"name": "issues_fixed", "type": "string"}],
-            }
-        },
-    }
-    import autoskillit.recipe.rules.rules_loop_progress as _rlp
-
-    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: mock_manifest)
+    monkeypatch.setattr(_rlp, "load_bundled_manifest", lambda: _MOCK_MANIFEST)
 
     recipe = _make_recipe(
         {

--- a/tests/recipe/test_skill_contract_completeness.py
+++ b/tests/recipe/test_skill_contract_completeness.py
@@ -1,0 +1,26 @@
+"""Tests for SKILL.md to skill_contracts.yaml completeness (planner-refine focus)."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.contracts import load_bundled_manifest
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestPlannerRefineContract:
+    """planner-refine-specific contract completeness tests for Part A."""
+
+    def test_planner_refine_outputs_in_contract(self) -> None:
+        """planner-refine contract must declare issues_fixed and refinement_complete."""
+        manifest = load_bundled_manifest()
+        contract = manifest.get("skills", {}).get("planner-refine")
+        assert contract is not None, "planner-refine not in bundled manifest"
+        output_names = {o["name"] for o in contract.get("outputs", [])}
+        assert "issues_fixed" in output_names, (
+            f"planner-refine contract missing 'issues_fixed'. Found: {output_names}"
+        )
+        assert "refinement_complete" in output_names, (
+            f"planner-refine contract missing 'refinement_complete'. Found: {output_names}"
+        )

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -27,6 +27,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_phase2_skills.py` | Phase 2 tests: open-kitchen and close-kitchen SKILL.md files |
 | `test_plan_experiment_schema_contracts.py` | Contract tests: plan-experiment YAML frontmatter schema and revision_guidance argument |
 | `test_planner_extract_domain.py` | Planner extract domain tests |
+| `test_planner_refine_cycle_breaking.py` | Tests for planner-refine SKILL.md 2-node cycle-breaking documentation |
 | `test_planner_skill_contracts.py` | Planner skill contract tests |
 | `test_project_local_audit_skill_content.py` | Tests for project-local audit skill content |
 | `test_promote_split_contracts.py` | Contract tests verifying the promote-to-main / review-promotion split |

--- a/tests/skills/test_planner_refine_cycle_breaking.py
+++ b/tests/skills/test_planner_refine_cycle_breaking.py
@@ -1,0 +1,40 @@
+"""Tests for planner-refine SKILL.md cycle-breaking documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.small]
+
+
+SKILLS_DIR = Path("src/autoskillit/skills_extended")
+
+
+class TestPlannerRefineCycleBreaking:
+    """Verify planner-refine SKILL.md documents 2-node cycle-breaking correctly."""
+
+    @pytest.fixture
+    def skill_md_text(self) -> str:
+        skill_md = SKILLS_DIR / "planner-refine" / "SKILL.md"
+        if not skill_md.exists():
+            pytest.skip("planner-refine SKILL.md not found")
+        return skill_md.read_text()
+
+    def test_skill_md_allows_2_node_cycle_breaking(self, skill_md_text) -> None:
+        """SKILL.md must allow breaking 2-node mutual cycles."""
+        assert "2-node mutual cycle" in skill_md_text or "two-node mutual" in skill_md_text, (
+            "SKILL.md must document 2-node mutual cycle-breaking capability"
+        )
+        assert "higher-numbered WP" in skill_md_text, (
+            "SKILL.md must document the higher-numbered WP heuristic for cycle-breaking"
+        )
+
+    def test_skill_md_prohibits_3_plus_node_cycle_breaking(self, skill_md_text) -> None:
+        """SKILL.md must still escalate 3+ node cycles."""
+        assert (
+            "cycle_size: 3" in skill_md_text
+            or "3+ node" in skill_md_text
+            or "three or more" in skill_md_text
+        ), "SKILL.md must document escalation of 3+ node cycles"

--- a/tests/skills/test_planner_refine_cycle_breaking.py
+++ b/tests/skills/test_planner_refine_cycle_breaking.py
@@ -9,7 +9,7 @@ import pytest
 pytestmark = [pytest.mark.layer("skills"), pytest.mark.small]
 
 
-SKILLS_DIR = Path("src/autoskillit/skills_extended")
+SKILLS_DIR = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "skills_extended"
 
 
 class TestPlannerRefineCycleBreaking:

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -337,6 +337,9 @@ def test_check_loop_with_progress_propagates_prev_count() -> None:
         prev_issues_fixed_count="",
     )
     assert result["prev_issues_fixed_count"] == "2"
+    assert result["zero_progress"] == "false"
+    assert result["next_iteration"] == "2"
+    assert result["max_exceeded"] == "false"
 
 
 def test_subprocess_calls_have_timeout() -> None:

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -11,6 +11,7 @@ from autoskillit.smoke_utils import (
     annotate_pr_diff,
     check_bug_report_non_empty,
     check_loop_iteration,
+    check_loop_with_progress,
     check_review_loop,
     enrich_diff_context,
     patch_pr_token_summary,
@@ -281,6 +282,61 @@ def test_check_loop_iteration_defaults() -> None:
     """No arguments → iteration=0, max=2 → next=1, max_exceeded=false."""
     result = check_loop_iteration()
     assert result == {"next_iteration": "1", "max_exceeded": "false"}
+
+
+# ---------------------------------------------------------------------------
+# T_SU_CL1–T_SU_CL4: check_loop_with_progress tests (progress-aware loop guard)
+# ---------------------------------------------------------------------------
+
+
+def test_check_loop_with_progress_zero_progress_first_iteration() -> None:
+    """First zero-progress iteration returns zero_progress=false (needs 2 consecutive)."""
+    result = check_loop_with_progress(
+        current_iteration="1",
+        max_iterations="5",
+        issues_fixed_count="0",
+        prev_issues_fixed_count="",
+    )
+    assert result["zero_progress"] == "false"
+    assert result["next_iteration"] == "2"
+    assert result["max_exceeded"] == "false"
+
+
+def test_check_loop_with_progress_two_consecutive_zero() -> None:
+    """Two consecutive zero-progress iterations returns zero_progress=true."""
+    result = check_loop_with_progress(
+        current_iteration="2",
+        max_iterations="5",
+        issues_fixed_count="0",
+        prev_issues_fixed_count="0",
+    )
+    assert result["zero_progress"] == "true"
+    assert result["next_iteration"] == "3"
+    assert result["max_exceeded"] == "false"
+
+
+def test_check_loop_with_progress_progress_after_zero() -> None:
+    """Progress after a zero-progress iteration resets the detection."""
+    result = check_loop_with_progress(
+        current_iteration="2",
+        max_iterations="5",
+        issues_fixed_count="3",
+        prev_issues_fixed_count="0",
+    )
+    assert result["zero_progress"] == "false"
+    assert result["next_iteration"] == "3"
+    assert result["max_exceeded"] == "false"
+
+
+def test_check_loop_with_progress_propagates_prev_count() -> None:
+    """zero_progress=false on first call propagates current as prev."""
+    result = check_loop_with_progress(
+        current_iteration="1",
+        max_iterations="5",
+        issues_fixed_count="2",
+        prev_issues_fixed_count="",
+    )
+    assert result["prev_issues_fixed_count"] == "2"
 
 
 def test_subprocess_calls_have_timeout() -> None:


### PR DESCRIPTION
## Summary

The planner recipe's validate/refine loop has two mutually-reinforcing architectural weaknesses: (A) a contract enforcement gap that allows skill output tokens to go uncaptured, silently disabling progress tracking in loops; and (B) a cycle detection algorithm that reports opaque aggregate findings, preventing the refine skill from applying safe deterministic fixes to trivial cycles. The immunity design addresses the class of bug — not just the instance — by: enforcing contract-to-capture completeness at static analysis time, upgrading loop guards to progress-aware convergence checks, decomposing cycle findings to enable partial repair, and adding the capture wiring + SKILL.md heuristic for the immediate planner loop.

## Requirements

### A. Zero-progress early-exit

1. Add `capture: issues_fixed_count` to the `refine` step in `planner.yaml` to capture the `issues_fixed` output token.
2. Add a `check_zero_progress` step between `refine` and `check_refine_loop` that:
   - Tracks `issues_fixed_count` across iterations (via `optional_context_refs`)
   - If `issues_fixed_count == 0` for 2 consecutive iterations, route to `escalate_stop`
   - Otherwise, route to `check_refine_loop` (continue loop)

This bounds the waste from unresolvable structural issues to ~40 minutes (2 loop iterations) instead of 3+ hours (5 iterations).

### B. Cycle-breaking heuristic in `planner-refine`

Update `planner-refine/SKILL.md` to allow cycle-breaking for 2-node mutual dependencies using a simple heuristic:

> **DAG Cycle Handling (Updated):**
> - For 2-node mutual cycles (A depends on B, B depends on A): remove the dependency from the **higher-numbered** WP (by natural sort). Write the corrected `depends_on` to the WP's `*_result.json` file. Count as `issues_fixed += 1`.
> - For cycles involving 3+ nodes: escalate as CRITICAL (unchanged).

Closes #2432

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260515-221724-475387/.autoskillit/temp/rectify/rectify_planner_validate_refine_loop_2026-05-15_221724.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 58 | 13.4k | 766.8k | 112.6k | 164 | 64.2k | 8m 17s |
| dry_walkthrough | claude-opus-4-6 | 1 | 2.2k | 21.6k | 1.8M | 81.7k | 150 | 67.3k | 12m 26s |
| implement* | MiniMax-M2.7-highspeed | 1 | 5.8M | 33.6k | 3.4M | 95.6k | 264 | 205.8k | 17m 37s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 178.1k | 5.3k | 356.5k | 29.9k | 33 | 15.7k | 1m 54s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 41.0k | 1.9k | 176.8k | 29.9k | 14 | 15.4k | 44s |
| review_pr | claude-sonnet-4-6 | 3 | 302 | 119.5k | 2.1M | 105.5k | 122 | 259.4k | 31m 32s |
| resolve_review | claude-sonnet-4-6 | 2 | 750 | 58.1k | 6.8M | 107.3k | 215 | 175.4k | 31m 10s |
| resolve_queue_merge_conflicts | claude-sonnet-4-6 | 2 | 311 | 13.6k | 1.7M | 64.5k | 101 | 85.6k | 4m 25s |
| **Total** | | | 6.0M | 266.9k | 17.2M | 112.6k | | 888.8k | 1h 48m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 697 | 4943.2 | 295.3 | 48.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 124 | 55178.8 | 1414.7 | 468.6 |
| resolve_queue_merge_conflicts | 984 | 1680.2 | 87.0 | 13.8 |
| **Total** | **1805** | 9509.4 | 492.4 | 147.9 |