### PR TITLE
Replace all Anthropic-era legacy field names in test_tokens_core.py and test_tokens_filters.py

### DIFF
--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -144,8 +144,12 @@ class DefaultTokenLog:
             e.model = _model
         e.input_tokens += token_usage.get("input_tokens", 0)
         e.output_tokens += token_usage.get("output_tokens", 0)
-        e.cache_write_tokens += token_usage.get("cache_creation_input_tokens", 0)
-        e.cache_read_tokens += token_usage.get("cache_read_input_tokens", 0)
+        e.cache_write_tokens += token_usage.get(
+            "cache_write_tokens", token_usage.get("cache_creation_input_tokens", 0)
+        )
+        e.cache_read_tokens += token_usage.get(
+            "cache_read_tokens", token_usage.get("cache_read_input_tokens", 0)
+        )
         e.invocation_count += 1
         e.loc_insertions += loc_insertions
         e.loc_deletions += loc_deletions

--- a/tests/pipeline/test_tokens_core.py
+++ b/tests/pipeline/test_tokens_core.py
@@ -17,8 +17,8 @@ def _make_usage(**overrides: int) -> dict[str, int]:
     defaults = {
         "input_tokens": 100,
         "output_tokens": 50,
-        "cache_creation_input_tokens": 10,
-        "cache_read_input_tokens": 5,
+        "cache_write_tokens": 10,
+        "cache_read_tokens": 5,
     }
     return {**defaults, **overrides}
 
@@ -234,8 +234,8 @@ class TestDefaultTokenLog:
             {
                 "input_tokens": 10,
                 "output_tokens": 20,
-                "cache_creation_input_tokens": 5,
-                "cache_read_input_tokens": 3,
+                "cache_write_tokens": 5,
+                "cache_read_tokens": 3,
             },
         )
         log.record(
@@ -243,8 +243,8 @@ class TestDefaultTokenLog:
             {
                 "input_tokens": 100,
                 "output_tokens": 200,
-                "cache_creation_input_tokens": 50,
-                "cache_read_input_tokens": 30,
+                "cache_write_tokens": 50,
+                "cache_read_tokens": 30,
             },
         )
         total = log.compute_total()
@@ -451,7 +451,7 @@ class TestLoadFromLogDirSchemaVersionCompat:
                     "input_tokens": 100,
                     "output_tokens": 50,
                     "cache_creation_input_tokens": 10,
-                    "cache_read_input_tokens": 5,
+                    "cache_read_tokens": 5,
                     "timing_seconds": 30.0,
                 },
                 id="v1-legacy-keys",
@@ -492,7 +492,7 @@ class TestLoadFromLogDirSchemaVersionCompat:
                 "input_tokens": 50,
                 "output_tokens": 25,
                 "cache_creation_input_tokens": 8,
-                "cache_read_input_tokens": 3,
+                "cache_read_tokens": 3,
                 "timing_seconds": 10.0,
             },
         )
@@ -526,8 +526,8 @@ def test_token_log_record_accumulates_loc():
         {
             "input_tokens": 100,
             "output_tokens": 10,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
         },
         loc_insertions=50,
         loc_deletions=20,
@@ -537,8 +537,8 @@ def test_token_log_record_accumulates_loc():
         {
             "input_tokens": 200,
             "output_tokens": 20,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
         },
         loc_insertions=30,
         loc_deletions=5,
@@ -559,8 +559,8 @@ def test_token_log_compute_total_includes_loc():
         {
             "input_tokens": 0,
             "output_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
         },
         loc_insertions=100,
         loc_deletions=30,
@@ -570,8 +570,8 @@ def test_token_log_compute_total_includes_loc():
         {
             "input_tokens": 0,
             "output_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
         },
         loc_insertions=20,
         loc_deletions=5,
@@ -601,15 +601,16 @@ def test_token_log_load_from_log_dir_reads_loc(tmp_path):
     (sessions_dir / "token_usage.json").write_text(
         json.dumps(
             {
-                "step_name": "implement",
+                "session_label": "implement",
                 "input_tokens": 100,
                 "output_tokens": 10,
-                "cache_creation_input_tokens": 0,
-                "cache_read_input_tokens": 0,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
                 "timing_seconds": 5.0,
                 "order_id": "",
                 "loc_insertions": 42,
                 "loc_deletions": 8,
+                "schema_version": 2,
             }
         )
     )
@@ -640,13 +641,14 @@ def test_token_log_load_from_log_dir_missing_loc_defaults_to_zero(tmp_path):
     (sessions_dir / "token_usage.json").write_text(
         json.dumps(
             {
-                "step_name": "plan",
+                "session_label": "plan",
                 "input_tokens": 500,
                 "output_tokens": 50,
-                "cache_creation_input_tokens": 0,
-                "cache_read_input_tokens": 0,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
                 "timing_seconds": 3.0,
                 "order_id": "",
+                "schema_version": 2,
                 # NO loc_insertions or loc_deletions
             }
         )
@@ -671,8 +673,8 @@ def test_token_entry_has_peak_context_and_turn_count_fields():
 
 def test_record_peak_context_uses_max():
     log = DefaultTokenLog()
-    log.record("impl", {"cache_read_input_tokens": 100, "peak_context": 50000, "turn_count": 10})
-    log.record("impl", {"cache_read_input_tokens": 200, "peak_context": 80000, "turn_count": 15})
+    log.record("impl", {"cache_read_tokens": 100, "peak_context": 50000, "turn_count": 10})
+    log.record("impl", {"cache_read_tokens": 200, "peak_context": 80000, "turn_count": 15})
     report = log.get_report()
     assert report[0]["peak_context"] == 80000
     assert report[0]["cache_write_tokens"] == 0
@@ -681,8 +683,8 @@ def test_record_peak_context_uses_max():
 
 def test_record_turn_count_sums():
     log = DefaultTokenLog()
-    log.record("impl", {"cache_read_input_tokens": 100, "peak_context": 50000, "turn_count": 10})
-    log.record("impl", {"cache_read_input_tokens": 200, "peak_context": 80000, "turn_count": 15})
+    log.record("impl", {"cache_read_tokens": 100, "peak_context": 50000, "turn_count": 10})
+    log.record("impl", {"cache_read_tokens": 200, "peak_context": 80000, "turn_count": 15})
     report = log.get_report()
     assert report[0]["turn_count"] == 25
     assert report[0]["cache_write_tokens"] == 0
@@ -691,8 +693,8 @@ def test_record_turn_count_sums():
 
 def test_compute_total_peak_context_is_max_across_steps():
     log = DefaultTokenLog()
-    log.record("plan", {"cache_read_input_tokens": 100, "peak_context": 40000, "turn_count": 5})
-    log.record("impl", {"cache_read_input_tokens": 200, "peak_context": 70000, "turn_count": 18})
+    log.record("plan", {"cache_read_tokens": 100, "peak_context": 40000, "turn_count": 5})
+    log.record("impl", {"cache_read_tokens": 200, "peak_context": 70000, "turn_count": 18})
     total = log.compute_total()
     assert total["peak_context"] == 70000
     assert total["turn_count"] == 23
@@ -761,7 +763,7 @@ def test_token_log_record_accepts_resolved_label():
     log = DefaultTokenLog()
     log.record(
         "dispatch:abc-123",
-        {"input_tokens": 100, "output_tokens": 50, "cache_read_input_tokens": 80},
+        {"input_tokens": 100, "output_tokens": 50, "cache_read_tokens": 80},
     )
     report = log.get_report()
     assert len(report) == 1

--- a/tests/pipeline/test_tokens_core.py
+++ b/tests/pipeline/test_tokens_core.py
@@ -451,7 +451,7 @@ class TestLoadFromLogDirSchemaVersionCompat:
                     "input_tokens": 100,
                     "output_tokens": 50,
                     "cache_creation_input_tokens": 10,
-                    "cache_read_tokens": 5,
+                    "cache_read_input_tokens": 5,
                     "timing_seconds": 30.0,
                 },
                 id="v1-legacy-keys",
@@ -492,7 +492,7 @@ class TestLoadFromLogDirSchemaVersionCompat:
                 "input_tokens": 50,
                 "output_tokens": 25,
                 "cache_creation_input_tokens": 8,
-                "cache_read_tokens": 3,
+                "cache_read_input_tokens": 3,
                 "timing_seconds": 10.0,
             },
         )

--- a/tests/pipeline/test_tokens_filters.py
+++ b/tests/pipeline/test_tokens_filters.py
@@ -142,8 +142,8 @@ class TestTokenLogStepNameNormalization:
         usage = {
             "input_tokens": 100,
             "output_tokens": 50,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
         }
 
         log.record("plan-30", usage)
@@ -167,8 +167,8 @@ class TestTokenLogStepNameNormalization:
         usage = {
             "input_tokens": 100,
             "output_tokens": 50,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
         }
 
         log.record("plan", usage)
@@ -187,8 +187,8 @@ class TestTokenLogStepNameNormalization:
         usage = {
             "input_tokens": 100,
             "output_tokens": 50,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
         }
         log.record("open-pr", usage)
 
@@ -243,8 +243,8 @@ class TestOrderIdScoping:
         base = {
             "input_tokens": 100,
             "output_tokens": 50,
-            "cache_creation_input_tokens": 10,
-            "cache_read_input_tokens": 5,
+            "cache_write_tokens": 10,
+            "cache_read_tokens": 5,
         }
         return {**base, **overrides}
 


### PR DESCRIPTION
## Summary

Replace all Anthropic-era legacy field names (`cache_creation_input_tokens`, `cache_read_input_tokens`) with their canonical equivalents (`cache_write_tokens`, `cache_read_tokens`) in `test_tokens_core.py` and `test_tokens_filters.py`. This requires a minimal production-side update to `DefaultTokenLog.record()` so it accepts both naming conventions in usage dicts — the same fallback pattern already used in `load_from_log_dir()` (tokens.py:329-334), `extract_token_usage` (_session_model.py), `flush_session_log`, and `token_summary_hook.py`. Additionally, two v1-format on-disk test payloads in T-LOC tests are migrated to v2 canonical format (`step_name` → `session_label`, add `schema_version: 2`). Backward-compatibility tests in `TestLoadFromLogDirSchemaVersionCompat` are preserved unchanged — they exist to validate v1 ingestion.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260517-184047-408488/.autoskillit/temp/make-plan/p2_a19_wp1_migrate_pipeline_core_test_files_plan_2026-05-17_184700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 68 | 14.4k | 1.2M | 75.6k | 47 | 66.2k | 5m 50s |
| verify | claude-opus-4-6 | 1 | 1.2k | 5.3k | 549.2k | 49.0k | 36 | 35.6k | 2m 56s |
| implement* | MiniMax-M2.7-highspeed | 1 | 742.6k | 7.0k | 747.9k | 28.9k | 70 | 16.6k | 3m 2s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 75.7k | 3.5k | 228.2k | 28.9k | 22 | 15.7k | 1m 25s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 136.8k | 2.9k | 430.3k | 28.9k | 31 | 15.4k | 1m 23s |
| review_pr | claude-sonnet-4-6 | 3 | 510 | 50.9k | 1.4M | 55.9k | 116 | 124.8k | 12m 44s |
| resolve_review | claude-sonnet-4-6 | 2 | 308 | 14.9k | 1.5M | 54.4k | 89 | 103.9k | 10m 52s |
| **Total** | | | 957.2k | 99.0k | 6.0M | 75.6k | | 378.2k | 38m 16s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 84 | 8903.7 | 197.3 | 83.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 367157.0 | 25986.5 | 3734.5 |
| **Total** | **88** | 68744.4 | 4297.3 | 1125.1 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 1.2k | 19.7k | 1.8M | 101.8k | 8m 47s |
| MiniMax-M2.7-highspeed | 3 | 955.1k | 13.4k | 1.4M | 47.6k | 5m 51s |