### PR TITLE
Split _TOKEN_FIELDS and Migrate _session_model.py to Canonical Names

### DIFF
--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -27,6 +27,9 @@ _API_TOKEN_FIELDS, _CANONICAL_TOKEN_FIELDS = (
     ("input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"),
     ("input_tokens", "output_tokens", "cache_write_tokens", "cache_read_tokens"),
 )
+_CACHE_READ_TOKENS_API_FIELD = _API_TOKEN_FIELDS[
+    _CANONICAL_TOKEN_FIELDS.index("cache_read_tokens")
+]
 
 FAILURE_SUBTYPES: frozenset[CliSubtype] = frozenset(
     {
@@ -257,7 +260,7 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
             bucket = model_buckets.setdefault(model, {f: 0 for f in _CANONICAL_TOKEN_FIELDS})
             for api_f, canon_f in zip(_API_TOKEN_FIELDS, _CANONICAL_TOKEN_FIELDS):
                 bucket[canon_f] += usage.get(api_f, 0)
-            cr = bucket["cache_read_tokens"]
+            cr = usage.get(_CACHE_READ_TOKENS_API_FIELD, 0)
             if cr > peak_context:
                 peak_context = cr
             turn_count += 1

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -257,7 +257,7 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
             bucket = model_buckets.setdefault(model, {f: 0 for f in _CANONICAL_TOKEN_FIELDS})
             for api_f, canon_f in zip(_API_TOKEN_FIELDS, _CANONICAL_TOKEN_FIELDS):
                 bucket[canon_f] += usage.get(api_f, 0)
-            cr = usage.get("cache_read_input_tokens", 0)
+            cr = bucket["cache_read_tokens"]
             if cr > peak_context:
                 peak_context = cr
             turn_count += 1

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -23,11 +23,9 @@ logger = get_logger(__name__)
 
 _ABS_PATH_RE: re.Pattern[str] = re.compile(r'(?:^|[\s="\'])(/(?:[a-zA-Z0-9._/~@+-]+))')
 
-_TOKEN_FIELDS = (
-    "input_tokens",
-    "output_tokens",
-    "cache_creation_input_tokens",
-    "cache_read_input_tokens",
+_API_TOKEN_FIELDS, _CANONICAL_TOKEN_FIELDS = (
+    ("input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"),
+    ("input_tokens", "output_tokens", "cache_write_tokens", "cache_read_tokens"),
 )
 
 FAILURE_SUBTYPES: frozenset[CliSubtype] = frozenset(
@@ -256,9 +254,9 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
             if not isinstance(usage, dict):
                 continue
             model = msg.get("model", "unknown")
-            bucket = model_buckets.setdefault(model, {f: 0 for f in _TOKEN_FIELDS})
-            for f in _TOKEN_FIELDS:
-                bucket[f] += usage.get(f, 0)
+            bucket = model_buckets.setdefault(model, {f: 0 for f in _CANONICAL_TOKEN_FIELDS})
+            for api_f, canon_f in zip(_API_TOKEN_FIELDS, _CANONICAL_TOKEN_FIELDS):
+                bucket[canon_f] += usage.get(api_f, 0)
             cr = usage.get("cache_read_input_tokens", 0)
             if cr > peak_context:
                 peak_context = cr
@@ -266,7 +264,10 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
         elif record_type == "result":
             usage = obj.get("usage")
             if isinstance(usage, dict):
-                result_usage = {f: usage.get(f, 0) for f in _TOKEN_FIELDS}
+                result_usage = {
+                    canon_f: usage.get(api_f, 0)
+                    for api_f, canon_f in zip(_API_TOKEN_FIELDS, _CANONICAL_TOKEN_FIELDS)
+                }
 
     if not model_buckets and result_usage is None:
         return None
@@ -274,9 +275,9 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
     if result_usage is not None:
         totals = dict(result_usage)
     else:
-        totals = {f: 0 for f in _TOKEN_FIELDS}
+        totals = {f: 0 for f in _CANONICAL_TOKEN_FIELDS}
         for bucket in model_buckets.values():
-            for f in _TOKEN_FIELDS:
+            for f in _CANONICAL_TOKEN_FIELDS:
                 totals[f] += bucket[f]
 
     return {

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -2001,8 +2001,8 @@ class TestBuildSkillResultTokenUsage:
         assert usage is not None
         assert usage["input_tokens"] == 200
         assert usage["output_tokens"] == 80
-        assert usage["cache_creation_input_tokens"] == 8
-        assert usage["cache_read_input_tokens"] == 3
+        assert usage["cache_write_tokens"] == 8
+        assert usage["cache_read_tokens"] == 3
         assert "model_breakdown" in usage
         assert "claude-sonnet-4-6" in usage["model_breakdown"]
 

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -192,5 +192,5 @@ class TestStaleTokenUsagePropagation:
         tu = skill_result.token_usage
         assert tu["input_tokens"] == 100
         assert tu["output_tokens"] == 200
-        assert tu["cache_creation_input_tokens"] == 50
-        assert tu["cache_read_input_tokens"] == 75
+        assert tu["cache_write_tokens"] == 50
+        assert tu["cache_read_tokens"] == 75

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -67,14 +67,14 @@ class TestExtractTokenUsage:
         assert result is not None
         assert result["input_tokens"] == 100
         assert result["output_tokens"] == 50
-        assert result["cache_creation_input_tokens"] == 10
-        assert result["cache_read_input_tokens"] == 5
+        assert result["cache_write_tokens"] == 10
+        assert result["cache_read_tokens"] == 5
         assert result["model_breakdown"] == {
             "claude-sonnet-4-6": {
                 "input_tokens": 100,
                 "output_tokens": 50,
-                "cache_creation_input_tokens": 10,
-                "cache_read_input_tokens": 5,
+                "cache_write_tokens": 10,
+                "cache_read_tokens": 5,
             }
         }
 
@@ -113,8 +113,8 @@ class TestExtractTokenUsage:
         assert result is not None
         assert result["input_tokens"] == 300
         assert result["output_tokens"] == 100
-        assert result["cache_creation_input_tokens"] == 20
-        assert result["cache_read_input_tokens"] == 10
+        assert result["cache_write_tokens"] == 20
+        assert result["cache_read_tokens"] == 10
         assert "claude-sonnet-4-6" in result["model_breakdown"]
         assert result["model_breakdown"]["claude-sonnet-4-6"]["input_tokens"] == 300
 
@@ -196,8 +196,8 @@ class TestExtractTokenUsage:
         # result record totals take precedence over assistant sum
         assert result["input_tokens"] == 999
         assert result["output_tokens"] == 888
-        assert result["cache_creation_input_tokens"] == 50
-        assert result["cache_read_input_tokens"] == 25
+        assert result["cache_write_tokens"] == 50
+        assert result["cache_read_tokens"] == 25
         # model breakdown still comes from assistant records
         assert "claude-sonnet-4-6" in result["model_breakdown"]
 
@@ -264,11 +264,11 @@ class TestExtractTokenUsage:
         )
         result = extract_token_usage(stdout)
         assert result is not None
-        assert result["cache_creation_input_tokens"] == 0
-        assert result["cache_read_input_tokens"] == 0
+        assert result["cache_write_tokens"] == 0
+        assert result["cache_read_tokens"] == 0
         breakdown = result["model_breakdown"]["claude-sonnet-4-6"]
-        assert breakdown["cache_creation_input_tokens"] == 0
-        assert breakdown["cache_read_input_tokens"] == 0
+        assert breakdown["cache_write_tokens"] == 0
+        assert breakdown["cache_read_tokens"] == 0
 
     def test_ignores_non_assistant_non_result_records(self):
         """user and system records are skipped."""


### PR DESCRIPTION
## Summary

Replace the single `_TOKEN_FIELDS` tuple in `_session_model.py` with two tuples: `_API_TOKEN_FIELDS` (wire format names from Claude CLI NDJSON) and `_CANONICAL_TOKEN_FIELDS` (canonical output names). Update `extract_token_usage()` to read from API names but emit canonical keys in all output dicts. Update test assertions in `test_session_parsing.py` to expect the new canonical key names.

## Requirements

## Goal

Replace _TOKEN_FIELDS with _API_TOKEN_FIELDS/_CANONICAL_TOKEN_FIELDS, update model_breakdown and extract_token_usage to emit canonical keys, and update all direct test assertions accordingly.

## Context

- Phase: Canonical Token Schema Normalization (Milestone: 2-canonical-token-schema-normalization)
- Assignment: P2-A3 (Migrate _session_model.py _TOKEN_FIELDS and extract_token_usage() to canonical field names)
- Depends on: None
- Depended on by: None

## Deliverables

- `_TOKEN_FIELDS removed; two new tuples defined`
- `All five reference sites updated`
- `peak_context read unchanged (API name)`
- `model_breakdown buckets keyed by canonical names`
- `Accumulation loop reads API names, writes canonical keys`
- `peak_context uses API field constant`
- `result_usage and totals emit canonical keys`
- `test_session_parsing.py assertions updated to canonical keys`
- `test_session_model_peak_context.py verified (may need zero changes)`

## Technical Steps

1. Define _API_TOKEN_FIELDS and _CANONICAL_TOKEN_FIELDS, remove _TOKEN_FIELDS
2. Update bucket initializer to use _CANONICAL_TOKEN_FIELDS
3. Update accumulation loop to zip(API,CANONICAL)
4. Update result_usage comprehension
5. Update totals fallback and accumulation
6. Change bucket init to _CANONICAL_TOKEN_FIELDS
7. Replace accumulation loop with zip mapping
8. Keep peak_context reading from _API_TOKEN_FIELDS
9. Update result_usage and totals dicts
10. Update result['cache_creation_input_tokens'] -> result['cache_write_tokens'] in test_session_parsing.py
11. Update model_breakdown sub-dict assertions to canonical keys
12. Leave NDJSON payload dicts unchanged (wire format)
13. Leave conftest.py unchanged (P2-A17-WP1)

## Acceptance Criteria

- No _TOKEN_FIELDS in _session_model.py
- extract_token_usage returns canonical keys
- peak_context still reads API payload field
- model_breakdown inner buckets use canonical keys
- peak_context reads correct API field
- extract_token_usage returns canonical top-level keys
- All assertions use cache_write_tokens and cache_read_tokens
- NDJSON payload keys unchanged
- conftest.py unmodified

Closes #2469

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-2469-20260516-161419-072348/.autoskillit/temp/make-plan/split_token_fields_migrate_session_model_plan_2026-05-16_161500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 45 | 8.8k | 321.5k | 42.8k | 81 | 33.4k | 5m 5s |
| dry_walkthrough | claude-opus-4-6 | 1 | 2.2k | 16.5k | 2.0M | 79.1k | 123 | 64.6k | 8m 55s |
| implement* | MiniMax-M2.7 | 1 | 152.3k | 50.1k | 14.5M | 21.2k | 331 | 0 | 11m 31s |
| **Total** | | | 154.6k | 75.4k | 16.7M | 79.1k | | 98.0k | 25m 32s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 828 | 17476.2 | 0.0 | 60.6 |
| **Total** | **828** | 20224.3 | 118.4 | 91.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 45 | 8.8k | 321.5k | 33.4k | 5m 5s |
| claude-opus-4-6 | 1 | 2.2k | 16.5k | 2.0M | 64.6k | 8m 55s |
| MiniMax-M2.7 | 1 | 152.3k | 50.1k | 14.5M | 0 | 11m 31s |