### PR TITLE
[FEATURE] Add AgentBackendConfig to Config System

### DIFF
--- a/src/autoskillit/config/__init__.py
+++ b/src/autoskillit/config/__init__.py
@@ -13,6 +13,7 @@ from autoskillit.config.settings import (
     _SECRETS_ONLY_KEYS as _SECRETS_ONLY_KEYS,
 )
 from autoskillit.config.settings import (
+    AgentBackendConfig,
     AutomationConfig,
     BranchingConfig,
     CIConfig,
@@ -47,6 +48,7 @@ from autoskillit.config.settings import (
 )
 
 __all__ = [
+    "AgentBackendConfig",
     "AutomationConfig",
     "BranchingConfig",
     "ConfigSchemaError",

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -422,3 +422,7 @@ class ProvidersConfig:
 @dataclass
 class AgentBackendConfig:
     backend: str = "claude-code"
+
+    def __post_init__(self) -> None:
+        if not self.backend:
+            raise ValueError("backend must not be empty")

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -421,6 +421,4 @@ class ProvidersConfig:
 
 @dataclass
 class AgentBackendConfig:
-    """Configuration for the agent backend selection."""
-
     backend: str = "claude-code"

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -417,3 +417,10 @@ class ProvidersConfig:
                     raise ValueError(
                         f"profiles[{name!r}][{k!r}] must be a string, got {type(v).__name__!r}"
                     )
+
+
+@dataclass
+class AgentBackendConfig:
+    """Configuration for the agent backend selection."""
+
+    backend: str = "claude-code"

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -298,4 +298,7 @@ providers:
   step_overrides: {}
   provider_retry_limit: 2
 
+agent_backend:
+  backend: claude-code
+
 features: {}

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -19,6 +19,7 @@ from autoskillit.config._config_dataclasses import (
     _COMMAND_UNSET,
     _METADATA_KEYS,
     _SECRETS_ONLY_KEYS,
+    AgentBackendConfig,
     BranchingConfig,
     CIConfig,
     ClassifyFixConfig,
@@ -110,6 +111,7 @@ def _timeout_coherence_gate(run_skill: RunSkillConfig) -> None:
 
 
 __all__ = [
+    "AgentBackendConfig",
     "AutomationConfig",
     "BranchingConfig",
     "CIConfig",
@@ -191,6 +193,7 @@ class AutomationConfig:
     workspace: WorkspaceConfig = field(default_factory=WorkspaceConfig)
     fleet: FleetConfig = field(default_factory=FleetConfig)
     providers: ProvidersConfig = field(default_factory=ProvidersConfig)
+    agent_backend: AgentBackendConfig = field(default_factory=AgentBackendConfig)
     features: dict[str, bool] = field(default_factory=dict)
     experimental_enabled: bool = False
 
@@ -308,6 +311,7 @@ class AutomationConfig:
         ws_raw = sec("workspace")
         fr = sec("fleet")
         pvd = sec("providers")
+        ab = sec("agent_backend")
         feat = sec("features")
 
         _tc = _field_defaults(TestCheckConfig)
@@ -334,6 +338,7 @@ class AutomationConfig:
         _wsc = _field_defaults(WorkspaceConfig)
         _fr = _field_defaults(FleetConfig)
         _pvd = _field_defaults(ProvidersConfig)
+        _ab = _field_defaults(AgentBackendConfig)
 
         _features_dict, _exp_enabled = AutomationConfig._build_features_dict(
             dict(feat) if isinstance(feat, dict) else {}
@@ -525,6 +530,9 @@ class AutomationConfig:
                     val(pvd, "provider_retry_limit", _pvd["provider_retry_limit"]),
                     "providers.provider_retry_limit",
                 ),
+            ),
+            agent_backend=AgentBackendConfig(
+                backend=str(val(ab, "backend", _ab["backend"])),
             ),
             features=_features_dict,
             experimental_enabled=_exp_enabled,

--- a/tests/config/CLAUDE.md
+++ b/tests/config/CLAUDE.md
@@ -7,6 +7,7 @@ Configuration loading, defaults, and schema tests.
 | File | Purpose |
 |------|---------|
 | `__init__.py` | empty |
+| `test_agent_backend_config.py` | Tests for AgentBackendConfig loading and validation |
 | `test_branching_config.py` | Tests for BranchingConfig and ReleaseReadinessConfig loading and validation |
 | `test_config.py` | Tests for configuration loading and resolution |
 | `test_config_split.py` | Structural guard for config split |

--- a/tests/config/test_agent_backend_config.py
+++ b/tests/config/test_agent_backend_config.py
@@ -1,5 +1,3 @@
-"""Tests for AgentBackendConfig loading and validation."""
-
 from __future__ import annotations
 
 import pytest

--- a/tests/config/test_agent_backend_config.py
+++ b/tests/config/test_agent_backend_config.py
@@ -1,0 +1,114 @@
+"""Tests for AgentBackendConfig loading and validation."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
+
+
+class TestAgentBackendConfigImports:
+    def test_agent_backend_config_importable_from_settings(self) -> None:
+        from autoskillit.config import AgentBackendConfig
+        from autoskillit.config.settings import AgentBackendConfig as ABC
+
+        assert ABC is AgentBackendConfig
+
+    def test_agent_backend_config_in_settings_all(self) -> None:
+        import autoskillit.config.settings as m
+
+        assert "AgentBackendConfig" in m.__all__
+
+    def test_agent_backend_config_in_config_all(self) -> None:
+        import autoskillit.config as m
+
+        assert "AgentBackendConfig" in m.__all__
+
+
+class TestAgentBackendConfigField:
+    def test_automation_config_has_agent_backend_field(self) -> None:
+        from dataclasses import fields as _dc_fields
+
+        from autoskillit.config import AgentBackendConfig, AutomationConfig
+
+        field_names = [f.name for f in _dc_fields(AutomationConfig)]
+        assert "agent_backend" in field_names
+        cfg = AutomationConfig()
+        assert isinstance(cfg.agent_backend, AgentBackendConfig)
+
+    def test_agent_backend_field_ordering(self) -> None:
+        from dataclasses import fields as _dc_fields
+
+        from autoskillit.config import AutomationConfig
+
+        field_names = [f.name for f in _dc_fields(AutomationConfig)]
+        providers_idx = field_names.index("providers")
+        agent_backend_idx = field_names.index("agent_backend")
+        features_idx = field_names.index("features")
+        assert providers_idx < agent_backend_idx < features_idx
+
+    def test_agent_backend_config_defaults(self) -> None:
+        from autoskillit.config.settings import AgentBackendConfig
+
+        cfg = AgentBackendConfig()
+        assert cfg.backend == "claude-code"
+
+    def test_agent_backend_config_custom_value(self) -> None:
+        from autoskillit.config.settings import AgentBackendConfig
+
+        cfg = AgentBackendConfig(backend="codex")
+        assert cfg.backend == "codex"
+
+
+class TestAgentBackendConfigLoading:
+    def test_load_config_agent_backend_defaults(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        cfg = load_config(tmp_path)
+        assert cfg.agent_backend.backend == "claude-code"
+
+    def test_defaults_yaml_has_agent_backend_section(self) -> None:
+        from autoskillit.core.io import load_yaml
+        from autoskillit.core.paths import pkg_root
+
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+        assert "agent_backend" in defaults
+        assert defaults["agent_backend"]["backend"] == "claude-code"
+
+    def test_agent_backend_env_var_override(self, tmp_path, monkeypatch) -> None:
+        from autoskillit.config import load_config
+
+        monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND__BACKEND", "codex")
+        cfg = load_config(tmp_path)
+        assert cfg.agent_backend.backend == "codex"
+
+    def test_agent_backend_yaml_override(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text(yaml.dump({"agent_backend": {"backend": "aider"}}))
+        cfg = load_config(tmp_path)
+        assert cfg.agent_backend.backend == "aider"
+
+    def test_agent_backend_key_accepted_by_schema_validator(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text(
+            yaml.dump({"agent_backend": {"backend": "claude-code"}})
+        )
+        cfg = load_config(tmp_path)
+        assert cfg.agent_backend.backend == "claude-code"
+
+    def test_agent_backend_unknown_key_rejected(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+        from autoskillit.config.settings import ConfigSchemaError
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("agent_backend:\n  invented_key: whatever\n")
+        with pytest.raises(ConfigSchemaError, match="unrecognized key"):
+            load_config(tmp_path)


### PR DESCRIPTION
## Summary

Add a new `AgentBackendConfig` leaf dataclass with a single `backend: str = "claude-code"` field, wire it into `AutomationConfig`, the Dynaconf loader (`from_dynaconf`), `defaults.yaml`, and both export surfaces (`settings.py` and `config/__init__.py`). Add a comprehensive test file covering importability, field presence, defaults, schema validation, and env var override.

Closes #2446

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-092843-222766/.autoskillit/temp/make-plan/p1_a2_wp1_add_agent_backend_config_plan_2026-05-16_093500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 63 | 6.8k | 683.0k | 53.6k | 59 | 57.3k | 4m 31s |
| verify | claude-opus-4-6 | 1 | 26 | 3.8k | 252.5k | 40.9k | 53 | 26.5k | 2m 21s |
| implement* | MiniMax-M2.7-highspeed | 1 | 583.0k | 6.9k | 895.5k | 29.9k | 83 | 39.9k | 2m 41s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 97.3k | 3.3k | 239.5k | 29.9k | 22 | 42.7k | 1m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 90.4k | 1.7k | 269.5k | 29.9k | 21 | 42.5k | 55s |
| review_pr | claude-sonnet-4-6 | 3 | 270 | 83.1k | 1.3M | 72.3k | 107 | 162.2k | 18m 22s |
| resolve_review | claude-sonnet-4-6 | 4 | 722 | 39.9k | 3.9M | 63.9k | 210 | 170.0k | 22m 47s |
| **Total** | | | 771.7k | 145.6k | 7.5M | 72.3k | | 541.1k | 53m 1s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 135 | 6633.0 | 295.8 | 51.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 482055.4 | 21254.2 | 4985.4 |
| **Total** | **143** | 52748.9 | 3783.9 | 1018.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 515 | 32.9k | 2.8M | 149.7k | 22m 17s |
| claude-opus-4-6 | 2 | 1.6k | 62.8k | 6.4M | 383.0k | 35m 7s |
| MiniMax-M2.7-highspeed | 3 | 4.2M | 47.4k | 5.0M | 381.3k | 21m 57s |