### PR TITLE
Recipe-Scoped Provider Step Overrides with Specificity-Based Resolution

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -410,6 +410,7 @@ class ProvidersConfig:
     default_provider: str | None = None
     profiles: dict[str, dict[str, str]] = field(default_factory=dict)
     step_overrides: dict[str, str] = field(default_factory=dict)
+    recipe_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
     provider_retry_limit: int = 2
 
     def __post_init__(self) -> None:
@@ -420,6 +421,18 @@ class ProvidersConfig:
                 if not isinstance(v, str):
                     raise ValueError(
                         f"profiles[{name!r}][{k!r}] must be a string, got {type(v).__name__!r}"
+                    )
+        for recipe, overrides in self.recipe_overrides.items():
+            if not isinstance(overrides, dict):
+                raise ValueError(
+                    f"recipe_overrides[{recipe!r}] must be a dict, "
+                    f"got {type(overrides).__name__!r}"
+                )
+            for step, provider in overrides.items():
+                if not isinstance(provider, str):
+                    raise ValueError(
+                        f"recipe_overrides[{recipe!r}][{step!r}] must be a string, "
+                        f"got {type(provider).__name__!r}"
                     )
 
 

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -296,6 +296,7 @@ providers:
   default_provider: null
   profiles: {}
   step_overrides: {}
+  recipe_overrides: {}
   provider_retry_limit: 2
 
 agent_backend:

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -528,6 +528,7 @@ class AutomationConfig:
                 default_provider=val(pvd, "default_provider", _pvd["default_provider"]),
                 profiles=val(pvd, "profiles", _pvd["profiles"]),
                 step_overrides=val(pvd, "step_overrides", _pvd["step_overrides"]),
+                recipe_overrides=val(pvd, "recipe_overrides", _pvd["recipe_overrides"]),
                 provider_retry_limit=_parse_int_field(
                     val(pvd, "provider_retry_limit", _pvd["provider_retry_limit"]),
                     "providers.provider_retry_limit",

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -160,6 +160,39 @@ def _resolve_provider_profile(
     config_providers: ProvidersConfig,
 ) -> tuple[str, dict[str, str]]:
 
+    # Tier 0: per-recipe per-step override (highest specificity)
+    if recipe_name and step_name:
+        recipe_map = config_providers.recipe_overrides.get(recipe_name)
+        if recipe_map:
+            recipe_step_override = recipe_map.get(step_name)
+            if recipe_step_override:
+                logger.debug(
+                    "provider_profile_resolved",
+                    tier="recipe_step_override",
+                    profile=recipe_step_override,
+                )
+                if recipe_step_override == "anthropic":
+                    return ("anthropic", {})
+                return (
+                    recipe_step_override,
+                    config_providers.profiles.get(recipe_step_override, {}),
+                )
+
+    # Tier 0W: per-recipe wildcard override
+    if recipe_name:
+        recipe_map = config_providers.recipe_overrides.get(recipe_name)
+        if recipe_map:
+            recipe_wildcard = recipe_map.get("*")
+            if recipe_wildcard:
+                logger.debug(
+                    "provider_profile_resolved",
+                    tier="recipe_wildcard_override",
+                    profile=recipe_wildcard,
+                )
+                if recipe_wildcard == "anthropic":
+                    return ("anthropic", {})
+                return (recipe_wildcard, config_providers.profiles.get(recipe_wildcard, {}))
+
     # Tier 1: per-step config override (requires recipe context)
     if recipe_name and step_name:
         step_override = config_providers.step_overrides.get(step_name)

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -154,6 +154,15 @@ def _check_dry_walkthrough(skill_command: str, cwd: str) -> str | None:
     return None
 
 
+def _provider_result(
+    provider: str,
+    profiles: dict[str, dict[str, str]],
+) -> tuple[str, dict[str, str]]:
+    if provider == "anthropic":
+        return ("anthropic", {})
+    return (provider, profiles.get(provider, {}))
+
+
 def _resolve_provider_profile(
     step_name: str,
     recipe_name: str,
@@ -173,12 +182,7 @@ def _resolve_provider_profile(
                         tier="recipe_step_override",
                         profile=recipe_step_override,
                     )
-                    if recipe_step_override == "anthropic":
-                        return ("anthropic", {})
-                    return (
-                        recipe_step_override,
-                        config_providers.profiles.get(recipe_step_override, {}),
-                    )
+                    return _provider_result(recipe_step_override, config_providers.profiles)
 
             # Tier 0W: per-recipe wildcard override
             recipe_wildcard = recipe_map.get("*")
@@ -188,9 +192,7 @@ def _resolve_provider_profile(
                     tier="recipe_wildcard_override",
                     profile=recipe_wildcard,
                 )
-                if recipe_wildcard == "anthropic":
-                    return ("anthropic", {})
-                return (recipe_wildcard, config_providers.profiles.get(recipe_wildcard, {}))
+                return _provider_result(recipe_wildcard, config_providers.profiles)
 
     # Tier 1: per-step config override (requires recipe context)
     if recipe_name and step_name:

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -160,28 +160,27 @@ def _resolve_provider_profile(
     config_providers: ProvidersConfig,
 ) -> tuple[str, dict[str, str]]:
 
-    # Tier 0: per-recipe per-step override (highest specificity)
-    if recipe_name and step_name:
-        recipe_map = config_providers.recipe_overrides.get(recipe_name)
-        if recipe_map:
-            recipe_step_override = recipe_map.get(step_name)
-            if recipe_step_override:
-                logger.debug(
-                    "provider_profile_resolved",
-                    tier="recipe_step_override",
-                    profile=recipe_step_override,
-                )
-                if recipe_step_override == "anthropic":
-                    return ("anthropic", {})
-                return (
-                    recipe_step_override,
-                    config_providers.profiles.get(recipe_step_override, {}),
-                )
-
-    # Tier 0W: per-recipe wildcard override
+    # Tiers 0/0W: recipe-scoped overrides — single lookup shared by both tiers
     if recipe_name:
         recipe_map = config_providers.recipe_overrides.get(recipe_name)
         if recipe_map:
+            # Tier 0: per-recipe per-step override (highest specificity)
+            if step_name:
+                recipe_step_override = recipe_map.get(step_name)
+                if recipe_step_override:
+                    logger.debug(
+                        "provider_profile_resolved",
+                        tier="recipe_step_override",
+                        profile=recipe_step_override,
+                    )
+                    if recipe_step_override == "anthropic":
+                        return ("anthropic", {})
+                    return (
+                        recipe_step_override,
+                        config_providers.profiles.get(recipe_step_override, {}),
+                    )
+
+            # Tier 0W: per-recipe wildcard override
             recipe_wildcard = recipe_map.get("*")
             if recipe_wildcard:
                 logger.debug(

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -48,6 +48,7 @@ class TestProvidersConfig:
         assert cfg.providers.default_provider is None
         assert cfg.providers.profiles == {}
         assert cfg.providers.step_overrides == {}
+        assert cfg.providers.recipe_overrides == {}
         assert cfg.providers.provider_retry_limit == 2
 
     def test_providers_config_defaults(self) -> None:
@@ -57,6 +58,7 @@ class TestProvidersConfig:
         assert cfg.default_provider is None
         assert cfg.profiles == {}
         assert cfg.step_overrides == {}
+        assert cfg.recipe_overrides == {}
         assert cfg.provider_retry_limit == 2
 
     def test_providers_config_is_mutable(self) -> None:
@@ -76,6 +78,7 @@ class TestProvidersConfig:
             "default_provider",
             "profiles",
             "step_overrides",
+            "recipe_overrides",
             "provider_retry_limit",
         }
 
@@ -96,6 +99,18 @@ class TestProvidersConfig:
 
         with pytest.raises(ValueError, match=r"profiles\[.+\]\[.+\] must be a string"):
             ProvidersConfig(profiles={"my_profile": {"model": 42}})  # type: ignore[arg-type]
+
+    def test_recipe_overrides_non_string_value_raises(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        with pytest.raises(ValueError, match="recipe_overrides"):
+            ProvidersConfig(recipe_overrides={"remediation": {"implement": 42}})  # type: ignore[arg-type]
+
+    def test_recipe_overrides_non_dict_inner_value_raises(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        with pytest.raises(ValueError, match="recipe_overrides"):
+            ProvidersConfig(recipe_overrides={"remediation": "not_a_dict"})  # type: ignore[arg-type]
 
 
 class TestProvidersConfigYaml:
@@ -143,3 +158,41 @@ class TestProvidersConfigYaml:
         (config_dir / "config.yaml").write_text("providers:\n  provider_retry_limit: 5\n")
         cfg = load_config(tmp_path)
         assert cfg.providers.provider_retry_limit == 5
+
+    def test_load_config_recipe_overrides_parsing(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {
+            "providers": {"recipe_overrides": {"remediation": {"implement": "anthropic"}}}
+        }
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.providers.recipe_overrides == {"remediation": {"implement": "anthropic"}}
+
+    def test_load_config_recipe_overrides_merges_across_layers(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        from autoskillit.config import load_config
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+        user_config_dir = tmp_path / "home" / ".autoskillit"
+        user_config_dir.mkdir(parents=True)
+        project_config_dir = tmp_path / ".autoskillit"
+        project_config_dir.mkdir()
+        (user_config_dir / "config.yaml").write_text(
+            yaml.dump(
+                {"providers": {"recipe_overrides": {"remediation": {"implement": "anthropic"}}}}
+            )
+        )
+        (project_config_dir / "config.yaml").write_text(
+            yaml.dump(
+                {"providers": {"recipe_overrides": {"implementation": {"implement": "minimax"}}}}
+            )
+        )
+        cfg = load_config(tmp_path)
+        assert cfg.providers.recipe_overrides == {
+            "remediation": {"implement": "anthropic"},
+            "implementation": {"implement": "minimax"},
+        }

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -103,13 +103,13 @@ class TestProvidersConfig:
     def test_recipe_overrides_non_string_value_raises(self) -> None:
         from autoskillit.config.settings import ProvidersConfig
 
-        with pytest.raises(ValueError, match="recipe_overrides"):
+        with pytest.raises(ValueError, match=r"recipe_overrides\[.+\]\[.+\] must be a string"):
             ProvidersConfig(recipe_overrides={"remediation": {"implement": 42}})  # type: ignore[arg-type]
 
     def test_recipe_overrides_non_dict_inner_value_raises(self) -> None:
         from autoskillit.config.settings import ProvidersConfig
 
-        with pytest.raises(ValueError, match="recipe_overrides"):
+        with pytest.raises(ValueError, match=r"recipe_overrides\[.+\] must be a dict"):
             ProvidersConfig(recipe_overrides={"remediation": "not_a_dict"})  # type: ignore[arg-type]
 
 

--- a/tests/server/test_resolve_provider_profile.py
+++ b/tests/server/test_resolve_provider_profile.py
@@ -1,4 +1,4 @@
-"""Tests for _resolve_provider_profile four-tier provider resolution."""
+"""Tests for _resolve_provider_profile six-tier provider resolution."""
 
 from __future__ import annotations
 
@@ -100,3 +100,90 @@ def test_no_recipe_name_skips_step_override():
     )
     result = _resolve_provider_profile("bedrock", "", cfg)
     assert result == ("bedrock", {"X": "Y"})
+
+
+def test_recipe_override_wins_over_global_step_override():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"implement": "anthropic"}},
+        step_overrides={"implement": "minimax"},
+    )
+    result = _resolve_provider_profile("implement", "remediation", cfg)
+    assert result == ("anthropic", {})
+
+
+def test_recipe_override_does_not_affect_other_recipes():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"implement": "anthropic"}},
+        step_overrides={"implement": "minimax"},
+        profiles={"minimax": {"K": "V"}},
+    )
+    result = _resolve_provider_profile("implement", "implementation", cfg)
+    assert result == ("minimax", {"K": "V"})
+
+
+def test_recipe_override_step_beats_recipe_wildcard():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"implement": "anthropic", "*": "vertex"}},
+    )
+    result = _resolve_provider_profile("implement", "remediation", cfg)
+    assert result == ("anthropic", {})
+
+
+def test_recipe_wildcard_override_wins_over_global_step():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"*": "anthropic"}},
+        step_overrides={"implement": "minimax"},
+    )
+    result = _resolve_provider_profile("implement", "remediation", cfg)
+    assert result == ("anthropic", {})
+
+
+def test_recipe_wildcard_override_applies_to_all_steps():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"*": "vertex"}},
+        profiles={"vertex": {"K": "V"}},
+    )
+    result = _resolve_provider_profile("investigate", "remediation", cfg)
+    assert result == ("vertex", {"K": "V"})
+
+
+def test_recipe_override_non_anthropic_returns_env_dict():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"implement": "bedrock"}},
+        profiles={"bedrock": {"AWS_REGION": "us-east-1"}},
+    )
+    result = _resolve_provider_profile("implement", "remediation", cfg)
+    assert result == ("bedrock", {"AWS_REGION": "us-east-1"})
+
+
+def test_recipe_override_requires_recipe_context():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"implement": "vertex"}},
+        profiles={"vertex": {"K": "V"}},
+    )
+    result = _resolve_provider_profile("implement", "", cfg)
+    assert result == ("implement", {})
+
+
+def test_recipe_override_requires_step_name():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"implement": "vertex"}},
+    )
+    result = _resolve_provider_profile("", "remediation", cfg)
+    assert result == ("anthropic", {})

--- a/tests/server/test_resolve_provider_profile.py
+++ b/tests/server/test_resolve_provider_profile.py
@@ -184,6 +184,19 @@ def test_recipe_override_requires_step_name():
 
     cfg = _make_config(
         recipe_overrides={"remediation": {"implement": "vertex"}},
+        profiles={"vertex": {"K": "V"}},
     )
     result = _resolve_provider_profile("", "remediation", cfg)
     assert result == ("anthropic", {})
+    assert result[0] != "vertex"  # override bypassed because step_name is empty
+
+
+def test_recipe_override_requires_step_name_with_step_name():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        recipe_overrides={"remediation": {"implement": "vertex"}},
+        profiles={"vertex": {"K": "V"}},
+    )
+    result = _resolve_provider_profile("implement", "remediation", cfg)
+    assert result == ("vertex", {"K": "V"})


### PR DESCRIPTION
## Summary

Add a `recipe_overrides` field to `ProvidersConfig` that enables per-recipe, per-step provider routing. The existing four-tier waterfall in `_resolve_provider_profile()` becomes a six-tier waterfall with two new tiers at the top: (1) per-recipe per-step override and (2) per-recipe wildcard override. This follows the specificity principle — the more specific the match, the higher priority it gets. The existing `step_overrides` behavior is unchanged; the new tiers only fire when `recipe_overrides` contains a matching entry.

Including the per-recipe wildcard (`recipe_overrides.{recipe}.*`) is the correct design. It completes the specificity matrix — without it, there's no way to say "route all steps of recipe X to provider Y" without enumerating every step name. This is a natural need (e.g., "all remediation steps should use anthropic") and deferring it would require a future breaking change to the resolution order.

Closes #2585

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260518-101157-129835/.autoskillit/temp/make-plan/recipe_scoped_provider_overrides_plan_2026-05-18_101500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 76 | 8.8k | 555.6k | 80.8k | 129 | 51.1k | 7m 6s |
| verify | claude-opus-4-6 | 1 | 1.6k | 12.0k | 1.6M | 70.0k | 71 | 55.4k | 4m 57s |
| implement | claude-sonnet-4-6 | 1 | 885 | 14.5k | 1.4M | 63.1k | 89 | 96.2k | 4m 53s |
| prepare_pr* | <synthetic> | 3 | 52 | 4.4k | 149.0k | 35.4k | 18 | 36.5k | 8m 5s |
| compose_pr | claude-sonnet-4-6 | 1 | 59 | 1.8k | 172.7k | 27.9k | 15 | 13.4k | 40s |
| review_pr | claude-sonnet-4-6 | 3 | 318 | 118.0k | 1.8M | 91.8k | 127 | 205.9k | 23m 45s |
| resolve_review | claude-sonnet-4-6 | 3 | 655 | 45.8k | 3.9M | 75.3k | 188 | 158.7k | 25m 15s |
| **Total** | | | 3.6k | 205.3k | 9.5M | 91.8k | | 617.1k | 1h 14m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 190 | 7455.4 | 506.3 | 76.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 74 | 52231.9 | 2143.9 | 619.5 |
| **Total** | **264** | 36133.4 | 2337.6 | 777.5 |