### PR TITLE
Relocate Eval Framework Fixtures from temp/ to recipes/eval/

### DIFF
--- a/.autoskillit/recipes/eval/canaries/C1-reference.md
+++ b/.autoskillit/recipes/eval/canaries/C1-reference.md
@@ -1,0 +1,1 @@
+A plan that identifies the downstream consumer `_extract_captures`, enumerates its format expectations, and includes a round-trip test verifying the output matches caller expectations.

--- a/.autoskillit/recipes/eval/canaries/C1-task.md
+++ b/.autoskillit/recipes/eval/canaries/C1-task.md
@@ -1,0 +1,1 @@
+Implement a feature that adds a new `_extract_captures` function to the smoke_utils module, exporting capture data for downstream analysis tools.

--- a/.autoskillit/recipes/eval/canaries/C4-task.md
+++ b/.autoskillit/recipes/eval/canaries/C4-task.md
@@ -1,0 +1,1 @@
+Rename the `before_commit` field to `checkout_ref` across all recipe YAML files, migration scripts, and workspace utilities. Update all affected call sites and tests.

--- a/.autoskillit/recipes/eval/canaries/C7-reference.md
+++ b/.autoskillit/recipes/eval/canaries/C7-reference.md
@@ -1,0 +1,1 @@
+A plan that traces all callers referencing `audit-cohesion`, provides a type-safe migration path, and verifies fixture completeness after the rename, including re-export aliases.

--- a/.autoskillit/recipes/eval/canaries/C7-task.md
+++ b/.autoskillit/recipes/eval/canaries/C7-task.md
@@ -1,0 +1,1 @@
+Rename the `audit-cohesion` skill to `cohesion-audit` across all skill references, test files, and documentation. Ensure backward-compatible re-exports exist.

--- a/.autoskillit/recipes/eval/canaries/impl_commit_b7fa51e2.patch
+++ b/.autoskillit/recipes/eval/canaries/impl_commit_b7fa51e2.patch
@@ -1,0 +1,12 @@
+--- begin patch ---
+diff --git a/src/autoskillit/smoke_utils.py b/src/autoskillit/smoke_utils.py
+--- a/src/autoskillit/smoke_utils.py
++++ b/src/autoskillit/smoke_utils.py
+@@ -10,7 +10,7 @@
+ from autoskillit.core import DISPATCH_ID_ENV_VAR, get_logger
+
+-    before_commit = canary.get("before_commit", "")
++    checkout_ref = canary.get("checkout_ref", "")
+     if before_commit:
+         # ... use it
+--- end patch ---

--- a/.autoskillit/recipes/eval/canaries/impl_commit_b7fa51e2.patch
+++ b/.autoskillit/recipes/eval/canaries/impl_commit_b7fa51e2.patch
@@ -7,6 +7,6 @@ diff --git a/src/autoskillit/smoke_utils.py b/src/autoskillit/smoke_utils.py
 
 -    before_commit = canary.get("before_commit", "")
 +    checkout_ref = canary.get("checkout_ref", "")
-     if before_commit:
+     if checkout_ref:
          # ... use it
 --- end patch ---

--- a/.autoskillit/recipes/eval/manifests/make-plan-canaries.json
+++ b/.autoskillit/recipes/eval/manifests/make-plan-canaries.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "C1",
+    "description": "Cross-component contract divergence in plan output",
+    "before_commit": "94fe7cd017ff9bf92c22c4ad2ef89e967e01195f",
+    "worktree_path": null,
+    "skill": "/autoskillit:make-plan",
+    "task_file": ".autoskillit/recipes/eval/canaries/C1-task.md",
+    "reference_path": ".autoskillit/recipes/eval/canaries/C1-reference.md",
+    "reference_type": "plan",
+    "gap_description": "Plan output diverges from cross-component contract — mentions _extract_captures without verifying its caller expectations",
+    "detection_criteria": [
+      "Identifies _extract_captures as downstream consumer",
+      "Enumerates format expectations of downstream callers",
+      "Includes round-trip verification test"
+    ]
+  },
+  {
+    "id": "C4",
+    "description": "Type registry gap during fixture rename",
+    "before_commit": null,
+    "worktree_path": null,
+    "skill": "/autoskillit:make-plan",
+    "task_file": ".autoskillit/recipes/eval/canaries/C4-task.md",
+    "reference_path": ".autoskillit/recipes/eval/canaries/impl_commit_b7fa51e2.patch",
+    "reference_type": "patch",
+    "gap_description": "Rename migration fails to trace sibling fields through type registry — leaves downstream analysis tools with stale type references",
+    "detection_criteria": [
+      "Traces all fixtures constructing objects with renamed field",
+      "Verifies sibling fields remain type-correct",
+      "Updates type registry for downstream tools"
+    ]
+  },
+  {
+    "id": "C7",
+    "description": "Fixture completeness during skill rename",
+    "before_commit": null,
+    "worktree_path": null,
+    "skill": "/autoskillit:make-plan",
+    "task_file": ".autoskillit/recipes/eval/canaries/C7-task.md",
+    "reference_path": ".autoskillit/recipes/eval/canaries/C7-reference.md",
+    "reference_type": "plan",
+    "gap_description": "Skill rename leaves fixture completeness gaps — downstream consumers reference stale skill name without type-safe fallbacks",
+    "detection_criteria": [
+      "Traces all callers referencing the renamed skill",
+      "Provides type-safe migration for callers",
+      "Verifies fixture completeness post-rename"
+    ]
+  }
+]

--- a/.autoskillit/recipes/eval/manifests/make-plan-variants.json
+++ b/.autoskillit/recipes/eval/manifests/make-plan-variants.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "baseline",
+    "label": "Baseline",
+    "overlay_file": null,
+    "description": "No overlay — plain task text only"
+  },
+  {
+    "id": "consumer-contract",
+    "label": "Consumer contract",
+    "overlay_file": ".autoskillit/recipes/eval/overlays/consumer-contract.md",
+    "description": "Add consumer contract verification overlay"
+  },
+  {
+    "id": "infrastructure-audit",
+    "label": "Infrastructure audit",
+    "overlay_file": ".autoskillit/recipes/eval/overlays/infrastructure-audit.md",
+    "description": "Add infrastructure audit overlay"
+  },
+  {
+    "id": "migration-scope",
+    "label": "Migration scope",
+    "overlay_file": ".autoskillit/recipes/eval/overlays/migration-scope.md",
+    "description": "Add migration scope overlay"
+  },
+  {
+    "id": "adversarial-review",
+    "label": "Adversarial review",
+    "overlay_file": ".autoskillit/recipes/eval/overlays/adversarial-review.md",
+    "description": "Add adversarial review overlay"
+  },
+  {
+    "id": "full-adversarial",
+    "label": "Full adversarial",
+    "overlay_file": ".autoskillit/recipes/eval/overlays/full-adversarial.md",
+    "description": "Add full adversarial overlay"
+  }
+]

--- a/.autoskillit/recipes/eval/overlays/adversarial-review.md
+++ b/.autoskillit/recipes/eval/overlays/adversarial-review.md
@@ -1,0 +1,1 @@
+When creating this plan, include an adversarial review section: assume the plan will be implemented exactly as written and actively identify what could go wrong. For each proposed change, check cross-component contracts, downstream consumers, implicit conventions, and fixture completeness. If you find a gap, revise the plan to address it before finalizing.

--- a/.autoskillit/recipes/eval/overlays/consumer-contract.md
+++ b/.autoskillit/recipes/eval/overlays/consumer-contract.md
@@ -1,0 +1,1 @@
+For each output this plan produces, enumerate all callers/parsers/extractors in the codebase and verify the format matches their expectations. Include at least one round-trip test.

--- a/.autoskillit/recipes/eval/overlays/full-adversarial.md
+++ b/.autoskillit/recipes/eval/overlays/full-adversarial.md
@@ -1,0 +1,7 @@
+For each output this plan produces, enumerate all callers/parsers/extractors in the codebase and verify the format matches their expectations. Include at least one round-trip test.
+
+For each data type introduced or governed by a new rule, verify it appears in the type registry of every downstream analysis tool.
+
+For rename migrations, trace all fixtures that construct objects containing the renamed field and verify all sibling fields remain type-correct.
+
+When creating this plan, include an adversarial review section: assume the plan will be implemented exactly as written and actively identify what could go wrong. For each proposed change, check cross-component contracts, downstream consumers, implicit conventions, and fixture completeness. If you find a gap, revise the plan to address it before finalizing.

--- a/.autoskillit/recipes/eval/overlays/infrastructure-audit.md
+++ b/.autoskillit/recipes/eval/overlays/infrastructure-audit.md
@@ -1,0 +1,1 @@
+For each data type introduced or governed by a new rule, verify it appears in the type registry of every downstream analysis tool.

--- a/.autoskillit/recipes/eval/overlays/migration-scope.md
+++ b/.autoskillit/recipes/eval/overlays/migration-scope.md
@@ -1,0 +1,1 @@
+For rename migrations, trace all fixtures that construct objects containing the renamed field and verify all sibling fields remain type-correct.

--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -194,3 +194,12 @@ tests/**/CLAUDE.md: []
 
 .autoskillit/temp/plan-quality-audit/canaries/**/*:
   - infra/
+
+.autoskillit/recipes/eval/canaries/**/*:
+  - recipe/
+
+.autoskillit/recipes/eval/overlays/**/*:
+  - recipe/
+
+.autoskillit/recipes/eval/manifests/**/*:
+  - recipe/

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -1069,11 +1069,12 @@ class TestHeadlessExecutorIdleOutputTimeout:
 
     @pytest.mark.anyio
     async def test_default_headless_executor_falls_back_to_cfg_idle_output_timeout(
-        self, tool_ctx
+        self, tool_ctx, monkeypatch
     ) -> None:
         """idle_output_timeout=None falls back to float(cfg.idle_output_timeout)."""
         from autoskillit.execution.headless import run_headless_core
 
+        monkeypatch.delenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", raising=False)
         marker = tool_ctx.config.run_skill.completion_marker
         tool_ctx.runner.push(self._success_payload(marker))
         await run_headless_core(

--- a/tests/recipe/test_io_discovery.py
+++ b/tests/recipe/test_io_discovery.py
@@ -472,3 +472,83 @@ def test_eval_scan_dir_discoverable(tmp_path: Path) -> None:
     r = next((x for x in result.items if x.name == "test-eval"), None)
     assert r is not None
     assert r.source == RecipeSource.PROJECT
+
+
+def test_eval_fixture_inventory() -> None:
+    """All eval fixture files must exist at their canonical .autoskillit/recipes/eval/ location.
+
+    This is a regression guard: if a file is accidentally deleted or moved back to temp/,
+    this test fails immediately rather than silently breaking the eval pipeline.
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    eval_dir = repo_root / ".autoskillit" / "recipes" / "eval"
+
+    expected_canaries = [
+        "C1-task.md",
+        "C1-reference.md",
+        "C4-task.md",
+        "C7-task.md",
+        "C7-reference.md",
+        "impl_commit_b7fa51e2.patch",
+    ]
+    expected_overlays = [
+        "baseline.md",
+        "consumer-contract.md",
+        "infrastructure-audit.md",
+        "migration-scope.md",
+        "adversarial-review.md",
+        "full-adversarial.md",
+    ]
+    expected_manifests = [
+        "make-plan-canaries.json",
+        "make-plan-variants.json",
+    ]
+
+    missing = []
+    for name in expected_canaries:
+        if not (eval_dir / "canaries" / name).exists():
+            missing.append(f"canaries/{name}")
+    for name in expected_overlays:
+        if not (eval_dir / "overlays" / name).exists():
+            missing.append(f"overlays/{name}")
+    for name in expected_manifests:
+        if not (eval_dir / "manifests" / name).exists():
+            missing.append(f"manifests/{name}")
+
+    assert not missing, (
+        f"Eval fixture files missing from .autoskillit/recipes/eval/: {missing}. "
+        "These files must be tracked at this canonical location, not under temp/."
+    )
+
+
+def test_eval_manifest_paths_point_to_recipes_eval() -> None:
+    """Manifest JSON files must reference fixture paths under .autoskillit/recipes/eval/,
+    not temp/.
+
+    Verifies that after relocation the canary_manifest and variant_manifest path fields
+    no longer contain 'temp/' — a stale reference would silently fail at eval runtime.
+    """
+    import json
+
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    manifests_dir = repo_root / ".autoskillit" / "recipes" / "eval" / "manifests"
+
+    canary_manifest = json.loads((manifests_dir / "make-plan-canaries.json").read_text())
+    for entry in canary_manifest:
+        if entry.get("task_file"):
+            assert "temp/" not in entry["task_file"], (
+                f"Canary {entry['id']} task_file still points to temp/: {entry['task_file']!r}"
+            )
+        if entry.get("reference_path"):
+            assert "temp/" not in entry["reference_path"], (
+                f"Canary {entry['id']} reference_path still points to temp/: "
+                f"{entry['reference_path']!r}"
+            )
+
+    variant_manifest = json.loads((manifests_dir / "make-plan-variants.json").read_text())
+    for entry in variant_manifest:
+        if entry.get("overlay_file"):
+            assert "temp/" not in entry["overlay_file"], (
+                f"Variant {entry['id']} overlay_file still points to temp/: "
+                f"{entry['overlay_file']!r}"
+            )


### PR DESCRIPTION
## Summary

The eval framework fixtures (canary task files, reference plans, overlay prompts, and manifest JSON files) currently live in `.autoskillit/temp/`, which is gitignored. This means the eval pipeline cannot be run from a fresh clone — the fixtures are silently absent. The fix is to move all static fixture inputs to `.autoskillit/recipes/eval/`, which is already a registered recipe scan directory and is tracked by git.

Three directories of files move:
- `.autoskillit/temp/plan-quality-audit/canaries/` → `.autoskillit/recipes/eval/canaries/`
- `.autoskillit/temp/skill-eval/overlays/` → `.autoskillit/recipes/eval/overlays/`
- `.autoskillit/temp/skill-eval/manifests/` → `.autoskillit/recipes/eval/manifests/`

After moving, the manifest JSON files have their path references updated to the new locations. Runtime eval output (scorecard, verdict files, resolved.json) continues to write to `{{AUTOSKILLIT_TEMP}}/skill-eval/runs/` because that output is ephemeral.

Closes #2574

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/relocate-eval-fixtures-20260517-182425-156588/.autoskillit/temp/make-plan/relocate_eval_fixtures_plan_2026-05-17_183847.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 145 | 14.4k | 818.9k | 107.3k | 89 | 67.4k | 17m 3s |
| verify | claude-sonnet-4-6 | 1 | 76 | 6.8k | 299.9k | 45.7k | 26 | 32.4k | 2m 2s |
| implement* | MiniMax-M2.7-highspeed | 1 | 481.6k | 6.1k | 693.0k | 28.9k | 52 | 67.5k | 2m 57s |
| fix | claude-sonnet-4-6 | 1 | 272 | 12.3k | 1.9M | 78.8k | 85 | 65.4k | 6m 40s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 111.2k | 3.4k | 259.9k | 28.9k | 20 | 41.7k | 1m 22s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 48.2k | 1.5k | 199.3k | 28.9k | 15 | 15.5k | 44s |
| review_pr | claude-sonnet-4-6 | 1 | 126 | 45.1k | 812.4k | 89.0k | 45 | 75.6k | 10m 22s |
| resolve_review | claude-sonnet-4-6 | 1 | 181 | 11.7k | 933.0k | 53.7k | 56 | 40.2k | 5m 21s |
| **Total** | | | 641.7k | 101.3k | 5.9M | 107.3k | | 405.7k | 46m 34s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 196 | 3535.5 | 344.3 | 30.9 |
| fix | 12 | 156376.0 | 5448.2 | 1028.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 466500.0 | 20120.5 | 5857.5 |
| **Total** | **210** | 28060.9 | 1932.1 | 482.3 |