### PR TITLE
[P2-A9-WP1] Add dual-name fallback to normalize_dispatch_token_usage (#2475)

### DIFF
--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -619,13 +619,18 @@ def normalize_dispatch_token_usage(raw: dict[str, Any]) -> dict[str, int]:
     """Map raw Claude session token keys to canonical DispatchTokenUsage key set.
 
     Idempotent: handles both raw keys (input_tokens/output_tokens) and canonical
-    keys (input/output) so that double-normalization is safe.
+    keys (input/output) so that double-normalization is safe. Canonical keys take
+    priority when both are present.
     """
     return {
-        "input": int(raw.get("input_tokens", raw.get("input", 0))),
-        "output": int(raw.get("output_tokens", raw.get("output", 0))),
+        "input": int(raw["input"] if "input" in raw else raw.get("input_tokens", 0)),
+        "output": int(raw["output"] if "output" in raw else raw.get("output_tokens", 0)),
         "cache_creation": int(
-            raw.get("cache_creation_input_tokens", raw.get("cache_creation", 0))
+            raw["cache_creation"]
+            if "cache_creation" in raw
+            else raw.get("cache_creation_input_tokens", 0)
         ),
-        "cache_read": int(raw.get("cache_read_input_tokens", raw.get("cache_read", 0))),
+        "cache_read": int(
+            raw["cache_read"] if "cache_read" in raw else raw.get("cache_read_input_tokens", 0)
+        ),
     }

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -320,6 +320,37 @@ class TestNormalizeDispatchTokenUsage:
 
         assert "normalize_dispatch_token_usage" in autoskillit.fleet.__all__
 
+    def test_canonical_name_only(self) -> None:
+        result = normalize_dispatch_token_usage(
+            {"input": 10, "output": 5, "cache_creation": 2, "cache_read": 3}
+        )
+        assert result == {"input": 10, "output": 5, "cache_creation": 2, "cache_read": 3}
+
+    def test_mixed_old_and_new_canonical_wins(self) -> None:
+        result = normalize_dispatch_token_usage(
+            {
+                "input": 0,
+                "input_tokens": 99,
+                "output": 0,
+                "output_tokens": 88,
+                "cache_creation": 0,
+                "cache_creation_input_tokens": 77,
+                "cache_read": 0,
+                "cache_read_input_tokens": 66,
+            }
+        )
+        assert result == {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0}
+
+    def test_existing_full_mapping_unchanged(self) -> None:
+        raw = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 30,
+        }
+        result = normalize_dispatch_token_usage(raw)
+        assert result == {"input": 100, "output": 50, "cache_creation": 20, "cache_read": 30}
+
 
 class TestDispatchRecordToDict:
     def test_dispatch_record_to_dict_all_fields(self) -> None:


### PR DESCRIPTION
Closes #2475

Refactors normalize_dispatch_token_usage() to use explicit key-presence checks with canonical (short) keys taking priority over old Anthropic (long) keys. Ensures zero-value correctness.