### PR TITLE
feat(pipeline): migrate telemetry_fmt.py to canonical cache field names

### DIFF
--- a/src/autoskillit/hooks/formatters/_fmt_status.py
+++ b/src/autoskillit/hooks/formatters/_fmt_status.py
@@ -13,11 +13,24 @@ from _fmt_primitives import (  # type: ignore[import-not-found]
     _fmt_tokens,
 )
 
+_LEGACY_TO_CANONICAL: dict[str, str] = {
+    "cache_creation_input_tokens": "cache_write_tokens",
+    "cache_read_input_tokens": "cache_read_tokens",
+}
+
+
+def _normalize_cache_keys(d: dict) -> dict:
+    out = dict(d)
+    for old, new in _LEGACY_TO_CANONICAL.items():
+        if old in out and new not in out:
+            out[new] = out.pop(old)
+    return out
+
 
 def _fmt_get_token_summary(data: dict, _pipeline: bool) -> str:
     """Format get_token_summary compact Markdown-KV output (JSON payload only)."""
     lines = ["## token_summary", ""]
-    steps = data.get("steps", [])
+    steps = [_normalize_cache_keys(s) for s in data.get("steps", [])]
     has_non_anthropic = False
     for step in steps:
         name = step.get("step_name", "?")
@@ -39,7 +52,7 @@ def _fmt_get_token_summary(data: dict, _pipeline: bool) -> str:
             f" [uc:{inp} out:{out} cr:{cache_rd} pk:{peak_ctx} cw:{cache_wr}"
             f" turns:{turns} t:{wc:.1f}s{model_tag}]"
         )
-    total = data.get("total", {})
+    total = _normalize_cache_keys(data.get("total", {}))
     if total:
         lines.append("")
         lines.append(f"total_uncached: {_fmt_tokens(total.get('input_tokens', 0))}")

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -145,6 +145,28 @@ def _ratio(tokens: int, loc: int) -> str:
     return f"{tokens / loc:.1f}" if loc > 0 else "—"
 
 
+_LEGACY_TO_CANONICAL: dict[str, str] = {
+    "cache_creation_input_tokens": "cache_write_tokens",
+    "cache_read_input_tokens": "cache_read_tokens",
+}
+
+
+def _normalize_keys(d: dict) -> dict:
+    """Normalize legacy cache field names to canonical. Drop after P2-A4-WP1."""
+    out = dict(d)
+    for old, new in _LEGACY_TO_CANONICAL.items():
+        if old in out and new not in out:
+            out[new] = out.pop(old)
+    return out
+
+
+def _h_cache(val: int | None) -> str:
+    """Humanize a cache token count; None → '—' (provider lacks cache)."""
+    if val is None:
+        return "—"
+    return TelemetryFormatter._humanize(val)
+
+
 class TelemetryFormatter:
     """Stateless formatter for token and timing telemetry data."""
 
@@ -179,6 +201,8 @@ class TelemetryFormatter:
         """Produce a markdown table for token usage with timing column."""
         h = TelemetryFormatter._humanize
         fmt_dur = TelemetryFormatter._fmt_duration
+        steps = [_normalize_keys(s) for s in steps]
+        total = _normalize_keys(total)
 
         lines = [
             "## Token Usage Summary",
@@ -196,10 +220,10 @@ class TelemetryFormatter:
             count = step.get("invocation_count", 1)
             inp = h(step.get("input_tokens", 0))
             out = h(step.get("output_tokens", 0))
-            cache_rd = h(step.get("cache_read_tokens", 0))
+            cache_rd = _h_cache(step.get("cache_read_tokens"))
             peak_ctx = h(step.get("peak_context", 0))
             turns = step.get("turn_count", 0)
-            cache_wr = h(step.get("cache_write_tokens", 0))
+            cache_wr = _h_cache(step.get("cache_write_tokens"))
             wc = step.get("wall_clock_seconds", step.get("elapsed_seconds", 0.0))
             lines.append(
                 f"| {name} | {model} | {count} | {inp} | {out} | {cache_rd} | {peak_ctx}"
@@ -208,9 +232,9 @@ class TelemetryFormatter:
 
         total_in = h(total.get("input_tokens", 0))
         total_out = h(total.get("output_tokens", 0))
-        total_cache_rd = h(total.get("cache_read_tokens", 0))
+        total_cache_rd = _h_cache(total.get("cache_read_tokens"))
         total_peak = h(total.get("peak_context", 0))
-        total_cache_wr = h(total.get("cache_write_tokens", 0))
+        total_cache_wr = _h_cache(total.get("cache_write_tokens"))
         total_time = total.get("total_elapsed_seconds", 0.0)
         lines.append(
             f"| **Total** | | | {total_in} | {total_out} | {total_cache_rd}"
@@ -247,6 +271,8 @@ class TelemetryFormatter:
         """Produce a padded-column plain text table for token usage."""
         h = TelemetryFormatter._humanize
         fmt_dur = TelemetryFormatter._fmt_duration
+        steps = [_normalize_keys(s) for s in steps]
+        total = _normalize_keys(total)
 
         rows: list[tuple[str, str, str, str, str, str, str, str, str, str]] = []
         has_non_anthropic = False
@@ -263,10 +289,10 @@ class TelemetryFormatter:
                     str(step.get("invocation_count", 1)),
                     h(step.get("input_tokens", 0)),
                     h(step.get("output_tokens", 0)),
-                    h(step.get("cache_read_tokens", 0)),
+                    _h_cache(step.get("cache_read_tokens")),
                     h(step.get("peak_context", 0)),
                     str(step.get("turn_count", 0)),
-                    h(step.get("cache_write_tokens", 0)),
+                    _h_cache(step.get("cache_write_tokens")),
                     fmt_dur(step.get("wall_clock_seconds", step.get("elapsed_seconds", 0.0))),
                 )
             )
@@ -277,10 +303,10 @@ class TelemetryFormatter:
             "",
             h(total.get("input_tokens", 0)),
             h(total.get("output_tokens", 0)),
-            h(total.get("cache_read_tokens", 0)),
+            _h_cache(total.get("cache_read_tokens")),
             h(total.get("peak_context", 0)),
             "",
-            h(total.get("cache_write_tokens", 0)),
+            _h_cache(total.get("cache_write_tokens")),
             fmt_dur(total.get("total_elapsed_seconds", 0.0)),
         )
 
@@ -313,6 +339,8 @@ class TelemetryFormatter:
     ) -> str:
         """Produce compact Markdown-KV one-liners for PostToolUse hook display."""
         h = TelemetryFormatter._humanize
+        steps = [_normalize_keys(s) for s in steps]
+        total = _normalize_keys(total)
 
         lines = ["## token_summary", ""]
         has_non_anthropic = False
@@ -325,9 +353,9 @@ class TelemetryFormatter:
             count = step.get("invocation_count", 1)
             inp = h(step.get("input_tokens", 0))
             out = h(step.get("output_tokens", 0))
-            cache_rd = h(step.get("cache_read_tokens", 0))
+            cache_rd = _h_cache(step.get("cache_read_tokens"))
             peak_ctx = h(step.get("peak_context", 0))
-            cache_wr = h(step.get("cache_write_tokens", 0))
+            cache_wr = _h_cache(step.get("cache_write_tokens"))
             turns = step.get("turn_count", 0)
             wc = step.get("wall_clock_seconds", step.get("elapsed_seconds", 0.0))
             model_tag = f" model:{model}" if model else ""
@@ -340,9 +368,9 @@ class TelemetryFormatter:
             lines.append("")
             lines.append(f"total_uncached: {h(total.get('input_tokens', 0))}")
             lines.append(f"total_out: {h(total.get('output_tokens', 0))}")
-            lines.append(f"total_cache_read: {h(total.get('cache_read_tokens', 0))}")
+            lines.append(f"total_cache_read: {_h_cache(total.get('cache_read_tokens'))}")
             lines.append(f"total_peak_context: {h(total.get('peak_context', 0))}")
-            lines.append(f"total_cache_write: {h(total.get('cache_write_tokens', 0))}")
+            lines.append(f"total_cache_write: {_h_cache(total.get('cache_write_tokens'))}")
         if mcp_responses:
             mcp_total = mcp_responses.get("total", {})
             if mcp_total:
@@ -360,6 +388,8 @@ class TelemetryFormatter:
         """Produce a markdown Token Efficiency table. Returns '' when all LoC=0."""
         if not any(s.get("loc_insertions", 0) + s.get("loc_deletions", 0) > 0 for s in steps):
             return ""
+        steps = [_normalize_keys(s) for s in steps]
+        total = _normalize_keys(total)
 
         lines = [
             "## Token Efficiency",
@@ -369,23 +399,23 @@ class TelemetryFormatter:
         ]
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
-            cr = step.get("cache_read_tokens", 0)
-            cw = step.get("cache_write_tokens", 0)
+            cr = step.get("cache_read_tokens")
+            cw = step.get("cache_write_tokens")
             out = step.get("output_tokens", 0)
             lines.append(
                 f"| {step.get('step_name', '?')} | {loc}"
-                f" | {_ratio(cr, loc)}"
-                f" | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
+                f" | {'—' if cr is None else _ratio(cr, loc)}"
+                f" | {'—' if cw is None else _ratio(cw, loc)} | {_ratio(out, loc)} |"
             )
 
         total_loc = total.get("loc_insertions", 0) + total.get("loc_deletions", 0)
-        total_cr = total.get("cache_read_tokens", 0)
-        total_cw = total.get("cache_write_tokens", 0)
+        total_cr = total.get("cache_read_tokens")
+        total_cw = total.get("cache_write_tokens")
         total_out = total.get("output_tokens", 0)
         lines.append(
             f"| **Total** | **{total_loc}**"
-            f" | {_ratio(total_cr, total_loc)}"
-            f" | {_ratio(total_cw, total_loc)} | {_ratio(total_out, total_loc)} |"
+            f" | {'—' if total_cr is None else _ratio(total_cr, total_loc)}"
+            f" | {'—' if total_cw is None else _ratio(total_cw, total_loc)} | {_ratio(total_out, total_loc)} |"
         )
         return "\n".join(lines)
 
@@ -396,6 +426,7 @@ class TelemetryFormatter:
             return ""
         h = TelemetryFormatter._humanize
         fmt_dur = TelemetryFormatter._fmt_duration
+        model_totals = [_normalize_keys(m) for m in model_totals]  # type: ignore[misc, arg-type]
         lines = [
             "## Model Usage Breakdown",
             "",
@@ -406,8 +437,8 @@ class TelemetryFormatter:
             lines.append(
                 f"| {m.get('model', '')} | {m.get('step_count', 0)}"
                 f" | {h(m.get('input_tokens', 0))} | {h(m.get('output_tokens', 0))}"
-                f" | {h(m.get('cache_read_tokens', 0))}"
-                f" | {h(m.get('cache_write_tokens', 0))}"
+                f" | {_h_cache(m.get('cache_read_tokens'))}"  # type: ignore[arg-type]
+                f" | {_h_cache(m.get('cache_write_tokens'))}"  # type: ignore[arg-type]
                 f" | {fmt_dur(m.get('elapsed_seconds', 0.0))} |"
             )
         return "\n".join(lines)
@@ -419,6 +450,7 @@ class TelemetryFormatter:
             return ""
         h = TelemetryFormatter._humanize
         fmt_dur = TelemetryFormatter._fmt_duration
+        model_totals = [_normalize_keys(m) for m in model_totals]  # type: ignore[misc, arg-type]
         rows: list[tuple[str, str, str, str, str, str, str]] = []
         for m in model_totals:
             rows.append(
@@ -427,8 +459,8 @@ class TelemetryFormatter:
                     str(m.get("step_count", 0)),
                     h(m.get("input_tokens", 0)),
                     h(m.get("output_tokens", 0)),
-                    h(m.get("cache_read_tokens", 0)),
-                    h(m.get("cache_write_tokens", 0)),
+                    _h_cache(m.get("cache_read_tokens")),  # type: ignore[arg-type]
+                    _h_cache(m.get("cache_write_tokens")),  # type: ignore[arg-type]
                     fmt_dur(m.get("elapsed_seconds", 0.0)),
                 )
             )
@@ -439,29 +471,33 @@ class TelemetryFormatter:
         """Produce a padded-column plain text efficiency table. Returns '' when all LoC=0."""
         if not any(s.get("loc_insertions", 0) + s.get("loc_deletions", 0) > 0 for s in steps):
             return ""
+        steps = [_normalize_keys(s) for s in steps]
+        total = _normalize_keys(total)
 
         rows: list[tuple[str, str, str, str, str]] = []
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
-            cr = step.get("cache_read_tokens", 0)
-            cw = step.get("cache_write_tokens", 0)
+            cr = step.get("cache_read_tokens")
+            cw = step.get("cache_write_tokens")
             out = step.get("output_tokens", 0)
             rows.append(
                 (
                     step.get("step_name", "?"),
                     str(loc),
-                    _ratio(cr, loc),
-                    _ratio(cw, loc),
+                    "—" if cr is None else _ratio(cr, loc),
+                    "—" if cw is None else _ratio(cw, loc),
                     _ratio(out, loc),
                 )
             )
 
         total_loc = total.get("loc_insertions", 0) + total.get("loc_deletions", 0)
+        total_cr = total.get("cache_read_tokens")
+        total_cw = total.get("cache_write_tokens")
         total_row = (
             "Total",
             str(total_loc),
-            _ratio(total.get("cache_read_tokens", 0), total_loc),
-            _ratio(total.get("cache_write_tokens", 0), total_loc),
+            "—" if total_cr is None else _ratio(total_cr, total_loc),
+            "—" if total_cw is None else _ratio(total_cw, total_loc),
             _ratio(total.get("output_tokens", 0), total_loc),
         )
         return _render_terminal_table(_EFFICIENCY_COLUMNS, rows + [total_row])

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -8,6 +8,8 @@ maintains an output-equivalent inline implementation guarded by test 1g.
 
 from __future__ import annotations
 
+from typing import Any
+
 from autoskillit.core import ModelTotalEntry, TerminalColumn, _render_terminal_table
 
 _TOKEN_COLUMNS = (
@@ -151,8 +153,8 @@ _LEGACY_TO_CANONICAL: dict[str, str] = {
 }
 
 
-def _normalize_keys(d: dict) -> dict:
-    """Normalize legacy cache field names to canonical. Drop after P2-A4-WP1."""
+def _normalize_keys(d: dict[str, Any]) -> dict[str, Any]:
+    """Normalize legacy cache field names to canonical. Drop after #2474 lands."""
     out = dict(d)
     for old, new in _LEGACY_TO_CANONICAL.items():
         if old in out and new not in out:
@@ -415,7 +417,8 @@ class TelemetryFormatter:
         lines.append(
             f"| **Total** | **{total_loc}**"
             f" | {'—' if total_cr is None else _ratio(total_cr, total_loc)}"
-            f" | {'—' if total_cw is None else _ratio(total_cw, total_loc)} | {_ratio(total_out, total_loc)} |"
+            f" | {'—' if total_cw is None else _ratio(total_cw, total_loc)}"
+            f" | {_ratio(total_out, total_loc)} |"
         )
         return "\n".join(lines)
 

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -18,8 +18,8 @@ _STEPS = [
         "step_name": "investigate",
         "input_tokens": 7000,
         "output_tokens": 5939,
-        "cache_creation_input_tokens": 8495,
-        "cache_read_input_tokens": 252179,
+        "cache_write_tokens": 8495,
+        "cache_read_tokens": 252179,
         "invocation_count": 1,
         "wall_clock_seconds": 45.0,
         "elapsed_seconds": 40.0,
@@ -28,8 +28,8 @@ _STEPS = [
         "step_name": "implement",
         "input_tokens": 2031000,
         "output_tokens": 122306,
-        "cache_creation_input_tokens": 280601,
-        "cache_read_input_tokens": 19071323,
+        "cache_write_tokens": 280601,
+        "cache_read_tokens": 19071323,
         "invocation_count": 3,
         "wall_clock_seconds": 492.0,
         "elapsed_seconds": 480.0,
@@ -39,8 +39,8 @@ _STEPS = [
 _TOTAL = {
     "input_tokens": 2038000,
     "output_tokens": 128245,
-    "cache_creation_input_tokens": 289096,
-    "cache_read_input_tokens": 19323502,
+    "cache_write_tokens": 289096,
+    "cache_read_tokens": 19323502,
     "total_elapsed_seconds": 537.0,
 }
 
@@ -96,8 +96,8 @@ class TestFormatTokenTable:
                 "step_name": "plan",
                 "input_tokens": 100,
                 "output_tokens": 50,
-                "cache_creation_input_tokens": 0,
-                "cache_read_input_tokens": 0,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
                 "invocation_count": 1,
                 "elapsed_seconds": 30.0,
             },
@@ -114,8 +114,8 @@ class TestFormatTokenTable:
                 "model": "MiniMax-M2.7-highspeed",
                 "input_tokens": 307600,
                 "output_tokens": 3400,
-                "cache_read_input_tokens": 0,
-                "cache_creation_input_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
                 "invocation_count": 1,
                 "wall_clock_seconds": 60.0,
             },
@@ -123,8 +123,8 @@ class TestFormatTokenTable:
         total = {
             "input_tokens": 307600,
             "output_tokens": 3400,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
             "total_elapsed_seconds": 60.0,
         }
         result = TelemetryFormatter.format_token_table(steps, total)
@@ -138,8 +138,8 @@ class TestFormatTokenTable:
                 "model": "MiniMax-M2.7-highspeed",
                 "input_tokens": 1000,
                 "output_tokens": 500,
-                "cache_read_input_tokens": 0,
-                "cache_creation_input_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
                 "invocation_count": 1,
                 "wall_clock_seconds": 10.0,
             },
@@ -147,8 +147,8 @@ class TestFormatTokenTable:
         total = {
             "input_tokens": 1000,
             "output_tokens": 500,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
             "total_elapsed_seconds": 10.0,
         }
         result = TelemetryFormatter.format_token_table(steps, total)
@@ -163,8 +163,8 @@ class TestFormatTokenTable:
                 "model": "claude-sonnet-4-6",
                 "input_tokens": 1000,
                 "output_tokens": 500,
-                "cache_read_input_tokens": 200,
-                "cache_creation_input_tokens": 100,
+                "cache_read_tokens": 200,
+                "cache_write_tokens": 100,
                 "invocation_count": 1,
                 "wall_clock_seconds": 10.0,
             },
@@ -172,8 +172,8 @@ class TestFormatTokenTable:
         total = {
             "input_tokens": 1000,
             "output_tokens": 500,
-            "cache_read_input_tokens": 200,
-            "cache_creation_input_tokens": 100,
+            "cache_read_tokens": 200,
+            "cache_write_tokens": 100,
             "total_elapsed_seconds": 10.0,
         }
         result = TelemetryFormatter.format_token_table(steps, total)
@@ -189,8 +189,8 @@ class TestFormatTokenTable:
                 "model": "",
                 "input_tokens": 1000,
                 "output_tokens": 500,
-                "cache_read_input_tokens": 200,
-                "cache_creation_input_tokens": 100,
+                "cache_read_tokens": 200,
+                "cache_write_tokens": 100,
                 "invocation_count": 1,
                 "wall_clock_seconds": 10.0,
             },
@@ -198,8 +198,8 @@ class TestFormatTokenTable:
         total = {
             "input_tokens": 1000,
             "output_tokens": 500,
-            "cache_read_input_tokens": 200,
-            "cache_creation_input_tokens": 100,
+            "cache_read_tokens": 200,
+            "cache_write_tokens": 100,
             "total_elapsed_seconds": 10.0,
         }
         result = TelemetryFormatter.format_token_table(steps, total)
@@ -454,8 +454,8 @@ def test_efficiency_table_omitted_when_no_loc() -> None:
     steps = [
         {
             "step_name": "plan",
-            "cache_read_input_tokens": 1000,
-            "cache_creation_input_tokens": 200,
+            "cache_read_tokens": 1000,
+            "cache_write_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 0,
             "loc_deletions": 0,
@@ -464,8 +464,8 @@ def test_efficiency_table_omitted_when_no_loc() -> None:
     total = {
         "loc_insertions": 0,
         "loc_deletions": 0,
-        "cache_read_input_tokens": 1000,
-        "cache_creation_input_tokens": 200,
+        "cache_read_tokens": 1000,
+        "cache_write_tokens": 200,
         "output_tokens": 50,
     }
     assert TelemetryFormatter.format_efficiency_table(steps, total) == ""
@@ -478,8 +478,8 @@ def test_efficiency_table_columns() -> None:
         {
             "step_name": "implement",
             "peak_context": 500,
-            "cache_read_input_tokens": 1000,
-            "cache_creation_input_tokens": 200,
+            "cache_read_tokens": 1000,
+            "cache_write_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 80,
             "loc_deletions": 20,
@@ -489,8 +489,8 @@ def test_efficiency_table_columns() -> None:
         "loc_insertions": 80,
         "loc_deletions": 20,
         "peak_context": 500,
-        "cache_read_input_tokens": 1000,
-        "cache_creation_input_tokens": 200,
+        "cache_read_tokens": 1000,
+        "cache_write_tokens": 200,
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
@@ -536,7 +536,7 @@ def test_efficiency_table_zero_loc_step_shows_dash() -> None:
         {
             "step_name": "no-change",
             "peak_context": 500,
-            "cache_creation_input_tokens": 100,
+            "cache_write_tokens": 100,
             "output_tokens": 20,
             "loc_insertions": 0,
             "loc_deletions": 0,
@@ -544,7 +544,7 @@ def test_efficiency_table_zero_loc_step_shows_dash() -> None:
         {
             "step_name": "implement",
             "peak_context": 1000,
-            "cache_creation_input_tokens": 200,
+            "cache_write_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 50,
             "loc_deletions": 10,
@@ -554,7 +554,7 @@ def test_efficiency_table_zero_loc_step_shows_dash() -> None:
         "loc_insertions": 50,
         "loc_deletions": 10,
         "peak_context": 1000,
-        "cache_creation_input_tokens": 300,
+        "cache_write_tokens": 300,
         "output_tokens": 70,
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
@@ -602,7 +602,7 @@ def test_efficiency_table_terminal_no_markdown() -> None:
         {
             "step_name": "implement",
             "peak_context": 1000,
-            "cache_creation_input_tokens": 200,
+            "cache_write_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 80,
             "loc_deletions": 20,
@@ -612,7 +612,7 @@ def test_efficiency_table_terminal_no_markdown() -> None:
         "loc_insertions": 80,
         "loc_deletions": 20,
         "peak_context": 1000,
-        "cache_creation_input_tokens": 200,
+        "cache_write_tokens": 200,
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table_terminal(steps, total)
@@ -630,8 +630,8 @@ def test_efficiency_table_has_all_ratio_columns() -> None:
         {
             "step_name": "implement",
             "peak_context": 500,
-            "cache_read_input_tokens": 1000,
-            "cache_creation_input_tokens": 200,
+            "cache_read_tokens": 1000,
+            "cache_write_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 80,
             "loc_deletions": 20,
@@ -641,8 +641,8 @@ def test_efficiency_table_has_all_ratio_columns() -> None:
         "loc_insertions": 80,
         "loc_deletions": 20,
         "peak_context": 500,
-        "cache_read_input_tokens": 1000,
-        "cache_creation_input_tokens": 200,
+        "cache_read_tokens": 1000,
+        "cache_write_tokens": 200,
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
@@ -660,8 +660,8 @@ def test_efficiency_table_terminal_has_all_columns() -> None:
         {
             "step_name": "implement",
             "peak_context": 1000,
-            "cache_read_input_tokens": 500,
-            "cache_creation_input_tokens": 200,
+            "cache_read_tokens": 500,
+            "cache_write_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 80,
             "loc_deletions": 20,
@@ -671,8 +671,8 @@ def test_efficiency_table_terminal_has_all_columns() -> None:
         "loc_insertions": 80,
         "loc_deletions": 20,
         "peak_context": 1000,
-        "cache_read_input_tokens": 500,
-        "cache_creation_input_tokens": 200,
+        "cache_read_tokens": 500,
+        "cache_write_tokens": 200,
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table_terminal(steps, total)
@@ -690,8 +690,8 @@ def test_efficiency_markdown_terminal_column_parity() -> None:
         {
             "step_name": "implement",
             "peak_context": 1000,
-            "cache_read_input_tokens": 500,
-            "cache_creation_input_tokens": 200,
+            "cache_read_tokens": 500,
+            "cache_write_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 80,
             "loc_deletions": 20,
@@ -701,14 +701,202 @@ def test_efficiency_markdown_terminal_column_parity() -> None:
         "loc_insertions": 80,
         "loc_deletions": 20,
         "peak_context": 1000,
-        "cache_read_input_tokens": 500,
-        "cache_creation_input_tokens": 200,
+        "cache_read_tokens": 500,
+        "cache_write_tokens": 200,
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
     md_header = result.split("\n")[2]
     md_cols = [c.strip() for c in md_header.strip("|").split("|")]
     assert len(md_cols) == len(_EFFICIENCY_COLUMNS)
+
+
+# ---------------------------------------------------------------------------
+# Cache column None-suppression
+# ---------------------------------------------------------------------------
+
+
+class TestCacheColumnSuppression:
+    """Cache columns render '—' when value is None (non-Anthropic provider)."""
+
+    def test_none_cache_read_produces_dash_in_token_table(self) -> None:
+        """format_token_table renders '—' for None cache_read_tokens."""
+        steps = [
+            {
+                "step_name": "plan",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": None,
+                "invocation_count": 1,
+                "wall_clock_seconds": 10.0,
+            }
+        ]
+        total = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": None,
+        }
+        result = TelemetryFormatter.format_token_table(steps, total)
+        assert "—" in result  # dash for None cache
+
+    def test_none_cache_write_produces_dash_in_token_table(self) -> None:
+        steps = [
+            {
+                "step_name": "plan",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_write_tokens": None,
+                "cache_read_tokens": 200,
+                "invocation_count": 1,
+                "wall_clock_seconds": 10.0,
+            }
+        ]
+        total = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": None,
+            "cache_read_tokens": 200,
+        }
+        result = TelemetryFormatter.format_token_table(steps, total)
+        assert "—" in result
+
+    def test_none_cache_produces_dash_in_terminal_table(self) -> None:
+        steps = [
+            {
+                "step_name": "plan",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_write_tokens": None,
+                "cache_read_tokens": None,
+                "invocation_count": 1,
+                "wall_clock_seconds": 10.0,
+            }
+        ]
+        total = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": None,
+            "cache_read_tokens": None,
+        }
+        result = TelemetryFormatter.format_token_table_terminal(steps, total)
+        assert "—" in result
+
+    def test_none_cache_produces_dash_in_compact_kv(self) -> None:
+        steps = [
+            {
+                "step_name": "plan",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_write_tokens": None,
+                "cache_read_tokens": None,
+                "invocation_count": 1,
+                "turn_count": 0,
+                "wall_clock_seconds": 10.0,
+            }
+        ]
+        total = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": None,
+            "cache_read_tokens": None,
+        }
+        result = TelemetryFormatter.format_compact_kv(steps, total)
+        assert "cr:—" in result
+        assert "cw:—" in result
+
+    def test_none_cache_produces_dash_in_efficiency_table(self) -> None:
+        steps = [
+            {
+                "step_name": "fix",
+                "cache_read_tokens": None,
+                "cache_write_tokens": None,
+                "output_tokens": 100,
+                "loc_insertions": 10,
+                "loc_deletions": 5,
+            }
+        ]
+        total = {
+            "cache_read_tokens": None,
+            "cache_write_tokens": None,
+            "output_tokens": 100,
+            "loc_insertions": 10,
+            "loc_deletions": 5,
+        }
+        result = TelemetryFormatter.format_efficiency_table(steps, total)
+        assert "—" in result
+
+    def test_none_cache_produces_dash_in_model_table(self) -> None:
+        model_totals = [
+            {
+                "model": "gpt-4o",
+                "step_count": 1,
+                "input_tokens": 500,
+                "output_tokens": 200,
+                "cache_read_tokens": None,
+                "cache_write_tokens": None,
+                "elapsed_seconds": 30.0,
+            }
+        ]
+        result = TelemetryFormatter.format_model_table(model_totals)
+        assert "—" in result
+
+    def test_mixed_none_and_int_cache_per_row(self) -> None:
+        """Steps with cache=None and steps with cache=int render correctly in same table."""
+        steps = [
+            {
+                "step_name": "anthropic-step",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_write_tokens": 100,
+                "cache_read_tokens": 5000,
+                "invocation_count": 1,
+                "wall_clock_seconds": 60.0,
+            },
+            {
+                "step_name": "openai-step",
+                "input_tokens": 800,
+                "output_tokens": 400,
+                "cache_write_tokens": None,
+                "cache_read_tokens": None,
+                "invocation_count": 1,
+                "wall_clock_seconds": 30.0,
+            },
+        ]
+        total = {
+            "input_tokens": 1800,
+            "output_tokens": 900,
+            "cache_write_tokens": 100,
+            "cache_read_tokens": 5000,
+        }
+        result = TelemetryFormatter.format_token_table(steps, total)
+        assert "5.0k" in result  # anthropic step cache_read rendered
+        assert "—" in result  # openai step shows dash
+
+    def test_zero_cache_still_shows_zero_not_dash(self) -> None:
+        """Explicit 0 should render as '0', not '—'. Only None triggers dash."""
+        steps = [
+            {
+                "step_name": "plan",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
+                "invocation_count": 1,
+                "wall_clock_seconds": 10.0,
+            }
+        ]
+        total = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+        result = TelemetryFormatter.format_token_table(steps, total)
+        # Should NOT contain — for zero values
+        lines = [l for l in result.splitlines() if "plan" in l]
+        assert "—" not in lines[0]
 
 
 # ---------------------------------------------------------------------------
@@ -723,7 +911,14 @@ def test_token_column_field_coverage() -> None:
     from autoskillit.pipeline.telemetry_fmt import _TOKEN_DISPLAY_FIELDS, _TOKEN_EXCLUDED_FIELDS
     from autoskillit.pipeline.tokens import TokenEntry
 
-    all_fields = frozenset(f.name for f in dataclasses.fields(TokenEntry))
+    # Bridge: TokenEntry still uses legacy names until P2-A4-WP1 lands
+    _LEGACY_TO_CANONICAL = {
+        "cache_creation_input_tokens": "cache_write_tokens",
+        "cache_read_input_tokens": "cache_read_tokens",
+    }
+    all_fields = frozenset(
+        _LEGACY_TO_CANONICAL.get(f.name, f.name) for f in dataclasses.fields(TokenEntry)
+    )
     covered = _TOKEN_DISPLAY_FIELDS | _TOKEN_EXCLUDED_FIELDS
     assert covered == all_fields, (
         f"Uncovered fields: {all_fields - covered}; Stale exclusions: {covered - all_fields}"
@@ -753,8 +948,8 @@ def test_token_table_renders_invocation_count() -> None:
             "step_name": "fix",
             "input_tokens": 100,
             "output_tokens": 50,
-            "cache_read_input_tokens": 200,
-            "cache_creation_input_tokens": 10,
+            "cache_read_tokens": 200,
+            "cache_write_tokens": 10,
             "peak_context": 500,
             "turn_count": 40,
             "invocation_count": 3,
@@ -764,8 +959,8 @@ def test_token_table_renders_invocation_count() -> None:
     total = {
         "input_tokens": 100,
         "output_tokens": 50,
-        "cache_read_input_tokens": 200,
-        "cache_creation_input_tokens": 10,
+        "cache_read_tokens": 200,
+        "cache_write_tokens": 10,
         "peak_context": 500,
         "total_elapsed_seconds": 120.0,
         "invocation_count": 3,
@@ -784,8 +979,8 @@ def test_token_markdown_terminal_column_parity() -> None:
             "step_name": "plan",
             "input_tokens": 1000,
             "output_tokens": 500,
-            "cache_read_input_tokens": 200,
-            "cache_creation_input_tokens": 100,
+            "cache_read_tokens": 200,
+            "cache_write_tokens": 100,
             "peak_context": 200,
             "turn_count": 5,
             "invocation_count": 1,
@@ -795,8 +990,8 @@ def test_token_markdown_terminal_column_parity() -> None:
     total = {
         "input_tokens": 1000,
         "output_tokens": 500,
-        "cache_read_input_tokens": 200,
-        "cache_creation_input_tokens": 100,
+        "cache_read_tokens": 200,
+        "cache_write_tokens": 100,
         "peak_context": 200,
         "total_elapsed_seconds": 45.7,
     }
@@ -825,8 +1020,8 @@ def test_efficiency_table_no_peak_ctx_ratio() -> None:
             "step_name": "fix",
             "input_tokens": 100,
             "output_tokens": 500,
-            "cache_read_input_tokens": 2000,
-            "cache_creation_input_tokens": 100,
+            "cache_read_tokens": 2000,
+            "cache_write_tokens": 100,
             "peak_context": 5000,
             "loc_insertions": 10,
             "loc_deletions": 5,
@@ -835,8 +1030,8 @@ def test_efficiency_table_no_peak_ctx_ratio() -> None:
     total = {
         "input_tokens": 100,
         "output_tokens": 500,
-        "cache_read_input_tokens": 2000,
-        "cache_creation_input_tokens": 100,
+        "cache_read_tokens": 2000,
+        "cache_write_tokens": 100,
         "peak_context": 5000,
         "loc_insertions": 10,
         "loc_deletions": 5,
@@ -858,8 +1053,8 @@ def test_format_token_table_includes_model_column() -> None:
             "model": "claude-sonnet-4-6",
             "input_tokens": 1000,
             "output_tokens": 500,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
             "invocation_count": 1,
             "wall_clock_seconds": 60.0,
             "peak_context": 0,
@@ -869,8 +1064,8 @@ def test_format_token_table_includes_model_column() -> None:
     total = {
         "input_tokens": 1000,
         "output_tokens": 500,
-        "cache_creation_input_tokens": 0,
-        "cache_read_input_tokens": 0,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
         "total_elapsed_seconds": 60.0,
         "peak_context": 0,
     }
@@ -945,8 +1140,8 @@ def test_compact_kv_includes_model() -> None:
             "model": "claude-sonnet-4-6",
             "input_tokens": 100,
             "output_tokens": 50,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
             "invocation_count": 1,
             "turn_count": 0,
             "wall_clock_seconds": 10.0,
@@ -981,8 +1176,8 @@ def test_non_anthropic_step_marked_terminal() -> None:
             "model": "MiniMax-M2.7-highspeed",
             "input_tokens": 307600,
             "output_tokens": 3400,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
             "invocation_count": 1,
             "wall_clock_seconds": 60.0,
         },
@@ -990,8 +1185,8 @@ def test_non_anthropic_step_marked_terminal() -> None:
     total = {
         "input_tokens": 307600,
         "output_tokens": 3400,
-        "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
         "total_elapsed_seconds": 60.0,
     }
     result = TelemetryFormatter.format_token_table_terminal(steps, total)
@@ -1007,8 +1202,8 @@ def test_non_anthropic_step_marked_compact_kv() -> None:
             "model": "MiniMax-M2.7-highspeed",
             "input_tokens": 307600,
             "output_tokens": 3400,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
             "invocation_count": 1,
             "wall_clock_seconds": 60.0,
         },
@@ -1016,8 +1211,8 @@ def test_non_anthropic_step_marked_compact_kv() -> None:
     total = {
         "input_tokens": 307600,
         "output_tokens": 3400,
-        "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
         "total_elapsed_seconds": 60.0,
     }
     result = TelemetryFormatter.format_compact_kv(steps, total)

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -895,7 +895,7 @@ class TestCacheColumnSuppression:
         }
         result = TelemetryFormatter.format_token_table(steps, total)
         # Should NOT contain — for zero values
-        lines = [l for l in result.splitlines() if "plan" in l]
+        lines = [row for row in result.splitlines() if "plan" in row]
         assert "—" not in lines[0]
 
 
@@ -908,14 +908,13 @@ def test_token_column_field_coverage() -> None:
     """Every TokenEntry field must be explicitly assigned to DISPLAY or EXCLUDED."""
     import dataclasses
 
-    from autoskillit.pipeline.telemetry_fmt import _TOKEN_DISPLAY_FIELDS, _TOKEN_EXCLUDED_FIELDS
+    from autoskillit.pipeline.telemetry_fmt import (
+        _LEGACY_TO_CANONICAL,
+        _TOKEN_DISPLAY_FIELDS,
+        _TOKEN_EXCLUDED_FIELDS,
+    )
     from autoskillit.pipeline.tokens import TokenEntry
 
-    # Bridge: TokenEntry still uses legacy names until P2-A4-WP1 lands
-    _LEGACY_TO_CANONICAL = {
-        "cache_creation_input_tokens": "cache_write_tokens",
-        "cache_read_input_tokens": "cache_read_tokens",
-    }
     all_fields = frozenset(
         _LEGACY_TO_CANONICAL.get(f.name, f.name) for f in dataclasses.fields(TokenEntry)
     )


### PR DESCRIPTION
## Summary

Rename all legacy Anthropic API field names (`cache_creation_input_tokens`, `cache_read_input_tokens`) to canonical project names (`cache_write_tokens`, `cache_read_tokens`) across `telemetry_fmt.py` constants, 24 `.get()` call sites, and 90 test fixture literals. Add a `_normalize_keys` bridge so the formatter works with both legacy and canonical input dicts during the migration window. Add a None-suppression guard so that cache columns render "—" (not "0") when a step's cache values are `None` (non-Anthropic provider).

## Changed Files

- `src/autoskillit/pipeline/telemetry_fmt.py`
- `tests/pipeline/test_telemetry_formatter.py`

Closes #2474

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-2474-20260516-161422-837013/.autoskillit/temp/make-plan/p2_a8_wp1_migrate_telemetry_fmt_canonical_names_plan_2026-05-16_163100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 45 | 8.8k | 321.5k | 42.8k | 81 | 33.4k | 5m 5s |
| dry_walkthrough | claude-opus-4-6 | 1 | 2.2k | 16.5k | 2.0M | 79.1k | 123 | 64.6k | 8m 55s |
| implement* | MiniMax-M2.7 | 1 | 152.3k | 50.1k | 14.5M | 21.2k | 331 | 0 | 11m 31s |
| **Total** | | | 154.6k | 75.4k | 16.7M | 79.1k | | 98.0k | 25m 32s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 828 | 17476.2 | 0.0 | 60.6 |
| **Total** | **828** | 20224.3 | 118.4 | 91.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 45 | 8.8k | 321.5k | 33.4k | 5m 5s |
| claude-opus-4-6 | 1 | 2.2k | 16.5k | 2.0M | 64.6k | 8m 55s |
| MiniMax-M2.7 | 1 | 152.3k | 50.1k | 14.5M | 0 | 11m 31s |