### PR TITLE
[P2-A19-WP5] Rename cache fields in remaining 3 test files

### DIFF
--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -127,8 +127,8 @@ def test_default_token_log_satisfies_token_store_with_order_id():
         {
             "input_tokens": 1,
             "output_tokens": 1,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
         },
         order_id="test-order",
     )

--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -377,8 +377,8 @@ def test_iter_session_log_entries_kitchen_id_filter(tmp_path):
                     "step_name": e["step_name"],
                     "input_tokens": 1,
                     "output_tokens": 1,
-                    "cache_creation_input_tokens": 0,
-                    "cache_read_input_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "cache_read_tokens": 0,
                     "timing_seconds": 1.0,
                 }
             )
@@ -435,8 +435,8 @@ def test_iter_session_log_entries_kitchen_id_backward_compat(tmp_path):
                     "step_name": e["step_name"],
                     "input_tokens": 1,
                     "output_tokens": 1,
-                    "cache_creation_input_tokens": 0,
-                    "cache_read_input_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "cache_read_tokens": 0,
                     "timing_seconds": 0.5,
                 }
             )

--- a/tests/pipeline/test_tokens_model.py
+++ b/tests/pipeline/test_tokens_model.py
@@ -18,8 +18,8 @@ def _make_usage_with_model(
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
-        "cache_creation_input_tokens": 0,
-        "cache_read_input_tokens": 0,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
         "model_breakdown": {model: {"input_tokens": input_tokens, "output_tokens": output_tokens}},
     }
 
@@ -110,8 +110,8 @@ def test_load_from_log_dir_reads_model_identifier(tmp_path: Path, use_session_la
                 step_key: "plan",
                 "input_tokens": 100,
                 "output_tokens": 50,
-                "cache_creation_input_tokens": 0,
-                "cache_read_input_tokens": 0,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
                 "timing_seconds": 10.0,
                 "model_identifier": "claude-sonnet-4-6",
             }
@@ -136,8 +136,8 @@ def test_load_from_log_dir_no_model_identifier_defaults_empty(tmp_path: Path) ->
                 "session_label": "plan",
                 "input_tokens": 100,
                 "output_tokens": 50,
-                "cache_creation_input_tokens": 0,
-                "cache_read_input_tokens": 0,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
                 "timing_seconds": 10.0,
             }
         )


### PR DESCRIPTION
## Summary

Rename legacy Anthropic cache field names (`cache_creation_input_tokens` → `cache_write_tokens`, `cache_read_input_tokens` → `cache_read_tokens`) in 3 test files. The plan identifies 12 field renames across `tests/pipeline/test_tokens_model.py` (6 refs), `tests/pipeline/test_audit.py` (4 refs), and `tests/contracts/test_protocol_satisfaction.py` (2 refs). Four other files from the parent issue are already canonical and one has intentional legacy references in a contract test that must remain.

## Requirements

## Goal

Replace 26 legacy field refs across 7 medium/low-effort test files.

## Context

- Phase: Canonical Token Schema Normalization (Milestone: 2-canonical-token-schema-normalization)
- Assignment: P2-A19 (Migrate ~30 test files (~459 references) from Anthropic field names to canonical names)
- Depends on: None
- Depended on by: P2-A20-WP1

## Deliverables

- `All 26 refs renamed across 7 files`
- `All tests pass`
- `test_state_schema.py excluded (P2-A9)`

## Technical Steps

1. Update test_token_summary_filters.py (6 refs)
2. Update test_tokens_model.py (6 refs)
3. Update test_audit.py (4 refs)
4. Update test_protocol_satisfaction.py (2 refs)
5. Update test_token_summary_contracts.py (2 refs)
6. Update test_fleet_status.py (4 refs)
7. Update test_smoke_utils.py (2 refs)

## Acceptance Criteria

- Zero old names across all 7 files
- All tests pass
- input_tokens/output_tokens unchanged

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):

tests/pipeline/test_tokens_model.py
tests/pipeline/test_audit.py
tests/contracts/test_protocol_satisfaction.py

Closes #2467

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260517-184050-818930/.autoskillit/temp/make-plan/p2_a19_wp5_rename_cache_fields_plan_2026-05-17_184500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 77 | 15.8k | 1.7M | 72.6k | 91 | 59.2k | 12m 56s |
| verify | claude-opus-4-6 | 1 | 27 | 8.2k | 410.1k | 68.6k | 51 | 55.3k | 5m 37s |
| implement* | MiniMax-M2.7-highspeed | 1 | 386.0k | 3.7k | 459.5k | 28.9k | 34 | 16.6k | 2m 4s |
| prepare_pr* | MiniMax-M2.7-highspeed | 2 | 203.3k | 6.6k | 515.1k | 35.4k | 55 | 111.7k | 2m 42s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 63.9k | 1.9k | 237.0k | 30.0k | 19 | 15.4k | 48s |
| review_pr | claude-sonnet-4-6 | 3 | 268 | 27.2k | 1.1M | 46.5k | 92 | 93.5k | 7m 42s |
| **Total** | | | 653.6k | 63.5k | 4.5M | 72.6k | | 351.6k | 31m 50s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 24 | 71499.2 | 2468.2 | 659.7 |
| verify | 24 | 17087.2 | 2302.9 | 340.4 |
| implement | 24 | 19144.9 | 691.7 | 155.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **72** | 62063.1 | 4883.9 | 881.3 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 104 | 24.0k | 2.1M | 114.5k | 18m 33s |
| MiniMax-M2.7-highspeed | 3 | 653.2k | 12.2k | 1.2M | 143.6k | 5m 34s |