### PR TITLE
test_backend_gating_root.py — gating for _llm_triage.py

### DIFF
--- a/tests/test_backend_gating_root.py
+++ b/tests/test_backend_gating_root.py
@@ -1,0 +1,131 @@
+"""Tests for agent_backend gating in _llm_triage."""
+
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+
+import pytest
+
+from autoskillit._llm_triage import _triage_batch, triage_staleness
+from autoskillit.execution.process import SubprocessResult, TerminationReason
+from autoskillit.recipe.contracts import StaleItem
+
+pytestmark = [pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_triage_batch_non_claude_backend_returns_all_meaningful(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Non-claude-code backend returns meaningful=True without spawning a subprocess."""
+    from unittest.mock import AsyncMock
+
+    skill_md_content = "# dummy\nContent."
+    cache = {"my-skill": skill_md_content}
+    items = [
+        StaleItem(
+            skill="my-skill",
+            reason="hash_mismatch",
+            stored_value="aaa",
+            current_value="bbb",
+        ),
+    ]
+
+    mock_run = AsyncMock()
+    monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
+
+    results = await _triage_batch(items, cache, agent_backend="aider")
+
+    assert len(results) == 1
+    assert results[0]["meaningful"] is True
+    assert "Skipped LLM triage" in results[0]["summary"]
+    mock_run.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_triage_staleness_non_claude_backend_returns_all_meaningful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """triage_staleness with non-claude-code backend skips subprocess and returns meaningful."""
+    from unittest.mock import AsyncMock
+
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# dummy\nContent.")
+
+    monkeypatch.setattr("autoskillit._llm_triage.bundled_skills_dir", lambda: tmp_path)
+    mock_run = AsyncMock()
+    monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
+
+    items = [
+        StaleItem(
+            skill="my-skill",
+            reason="hash_mismatch",
+            stored_value="aaa",
+            current_value="bbb",
+        ),
+    ]
+
+    results = await triage_staleness(items, agent_backend="aider")
+
+    assert len(results) == 1
+    assert results[0]["meaningful"] is True
+    assert "Skipped LLM triage" in results[0]["summary"]
+    mock_run.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_triage_batch_claude_code_backend_does_call_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """claude-code backend reaches the subprocess call."""
+    from unittest.mock import AsyncMock
+
+    skill_md_content = "# dummy\nContent."
+    cache = {"my-skill": skill_md_content}
+    items = [
+        StaleItem(
+            skill="my-skill",
+            reason="hash_mismatch",
+            stored_value="aaa",
+            current_value="bbb",
+        ),
+    ]
+
+    ndjson = "\n".join(
+        [
+            _json.dumps({"type": "assistant", "message": {"content": []}}),
+            _json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "result": _json.dumps(
+                        [
+                            {
+                                "index": 1,
+                                "skill": "my-skill",
+                                "meaningful_change": False,
+                                "summary": "no change",
+                            }
+                        ]
+                    ),
+                    "session_id": "test-session",
+                    "is_error": False,
+                }
+            ),
+        ]
+    )
+    fake_result = SubprocessResult(
+        returncode=0,
+        stdout=ndjson,
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=0,
+    )
+    mock_run = AsyncMock(return_value=fake_result)
+    monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
+
+    await _triage_batch(items, cache, agent_backend="claude-code")
+
+    mock_run.assert_called_once()

--- a/tests/test_backend_gating_root.py
+++ b/tests/test_backend_gating_root.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json as _json
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -19,7 +20,6 @@ async def test_triage_batch_non_claude_backend_returns_all_meaningful(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Non-claude-code backend returns meaningful=True without spawning a subprocess."""
-    from unittest.mock import AsyncMock
 
     skill_md_content = "# dummy\nContent."
     cache = {"my-skill": skill_md_content}
@@ -48,7 +48,6 @@ async def test_triage_staleness_non_claude_backend_returns_all_meaningful(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """triage_staleness with non-claude-code backend skips subprocess and returns meaningful."""
-    from unittest.mock import AsyncMock
 
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
@@ -80,7 +79,6 @@ async def test_triage_batch_claude_code_backend_does_call_subprocess(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """claude-code backend reaches the subprocess call."""
-    from unittest.mock import AsyncMock
 
     skill_md_content = "# dummy\nContent."
     cache = {"my-skill": skill_md_content}
@@ -126,6 +124,9 @@ async def test_triage_batch_claude_code_backend_does_call_subprocess(
     mock_run = AsyncMock(return_value=fake_result)
     monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
 
-    await _triage_batch(items, cache, agent_backend="claude-code")
+    results = await _triage_batch(items, cache, agent_backend="claude-code")
 
     mock_run.assert_called_once()
+    assert len(results) == 1
+    assert results[0]["meaningful"] is False
+    assert results[0]["summary"] == "no change"


### PR DESCRIPTION
## Summary

Create `tests/test_backend_gating_root.py` with three async tests verifying the `agent_backend` gating behavior in `_llm_triage._triage_batch` and `triage_staleness`. Two tests confirm that non-claude-code backends return all-meaningful results without spawning a subprocess. One positive-control test confirms that the claude-code backend does invoke the subprocess.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

Closes #2442

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260516-135650-327657/.autoskillit/temp/make-plan/test_backend_gating_root_plan_2026-05-16_140300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 62 | 6.3k | 650.7k | 59.0k | 76 | 38.2k | 4m 16s |
| verify | claude-opus-4-6 | 1 | 837 | 8.2k | 713.6k | 57.8k | 62 | 43.1k | 3m 58s |
| implement* | MiniMax-M2.7-highspeed | 1 | 484.1k | 5.7k | 721.8k | 35.4k | 57 | 32.9k | 5m 3s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 57.6k | 1.9k | 206.8k | 30.0k | 16 | 15.6k | 47s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 83.5k | 1.8k | 296.7k | 30.0k | 21 | 15.4k | 51s |
| review_pr | claude-sonnet-4-6 | 2 | 154 | 25.1k | 632.7k | 49.7k | 53 | 70.3k | 6m 12s |
| resolve_review | claude-sonnet-4-6 | 1 | 151 | 9.2k | 786.9k | 55.8k | 42 | 41.8k | 3m 35s |
| **Total** | | | 626.5k | 58.1k | 4.0M | 59.0k | | 257.3k | 24m 43s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 131 | 5509.8 | 251.4 | 43.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 87431.1 | 4642.0 | 1019.2 |
| **Total** | **140** | 28637.7 | 1837.8 | 415.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 62 | 6.3k | 650.7k | 38.2k | 4m 16s |
| claude-opus-4-6 | 1 | 837 | 8.2k | 713.6k | 43.1k | 3m 58s |
| MiniMax-M2.7-highspeed | 3 | 625.3k | 9.3k | 1.2M | 64.0k | 6m 40s |