### PR TITLE
[RECTIFY] Planner Tier Sentinel Directory Isolation

### DIFF
--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -37,6 +37,12 @@ class _PhaseBucket(TypedDict):
     wp_count: int
 
 
+def _ensure_sentinel_dir(tier_dir: Path, sentinel_name: str) -> Path:
+    sentinel_dir = tier_dir / sentinel_name
+    sentinel_dir.mkdir(parents=True, exist_ok=True)
+    return sentinel_dir
+
+
 def create_run_dir(temp_dir: str) -> RunDirResult:
     if not temp_dir:
         raise ValueError("temp_dir must be a non-empty path")
@@ -103,7 +109,7 @@ def build_phase_assignment_manifest(phases_dir: str, output_dir: str) -> dict[st
 
     manifest = {
         "pass_name": "phase_assignments",
-        "result_dir": str(assign_dir),
+        "result_dir": str(_ensure_sentinel_dir(assign_dir, "assign_sentinels")),
         "created_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": items,
     }
@@ -189,8 +195,7 @@ def build_phase_wp_manifest(
             }
         )
 
-    sentinel_dir = wp_dir / "wp_sentinels"
-    sentinel_dir.mkdir(parents=True, exist_ok=True)
+    sentinel_dir = _ensure_sentinel_dir(wp_dir, "wp_sentinels")
 
     manifest = {
         "pass_name": "phase_work_packages",
@@ -277,7 +282,7 @@ def expand_assignments(
     phases = plan.get("phases", [])
     task_file_path: str = str(kwargs.get("task_file_path") or "")
     assign_dir = Path(output_dir) / "assignments"
-    assign_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_sentinel_dir(assign_dir, "assign_sentinels")
 
     items: list[dict[str, object]] = []
     context_paths: list[str] = []
@@ -325,7 +330,7 @@ def expand_assignments(
 
     manifest = {
         "pass_name": "phase_assignments",
-        "result_dir": str(assign_dir),
+        "result_dir": str(_ensure_sentinel_dir(assign_dir, "assign_sentinels")),
         "created_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": items,
     }
@@ -416,8 +421,7 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
         context_paths.append(str(ctx_path))
         item_ids.append(str(phase_id))
 
-    sentinel_dir = wp_dir / "wp_sentinels"
-    sentinel_dir.mkdir(parents=True, exist_ok=True)
+    sentinel_dir = _ensure_sentinel_dir(wp_dir, "wp_sentinels")
     manifest = {
         "pass_name": "phase_work_packages",
         "result_dir": str(sentinel_dir),

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -107,9 +107,10 @@ def build_phase_assignment_manifest(phases_dir: str, output_dir: str) -> dict[st
             }
         )
 
+    sentinel_dir = _ensure_sentinel_dir(assign_dir, "assign_sentinels")
     manifest = {
         "pass_name": "phase_assignments",
-        "result_dir": str(_ensure_sentinel_dir(assign_dir, "assign_sentinels")),
+        "result_dir": str(sentinel_dir),
         "created_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": items,
     }
@@ -282,7 +283,6 @@ def expand_assignments(
     phases = plan.get("phases", [])
     task_file_path: str = str(kwargs.get("task_file_path") or "")
     assign_dir = Path(output_dir) / "assignments"
-    _ensure_sentinel_dir(assign_dir, "assign_sentinels")
 
     items: list[dict[str, object]] = []
     context_paths: list[str] = []
@@ -328,9 +328,10 @@ def expand_assignments(
         context_paths.append(str(ctx_path))
         item_ids.append(phase_id)
 
+    sentinel_dir = _ensure_sentinel_dir(assign_dir, "assign_sentinels")
     manifest = {
         "pass_name": "phase_assignments",
-        "result_dir": str(_ensure_sentinel_dir(assign_dir, "assign_sentinels")),
+        "result_dir": str(sentinel_dir),
         "created_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": items,
     }

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -46,6 +46,8 @@ _NEGATION_PREFIX_RE: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
+_WP_DEP_RE: re.Pattern[str] = re.compile(r"^P\d+-A\d+-WP\d+$")
+
 
 class DiscoveryResult(NamedTuple):
     accepted: list[Path]
@@ -222,6 +224,22 @@ def _check_dep_references(wp_results: dict[str, dict]) -> list[ValidationFinding
                         "message": f"WP {wp_id} depends on itself",
                         "severity": "error",
                         "check": "dep_references",
+                    }
+                )
+    return findings
+
+
+def _check_dep_id_format(wp_results: dict[str, dict]) -> list[ValidationFinding]:
+    findings: list[ValidationFinding] = []
+    for wp_id, wp in wp_results.items():
+        for dep in wp.get("depends_on", []):
+            if not _WP_DEP_RE.match(dep):
+                findings.append(
+                    {
+                        "severity": "error",
+                        "check": "dep_id_format",
+                        "message": f"WP {wp_id} depends_on '{dep}' which does not match "
+                        f"WP ID format {_WP_DEP_RE.pattern}",
                     }
                 )
     return findings
@@ -406,6 +424,7 @@ def validate_plan(output_dir: str) -> dict[str, str]:
         _check_assignment_completeness(assignment_results, wp_results, absorption_registry)
     )
     all_findings.extend(_check_dep_references(wp_results))
+    all_findings.extend(_check_dep_id_format(wp_results))
     all_findings.extend(_check_dag_acyclic(wp_results))
     all_findings.extend(_check_sizing_bounds(wp_results))
     all_findings.extend(_check_duplicate_deliverables(wp_results))

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -154,13 +154,13 @@ After writing all assignment files, update `$2/work_packages/wp_index.json` by a
 for all **successful** results only (skip stubs). Read the current index, append, and write back
 atomically. L1 is the sole writer for this phase's assignments — no concurrent writes.
 
-Finally, write the phase sentinel file to `$2/assignments/{phase_id}_result.json`:
+Finally, write the phase sentinel file to `$2/assignments/assign_sentinels/{phase_id}_result.json`:
 ```json
 {"id": "<phase_id>", "status": "complete", "assignment_count": N, "failed_count": M}
 ```
 
-> The sentinel path MUST be `$2/assignments/{phase_id}_result.json`. The manifest's
-> `result_dir` points to `$2/assignments/`, and this path is used to detect phase
+> The sentinel path MUST be `$2/assignments/assign_sentinels/{phase_id}_result.json`. The manifest's
+> `result_dir` points to `$2/assignments/assign_sentinels/`, and this path is used to detect phase
 > completion. Verify the path before writing.
 
 ### Step 7: Emit output token

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -153,7 +153,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
     ("src/autoskillit/planner/consolidation.py", 335),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 267),
+    ("src/autoskillit/planner/manifests.py", 268),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc.py", 445),
 }

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -153,7 +153,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
     ("src/autoskillit/planner/consolidation.py", 335),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 262),
+    ("src/autoskillit/planner/manifests.py", 267),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc.py", 445),
 }

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -927,36 +927,8 @@ def test_all_tiers_result_dir_points_to_sentinel_subdir(expand_fn, sentinel_subd
         result = expand_wps(str(refined_path), str(tmp_path))
 
     manifest = json.loads(Path(result["manifest_path"]).read_text())
-    assert manifest["result_dir"].endswith(sentinel_subdir), (
-        f"{expand_fn} result_dir was {manifest['result_dir']}, "
-        f"expected to end with {sentinel_subdir}"
-    )
     assert Path(manifest["result_dir"]).name == sentinel_subdir
     assert Path(manifest["result_dir"]).is_dir()
-
-
-def test_expand_assignments_result_dir_points_to_assign_sentinels(tmp_path):
-    """expand_assignments must create assign_sentinels/ and point result_dir there."""
-    from autoskillit.planner import expand_assignments
-
-    refined = {
-        "phases": [
-            {
-                "id": "P1",
-                "name": "Phase 1",
-                "assignments_preview": [{"id": "P1-A1", "name": "Assignment 1"}],
-            }
-        ],
-        "task": "test task",
-    }
-    refined_path = tmp_path / "refined_plan.json"
-    refined_path.write_text(json.dumps(refined))
-
-    result = expand_assignments(str(refined_path), str(tmp_path))
-
-    manifest = json.loads(Path(result["manifest_path"]).read_text())
-    assert manifest["result_dir"].endswith("assign_sentinels")
-    assert (tmp_path / "assignments" / "assign_sentinels").is_dir()
 
 
 def test_build_phase_assignment_manifest_result_dir_isolated(tmp_path):

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -868,66 +868,62 @@ def test_finalize_wp_manifest_upper_bound_violation_warns_not_fails(tmp_path: Pa
     assert "manifest_path" in result
 
 
-# ---------------------------------------------------------------------------
-# Sentinel isolation tests
-# ---------------------------------------------------------------------------
+def test_expand_assignments_result_dir_points_to_sentinel_subdir(tmp_path):
+    """expand_assignments result_dir MUST point to assign_sentinels/ subdirectory."""
+    from autoskillit.planner import expand_assignments
 
-
-@pytest.mark.parametrize(
-    "expand_fn,sentinel_subdir",
-    [
-        ("expand_assignments", "assign_sentinels"),
-        ("expand_wps", "wp_sentinels"),
-    ],
-)
-def test_all_tiers_result_dir_points_to_sentinel_subdir(expand_fn, sentinel_subdir, tmp_path):
-    """Every tier's manifest result_dir MUST point to an isolated sentinel subdirectory."""
-    from autoskillit.planner import expand_assignments, expand_wps
-
-    if expand_fn == "expand_assignments":
-        refined = {
-            "phases": [
-                {
-                    "id": "P1",
-                    "name": "Phase 1",
-                    "assignments_preview": [
-                        {"id": "P1-A1", "name": "Assignment 1"},
-                    ],
-                }
-            ],
-            "task": "test task",
-        }
-        refined_path = tmp_path / "refined_plan.json"
-        refined_path.write_text(json.dumps(refined))
-        result = expand_assignments(str(refined_path), str(tmp_path))
-    else:
-        refined = {
-            "assignments": [
-                {
-                    "id": "P1-A1",
-                    "name": "Assignment 1",
-                    "phase_id": "P1",
-                    "phase_name": "Phase 1",
-                    "goal": "test",
-                    "technical_approach": "test",
-                    "proposed_work_packages": [
-                        {
-                            "id_suffix": "WP1",
-                            "name": "WP 1",
-                            "scope": "core",
-                            "estimated_files": ["f.py"],
-                        }
-                    ],
-                }
-            ],
-            "task": "test task",
-        }
-        refined_path = tmp_path / "refined_assignments.json"
-        refined_path.write_text(json.dumps(refined))
-        result = expand_wps(str(refined_path), str(tmp_path))
+    refined = {
+        "phases": [
+            {
+                "id": "P1",
+                "name": "Phase 1",
+                "assignments_preview": [
+                    {"id": "P1-A1", "name": "Assignment 1"},
+                ],
+            }
+        ],
+        "task": "test task",
+    }
+    refined_path = tmp_path / "refined_plan.json"
+    refined_path.write_text(json.dumps(refined))
+    result = expand_assignments(str(refined_path), str(tmp_path))
 
     manifest = json.loads(Path(result["manifest_path"]).read_text())
-    assert Path(manifest["result_dir"]).name == sentinel_subdir
+    assert Path(manifest["result_dir"]).name == "assign_sentinels"
+    assert Path(manifest["result_dir"]).is_dir()
+
+
+def test_expand_wps_result_dir_points_to_sentinel_subdir(tmp_path):
+    """expand_wps result_dir MUST point to wp_sentinels/ subdirectory."""
+    from autoskillit.planner import expand_wps
+
+    refined = {
+        "assignments": [
+            {
+                "id": "P1-A1",
+                "name": "Assignment 1",
+                "phase_id": "P1",
+                "phase_name": "Phase 1",
+                "goal": "test",
+                "technical_approach": "test",
+                "proposed_work_packages": [
+                    {
+                        "id_suffix": "WP1",
+                        "name": "WP 1",
+                        "scope": "core",
+                        "estimated_files": ["f.py"],
+                    }
+                ],
+            }
+        ],
+        "task": "test task",
+    }
+    refined_path = tmp_path / "refined_assignments.json"
+    refined_path.write_text(json.dumps(refined))
+    result = expand_wps(str(refined_path), str(tmp_path))
+
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert Path(manifest["result_dir"]).name == "wp_sentinels"
     assert Path(manifest["result_dir"]).is_dir()
 
 
@@ -947,5 +943,5 @@ def test_build_phase_assignment_manifest_result_dir_isolated(tmp_path):
     result = build_phase_assignment_manifest(str(phases_dir), str(output_dir))
 
     manifest = json.loads(Path(result["manifest_path"]).read_text())
-    assert manifest["result_dir"].endswith("assign_sentinels")
+    assert Path(manifest["result_dir"]).name == "assign_sentinels"
     assert (output_dir / "assign_sentinels").is_dir()

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -866,3 +866,114 @@ def test_finalize_wp_manifest_upper_bound_violation_warns_not_fails(tmp_path: Pa
         result = finalize_wp_manifest(str(wp_dir), str(tmp_path))
 
     assert "manifest_path" in result
+
+
+# ---------------------------------------------------------------------------
+# Sentinel isolation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "expand_fn,sentinel_subdir",
+    [
+        ("expand_assignments", "assign_sentinels"),
+        ("expand_wps", "wp_sentinels"),
+    ],
+)
+def test_all_tiers_result_dir_points_to_sentinel_subdir(expand_fn, sentinel_subdir, tmp_path):
+    """Every tier's manifest result_dir MUST point to an isolated sentinel subdirectory."""
+    from autoskillit.planner import expand_assignments, expand_wps
+
+    if expand_fn == "expand_assignments":
+        refined = {
+            "phases": [
+                {
+                    "id": "P1",
+                    "name": "Phase 1",
+                    "assignments_preview": [
+                        {"id": "P1-A1", "name": "Assignment 1"},
+                    ],
+                }
+            ],
+            "task": "test task",
+        }
+        refined_path = tmp_path / "refined_plan.json"
+        refined_path.write_text(json.dumps(refined))
+        result = expand_assignments(str(refined_path), str(tmp_path))
+    else:
+        refined = {
+            "assignments": [
+                {
+                    "id": "P1-A1",
+                    "name": "Assignment 1",
+                    "phase_id": "P1",
+                    "phase_name": "Phase 1",
+                    "goal": "test",
+                    "technical_approach": "test",
+                    "proposed_work_packages": [
+                        {
+                            "id_suffix": "WP1",
+                            "name": "WP 1",
+                            "scope": "core",
+                            "estimated_files": ["f.py"],
+                        }
+                    ],
+                }
+            ],
+            "task": "test task",
+        }
+        refined_path = tmp_path / "refined_assignments.json"
+        refined_path.write_text(json.dumps(refined))
+        result = expand_wps(str(refined_path), str(tmp_path))
+
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert manifest["result_dir"].endswith(sentinel_subdir), (
+        f"{expand_fn} result_dir was {manifest['result_dir']}, "
+        f"expected to end with {sentinel_subdir}"
+    )
+    assert Path(manifest["result_dir"]).name == sentinel_subdir
+    assert Path(manifest["result_dir"]).is_dir()
+
+
+def test_expand_assignments_result_dir_points_to_assign_sentinels(tmp_path):
+    """expand_assignments must create assign_sentinels/ and point result_dir there."""
+    from autoskillit.planner import expand_assignments
+
+    refined = {
+        "phases": [
+            {
+                "id": "P1",
+                "name": "Phase 1",
+                "assignments_preview": [{"id": "P1-A1", "name": "Assignment 1"}],
+            }
+        ],
+        "task": "test task",
+    }
+    refined_path = tmp_path / "refined_plan.json"
+    refined_path.write_text(json.dumps(refined))
+
+    result = expand_assignments(str(refined_path), str(tmp_path))
+
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert manifest["result_dir"].endswith("assign_sentinels")
+    assert (tmp_path / "assignments" / "assign_sentinels").is_dir()
+
+
+def test_build_phase_assignment_manifest_result_dir_isolated(tmp_path):
+    """build_phase_assignment_manifest must also use assign_sentinels/ subdir."""
+    from autoskillit.planner import build_phase_assignment_manifest
+
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    output_dir = tmp_path / "assignments"
+    output_dir.mkdir()
+
+    (phases_dir / "P1_result.json").write_text(
+        json.dumps(make_phase_result(1, assignments_preview=["Task A"]))
+    )
+
+    result = build_phase_assignment_manifest(str(phases_dir), str(output_dir))
+
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert manifest["result_dir"].endswith("assign_sentinels")
+    assert (output_dir / "assign_sentinels").is_dir()

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -13,7 +13,12 @@ from autoskillit.planner.merge import (
     merge_tier_results,
     replace_item,
 )
-from tests.planner.conftest import make_phase_result, write_json, write_task_file
+from tests.planner.conftest import (
+    make_assignment_result,
+    make_phase_result,
+    write_json,
+    write_task_file,
+)
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -1001,3 +1006,33 @@ def test_write_refine_contexts_detects_missing_expected_phases(tmp_path: Path) -
             task_file_path="",
             expected_phase_ids=expected_phase_ids,
         )
+
+
+def test_merge_assignments_succeeds_with_sentinels_present(tmp_path):
+    """merge_tier_results must succeed when sentinels exist in their isolated subdir."""
+    results_dir = tmp_path / "assignments"
+    results_dir.mkdir()
+
+    write_json(
+        results_dir / "P1-A1_result.json",
+        make_assignment_result(1, 1),
+    )
+    write_json(
+        results_dir / "P1-A2_result.json",
+        make_assignment_result(1, 2),
+    )
+    sentinel_dir = results_dir / "assign_sentinels"
+    sentinel_dir.mkdir()
+    write_json(
+        sentinel_dir / "P1_result.json",
+        {"id": "P1", "status": "complete", "assignment_count": 2, "failed_count": 0},
+    )
+
+    out = tmp_path / "combined.json"
+    result = merge_tier_results(str(results_dir), str(out), "assignments")
+
+    assert result["merged_path"] == str(out)
+    data = json.loads(out.read_text())
+    assert len(data["assignments"]) == 2
+    ids = {a["id"] for a in data["assignments"]}
+    assert ids == {"P1-A1", "P1-A2"}

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -541,6 +541,29 @@ def test_validate_plan_warns_on_phase_sentinel_in_assignments_dir(tmp_path: Path
     )
 
 
+@pytest.mark.parametrize(
+    "bad_dep,reason",
+    [
+        ("P1-A1", "assignment-level ID in WP depends_on"),
+        ("P1", "phase-level ID in WP depends_on"),
+        ("WP1", "bare WP ID without phase/assignment prefix"),
+    ],
+)
+def test_check_dep_id_format_rejects_malformed(bad_dep, reason, tmp_path: Path) -> None:
+    """depends_on entries must match WP ID format (P\\d+-A\\d+-WP\\d+)."""
+    from autoskillit.planner.validation import _check_dep_id_format
+
+    wp_results = {
+        "P1-A1-WP1": {"id": "P1-A1-WP1", "depends_on": [bad_dep]},
+        "P1-A1-WP2": {"id": "P1-A1-WP2", "depends_on": []},
+    }
+    findings = _check_dep_id_format(wp_results)
+    assert any(f["severity"] == "error" for f in findings), (
+        f"Expected error for malformed dep {bad_dep!r}: {reason}"
+    )
+    assert any(bad_dep in f["message"] for f in findings if f["severity"] == "error")
+
+
 def test_validate_plan_warns_on_non_wp_result_file_in_work_packages_dir(tmp_path: Path) -> None:
     """Non-WP result files in work_packages/ emit a file_discovery_miss warning."""
     _make_minimal_output_dir(tmp_path)

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -558,10 +558,9 @@ def test_check_dep_id_format_rejects_malformed(bad_dep, reason, tmp_path: Path) 
         "P1-A1-WP2": {"id": "P1-A1-WP2", "depends_on": []},
     }
     findings = _check_dep_id_format(wp_results)
-    assert any(f["severity"] == "error" for f in findings), (
+    assert any(f["severity"] == "error" and bad_dep in f["message"] for f in findings), (
         f"Expected error for malformed dep {bad_dep!r}: {reason}"
     )
-    assert any(bad_dep in f["message"] for f in findings if f["severity"] == "error")
 
 
 def test_validate_plan_warns_on_non_wp_result_file_in_work_packages_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The planner pipeline has an architectural asymmetry: the WP tier isolates phase-completion sentinel files in a `wp_sentinels/` subdirectory, but the assignment tier dumps sentinels directly into the flat `assignments/` directory. When `merge_tier_results` scans that directory with a strict regex, it raises `ValueError` on the non-matching sentinel files. The broader weakness is that **no structural contract enforces sentinel isolation across tiers**, leaving each tier's manifest builder free to omit isolation without any test or guard catching the omission. A secondary weakness: `depends_on` arrays in WP results are never format-validated, allowing assignment-level IDs to propagate silently through the pipeline.

## Requirements

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260516-230521-618347/.autoskillit/temp/rectify/rectify_planner_sentinel_isolation_2026-05-16_230521.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 66 | 9.6k | 0 | 87.6k | 153 | 0 | 5m 40s |
| dry_walkthrough | claude-opus-4-6 | 1 | 43 | 9.7k | 0 | 58.3k | 87 | 0 | 4m 7s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.5M | 17.4k | 0 | 34.4k | 162 | 0 | 7m 55s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 99.3k | 2.6k | 0 | 28.9k | 19 | 0 | 57s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 59.4k | 1.5k | 0 | 28.9k | 16 | 0 | 37s |
| review_pr | claude-sonnet-4-6 | 3 | 513 | 106.3k | 0 | 95.6k | 149 | 0 | 20m 6s |
| resolve_review | claude-sonnet-4-6 | 3 | 769 | 42.8k | 0 | 70.5k | 218 | 0 | 16m 42s |
| **Total** | | | 2.6M | 189.8k | 0 | 95.6k | | 0 | 56m 5s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 214 | 0.0 | 0.0 | 81.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 150 | 0.0 | 0.0 | 285.2 |
| **Total** | **364** | 0.0 | 0.0 | 521.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 190 | 18.3k | 0 | 0 | 17m 47s |
| claude-opus-4-6 | 1 | 78 | 19.0k | 0 | 0 | 11m 34s |
| MiniMax-M2.7-highspeed | 1 | 13.6M | 81.7k | 0 | 0 | 37m 31s |