### PR TITLE
test_backend_capabilities.py — BackendCapabilities frozen invariants and field values

### DIFF
--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -36,7 +36,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_session_type.py` | Tests for SessionType resolver and constants |
 | `test_skill_command_parsing.py` | Unit tests for extract_path_arg in core._type_helpers |
 | `test_tool_sequence_analysis.py` | Tool sequence analysis tests |
-| `test_type_backend.py` | Tests for BackendCapabilities and CLAUDE_CODE_CAPABILITIES |
+| `test_backend_capabilities.py` | Tests for BackendCapabilities frozen invariants and CLAUDE_CODE_CAPABILITIES field values |
 | `test_type_constants.py` | Tests for PACK_REGISTRY and related constants in core._type_constants |
 | `test_type_protocol_shards.py` | Type protocol shards guard |
 | `test_types.py` | Tests for shared type contracts — enum exhaustiveness |

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -1,4 +1,4 @@
-"""Tests for core/types/_type_backend.py — BackendCapabilities and CLAUDE_CODE_CAPABILITIES."""
+"""Tests for BackendCapabilities frozen invariants and CLAUDE_CODE_CAPABILITIES field values."""
 
 from __future__ import annotations
 
@@ -18,6 +18,14 @@ def test_backend_capabilities_importable_from_core():
     assert isinstance(CLAUDE_CODE_CAPABILITIES, BackendCapabilities)
 
 
+def test_backend_capabilities_in_core_all():
+    """Both symbols appear in the core gateway __all__."""
+    from autoskillit.core import __all__ as core_all
+
+    assert "BackendCapabilities" in core_all
+    assert "CLAUDE_CODE_CAPABILITIES" in core_all
+
+
 def test_backend_capabilities_in_types_all():
     """Both symbols appear in the types hub __all__."""
     from autoskillit.core.types import __all__ as types_all
@@ -26,7 +34,7 @@ def test_backend_capabilities_in_types_all():
     assert "CLAUDE_CODE_CAPABILITIES" in types_all
 
 
-def test_backend_capabilities_frozen():
+def test_backend_capabilities_is_frozen_dataclass():
     """BackendCapabilities instances are immutable."""
     from autoskillit.core import CLAUDE_CODE_CAPABILITIES
 
@@ -54,7 +62,7 @@ def test_backend_capabilities_field_count():
     assert len(frozenset_fields) == 2
 
 
-def test_backend_capabilities_field_names():
+def test_backend_capabilities_field_names_locked():
     """Field names match the design specification."""
     from autoskillit.core import BackendCapabilities
 
@@ -72,7 +80,7 @@ def test_backend_capabilities_field_names():
     assert actual == expected
 
 
-def test_claude_code_capabilities_values():
+def test_claude_code_capabilities_field_values():
     """CLAUDE_CODE_CAPABILITIES field values match the Part 13.2 design."""
     from autoskillit.core import CLAUDE_CODE_CAPABILITIES
 
@@ -99,7 +107,7 @@ def test_no_autoskillit_imports():
             pytest.fail(f"IL-0 violation: {stripped}")
 
 
-def test_type_backend_all():
+def test_backend_capabilities_module_all():
     """__all__ contains exactly the two public symbols."""
     from autoskillit.core.types._type_backend import __all__
 


### PR DESCRIPTION
## Summary

Rename the existing `tests/core/test_type_backend.py` to `tests/core/test_backend_capabilities.py` and ensure it contains the 5 tests named in the issue (plus retaining the existing bonus invariant tests). The existing file already covers 4 of the 5 required tests — the one gap is `test_backend_capabilities_in_core_all` which must verify both symbols appear in `autoskillit.core.__all__`. A new file is NOT created alongside the existing one — that would duplicate test coverage.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-135649-303753/.autoskillit/temp/make-plan/test_backend_capabilities_plan_2026-05-16_140200.md`

## Changed Files

### New (★):
- `tests/core/test_backend_capabilities.py`

### Modified (●):
- `tests/core/CLAUDE.md`

Closes #2441

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 60 | 7.4k | 530.0k | 48.6k | 52 | 52.2k | 4m 7s |
| verify | claude-opus-4-6 | 1 | 381 | 6.0k | 560.7k | 45.9k | 43 | 34.0k | 2m 29s |
| implement* | MiniMax-M2.7-highspeed | 1 | 469.0k | 3.9k | 749.0k | 30.0k | 56 | 43.7k | 4m 44s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 137.6k | 3.4k | 389.5k | 30.0k | 28 | 42.7k | 1m 26s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 35.9k | 1.2k | 176.9k | 30.0k | 13 | 15.4k | 33s |
| review_pr | claude-sonnet-4-6 | 2 | 144 | 16.9k | 570.9k | 43.8k | 50 | 60.7k | 4m 23s |
| **Total** | | | 643.1k | 38.7k | 3.0M | 48.6k | | 248.7k | 17m 44s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 20 | 37450.0 | 2182.9 | 193.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **20** | 148848.0 | 12433.1 | 1935.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 441 | 13.4k | 1.1M | 86.2k | 6m 37s |
| MiniMax-M2.7-highspeed | 3 | 642.5k | 8.5k | 1.3M | 101.7k | 6m 43s |