### PR TITLE
Add Backend Guard to Replay Runner Path and Tests

### DIFF
--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -215,49 +215,63 @@ def make_context(
         runner = DefaultSubprocessRunner()
 
     if runner is not None and os.environ.get(REPLAY_SCENARIO_ENV):
-        replay_dir = os.environ.get(REPLAY_SCENARIO_DIR_ENV, "")
-        if not replay_dir:
+        if config.agent_backend.backend != "claude-code":
             logger.warning(
-                "REPLAY_SCENARIO is set but REPLAY_SCENARIO_DIR is empty — skipping replay"
-            )
-        elif not os.path.isdir(replay_dir):
-            logger.warning(
-                "REPLAY_SCENARIO_DIR=%r is not an existing directory — skipping replay",
-                replay_dir,
+                "REPLAY_SCENARIO is set but agent_backend=%r is not claude-code "
+                "— skipping replay runner construction",
+                config.agent_backend.backend,
             )
         else:
-            runner = build_replay_runner(replay_dir)
-
-    elif runner is not None and os.environ.get(RECORD_SCENARIO_ENV):
-        scenario_dir = os.environ.get(RECORD_SCENARIO_DIR_ENV, "")
-        recipe_name = os.environ.get(RECORD_SCENARIO_RECIPE_ENV, "unknown")
-        if scenario_dir:
-            if not os.path.isdir(scenario_dir):
+            replay_dir = os.environ.get(REPLAY_SCENARIO_DIR_ENV, "")
+            if not replay_dir:
                 logger.warning(
-                    "RECORD_SCENARIO_DIR=%r is not an existing directory — skipping recording",
-                    scenario_dir,
+                    "REPLAY_SCENARIO is set but REPLAY_SCENARIO_DIR is empty — skipping replay"
+                )
+            elif not os.path.isdir(replay_dir):
+                logger.warning(
+                    "REPLAY_SCENARIO_DIR=%r is not an existing directory — skipping replay",
+                    replay_dir,
                 )
             else:
-                try:
-                    from api_simulator.claude import make_scenario_recorder
-                except ImportError:
+                runner = build_replay_runner(replay_dir)
+
+    elif runner is not None and os.environ.get(RECORD_SCENARIO_ENV):
+        if config.agent_backend.backend != "claude-code":
+            logger.warning(
+                "RECORD_SCENARIO is set but agent_backend=%r is not claude-code "
+                "— skipping record runner construction",
+                config.agent_backend.backend,
+            )
+        else:
+            scenario_dir = os.environ.get(RECORD_SCENARIO_DIR_ENV, "")
+            recipe_name = os.environ.get(RECORD_SCENARIO_RECIPE_ENV, "unknown")
+            if scenario_dir:
+                if not os.path.isdir(scenario_dir):
                     logger.warning(
-                        "RECORD_SCENARIO is set but 'api_simulator' is not installed "
-                        "— skipping recording"
+                        "RECORD_SCENARIO_DIR=%r is not an existing directory — skipping recording",
+                        scenario_dir,
                     )
-                    make_scenario_recorder = None  # type: ignore[assignment]
+                else:
+                    try:
+                        from api_simulator.claude import make_scenario_recorder
+                    except ImportError:
+                        logger.warning(
+                            "RECORD_SCENARIO is set but 'api_simulator' is not installed "
+                            "— skipping recording"
+                        )
+                        make_scenario_recorder = None  # type: ignore[assignment]
 
-                if make_scenario_recorder is not None:
-                    from autoskillit.execution import RecordingSubprocessRunner
+                    if make_scenario_recorder is not None:
+                        from autoskillit.execution import RecordingSubprocessRunner
 
-                    recorder = make_scenario_recorder(
-                        output_dir=scenario_dir, recipe_name=recipe_name
-                    )
-                    runner = RecordingSubprocessRunner(
-                        recorder=recorder,
-                        inner=runner,
-                        scenario_dir=Path(scenario_dir),
-                    )
+                        recorder = make_scenario_recorder(
+                            output_dir=scenario_dir, recipe_name=recipe_name
+                        )
+                        runner = RecordingSubprocessRunner(
+                            recorder=recorder,
+                            inner=runner,
+                            scenario_dir=Path(scenario_dir),
+                        )
 
     # Lazy token resolution: config → GITHUB_TOKEN env var → gh CLI → None.
     # The _gh_cli_token() subprocess (up to 5s) is deferred until the first

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.config import AutomationConfig
+from autoskillit.config import AgentBackendConfig, AutomationConfig
 from autoskillit.core.types import SkillResult, SubprocessResult, TerminationReason
 from autoskillit.execution.db import DefaultDatabaseReader
 from autoskillit.execution.github import DefaultGitHubFetcher
@@ -597,3 +597,35 @@ def test_minimal_ctx_fixture_gate_starts_closed(minimal_ctx) -> None:
 def test_tool_ctx_kitchen_open_fixture_gate_starts_open(tool_ctx_kitchen_open) -> None:
     """tool_ctx_kitchen_open must start with gate open."""
     assert tool_ctx_kitchen_open.gate.enabled is True
+
+
+def test_make_context_skips_replay_runner_for_non_claude_backend(monkeypatch, tmp_path):
+    monkeypatch.setenv("REPLAY_SCENARIO", "1")
+    monkeypatch.setenv("REPLAY_SCENARIO_DIR", str(tmp_path))
+    monkeypatch.delenv("RECORD_SCENARIO", raising=False)
+
+    from unittest.mock import Mock
+
+    mock_build = Mock()
+    monkeypatch.setattr("autoskillit.server._factory.build_replay_runner", mock_build)
+
+    from autoskillit.execution.process import DefaultSubprocessRunner
+
+    cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
+    ctx = make_context(cfg, plugin_dir=str(tmp_path))
+
+    assert mock_build.call_count == 0
+    assert isinstance(ctx.runner, DefaultSubprocessRunner)
+
+
+def test_make_context_skips_record_runner_for_non_claude_backend(monkeypatch, tmp_path):
+    monkeypatch.setenv("RECORD_SCENARIO", "1")
+    monkeypatch.setenv("RECORD_SCENARIO_DIR", str(tmp_path))
+    monkeypatch.delenv("REPLAY_SCENARIO", raising=False)
+
+    from autoskillit.execution.process import DefaultSubprocessRunner
+
+    cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
+    ctx = make_context(cfg, plugin_dir=str(tmp_path))
+
+    assert isinstance(ctx.runner, DefaultSubprocessRunner)

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -11,6 +12,8 @@ from autoskillit.core.types import SkillResult, SubprocessResult, TerminationRea
 from autoskillit.execution.db import DefaultDatabaseReader
 from autoskillit.execution.github import DefaultGitHubFetcher
 from autoskillit.execution.headless import DefaultHeadlessExecutor
+from autoskillit.execution.process import DefaultSubprocessRunner
+from autoskillit.execution.recording import RecordingSubprocessRunner
 from autoskillit.execution.testing import DefaultTestRunner
 from autoskillit.migration.engine import DefaultMigrationService
 from autoskillit.pipeline.context import ToolContext
@@ -604,12 +607,8 @@ def test_make_context_skips_replay_runner_for_non_claude_backend(monkeypatch, tm
     monkeypatch.setenv("REPLAY_SCENARIO_DIR", str(tmp_path))
     monkeypatch.delenv("RECORD_SCENARIO", raising=False)
 
-    from unittest.mock import Mock
-
     mock_build = Mock()
     monkeypatch.setattr("autoskillit.server._factory.build_replay_runner", mock_build)
-
-    from autoskillit.execution.process import DefaultSubprocessRunner
 
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
     ctx = make_context(cfg, plugin_dir=str(tmp_path))
@@ -623,9 +622,8 @@ def test_make_context_skips_record_runner_for_non_claude_backend(monkeypatch, tm
     monkeypatch.setenv("RECORD_SCENARIO_DIR", str(tmp_path))
     monkeypatch.delenv("REPLAY_SCENARIO", raising=False)
 
-    from autoskillit.execution.process import DefaultSubprocessRunner
-
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
     ctx = make_context(cfg, plugin_dir=str(tmp_path))
 
     assert isinstance(ctx.runner, DefaultSubprocessRunner)
+    assert not isinstance(ctx.runner, RecordingSubprocessRunner)


### PR DESCRIPTION
## Summary

Add a backend guard to the REPLAY_SCENARIO and RECORD_SCENARIO blocks in `server/_factory.py` so that `build_replay_runner()` and `RecordingSubprocessRunner` construction are skipped for non-`claude-code` backends. When skipped, a `logger.warning` is emitted and the runner remains `DefaultSubprocessRunner`. Two tests verify the guard behavior without importing `api_simulator`.

## Requirements

1. claude-code backend: replay runner constructed as before
2. Non-claude-code backend: build_replay_runner() not called, warning logged
3. Existing tests pass unchanged
4. Both tests pass without api_simulator installed
5. build_replay_runner call count is 0 for non-claude-code backend
6. ctx.runner is DefaultSubprocessRunner
7. Tests carry layer('server') and small markers

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None

Closes #2439

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-135653-043069/.autoskillit/temp/make-plan/add_backend_guard_replay_runner_plan_2026-05-16_140300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.7k | 7.4k | 756.9k | 71.3k | 97 | 49.8k | 4m 24s |
| verify | claude-opus-4-6 | 1 | 29 | 4.9k | 414.4k | 50.8k | 62 | 36.2k | 3m 14s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 13.2k | 1.0M | 30.0k | 91 | 16.7k | 7m 31s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 75.9k | 3.1k | 236.8k | 30.0k | 21 | 15.6k | 1m 14s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 54.6k | 1.3k | 236.8k | 30.0k | 16 | 15.4k | 39s |
| review_pr | claude-sonnet-4-6 | 2 | 216 | 32.0k | 1.0M | 58.6k | 73 | 79.4k | 8m 1s |
| resolve_review | claude-sonnet-4-6 | 2 | 564 | 34.2k | 3.8M | 81.1k | 159 | 115.9k | 25m 46s |
| **Total** | | | 1.3M | 96.1k | 7.5M | 81.1k | | 329.0k | 50m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 118 | 8609.8 | 141.6 | 112.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 377842.3 | 11587.9 | 3419.9 |
| **Total** | **128** | 58483.7 | 2570.6 | 750.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 1.7k | 7.4k | 756.9k | 49.8k | 4m 24s |
| claude-opus-4-6 | 1 | 29 | 4.9k | 414.4k | 36.2k | 3m 14s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 17.7k | 1.5M | 47.7k | 9m 25s |