### PR TITLE
Update _merge_token_usage() to canonical field names with old-name fallback

### DIFF
--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -324,33 +324,14 @@ def _merge_token_usage(
         return base
     merged = dict(base)
     for canonical, legacy in _CANONICAL_TO_LEGACY.items():
-        in_base = canonical in base or (legacy is not None and legacy in base)
-        in_nudge = canonical in nudge or (legacy is not None and legacy in nudge)
-        if not in_base and not in_nudge:
+        b = base.get(canonical) if canonical in base else base.get(legacy) if legacy else None
+        n = nudge.get(canonical) if canonical in nudge else nudge.get(legacy) if legacy else None
+        if b is None and n is None:
             continue
-        if legacy is not None:
-            if canonical in base and legacy in base:
-                logger.debug(
-                    "Both canonical %r and legacy %r present in base; using canonical value",
-                    canonical,
-                    legacy,
-                )
-            if canonical in nudge and legacy in nudge:
-                logger.debug(
-                    "Both canonical %r and legacy %r present in nudge; using canonical value",
-                    canonical,
-                    legacy,
-                )
-        base_val = base.get(canonical) if canonical in base else base.get(legacy) if legacy else 0
-        nudge_val = (
-            nudge.get(canonical) if canonical in nudge else nudge.get(legacy) if legacy else 0
-        )
-        if base_val is None:
-            base_val = 0
-        if nudge_val is None:
-            nudge_val = 0
-        if isinstance(base_val, (int, float)) and isinstance(nudge_val, (int, float)):
-            merged[canonical] = base_val + nudge_val
+        bv = b if b is not None else 0
+        nv = n if n is not None else 0
+        if isinstance(bv, (int, float)) and isinstance(nv, (int, float)):
+            merged[canonical] = bv + nv
     for legacy in _CANONICAL_TO_LEGACY.values():
         if legacy and legacy in merged:
             del merged[legacy]

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -24,14 +24,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Subtypes eligible for Channel B drain-race recovery.
-#
-# These are the failure subtypes that can arise when Claude Code defers ``type=result``
-# until all background agents finish.  The deferred record is never flushed if the
-# process tree is killed after Channel B fires on the session JSONL marker.
-#
-# TIMEOUT is excluded — it indicates a genuine time limit breach, not a drain-race.
-# UNKNOWN is excluded — it indicates unrecognised CLI behaviour, not a missing record.
+# Drain-race recovery subtypes: TIMEOUT (genuine time limit) and UNKNOWN (unrecognised CLI) excluded.
 _CHANNEL_B_RECOVERABLE_SUBTYPES: frozenset[CliSubtype] = frozenset(
     {CliSubtype.UNPARSEABLE, CliSubtype.EMPTY_OUTPUT}
 )

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -40,6 +40,13 @@ _TOKEN_NAME_RE: re.Pattern[str] = re.compile(r"^(\w+)")
 
 _NUDGE_TIMEOUT: float = 60.0
 
+_CANONICAL_TO_LEGACY: dict[str, str | None] = {
+    "input_tokens": None,
+    "output_tokens": None,
+    "cache_write_tokens": "cache_creation_input_tokens",
+    "cache_read_tokens": "cache_read_input_tokens",
+}
+
 
 def _is_path_capture_pattern(pattern: str) -> str | None:
     """Return the token name if pattern is a path-capture pattern, else None.
@@ -323,14 +330,18 @@ def _merge_token_usage(
     if nudge is None:
         return base
     merged = dict(base)
-    for key in (
-        "input_tokens",
-        "output_tokens",
-        "cache_creation_input_tokens",
-        "cache_read_input_tokens",
-    ):
-        base_val = base.get(key, 0)
-        nudge_val = nudge.get(key, 0)
+    for canonical, legacy in _CANONICAL_TO_LEGACY.items():
+        base_val = base.get(canonical) if canonical in base else base.get(legacy) if legacy else 0
+        nudge_val = (
+            nudge.get(canonical) if canonical in nudge else nudge.get(legacy) if legacy else 0
+        )
+        if base_val is None:
+            base_val = 0
+        if nudge_val is None:
+            nudge_val = 0
         if isinstance(base_val, (int, float)) and isinstance(nudge_val, (int, float)):
-            merged[key] = base_val + nudge_val
+            merged[canonical] = base_val + nudge_val
+    for legacy in _CANONICAL_TO_LEGACY.values():
+        if legacy and legacy in merged:
+            del merged[legacy]
     return merged

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Drain-race recovery subtypes: TIMEOUT (genuine time limit) and UNKNOWN (unrecognised CLI) excluded.
+# Drain-race recovery subtypes: TIMEOUT and UNKNOWN excluded (time-limit breach; unrecognised CLI).
 _CHANNEL_B_RECOVERABLE_SUBTYPES: frozenset[CliSubtype] = frozenset(
     {CliSubtype.UNPARSEABLE, CliSubtype.EMPTY_OUTPUT}
 )
@@ -324,6 +324,23 @@ def _merge_token_usage(
         return base
     merged = dict(base)
     for canonical, legacy in _CANONICAL_TO_LEGACY.items():
+        in_base = canonical in base or (legacy is not None and legacy in base)
+        in_nudge = canonical in nudge or (legacy is not None and legacy in nudge)
+        if not in_base and not in_nudge:
+            continue
+        if legacy is not None:
+            if canonical in base and legacy in base:
+                logger.debug(
+                    "Both canonical %r and legacy %r present in base; using canonical value",
+                    canonical,
+                    legacy,
+                )
+            if canonical in nudge and legacy in nudge:
+                logger.debug(
+                    "Both canonical %r and legacy %r present in nudge; using canonical value",
+                    canonical,
+                    legacy,
+                )
         base_val = base.get(canonical) if canonical in base else base.get(legacy) if legacy else 0
         nudge_val = (
             nudge.get(canonical) if canonical in nudge else nudge.get(legacy) if legacy else 0

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -47,6 +47,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_merge_queue_ejection.py` | Tests for merge queue ejection: RelatedCoverage, EjectionEnrichment, FetchRepoMergeStateRetry |
 | `test_merge_queue_group_ci.py` | Unit tests for `_query_merge_group_ci` — regression guard for `conclusion` vs `state` field usage |
 | `test_merge_queue_polling.py` | Tests for DefaultMergeQueueWatcher polling state machine |
+| `test_merge_token_usage.py` | Tests for _merge_token_usage canonical field name migration |
 | `test_normalize_subtype.py` | Unit tests for ClaudeSessionResult.normalize_subtype() normalization gate |
 | `test_on_spawn_timing.py` | Tests for on_pid_resolved callback timing in run_managed_async (Group J) |
 | `test_output_format_contract.py` | Contract tests binding output format to data availability |

--- a/tests/execution/test_merge_token_usage.py
+++ b/tests/execution/test_merge_token_usage.py
@@ -1,0 +1,115 @@
+import pytest
+
+from autoskillit.execution.headless import _merge_token_usage
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestMergeTokenUsageCanonical:
+    """Tests for _merge_token_usage canonical field name migration."""
+
+    def test_canonical_inputs_produce_canonical_outputs(self):
+        """Both dicts use canonical names → output uses canonical names."""
+        base = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": 10,
+            "cache_read_tokens": 20,
+        }
+        nudge = {
+            "input_tokens": 200,
+            "output_tokens": 100,
+            "cache_write_tokens": 5,
+            "cache_read_tokens": 30,
+        }
+        result = _merge_token_usage(base, nudge)
+        assert result["input_tokens"] == 300
+        assert result["output_tokens"] == 150
+        assert result["cache_write_tokens"] == 15
+        assert result["cache_read_tokens"] == 50
+
+    def test_legacy_inputs_produce_canonical_outputs(self):
+        """Both dicts use legacy names → output uses canonical names."""
+        base = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 20,
+        }
+        nudge = {
+            "input_tokens": 200,
+            "output_tokens": 100,
+            "cache_creation_input_tokens": 5,
+            "cache_read_input_tokens": 30,
+        }
+        result = _merge_token_usage(base, nudge)
+        assert result["cache_write_tokens"] == 15
+        assert result["cache_read_tokens"] == 50
+        assert "cache_creation_input_tokens" not in result
+        assert "cache_read_input_tokens" not in result
+
+    def test_mixed_inputs_canonical_base_legacy_nudge(self):
+        """Base uses canonical, nudge uses legacy → output uses canonical names."""
+        base = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": 10,
+            "cache_read_tokens": 20,
+        }
+        nudge = {
+            "input_tokens": 200,
+            "output_tokens": 100,
+            "cache_creation_input_tokens": 5,
+            "cache_read_input_tokens": 30,
+        }
+        result = _merge_token_usage(base, nudge)
+        assert result["cache_write_tokens"] == 15
+        assert result["cache_read_tokens"] == 50
+
+    def test_mixed_inputs_legacy_base_canonical_nudge(self):
+        """Base uses legacy, nudge uses canonical → output uses canonical names."""
+        base = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 20,
+        }
+        nudge = {
+            "input_tokens": 200,
+            "output_tokens": 100,
+            "cache_write_tokens": 5,
+            "cache_read_tokens": 30,
+        }
+        result = _merge_token_usage(base, nudge)
+        assert result["cache_write_tokens"] == 15
+        assert result["cache_read_tokens"] == 50
+
+    def test_none_base_returns_nudge(self):
+        """None base → return nudge unchanged."""
+        nudge = {"input_tokens": 200, "output_tokens": 100}
+        assert _merge_token_usage(None, nudge) is nudge
+
+    def test_none_nudge_returns_base(self):
+        """None nudge → return base unchanged."""
+        base = {"input_tokens": 100, "output_tokens": 50}
+        assert _merge_token_usage(base, None) is base
+
+    def test_both_none_returns_none(self):
+        """Both None → return None."""
+        assert _merge_token_usage(None, None) is None
+
+    def test_non_numeric_values_skipped(self):
+        """Non-numeric values for token fields are not summed."""
+        base = {"input_tokens": "not_a_number", "output_tokens": 50, "cache_write_tokens": 10}
+        nudge = {"input_tokens": 200, "output_tokens": 100, "cache_write_tokens": 5}
+        result = _merge_token_usage(base, nudge)
+        assert result.get("input_tokens") == "not_a_number"
+        assert result["output_tokens"] == 150
+        assert result["cache_write_tokens"] == 15
+
+    def test_extra_keys_preserved_from_base(self):
+        """Extra keys in base dict are preserved in output."""
+        base = {"input_tokens": 100, "output_tokens": 50, "provider": "anthropic"}
+        nudge = {"input_tokens": 200, "output_tokens": 100}
+        result = _merge_token_usage(base, nudge)
+        assert result["provider"] == "anthropic"

--- a/tests/execution/test_merge_token_usage.py
+++ b/tests/execution/test_merge_token_usage.py
@@ -43,6 +43,8 @@ class TestMergeTokenUsageCanonical:
             "cache_read_input_tokens": 30,
         }
         result = _merge_token_usage(base, nudge)
+        assert result["input_tokens"] == 300
+        assert result["output_tokens"] == 150
         assert result["cache_write_tokens"] == 15
         assert result["cache_read_tokens"] == 50
         assert "cache_creation_input_tokens" not in result
@@ -63,6 +65,8 @@ class TestMergeTokenUsageCanonical:
             "cache_read_input_tokens": 30,
         }
         result = _merge_token_usage(base, nudge)
+        assert result["input_tokens"] == 300
+        assert result["output_tokens"] == 150
         assert result["cache_write_tokens"] == 15
         assert result["cache_read_tokens"] == 50
 
@@ -81,6 +85,8 @@ class TestMergeTokenUsageCanonical:
             "cache_read_tokens": 30,
         }
         result = _merge_token_usage(base, nudge)
+        assert result["input_tokens"] == 300
+        assert result["output_tokens"] == 150
         assert result["cache_write_tokens"] == 15
         assert result["cache_read_tokens"] == 50
 
@@ -111,9 +117,12 @@ class TestMergeTokenUsageCanonical:
         base = {"input_tokens": "not_a_number", "output_tokens": 50, "cache_write_tokens": 10}
         nudge = {"input_tokens": 200, "output_tokens": 100, "cache_write_tokens": 5}
         result = _merge_token_usage(base, nudge)
+        # base_val fails isinstance check → nudge's 200 is dropped; base value survives unchanged
         assert result["input_tokens"] == "not_a_number"
         assert result["output_tokens"] == 150
         assert result["cache_write_tokens"] == 15
+        # cache_read_tokens absent from both dicts → must not be injected as a spurious zero
+        assert "cache_read_tokens" not in result
 
     def test_extra_keys_preserved_from_base(self):
         """Extra keys in base dict are preserved in output."""
@@ -121,3 +130,6 @@ class TestMergeTokenUsageCanonical:
         nudge = {"input_tokens": 200, "output_tokens": 100}
         result = _merge_token_usage(base, nudge)
         assert result["provider"] == "anthropic"
+        # cache fields absent from both dicts → must not be injected as spurious zeros
+        assert "cache_write_tokens" not in result
+        assert "cache_read_tokens" not in result

--- a/tests/execution/test_merge_token_usage.py
+++ b/tests/execution/test_merge_token_usage.py
@@ -90,6 +90,19 @@ class TestMergeTokenUsageCanonical:
         assert result["cache_write_tokens"] == 15
         assert result["cache_read_tokens"] == 50
 
+    def test_canonical_wins_when_both_canonical_and_legacy_coexist(self):
+        """Coexistent canonical + legacy keys: canonical wins, legacy is discarded."""
+        base = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": 10,
+            "cache_creation_input_tokens": 5,
+        }
+        nudge = {"input_tokens": 200, "output_tokens": 100, "cache_write_tokens": 3}
+        result = _merge_token_usage(base, nudge)
+        assert result["cache_write_tokens"] == 13
+        assert "cache_creation_input_tokens" not in result
+
     def test_none_base_returns_nudge(self):
         """None base → return nudge unchanged."""
         nudge = {"input_tokens": 200, "output_tokens": 100}

--- a/tests/execution/test_merge_token_usage.py
+++ b/tests/execution/test_merge_token_usage.py
@@ -94,6 +94,14 @@ class TestMergeTokenUsageCanonical:
         base = {"input_tokens": 100, "output_tokens": 50}
         assert _merge_token_usage(base, None) is base
 
+    def test_none_base_legacy_keys_not_canonicalized(self):
+        """None base + legacy-keyed nudge → nudge returned as-is, no canonicalization."""
+        nudge = {"cache_creation_input_tokens": 5, "cache_read_input_tokens": 30}
+        result = _merge_token_usage(None, nudge)
+        assert result is nudge
+        assert "cache_creation_input_tokens" in result
+        assert "cache_read_input_tokens" in result
+
     def test_both_none_returns_none(self):
         """Both None → return None."""
         assert _merge_token_usage(None, None) is None
@@ -103,7 +111,7 @@ class TestMergeTokenUsageCanonical:
         base = {"input_tokens": "not_a_number", "output_tokens": 50, "cache_write_tokens": 10}
         nudge = {"input_tokens": 200, "output_tokens": 100, "cache_write_tokens": 5}
         result = _merge_token_usage(base, nudge)
-        assert result.get("input_tokens") == "not_a_number"
+        assert result["input_tokens"] == "not_a_number"
         assert result["output_tokens"] == 150
         assert result["cache_write_tokens"] == 15
 


### PR DESCRIPTION
## Summary

Replace the hardcoded four-key tuple in `_merge_token_usage()` with a canonical-key-first iteration that falls back to legacy Anthropic API field names. The function will read from either naming convention but always write merged values under canonical keys. No `CanonicalTokenUsage` import — stays dict-based.

## Changed Files

### New (★):
tests/execution/test_merge_token_usage.py

### Modified (●):
src/autoskillit/execution/headless/_headless_recovery.py
tests/execution/CLAUDE.md

Closes #2455

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260517-144156-049292/.autoskillit/temp/make-plan/p2-a11-wp1-update-merge-token-usage-canonical-fields_plan_2026-05-17_144500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 70 | 6.6k | 633.5k | 63.9k | 77 | 42.6k | 4m 52s |
| verify | claude-sonnet-4-6 | 1 | 41 | 8.8k | 534.5k | 52.6k | 103 | 35.2k | 6m 28s |
| implement* | MiniMax-M2.7-highspeed | 1 | 364.4k | 4.5k | 650.8k | 46.5k | 46 | 56.7k | 2m 8s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 72.2k | 2.9k | 209.6k | 29.9k | 19 | 42.6k | 1m 14s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 45.5k | 1.5k | 149.7k | 29.9k | 15 | 42.5k | 44s |
| review_pr | claude-sonnet-4-6 | 3 | 1.6k | 67.6k | 1.5M | 68.2k | 115 | 148.6k | 16m 44s |
| resolve_review | claude-sonnet-4-6 | 3 | 761 | 78.2k | 5.8M | 117.2k | 227 | 225.3k | 37m 49s |
| **Total** | | | 484.6k | 170.0k | 9.5M | 117.2k | | 593.4k | 1h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 145 | 4488.2 | 391.1 | 30.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 55 | 104810.9 | 4095.7 | 1421.6 |
| **Total** | **200** | 47357.6 | 2967.2 | 850.2 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 1.1k | 94.0k | 9.3M | 275.3k | 44m 21s |
| claude-opus-4-6 | 2 | 1.1k | 98.8k | 7.9M | 462.7k | 57m 59s |
| MiniMax-M2.7-highspeed | 4 | 3.1M | 51.1k | 6.5M | 453.4k | 34m 33s |