### PR TITLE
[P2-A10-WP1] Rename legacy field keys in _fleet_display.py (#2454)

### DIFF
--- a/src/autoskillit/cli/fleet/_fleet_display.py
+++ b/src/autoskillit/cli/fleet/_fleet_display.py
@@ -104,8 +104,8 @@ def _aggregate_totals(state: CampaignState) -> dict[str, int]:
         tu = d.token_usage
         totals["input_tokens"] += tu.get("input_tokens", 0)
         totals["output_tokens"] += tu.get("output_tokens", 0)
-        totals["cache_read"] += tu.get("cache_read_input_tokens", 0)
-        totals["cache_creation"] += tu.get("cache_creation_input_tokens", 0)
+        totals["cache_read"] += tu.get("cache_read", 0)
+        totals["cache_creation"] += tu.get("cache_creation", 0)
     return totals
 
 
@@ -121,8 +121,8 @@ def _build_status_rows(state: CampaignState) -> list[tuple[str, ...]]:
                 _fmt_elapsed(d),
                 _humanize(tu.get("input_tokens", 0)),
                 _humanize(tu.get("output_tokens", 0)),
-                _humanize(tu.get("cache_read_input_tokens", 0)),
-                _humanize(tu.get("cache_creation_input_tokens", 0)),
+                _humanize(tu.get("cache_read", 0)),
+                _humanize(tu.get("cache_creation", 0)),
                 d.dispatched_session_log_dir or "-",
             )
         )
@@ -170,8 +170,8 @@ def _cross_check_tokens(state: CampaignState, state_totals: dict[str, int]) -> N
     for label, state_key, log_key in [
         ("input_tokens", "input_tokens", "input_tokens"),
         ("output_tokens", "output_tokens", "output_tokens"),
-        ("cache_read", "cache_read", "cache_read_input_tokens"),
-        ("cache_creation", "cache_creation", "cache_creation_input_tokens"),
+        ("cache_read", "cache_read", "cache_read_tokens"),
+        ("cache_creation", "cache_creation", "cache_write_tokens"),
     ]:
         sv = state_totals.get(state_key, 0)
         lv = log_totals.get(log_key, 0)

--- a/tests/cli/test_fleet_status.py
+++ b/tests/cli/test_fleet_status.py
@@ -107,8 +107,8 @@ def test_fleet_status_json_includes_totals(
         token_usage={
             "input_tokens": 100,
             "output_tokens": 50,
-            "cache_creation_input_tokens": 10,
-            "cache_read_input_tokens": 20,
+            "cache_creation": 10,
+            "cache_read": 20,
         },
     )
     monkeypatch.chdir(tmp_path)
@@ -188,8 +188,8 @@ def test_cross_check_warns_on_divergence(
         lambda self, **kw: {
             "input_tokens": 8000,
             "output_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
             "total_elapsed_seconds": 0.0,
         },
     )


### PR DESCRIPTION
Closes #2454

Renames 6 legacy .get() key references in _fleet_display.py to canonical names (cache_read/cache_creation for dispatch output, cache_read_tokens/cache_write_tokens for log output) and updates 4 corresponding test fixture keys.