### PR TITLE
Rename build_claude_env to build_agent_env with alias and call-site migration

### DIFF
--- a/src/autoskillit/_llm_triage.py
+++ b/src/autoskillit/_llm_triage.py
@@ -16,7 +16,7 @@ from autoskillit.core import (
     OutputFormat,
     SubprocessResult,
     TerminationReason,
-    build_claude_env,
+    build_agent_env,
     get_logger,
 )
 from autoskillit.execution import parse_session_result, run_managed_async
@@ -123,7 +123,7 @@ async def _triage_batch(
             cmd=triage_cmd,
             cwd=Path.cwd(),
             timeout=30.0,
-            env=build_claude_env(),
+            env=build_agent_env(),
             pty_mode=True,
         )
         if result.termination == TerminationReason.TIMED_OUT:

--- a/src/autoskillit/cli/doctor/_doctor_mcp.py
+++ b/src/autoskillit/cli/doctor/_doctor_mcp.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from autoskillit.core import DIRECT_INSTALL_CACHE_SUBDIR, Severity, build_claude_env, get_logger
+from autoskillit.core import DIRECT_INSTALL_CACHE_SUBDIR, Severity, build_agent_env, get_logger
 
 from ._doctor_types import DoctorResult
 
@@ -88,7 +88,7 @@ def _check_mcp_server_registered(claude_json_path: Path | None = None) -> Doctor
             capture_output=True,
             text=True,
             timeout=10,
-            env=build_claude_env(),
+            env=build_agent_env(),
         )
         if result.returncode == 0 and "autoskillit" in result.stdout:
             return DoctorResult(

--- a/src/autoskillit/core/CLAUDE.md
+++ b/src/autoskillit/core/CLAUDE.md
@@ -12,7 +12,7 @@ Sub-packages: types/ (see types/CLAUDE.md) and runtime/ (see runtime/CLAUDE.md).
 | `_json.py` | Fast JSON via orjson (with stdlib fallback) — `fast_loads`, `fast_dumps` |
 | `logging.py` | Logging configuration |
 | `paths.py` | `pkg_root()`, `is_git_worktree()` |
-| `_claude_env.py` | IDE-scrubbing canonical env builder for claude subprocesses |
+| `_claude_env.py` | IDE-scrubbing canonical env builder for agent subprocesses |
 | `_terminal_table.py` | IL-0 color-agnostic terminal table primitive |
 | `_version_snapshot.py` | Process-scoped version snapshot for session telemetry (`lru_cache`'d) |
 | `branch_guard.py` | Branch protection helpers |

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -1,3 +1,4 @@
+from ._claude_env import build_agent_env as build_agent_env
 from ._claude_env import build_claude_env as build_claude_env
 from ._install_detect import DirectUrlInfo as DirectUrlInfo
 from ._install_detect import _is_release_tag as _is_release_tag

--- a/src/autoskillit/core/_claude_env.py
+++ b/src/autoskillit/core/_claude_env.py
@@ -1,7 +1,7 @@
-"""Canonical env builder for claude-launching subprocesses.
+"""Canonical env builder for agent subprocesses.
 
 Every subprocess that invokes the ``claude`` CLI must route its environment
-through :func:`build_claude_env` so that host-process IDE state (VS Code,
+through :func:`build_agent_env` so that host-process IDE state (VS Code,
 Cursor, Zed, JetBrains, Neovim bridges) cannot leak across the trust
 boundary and silently widen the child's tool surface.
 
@@ -68,13 +68,13 @@ IDE_ENV_ALWAYS_EXTRAS: Mapping[str, str] = MappingProxyType(
 )
 
 
-def build_claude_env(
+def build_agent_env(
     base: Mapping[str, str] | None = None,
     *,
     extras: Mapping[str, str] | None = None,
     required: frozenset[str] | None = None,
 ) -> Mapping[str, str]:
-    """Return a scrubbed, sealed env dict suitable for a claude subprocess.
+    """Return a scrubbed, sealed env dict suitable for an agent subprocess.
 
     Parameters
     ----------
@@ -113,3 +113,6 @@ def build_claude_env(
         if missing:
             raise ValueError(f"Required env vars missing from session env: {sorted(missing)}")
     return MappingProxyType(out)
+
+
+build_claude_env = build_agent_env

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -24,7 +24,7 @@ from autoskillit.core import (
     ResumeSpec,
     SessionCheckpoint,  # noqa: F401, TC001
     ValidatedAddDir,
-    build_claude_env,
+    build_agent_env,
     extract_skill_name,
     temp_dir_display_str,
 )
@@ -35,7 +35,7 @@ class ClaudeInteractiveCmd:
     """Resolved argv + env for a claude interactive subprocess.
 
     ``env`` is the fully resolved environment returned by
-    :func:`build_claude_env` — pass directly to ``subprocess.run(env=...)``.
+    :func:`build_agent_env` — pass directly to ``subprocess.run(env=...)``.
     Callers must NOT merge in ``os.environ`` again; the sanitization layer
     has already applied the denylist and the auto-connect suppressor.
     """
@@ -49,7 +49,7 @@ class ClaudeHeadlessCmd:
     """Resolved argv + env for a claude headless subprocess.
 
     ``env`` is the fully resolved environment returned by
-    :func:`build_claude_env`, including any headless-only extras such as
+    :func:`build_agent_env`, including any headless-only extras such as
     ``AUTOSKILLIT_HEADLESS=1``. Pass directly to the subprocess runner.
     """
 
@@ -126,9 +126,7 @@ def build_interactive_cmd(
     merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)
     if env_extras:
         merged.update(env_extras)
-    return ClaudeInteractiveCmd(
-        cmd=cmd, env=build_claude_env(extras=merged, required=required_env)
-    )
+    return ClaudeInteractiveCmd(cmd=cmd, env=build_agent_env(extras=merged, required=required_env))
 
 
 def build_headless_cmd(
@@ -142,7 +140,7 @@ def build_headless_cmd(
     cmd = ["claude", ClaudeFlags.PRINT, prompt, ClaudeFlags.DANGEROUSLY_SKIP_PERMISSIONS]
     if model:
         cmd += [ClaudeFlags.MODEL, model]
-    return ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(base=base, extras=env_extras))
+    return ClaudeHeadlessCmd(cmd=cmd, env=build_agent_env(base=base, extras=env_extras))
 
 
 # Injected into every AutoSkillit-launched headless and cook session.
@@ -169,7 +167,7 @@ _SESSION_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
 # MAX_MCP_OUTPUT_TOKENS also overlap with IDE_ENV_DENYLIST in
 # core/_claude_env.py. AUTOSKILLIT_SESSION_TYPE, AUTOSKILLIT_CAMPAIGN_ID, and
 # AUTOSKILLIT_PROVIDER_PROFILE overlap with AUTOSKILLIT_PRIVATE_ENV_VARS
-# (scrubbed by build_claude_env).
+# (scrubbed by build_agent_env).
 # All lists must be kept in sync when adding new exclusive variables.
 _HEADLESS_EXCLUSIVE_VARS: frozenset[str] = frozenset(
     {
@@ -232,7 +230,7 @@ def build_headless_resume_cmd(
     merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)
     if env_extras:
         merged.update(env_extras)
-    return ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(base={}, extras=merged))
+    return ClaudeHeadlessCmd(cmd=cmd, env=build_agent_env(base={}, extras=merged))
 
 
 def _ensure_skill_prefix(skill_command: str, *, provider_profile: str = "") -> str:

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -14,7 +14,7 @@ Contract: each call site must satisfy BOTH conditions:
 
 Also contains ``test_no_raw_claude_env``: the sibling rule for claude-launching
 subprocess calls. Every claude-launching site must route its env through
-:func:`autoskillit.core.build_claude_env` (via ``spec.env`` from a
+:func:`autoskillit.core.build_agent_env` (via ``spec.env`` from a
 ``Claude*Cmd`` dataclass, or via a direct builder call). The rule bans
 ``env={**os.environ, ...}``, ``env=os.environ``, ``env=None``, missing ``env=``,
 and ``env=<literal dict>`` at every claude-launching site.
@@ -310,7 +310,7 @@ def test_run_subprocess_callers_use_safe_env_pattern() -> None:
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Sibling rule: claude-launching subprocess calls must route env through
-# build_claude_env() — enforced via intra-function AST walk.
+# build_agent_env() — enforced via intra-function AST walk.
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -347,7 +347,7 @@ class _ClaudeLaunchWalker:
     - ``Attribute(value=Name, attr="env")`` where Name was assigned from a
       ``build_interactive_cmd``/``build_headless_cmd``/``build_skill_session_cmd``
       call earlier in the same function body (spec.env pattern).
-    - ``Call(func=Name("build_claude_env") | Attribute(..., "build_claude_env"))``
+    - ``Call(func=Name("build_agent_env") | Attribute(..., "build_agent_env"))``
       (direct builder escape hatch).
     """
 
@@ -454,7 +454,7 @@ class _ClaudeLaunchWalker:
                 return True, ""
         if isinstance(env_val, ast.Call):
             fn = _call_func_name(env_val.func)
-            if fn == "build_claude_env":
+            if fn in {"build_claude_env", "build_agent_env"}:
                 return True, ""
         if isinstance(env_val, ast.Name):
             # Resolve one level of local binding to catch aliased os.environ.
@@ -488,7 +488,7 @@ class _ClaudeLaunchWalker:
 # concern. Each entry is (filename, enclosing_function_name).
 #
 # Adding a new entry requires a comment justifying why the call cannot use
-# build_claude_env — matching the convention in
+# build_agent_env — matching the convention in
 # ``tests/arch/test_ast_rules.py::test_no_raw_claude_list_construction``.
 _CLAUDE_ENV_RULE_ALLOWED: frozenset[tuple[str, str]] = frozenset(
     {
@@ -507,14 +507,14 @@ _CLAUDE_ENV_RULE_ALLOWED: frozenset[tuple[str, str]] = frozenset(
         ("__init__.py", "dispatch_food_truck"),
         # build_headless_resume_cmd constructs cmd = ["claude", ...] then calls
         # _apply_output_format(cmd, ...) — an in-place list mutation, not a subprocess
-        # launch. The function returns ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(...)).
+        # launch. The function returns ClaudeHeadlessCmd(cmd=cmd, env=build_agent_env(...)).
         ("commands.py", "build_headless_resume_cmd"),
     }
 )
 
 
 def test_no_raw_claude_env() -> None:
-    """Every claude-launching subprocess call must route env through build_claude_env()."""
+    """Every claude-launching subprocess call must route env through build_agent_env()."""
     if not SRC_ROOT.is_dir():
         pytest.skip("Source tree unavailable")
 
@@ -534,6 +534,6 @@ def test_no_raw_claude_env() -> None:
             violations.extend(walker.violations)
 
     assert not violations, (
-        "Found claude-launching subprocess calls that bypass build_claude_env():\n"
+        "Found claude-launching subprocess calls that bypass build_agent_env():\n"
         + "\n".join(f"  {v}" for v in violations)
     )

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -10,7 +10,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_add_dir_validation.py` | Tests for ValidatedAddDir and validate_add_dir |
 | `test_capture.py` | Tests for CaptureEntrySpec and resolve_payload_field |
 | `test_branch_guard.py` | Tests for core.branch_guard — protected-branch validation |
-| `test_claude_env.py` | Unit tests for build_claude_env() — IDE env scrubbing at the subprocess launch boundary |
+| `test_claude_env.py` | Unit tests for build_agent_env() — IDE env scrubbing at the subprocess launch boundary |
 | `test_core.py` | Tests for the core/ sub-package foundation layer |
 | `test_core_terminal_table.py` | Tests for core/_terminal_table.py — the L0 shared table primitive |
 | `test_ensure_project_temp_with_config.py` | Tests for ensure_project_temp with configurable override |

--- a/tests/core/test_claude_env.py
+++ b/tests/core/test_claude_env.py
@@ -1,4 +1,4 @@
-"""Unit tests for build_claude_env() — IDE env scrubbing at the subprocess launch boundary."""
+"""Unit tests for build_agent_env() — IDE env scrubbing at the subprocess launch boundary."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from types import MappingProxyType
 
 import pytest
 
-from autoskillit.core import build_claude_env
+from autoskillit.core import build_agent_env
 from autoskillit.core._claude_env import (
     IDE_ENV_ALWAYS_EXTRAS,
     IDE_ENV_DENYLIST,
@@ -20,7 +20,7 @@ pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 def test_build_claude_env_strips_sse_port() -> None:
     base = {"CLAUDE_CODE_SSE_PORT": "23270", "HOME": "/tmp", "PATH": "/usr/bin"}
-    result = build_claude_env(base=base)
+    result = build_agent_env(base=base)
     assert "CLAUDE_CODE_SSE_PORT" not in result
     assert result["HOME"] == "/tmp"
     assert result["PATH"] == "/usr/bin"
@@ -37,7 +37,7 @@ def test_build_claude_env_strips_sse_port() -> None:
     ],
 )
 def test_build_claude_env_strips_ide_prefix(key: str) -> None:
-    result = build_claude_env(base={key: "value", "HOME": "/tmp"})
+    result = build_agent_env(base={key: "value", "HOME": "/tmp"})
     assert key not in result
     assert "HOME" in result
 
@@ -54,7 +54,7 @@ def test_build_claude_env_strips_ide_prefix(key: str) -> None:
     ],
 )
 def test_build_claude_env_strips_expanded_denylist(key: str) -> None:
-    result = build_claude_env(base={key: "value", "HOME": "/tmp"})
+    result = build_agent_env(base={key: "value", "HOME": "/tmp"})
     assert key not in result
     assert "HOME" in result
 
@@ -65,42 +65,42 @@ def test_build_claude_env_preserves_unrelated_claude_vars() -> None:
         "ANTHROPIC_API_KEY": "sk-...",
         "ANTHROPIC_LOG": "debug",
     }
-    result = build_claude_env(base=base)
+    result = build_agent_env(base=base)
     assert result["CLAUDE_CONFIG_DIR"] == "/home/user/.claude"
     assert result["ANTHROPIC_API_KEY"] == "sk-..."
     assert result["ANTHROPIC_LOG"] == "debug"
 
 
 def test_build_claude_env_injects_auto_connect_off() -> None:
-    result = build_claude_env(base={})
+    result = build_agent_env(base={})
     assert result["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
 
 
 def test_build_claude_env_caller_extras_can_override_auto_connect() -> None:
-    result = build_claude_env(base={}, extras={"CLAUDE_CODE_AUTO_CONNECT_IDE": "1"})
+    result = build_agent_env(base={}, extras={"CLAUDE_CODE_AUTO_CONNECT_IDE": "1"})
     assert result["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "1"
 
 
 def test_build_claude_env_applies_extras() -> None:
-    result = build_claude_env(base={}, extras={"AUTOSKILLIT_HEADLESS": "1"})
+    result = build_agent_env(base={}, extras={"AUTOSKILLIT_HEADLESS": "1"})
     assert result["AUTOSKILLIT_HEADLESS"] == "1"
 
 
 def test_build_claude_env_extras_override_base() -> None:
-    result = build_claude_env(base={"FOO": "original"}, extras={"FOO": "overridden"})
+    result = build_agent_env(base={"FOO": "original"}, extras={"FOO": "overridden"})
     assert result["FOO"] == "overridden"
 
 
 def test_build_claude_env_defaults_to_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_TEST_DEFAULT_ENV_MARKER", "present")
     monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
-    result = build_claude_env()
+    result = build_agent_env()
     assert result.get("AUTOSKILLIT_TEST_DEFAULT_ENV_MARKER") == "present"
     assert "CLAUDE_CODE_SSE_PORT" not in result
 
 
 def test_build_claude_env_returns_mappingproxy() -> None:
-    result = build_claude_env(base={"HOME": "/tmp"})
+    result = build_agent_env(base={"HOME": "/tmp"})
     assert isinstance(result, MappingProxyType)
     with pytest.raises(TypeError):
         result["X"] = "Y"  # type: ignore[index]
@@ -131,20 +131,20 @@ def test_ide_env_denylist_contains_max_mcp_output_tokens() -> None:
 
 def test_build_claude_env_strips_max_mcp_output_tokens() -> None:
     """MAX_MCP_OUTPUT_TOKENS must be stripped from base env by build_claude_env."""
-    result = build_claude_env(base={"MAX_MCP_OUTPUT_TOKENS": "99999", "HOME": "/tmp"})
+    result = build_agent_env(base={"MAX_MCP_OUTPUT_TOKENS": "99999", "HOME": "/tmp"})
     assert "MAX_MCP_OUTPUT_TOKENS" not in result
     assert result["HOME"] == "/tmp"
 
 
 @pytest.mark.parametrize("var", sorted(AUTOSKILLIT_PRIVATE_ENV_VARS))
 def test_build_claude_env_scrubs_autoskillit_private_vars(var: str) -> None:
-    result = build_claude_env(base={var: "leaked", "HOME": "/tmp"})
+    result = build_agent_env(base={var: "leaked", "HOME": "/tmp"})
     assert var not in result
     assert result["HOME"] == "/tmp"
 
 
 def test_build_claude_env_extras_override_scrubbed_private_vars() -> None:
-    result = build_claude_env(
+    result = build_agent_env(
         base={"AUTOSKILLIT_SESSION_TYPE": "franchise", "HOME": "/tmp"},
         extras={"AUTOSKILLIT_SESSION_TYPE": "skill"},
     )
@@ -152,8 +152,8 @@ def test_build_claude_env_extras_override_scrubbed_private_vars() -> None:
 
 
 def test_build_claude_env_subprocess_compatible() -> None:
-    """build_claude_env() result must be accepted by subprocess.Popen."""
-    env = build_claude_env()
+    """build_agent_env() result must be accepted by subprocess.Popen."""
+    env = build_agent_env()
     proc = subprocess.Popen(
         ["echo", "ok"],
         env=dict(env),
@@ -168,13 +168,13 @@ def test_build_claude_env_subprocess_compatible() -> None:
 def test_build_claude_env_required_raises_on_missing() -> None:
     """build_claude_env raises ValueError when required keys are absent."""
     with pytest.raises(ValueError) as exc_info:
-        build_claude_env(extras={"FOO": "bar"}, required=frozenset({"MISSING_KEY"}))
+        build_agent_env(extras={"FOO": "bar"}, required=frozenset({"MISSING_KEY"}))
     assert "MISSING_KEY" in str(exc_info.value)
 
 
 def test_build_claude_env_required_passes_when_all_present() -> None:
     """build_claude_env succeeds when all required keys are present."""
-    result = build_claude_env(
+    result = build_agent_env(
         extras={"REQUIRED_KEY": "val"},
         required=frozenset({"REQUIRED_KEY"}),
     )
@@ -183,11 +183,34 @@ def test_build_claude_env_required_passes_when_all_present() -> None:
 
 def test_build_claude_env_required_empty_set_succeeds() -> None:
     """required=frozenset() (empty) always passes."""
-    result = build_claude_env(extras={"A": "1"}, required=frozenset())
+    result = build_agent_env(extras={"A": "1"}, required=frozenset())
     assert result["A"] == "1"
 
 
 def test_build_claude_env_required_none_defaults_to_no_check() -> None:
     """required=None (default) skips the check entirely."""
-    result = build_claude_env(extras={"B": "2"})
+    result = build_agent_env(extras={"B": "2"})
     assert result["B"] == "2"
+
+
+def test_build_agent_env_importable() -> None:
+    """build_agent_env is the canonical name and importable from core."""
+    from autoskillit.core import build_agent_env
+
+    result = build_agent_env(base={"PATH": "/usr/bin"})
+    assert "PATH" in result
+
+
+def test_build_claude_env_alias_still_works() -> None:
+    """build_claude_env remains importable as a backward-compatible alias."""
+    from autoskillit.core import build_claude_env
+
+    result = build_claude_env(base={"PATH": "/usr/bin"})
+    assert "PATH" in result
+
+
+def test_alias_identity() -> None:
+    """Alias and canonical name are the same function object."""
+    from autoskillit.core._claude_env import build_agent_env, build_claude_env
+
+    assert build_agent_env is build_claude_env

--- a/tests/core/test_claude_env.py
+++ b/tests/core/test_claude_env.py
@@ -18,7 +18,7 @@ from autoskillit.core.types._type_constants import AUTOSKILLIT_PRIVATE_ENV_VARS
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
-def test_build_claude_env_strips_sse_port() -> None:
+def test_build_agent_env_strips_sse_port() -> None:
     base = {"CLAUDE_CODE_SSE_PORT": "23270", "HOME": "/tmp", "PATH": "/usr/bin"}
     result = build_agent_env(base=base)
     assert "CLAUDE_CODE_SSE_PORT" not in result
@@ -36,7 +36,7 @@ def test_build_claude_env_strips_sse_port() -> None:
         "CLAUDE_CODE_SSE_HOST",
     ],
 )
-def test_build_claude_env_strips_ide_prefix(key: str) -> None:
+def test_build_agent_env_strips_ide_prefix(key: str) -> None:
     result = build_agent_env(base={key: "value", "HOME": "/tmp"})
     assert key not in result
     assert "HOME" in result
@@ -53,13 +53,13 @@ def test_build_claude_env_strips_ide_prefix(key: str) -> None:
         "ZED_TERM",
     ],
 )
-def test_build_claude_env_strips_expanded_denylist(key: str) -> None:
+def test_build_agent_env_strips_expanded_denylist(key: str) -> None:
     result = build_agent_env(base={key: "value", "HOME": "/tmp"})
     assert key not in result
     assert "HOME" in result
 
 
-def test_build_claude_env_preserves_unrelated_claude_vars() -> None:
+def test_build_agent_env_preserves_unrelated_claude_vars() -> None:
     base = {
         "CLAUDE_CONFIG_DIR": "/home/user/.claude",
         "ANTHROPIC_API_KEY": "sk-...",
@@ -71,27 +71,27 @@ def test_build_claude_env_preserves_unrelated_claude_vars() -> None:
     assert result["ANTHROPIC_LOG"] == "debug"
 
 
-def test_build_claude_env_injects_auto_connect_off() -> None:
+def test_build_agent_env_injects_auto_connect_off() -> None:
     result = build_agent_env(base={})
     assert result["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
 
 
-def test_build_claude_env_caller_extras_can_override_auto_connect() -> None:
+def test_build_agent_env_caller_extras_can_override_auto_connect() -> None:
     result = build_agent_env(base={}, extras={"CLAUDE_CODE_AUTO_CONNECT_IDE": "1"})
     assert result["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "1"
 
 
-def test_build_claude_env_applies_extras() -> None:
+def test_build_agent_env_applies_extras() -> None:
     result = build_agent_env(base={}, extras={"AUTOSKILLIT_HEADLESS": "1"})
     assert result["AUTOSKILLIT_HEADLESS"] == "1"
 
 
-def test_build_claude_env_extras_override_base() -> None:
+def test_build_agent_env_extras_override_base() -> None:
     result = build_agent_env(base={"FOO": "original"}, extras={"FOO": "overridden"})
     assert result["FOO"] == "overridden"
 
 
-def test_build_claude_env_defaults_to_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_agent_env_defaults_to_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_TEST_DEFAULT_ENV_MARKER", "present")
     monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
     result = build_agent_env()
@@ -99,7 +99,7 @@ def test_build_claude_env_defaults_to_os_environ(monkeypatch: pytest.MonkeyPatch
     assert "CLAUDE_CODE_SSE_PORT" not in result
 
 
-def test_build_claude_env_returns_mappingproxy() -> None:
+def test_build_agent_env_returns_mappingproxy() -> None:
     result = build_agent_env(base={"HOME": "/tmp"})
     assert isinstance(result, MappingProxyType)
     with pytest.raises(TypeError):
@@ -129,21 +129,21 @@ def test_ide_env_denylist_contains_max_mcp_output_tokens() -> None:
     assert "MAX_MCP_OUTPUT_TOKENS" in IDE_ENV_DENYLIST
 
 
-def test_build_claude_env_strips_max_mcp_output_tokens() -> None:
-    """MAX_MCP_OUTPUT_TOKENS must be stripped from base env by build_claude_env."""
+def test_build_agent_env_strips_max_mcp_output_tokens() -> None:
+    """MAX_MCP_OUTPUT_TOKENS must be stripped from base env by build_agent_env."""
     result = build_agent_env(base={"MAX_MCP_OUTPUT_TOKENS": "99999", "HOME": "/tmp"})
     assert "MAX_MCP_OUTPUT_TOKENS" not in result
     assert result["HOME"] == "/tmp"
 
 
 @pytest.mark.parametrize("var", sorted(AUTOSKILLIT_PRIVATE_ENV_VARS))
-def test_build_claude_env_scrubs_autoskillit_private_vars(var: str) -> None:
+def test_build_agent_env_scrubs_autoskillit_private_vars(var: str) -> None:
     result = build_agent_env(base={var: "leaked", "HOME": "/tmp"})
     assert var not in result
     assert result["HOME"] == "/tmp"
 
 
-def test_build_claude_env_extras_override_scrubbed_private_vars() -> None:
+def test_build_agent_env_extras_override_scrubbed_private_vars() -> None:
     result = build_agent_env(
         base={"AUTOSKILLIT_SESSION_TYPE": "franchise", "HOME": "/tmp"},
         extras={"AUTOSKILLIT_SESSION_TYPE": "skill"},
@@ -151,7 +151,7 @@ def test_build_claude_env_extras_override_scrubbed_private_vars() -> None:
     assert result["AUTOSKILLIT_SESSION_TYPE"] == "skill"
 
 
-def test_build_claude_env_subprocess_compatible() -> None:
+def test_build_agent_env_subprocess_compatible() -> None:
     """build_agent_env() result must be accepted by subprocess.Popen."""
     env = build_agent_env()
     proc = subprocess.Popen(
@@ -165,15 +165,15 @@ def test_build_claude_env_subprocess_compatible() -> None:
     assert b"ok" in stdout
 
 
-def test_build_claude_env_required_raises_on_missing() -> None:
-    """build_claude_env raises ValueError when required keys are absent."""
+def test_build_agent_env_required_raises_on_missing() -> None:
+    """build_agent_env raises ValueError when required keys are absent."""
     with pytest.raises(ValueError) as exc_info:
         build_agent_env(extras={"FOO": "bar"}, required=frozenset({"MISSING_KEY"}))
     assert "MISSING_KEY" in str(exc_info.value)
 
 
-def test_build_claude_env_required_passes_when_all_present() -> None:
-    """build_claude_env succeeds when all required keys are present."""
+def test_build_agent_env_required_passes_when_all_present() -> None:
+    """build_agent_env succeeds when all required keys are present."""
     result = build_agent_env(
         extras={"REQUIRED_KEY": "val"},
         required=frozenset({"REQUIRED_KEY"}),
@@ -181,13 +181,13 @@ def test_build_claude_env_required_passes_when_all_present() -> None:
     assert result["REQUIRED_KEY"] == "val"
 
 
-def test_build_claude_env_required_empty_set_succeeds() -> None:
+def test_build_agent_env_required_empty_set_succeeds() -> None:
     """required=frozenset() (empty) always passes."""
     result = build_agent_env(extras={"A": "1"}, required=frozenset())
     assert result["A"] == "1"
 
 
-def test_build_claude_env_required_none_defaults_to_no_check() -> None:
+def test_build_agent_env_required_none_defaults_to_no_check() -> None:
     """required=None (default) skips the check entirely."""
     result = build_agent_env(extras={"B": "2"})
     assert result["B"] == "2"

--- a/tests/test_llm_triage.py
+++ b/tests/test_llm_triage.py
@@ -495,7 +495,7 @@ async def test_triage_command_includes_format_required_flags(
 
 @pytest.mark.anyio
 async def test_triage_env_excludes_ide_vars(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """triage_staleness must route env through build_claude_env() — no IDE leak."""
+    """triage_staleness must route env through build_agent_env() — no IDE leak."""
     from unittest.mock import AsyncMock
 
     from autoskillit._llm_triage import triage_staleness


### PR DESCRIPTION
## Summary

Rename the canonical env builder function from `build_claude_env` to `build_agent_env` in `src/autoskillit/core/_claude_env.py`, add a backward-compatible alias (`build_claude_env = build_agent_env`), update the `.pyi` stub to export both names, migrate all production call sites to the new name, and widen the AST walker contract in `test_subprocess_env_contracts.py` to accept both function names.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
src/autoskillit/_llm_triage.py
src/autoskillit/cli/doctor/_doctor_mcp.py
src/autoskillit/core/CLAUDE.md
src/autoskillit/core/__init__.pyi
src/autoskillit/core/_claude_env.py
src/autoskillit/execution/commands.py
tests/cli/test_subprocess_env_contracts.py
tests/core/CLAUDE.md
tests/core/test_claude_env.py
tests/test_llm_triage.py

Closes #2447

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-092844-239080/.autoskillit/temp/make-plan/p1_a3_wp1_rename_build_claude_env_plan_2026-05-16_093200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 61 | 6.0k | 719.2k | 63.7k | 58 | 52.0k | 3m 48s |
| verify | claude-opus-4-6 | 1 | 46 | 9.0k | 1.4M | 61.0k | 75 | 46.5k | 4m 36s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.7M | 13.1k | 1.6M | 29.9k | 153 | 90.8k | 6m 9s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 65.2k | 3.1k | 206.8k | 29.9k | 20 | 15.6k | 1m 6s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 59.2k | 1.7k | 206.8k | 29.9k | 16 | 15.4k | 42s |
| review_pr | claude-sonnet-4-6 | 3 | 286 | 104.3k | 1.6M | 83.5k | 120 | 203.6k | 25m 12s |
| resolve_review | claude-sonnet-4-6 | 4 | 624 | 45.4k | 3.1M | 66.3k | 186 | 171.1k | 31m 43s |
| **Total** | | | 1.9M | 182.6k | 8.8M | 83.5k | | 594.9k | 1h 13m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 123 | 12881.1 | 738.0 | 106.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 42 | 74605.0 | 4074.2 | 1080.5 |
| **Total** | **165** | 53459.0 | 3605.5 | 1106.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 515 | 32.9k | 2.8M | 149.7k | 22m 17s |
| claude-opus-4-6 | 2 | 1.6k | 62.8k | 6.4M | 383.0k | 35m 7s |
| MiniMax-M2.7-highspeed | 3 | 4.1M | 45.7k | 4.7M | 338.8k | 21m 2s |