### PR TITLE
Implementation Plan: Add agent_backend parameter and early-return guard to _is_plugin_installed()

### DIFF
--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -278,11 +278,14 @@ def _check_secret_scanning(project_dir: Path) -> _ScanResult:
     return _ScanResult(True, bypass_accepted=True)
 
 
-def _is_plugin_installed() -> bool:
+def _is_plugin_installed(*, agent_backend: str = "claude-code") -> bool:
     """Return True if autoskillit is installed as a Claude plugin.
 
     Returns False when claude CLI is not on PATH, times out, or is otherwise unavailable.
+    Non-claude-code backends return False immediately without subprocess.
     """
+    if agent_backend != "claude-code":
+        return False
     try:
         result = subprocess.run(
             ["claude", "plugin", "list"],

--- a/tests/cli/CLAUDE.md
+++ b/tests/cli/CLAUDE.md
@@ -42,6 +42,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_food_truck_prompt.py` | Group E tests: L2 food truck prompt builder — sous-chef subset, inversions, budget guidance |
 | `test_init.py` | Tests for CLI init, config, and serve-related commands |
 | `test_input_tty_contracts.py` | Structural enforcement: every input() call in cli/ must go through timed_prompt() |
+| `test_init_helpers.py` | Unit tests for _is_plugin_installed backend guard |
 | `test_install.py` | Tests for CLI install, upgrade, and quota-related commands |
 | `test_install_info.py` | Tests for cli/_install_info.py — install classification and update policy |
 | `test_installed_plugins_file.py` | Unit tests for the InstalledPluginsFile repository |

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -23,7 +23,7 @@ class TestIsPluginInstalledBackendGuard:
 
         def fake_run(*args, **kwargs):
             called.append(args)
-            return type("CP", (), {"returncode": 0, "stdout": "autoskillit\n"})()
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="autoskillit\n")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         result = _is_plugin_installed(agent_backend="claude-code")

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 from autoskillit.cli._init_helpers import _is_plugin_installed
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 class TestIsPluginInstalledBackendGuard:

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -1,0 +1,27 @@
+"""Unit tests for _is_plugin_installed backend guard."""
+
+from __future__ import annotations
+
+import subprocess
+
+from autoskillit.cli._init_helpers import _is_plugin_installed
+
+
+class TestIsPluginInstalledBackendGuard:
+    """Backend guard returns False without subprocess for non-claude-code."""
+
+    def test_non_claude_code_backend_returns_false(self):
+        result = _is_plugin_installed(agent_backend="aider")
+        assert result is False
+
+    def test_claude_code_backend_calls_subprocess(self, monkeypatch):
+        called = []
+
+        def fake_run(*args, **kwargs):
+            called.append(args)
+            return type("CP", (), {"returncode": 0, "stdout": "autoskillit\n"})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        result = _is_plugin_installed(agent_backend="claude-code")
+        assert result is True
+        assert len(called) == 1

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -126,9 +126,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 376),
+    ("src/autoskillit/cli/_init_helpers.py", 379),
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 395),
+    ("src/autoskillit/cli/_init_helpers.py", 398),
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_installed_plugins.py", 71),
     # _marketplace.py — marketplace.json (co-owned)


### PR DESCRIPTION
## Summary

Add an `agent_backend: str = "claude-code"` keyword parameter to `_is_plugin_installed()` with an early-return guard that returns `False` without invoking the subprocess when the backend is not `claude-code`. This follows the identical pattern used in `_llm_triage._triage_batch()` and `cli._marketplace.install()`.

## Changed Files

### New (★):
- `tests/cli/test_init_helpers.py`

### Modified (●):
- `src/autoskillit/cli/_init_helpers.py`
- `tests/cli/CLAUDE.md`
- `tests/infra/test_schema_version_convention.py`

Closes #2452

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-135652-124499/.autoskillit/temp/make-plan/add_agent_backend_guard_is_plugin_installed_plan_2026-05-16_140100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 62 | 5.5k | 595.8k | 44.7k | 72 | 32.4k | 4m 35s |
| verify | claude-opus-4-6 | 1 | 43 | 7.3k | 570.3k | 46.0k | 52 | 32.2k | 2m 52s |
| implement* | MiniMax-M2.7-highspeed | 1 | 248.0k | 3.2k | 596.3k | 30.0k | 41 | 30.8k | 1m 44s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 100.1k | 4.2k | 266.8k | 30.0k | 22 | 15.6k | 1m 34s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 66.1k | 1.7k | 236.8k | 30.0k | 19 | 15.4k | 46s |
| review_pr | claude-sonnet-4-6 | 2 | 170 | 19.6k | 713.7k | 49.0k | 55 | 64.7k | 5m 19s |
| resolve_review | claude-sonnet-4-6 | 1 | 109 | 5.2k | 501.2k | 49.5k | 29 | 35.6k | 2m 27s |
| **Total** | | | 414.4k | 46.7k | 3.5M | 49.5k | | 226.7k | 19m 18s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 33 | 18070.4 | 934.3 | 96.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 250588.0 | 17781.0 | 2605.0 |
| **Total** | **35** | 99453.0 | 6475.7 | 1333.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 105 | 12.8k | 1.2M | 64.5k | 7m 27s |
| MiniMax-M2.7-highspeed | 3 | 414.1k | 9.0k | 1.1M | 61.9k | 4m 4s |
| claude-sonnet-4-6 | 1 | 125 | 4.4k | 574.7k | 37.3k | 3m 3s |