### PR TITLE
[P2-A19-WP2] High-effort infra / pretty-output test renames

### DIFF
--- a/tests/infra/test_pretty_output_integration.py
+++ b/tests/infra/test_pretty_output_integration.py
@@ -67,8 +67,8 @@ class TestFormatterSchemaConsistency:
                 "step_name": "implement",
                 "input_tokens": 45000,
                 "output_tokens": 12000,
-                "cache_read_input_tokens": 0,
-                "cache_creation_input_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
                 "invocation_count": 1,
                 "wall_clock_seconds": 120.0,
             }
@@ -76,8 +76,8 @@ class TestFormatterSchemaConsistency:
         total = {
             "input_tokens": 45000,
             "output_tokens": 12000,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
             "total_elapsed_seconds": 120.0,
         }
         table_str = TelemetryFormatter.format_token_table(steps, total)


### PR DESCRIPTION
## Summary

Replace legacy Anthropic token field names (`cache_creation_input_tokens`, `cache_read_input_tokens`) with canonical names (`cache_write_tokens`, `cache_read_tokens`) across the 4 target test files in `tests/infra/`. Investigation reveals that 2 of the 4 files are already fully migrated, 1 file has 4 stale legacy refs to rename, and 1 file has 2 legacy refs that are intentional backward-compat test fixtures and must be preserved.

## Requirements

- Zero old names across all 4 files
- All tests collect without import errors

## Changed Files

- pyproject.toml
- src/autoskillit/.claude-plugin/plugin.json
- tests/infra/test_pretty_output_integration.py
- uv.lock

Closes #2464

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260517-184048-417671/.autoskillit/temp/make-plan/p2_a19_wp2_high_effort_infra_pretty_output_test_renames_plan_2026-05-17_184600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 59 | 5.8k | 482.8k | 60.1k | 54 | 34.0k | 4m 5s |
| verify | claude-sonnet-4-6 | 1 | 865 | 3.4k | 295.9k | 47.7k | 56 | 30.1k | 2m 53s |
| implement* | MiniMax-M2.7-highspeed | 1 | 153.0k | 2.6k | 372.5k | 28.9k | 32 | 16.6k | 4m 5s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 124.0k | 2.9k | 401.5k | 28.9k | 28 | 27.1k | 1m 40s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.3k | 1.4k | 170.4k | 28.9k | 13 | 15.4k | 41s |
| review_pr | claude-sonnet-4-6 | 3 | 342 | 25.4k | 1.4M | 45.6k | 102 | 92.1k | 6m 58s |
| **Total** | | | 315.5k | 41.6k | 3.2M | 60.1k | | 215.2k | 20m 24s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 8 | 46558.9 | 2074.0 | 329.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **8** | 396335.0 | 26903.8 | 5197.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 924 | 9.2k | 778.7k | 64.1k | 6m 59s |
| MiniMax-M2.7-highspeed | 3 | 314.2k | 6.9k | 944.4k | 59.1k | 6m 26s |