### PR TITLE
[P2-A14-WP1] Migrate token_summary_hook.py to canonical names

### DIFF
--- a/tests/contracts/test_token_summary_contracts.py
+++ b/tests/contracts/test_token_summary_contracts.py
@@ -79,6 +79,47 @@ def test_hook_load_sessions_reads_only_declared_keys():
         raise AssertionError("_load_sessions function not found in token_summary_hook.py")
 
 
+def test_format_functions_use_no_legacy_cache_keys():
+    """AST contract: format functions must not contain legacy cache field name literals.
+
+    Guards against re-introducing cache_creation_input_tokens or cache_read_input_tokens
+    in _format_table, _format_efficiency_table, and _format_model_table after the
+    canonical migration (P2-A14-WP1).
+    """
+    from autoskillit.hooks._hook_settings import _V1_TOKEN_FIELD_ALIASES
+
+    hook_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "autoskillit"
+        / "hooks"
+        / "token_summary_hook.py"
+    )
+    tree = ast.parse(hook_path.read_text())
+
+    target_functions = {"_format_table", "_format_efficiency_table", "_format_model_table"}
+    found: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name in target_functions:
+            found.add(node.name)
+            for const in ast.walk(node):
+                if (
+                    isinstance(const, ast.Constant)
+                    and isinstance(const.value, str)
+                    and const.value in _V1_TOKEN_FIELD_ALIASES
+                ):
+                    pytest.fail(
+                        f"{node.name} contains legacy key literal {const.value!r} "
+                        f"(maps to {_V1_TOKEN_FIELD_ALIASES[const.value]!r})"
+                    )
+
+    assert found == target_functions, (
+        f"Expected to find functions {target_functions}, found {found}. "
+        "One or more format functions were renamed."
+    )
+
+
 # ── Step 1c: Cross-seam integration test ──
 
 


### PR DESCRIPTION
## Summary

The code migration described in issue #2458 is **already complete** — it was implemented by P2-A6-WP1 (commit `4b0331b2`, PR #2553) which landed on `main` before this branch was created. All 12 format-function references, the `_load_sessions` init keys, accumulation statements, and v1-fallback `data.get()` chains already use canonical names (`cache_write_tokens`, `cache_read_tokens`).

The remaining deliverable is a **format-function AST regression contract** — an automated guard that prevents future edits from accidentally reintroducing legacy field names (`cache_creation_input_tokens`, `cache_read_input_tokens`) into the three format functions. The existing AST contract (`test_hook_load_sessions_reads_only_declared_keys`) only covers `_load_sessions`; the format functions have no equivalent protection.

Closes #2458

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260517-173653-492945/.autoskillit/temp/make-plan/p2-a14-wp1-migrate-token-summary-hook-canonical-names_plan_2026-05-17_174600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.4k | 13.0k | 810.1k | 68.5k | 109 | 57.7k | 8m 7s |
| verify | claude-sonnet-4-6 | 1 | 985 | 3.7k | 209.8k | 39.2k | 43 | 25.8k | 3m 24s |
| implement* | MiniMax-M2.7-highspeed | 1 | 210.2k | 2.8k | 346.5k | 28.9k | 30 | 42.7k | 1m 39s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 95.9k | 3.0k | 285.9k | 28.9k | 22 | 15.5k | 1m 36s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 63.9k | 1.4k | 257.0k | 28.9k | 18 | 15.3k | 52s |
| review_pr | claude-sonnet-4-6 | 3 | 252 | 26.0k | 1.0M | 44.5k | 87 | 106.3k | 7m 47s |
| **Total** | | | 374.7k | 49.9k | 2.9M | 68.5k | | 263.4k | 23m 27s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 41 | 8451.8 | 1042.4 | 68.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **41** | 71156.0 | 6423.2 | 1217.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 2.2k | 14.2k | 608.4k | 119.4k | 6m 0s |
| claude-sonnet-4-6 | 1 | 35 | 7.7k | 825.8k | 69.1k | 5m 35s |
| MiniMax-M2.7 | 1 | 101.8k | 16.1k | 4.3M | 0 | 6m 41s |