### PR TITLE
Implementation Plan: Gate LLM Triage Behind agent_backend

### DIFF
--- a/src/autoskillit/_llm_triage.py
+++ b/src/autoskillit/_llm_triage.py
@@ -29,7 +29,9 @@ logger = get_logger(__name__)
 _SKILL_MD_TRUNCATE = 1500
 
 
-async def triage_staleness(stale_items: list[StaleItem]) -> list[dict[str, Any]]:
+async def triage_staleness(
+    stale_items: list[StaleItem], *, agent_backend: str = "claude-code"
+) -> list[dict[str, Any]]:
     """Use Haiku to determine if stale contracts changed meaningfully.
 
     For each stale item with reason="hash_mismatch", reads the current
@@ -69,13 +71,13 @@ async def triage_staleness(stale_items: list[StaleItem]) -> list[dict[str, Any]]
             if skill_md_path.is_file():
                 skill_md_cache[item.skill] = skill_md_path.read_text()
 
-    results.extend(await _triage_batch(hash_items, skill_md_cache))
+    results.extend(await _triage_batch(hash_items, skill_md_cache, agent_backend=agent_backend))
 
     return results
 
 
 async def _triage_batch(
-    batch: list[StaleItem], skill_md_cache: dict[str, str]
+    batch: list[StaleItem], skill_md_cache: dict[str, str], *, agent_backend: str = "claude-code"
 ) -> list[dict[str, Any]]:
     """Triage one batch of hash_mismatch items with a single Haiku subprocess call.
 
@@ -100,6 +102,16 @@ async def _triage_batch(
 
     if not triageable:
         return pre_results
+
+    if agent_backend != "claude-code":
+        return pre_results + [
+            {
+                "skill": i.skill,
+                "meaningful": True,
+                "summary": f"Skipped LLM triage (backend={agent_backend}).",
+            }
+            for i in triageable
+        ]
 
     prompt = _build_batch_prompt(triageable, skill_md_cache)
 

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -134,10 +134,19 @@ async def _apply_triage_gate(
     if _ctx is None or _ctx.recipes is None:
         return result
 
+    import functools
+
     from autoskillit._llm_triage import triage_staleness
 
+    agent_backend = _ctx.config.agent_backend.backend
+
+    if agent_backend == "claude-code":
+        triage_fn = functools.partial(triage_staleness, agent_backend=agent_backend)
+    else:
+        triage_fn = None
+
     return await _ctx.recipes.apply_triage_gate(
-        result, name, recipe_info, _ctx.temp_dir, logger, triage_fn=triage_staleness
+        result, name, recipe_info, _ctx.temp_dir, logger, triage_fn=triage_fn
     )
 
 

--- a/tests/test_llm_triage.py
+++ b/tests/test_llm_triage.py
@@ -65,7 +65,7 @@ async def test_triage_staleness_reads_skill_md_once_per_unique_skill(
             current_value="new2",
         ),
     ]
-    await triage_staleness(items)
+    await triage_staleness(items, agent_backend="claude-code")
     assert len(read_calls) == 1, (
         f"SKILL.md read {len(read_calls)} times; expected exactly 1 (cache hit on second item)"
     )
@@ -113,7 +113,7 @@ class TestTriageStaleness:
             stored_value="abc123",
             current_value="def456",
         )
-        result = await triage_staleness([item])
+        result = await triage_staleness([item], agent_backend="claude-code")
 
         assert len(result) == 1
         assert result[0]["meaningful"] is True
@@ -157,7 +157,7 @@ class TestTriageStaleness:
         )
 
         with structlog.testing.capture_logs() as logs:
-            await triage_staleness([item])
+            await triage_staleness([item], agent_backend="claude-code")
 
         assert any(log["log_level"] == "warning" for log in logs), (
             "A warning log must be emitted on timeout"
@@ -205,7 +205,7 @@ class TestTriageStaleness:
         )
 
         with structlog.testing.capture_logs() as logs:
-            result = await triage_staleness([item])
+            result = await triage_staleness([item], agent_backend="claude-code")
 
         assert result[0]["meaningful"] is True
         assert any(log["log_level"] == "warning" for log in logs), (
@@ -270,7 +270,7 @@ class TestTriageStaleness:
             stored_value="abc123",
             current_value="def456",
         )
-        result = await triage_staleness([item])
+        result = await triage_staleness([item], agent_backend="claude-code")
 
         assert result[0]["meaningful"] is False
         assert result[0]["summary"] == "ok"
@@ -295,7 +295,7 @@ class TestTriageStaleness:
             stored_value="abc123",
             current_value="def456",
         )
-        result = await triage_staleness([item])
+        result = await triage_staleness([item], agent_backend="claude-code")
 
         assert len(result) == 1
         assert result[0]["meaningful"] is True
@@ -368,7 +368,7 @@ class TestTriageStaleness:
             stored_value="abc123",
             current_value="def456",
         )
-        result = await triage_staleness([item])
+        result = await triage_staleness([item], agent_backend="claude-code")
 
         assert result[0]["meaningful"] is False, (
             f"triage_staleness must parse NDJSON via parse_session_result, not json.loads. "
@@ -435,7 +435,7 @@ async def test_triage_staleness_batch_fallback_on_malformed_response(
         )
         for i in range(n)
     ]
-    results = await triage_staleness(items)
+    results = await triage_staleness(items, agent_backend="claude-code")
 
     assert len(results) == n
     assert all(r["meaningful"] is True for r in results), (
@@ -484,7 +484,7 @@ async def test_triage_command_includes_format_required_flags(
     item = StaleItem(
         skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
     )
-    await triage_staleness([item])
+    await triage_staleness([item], agent_backend="claude-code")
 
     # Verify the command passed to run_managed_async includes format-required flags
     cmd = mock_run.call_args.kwargs["cmd"]
@@ -538,7 +538,7 @@ async def test_triage_env_excludes_ide_vars(tmp_path: Path, monkeypatch: pytest.
     item = StaleItem(
         skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
     )
-    await triage_staleness([item])
+    await triage_staleness([item], agent_backend="claude-code")
 
     env = mock_run.call_args.kwargs["env"]
     assert env is not None


### PR DESCRIPTION
## Summary

Add `agent_backend` parameter to `triage_staleness()` and `_triage_batch()` with a default of `'claude-code'`. Insert an early-return guard in `_triage_batch()` that returns all items as `meaningful=True` without launching a subprocess when the backend is not `'claude-code'`. Thread the backend value through `_apply_triage_gate()` in `server/_misc.py` by conditionally binding `triage_fn`: pass `triage_staleness` for `'claude-code'` backends, pass `None` for all others. Update all 10 test call sites to explicitly pass `agent_backend='claude-code'`.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):

- `src/autoskillit/_llm_triage.py`
- `src/autoskillit/server/_misc.py`
- `tests/test_llm_triage.py`

Closes #2449

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-122758-850167/.autoskillit/temp/make-plan/p1_a6_wp1_gate_llm_triage_plan_2026-05-16_123600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| build_execution_map | claude-sonnet-4-6 | 1 | 78 | 12.2k | 323.4k | 51.5k | 39 | 53.0k | 4m 16s |
| plan | claude-opus-4-6 | 7 | 2.6k | 52.5k | 4.9M | 63.7k | 468 | 373.9k | 29m 48s |
| verify | claude-opus-4-6 | 7 | 1.5k | 59.3k | 6.7M | 74.6k | 522 | 317.6k | 32m 12s |
| implement* | MiniMax-M2.7-highspeed | 7 | 6.2M | 62.0k | 7.4M | 66.9k | 614 | 436.0k | 29m 39s |
| fix | claude-sonnet-4-6 | 5 | 687 | 36.0k | 3.7M | 77.3k | 210 | 205.7k | 31m 35s |
| prepare_pr* | MiniMax-M2.7-highspeed | 7 | 532.1k | 23.1k | 1.5M | 30.0k | 141 | 217.8k | 8m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 6 | 367.4k | 9.6k | 1.3M | 30.0k | 101 | 173.4k | 4m 21s |
| review_pr | claude-sonnet-4-6 | 12 | 1.2k | 387.5k | 6.5M | 83.5k | 471 | 733.3k | 1h 25m |
| resolve_review | claude-sonnet-4-6 | 13 | 2.2k | 141.4k | 11.9M | 85.3k | 651 | 578.9k | 1h 35m |
| **Total** | | | 7.1M | 783.6k | 44.2M | 85.3k | | 3.1M | 5h 21m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| build_execution_map | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 792 | 9381.1 | 550.5 | 78.2 |
| fix | 18 | 206811.1 | 11427.2 | 2000.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 85 | 140080.8 | 6811.1 | 1663.5 |
| **Total** | **895** | 49342.8 | 3452.1 | 875.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 4.1k | 577.1k | 22.4M | 1.6M | 3h 36m |
| claude-opus-4-6 | 2 | 4.1k | 111.8k | 11.5M | 691.5k | 1h 2m |
| MiniMax-M2.7-highspeed | 3 | 7.1M | 94.6k | 10.2M | 827.2k | 42m 22s |