### PR TITLE
[P2-A5-WP1] Rename cache fields in all three TypedDicts in _type_results.py (#2471)

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -364,19 +364,11 @@ class ModelTotalEntry(TypedDict):
 
 
 class TokenUsageFileEntry(TypedDict):
-    """Schema contract for token_usage.json written by flush_session_log.
-
-    v1 keys (cache_creation_input_tokens, cache_read_input_tokens) are retained
-    for backward compatibility with existing on-disk session files.
-    v2 canonical keys (cache_write_tokens, cache_read_tokens) are the new format
-    read with v1 fallback by load_from_log_dir and _load_sessions.
-    """
+    """Schema contract for token_usage.json written by flush_session_log."""
 
     session_label: str
     input_tokens: int
     output_tokens: int
-    cache_creation_input_tokens: int
-    cache_read_input_tokens: int
     cache_write_tokens: int
     cache_read_tokens: int
     peak_context: int
@@ -389,6 +381,7 @@ class TokenUsageFileEntry(TypedDict):
     model_identifier: str
     dispatch_id: str
     campaign_id: str
+    schema_version: int
 
 
 class SessionIndexEntry(TypedDict):
@@ -415,8 +408,8 @@ class SessionIndexEntry(TypedDict):
     step_name: str
     input_tokens: int
     output_tokens: int
-    cache_creation_input_tokens: int
-    cache_read_input_tokens: int
+    cache_write_tokens: int
+    cache_read_tokens: int
     write_call_count: int
     tracked_comm: str | None
     tracked_comm_drift: bool

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -384,14 +384,16 @@ def flush_session_log(
     # Write per-session telemetry files; gate on data presence, not session identity
     label = _resolve_session_label(step_name, dispatch_id)
     if token_usage is not None:
-        _cache_write = token_usage.get("cache_creation_input_tokens", 0)
-        _cache_read = token_usage.get("cache_read_input_tokens", 0)
+        _cache_write = token_usage.get(
+            "cache_write_tokens", token_usage.get("cache_creation_input_tokens", 0)
+        )
+        _cache_read = token_usage.get(
+            "cache_read_tokens", token_usage.get("cache_read_input_tokens", 0)
+        )
         tu_data = {
             "session_label": label,
             "input_tokens": token_usage.get("input_tokens", 0),
             "output_tokens": token_usage.get("output_tokens", 0),
-            "cache_creation_input_tokens": _cache_write,
-            "cache_read_input_tokens": _cache_read,
             "cache_write_tokens": _cache_write,
             "cache_read_tokens": _cache_read,
             "timing_seconds": timing_seconds if timing_seconds is not None else 0.0,
@@ -404,6 +406,7 @@ def flush_session_log(
             "model_identifier": model_identifier or _primary_model_identifier(token_usage),
             "dispatch_id": dispatch_id,
             "campaign_id": campaign_id,
+            "schema_version": 2,
         }
         atomic_write(session_dir / "token_usage.json", _fast_dumps(tu_data))
 

--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -48,8 +48,6 @@ TOKEN_USAGE_FILE_KEYS: frozenset[str] = frozenset(
         "session_label",
         "input_tokens",
         "output_tokens",
-        "cache_creation_input_tokens",
-        "cache_read_input_tokens",
         "cache_write_tokens",
         "cache_read_tokens",
         "peak_context",
@@ -62,6 +60,7 @@ TOKEN_USAGE_FILE_KEYS: frozenset[str] = frozenset(
         "model_identifier",
         "dispatch_id",
         "campaign_id",
+        "schema_version",
     }
 )
 

--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -239,12 +239,8 @@ def _load_sessions(
             entry["model"] = _model
         entry["input_tokens"] += data.get("input_tokens", 0)
         entry["output_tokens"] += data.get("output_tokens", 0)
-        entry["cache_write_tokens"] += data.get(
-            "cache_write_tokens", data.get("cache_creation_input_tokens", 0)
-        )
-        entry["cache_read_tokens"] += data.get(
-            "cache_read_tokens", data.get("cache_read_input_tokens", 0)
-        )
+        entry["cache_write_tokens"] += data.get("cache_write_tokens", 0)
+        entry["cache_read_tokens"] += data.get("cache_read_tokens", 0)
         _raw_timing = data.get("timing_seconds")
         entry["elapsed_seconds"] += float(_raw_timing) if _raw_timing is not None else 0.0
         entry["invocation_count"] += 1

--- a/tests/contracts/test_token_summary_contracts.py
+++ b/tests/contracts/test_token_summary_contracts.py
@@ -112,8 +112,8 @@ def test_flush_to_hook_cross_seam(tmp_path):
         "session_label": "plan",
         "input_tokens": 100,
         "output_tokens": 200,
-        "cache_creation_input_tokens": 0,
-        "cache_read_input_tokens": 0,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
         "timing_seconds": 1.5,
         "order_id": "test-order",
         "loc_insertions": 10,
@@ -124,6 +124,7 @@ def test_flush_to_hook_cross_seam(tmp_path):
         "model_identifier": "test-model",
         "dispatch_id": "test-dispatch",
         "campaign_id": "test-campaign",
+        "schema_version": 2,
     }
     (session_dir / "token_usage.json").write_text(json.dumps(tu_data))
 

--- a/tests/core/test_session_index_schema.py
+++ b/tests/core/test_session_index_schema.py
@@ -25,3 +25,35 @@ class TestSessionIndexEntryCompleteness:
         declared = set(SessionIndexEntry.__annotations__)
         missing = _REQUIRED_INDEX_FIELDS - declared
         assert not missing, f"SessionIndexEntry missing fields: {missing}"
+
+    def test_canonical_cache_fields(self):
+        """SessionIndexEntry must use canonical cache field names, not v1 API names."""
+        from autoskillit.core.types._type_results import SessionIndexEntry
+
+        declared = set(SessionIndexEntry.__annotations__)
+        assert "cache_write_tokens" in declared
+        assert "cache_read_tokens" in declared
+        assert "cache_creation_input_tokens" not in declared
+        assert "cache_read_input_tokens" not in declared
+
+
+class TestTokenUsageFileEntrySchema:
+    """TokenUsageFileEntry must use canonical cache fields and include schema_version."""
+
+    def test_canonical_cache_fields(self):
+        from autoskillit.core.types._type_results import TokenUsageFileEntry
+
+        declared = set(TokenUsageFileEntry.__annotations__)
+        assert "cache_write_tokens" in declared
+        assert "cache_read_tokens" in declared
+        assert "cache_creation_input_tokens" not in declared
+        assert "cache_read_input_tokens" not in declared
+
+    def test_has_schema_version(self):
+        from typing import get_type_hints
+
+        from autoskillit.core.types._type_results import TokenUsageFileEntry
+
+        hints = get_type_hints(TokenUsageFileEntry)
+        assert "schema_version" in hints
+        assert hints["schema_version"] is int

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -444,8 +444,8 @@ def test_flush_writes_token_usage_json_when_step_name_empty(tmp_path):
     data = json.loads((session_dir / "token_usage.json").read_text())
     assert data["session_label"] == "(ad-hoc)"
     assert "step_name" not in data
-    assert data["cache_creation_input_tokens"] == 20
-    assert data["cache_read_input_tokens"] == 80
+    assert data["cache_write_tokens"] == 20
+    assert data["cache_read_tokens"] == 80
 
 
 def test_flush_writes_step_timing_json(tmp_path):
@@ -569,8 +569,8 @@ def test_token_usage_json_schema(tmp_path):
     assert tu["session_label"] == "plan"
     assert tu["input_tokens"] == 10
     assert tu["output_tokens"] == 5
-    assert tu["cache_creation_input_tokens"] == 2
-    assert tu["cache_read_input_tokens"] == 1
+    assert tu["cache_write_tokens"] == 2
+    assert tu["cache_read_tokens"] == 1
     assert tu["timing_seconds"] == 15.0
     assert tu["peak_context"] == 0
     assert tu["turn_count"] == 0
@@ -739,8 +739,8 @@ def test_flush_writes_token_usage_with_dispatch_label(tmp_path):
     assert (session_dir / "token_usage.json").exists()
     data = json.loads((session_dir / "token_usage.json").read_text())
     assert data["session_label"] == "dispatch:abc-123"
-    assert data["cache_creation_input_tokens"] == 20
-    assert data["cache_read_input_tokens"] == 80
+    assert data["cache_write_tokens"] == 20
+    assert data["cache_read_tokens"] == 80
 
 
 def test_token_usage_file_entry_type_matches_written_fields(tmp_path):


### PR DESCRIPTION
Closes #2471

Renames cache fields in SessionIndexEntry and TokenUsageFileEntry to canonical names (cache_write_tokens/cache_read_tokens), updates TOKEN_USAGE_FILE_KEYS frozenset, adds schema_version field, and updates session_log writer + token_summary_hook reader to emit/consume v2 canonical names.