### PR TITLE
[FIX] Add plugin-installed guards to hook drift detection read paths

### DIFF
--- a/src/autoskillit/cli/doctor/_doctor_hooks.py
+++ b/src/autoskillit/cli/doctor/_doctor_hooks.py
@@ -17,6 +17,15 @@ logger = get_logger(__name__)
 
 
 def _check_hook_registration(settings_path: Path) -> DoctorResult:
+    from autoskillit.cli._init_helpers import _is_plugin_installed
+
+    if _is_plugin_installed():
+        return DoctorResult(
+            severity=Severity.OK,
+            check="hook_registration",
+            message="Hooks delivered via plugin cache — settings.json check skipped.",
+        )
+
     from autoskillit.cli._hooks import _load_settings_data
 
     data = _load_settings_data(settings_path)
@@ -64,6 +73,17 @@ def _check_hook_registry_drift(
             msg = f"[{scope_label}] {msg}"
         return DoctorResult(Severity.ERROR, "hook_registry_drift", msg)
     if result.missing > 0:
+        from autoskillit.cli._init_helpers import _is_plugin_installed
+
+        if _is_plugin_installed():
+            msg = "Hooks delivered via plugin cache — settings.json drift is expected."
+            if scope_label:
+                msg = f"[{scope_label}] {msg}"
+            return DoctorResult(
+                severity=Severity.OK,
+                check="hook_registry_drift",
+                message=msg,
+            )
         msg = (
             f"Hook registry has changed since last install. "
             f"Run 'autoskillit install' to deploy {result.missing} new/changed hook(s)."

--- a/src/autoskillit/cli/update/_update_checks.py
+++ b/src/autoskillit/cli/update/_update_checks.py
@@ -148,10 +148,13 @@ def _hooks_signal(settings_path: Path) -> Signal | None:
                 f"will block tool calls with ENOENT — run 'autoskillit install' to fix",
             )
         if drift.missing > 0:
-            return Signal(
-                "hooks",
-                f"{drift.missing} new/changed hook(s) detected since last install",
-            )
+            from autoskillit.cli._init_helpers import _is_plugin_installed
+
+            if not _is_plugin_installed():
+                return Signal(
+                    "hooks",
+                    f"{drift.missing} new/changed hook(s) detected since last install",
+                )
     except Exception:
         logger.debug("hooks signal check failed", exc_info=True)
     return None

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -77,7 +77,11 @@ def _extract_block(text: str, start_delim: str, end_delim: str) -> list[str]:
 
 def _build_hook_diagnostic_warning() -> str | None:
     """Run hook health and drift checks. Return a warning string if issues are found."""
-    from autoskillit.core import DIRECT_INSTALL_CACHE_SUBDIR
+    from autoskillit.core import (
+        DIRECT_INSTALL_CACHE_SUBDIR,
+        MARKETPLACE_PREFIX,
+        detect_autoskillit_mcp_prefix,
+    )
     from autoskillit.hook_registry import (
         _claude_settings_path,
         _count_hook_registry_drift,
@@ -98,7 +102,7 @@ def _build_hook_diagnostic_warning() -> str | None:
                 f"{drift.orphaned} orphaned hook entry(ies) in settings.json are not in "
                 f"HOOK_REGISTRY — every matching tool call will be denied with ENOENT."
             )
-        if drift.missing > 0:
+        if drift.missing > 0 and detect_autoskillit_mcp_prefix() != MARKETPLACE_PREFIX:
             issues.append(
                 f"{drift.missing} hook(s) from HOOK_REGISTRY are not deployed in settings.json."
             )

--- a/tests/cli/CLAUDE.md
+++ b/tests/cli/CLAUDE.md
@@ -31,6 +31,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_doctor_scripts.py` | Tests for doctor script/recipe version health checks |
 | `test_doctor_fleet.py` | Tests for fleet state schema version doctor check |
 | `test_doctor_split.py` | Structural guards: test_doctor.py split into three files (P1-F02) |
+| `test_hook_drift_plugin_guard.py` | Tests for hook drift false-positive fix when plugin is marketplace-installed |
 | `test_features_cli.py` | Tests for the features CLI subcommand |
 | `test_fleet_campaign.py` | Tests: fleet CLI campaign command |
 | `test_fleet_campaign_preview.py` | Tests: fleet_campaign shows preview + confirmation before launch |

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -771,6 +771,7 @@ def test_check_hook_registry_drift_orphaned_still_fires_when_plugin_installed(
     assert result.severity == Severity.ERROR
     assert result.check == "hook_registry_drift"
     assert "orphaned" in result.message.lower()
+    assert "fake_orphan_dispatch.py" in result.message
 
 
 class TestEditableInstallSourceExistsCheck:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -760,7 +760,7 @@ def test_check_hook_registry_drift_orphaned_still_fires_when_plugin_installed(
 
     monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
     monkeypatch.setattr(
-        "autoskillit.hook_registry._count_hook_registry_drift",
+        "autoskillit.cli.doctor._doctor_hooks._count_hook_registry_drift",
         lambda _path: HookDriftResult(
             missing=0, orphaned=1, orphaned_cmds=frozenset(["fake_orphan_dispatch.py"])
         ),

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -718,6 +718,61 @@ def test_doctor_json_output_includes_hook_registry_drift(
     assert drift["severity"] == Severity.WARNING
 
 
+# DC-14: _check_hook_registration — plugin installed → OK (plugin delivers via cache)
+def test_check_hook_registration_ok_when_plugin_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoskillit.cli.doctor._doctor_hooks import _check_hook_registration
+    from autoskillit.core import Severity
+
+    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"hooks": {}}')
+    result = _check_hook_registration(settings)
+    assert result.severity == Severity.OK
+    assert result.check == "hook_registration"
+    assert "plugin" in result.message
+
+
+# DC-15: _check_hook_registry_drift — plugin installed → OK (missing drift expected)
+def test_check_hook_registry_drift_ok_when_plugin_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoskillit.cli.doctor._doctor_hooks import _check_hook_registry_drift
+    from autoskillit.core import Severity
+
+    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"hooks": {}}')
+    result = _check_hook_registry_drift(settings)
+    assert result.severity == Severity.OK
+    assert result.check == "hook_registry_drift"
+    assert "plugin" in result.message
+
+
+# DC-16: _check_hook_registry_drift — orphaned still fires when plugin installed
+def test_check_hook_registry_drift_orphaned_still_fires_when_plugin_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoskillit.cli.doctor._doctor_hooks import _check_hook_registry_drift
+    from autoskillit.core import Severity
+    from autoskillit.hook_registry import HookDriftResult
+
+    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
+    monkeypatch.setattr(
+        "autoskillit.hook_registry._count_hook_registry_drift",
+        lambda _path: HookDriftResult(
+            missing=0, orphaned=1, orphaned_cmds=frozenset(["fake_orphan_dispatch.py"])
+        ),
+    )
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"hooks": {}}')
+    result = _check_hook_registry_drift(settings)
+    assert result.severity == Severity.ERROR
+    assert result.check == "hook_registry_drift"
+    assert "orphaned" in result.message
+
+
 class TestEditableInstallSourceExistsCheck:
     """Tests for the editable_install_source_exists doctor check."""
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -770,7 +770,7 @@ def test_check_hook_registry_drift_orphaned_still_fires_when_plugin_installed(
     result = _check_hook_registry_drift(settings)
     assert result.severity == Severity.ERROR
     assert result.check == "hook_registry_drift"
-    assert "orphaned" in result.message
+    assert "orphaned" in result.message.lower()
 
 
 class TestEditableInstallSourceExistsCheck:

--- a/tests/cli/test_hook_drift_plugin_guard.py
+++ b/tests/cli/test_hook_drift_plugin_guard.py
@@ -1,0 +1,48 @@
+"""Tests for hook drift false-positive fix when plugin is marketplace-installed.
+
+Site 1 coverage: _hooks_signal() in cli/update/_update_checks.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.hook_registry import HookDriftResult
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+
+
+def test_hooks_signal_silent_when_plugin_installed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Site 1: _hooks_signal() returns None when plugin is installed (missing drift suppressed)."""
+    from autoskillit.cli.update._update_checks import _hooks_signal
+
+    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"hooks": {}}')
+
+    sig = _hooks_signal(settings)
+    assert sig is None
+
+
+def test_hooks_signal_orphaned_still_fires_when_plugin_installed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Site 1: orphaned hook detection remains unconditional when plugin is installed."""
+    from autoskillit.cli.update._update_checks import _hooks_signal
+
+    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
+    monkeypatch.setattr(
+        "autoskillit.cli.update._update_checks._count_hook_registry_drift",
+        lambda _path: HookDriftResult(missing=5, orphaned=2),
+    )
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"hooks": {}}')
+
+    sig = _hooks_signal(settings)
+    assert sig is not None
+    assert sig.kind == "hooks"
+    assert "orphaned" in sig.message.lower()

--- a/tests/cli/test_hook_drift_plugin_guard.py
+++ b/tests/cli/test_hook_drift_plugin_guard.py
@@ -37,7 +37,7 @@ def test_hooks_signal_orphaned_still_fires_when_plugin_installed(
     monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
     monkeypatch.setattr(
         "autoskillit.cli.update._update_checks._count_hook_registry_drift",
-        lambda _path: HookDriftResult(missing=5, orphaned=2),
+        lambda _path: HookDriftResult(missing=0, orphaned=2),
     )
     settings = tmp_path / "settings.json"
     settings.write_text('{"hooks": {}}')
@@ -46,3 +46,4 @@ def test_hooks_signal_orphaned_still_fires_when_plugin_installed(
     assert sig is not None
     assert sig.kind == "hooks"
     assert "orphaned" in sig.message.lower()
+    assert "2" in sig.message

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -104,6 +104,67 @@ async def test_open_kitchen_warns_on_missing_hook_scripts(tmp_path, monkeypatch)
     )
 
 
+# T-KITCHEN-3: Site 2 — _build_hook_diagnostic_warning skips missing when plugin marketplace-active
+@pytest.mark.anyio
+async def test_build_hook_diagnostic_warning_skips_missing_when_plugin_active(
+    tmp_path, monkeypatch
+):
+    """Site 2: _build_hook_diagnostic_warning returns None when plugin is marketplace-installed."""
+    from autoskillit.core._plugin_ids import MARKETPLACE_PREFIX
+
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    (settings_dir / "settings.json").write_text('{"hooks": {}}')
+
+    monkeypatch.setattr(
+        "autoskillit.hook_registry._claude_settings_path",
+        lambda scope: settings_dir / "settings.json",
+    )
+    monkeypatch.setattr("autoskillit.hook_registry.validate_plugin_cache_hooks", lambda **_: [])
+    monkeypatch.setattr(
+        "autoskillit.core.detect_autoskillit_mcp_prefix", lambda: MARKETPLACE_PREFIX
+    )
+
+    from autoskillit.server._misc import _build_hook_diagnostic_warning
+
+    result = _build_hook_diagnostic_warning()
+    assert result is None
+
+
+# T-KITCHEN-4: Site 2 — orphaned hook detection remains unconditional in MCP path
+@pytest.mark.anyio
+async def test_build_hook_diagnostic_warning_orphaned_still_fires_when_plugin_active(
+    tmp_path, monkeypatch
+):
+    """Site 2: orphaned detection remains unconditional even when plugin is marketplace-active."""
+    from autoskillit.core._plugin_ids import MARKETPLACE_PREFIX
+    from autoskillit.hook_registry import HookDriftResult
+
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    (settings_dir / "settings.json").write_text('{"hooks": {}}')
+
+    monkeypatch.setattr(
+        "autoskillit.hook_registry._claude_settings_path",
+        lambda scope: settings_dir / "settings.json",
+    )
+    monkeypatch.setattr(
+        "autoskillit.hook_registry._count_hook_registry_drift",
+        lambda _: HookDriftResult(missing=0, orphaned=1),
+    )
+    monkeypatch.setattr("autoskillit.hook_registry.find_broken_hook_scripts", lambda _: [])
+    monkeypatch.setattr("autoskillit.hook_registry.validate_plugin_cache_hooks", lambda **_: [])
+    monkeypatch.setattr(
+        "autoskillit.core.detect_autoskillit_mcp_prefix", lambda: MARKETPLACE_PREFIX
+    )
+
+    from autoskillit.server._misc import _build_hook_diagnostic_warning
+
+    result = _build_hook_diagnostic_warning()
+    assert result is not None
+    assert "orphan" in result.lower()
+
+
 @pytest.mark.anyio
 async def test_prime_quota_cache_catches_typeerror(monkeypatch):
     """_prime_quota_cache must catch TypeError and not propagate — 'fails open' contract."""

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -163,6 +163,7 @@ async def test_build_hook_diagnostic_warning_orphaned_still_fires_when_plugin_ac
     result = _build_hook_diagnostic_warning()
     assert result is not None
     assert "orphan" in result.lower()
+    assert "1" in result
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Add `_is_plugin_installed()` guards to four read-path sites that check hook drift against `settings.json`, suppressing the `missing > 0` signal when the plugin delivers hooks via its own cache. The orphaned-hook check remains unconditional at all sites because orphaned entries cause ENOENT regardless of delivery path. Site 2 (MCP server hot path) uses `detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX` instead of `_is_plugin_installed()` to satisfy REQ-ARCH-003b (no `cli` imports in non-`tools_*` server files).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260517-173319-394461/.autoskillit/temp/make-plan/fix_hook_drift_false_positive_plan_2026-05-17_173600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 2.2k | 14.2k | 608.4k | 66.7k | 56 | 119.4k | 6m 0s |
| verify | claude-sonnet-4-6 | 1 | 35 | 7.7k | 825.8k | 62.8k | 122 | 69.1k | 5m 35s |
| implement* | MiniMax-M2.7 | 1 | 101.8k | 16.1k | 4.3M | 21.2k | 167 | 0 | 6m 41s |
| audit_impl | claude-sonnet-4-6 | 1 | 299 | 8.1k | 196.0k | 37.7k | 61 | 33.4k | 5m 15s |
| prepare_pr* | MiniMax-M2.7 | 1 | 47.1k | 2.8k | 349.7k | 0 | 21 | 0 | 1m 0s |
| compose_pr* | MiniMax-M2.7 | 1 | 43.4k | 2.2k | 450.6k | 0 | 30 | 0 | 41s |
| review_pr | claude-opus-4-6 | 2 | 875 | 31.7k | 457.8k | 68.8k | 57 | 88.3k | 20m 8s |
| resolve_review | claude-opus-4-6 | 1 | 44 | 10.7k | 1.7M | 79.1k | 50 | 66.3k | 7m 21s |
| **Total** | | | 195.9k | 93.6k | 8.9M | 79.1k | | 376.5k | 52m 43s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 204 | 21101.5 | 0.0 | 79.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 334737.8 | 13251.4 | 2130.2 |
| **Total** | **209** | 42425.0 | 1801.3 | 447.9 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 2.3k | 19.8k | 1.5M | 168.6k | 11m 13s |
| claude-sonnet-4-6 | 2 | 334 | 15.8k | 1.0M | 102.5k | 10m 50s |
| MiniMax-M2.7 | 3 | 192.4k | 21.2k | 5.1M | 0 | 8m 22s |