### PR TITLE
Add _V1_TOKEN_FIELD_ALIASES and bridge contract tests

### DIFF
--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -43,6 +43,9 @@ QUOTA_GUARD_HOOK_PAYLOAD_KEYS: frozenset[str] = frozenset(
 # The exact keys that appear in token_usage.json files written by flush_session_log.
 # The bridge contract test asserts equality between this set and TokenUsageFileEntry
 # annotations — update both together.
+#
+# v1 field aliases (Anthropic API names) are mapped in _V1_TOKEN_FIELD_ALIASES below.
+# Read-side consumers use the alias map for backward-compatible dual-key fallback.
 TOKEN_USAGE_FILE_KEYS: frozenset[str] = frozenset(
     {
         "session_label",
@@ -63,6 +66,14 @@ TOKEN_USAGE_FILE_KEYS: frozenset[str] = frozenset(
         "schema_version",
     }
 )
+
+# Mapping from v1 on-disk field names (Anthropic API names, schema_version < 2)
+# to their canonical v2 equivalents. Read-side consumers use this for dual-key
+# fallback when reading older token_usage.json files.
+_V1_TOKEN_FIELD_ALIASES: dict[str, str] = {
+    "cache_creation_input_tokens": "cache_write_tokens",
+    "cache_read_input_tokens": "cache_read_tokens",
+}
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/contracts/test_token_summary_contracts.py
+++ b/tests/contracts/test_token_summary_contracts.py
@@ -143,6 +143,51 @@ def test_flush_to_hook_cross_seam(tmp_path):
     assert entry["output_tokens"] == 200
 
 
+# ── Step 1d-alias: Bridge contract: _V1_TOKEN_FIELD_ALIASES structural correctness ──
+
+
+def test_v1_alias_map_structural_correctness():
+    """Bridge contract: _V1_TOKEN_FIELD_ALIASES must map exactly 2 old names to canonical names.
+
+    Structural invariants:
+    - Exactly 2 entries (one per renamed cache field).
+    - Every value is a canonical name in TOKEN_USAGE_FILE_KEYS.
+    - No key appears in TOKEN_USAGE_FILE_KEYS (old names are excluded).
+    """
+    from autoskillit.hooks._hook_settings import (
+        _V1_TOKEN_FIELD_ALIASES,
+        TOKEN_USAGE_FILE_KEYS,
+    )
+
+    assert len(_V1_TOKEN_FIELD_ALIASES) == 2, (
+        f"Expected exactly 2 alias entries, got {len(_V1_TOKEN_FIELD_ALIASES)}"
+    )
+    for old_name, canonical_name in _V1_TOKEN_FIELD_ALIASES.items():
+        assert isinstance(old_name, str) and old_name, (
+            f"Alias key must be non-empty str: {old_name!r}"
+        )
+        assert isinstance(canonical_name, str) and canonical_name, (
+            f"Alias value must be non-empty str: {canonical_name!r}"
+        )
+        assert canonical_name in TOKEN_USAGE_FILE_KEYS, (
+            f"Alias value {canonical_name!r} not in TOKEN_USAGE_FILE_KEYS"
+        )
+        assert old_name not in TOKEN_USAGE_FILE_KEYS, (
+            f"Alias key {old_name!r} must not be in TOKEN_USAGE_FILE_KEYS "
+            "(old name leaked into canonical set)"
+        )
+
+
+def test_v1_alias_map_covers_known_legacy_keys():
+    """Content-pinning: alias map must contain the exact known v1 -> v2 mappings."""
+    from autoskillit.hooks._hook_settings import _V1_TOKEN_FIELD_ALIASES
+
+    assert _V1_TOKEN_FIELD_ALIASES == {
+        "cache_creation_input_tokens": "cache_write_tokens",
+        "cache_read_input_tokens": "cache_read_tokens",
+    }
+
+
 # ── Step 1d: patch_pr_token_summary accepts timeout ──
 
 

--- a/tests/contracts/test_token_summary_contracts.py
+++ b/tests/contracts/test_token_summary_contracts.py
@@ -147,10 +147,9 @@ def test_flush_to_hook_cross_seam(tmp_path):
 
 
 def test_v1_alias_map_structural_correctness():
-    """Bridge contract: _V1_TOKEN_FIELD_ALIASES must map exactly 2 old names to canonical names.
+    """Bridge contract: _V1_TOKEN_FIELD_ALIASES maps old names to canonical names.
 
     Structural invariants:
-    - Exactly 2 entries (one per renamed cache field).
     - Every value is a canonical name in TOKEN_USAGE_FILE_KEYS.
     - No key appears in TOKEN_USAGE_FILE_KEYS (old names are excluded).
     """
@@ -159,9 +158,6 @@ def test_v1_alias_map_structural_correctness():
         TOKEN_USAGE_FILE_KEYS,
     )
 
-    assert len(_V1_TOKEN_FIELD_ALIASES) == 2, (
-        f"Expected exactly 2 alias entries, got {len(_V1_TOKEN_FIELD_ALIASES)}"
-    )
     for old_name, canonical_name in _V1_TOKEN_FIELD_ALIASES.items():
         assert isinstance(old_name, str) and old_name, (
             f"Alias key must be non-empty str: {old_name!r}"


### PR DESCRIPTION
## Summary

Add a `_V1_TOKEN_FIELD_ALIASES` dict to `src/autoskillit/hooks/_hook_settings.py` that maps the two legacy Anthropic API field names to their canonical v2 equivalents. Update the comment block above `TOKEN_USAGE_FILE_KEYS` to document the alias map. Add a bridge contract test that structurally enforces the alias map's correctness. The frozenset itself and the cross-seam fixture already use canonical names (completed by prior P2 assignments), so no key renames are needed in either.

Closes #2456

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260517-144156-931518/.autoskillit/temp/make-plan/p2-a12-wp1-rename-token-usage-file-keys_plan_2026-05-17_144500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 66 | 11.2k | 1.0M | 96.9k | 119 | 52.2k | 8m 6s |
| verify | claude-sonnet-4-6 | 1 | 36 | 7.1k | 351.5k | 54.4k | 74 | 39.9k | 4m 9s |
| implement* | MiniMax-M2.7-highspeed | 1 | 461.1k | 6.0k | 835.5k | 29.9k | 64 | 32.5k | 5m 48s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 124.4k | 2.8k | 356.5k | 29.9k | 24 | 15.5k | 1m 18s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 38.3k | 1.3k | 176.8k | 29.9k | 13 | 15.3k | 40s |
| review_pr | claude-sonnet-4-6 | 3 | 366 | 36.1k | 1.1M | 50.4k | 95 | 108.5k | 10m 51s |
| resolve_review | claude-sonnet-4-6 | 1 | 157 | 8.0k | 801.4k | 53.9k | 44 | 39.9k | 3m 40s |
| **Total** | | | 624.3k | 72.5k | 4.7M | 96.9k | | 303.7k | 34m 33s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 56 | 14919.3 | 580.6 | 107.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 133570.3 | 6650.8 | 1329.5 |
| **Total** | **62** | 75027.5 | 4899.0 | 1169.2 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 945 | 88.5k | 8.8M | 246.8k | 39m 45s |
| claude-opus-4-6 | 2 | 1.1k | 98.8k | 7.9M | 462.7k | 57m 59s |
| MiniMax-M2.7-highspeed | 4 | 2.8M | 43.0k | 5.7M | 337.4k | 31m 0s |