### PR TITLE
Rectify: Planner File-Discovery Silent Drop Immunity

### DIFF
--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -15,6 +15,7 @@ from autoskillit.planner.schema import (
     WP_RESULT_FILE_RE,
     RunDirResult,
     TaskResolutionResult,
+    collect_tier_result_files,
     make_canonical_assignment_id,
     validate_assignment_result,
     validate_phase_result,
@@ -60,16 +61,9 @@ def build_phase_assignment_manifest(phases_dir: str, output_dir: str) -> dict[st
     out_dir = Path(output_dir)
     assign_dir = out_dir.resolve()
 
-    all_phase_files = sorted(phases_path.glob("*_result.json"))
-    excluded = [f for f in all_phase_files if not PHASE_RESULT_FILE_RE.match(f.name)]
-    if excluded:
-        names = [f.name for f in excluded[:5]]
-        raise ValueError(
-            f"Result files in {phases_path} excluded by {PHASE_RESULT_FILE_RE.pattern}: {names}. "
-            f"This indicates non-canonical IDs were generated upstream."
-        )
+    phase_files = collect_tier_result_files(phases_path, PHASE_RESULT_FILE_RE)
     parsed_phases = []
-    for f in all_phase_files:
+    for f in phase_files:
         try:
             raw = json.loads(f.read_text())
         except json.JSONDecodeError as exc:
@@ -129,16 +123,9 @@ def build_phase_wp_manifest(
         else (out_dir / "work_packages").resolve()
     )
 
-    all_assign_files = sorted(assign_path.glob("*_result.json"))
-    excluded = [f for f in all_assign_files if not ASSIGN_RESULT_FILE_RE.match(f.name)]
-    if excluded:
-        names = [f.name for f in excluded[:5]]
-        raise ValueError(
-            f"Result files in {assign_path} excluded by {ASSIGN_RESULT_FILE_RE.pattern}: {names}. "
-            f"This indicates non-canonical IDs were generated upstream."
-        )
+    assign_files = collect_tier_result_files(assign_path, ASSIGN_RESULT_FILE_RE)
     parsed_assignments: list[dict] = []
-    for f in all_assign_files:
+    for f in assign_files:
         try:
             raw = json.loads(f.read_text())
         except json.JSONDecodeError as exc:
@@ -217,16 +204,8 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
     if not wp_dir.is_dir():
         raise FileNotFoundError(f"work_packages_dir does not exist: {wp_dir}")
 
-    all_result_files = sorted(wp_dir.glob("*_result.json"))
-    excluded = [f for f in all_result_files if not WP_RESULT_FILE_RE.match(f.name)]
-    if excluded:
-        names = [f.name for f in excluded[:5]]
-        raise ValueError(
-            f"Result files in {wp_dir} excluded by {WP_RESULT_FILE_RE.pattern}: {names}. "
-            f"This indicates non-canonical IDs were generated upstream."
-        )
     result_files = sorted(
-        all_result_files,
+        collect_tier_result_files(wp_dir, WP_RESULT_FILE_RE),
         key=lambda p: _natural_sort_key(p.name),
     )
     items = []

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -242,6 +242,8 @@ def merge_tier_results(
     if tier_re is not None:
         paths = collect_tier_result_files(Path(results_dir), tier_re)
     else:
+        # No canonical regex defined for this key — accept all *_result.json files without
+        # tier validation. This is intentional: unknown key types have no naming constraint.
         paths = sorted(Path(results_dir).glob("*_result.json"))
     if not paths:
         raise ValueError(f"No *_result.json files found in {results_dir}")

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -12,6 +12,7 @@ from autoskillit.planner.schema import (
     ASSIGN_RESULT_FILE_RE,
     PHASE_RESULT_FILE_RE,
     WP_RESULT_FILE_RE,
+    collect_tier_result_files,
     validate_phase_result,
 )
 
@@ -238,20 +239,10 @@ def merge_tier_results(
     **kwargs: Any,
 ) -> dict[str, Any]:
     tier_re = _TIER_FILE_RE.get(key)
-    all_files = sorted(Path(results_dir).glob("*_result.json"))
     if tier_re is not None:
-        excluded = [f for f in all_files if not tier_re.match(f.name)]
-        if excluded:
-            names = [f.name for f in excluded]
-            display = names[:10]
-            suffix = f" and {len(names) - 10} more" if len(names) > 10 else ""
-            raise ValueError(
-                f"Result files in {results_dir} excluded by {tier_re.pattern}: {display}{suffix}. "
-                f"This indicates non-canonical IDs were generated upstream."
-            )
-        paths = [f for f in all_files if tier_re.match(f.name)]
+        paths = collect_tier_result_files(Path(results_dir), tier_re)
     else:
-        paths = all_files
+        paths = sorted(Path(results_dir).glob("*_result.json"))
     if not paths:
         raise ValueError(f"No *_result.json files found in {results_dir}")
     result = merge_files(
@@ -377,17 +368,8 @@ def build_plan_snapshot(
     **kwargs: Any,
 ) -> dict[str, Any]:
     task = Path(task_file_path).read_text(encoding="utf-8") if task_file_path else ""
-    phases_path = Path(phases_dir)
-    all_phase_files = sorted(phases_path.glob("*_result.json"))
-    excluded = [f for f in all_phase_files if not PHASE_RESULT_FILE_RE.match(f.name)]
-    if excluded:
-        names = [f.name for f in excluded[:5]]
-        raise ValueError(
-            f"Result files in {phases_path} excluded by {PHASE_RESULT_FILE_RE.pattern}: {names}. "
-            f"This indicates non-canonical IDs were generated upstream."
-        )
     phase_pairs: list[tuple[int, dict[str, Any]]] = []
-    for p in all_phase_files:
+    for p in collect_tier_result_files(Path(phases_dir), PHASE_RESULT_FILE_RE):
         try:
             raw = json.loads(p.read_text())
             validated = validate_phase_result(raw)

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
 from typing import Any, Literal, TypedDict
 
 import regex as re
@@ -174,6 +175,27 @@ WP_RESULT_FILE_RE = re.compile(r"^P\d+-A\d+-WP\d+_result\.json$")
 PHASE_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "ordering"})
 ASSIGNMENT_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "proposed_work_packages"})
 WP_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "deliverables"})
+
+
+def collect_tier_result_files(directory: Path, tier_re: re.Pattern[str]) -> list[Path]:
+    """Collect ``*_result.json`` files matching the tier regex.
+
+    Raises ``ValueError`` if any ``*_result.json`` file in ``directory`` is
+    excluded by ``tier_re``, listing all excluded names along with the
+    expected pattern. This prevents silent drops of non-canonical result files.
+    """
+    all_files = sorted(directory.glob("*_result.json"))
+    excluded = [f for f in all_files if not tier_re.match(f.name)]
+    if excluded:
+        names = [f.name for f in excluded]
+        display = names[:10]
+        suffix = f" and {len(names) - 10} more" if len(names) > 10 else ""
+        raise ValueError(
+            f"Result files in {directory} excluded by {tier_re.pattern}: {display}{suffix}. "
+            f"This indicates non-canonical IDs were generated upstream."
+        )
+    return [f for f in all_files if tier_re.match(f.name)]
+
 
 DELIVERABLE_BOUNDS: tuple[int, int] = (1, 5)
 

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -49,7 +49,7 @@ _NEGATION_PREFIX_RE: re.Pattern[str] = re.compile(
 
 
 def _iter_tier_files(directory: Path, filename_re: re.Pattern[str]) -> Iterator[Path]:
-    """Yield *_result.json files whose names match the tier's naming convention."""
+    """Yield *_result.json files matching ``tier_re``; raises ValueError on non-canonical names."""
     yield from collect_tier_result_files(directory, filename_re)
 
 

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -23,6 +23,7 @@ from autoskillit.planner.schema import (
     PHASE_RESULT_FILE_RE,
     WP_RESULT_FILE_RE,
     ValidationFinding,
+    collect_tier_result_files,
     validate_assignment_result,
     validate_phase_result,
     validate_wp_result,
@@ -48,20 +49,8 @@ _NEGATION_PREFIX_RE: re.Pattern[str] = re.compile(
 
 
 def _iter_tier_files(directory: Path, filename_re: re.Pattern[str]) -> Iterator[Path]:
-    """Yield *_result.json files whose names match the tier's naming convention.
-
-    Raises ValueError if any *_result.json file is found that does not match
-    the expected pattern, indicating non-canonical IDs were generated upstream.
-    """
-    all_files = sorted(directory.glob("*_result.json"))
-    excluded = [f for f in all_files if not filename_re.match(f.name)]
-    if excluded:
-        names = [f.name for f in excluded[:5]]
-        raise ValueError(
-            f"Result files in {directory} excluded by {filename_re.pattern}: {names}. "
-            f"This indicates non-canonical IDs were generated upstream."
-        )
-    yield from all_files
+    """Yield *_result.json files whose names match the tier's naming convention."""
+    yield from collect_tier_result_files(directory, filename_re)
 
 
 def _load_phase_results(root: Path) -> dict[str, dict]:

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -151,7 +151,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 308),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 275),
+    ("src/autoskillit/planner/manifests.py", 254),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc.py", 445),
 }

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -364,6 +364,116 @@ def test_finalize_wp_manifest_skips_non_result_files(tmp_path):
     assert manifest["items"][0]["id"] == wp_id
 
 
+def test_finalize_wp_manifest_raises_on_non_canonical_wp_filename(tmp_path):
+    """Test 1a: Non-canonical WP result file (matches glob but not tier regex) raises."""
+    from autoskillit.planner import finalize_wp_manifest
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    (wp_dir / "P1-A1-WP1_result.json").write_text(json.dumps(make_wp_result("P1-A1-WP1")))
+    # Alpha-suffixed file matches *_result.json but NOT WP_RESULT_FILE_RE
+    (wp_dir / "P1-A1-WPa_result.json").write_text(
+        json.dumps(make_wp_result("P1-A1-WP1", name="NonCanonical"))
+    )
+
+    with pytest.raises(ValueError, match="P1-A1-WPa_result.json"):
+        finalize_wp_manifest(str(wp_dir), str(output_dir))
+
+
+def test_build_phase_assignment_manifest_raises_on_non_canonical_phase_filename(tmp_path):
+    """Test 1b: Non-canonical phase file in phases/ raises instead of silent drop."""
+    from autoskillit.planner import build_phase_assignment_manifest
+
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    output_dir = tmp_path / "assignments"
+    output_dir.mkdir()
+
+    (phases_dir / "P1_result.json").write_text(
+        json.dumps(make_phase_result(1, assignments_preview=[]))
+    )
+    # Alpha-suffixed: matches *_result.json but NOT PHASE_RESULT_FILE_RE
+    (phases_dir / "P1a_result.json").write_text(
+        json.dumps({"id": "P1a", "name": "Phase 1a", "ordering": 1})
+    )
+
+    with pytest.raises(ValueError, match="P1a_result.json"):
+        build_phase_assignment_manifest(str(phases_dir), str(output_dir))
+
+
+def test_build_phase_wp_manifest_raises_on_non_canonical_assignment_filename(tmp_path):
+    """Test 1c: Non-canonical assignment file in assignments/ raises instead of silent drop."""
+    from autoskillit.planner import build_phase_wp_manifest
+
+    assign_dir = tmp_path / "assignments"
+    assign_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    (assign_dir / "P1-A1_result.json").write_text(
+        json.dumps(make_assignment_result(1, 1, proposed_work_packages=[]))
+    )
+    # Alpha-suffixed: matches *_result.json but NOT ASSIGN_RESULT_FILE_RE
+    (assign_dir / "P1-Aa_result.json").write_text(
+        json.dumps(
+            {"id": "P1-Aa", "phase_id": "P1", "name": "Assign A", "proposed_work_packages": []}
+        )
+    )
+
+    with pytest.raises(ValueError, match="P1-Aa_result.json"):
+        build_phase_wp_manifest(str(assign_dir), str(out_dir))
+
+
+def test_finalize_wp_manifest_tolerates_known_non_result_files(tmp_path):
+    """Test 1f: Known non-result files (not matching *_result.json) are fully ignored."""
+    from autoskillit.planner import finalize_wp_manifest
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    (wp_dir / "P1-A1-WP1_result.json").write_text(json.dumps(make_wp_result("P1-A1-WP1")))
+    (wp_dir / "wp_manifest.json").write_text('{"pass_name": "old"}')
+    (wp_dir / "wp_index.json").write_text("[]")
+    (wp_dir / "context_P1.json").write_text('{"id": "P1"}')
+    sentinel_dir = wp_dir / "wp_sentinels"
+    sentinel_dir.mkdir()
+    (sentinel_dir / "P1_result.json").write_text('{"ok": true}')
+
+    # Must NOT raise — these files don't match *_result.json glob so are excluded before regex
+    result = finalize_wp_manifest(str(wp_dir), str(output_dir))
+    assert result["total_count"] == "1"
+
+
+def test_collect_tier_result_files_multiple_non_canonical(tmp_path):
+    """Test 1g: Multiple non-canonical files all appear in the error message."""
+    from autoskillit.planner.schema import WP_RESULT_FILE_RE
+
+    results_dir = tmp_path / "work_packages"
+    results_dir.mkdir()
+
+    (results_dir / "P1-A1-WP1_result.json").write_text(json.dumps(make_wp_result("P1-A1-WP1")))
+    (results_dir / "P1-A1-WPa_result.json").write_text(
+        json.dumps(make_wp_result("P1-A1-WP1", name="Alpha"))
+    )
+    (results_dir / "P1-A1-WP2a_result.json").write_text(
+        json.dumps(make_wp_result("P1-A1-WP1", name="Alpha2"))
+    )
+
+    from autoskillit.planner.schema import collect_tier_result_files
+
+    with pytest.raises(ValueError, match="P1-A1-WPa_result.json") as exc_info:
+        collect_tier_result_files(results_dir, WP_RESULT_FILE_RE)
+    # Both non-canonical names should be mentioned
+    error_msg = str(exc_info.value)
+    assert "P1-A1-WPa_result.json" in error_msg
+    assert "P1-A1-WP2a_result.json" in error_msg
+
+
 def test_finalize_wp_manifest_empty_dir(tmp_path):
     """T10: Empty work_packages/ produces manifest with items: []."""
     from autoskillit.planner import finalize_wp_manifest
@@ -591,6 +701,7 @@ def test_build_phase_wp_manifest_raises_on_non_canonical_in_assignments(tmp_path
     (assign_dir / "P1-A1_result.json").write_text(
         json.dumps(make_assignment_result(1, 1, proposed_work_packages=[]))
     )
+    # P1_result.json matches *_result.json but NOT ASSIGN_RESULT_FILE_RE — must raise
     (assign_dir / "P1_result.json").write_text(
         json.dumps({"id": "P1", "status": "complete", "assignment_count": 1, "failed_count": 0})
     )

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -402,6 +402,22 @@ def test_build_plan_snapshot_raises_on_unrecognized_result_filename(tmp_path) ->
         build_plan_snapshot(str(phases_dir), str(out))
 
 
+def test_build_plan_snapshot_skips_corrupt_canonical_json(tmp_path) -> None:
+    """Corrupt JSON in a canonical filename (P2_result.json) is silently skipped."""
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    (phases_dir / "P1_result.json").write_text(json.dumps(make_phase_result(1)))
+    (phases_dir / "P2_result.json").write_text("{not valid json")
+    out = tmp_path / "snapshot.json"
+
+    result = build_plan_snapshot(str(phases_dir), str(out))
+
+    data = json.loads(out.read_text())
+    assert len(data["phases"]) == 1
+    assert "P1" in result["phase_ids"]
+    assert "P2" not in result["phase_ids"]
+
+
 def test_build_plan_snapshot_nonexistent_phases_dir(tmp_path) -> None:
     out = tmp_path / "snapshot.json"
 

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -427,6 +427,24 @@ def test_build_plan_snapshot_empty_dir_produces_empty_phases(tmp_path) -> None:
     assert result["phase_ids"] == ""
 
 
+def test_build_plan_snapshot_raises_on_non_canonical_phase_filename(tmp_path) -> None:
+    """Test 1d: Non-canonical phase file in phases/ raises instead of silent drop."""
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    out = tmp_path / "snapshot.json"
+
+    (phases_dir / "P1_result.json").write_text(
+        json.dumps({"id": "P1", "name": "Phase 1", "ordering": 1})
+    )
+    # Non-canonical: matches *_result.json but NOT PHASE_RESULT_FILE_RE
+    (phases_dir / "Phase1_result.json").write_text(
+        json.dumps({"id": "Phase1", "name": "Phase One", "ordering": 1})
+    )
+
+    with pytest.raises(ValueError, match="Phase1_result.json"):
+        build_plan_snapshot(str(phases_dir), str(out))
+
+
 # ---------------------------------------------------------------------------
 # WP3: merge_tier_results tests
 # ---------------------------------------------------------------------------

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -391,18 +391,15 @@ def test_build_plan_snapshot_happy_path_two_phases_sorted(tmp_path) -> None:
     assert "P2" in result["phase_ids"]
 
 
-def test_build_plan_snapshot_corrupt_json_silently_drops_phase(tmp_path) -> None:
+def test_build_plan_snapshot_raises_on_unrecognized_result_filename(tmp_path) -> None:
     phases_dir = tmp_path / "phases"
     phases_dir.mkdir()
     (phases_dir / "P1_result.json").write_text(json.dumps(make_phase_result(1)))
-    (phases_dir / "P2_result.json").write_text("{not json")
+    (phases_dir / "bad_result.json").write_text("{not json")
     out = tmp_path / "snapshot.json"
 
-    result = build_plan_snapshot(str(phases_dir), str(out))
-
-    data = json.loads(out.read_text())
-    assert len(data["phases"]) == 1
-    assert result["phase_ids"] == "P1"
+    with pytest.raises(ValueError, match="bad_result.json"):
+        build_plan_snapshot(str(phases_dir), str(out))
 
 
 def test_build_plan_snapshot_nonexistent_phases_dir(tmp_path) -> None:

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -399,7 +399,7 @@ def test_phase_result_file_re_rejects_plausible_llm_deviations(name: str) -> Non
 
 
 def test_schema_tier_regex_rejects_alpha_suffix() -> None:
-    """Test 1h: Tier result-file regexes reject alpha-suffixed names like P1-A1-WPa_result.json."""
+    """Test 1i: Tier result-file regexes reject alpha-suffixed names like P1-A1-WPa_result.json."""
     from autoskillit.planner.schema import (
         ASSIGN_RESULT_FILE_RE,
         PHASE_RESULT_FILE_RE,

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -398,7 +398,32 @@ def test_phase_result_file_re_rejects_plausible_llm_deviations(name: str) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_wp_id_validation_raises_on_noncanonical(tmp_path: Path) -> None:
+def test_schema_tier_regex_rejects_alpha_suffix() -> None:
+    """Test 1h: Tier result-file regexes reject alpha-suffixed names like P1-A1-WPa_result.json."""
+    from autoskillit.planner.schema import (
+        ASSIGN_RESULT_FILE_RE,
+        PHASE_RESULT_FILE_RE,
+        WP_RESULT_FILE_RE,
+    )
+
+    # Alpha suffixes on phase
+    assert PHASE_RESULT_FILE_RE.match("P1a_result.json") is None
+    assert PHASE_RESULT_FILE_RE.match("P1_result.json") is not None
+
+    # Alpha suffixes on assignment
+    assert ASSIGN_RESULT_FILE_RE.match("P1-Aa_result.json") is None
+    assert ASSIGN_RESULT_FILE_RE.match("P1-A1_result.json") is not None
+
+    # Alpha suffixes on WP
+    assert WP_RESULT_FILE_RE.match("P1-A1-WPa_result.json") is None
+    assert WP_RESULT_FILE_RE.match("P1-A1-WP1a_result.json") is None
+    assert WP_RESULT_FILE_RE.match("P1-A1-WP1_result.json") is not None
+
+    # Bare alpha suffix on WP (trailing 'a' without number)
+    assert WP_RESULT_FILE_RE.match("P1-A1-WP_result.json") is None
+
+
+def test_wp_id_validation_raises_on_noncanonical() -> None:
     """Test 1h: validate_wp_result raises (not warns) for non-canonical WP IDs."""
     from autoskillit.planner.schema import validate_wp_result
 

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -526,26 +526,24 @@ def test_version_bump_step_via_summary(tmp_path: Path) -> None:
     assert any(w["check"] == "version_bump_step" for w in validation["warnings"])
 
 
-def test_validate_plan_ignores_phase_sentinel_in_subdirectory(tmp_path: Path) -> None:
-    """Phase sentinel files in a subdirectory of assignments/ must not crash validate_plan."""
+def test_validate_plan_raises_on_phase_sentinel_in_assignments_dir(tmp_path: Path) -> None:
+    """Phase-tier result files in assignments/ must raise ValueError (non-canonical ID)."""
     _make_minimal_output_dir(tmp_path)
     sentinel = {"id": "P1", "status": "complete", "assignment_count": 1, "failed_count": 0}
-    # Place in a subdirectory so _result.json suffix check is bypassed
-    write_json(tmp_path / "assignments" / "sentinels" / "P1_result.json", sentinel)
+    write_json(tmp_path / "assignments" / "P1_result.json", sentinel)
 
-    result = validate_plan(str(tmp_path))
-    assert result["verdict"] == "pass"
+    with pytest.raises(ValueError, match="P1_result.json"):
+        validate_plan(str(tmp_path))
 
 
-def test_validate_plan_ignores_non_wp_file_in_work_packages_subdir(tmp_path: Path) -> None:
-    """Non-WP files at top level of work_packages/ must not crash validate_plan."""
+def test_validate_plan_raises_on_non_wp_result_file_in_work_packages_dir(tmp_path: Path) -> None:
+    """Non-WP result files in work_packages/ must raise ValueError (non-canonical ID)."""
     _make_minimal_output_dir(tmp_path)
     sentinel = {"id": "P1", "status": "complete", "assignment_count": 1, "failed_count": 0}
-    # Place in wp_sentinels subdirectory so _result.json suffix check is bypassed
-    write_json(tmp_path / "work_packages" / "wp_sentinels" / "P1_result.json", sentinel)
+    write_json(tmp_path / "work_packages" / "P1_result.json", sentinel)
 
-    result = validate_plan(str(tmp_path))
-    assert result["verdict"] == "pass"
+    with pytest.raises(ValueError, match="P1_result.json"):
+        validate_plan(str(tmp_path))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The planner's file-discovery layer uses a two-step filter pattern at 5 call sites across 3 files. Files matching the glob but not the tier regex are silently dropped. The fix extracts the correct pattern from `merge_tier_results` into a shared `collect_tier_result_files` utility and replaces all 5 silent-drop sites with calls to it.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260515-221724-717587/.autoskillit/temp/rectify/rectify_finalize_wp_manifest_silent_drop_2026-05-15_221724.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 55 | 12.7k | 575.5k | 75.1k | 103 | 67.8k | 6m 0s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 33 | 8.4k | 628.3k | 53.4k | 84 | 39.0k | 6m 10s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.5M | 16.4k | 2.0M | 35.4k | 163 | 68.7k | 7m 38s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 65.2k | 3.4k | 176.8k | 29.9k | 19 | 15.6k | 1m 19s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 38.6k | 1.9k | 176.8k | 29.9k | 14 | 15.4k | 50s |
| review_pr | claude-sonnet-4-6 | 3 | 370 | 93.0k | 2.2M | 87.1k | 148 | 210.0k | 25m 18s |
| resolve_review | claude-sonnet-4-6 | 1 | 301 | 18.5k | 2.1M | 72.4k | 87 | 58.5k | 6m 41s |
| resolve_queue_merge_conflicts | claude-sonnet-4-6 | 1 | 363 | 32.8k | 3.4M | 114.6k | 118 | 100.9k | 10m 14s |
| **Total** | | | 2.6M | 187.1k | 11.3M | 114.6k | | 575.8k | 1h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 219 | 9307.2 | 313.8 | 74.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 22 | 93295.6 | 2657.3 | 839.1 |
| resolve_queue_merge_conflicts | 592 | 5797.2 | 170.4 | 55.5 |
| **Total** | **833** | 13593.9 | 691.3 | 224.6 |