### PR TITLE
[P2-A7-WP1] Add schema_version and caller_session_id to sessions.jsonl (#2473)

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -423,3 +423,5 @@ class SessionIndexEntry(TypedDict):
     github_api_requests: int
     provider_used: str
     provider_fallback: bool
+    caller_session_id: str
+    schema_version: int

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -468,6 +468,7 @@ def flush_session_log(
         "provider_used": provider_outcome.provider_used,
         "provider_fallback": provider_outcome.fallback_activated,
         "caller_session_id": caller_session_id,
+        "schema_version": 2,
     }
     index_path = log_root / "sessions.jsonl"
     with index_path.open("a") as f:

--- a/src/autoskillit/recipes/contracts/implementation-groups.json
+++ b/src/autoskillit/recipes/contracts/implementation-groups.json
@@ -558,7 +558,7 @@
         }
       ],
       "expected_output_patterns": [
-        "diagnosis_path\\s*=",
+        "diagnosis_path\\s*=\\s*(?:/.+)?",
         "failure_subtype\\s*=\\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
       ],
       "pattern_examples": [

--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -389,7 +389,7 @@ skills:
     - name: is_fixable
       type: string
     expected_output_patterns:
-    - diagnosis_path\s*=
+    - diagnosis_path\s*=\s*(?:/.+)?
     - failure_subtype\s*=\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)
     pattern_examples:
     - 'diagnosis_path = /tmp/diagnosis.md

--- a/src/autoskillit/recipes/contracts/implementation.json
+++ b/src/autoskillit/recipes/contracts/implementation.json
@@ -527,7 +527,7 @@
         }
       ],
       "expected_output_patterns": [
-        "diagnosis_path\\s*=",
+        "diagnosis_path\\s*=\\s*(?:/.+)?",
         "failure_subtype\\s*=\\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
       ],
       "pattern_examples": [

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -369,7 +369,7 @@ skills:
     - name: is_fixable
       type: string
     expected_output_patterns:
-    - diagnosis_path\s*=
+    - diagnosis_path\s*=\s*(?:/.+)?
     - failure_subtype\s*=\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)
     pattern_examples:
     - 'diagnosis_path = /tmp/diagnosis.md

--- a/src/autoskillit/recipes/contracts/merge-prs.json
+++ b/src/autoskillit/recipes/contracts/merge-prs.json
@@ -149,7 +149,7 @@
         }
       ],
       "expected_output_patterns": [
-        "diagnosis_path\\s*=",
+        "diagnosis_path\\s*=\\s*(?:/.+)?",
         "failure_subtype\\s*=\\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
       ],
       "pattern_examples": [

--- a/src/autoskillit/recipes/contracts/merge-prs.yaml
+++ b/src/autoskillit/recipes/contracts/merge-prs.yaml
@@ -91,7 +91,7 @@ skills:
     - name: is_fixable
       type: string
     expected_output_patterns:
-    - diagnosis_path\s*=
+    - diagnosis_path\s*=\s*(?:/.+)?
     - failure_subtype\s*=\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)
     pattern_examples:
     - 'diagnosis_path = /tmp/diagnosis.md

--- a/src/autoskillit/recipes/contracts/remediation.json
+++ b/src/autoskillit/recipes/contracts/remediation.json
@@ -577,7 +577,7 @@
         }
       ],
       "expected_output_patterns": [
-        "diagnosis_path\\s*=",
+        "diagnosis_path\\s*=\\s*(?:/.+)?",
         "failure_subtype\\s*=\\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
       ],
       "pattern_examples": [

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -403,7 +403,7 @@ skills:
     - name: is_fixable
       type: string
     expected_output_patterns:
-    - diagnosis_path\s*=
+    - diagnosis_path\s*=\s*(?:/.+)?
     - failure_subtype\s*=\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)
     pattern_examples:
     - 'diagnosis_path = /tmp/diagnosis.md

--- a/tests/core/test_session_index_schema.py
+++ b/tests/core/test_session_index_schema.py
@@ -13,6 +13,8 @@ _REQUIRED_INDEX_FIELDS = {
     "recipe_content_hash",
     "recipe_composite_hash",
     "recipe_version",
+    "schema_version",
+    "caller_session_id",
 }
 
 
@@ -25,6 +27,24 @@ class TestSessionIndexEntryCompleteness:
         declared = set(SessionIndexEntry.__annotations__)
         missing = _REQUIRED_INDEX_FIELDS - declared
         assert not missing, f"SessionIndexEntry missing fields: {missing}"
+
+    def test_has_schema_version(self):
+        from typing import get_type_hints
+
+        from autoskillit.core.types._type_results import SessionIndexEntry
+
+        hints = get_type_hints(SessionIndexEntry)
+        assert "schema_version" in hints
+        assert hints["schema_version"] is int
+
+    def test_has_caller_session_id(self):
+        from typing import get_type_hints
+
+        from autoskillit.core.types._type_results import SessionIndexEntry
+
+        hints = get_type_hints(SessionIndexEntry)
+        assert "caller_session_id" in hints
+        assert hints["caller_session_id"] is str
 
     def test_canonical_cache_fields(self):
         """SessionIndexEntry must use canonical cache field names, not v1 API names."""

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -804,6 +804,20 @@ def test_parallel_lists_aligned_when_timestamp_missing(tmp_path, monkeypatch):
     assert summary["turn_tool_calls"] == [["Read"], ["Edit"]]
 
 
+def test_flush_index_includes_caller_session_id(tmp_path):
+    """sessions.jsonl index entry includes caller_session_id when provided."""
+    _flush(tmp_path, session_id="caller-test", caller_session_id="parent-abc")
+    entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])
+    assert entry["caller_session_id"] == "parent-abc"
+
+
+def test_flush_index_caller_session_id_defaults_to_empty(tmp_path):
+    """caller_session_id defaults to empty string in sessions.jsonl index entry."""
+    _flush(tmp_path, session_id="caller-default")
+    entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])
+    assert entry["caller_session_id"] == ""
+
+
 def test_flush_session_log_provider_used_defaults_to_empty_string(tmp_path):
     _flush(tmp_path, session_id="prov-def-001", proc_snapshots=None)
     entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -536,6 +536,14 @@ def test_flush_index_includes_step_name_and_token_fields(tmp_path):
     assert entry["cache_read_input_tokens"] == 80
 
 
+def test_flush_index_includes_schema_version_2(tmp_path):
+    """sessions.jsonl entry must contain schema_version: 2."""
+    _flush(tmp_path)
+    index_path = tmp_path / "sessions.jsonl"
+    entry = json.loads(index_path.read_text().strip().split("\n")[-1])
+    assert entry["schema_version"] == 2
+
+
 def test_flush_index_token_fields_zero_when_no_step(tmp_path):
     """sessions.jsonl entry has step_name='' and token fields=0 when no step telemetry."""
     _flush(tmp_path, proc_snapshots=None, success=False)  # no step_name


### PR DESCRIPTION
Closes #2473

Adds schema_version (int, value 2) and caller_session_id (str) fields to SessionIndexEntry TypedDict and the flush_session_log writer. Includes 5 new tests covering field presence, type assertions, and default behavior.