### PR TITLE
fix: eliminate lossy boolean display normalization in build_ingredient_rows

### DIFF
--- a/src/autoskillit/recipe/_recipe_ingredients.py
+++ b/src/autoskillit/recipe/_recipe_ingredients.py
@@ -69,9 +69,9 @@ def build_ingredient_rows(
         elif default == "":
             default_str, name_str = "auto-detect", name
         elif default == "true":
-            default_str, name_str = "on", name
+            default_str, name_str = "true", name
         elif default == "false":
-            default_str, name_str = "off", name
+            default_str, name_str = "false", name
         elif default is None:
             default_str, name_str = "--", name
         else:

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -22,7 +22,7 @@ Semantic validation rule modules for recipe analysis (31 rule files).
 | `rules_fixing.py` | Conditional-write skill must gate on declared verdict output |
 | `rules_graph.py` | Graph/routing analysis rules |
 | `rules_inline_script.py` | Detects inline shell scripts in `run_cmd` cmd fields |
-| `rules_inputs.py` | Input/ingredient validation; version compatibility checks |
+| `rules_inputs.py` | Input/ingredient validation; version compatibility checks; condition-value-domain checks |
 | `rules_isolation.py` | Workspace isolation rules (prevents operating on source repo) |
 | `rules_merge.py` | `merge_worktree` routing completeness |
 | `rules_merge_queue.py` | Merge queue push routing: `queued_branch` error route enforcement |

--- a/src/autoskillit/recipe/rules/rules_inputs.py
+++ b/src/autoskillit/recipe/rules/rules_inputs.py
@@ -520,7 +520,7 @@ def _check_ingredient_condition_value_domain(
                             ),
                         )
                     )
-                elif ing.default in ("true", "false") and operand not in ("true", "false"):
+                elif ing.default in ("true", "false") and operand.lower() not in ("true", "false"):
                     findings.append(
                         RuleFinding(
                             rule="ingredient-condition-value-domain",

--- a/src/autoskillit/recipe/rules/rules_inputs.py
+++ b/src/autoskillit/recipe/rules/rules_inputs.py
@@ -475,3 +475,62 @@ def _check_local_rounds_alignment(ctx: ValidationContext) -> list[RuleFinding]:
             ),
         )
     ]
+
+
+_DISPLAY_ONLY_VALUES: frozenset[str] = frozenset({"on", "off", "auto-detect"})
+
+_INPUTS_CONDITION_RE = re.compile(r"\$\{\{\s*inputs\.(\w+)\s*\}\}\s*(?:==|!=)\s*'([^']*)'")
+
+
+@semantic_rule(
+    name="ingredient-condition-value-domain",
+    description=(
+        "A when: condition compares inputs.<name> against a value that is not "
+        "in the ingredient's valid value domain, or uses a display-only value "
+        "('on', 'off', 'auto-detect') that diverges from the raw YAML default."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_ingredient_condition_value_domain(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    ingredients = ctx.recipe.ingredients
+    for step_name, step in ctx.recipe.steps.items():
+        if not step.on_result:
+            continue
+        for cond in step.on_result.conditions:
+            if cond.when is None:
+                continue
+            for match in _INPUTS_CONDITION_RE.finditer(cond.when):
+                ing_name, operand = match.group(1), match.group(2)
+                ing = ingredients.get(ing_name)
+                if ing is None:
+                    continue
+                if operand in _DISPLAY_ONLY_VALUES:
+                    findings.append(
+                        RuleFinding(
+                            rule="ingredient-condition-value-domain",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Condition on inputs.{ing_name} uses display-only "
+                                f"value '{operand}' — use the raw YAML value instead "
+                                f"(ingredient default: '{ing.default}')."
+                            ),
+                        )
+                    )
+                elif ing.default in ("true", "false") and operand not in ("true", "false"):
+                    findings.append(
+                        RuleFinding(
+                            rule="ingredient-condition-value-domain",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Condition on inputs.{ing_name} uses '{operand}' "
+                                f"which is not in the boolean value domain "
+                                f"{{'true', 'false'}} (ingredient default: '{ing.default}')."
+                            ),
+                        )
+                    )
+    return findings

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -751,8 +751,29 @@ def test_build_ingredient_rows_resolved_does_not_override_required_marker():
     assert any(r[0] == "x *" and r[2] == "(required)" for r in rows)
 
 
+@pytest.mark.parametrize("default_val", ["true", "false"])
+def test_build_ingredient_rows_boolean_default_preserves_raw_value(default_val):
+    """Display value for boolean-defaulted ingredients must equal the raw YAML string.
+
+    The round-trip invariant: ingredient.default → build_ingredient_rows output
+    must produce a value that is a valid operand in when: conditions that compare
+    against the raw YAML string. Breaking this invariant causes silent condition
+    mismatch (issue #2584).
+    """
+    from autoskillit.recipe._api import build_ingredient_rows
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe = _make_recipe_with_ingredient(
+        "flag",
+        RecipeIngredient(description="A boolean flag", default=default_val),
+    )
+    rows = build_ingredient_rows(recipe)
+    display_values = {r[0]: r[2] for r in rows}
+    assert display_values["flag"] == default_val
+
+
 def test_build_ingredient_rows_resolved_overrides_boolean_literal():
-    """T6: resolved value wins over a boolean-literal default ('true'/'false' → 'on'/'off')."""
+    """T6: resolved value wins over a boolean-literal default."""
     from autoskillit.recipe._api import build_ingredient_rows
     from autoskillit.recipe.schema import RecipeIngredient
 

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -941,19 +941,32 @@ class TestDisplayConditionContract:
         }
 
     def test_ingredient_display_values_match_condition_operands(self, recipe_modules) -> None:
-        """Every when: condition comparing inputs.<name> against a literal must use
-        a value that matches what build_ingredient_rows produces for that ingredient.
+        """Boolean display values must not be normalized, and condition
+        operands must not use display-only values.
 
-        This is the cross-system contract guard: display table ↔ condition evaluation
-        must agree on the value domain. Mismatch causes silent condition routing failures
-        (issue #2584).
+        Guards against issue #2584: display normalization (true→on) caused
+        condition operands to silently diverge from raw YAML values.
         """
         from autoskillit.recipe._recipe_ingredients import build_ingredient_rows
-        from autoskillit.recipe.rules.rules_inputs import _INPUTS_CONDITION_RE
+        from autoskillit.recipe.rules.rules_inputs import (
+            _DISPLAY_ONLY_VALUES,
+            _INPUTS_CONDITION_RE,
+        )
 
         for recipe_name, recipe in recipe_modules.items():
             rows = build_ingredient_rows(recipe)
             display = {r[0].rstrip(" *"): r[2] for r in rows}
+
+            for name, ing in recipe.ingredients.items():
+                if getattr(ing, "hidden", False) or name not in display:
+                    continue
+                if ing.default in ("true", "false"):
+                    assert display[name] == ing.default, (
+                        f"{recipe_name}: boolean ingredient {name} has "
+                        f"default '{ing.default}' but display shows "
+                        f"'{display[name]}' — boolean normalization "
+                        f"must not occur"
+                    )
 
             for step_name, step in recipe.steps.items():
                 if not step.on_result:
@@ -965,10 +978,8 @@ class TestDisplayConditionContract:
                         ing_name, operand = match.group(1), match.group(2)
                         if ing_name not in display:
                             continue
-                        display_val = display[ing_name]
-                        assert display_val == operand, (
+                        assert operand not in _DISPLAY_ONLY_VALUES, (
                             f"{recipe_name}::{step_name}: condition uses "
-                            f"inputs.{ing_name} == '{operand}' but "
-                            f"build_ingredient_rows shows '{display_val}' — "
-                            f"display value must match condition operand"
+                            f"display-only value '{operand}' for "
+                            f"inputs.{ing_name} — use raw YAML value instead"
                         )

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -948,25 +948,27 @@ class TestDisplayConditionContract:
         must agree on the value domain. Mismatch causes silent condition routing failures
         (issue #2584).
         """
-        import re
-
         from autoskillit.recipe._recipe_ingredients import build_ingredient_rows
+        from autoskillit.recipe.rules.rules_inputs import _INPUTS_CONDITION_RE
 
         for recipe_name, recipe in recipe_modules.items():
             rows = build_ingredient_rows(recipe)
             display = {r[0].rstrip(" *"): r[2] for r in rows}
 
             for step_name, step in recipe.steps.items():
-                when = getattr(step, "skip_when_false", None) or ""
-                matches = re.findall(r"inputs\.(\w+)\s*(==|!=|>=|<=|>|<)\s*'([^']*)'", when)
-                for ing_name, op, operand in matches:
-                    name_key = ing_name if ing_name in display else None
-                    if name_key is None:
+                if not step.on_result:
+                    continue
+                for cond in step.on_result.conditions:
+                    if cond.when is None:
                         continue
-                    display_val = display[name_key]
-                    assert display_val == operand, (
-                        f"{recipe_name}::{step_name}: condition uses "
-                        f"inputs.{ing_name} {op} '{operand}' but "
-                        f"build_ingredient_rows shows '{display_val}' — "
-                        f"display value must match condition operand"
-                    )
+                    for match in _INPUTS_CONDITION_RE.finditer(cond.when):
+                        ing_name, operand = match.group(1), match.group(2)
+                        if ing_name not in display:
+                            continue
+                        display_val = display[ing_name]
+                        assert display_val == operand, (
+                            f"{recipe_name}::{step_name}: condition uses "
+                            f"inputs.{ing_name} == '{operand}' but "
+                            f"build_ingredient_rows shows '{display_val}' — "
+                            f"display value must match condition operand"
+                        )

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -925,3 +925,48 @@ class TestInvestigateFirstStructure:
             f"remediation.yaml assess step must declare on_context_limit: test, "
             f"got: {assess.on_context_limit!r}"
         )
+
+
+class TestDisplayConditionContract:
+    """Cross-system contract guards: display table values must match condition operands."""
+
+    @pytest.fixture(scope="class")
+    def recipe_modules(self) -> dict:
+        return {
+            "implementation": load_recipe(builtin_recipes_dir() / "implementation.yaml"),
+            "remediation": load_recipe(builtin_recipes_dir() / "remediation.yaml"),
+            "implementation-groups": load_recipe(
+                builtin_recipes_dir() / "implementation-groups.yaml"
+            ),
+        }
+
+    def test_ingredient_display_values_match_condition_operands(self, recipe_modules) -> None:
+        """Every when: condition comparing inputs.<name> against a literal must use
+        a value that matches what build_ingredient_rows produces for that ingredient.
+
+        This is the cross-system contract guard: display table ↔ condition evaluation
+        must agree on the value domain. Mismatch causes silent condition routing failures
+        (issue #2584).
+        """
+        import re
+
+        from autoskillit.recipe._recipe_ingredients import build_ingredient_rows
+
+        for recipe_name, recipe in recipe_modules.items():
+            rows = build_ingredient_rows(recipe)
+            display = {r[0].rstrip(" *"): r[2] for r in rows}
+
+            for step_name, step in recipe.steps.items():
+                when = getattr(step, "skip_when_false", None) or ""
+                matches = re.findall(r"inputs\.(\w+)\s*(==|!=|>=|<=|>|<)\s*'([^']*)'", when)
+                for ing_name, op, operand in matches:
+                    name_key = ing_name if ing_name in display else None
+                    if name_key is None:
+                        continue
+                    display_val = display[name_key]
+                    assert display_val == operand, (
+                        f"{recipe_name}::{step_name}: condition uses "
+                        f"inputs.{ing_name} {op} '{operand}' but "
+                        f"build_ingredient_rows shows '{display_val}' — "
+                        f"display value must match condition operand"
+                    )

--- a/tests/recipe/test_rules_inputs.py
+++ b/tests/recipe/test_rules_inputs.py
@@ -9,7 +9,13 @@ import pytest
 
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
-from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
+from autoskillit.recipe.schema import (
+    Recipe,
+    RecipeIngredient,
+    RecipeStep,
+    StepResultCondition,
+    StepResultRoute,
+)
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -351,3 +357,70 @@ class TestIngredientTypeDefaultInvalid:
         findings = run_semantic_rules(recipe)
         rule_findings = [f for f in findings if f.rule == "ingredient-type-default-invalid"]
         assert len(rule_findings) == 0
+
+
+class TestIngredientConditionValueDomain:
+    def test_fires_on_display_value_operand(self):
+        recipe = Recipe(
+            name="test-recipe",
+            description="test",
+            ingredients={"flag": RecipeIngredient(description="A flag", default="true")},
+            steps={
+                "check": RecipeStep(
+                    name="check",
+                    on_result=StepResultRoute(
+                        conditions=[
+                            StepResultCondition(when="${{ inputs.flag }} == 'on'", route="a"),
+                            StepResultCondition(when="true", route="b"),
+                        ]
+                    ),
+                ),
+            },
+        )
+        findings = run_semantic_rules(recipe)
+        rule_findings = [f for f in findings if f.rule == "ingredient-condition-value-domain"]
+        assert len(rule_findings) == 1
+        assert "on" in rule_findings[0].message
+        assert "flag" in rule_findings[0].message
+
+    def test_passes_for_raw_values(self):
+        recipe = Recipe(
+            name="test-recipe",
+            description="test",
+            ingredients={"flag": RecipeIngredient(description="A flag", default="true")},
+            steps={
+                "check": RecipeStep(
+                    name="check",
+                    on_result=StepResultRoute(
+                        conditions=[
+                            StepResultCondition(when="${{ inputs.flag }} != 'true'", route="a"),
+                            StepResultCondition(when="true", route="b"),
+                        ]
+                    ),
+                ),
+            },
+        )
+        findings = run_semantic_rules(recipe)
+        rule_findings = [f for f in findings if f.rule == "ingredient-condition-value-domain"]
+        assert rule_findings == []
+
+    def test_skips_none_when(self):
+        recipe = Recipe(
+            name="test-recipe",
+            description="test",
+            ingredients={"flag": RecipeIngredient(description="A flag", default="true")},
+            steps={
+                "check": RecipeStep(
+                    name="check",
+                    on_result=StepResultRoute(
+                        conditions=[
+                            StepResultCondition(when="${{ inputs.flag }} == 'true'", route="a"),
+                            StepResultCondition(when=None, route="b"),
+                        ]
+                    ),
+                ),
+            },
+        )
+        findings = run_semantic_rules(recipe)
+        rule_findings = [f for f in findings if f.rule == "ingredient-condition-value-domain"]
+        assert rule_findings == []

--- a/tests/recipe/test_rules_inputs.py
+++ b/tests/recipe/test_rules_inputs.py
@@ -380,6 +380,8 @@ class TestIngredientConditionValueDomain:
         findings = run_semantic_rules(recipe)
         rule_findings = [f for f in findings if f.rule == "ingredient-condition-value-domain"]
         assert len(rule_findings) == 1
+        assert rule_findings[0].step_name == "check"
+        assert rule_findings[0].severity == Severity.ERROR
         assert "on" in rule_findings[0].message
         assert "flag" in rule_findings[0].message
 


### PR DESCRIPTION
## Summary

The ingredient display system in `build_ingredient_rows` performs lossy normalization (`"true"→"on"`, `"false"→"off"`) with no structural link to the condition evaluation system. Recipe `when:` conditions compare against raw YAML strings (`'true'`, `'false'`), but the LLM orchestrator sees display-normalized values (`"on"`, `"off"`). This creates a silent mismatch causing fleet dispatch L2 sessions to bypass merge steps and report success without merging (issue #2584).

**Fix:** Remove the boolean display normalization from `_recipe_ingredients.py:71-74`, change `"on"`→`"true"` and `"off"`→`"false"`. Add round-trip invariant tests proving display values equal raw YAML strings. Update a stale test docstring.

## Requirements

Fleet dispatch L2 sessions must report PRs as "complete" only after actually merging them. The root cause is display normalization that causes `when:` conditions to evaluate incorrectly. The fix eliminates the normalization so the display layer and condition evaluation layer share a single source of truth for ingredient values.

Closes #2584

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_ingredient_display_normalization_desync_2026-05-18_090500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-opus-4-6 | 1 | 53 | 17.5k | 999.9k | 82.8k | 115 | 84.9k | 6m 57s |
| dry_walkthrough | claude-sonnet-4-6 | 2 | 500 | 14.7k | 885.2k | 54.9k | 161 | 84.0k | 8m 56s |
| implement* | MiniMax-M2.7 | 2 | 563.1k | 14.3k | 2.3M | 30.0k | 161 | 104.9k | 12m 43s |
| prepare_pr* | MiniMax-M2.7 | 1 | 44.7k | 2.8k | 228.7k | 30.0k | 18 | 15.5k | 1m 55s |
| compose_pr* | MiniMax-M2.7 | 1 | 52.8k | 1.6k | 253.6k | 30.0k | 17 | 15.4k | 1m 1s |
| review_pr | claude-opus-4-6 | 3 | 88 | 94.0k | 1.2M | 80.7k | 86 | 176.7k | 19m 24s |
| resolve_review | claude-opus-4-6 | 1 | 64 | 16.0k | 2.4M | 81.6k | 67 | 67.3k | 9m 39s |
| **Total** | | | 661.4k | 160.9k | 8.2M | 82.8k | | 548.9k | 1h 0m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 208 | 10938.4 | 504.6 | 68.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 55 | 43259.3 | 1224.3 | 290.2 |
| **Total** | **263** | 31122.6 | 2087.0 | 611.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 53 | 17.5k | 999.9k | 84.9k | 6m 57s |
| claude-sonnet-4-6 | 1 | 500 | 14.7k | 885.2k | 84.0k | 8m 56s |
| MiniMax-M2.7 | 3 | 660.7k | 18.7k | 2.8M | 135.9k | 15m 40s |