### PR TITLE
Author CanonicalTokenUsage IL-0 Type, Wire Re-exports, and Tests

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -159,6 +159,7 @@ from .types import CampaignProtector as CampaignProtector
 from .types import CAPTURE_VALID_VALUE_TYPES as CAPTURE_VALID_VALUE_TYPES
 from .types import CaptureEntrySpec as CaptureEntrySpec
 from .types import CaptureValueTypeError as CaptureValueTypeError
+from .types import CanonicalTokenUsage as CanonicalTokenUsage
 from .types import ChannelBStatus as ChannelBStatus
 from .types import ChannelConfirmation as ChannelConfirmation
 from .types import CIRunScope as CIRunScope

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -12,6 +12,7 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 | `_type_constants.py` | Shared constants: tool lists, env var names, env var sets for session kinds |
 | `_type_session_env.py` | Typed env spec dataclasses for session launch boundaries (`FleetSessionEnv`) |
 | `_type_subprocess.py` | `SubprocessResult` dataclass and `SubprocessRunner` protocol |
+| `_type_token.py` | `CanonicalTokenUsage` frozen dataclass with factory methods and merge |
 | `_type_results_execution.py` | Execution-scoped result dataclasses: `SessionTelemetry`, `RecipeIdentity`, `CIRunScope` |
 | `_type_results.py` | Core result dataclasses: `SkillResult`, `ProviderOutcome`, `LoadResult`, `FailureRecord`, `WriteBehaviorSpec` |
 | `_type_protocols_logging.py` | Protocols: `AuditLog`, `TokenLog`, `TimingLog`, `McpResponseLog`, `GitHubApiLog`, `SupportsDebug`, `SupportsLogger` |

--- a/src/autoskillit/core/types/__init__.py
+++ b/src/autoskillit/core/types/__init__.py
@@ -46,6 +46,8 @@ from ._type_session_env import *  # noqa: F401, F403
 from ._type_session_env import __all__ as _session_env_all
 from ._type_subprocess import *  # noqa: F401, F403
 from ._type_subprocess import __all__ as _subprocess_all
+from ._type_token import *  # noqa: F401, F403
+from ._type_token import __all__ as _token_all
 
 __all__ = (
     _backend_all
@@ -68,4 +70,5 @@ __all__ = (
     + _resume_all
     + _session_env_all
     + _subprocess_all
+    + _token_all
 )

--- a/src/autoskillit/core/types/_type_token.py
+++ b/src/autoskillit/core/types/_type_token.py
@@ -1,0 +1,72 @@
+"""Canonical token usage type. Zero autoskillit imports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["CanonicalTokenUsage"]
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalTokenUsage:
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int | None
+    cache_write_tokens: int | None
+    provider: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_anthropic_dict(cls, d: dict[str, Any]) -> CanonicalTokenUsage:
+        return cls(
+            input_tokens=d["input_tokens"],
+            output_tokens=d["output_tokens"],
+            cache_read_tokens=d.get("cache_read_input_tokens"),
+            cache_write_tokens=d.get("cache_creation_input_tokens"),
+            provider="anthropic",
+            raw=d,
+        )
+
+    @classmethod
+    def from_codex_dict(cls, d: dict[str, Any]) -> CanonicalTokenUsage:
+        return cls(
+            input_tokens=d["input_tokens"],
+            output_tokens=d["output_tokens"],
+            cache_read_tokens=d.get("cached_input_tokens"),
+            cache_write_tokens=None,
+            provider="codex",
+            raw=d,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "provider": self.provider,
+        }
+
+    @classmethod
+    def merge(
+        cls, base: CanonicalTokenUsage | None, other: CanonicalTokenUsage | None
+    ) -> CanonicalTokenUsage | None:
+        if base is None:
+            return other
+        if other is None:
+            return base
+
+        def _add_optional(a: int | None, b: int | None) -> int | None:
+            if a is None and b is None:
+                return None
+            return (a or 0) + (b or 0)
+
+        return cls(
+            input_tokens=base.input_tokens + other.input_tokens,
+            output_tokens=base.output_tokens + other.output_tokens,
+            cache_read_tokens=_add_optional(base.cache_read_tokens, other.cache_read_tokens),
+            cache_write_tokens=_add_optional(base.cache_write_tokens, other.cache_write_tokens),
+            provider=base.provider,
+            raw={**base.raw, **other.raw},
+        )

--- a/src/autoskillit/core/types/_type_token.py
+++ b/src/autoskillit/core/types/_type_token.py
@@ -25,7 +25,7 @@ class CanonicalTokenUsage:
             cache_read_tokens=d.get("cache_read_input_tokens"),
             cache_write_tokens=d.get("cache_creation_input_tokens"),
             provider="anthropic",
-            raw=d,
+            raw=dict(d),
         )
 
     @classmethod
@@ -36,7 +36,7 @@ class CanonicalTokenUsage:
             cache_read_tokens=d.get("cached_input_tokens"),
             cache_write_tokens=None,
             provider="codex",
-            raw=d,
+            raw=dict(d),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/autoskillit/core/types/_type_token.py
+++ b/src/autoskillit/core/types/_type_token.py
@@ -57,6 +57,12 @@ class CanonicalTokenUsage:
         if other is None:
             return base
 
+        if base.provider != other.provider:
+            raise ValueError(
+                f"Cannot merge CanonicalTokenUsage with mismatched providers: "
+                f"{base.provider!r} vs {other.provider!r}"
+            )
+
         def _add_optional(a: int | None, b: int | None) -> int | None:
             if a is None and b is None:
                 return None

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -757,7 +757,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         at the session launch boundary, bringing the count to 20.
         _type_backend.py adds BackendCapabilities frozen dataclass and CLAUDE_CODE_CAPABILITIES
         constant for backend capability declarations (IL-0), bringing the count to 21.
-        Exempt at 34 files (core/types: 21).
+        _type_token.py adds CanonicalTokenUsage frozen dataclass for provider-agnostic
+        token usage normalization (IL-0), bringing the count to 22.
+        Exempt at 34 files (core/types: 22).
       cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
         for backward-compatible cli/ imports; canonical implementation lives in
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -813,7 +815,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 31,
         "execution": 18,
         "core": 20,
-        "core/types": 21,
+        "core/types": 22,
         "cli": 20,
         "hooks": 10,
         "pipeline": 12,

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -33,6 +33,7 @@ class TestCoreSubpackages:
             "_type_figure_spec",
             "_type_capture",
             "_type_session_env",
+            "_type_token",
         }
         actual = {p.stem for p in (SRC / "core" / "types").glob("_type_*.py")}
         assert actual == expected

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -8,6 +8,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 |------|---------|
 | `__init__.py` | empty |
 | `test_add_dir_validation.py` | Tests for ValidatedAddDir and validate_add_dir |
+| `test_canonical_token_usage.py` | Tests for CanonicalTokenUsage frozen dataclass — factory methods, merge, and immutability |
 | `test_capture.py` | Tests for CaptureEntrySpec and resolve_payload_field |
 | `test_branch_guard.py` | Tests for core.branch_guard — protected-branch validation |
 | `test_claude_env.py` | Unit tests for build_agent_env() — IDE env scrubbing at the subprocess launch boundary |

--- a/tests/core/test_canonical_token_usage.py
+++ b/tests/core/test_canonical_token_usage.py
@@ -1,0 +1,192 @@
+"""Tests for CanonicalTokenUsage type."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from autoskillit.core.types import CanonicalTokenUsage
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+class TestFromAnthropicDictRoundTrip:
+    def test_full_payload(self):
+        raw = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 20,
+        }
+        result = CanonicalTokenUsage.from_anthropic_dict(raw)
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+        assert result.cache_write_tokens == 10
+        assert result.cache_read_tokens == 20
+        assert result.provider == "anthropic"
+        assert result.raw == raw
+
+    def test_round_trip_via_to_dict(self):
+        raw = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 20,
+        }
+        result = CanonicalTokenUsage.from_anthropic_dict(raw)
+        d = result.to_dict()
+        assert d["input_tokens"] == 100
+        assert d["output_tokens"] == 50
+        assert d["cache_write_tokens"] == 10
+        assert d["cache_read_tokens"] == 20
+        assert d["provider"] == "anthropic"
+
+
+class TestFromCodexDictRoundTrip:
+    def test_full_payload(self):
+        raw = {"input_tokens": 200, "output_tokens": 80, "cached_input_tokens": 30}
+        result = CanonicalTokenUsage.from_codex_dict(raw)
+        assert result.input_tokens == 200
+        assert result.output_tokens == 80
+        assert result.cache_read_tokens == 30
+        assert result.cache_write_tokens is None
+        assert result.provider == "codex"
+        assert result.raw == raw
+
+
+class TestMergeCommutativity:
+    def test_merge_sums_fields(self):
+        a = CanonicalTokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            cache_write_tokens=5,
+            provider="anthropic",
+            raw={"a": 1},
+        )
+        b = CanonicalTokenUsage(
+            input_tokens=200,
+            output_tokens=80,
+            cache_read_tokens=20,
+            cache_write_tokens=10,
+            provider="anthropic",
+            raw={"b": 2},
+        )
+        merged = CanonicalTokenUsage.merge(a, b)
+        assert merged.input_tokens == 300
+        assert merged.output_tokens == 130
+        assert merged.cache_read_tokens == 30
+        assert merged.cache_write_tokens == 15
+        assert merged.provider == "anthropic"
+        assert merged.raw == {"a": 1, "b": 2}
+
+
+class TestNoneCacheFields:
+    def test_none_cache_in_merge_treated_as_zero(self):
+        a = CanonicalTokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=None,
+            cache_write_tokens=None,
+            provider="anthropic",
+            raw={},
+        )
+        b = CanonicalTokenUsage(
+            input_tokens=200,
+            output_tokens=80,
+            cache_read_tokens=20,
+            cache_write_tokens=10,
+            provider="anthropic",
+            raw={},
+        )
+        merged = CanonicalTokenUsage.merge(a, b)
+        assert merged.cache_read_tokens == 20
+        assert merged.cache_write_tokens == 10
+
+    def test_merge_none_with_none_returns_none(self):
+        a = CanonicalTokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=None,
+            cache_write_tokens=None,
+            provider="anthropic",
+            raw={},
+        )
+        b = CanonicalTokenUsage(
+            input_tokens=200,
+            output_tokens=80,
+            cache_read_tokens=None,
+            cache_write_tokens=None,
+            provider="anthropic",
+            raw={},
+        )
+        merged = CanonicalTokenUsage.merge(a, b)
+        assert merged.cache_read_tokens is None
+        assert merged.cache_write_tokens is None
+
+    def test_merge_none_base_returns_other(self):
+        b = CanonicalTokenUsage(
+            input_tokens=200,
+            output_tokens=80,
+            cache_read_tokens=20,
+            cache_write_tokens=10,
+            provider="anthropic",
+            raw={},
+        )
+        assert CanonicalTokenUsage.merge(None, b) is b
+
+    def test_merge_none_other_returns_base(self):
+        a = CanonicalTokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            cache_write_tokens=5,
+            provider="anthropic",
+            raw={},
+        )
+        assert CanonicalTokenUsage.merge(a, None) is a
+
+
+class TestFrozen:
+    def test_cannot_mutate_fields(self):
+        usage = CanonicalTokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            cache_write_tokens=5,
+            provider="anthropic",
+            raw={},
+        )
+        with pytest.raises(FrozenInstanceError):
+            usage.input_tokens = 999  # type: ignore[misc]
+
+
+def test_importable_via_core_gateway():
+    from autoskillit.core.types import CanonicalTokenUsage
+
+    assert CanonicalTokenUsage is not None
+
+
+def test_canonical_token_usage_importable_from_core():
+    from autoskillit.core import CanonicalTokenUsage
+
+    assert CanonicalTokenUsage is not None
+
+
+def test_canonical_token_usage_in_types_all():
+    from autoskillit.core.types import __all__ as types_all
+
+    assert "CanonicalTokenUsage" in types_all
+
+
+def test_canonical_token_usage_in_core_all():
+    import autoskillit.core as core
+
+    assert "CanonicalTokenUsage" in core.__all__
+
+
+def test_canonical_token_usage_not_in_private_reexports():
+    import autoskillit.core as core
+
+    assert "CanonicalTokenUsage" not in core._PRIVATE_REEXPORTS

--- a/tests/core/test_canonical_token_usage.py
+++ b/tests/core/test_canonical_token_usage.py
@@ -148,6 +148,20 @@ class TestNoneCacheFields:
         assert CanonicalTokenUsage.merge(a, None) is a
 
 
+class TestRawSnapshot:
+    def test_from_anthropic_dict_snapshots_raw(self):
+        raw = {"input_tokens": 1, "output_tokens": 2}
+        result = CanonicalTokenUsage.from_anthropic_dict(raw)
+        raw["input_tokens"] = 999
+        assert result.raw["input_tokens"] == 1
+
+    def test_from_codex_dict_snapshots_raw(self):
+        raw = {"input_tokens": 1, "output_tokens": 2}
+        result = CanonicalTokenUsage.from_codex_dict(raw)
+        raw["input_tokens"] = 999
+        assert result.raw["input_tokens"] == 1
+
+
 class TestFrozen:
     def test_cannot_mutate_fields(self):
         usage = CanonicalTokenUsage(

--- a/tests/core/test_canonical_token_usage.py
+++ b/tests/core/test_canonical_token_usage.py
@@ -162,6 +162,28 @@ class TestRawSnapshot:
         assert result.raw["input_tokens"] == 1
 
 
+class TestMergeProviderGuard:
+    def test_merge_raises_on_mismatched_providers(self):
+        a = CanonicalTokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=None,
+            cache_write_tokens=None,
+            provider="anthropic",
+            raw={},
+        )
+        b = CanonicalTokenUsage(
+            input_tokens=200,
+            output_tokens=80,
+            cache_read_tokens=None,
+            cache_write_tokens=None,
+            provider="codex",
+            raw={},
+        )
+        with pytest.raises(ValueError, match="mismatched providers"):
+            CanonicalTokenUsage.merge(a, b)
+
+
 class TestFrozen:
     def test_cannot_mutate_fields(self):
         usage = CanonicalTokenUsage(


### PR DESCRIPTION
## Summary

Create a new `_type_token.py` module in `src/autoskillit/core/types/` containing a frozen dataclass `CanonicalTokenUsage` with factory classmethods (`from_anthropic_dict`, `from_codex_dict`), a `to_dict` serializer, and an additive `merge` classmethod. Wire the type through the standard re-export chain (`core/types/__init__.py` → `core/__init__.pyi`) and add comprehensive tests.

Closes #2453

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-2453-20260516-161417-656885/.autoskillit/temp/make-plan/impl_canonical_token_usage_plan_2026-05-16_161500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 45 | 8.8k | 321.5k | 42.8k | 81 | 33.4k | 5m 5s |
| dry_walkthrough | claude-opus-4-6 | 1 | 2.2k | 16.5k | 2.0M | 79.1k | 123 | 64.6k | 8m 55s |
| implement* | MiniMax-M2.7 | 1 | 152.3k | 50.1k | 14.5M | 21.2k | 331 | 0 | 11m 31s |
| **Total** | | | 154.6k | 75.4k | 16.7M | 79.1k | | 98.0k | 25m 32s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 828 | 17476.2 | 0.0 | 60.6 |
| **Total** | **828** | 20224.3 | 118.4 | 91.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 45 | 8.8k | 321.5k | 33.4k | 5m 5s |
| claude-opus-4-6 | 1 | 2.2k | 16.5k | 2.0M | 64.6k | 8m 55s |
| MiniMax-M2.7 | 1 | 152.3k | 50.1k | 14.5M | 0 | 11m 31s |