### PR TITLE
[P1-A8-WP1] Add Backend Guards to Doctor Checks

### DIFF
--- a/src/autoskillit/cli/doctor/__init__.py
+++ b/src/autoskillit/cli/doctor/__init__.py
@@ -73,10 +73,16 @@ def run_doctor(*, output_json: bool = False) -> None:
     results: list[DoctorResult] = []
 
     # Check 1: Stale MCP servers — dead binaries or nonexistent paths
-    results.extend(_check_stale_mcp_servers(Path.home() / ".claude.json"))
+    results.extend(
+        _check_stale_mcp_servers(Path.home() / ".claude.json", backend=cfg.agent_backend.backend)
+    )
 
     # Check 2: MCP server registered in ~/.claude.json or via plugin
-    results.append(_check_mcp_server_registered(claude_json_path=Path.home() / ".claude.json"))
+    results.append(
+        _check_mcp_server_registered(
+            claude_json_path=Path.home() / ".claude.json", backend=cfg.agent_backend.backend
+        )
+    )
 
     # Check 2b: Dual MCP registration — direct entry and marketplace plugin both present
     results.append(_check_dual_mcp_registration())
@@ -133,7 +139,7 @@ def run_doctor(*, output_json: bool = False) -> None:
     results.append(_check_quota_cache_schema())
 
     # Check 15: claude process state breakdown
-    results.append(_check_claude_process_state_breakdown())
+    results.append(_check_claude_process_state_breakdown(backend=cfg.agent_backend.backend))
 
     # Check 16: Install classification from direct_url.json
     results.append(_check_install_classification())

--- a/src/autoskillit/cli/doctor/_doctor_mcp.py
+++ b/src/autoskillit/cli/doctor/_doctor_mcp.py
@@ -14,8 +14,12 @@ from ._doctor_types import DoctorResult
 logger = get_logger(__name__)
 
 
-def _check_stale_mcp_servers(claude_json_path: Path | None = None) -> list[DoctorResult]:
+def _check_stale_mcp_servers(
+    claude_json_path: Path | None = None, *, backend: str | None = None
+) -> list[DoctorResult]:
     """Check ~/.claude.json for stale autoskillit* MCP server entries with dead paths."""
+    if backend is not None and backend != "claude-code":
+        return [DoctorResult(Severity.OK, "stale_mcp_servers", f"Skipped (backend={backend})")]
     _path = claude_json_path or (Path.home() / ".claude.json")
     if not _path.is_file():
         return [DoctorResult(Severity.OK, "stale_mcp_servers", "No stale MCP servers detected")]
@@ -54,8 +58,12 @@ def _check_stale_mcp_servers(claude_json_path: Path | None = None) -> list[Docto
     return [DoctorResult(Severity.OK, "stale_mcp_servers", "No stale MCP servers detected")]
 
 
-def _check_mcp_server_registered(claude_json_path: Path | None = None) -> DoctorResult:
+def _check_mcp_server_registered(
+    claude_json_path: Path | None = None, *, backend: str | None = None
+) -> DoctorResult:
     """Check that autoskillit MCP server is registered (via mcpServers or plugin)."""
+    if backend is not None and backend != "claude-code":
+        return DoctorResult(Severity.OK, "mcp_server_registered", f"Skipped (backend={backend})")
     if claude_json_path is None:
         claude_json_path = Path.home() / ".claude.json"
 

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -44,9 +44,11 @@ def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:
     )
 
 
-def _check_claude_process_state_breakdown() -> DoctorResult:
+def _check_claude_process_state_breakdown(*, backend: str | None = None) -> DoctorResult:
     """Check current D-state and CPU usage of claude processes via ps."""
     check_name = "claude_process_state"
+    if backend is not None and backend != "claude-code":
+        return DoctorResult(Severity.OK, check_name, f"Skipped (backend={backend})")
     try:
         result = subprocess.run(
             ["ps", "-axo", "pid,state,pcpu,comm"],

--- a/tests/cli/test_doctor_migration.py
+++ b/tests/cli/test_doctor_migration.py
@@ -326,10 +326,7 @@ class TestRunDoctorBackendWiring:
             return [DoctorResult(Severity.OK, "stale_mcp_servers", "captured")]
 
         with patch("autoskillit.cli.doctor._check_stale_mcp_servers", side_effect=_capture_stale):
-            try:
-                run_doctor()
-            except Exception:
-                pass
+            run_doctor()
 
         assert captured_backends == ["aider"]
 

--- a/tests/cli/test_doctor_migration.py
+++ b/tests/cli/test_doctor_migration.py
@@ -177,6 +177,163 @@ class TestCheckClaudeProcessStateBreakdown:
         assert "FileNotFoundError" in result.message
 
 
+class TestCheckStaleMcpServersBackendGuard:
+    def test_non_claude_code_backend_returns_ok_skip(self) -> None:
+        """Non-claude-code backend returns OK skip without filesystem access."""
+        from autoskillit.cli.doctor._doctor_mcp import _check_stale_mcp_servers
+        from autoskillit.core import Severity
+
+        results = _check_stale_mcp_servers(backend="aider")
+        assert len(results) == 1
+        assert results[0].severity == Severity.OK
+        assert results[0].check == "stale_mcp_servers"
+        assert "skipped" in results[0].message.lower()
+
+    def test_none_backend_preserves_existing_behavior(self, tmp_path: Path) -> None:
+        """Default None backend does NOT skip — existing behavior intact."""
+        from autoskillit.cli.doctor._doctor_mcp import _check_stale_mcp_servers
+        from autoskillit.core import Severity
+
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text('{"mcpServers": {}}')
+        results = _check_stale_mcp_servers(claude_json_path=claude_json, backend=None)
+        assert len(results) == 1
+        assert results[0].severity == Severity.OK
+        assert "skipped" not in results[0].message.lower()
+
+    def test_claude_code_backend_preserves_existing_behavior(self, tmp_path: Path) -> None:
+        """Explicit claude-code backend does NOT skip — existing behavior intact."""
+        from autoskillit.cli.doctor._doctor_mcp import _check_stale_mcp_servers
+        from autoskillit.core import Severity
+
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text('{"mcpServers": {}}')
+        results = _check_stale_mcp_servers(claude_json_path=claude_json, backend="claude-code")
+        assert len(results) == 1
+        assert results[0].severity == Severity.OK
+        assert "skipped" not in results[0].message.lower()
+
+
+class TestCheckMcpServerRegisteredBackendGuard:
+    def test_non_claude_code_backend_returns_ok_skip(self) -> None:
+        """Non-claude-code backend returns OK skip without filesystem/subprocess access."""
+        from autoskillit.cli.doctor._doctor_mcp import _check_mcp_server_registered
+        from autoskillit.core import Severity
+
+        result = _check_mcp_server_registered(backend="aider")
+        assert result.severity == Severity.OK
+        assert result.check == "mcp_server_registered"
+        assert "skipped" in result.message.lower()
+
+    def test_none_backend_preserves_existing_behavior(self, tmp_path: Path) -> None:
+        """Default None backend does NOT skip."""
+        from autoskillit.cli.doctor._doctor_mcp import _check_mcp_server_registered
+        from autoskillit.core import Severity
+
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text('{"mcpServers": {"autoskillit": {"command": "x"}}}')
+        result = _check_mcp_server_registered(claude_json_path=claude_json, backend=None)
+        assert result.severity == Severity.OK
+        assert "skipped" not in result.message.lower()
+
+    def test_claude_code_backend_preserves_existing_behavior(self, tmp_path: Path) -> None:
+        """Explicit claude-code backend does NOT skip."""
+        from autoskillit.cli.doctor._doctor_mcp import _check_mcp_server_registered
+        from autoskillit.core import Severity
+
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text('{"mcpServers": {"autoskillit": {"command": "x"}}}')
+        result = _check_mcp_server_registered(claude_json_path=claude_json, backend="claude-code")
+        assert result.severity == Severity.OK
+        assert "skipped" not in result.message.lower()
+
+
+class TestCheckClaudeProcessStateBreakdownBackendGuard:
+    def test_non_claude_code_backend_returns_ok_skip(self) -> None:
+        """Non-claude-code backend returns OK skip without subprocess access."""
+        from autoskillit.cli.doctor._doctor_runtime import _check_claude_process_state_breakdown
+        from autoskillit.core import Severity
+
+        result = _check_claude_process_state_breakdown(backend="aider")
+        assert result.severity == Severity.OK
+        assert result.check == "claude_process_state"
+        assert "skipped" in result.message.lower()
+
+    def test_none_backend_preserves_existing_behavior(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default None backend does NOT skip — runs ps as before."""
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_claude_process_state_breakdown
+        from autoskillit.core import Severity
+
+        header = "PID STAT %CPU COMMAND\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: type(
+                "CP", (), {"returncode": 0, "stdout": header + "1234 S 0.5 claude"}
+            )(),
+        )
+        result = _check_claude_process_state_breakdown(backend=None)
+        assert result.severity == Severity.OK
+        assert "skipped" not in result.message.lower()
+
+    def test_claude_code_backend_preserves_existing_behavior(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit claude-code backend does NOT skip."""
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_claude_process_state_breakdown
+        from autoskillit.core import Severity
+
+        header = "PID STAT %CPU COMMAND\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: type(
+                "CP", (), {"returncode": 0, "stdout": header + "1234 S 0.5 claude"}
+            )(),
+        )
+        result = _check_claude_process_state_breakdown(backend="claude-code")
+        assert result.severity == Severity.OK
+        assert "skipped" not in result.message.lower()
+
+
+class TestRunDoctorBackendWiring:
+    def test_run_doctor_passes_backend_to_guarded_checks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_doctor passes cfg.agent_backend.backend to guarded checks."""
+        from unittest.mock import patch
+
+        from autoskillit.cli.doctor import run_doctor
+        from autoskillit.cli.doctor._doctor_types import DoctorResult
+        from autoskillit.core import Severity
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".autoskillit").mkdir()
+        (tmp_path / ".autoskillit" / "config.yaml").write_text(
+            "agent_backend:\n  backend: aider\n"
+        )
+
+        captured_backends: list[str | None] = []
+
+        def _capture_stale(*args: object, **kwargs: object) -> list[DoctorResult]:
+            captured_backends.append(kwargs.get("backend"))
+            return [DoctorResult(Severity.OK, "stale_mcp_servers", "captured")]
+
+        with patch("autoskillit.cli.doctor._check_stale_mcp_servers", side_effect=_capture_stale):
+            try:
+                run_doctor()
+            except Exception:
+                pass
+
+        assert captured_backends == ["aider"]
+
+
 class TestDoctorInstallClassification:
     """Tests for _check_install_classification doctor check."""
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -198,7 +198,8 @@ class TestLoadConfig:
         assert cfg.model.model_override is None
 
     def test_partial_model_config(self, tmp_path):
-        """MOD_C3: YAML key 'override' maps to Python field model_override; unset default_model is preserved at its default."""
+        """MOD_C3: YAML key 'override' maps to Python field model_override;
+        unset default_model is preserved at its default."""
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         config_data = {"model": {"override": "haiku"}}


### PR DESCRIPTION
## Summary

Add a `backend: str | None = None` parameter to `_check_stale_mcp_servers`, `_check_mcp_server_registered`, and `_check_claude_process_state_breakdown`. Each function gets a skip guard that returns an OK result immediately when the backend is not `"claude-code"`, avoiding filesystem/subprocess access. Wire `backend=cfg.agent_backend.backend` through both call sites in `run_doctor()`.

## Changed Files

### Modified (●):
● src/autoskillit/cli/doctor/__init__.py
● src/autoskillit/cli/doctor/_doctor_mcp.py
● src/autoskillit/cli/doctor/_doctor_runtime.py
● tests/cli/test_doctor_migration.py
● tests/config/test_config.py

Closes #2451

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-122800-369457/.autoskillit/temp/make-plan/p1_a8_wp1_backend_guards_doctor_plan_2026-05-16_122800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| build_execution_map | claude-sonnet-4-6 | 1 | 78 | 12.2k | 323.4k | 51.5k | 39 | 53.0k | 4m 16s |
| plan | claude-opus-4-6 | 7 | 2.6k | 52.5k | 4.9M | 63.7k | 468 | 373.9k | 29m 48s |
| verify | claude-opus-4-6 | 7 | 1.5k | 59.3k | 6.7M | 74.6k | 522 | 317.6k | 32m 12s |
| implement* | MiniMax-M2.7-highspeed | 7 | 6.2M | 62.0k | 7.4M | 66.9k | 614 | 436.0k | 29m 39s |
| fix | claude-sonnet-4-6 | 5 | 687 | 36.0k | 3.7M | 77.3k | 210 | 205.7k | 31m 35s |
| prepare_pr* | MiniMax-M2.7-highspeed | 7 | 532.1k | 23.1k | 1.5M | 30.0k | 141 | 217.8k | 8m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 7 | 426.7k | 11.6k | 1.5M | 30.0k | 119 | 188.8k | 5m 5s |
| review_pr | claude-sonnet-4-6 | 12 | 1.2k | 387.5k | 6.5M | 83.5k | 471 | 733.3k | 1h 25m |
| resolve_review | claude-sonnet-4-6 | 13 | 2.2k | 141.4k | 11.9M | 85.3k | 651 | 578.9k | 1h 35m |
| **Total** | | | 7.2M | 785.6k | 44.4M | 85.3k | | 3.1M | 5h 21m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| build_execution_map | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 792 | 9381.1 | 550.5 | 78.2 |
| fix | 18 | 206811.1 | 11427.2 | 2000.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 85 | 140080.8 | 6811.1 | 1663.5 |
| **Total** | **895** | 49607.4 | 3469.3 | 877.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 4.1k | 577.1k | 22.4M | 1.6M | 3h 36m |
| claude-opus-4-6 | 2 | 4.1k | 111.8k | 11.5M | 691.5k | 1h 2m |
| MiniMax-M2.7-highspeed | 3 | 7.2M | 96.7k | 10.4M | 842.6k | 43m 6s |