### PR TITLE
[FEATURE] Add git-level write evidence to zero-writes gate and DIRTY_MAIN_REPO recovery

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -192,6 +192,7 @@ class SkillResult:
     write_path_warnings: list[str] = field(default_factory=list)
     write_call_count: int = 0
     fs_writes_detected: bool = False
+    git_writes_detected: bool = False
     order_id: str = ""
     kill_reason: KillReason = KillReason.NATURAL_EXIT
     """Why the subprocess was (or was not) killed after the race loop.
@@ -224,6 +225,7 @@ class SkillResult:
             "write_path_warnings": self.write_path_warnings,
             "write_call_count": self.write_call_count,
             "fs_writes_detected": self.fs_writes_detected,
+            "git_writes_detected": self.git_writes_detected,
             "has_progress_evidence": self.has_progress_evidence,
             "last_stop_reason": self.last_stop_reason,
             "lifespan_started": self.lifespan_started,
@@ -288,7 +290,10 @@ class SkillResult:
         checking individual artifact fields.
         """
         return (
-            self.worktree_path is not None or self.fs_writes_detected or self.write_call_count > 0
+            self.worktree_path is not None
+            or self.fs_writes_detected
+            or self.write_call_count > 0
+            or self.git_writes_detected
         )
 
 

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -445,7 +445,7 @@ async def _execute_claude_headless(
                     break
 
         _git_writes_detected = False
-        if not _fs_writes_detected and is_git_worktree(Path(cwd)):
+        if is_git_worktree(Path(cwd)):
             _git_writes_detected = _detect_branch_divergence(cwd)
 
         audit_count_before = len(ctx.audit.get_report())

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -54,6 +54,7 @@ from autoskillit.execution.commands import (
 from autoskillit.execution.headless._headless_git import (
     _capture_git_head_sha,
     _compute_loc_changed,
+    _detect_branch_divergence,
 )
 from autoskillit.execution.headless._headless_path_tokens import (  # noqa: F401
     _INTENTIONALLY_EXCLUDED_PATH_TOKENS,
@@ -443,6 +444,10 @@ async def _execute_claude_headless(
                     _fs_writes_detected = True
                     break
 
+        _git_writes_detected = False
+        if not _fs_writes_detected and is_git_worktree(Path(cwd)):
+            _git_writes_detected = _detect_branch_divergence(cwd)
+
         audit_count_before = len(ctx.audit.get_report())
         skill_result = _build_skill_result(
             result,
@@ -453,6 +458,7 @@ async def _execute_claude_headless(
             cwd=cwd,
             write_behavior=write_behavior,
             fs_writes_detected=_fs_writes_detected,
+            git_writes_detected=_git_writes_detected,
             prior_completion_markers=prior_completion_markers,
             provider_used=current_provider_name,
         )

--- a/src/autoskillit/execution/headless/_headless_git.py
+++ b/src/autoskillit/execution/headless/_headless_git.py
@@ -98,7 +98,13 @@ def _detect_branch_divergence(cwd: str) -> bool:
                 timeout=10,
             )
             if rl.returncode == 0:
-                count = int(rl.stdout.strip())
+                raw = rl.stdout.strip()
+                if not raw:
+                    continue
+                try:
+                    count = int(raw)
+                except ValueError:
+                    continue
                 return count > 0
         except Exception:
             logger.debug(

--- a/src/autoskillit/execution/headless/_headless_git.py
+++ b/src/autoskillit/execution/headless/_headless_git.py
@@ -65,3 +65,46 @@ def _compute_loc_changed(cwd: str, pre_sha: str) -> tuple[int, int]:
     except Exception:
         logger.debug("compute_loc_changed_failed", cwd=cwd, pre_sha=pre_sha, exc_info=True)
         return 0, 0
+
+
+def _detect_branch_divergence(cwd: str) -> bool:
+    """Check if current branch has commits ahead of the remote default branch.
+
+    Tries origin/HEAD, origin/main, origin/master as base references.
+    Returns False on any error or non-git directory.
+    """
+    for ref in ("origin/HEAD", "origin/main", "origin/master"):
+        try:
+            mb = subprocess.run(
+                ["git", "merge-base", "HEAD", ref],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if mb.returncode != 0:
+                continue
+            merge_base_sha = mb.stdout.strip()
+            if not merge_base_sha:
+                continue
+
+            rl = subprocess.run(
+                ["git", "rev-list", "--count", f"{merge_base_sha}..HEAD"],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if rl.returncode == 0:
+                count = int(rl.stdout.strip())
+                return count > 0
+        except Exception:
+            logger.debug(
+                "detect_branch_divergence_failed",
+                cwd=cwd,
+                ref=ref,
+                exc_info=True,
+            )
+            continue
+
+    return False

--- a/src/autoskillit/execution/headless/_headless_git.py
+++ b/src/autoskillit/execution/headless/_headless_git.py
@@ -71,6 +71,8 @@ def _detect_branch_divergence(cwd: str) -> bool:
     """Check if current branch has commits ahead of the remote default branch.
 
     Tries origin/HEAD, origin/main, origin/master as base references.
+    Returns the result from the first ref that resolves successfully;
+    remaining refs are only tried when merge-base or rev-list fails.
     Returns False on any error or non-git directory.
     """
     for ref in ("origin/HEAD", "origin/main", "origin/master"):

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -164,6 +164,7 @@ def _build_skill_result(
     cwd: str = "",
     write_behavior: WriteBehaviorSpec | None = None,
     fs_writes_detected: bool = False,
+    git_writes_detected: bool = False,
     prior_completion_markers: Sequence[str] | None = None,
     *,
     provider_used: str = "",
@@ -320,7 +321,7 @@ def _build_skill_result(
         session = parse_session_result(result.stdout)
 
     write_call_count = sum(1 for t in session.tool_uses if t.get("name") in {"Write", "Edit"})
-    _has_write_evidence = write_call_count >= 1 or fs_writes_detected
+    _has_write_evidence = write_call_count >= 1 or fs_writes_detected or git_writes_detected
 
     # Channel B drain-race: recover from assistant_messages if type=result was not flushed.
     match result.channel_confirmation:
@@ -542,6 +543,7 @@ def _build_skill_result(
             write_path_warnings=write_path_warnings,
             write_call_count=write_call_count,
             fs_writes_detected=fs_writes_detected,
+            git_writes_detected=git_writes_detected,
             kill_reason=result.kill_reason,
             last_stop_reason=session.last_stop_reason,
             lifespan_started=session.lifespan_started,
@@ -565,6 +567,7 @@ def _build_skill_result(
             write_path_warnings=write_path_warnings,
             write_call_count=write_call_count,
             fs_writes_detected=fs_writes_detected,
+            git_writes_detected=git_writes_detected,
             kill_reason=result.kill_reason,
             last_stop_reason=session.last_stop_reason,
             lifespan_started=session.lifespan_started,

--- a/src/autoskillit/hooks/formatters/_fmt_execution.py
+++ b/src/autoskillit/hooks/formatters/_fmt_execution.py
@@ -225,6 +225,7 @@ _FMT_RUN_SKILL_SUPPRESSED: frozenset[str] = frozenset(
         "write_path_warnings",
         "write_call_count",
         "fs_writes_detected",
+        "git_writes_detected",
         "last_stop_reason",
         "lifespan_started",
         "order_id",

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -74,7 +74,7 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
     )
     if result.returncode != 0:
         raise subprocess.CalledProcessError(
-            result.returncode, result.args, result.stdout.encode(), result.stderr.encode()
+            result.returncode, result.args, result.stdout, result.stderr
         )
 
     if not result.stdout.strip():
@@ -124,6 +124,8 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
                 cl.returncode,
                 cl.stderr.strip(),
             )
+        if co.returncode != 0 and cl.returncode != 0:
+            return {"cleaned": "failed"}
         return {"cleaned": "force"}
 
     return {"cleaned": "true"}

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -93,6 +93,7 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
     if stash_result.returncode != 0:
         subprocess.run(["git", "checkout", "--", "."], cwd=clone_path, check=True)
         subprocess.run(["git", "clean", "-fd"], cwd=clone_path, check=True)
+        return {"cleaned": "force"}
 
     return {"cleaned": "true"}
 

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -62,6 +62,41 @@ def check_dropped_healthy_loop(
     return {"status": status, "count": str(count)}
 
 
+def main_repo_guard(clone_path: str) -> dict[str, str]:
+    """Stash dirty state from the main repo before merge."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=clone_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, result.args, result.stdout.encode(), result.stderr.encode()
+        )
+
+    if not result.stdout.strip():
+        return {"cleaned": "false"}
+
+    stash_result = subprocess.run(
+        [
+            "git",
+            "stash",
+            "--include-untracked",
+            "-m",
+            "autoskillit: main_repo_guard pre-merge stash",
+        ],
+        cwd=clone_path,
+        capture_output=True,
+        text=True,
+    )
+    if stash_result.returncode != 0:
+        subprocess.run(["git", "checkout", "--", "."], cwd=clone_path, check=True)
+        subprocess.run(["git", "clean", "-fd"], cwd=clone_path, check=True)
+
+    return {"cleaned": "true"}
+
+
 def commit_guard(worktree_path: str) -> dict[str, str]:
     """Auto-commit pending changes if worktree is dirty, excluding generated files."""
     result = subprocess.run(

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -98,18 +98,32 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
             stash_result.returncode,
             stash_result.stderr.strip(),
         )
-        subprocess.run(
+        co = subprocess.run(
             ["git", "checkout", "--", "."],
             cwd=clone_path,
             capture_output=True,
+            text=True,
             check=False,
         )
-        subprocess.run(
+        if co.returncode != 0:
+            logger.warning(
+                "git checkout force-clean failed (rc=%d): %s",
+                co.returncode,
+                co.stderr.strip(),
+            )
+        cl = subprocess.run(
             ["git", "clean", "-fd"],
             cwd=clone_path,
             capture_output=True,
+            text=True,
             check=False,
         )
+        if cl.returncode != 0:
+            logger.warning(
+                "git clean force-clean failed (rc=%d): %s",
+                cl.returncode,
+                cl.stderr.strip(),
+            )
         return {"cleaned": "force"}
 
     return {"cleaned": "true"}

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 import regex as re
 
-from autoskillit.core import atomic_write, is_generated_path
+from autoskillit.core import atomic_write, get_logger, is_generated_path
+
+logger = get_logger(__name__)
 
 
 def compute_branch(
@@ -91,6 +93,11 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
         text=True,
     )
     if stash_result.returncode != 0:
+        logger.warning(
+            "git stash failed (rc=%d) — falling back to force-clean: %s",
+            stash_result.returncode,
+            stash_result.stderr.strip(),
+        )
         subprocess.run(
             ["git", "checkout", "--", "."],
             cwd=clone_path,

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -91,8 +91,18 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
         text=True,
     )
     if stash_result.returncode != 0:
-        subprocess.run(["git", "checkout", "--", "."], cwd=clone_path, check=True)
-        subprocess.run(["git", "clean", "-fd"], cwd=clone_path, check=True)
+        subprocess.run(
+            ["git", "checkout", "--", "."],
+            cwd=clone_path,
+            capture_output=True,
+            check=False,
+        )
+        subprocess.run(
+            ["git", "clean", "-fd"],
+            cwd=clone_path,
+            capture_output=True,
+            check=False,
+        )
         return {"cleaned": "force"}
 
     return {"cleaned": "true"}

--- a/src/autoskillit/recipe/rules/rules_merge.py
+++ b/src/autoskillit/recipe/rules/rules_merge.py
@@ -34,6 +34,7 @@ _RECOVERABLE_FAILED_STEPS: frozenset[str] = frozenset(
         MergeFailedStep.TEST_GATE,
         MergeFailedStep.POST_REBASE_TEST_GATE,
         MergeFailedStep.REBASE,
+        MergeFailedStep.DIRTY_MAIN_REPO,
     }
 )
 

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -248,6 +248,7 @@
           "route": "test"
         }
       ],
+      "on_context_limit": "test",
       "on_exhausted": "release_issue_failure",
       "on_failure": "release_issue_failure"
     },
@@ -290,9 +291,19 @@
         "callable": "autoskillit.recipe._cmd_rpc.commit_guard",
         "worktree_path": "${{ context.worktree_path }}"
       },
+      "on_success": "main_repo_guard",
+      "on_failure": "main_repo_guard",
+      "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. Routes to main_repo_guard to handle dirty main repo state.\n"
+    },
+    "main_repo_guard": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.recipe._cmd_rpc.main_repo_guard",
+        "clone_path": "${{ context.work_dir }}"
+      },
       "on_success": "merge",
       "on_failure": "merge",
-      "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. on_failure routes to merge (dirty-tree gate will catch real issues).\n"
+      "note": "Stashes uncommitted changes in the main repo before merge. Catches dirty state from infrastructure-terminated sessions that left artifacts in the clone. Routes to merge on both success and failure (merge's dirty_main_repo gate handles persistent issues).\n"
     },
     "merge": {
       "tool": "merge_worktree",
@@ -320,6 +331,10 @@
         {
           "when": "result.failed_step == 'rebase'",
           "route": "rebase_conflict_fix"
+        },
+        {
+          "when": "result.failed_step == 'dirty_main_repo'",
+          "route": "check_merge_fix_loop"
         },
         {
           "when": "result.error",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -256,6 +256,7 @@ steps:
       - when: "${{ result.phases_implemented }} > 0"
         route: test
       - route: test
+    on_context_limit: test
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
 
@@ -291,12 +292,25 @@ steps:
     with:
       callable: "autoskillit.recipe._cmd_rpc.commit_guard"
       worktree_path: "${{ context.worktree_path }}"
-    on_success: merge
-    on_failure: merge
+    on_success: main_repo_guard
+    on_failure: main_repo_guard
     note: >
       Belt-and-suspenders guard: auto-commits any uncommitted changes before merge.
       Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes,
-      or any other source. on_failure routes to merge (dirty-tree gate will catch real issues).
+      or any other source. Routes to main_repo_guard to handle dirty main repo state.
+
+  main_repo_guard:
+    tool: run_python
+    with:
+      callable: "autoskillit.recipe._cmd_rpc.main_repo_guard"
+      clone_path: "${{ context.work_dir }}"
+    on_success: merge
+    on_failure: merge
+    note: >
+      Stashes uncommitted changes in the main repo before merge. Catches dirty state
+      from infrastructure-terminated sessions that left artifacts in the clone.
+      Routes to merge on both success and failure (merge's dirty_main_repo gate
+      handles persistent issues).
 
   merge:
     tool: merge_worktree
@@ -315,6 +329,8 @@ steps:
         route: fix
       - when: "result.failed_step == 'rebase'"
         route: rebase_conflict_fix
+      - when: "result.failed_step == 'dirty_main_repo'"
+        route: check_merge_fix_loop
       - when: "result.error"
         route: release_issue_failure
       - route: next_or_done

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -243,6 +243,7 @@
           "route": "test"
         }
       ],
+      "on_context_limit": "test",
       "on_exhausted": "release_issue_failure",
       "on_failure": "release_issue_failure"
     },
@@ -285,9 +286,19 @@
         "callable": "autoskillit.recipe._cmd_rpc.commit_guard",
         "worktree_path": "${{ context.worktree_path }}"
       },
+      "on_success": "main_repo_guard",
+      "on_failure": "main_repo_guard",
+      "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. Routes to main_repo_guard to handle dirty main repo state.\n"
+    },
+    "main_repo_guard": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.recipe._cmd_rpc.main_repo_guard",
+        "clone_path": "${{ context.work_dir }}"
+      },
       "on_success": "merge",
       "on_failure": "merge",
-      "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. on_failure routes to merge (dirty-tree gate will catch real issues).\n"
+      "note": "Stashes uncommitted changes in the main repo before merge. Catches dirty state from infrastructure-terminated sessions that left artifacts in the clone. Routes to merge on both success and failure (merge's dirty_main_repo gate handles persistent issues).\n"
     },
     "merge": {
       "tool": "merge_worktree",
@@ -315,6 +326,10 @@
         {
           "when": "result.failed_step == 'rebase'",
           "route": "rebase_conflict_fix"
+        },
+        {
+          "when": "result.failed_step == 'dirty_main_repo'",
+          "route": "check_merge_fix_loop"
         },
         {
           "when": "result.error",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -256,8 +256,10 @@ steps:
       - when: "${{ result.phases_implemented }} > 0"
         route: test
       - route: test
+    on_context_limit: test
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
+    on_context_limit: test
 
   test:
     tool: test_check
@@ -291,12 +293,25 @@ steps:
     with:
       callable: "autoskillit.recipe._cmd_rpc.commit_guard"
       worktree_path: "${{ context.worktree_path }}"
-    on_success: merge
-    on_failure: merge
+    on_success: main_repo_guard
+    on_failure: main_repo_guard
     note: >
       Belt-and-suspenders guard: auto-commits any uncommitted changes before merge.
       Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes,
-      or any other source. on_failure routes to merge (dirty-tree gate will catch real issues).
+      or any other source. Routes to main_repo_guard to handle dirty main repo state.
+
+  main_repo_guard:
+    tool: run_python
+    with:
+      callable: "autoskillit.recipe._cmd_rpc.main_repo_guard"
+      clone_path: "${{ context.work_dir }}"
+    on_success: merge
+    on_failure: merge
+    note: >
+      Stashes uncommitted changes in the main repo before merge. Catches dirty state
+      from infrastructure-terminated sessions that left artifacts in the clone.
+      Routes to merge on both success and failure (merge's dirty_main_repo gate
+      handles persistent issues).
 
   merge:
     tool: merge_worktree
@@ -315,6 +330,8 @@ steps:
         route: fix
       - when: "result.failed_step == 'rebase'"
         route: rebase_conflict_fix
+      - when: "result.failed_step == 'dirty_main_repo'"
+        route: check_merge_fix_loop
       - when: "result.error"
         route: release_issue_failure
       - route: next_or_done

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -259,7 +259,6 @@ steps:
     on_context_limit: test
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
-    on_context_limit: test
 
   test:
     tool: test_check

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -265,6 +265,7 @@
           "route": "test"
         }
       ],
+      "on_context_limit": "test",
       "on_exhausted": "release_issue_failure",
       "on_failure": "release_issue_failure"
     },
@@ -292,7 +293,7 @@
           "route": "release_issue_failure"
         },
         {
-          "route": "audit_impl"
+          "route": "commit_guard"
         }
       ],
       "on_failure": "release_issue_failure",
@@ -426,9 +427,19 @@
         "callable": "autoskillit.recipe._cmd_rpc.commit_guard",
         "worktree_path": "${{ context.implementation_ref }}"
       },
+      "on_success": "main_repo_guard",
+      "on_failure": "main_repo_guard",
+      "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. Routes to main_repo_guard to handle dirty main repo state.\n"
+    },
+    "main_repo_guard": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.recipe._cmd_rpc.main_repo_guard",
+        "clone_path": "${{ context.work_dir }}"
+      },
       "on_success": "merge",
       "on_failure": "merge",
-      "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. on_failure routes to merge (dirty-tree gate will catch real issues).\n"
+      "note": "Stashes uncommitted changes in the main repo before merge. Catches dirty state from infrastructure-terminated sessions that left artifacts in the clone. Routes to merge on both success and failure (merge's dirty_main_repo gate handles persistent issues).\n"
     },
     "merge": {
       "tool": "merge_worktree",
@@ -456,6 +467,10 @@
         {
           "when": "result.failed_step == 'rebase'",
           "route": "rebase_conflict_fix"
+        },
+        {
+          "when": "result.failed_step == 'dirty_main_repo'",
+          "route": "check_merge_fix_loop"
         },
         {
           "when": "result.error",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -293,7 +293,7 @@
           "route": "release_issue_failure"
         },
         {
-          "route": "commit_guard"
+          "route": "audit_impl"
         }
       ],
       "on_failure": "release_issue_failure",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -268,6 +268,7 @@ steps:
       - when: "${{ result.phases_implemented }} > 0"
         route: test
       - route: test
+    on_context_limit: test
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
 
@@ -289,7 +290,7 @@ steps:
     on_result:
       - when: "${{ result.max_exceeded }} == true"
         route: release_issue_failure
-      - route: audit_impl
+      - route: commit_guard
     on_failure: release_issue_failure
     optional_context_refs:
       - merge_fix_count
@@ -389,12 +390,25 @@ steps:
     with:
       callable: "autoskillit.recipe._cmd_rpc.commit_guard"
       worktree_path: "${{ context.implementation_ref }}"
-    on_success: merge
-    on_failure: merge
+    on_success: main_repo_guard
+    on_failure: main_repo_guard
     note: >
       Belt-and-suspenders guard: auto-commits any uncommitted changes before merge.
       Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes,
-      or any other source. on_failure routes to merge (dirty-tree gate will catch real issues).
+      or any other source. Routes to main_repo_guard to handle dirty main repo state.
+
+  main_repo_guard:
+    tool: run_python
+    with:
+      callable: "autoskillit.recipe._cmd_rpc.main_repo_guard"
+      clone_path: "${{ context.work_dir }}"
+    on_success: merge
+    on_failure: merge
+    note: >
+      Stashes uncommitted changes in the main repo before merge. Catches dirty state
+      from infrastructure-terminated sessions that left artifacts in the clone.
+      Routes to merge on both success and failure (merge's dirty_main_repo gate
+      handles persistent issues).
 
   merge:
     tool: merge_worktree
@@ -413,6 +427,8 @@ steps:
         route: assess
       - when: "result.failed_step == 'rebase'"
         route: rebase_conflict_fix
+      - when: "result.failed_step == 'dirty_main_repo'"
+        route: check_merge_fix_loop
       - when: "result.error"
         route: release_issue_failure
       - route: next_or_done

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -290,7 +290,7 @@ steps:
     on_result:
       - when: "${{ result.max_exceeded }} == true"
         route: release_issue_failure
-      - route: commit_guard
+      - route: audit_impl
     on_failure: release_issue_failure
     optional_context_refs:
       - merge_fix_count

--- a/src/autoskillit/server/tools/_types.py
+++ b/src/autoskillit/server/tools/_types.py
@@ -45,6 +45,7 @@ class RunSkillResult(_RunSkillResultBase, total=False):
     write_path_warnings: list[str]
     write_call_count: int
     fs_writes_detected: bool
+    git_writes_detected: bool
     last_stop_reason: str
     lifespan_started: bool
     worktree_path: str

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -14,7 +14,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_result.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 920,
+    "headless/__init__.py": 925,
     "headless/_headless_recovery.py": 340,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 673,

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -17,7 +17,7 @@ HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 925,
     "headless/_headless_recovery.py": 340,
     "headless/_headless_path_tokens.py": 175,
-    "headless/_headless_result.py": 673,
+    "headless/_headless_result.py": 677,
 }
 
 

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -661,3 +661,68 @@ class TestSkillResultExtensionBundles:
         )
         assert sr2.provider.provider_used == "vertex"
         assert sr2.provider.fallback_activated is True
+
+
+# ---------------------------------------------------------------------------
+# T-ZW-6: git_writes_detected in has_progress_evidence
+# ---------------------------------------------------------------------------
+
+
+def test_git_writes_detected_in_has_progress_evidence() -> None:
+    """SkillResult with git_writes_detected=True has has_progress_evidence=True
+    even when worktree_path=None and write_call_count=0."""
+    sr = SkillResult(
+        success=True,
+        result="done",
+        session_id="s1",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+        worktree_path=None,
+        fs_writes_detected=False,
+        write_call_count=0,
+        git_writes_detected=True,
+    )
+    assert sr.has_progress_evidence is True
+
+
+# T-DM-6
+def test_skill_result_git_writes_detected_in_json() -> None:
+    """to_json() must include git_writes_detected when True."""
+    sr = SkillResult(
+        success=True,
+        result="done",
+        session_id="s1",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+        git_writes_detected=True,
+    )
+    data = json.loads(sr.to_json())
+    assert data["git_writes_detected"] is True
+
+
+def test_skill_result_git_writes_detected_false_omitted() -> None:
+    """to_json() must omit git_writes_detected when False (matches fs_writes_detected pattern)."""
+    sr = SkillResult(
+        success=True,
+        result="done",
+        session_id="s1",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+        git_writes_detected=False,
+    )
+    data = json.loads(sr.to_json())
+    # git_writes_detected=False is the default; key should be absent in JSON output
+    # (mirrors the fs_writes_detected omission pattern)
+    assert data.get("git_writes_detected", False) is False

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -708,8 +708,8 @@ def test_skill_result_git_writes_detected_in_json() -> None:
     assert data["git_writes_detected"] is True
 
 
-def test_skill_result_git_writes_detected_false_omitted() -> None:
-    """to_json() must omit git_writes_detected when False (matches fs_writes_detected pattern)."""
+def test_skill_result_git_writes_detected_false_included() -> None:
+    """to_json() unconditionally includes git_writes_detected (even when False)."""
     sr = SkillResult(
         success=True,
         result="done",
@@ -723,6 +723,5 @@ def test_skill_result_git_writes_detected_false_omitted() -> None:
         git_writes_detected=False,
     )
     data = json.loads(sr.to_json())
-    # git_writes_detected=False is the default; key should be absent in JSON output
-    # (mirrors the fs_writes_detected omission pattern)
-    assert data.get("git_writes_detected", False) is False
+    assert "git_writes_detected" in data
+    assert data["git_writes_detected"] is False

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -931,6 +931,7 @@ class TestBuildSkillResultCrossValidation:
         "write_path_warnings",
         "write_call_count",
         "fs_writes_detected",
+        "git_writes_detected",
         "has_progress_evidence",
         "infra_exit_category",
     }

--- a/tests/execution/test_loc_capture.py
+++ b/tests/execution/test_loc_capture.py
@@ -159,6 +159,86 @@ def test_compute_loc_changed_clone_root_vs_worktree(tmp_path: Path):
     assert wt_del == 0
 
 
+# T-ZW-4
+@pytest.mark.medium
+def test_detect_branch_divergence_with_commits_ahead(tmp_path: Path):
+    """_detect_branch_divergence returns True when current branch has commits ahead of remote."""
+    from autoskillit.execution.headless._headless_git import _detect_branch_divergence
+
+    repo_path = tmp_path / "repo"
+    _setup_git_repo(repo_path)
+
+    # Set up a bare remote so origin/* refs exist for _detect_branch_divergence
+    bare_remote = tmp_path / "bare.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(repo_path), str(bare_remote)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(bare_remote)],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "fetch", "origin"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+    )
+
+    worktree_path = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature-branch", str(worktree_path)],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+    )
+    (worktree_path / "feature.txt").write_text("new content\n")
+    subprocess.run(["git", "add", "."], cwd=worktree_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add feature"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+    )
+
+    assert _detect_branch_divergence(str(worktree_path)) is True
+
+
+# T-ZW-5
+@pytest.mark.medium
+def test_detect_branch_divergence_at_merge_base(tmp_path: Path):
+    """_detect_branch_divergence returns False when at merge base (0 commits ahead)."""
+    from autoskillit.execution.headless._headless_git import _detect_branch_divergence
+
+    repo_path = tmp_path / "repo"
+    _setup_git_repo(repo_path)
+
+    worktree_path = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "worktree", "add", str(worktree_path)],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+    )
+
+    assert _detect_branch_divergence(str(worktree_path)) is False
+
+
 # T-GIT-6
 def test_post_session_metrics_effective_cwd_resolution(tmp_path: Path):
     """PostSessionMetrics resolves effective_cwd from worktree_path when set."""

--- a/tests/execution/test_loc_capture.py
+++ b/tests/execution/test_loc_capture.py
@@ -228,9 +228,28 @@ def test_detect_branch_divergence_at_merge_base(tmp_path: Path):
     repo_path = tmp_path / "repo"
     _setup_git_repo(repo_path)
 
+    bare_remote = tmp_path / "bare.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(repo_path), str(bare_remote)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(bare_remote)],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "fetch", "origin"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+    )
+
     worktree_path = tmp_path / "worktree"
     subprocess.run(
-        ["git", "worktree", "add", str(worktree_path)],
+        ["git", "worktree", "add", "-b", "at-base", str(worktree_path)],
         cwd=repo_path,
         check=True,
         capture_output=True,

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -529,6 +529,7 @@ class TestSkillResult:
             "write_path_warnings",
             "write_call_count",
             "fs_writes_detected",
+            "git_writes_detected",
             "has_progress_evidence",
             "infra_exit_category",
         }

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -708,6 +708,55 @@ class TestTempDirSnapshot:
         assert post - pre == set()
 
 
+class TestGitWritesDetection:
+    """Git-level write detection suppresses zero_writes false positives."""
+
+    def test_git_writes_detected_suppresses_zero_writes_gate(self) -> None:
+        """When git_writes_detected=True, zero_writes gate must NOT fire
+        even when write_call_count == 0."""
+        stdout = _ndjson_with_tool_uses(["Read", "Grep"])
+        sr = _build_skill_result(
+            _make_result(returncode=0, stdout=stdout),
+            skill_command="/make-plan task",
+            write_behavior=WriteBehaviorSpec(mode="always"),
+            git_writes_detected=True,
+        )
+        assert sr.success is True
+        assert sr.subtype != "zero_writes"
+        assert sr.git_writes_detected is True
+
+    def test_git_writes_detected_false_still_allows_gate(self) -> None:
+        """When git_writes_detected=False and write_call_count == 0,
+        zero_writes gate must fire as before."""
+        stdout = _ndjson_with_tool_uses(["Read", "Grep"])
+        sr = _build_skill_result(
+            _make_result(returncode=0, stdout=stdout),
+            skill_command="/make-plan task",
+            write_behavior=WriteBehaviorSpec(mode="always"),
+            git_writes_detected=False,
+        )
+        assert sr.success is False
+        assert sr.subtype == "zero_writes"
+
+    def test_git_writes_detected_suppresses_conditional_zero_writes(self) -> None:
+        """Conditional skill, zero writes, git_writes_detected=True → success preserved."""
+        stdout = _ndjson_with_tool_uses(["Read", "Grep"])
+        sr = _build_skill_result(
+            _make_result(returncode=0, stdout=stdout),
+            skill_command="/autoskillit:resolve-failures /tmp/wt /tmp/plan.md main",
+            write_behavior=WriteBehaviorSpec(
+                mode="conditional",
+                expected_when=(r"verdict\s*=\s*real_fix",),
+            ),
+            git_writes_detected=True,
+        )
+        assert sr.success is True, (
+            "git_writes_detected=True must suppress zero_writes gate even when "
+            "write_behavior is conditional and pattern matches"
+        )
+        assert sr.subtype != "zero_writes"
+
+
 class TestWriteExpectedWhenPatternSync:
     """write_expected_when patterns in tests must match skill_contracts.yaml."""
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -160,7 +160,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 268),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 532),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 534),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -160,7 +160,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 268),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 501),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 511),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -160,7 +160,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 268),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 518),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 532),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -160,7 +160,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 268),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 500),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 501),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -160,7 +160,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 268),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 511),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 518),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -160,7 +160,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 268),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 465),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 500),
 }
 
 

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -598,12 +598,21 @@ def test_merge_worktree_has_commit_guard_predecessor() -> None:
             continue
         ctx = make_validation_context(recipe)
         for step_name in merge_steps:
-            preds = ctx.predecessors.get(step_name, set())
-            has_guard = any(_is_commit_guard(p, ctx) for p in preds)
+            visited: set[str] = set()
+            frontier = list(ctx.predecessors.get(step_name, set()))
+            has_guard = False
+            while frontier and not has_guard:
+                p = frontier.pop()
+                if p in visited:
+                    continue
+                visited.add(p)
+                if _is_commit_guard(p, ctx):
+                    has_guard = True
+                else:
+                    frontier.extend(ctx.predecessors.get(p, set()))
             assert has_guard, (
                 f"{yaml_path.name}: merge_worktree step '{step_name}' has no commit_guard "
-                f"predecessor. Add a commit_guard run_cmd step immediately before merge. "
-                f"Predecessors: {sorted(preds)}"
+                f"in its predecessor chain. Predecessors: {sorted(ctx.predecessors.get(step_name, set()))}"
             )
 
 

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -160,6 +160,15 @@ def test_main_repo_guard_cleans_dirty_state(tmp_path):
     assert status_result.stdout.strip() == "", (
         f"main_repo_guard should leave repo clean, but status was: {status_result.stdout!r}"
     )
+    stash_list = subprocess.run(
+        ["git", "stash", "list"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert "autoskillit: main_repo_guard pre-merge stash" in stash_list.stdout, (
+        f"stash entry not found; git stash list output: {stash_list.stdout!r}"
+    )
 
 
 # T-DM-4

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -20,6 +20,7 @@ from autoskillit.recipe._cmd_rpc import (
     ensure_results,
     export_local_bundle,
     force_push_and_wait_mergeability,
+    main_repo_guard,
     refetch_issues,
     wait_for_direct_merge,
 )
@@ -139,6 +140,35 @@ def test_commit_guard_excludes_generated_files(tmp_path):
     assert not any("contracts/" in f for f in committed_files), (
         f"Generated contracts/ files should NOT be committed, but were: {committed_files}"
     )
+
+
+# T-DM-3
+@pytest.mark.medium
+def test_main_repo_guard_cleans_dirty_state(tmp_path):
+    """main_repo_guard stashes dirty state and returns cleaned=true."""
+    _init_git_repo(tmp_path)
+    (tmp_path / "uncommitted.txt").write_text("dirty content")
+    result = main_repo_guard(clone_path=str(tmp_path))
+    assert result["cleaned"] == "true"
+    # git status --porcelain must be empty after stash
+    status_result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert status_result.stdout.strip() == "", (
+        f"main_repo_guard should leave repo clean, but status was: {status_result.stdout!r}"
+    )
+
+
+# T-DM-4
+@pytest.mark.medium
+def test_main_repo_guard_clean_repo_noop(tmp_path):
+    """main_repo_guard returns cleaned=false when repo is already clean."""
+    _init_git_repo(tmp_path)
+    result = main_repo_guard(clone_path=str(tmp_path))
+    assert result["cleaned"] == "false"
 
 
 def test_ensure_results_with_existing_path():

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -213,3 +213,33 @@ def test_register_clone_unconfirmed_routes_to_done_unconfirmed(recipe) -> None:
     step = recipe.steps["register_clone_unconfirmed"]
     assert step.on_success == "done_unconfirmed"
     assert step.on_failure == "done_unconfirmed"
+
+
+# ---------------------------------------------------------------------------
+# T-ZW-7: retry_worktree on_context_limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
+def test_retry_worktree_has_on_context_limit(recipe_name: str) -> None:
+    """retry_worktree step must have on_context_limit set for EARLY_STOP retry routing."""
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    assert "retry_worktree" in recipe.steps, f"{recipe_name}: retry_worktree step not found"
+    step = recipe.steps["retry_worktree"]
+    assert step.on_context_limit is not None, (
+        f"{recipe_name}: retry_worktree.on_context_limit must not be None "
+        f"to support EARLY_STOP retry routing"
+    )
+
+
+# T-DM-5
+@pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
+def test_main_repo_guard_step_exists(recipe_name: str) -> None:
+    """main_repo_guard step must exist with tool=run_python for dirty main repo recovery."""
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    assert "main_repo_guard" in recipe.steps, f"{recipe_name}: main_repo_guard step not found"
+    step = recipe.steps["main_repo_guard"]
+    assert step.tool == "run_python", f"{recipe_name}: main_repo_guard must use run_python tool"
+    assert "main_repo_guard" in step.with_args.get("callable", ""), (
+        f"{recipe_name}: main_repo_guard callable must reference main_repo_guard"
+    )

--- a/tests/recipe/test_rules_integration_predicate.py
+++ b/tests/recipe/test_rules_integration_predicate.py
@@ -21,7 +21,7 @@ class TestRecipeIntegrationPredicateRouting:
         """The merge step in remediation.yaml has predicate on_result."""
         step = self.if_recipe.steps["merge"]
         assert step.on_result is not None
-        assert len(step.on_result.conditions) == 6
+        assert len(step.on_result.conditions) == 7
 
         cond0 = step.on_result.conditions[0]
         assert cond0.when == "result.failed_step == 'dirty_tree'"
@@ -40,12 +40,16 @@ class TestRecipeIntegrationPredicateRouting:
         assert cond3.route == "rebase_conflict_fix"
 
         cond4 = step.on_result.conditions[4]
-        assert cond4.when == "result.error"
-        assert cond4.route == "release_issue_failure"
+        assert cond4.when == "result.failed_step == 'dirty_main_repo'"
+        assert cond4.route == "check_merge_fix_loop"
 
         cond5 = step.on_result.conditions[5]
-        assert cond5.when is None
-        assert cond5.route == "next_or_done"
+        assert cond5.when == "result.error"
+        assert cond5.route == "release_issue_failure"
+
+        cond6 = step.on_result.conditions[6]
+        assert cond6.when is None
+        assert cond6.route == "next_or_done"
 
     def test_investigate_first_merge_step_captures_worktree_path(self) -> None:
         """The merge step captures worktree_path from result.worktree_path."""
@@ -57,7 +61,7 @@ class TestRecipeIntegrationPredicateRouting:
         """The merge step in implementation.yaml has predicate on_result."""
         step = self.ip_recipe.steps["merge"]
         assert step.on_result is not None
-        assert len(step.on_result.conditions) == 6
+        assert len(step.on_result.conditions) == 7
 
         cond0 = step.on_result.conditions[0]
         assert cond0.when == "result.failed_step == 'dirty_tree'"
@@ -76,12 +80,16 @@ class TestRecipeIntegrationPredicateRouting:
         assert cond3.route == "rebase_conflict_fix"
 
         cond4 = step.on_result.conditions[4]
-        assert cond4.when == "result.error"
-        assert cond4.route == "release_issue_failure"
+        assert cond4.when == "result.failed_step == 'dirty_main_repo'"
+        assert cond4.route == "check_merge_fix_loop"
 
         cond5 = step.on_result.conditions[5]
-        assert cond5.when is None
-        assert cond5.route == "next_or_done"
+        assert cond5.when == "result.error"
+        assert cond5.route == "release_issue_failure"
+
+        cond6 = step.on_result.conditions[6]
+        assert cond6.when is None
+        assert cond6.route == "next_or_done"
 
     def test_implementation_pipeline_merge_step_captures_worktree_path(self) -> None:
         """The merge step in implementation.yaml captures worktree_path."""

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -13,6 +13,53 @@ from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, S
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
+# ---------------------------------------------------------------------------
+# T-DM-1: DIRTY_MAIN_REPO in _RECOVERABLE_FAILED_STEPS
+# ---------------------------------------------------------------------------
+
+
+def test_dirty_main_repo_in_recoverable_steps() -> None:
+    """MergeFailedStep.DIRTY_MAIN_REPO must be in _RECOVERABLE_FAILED_STEPS."""
+    from autoskillit.core.types import MergeFailedStep
+
+    assert MergeFailedStep.DIRTY_MAIN_REPO in _RECOVERABLE_FAILED_STEPS, (
+        "DIRTY_MAIN_REPO must be recoverable so the merge worktree can be retried "
+        "after main_repo_guard cleans dirty state"
+    )
+
+
+# T-DM-2
+@pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
+def test_bundled_recipes_route_dirty_main_repo(recipe_name: str) -> None:
+    """All bundled recipes must route DIRTY_MAIN_REPO in their merge_worktree on_result."""
+    from autoskillit.core.types import MergeFailedStep
+
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+
+    merge_steps = {
+        name: step
+        for name, step in recipe.steps.items()
+        if getattr(step, "tool", None) == "merge_worktree"
+    }
+    assert merge_steps, f"{recipe_name}: no merge_worktree step found"
+
+    for step_name, step in merge_steps.items():
+        if step.on_result is None:
+            continue  # tested separately by other rules
+        matched = set()
+        for cond in step.on_result.conditions:
+            if cond.when is None:
+                continue
+            if "dirty_main_repo" in cond.when.lower() or "DIRTY_MAIN_REPO" in cond.when:
+                matched.add(MergeFailedStep.DIRTY_MAIN_REPO)
+        assert MergeFailedStep.DIRTY_MAIN_REPO in matched, (
+            f"{recipe_name}: merge_worktree step '{step_name}' does not route "
+            f"DIRTY_MAIN_REPO in on_result. Add a condition like "
+            f"${{{{ result.failed_step == 'DIRTY_MAIN_REPO' }}}} to route to the "
+            f"appropriate recovery step."
+        )
+
+
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
     """Minimal recipe factory for rules_merge tests."""
     return Recipe(

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -50,7 +50,7 @@ def test_bundled_recipes_route_dirty_main_repo(recipe_name: str) -> None:
         for cond in step.on_result.conditions:
             if cond.when is None:
                 continue
-            if "dirty_main_repo" in cond.when.lower() or "DIRTY_MAIN_REPO" in cond.when:
+            if "dirty_main_repo" in cond.when.lower():
                 matched.add(MergeFailedStep.DIRTY_MAIN_REPO)
         assert MergeFailedStep.DIRTY_MAIN_REPO in matched, (
             f"{recipe_name}: merge_worktree step '{step_name}' does not route "

--- a/tests/recipe/test_rules_merge_routing_incomplete.py
+++ b/tests/recipe/test_rules_merge_routing_incomplete.py
@@ -84,6 +84,7 @@ class TestMergeRoutingIncompleteRule:
                 {"when": "result.failed_step == 'test_gate'", "route": "recover"},
                 {"when": "result.failed_step == 'post_rebase_test_gate'", "route": "recover"},
                 {"when": "result.failed_step == 'rebase'", "route": "recover"},
+                {"when": "result.failed_step == 'dirty_main_repo'", "route": "recover"},
                 {"when": "result.error", "route": "escalate"},
                 {"route": "done"},
             ]


### PR DESCRIPTION
## Summary

Two infrastructure failures (#2465, #2467) caused complete work to be rejected because (1) the zero-writes gate has no git-level awareness — it interprets "retry session found all work already committed" as "failed silently," and (2) `DIRTY_MAIN_REPO` was added as a detection guard without any recovery mechanism or recipe routing.

This plan adds git-level branch-divergence evidence to the zero-writes gate (so worktree sessions with prior commits aren't falsely demoted), adds `on_context_limit` to all retry_worktree recipe steps, adds `DIRTY_MAIN_REPO` to the recoverable failure set with recipe routing, and adds a `main_repo_guard` pre-merge step.

## Requirements

### REQ-ZW-1: Git-level write evidence in zero-writes gate

The zero-writes gate at `_headless_result.py:597-613` must incorporate git-level evidence (commits ahead of merge base on the worktree branch) into `_has_write_evidence`. If `git log --oneline $(git merge-base HEAD base)..HEAD` shows commits, `_has_write_evidence` should be True regardless of session-level Write/Edit tool call count.

### REQ-ZW-2: Add `on_context_limit` to retry_worktree in all recipes

The `retry_worktree` step in `implementation.yaml`, `remediation.yaml`, and `implementation-groups.yaml` must declare `on_context_limit: test` so the orchestrator's progress-evidence carve-out can route to recovery instead of falling through to terminal failure.

### REQ-DM-1: Add DIRTY_MAIN_REPO to recoverable failed steps

Add `MergeFailedStep.DIRTY_MAIN_REPO` to `_RECOVERABLE_FAILED_STEPS` in `rules_merge.py:31-38`. This activates the `merge-routing-incomplete` semantic rule enforcement, requiring all recipes to explicitly route this failure mode.

### REQ-DM-2: Implement recipe routing for dirty_main_repo

All three implementation recipes must add explicit `dirty_main_repo` routing in the `merge` step's `on_result` conditions. The route should lead to a recovery step that handles dirty main repo state before retrying the merge.

### REQ-DM-3: Main repo pre-merge guard

Add a `main_repo_commit_guard` or `main_repo_stash_guard` as a `run_python` pre-merge step (analogous to the existing `commit_guard` for worktrees). This should detect dirty state on the main repo and either stash it (if recoverable artifacts) or reset it (if contamination), before `merge_worktree` is called.

## Architecture Impact

### Error Resilience + Process Flow + Repository Access

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    subgraph ZeroWritesGate ["ZERO-WRITES GATE (_headless_result.py)"]
        direction TB
        WC["Write/Edit<br/>tool call count"]
        FS["fs_writes_detected<br/>━━━━━━━━━━<br/>temp dir snapshot diff"]
        GIT["★ git_writes_detected<br/>━━━━━━━━━━<br/>branch divergence check"]
        HWE["● _has_write_evidence<br/>━━━━━━━━━━<br/>write_call_count >= 1<br/>OR fs_writes_detected<br/>OR git_writes_detected"]
        GATE{"Zero-writes<br/>gate check"}
        PASS["success=True<br/>preserved"]
        DEMOTE["success=False<br/>subtype=zero_writes"]
    end

    subgraph GitEvidence ["★ GIT EVIDENCE (_headless_git.py)"]
        direction TB
        WCHECK{"is_git_worktree<br/>(cwd)?"}
        MB["git merge-base<br/>HEAD origin/HEAD"]
        RL["git rev-list --count<br/>merge_base..HEAD"]
        RESULT["git_writes_detected<br/>= count > 0"]
    end

    subgraph MergeRecovery ["MERGE RECOVERY FLOW (recipes)"]
        direction TB
        MERGE["merge_worktree<br/>━━━━━━━━━━<br/>step 7.6: dirty check"]
        DMR["● dirty_main_repo<br/>━━━━━━━━━━<br/>now routes to recovery"]
        LOOP["check_merge_fix_loop<br/>━━━━━━━━━━<br/>iteration guard (max 3)"]
        CG["commit_guard<br/>━━━━━━━━━━<br/>worktree cleanup"]
        MRG["★ main_repo_guard<br/>━━━━━━━━━━<br/>stash/clean main repo"]
        RETRY_MERGE["merge retry"]
    end

    subgraph Terminals ["TERMINAL STATES"]
        T_SUCCESS([Session SUCCESS])
        T_FAILURE([release_issue_failure])
    end

    %% Zero-writes gate flow
    WC --> HWE
    FS --> HWE
    GIT --> HWE
    HWE --> GATE
    GATE -->|"evidence=True"| PASS
    GATE -->|"evidence=False<br/>+ write_expected"| DEMOTE
    PASS --> T_SUCCESS

    %% Git evidence flow
    WCHECK -->|"Yes"| MB
    WCHECK -->|"No"| GIT
    MB --> RL --> RESULT --> GIT

    %% Merge recovery flow
    MERGE -->|"dirty_main_repo"| DMR
    DMR --> LOOP
    LOOP -->|"max_exceeded"| T_FAILURE
    LOOP -->|"OK"| CG
    CG --> MRG
    MRG --> RETRY_MERGE
    RETRY_MERGE --> MERGE

    %% Class assignments
    class WC,FS stateNode;
    class GIT,RESULT newComponent;
    class HWE,GATE detector;
    class PASS,DEMOTE output;
    class WCHECK stateNode;
    class MB,RL handler;
    class MERGE,DMR,CG handler;
    class LOOP stateNode;
    class MRG newComponent;
    class RETRY_MERGE handler;
    class T_SUCCESS,T_FAILURE terminal;
```

**Color Legend:**

| Color | Category | Description |
|-------|----------|-------------|
| Green | New Component | `_detect_branch_divergence`, `main_repo_guard`, `git_writes_detected` |
| Red | Detector/Gate | Zero-writes gate, `_has_write_evidence` check |
| Orange | Handler | Git operations, merge steps, commit guards |
| Teal | State | Evidence signals, decision points, iteration guards |
| Dark Teal | Output | Gate outcomes (pass/demote) |
| Dark Blue | Terminal | Final success/failure states |

Closes #2581

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260517-211727-500410/.autoskillit/temp/make-plan/zero_writes_gate_dirty_main_repo_plan_2026-05-17_214500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 75 | 35.4k | 1.2M | 91.6k | 108 | 117.5k | 23m 24s |
| verify | claude-sonnet-4-6 | 1 | 2.9k | 13.3k | 1.3M | 69.4k | 151 | 78.1k | 9m 16s |
| implement* | MiniMax-M2.7 | 1 | 563.9k | 24.0k | 6.1M | 81.1k | 197 | 28.9k | 19m 6s |
| audit_impl | claude-sonnet-4-6 | 1 | 369 | 10.8k | 246.7k | 109.3k | 58 | 50.7k | 4m 48s |
| prepare_pr* | MiniMax-M2.7 | 1 | 80.7k | 13.5k | 608.0k | 0 | 33 | 0 | 2m 56s |
| compose_pr* | MiniMax-M2.7 | 1 | 74.9k | 3.6k | 490.3k | 0 | 29 | 0 | 2m 42s |
| review_pr | claude-opus-4-6 | 5 | 2.5k | 135.2k | 3.0M | 94.0k | 181 | 376.6k | 34m 9s |
| resolve_review | claude-opus-4-6 | 5 | 302 | 52.2k | 10.7M | 114.4k | 313 | 330.3k | 1h 2m |
| **Total** | | | 725.7k | 288.0k | 23.7M | 114.4k | | 982.2k | 2h 39m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 521 | 11638.2 | 55.5 | 46.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 110 | 97640.3 | 3003.1 | 474.4 |
| **Total** | **631** | 37545.5 | 1556.5 | 456.4 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 138 | 55.8k | 4.3M | 226.8k | 40m 22s |
| claude-sonnet-4-6 | 2 | 3.3k | 24.1k | 1.5M | 128.8k | 14m 4s |
| MiniMax-M2.7 | 3 | 719.5k | 41.1k | 7.2M | 28.9k | 24m 45s |