### PR TITLE
[P1-A7-WP1] Add agent_backend guard to install()

### DIFF
--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -148,6 +148,16 @@ def install(*, scope: str = "user") -> bool:
         print(f"Invalid scope: {scope!r}. Must be one of: {', '.join(sorted(_VALID_SCOPES))}")
         sys.exit(1)
 
+    from autoskillit.config import load_config
+
+    cfg = load_config(Path.cwd())
+    if cfg.agent_backend.backend != "claude-code":
+        print(
+            f"\nautoskillit install is only supported with the claude-code backend.\n"
+            f"Current backend: {cfg.agent_backend.backend!r}\n"
+        )
+        return False
+
     marketplace_dir = _ensure_marketplace()
     plugin_ref = f"autoskillit@{_MARKETPLACE_NAME}"
     print(f"Marketplace prepared: {marketplace_dir}")

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -174,6 +174,80 @@ class TestCLIInstall:
         assert (tmp_path / ".autoskillit" / "marketplace" / "plugins" / "autoskillit").is_symlink()
 
     @patch("autoskillit.cli._marketplace.subprocess.run")
+    def test_install_backend_guard_returns_false_for_non_claude_code(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """install() returns False with message when backend != 'claude-code'."""
+        from autoskillit.config import AgentBackendConfig, AutomationConfig
+
+        mock_cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
+        monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path))
+
+        from autoskillit.cli._marketplace import install
+
+        result = install(scope="user")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "claude-code" in captured.out.lower() or "not supported" in captured.out.lower()
+
+    def test_install_backend_guard_allows_claude_code(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """install() proceeds past backend guard when backend == 'claude-code'."""
+        from autoskillit.config import AgentBackendConfig, AutomationConfig
+
+        mock_cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="claude-code"))
+        monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path))
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
+
+        _app_mod = importlib.import_module("autoskillit.cli._marketplace")
+        monkeypatch.setattr(_app_mod, "is_git_worktree", lambda path: False)
+
+        # Patch subprocess to prevent actual CLI call, verify we got past the guard
+        called = []
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: (
+                called.append(a),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr=""),
+            )[1],
+        )
+        monkeypatch.setattr(_app_mod, "evict_direct_mcp_entry", lambda _: False)
+        monkeypatch.setattr(_app_mod, "sweep_all_scopes_for_orphans", lambda _: None)
+        monkeypatch.setattr(_app_mod, "sync_hooks_to_settings", lambda _: None)
+        monkeypatch.setattr(_app_mod, "generate_hooks_json", lambda: {})
+        monkeypatch.setattr(_app_mod, "atomic_write", lambda *a, **kw: None)
+
+        from autoskillit.cli._marketplace import install
+
+        result = install(scope="user")
+
+        assert result is True
+        assert len(called) >= 1  # subprocess was invoked (past the guard)
+
+    def test_install_backend_guard_no_new_module_level_imports(self) -> None:
+        """Verify load_config is NOT at module level in _marketplace.py."""
+        import ast
+
+        from autoskillit.core.paths import pkg_root
+
+        source = (pkg_root() / "cli" / "_marketplace.py").read_text()
+        tree = ast.parse(source)
+
+        # Check that no top-level import references autoskillit.config
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                if isinstance(node, ast.ImportFrom) and node.module:
+                    assert "autoskillit.config" not in node.module, (
+                        "load_config must be a deferred import inside install(), not module-level"
+                    )
+
     def test_install_evicts_stale_direct_mcp_entry(
         self, mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -173,7 +173,6 @@ class TestCLIInstall:
 
         assert (tmp_path / ".autoskillit" / "marketplace" / "plugins" / "autoskillit").is_symlink()
 
-    @patch("autoskillit.cli._marketplace.subprocess.run")
     def test_install_backend_guard_returns_false_for_non_claude_code(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
@@ -248,6 +247,7 @@ class TestCLIInstall:
                         "load_config must be a deferred import inside install(), not module-level"
                     )
 
+    @patch("autoskillit.cli._marketplace.subprocess.run")
     def test_install_evicts_stale_direct_mcp_entry(
         self, mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -190,7 +190,7 @@ class TestCLIInstall:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "claude-code" in captured.out.lower() or "not supported" in captured.out.lower()
+        assert "only supported with the claude-code backend" in captured.out.lower()
 
     def test_install_backend_guard_allows_claude_code(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
@@ -241,9 +241,13 @@ class TestCLIInstall:
 
         # Check that no top-level import references autoskillit.config
         for node in ast.iter_child_nodes(tree):
-            if isinstance(node, (ast.Import, ast.ImportFrom)):
-                if isinstance(node, ast.ImportFrom) and node.module:
-                    assert "autoskillit.config" not in node.module, (
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert "autoskillit.config" not in node.module, (
+                    "load_config must be a deferred import inside install(), not module-level"
+                )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert "autoskillit.config" not in alias.name, (
                         "load_config must be a deferred import inside install(), not module-level"
                     )
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -134,7 +134,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — marketplace.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 100),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 182),
+    ("src/autoskillit/cli/_marketplace.py", 192),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/update/_update_checks.py", 77),
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)


### PR DESCRIPTION
## Summary

Add an early-return guard to `install()` in `src/autoskillit/cli/_marketplace.py` that checks `cfg.agent_backend.backend != "claude-code"` and returns `False` with a user-facing message when the configured backend is not `claude-code`. The guard is placed between scope validation (line 149) and `_ensure_marketplace()` (line 151), using a deferred import of `load_config` inside the function body.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

| File | Conflict Resolution |
|------|-------------------|
| None | — |



Closes #2450

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-122759-838719/.autoskillit/temp/make-plan/p1_a7_wp1_add_agent_backend_guard_plan_2026-05-16_123600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| build_execution_map | claude-sonnet-4-6 | 1 | 78 | 12.2k | 323.4k | 51.5k | 39 | 53.0k | 4m 16s |
| plan | claude-opus-4-6 | 7 | 2.6k | 52.5k | 4.9M | 63.7k | 468 | 373.9k | 29m 48s |
| verify | claude-opus-4-6 | 7 | 1.5k | 59.3k | 6.7M | 74.6k | 522 | 317.6k | 32m 12s |
| implement* | MiniMax-M2.7-highspeed | 7 | 6.2M | 62.0k | 7.4M | 66.9k | 614 | 436.0k | 29m 39s |
| fix | claude-sonnet-4-6 | 5 | 687 | 36.0k | 3.7M | 77.3k | 210 | 205.7k | 31m 35s |
| prepare_pr* | MiniMax-M2.7-highspeed | 7 | 532.1k | 23.1k | 1.5M | 30.0k | 141 | 217.8k | 8m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 5 | 306.9k | 7.7k | 1.1M | 29.9k | 84 | 158.0k | 3m 35s |
| review_pr | claude-sonnet-4-6 | 12 | 1.2k | 387.5k | 6.5M | 83.5k | 471 | 733.3k | 1h 25m |
| resolve_review | claude-sonnet-4-6 | 13 | 2.2k | 141.4k | 11.9M | 85.3k | 651 | 578.9k | 1h 35m |
| **Total** | | | 7.1M | 781.7k | 44.0M | 85.3k | | 3.1M | 5h 20m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| build_execution_map | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 792 | 9381.1 | 550.5 | 78.2 |
| fix | 18 | 206811.1 | 11427.2 | 2000.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 85 | 140080.8 | 6811.1 | 1663.5 |
| **Total** | **895** | 49111.6 | 3434.9 | 873.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 4.1k | 577.1k | 22.4M | 1.6M | 3h 36m |
| claude-opus-4-6 | 2 | 4.1k | 111.8k | 11.5M | 691.5k | 1h 2m |
| MiniMax-M2.7-highspeed | 3 | 7.0M | 92.8k | 10.0M | 811.8k | 41m 36s |