### PR TITLE
Fix _jsonl_has_record_type marker-validation fallthrough

### DIFF
--- a/src/autoskillit/execution/process/_process_jsonl.py
+++ b/src/autoskillit/execution/process/_process_jsonl.py
@@ -16,6 +16,26 @@ def _marker_is_standalone(text: str, marker: str) -> bool:
     return False
 
 
+def _extract_record_text(obj: dict, record_type: str) -> str:
+    if record_type == "assistant":
+        raw = (obj.get("message") or {}).get("content", "")
+    elif record_type == "result":
+        raw = obj.get("result", "")
+    else:
+        raw = " ".join(v for v in obj.values() if isinstance(v, str))
+
+    if isinstance(raw, list):
+        return "\n".join(
+            b.get("text", "")
+            for b in raw
+            if isinstance(b, dict)
+            and ClaudeContentBlockType.from_api(b.get("type", "")) == ClaudeContentBlockType.TEXT
+        )
+    if not isinstance(raw, str):
+        return "" if raw is None else str(raw)
+    return raw
+
+
 def _jsonl_contains_marker(
     content: str,
     marker: str,
@@ -47,25 +67,7 @@ def _jsonl_contains_marker(
         if record_type not in record_types:
             continue
 
-        if record_type == "assistant":
-            raw = (obj.get("message") or {}).get("content", "")
-        elif record_type == "result":
-            raw = obj.get("result", "")
-        else:
-            raw = " ".join(v for v in obj.values() if isinstance(v, str))
-
-        if isinstance(raw, list):
-            text = "\n".join(
-                b.get("text", "")
-                for b in raw
-                if isinstance(b, dict)
-                and ClaudeContentBlockType.from_api(b.get("type", ""))
-                == ClaudeContentBlockType.TEXT
-            )
-        elif not isinstance(raw, str):
-            text = "" if raw is None else str(raw)
-        else:
-            text = raw
+        text = _extract_record_text(obj, record_type)
         if _marker_is_standalone(text, marker):
             return True
     return False
@@ -78,15 +80,17 @@ def _jsonl_has_record_type(
 ) -> bool:
     """Check if any JSONL record of an allowed type exists in content.
 
-    Used by the heartbeat to detect when Claude CLI emits a result record
+    Used by the heartbeat to detect when Claude CLI emits a completion record
     to stdout. For ``type=result`` records, additionally requires the ``result``
     field to be a non-empty string — confirming on an empty-result envelope
     is the source of the drain-race false negative.
 
-    When *completion_marker* is non-empty, ``type=result`` records additionally
-    require the marker to appear as a standalone line in the ``result`` field.
-    This prevents Channel A from confirming on premature exits where the model
-    produced output but did not complete its task.
+    When *completion_marker* is non-empty, all matching record types additionally
+    require the marker to appear as a standalone line in the record's text
+    content. Text is extracted per record type: ``message.content`` for
+    assistant records, ``result`` for result records, joined string values
+    for other types. This prevents Channel A from confirming on premature
+    exits where the model produced output but did not complete its task.
     """
     for line in content.splitlines():
         line = line.strip()
@@ -104,9 +108,13 @@ def _jsonl_has_record_type(
         if record_type == "result":
             result_field = obj.get("result", "")
             if not (isinstance(result_field, str) and result_field.strip()):
-                continue  # result absent, null, or empty — do not confirm
-            if completion_marker and not _marker_is_standalone(result_field, completion_marker):
-                continue  # marker configured but absent — do not confirm
+                continue
+
+        if completion_marker:
+            text = _extract_record_text(obj, record_type)
+            if not _marker_is_standalone(text, completion_marker):
+                continue
+
         return True
     return False
 

--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -42,8 +42,8 @@ async def _heartbeat(
     This guards against confirming on empty-result envelopes flushed before content
     is populated (drain-race false negative).
 
-    When *completion_marker* is non-empty, ``type=result`` records additionally
-    require the marker as a standalone line in the ``result`` field before Channel A
+    When *completion_marker* is non-empty, all matching record types additionally
+    require the marker as a standalone line in their text content before Channel A
     fires — preventing premature confirmation on partial output.
 
     *_on_poll* is a test-only callback invoked after each sleep iteration. Pass

--- a/tests/execution/test_process_jsonl.py
+++ b/tests/execution/test_process_jsonl.py
@@ -322,6 +322,122 @@ class TestJsonlHasRecordTypeResultContent:
             line, frozenset({"result"}), completion_marker="%%ORDER_UP%%"
         )
 
+    def test_rejects_assistant_without_marker_when_marker_configured(self):
+        """Non-result record missing the marker must NOT confirm when marker is set."""
+        line = (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "Task done."}]},
+                }
+            )
+            + "\n"
+        )
+        assert not _jsonl_has_record_type(
+            line, frozenset({"assistant"}), completion_marker="%%ORDER_UP%%"
+        )
+
+    def test_accepts_assistant_with_marker_when_marker_configured(self):
+        """Non-result record with standalone marker must confirm."""
+        line = (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "Done.\n%%ORDER_UP%%"}]},
+                }
+            )
+            + "\n"
+        )
+        assert _jsonl_has_record_type(
+            line, frozenset({"assistant"}), completion_marker="%%ORDER_UP%%"
+        )
+
+    def test_assistant_without_marker_accepted_when_no_marker_configured(self):
+        """Empty completion_marker skips marker check — backward-compatible for all types."""
+        line = (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "hi"}]},
+                }
+            )
+            + "\n"
+        )
+        assert _jsonl_has_record_type(line, frozenset({"assistant"}), completion_marker="")
+
+    def test_rejects_assistant_with_embedded_marker(self):
+        """Marker in prose (not standalone) must NOT confirm for assistant records."""
+        line = (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "text", "text": "I will emit %%ORDER_UP%% soon"}]
+                    },
+                }
+            )
+            + "\n"
+        )
+        assert not _jsonl_has_record_type(
+            line, frozenset({"assistant"}), completion_marker="%%ORDER_UP%%"
+        )
+
+    def test_fallback_record_type_with_marker(self):
+        """Non-assistant, non-result types use fallback text extraction for marker check."""
+        line = (
+            json.dumps(
+                {
+                    "type": "system",
+                    "content": "Setup complete.\n%%ORDER_UP%%",
+                }
+            )
+            + "\n"
+        )
+        assert _jsonl_has_record_type(
+            line, frozenset({"system"}), completion_marker="%%ORDER_UP%%"
+        )
+
+    def test_fallback_record_type_without_marker_rejected(self):
+        """Fallback record type missing marker must NOT confirm."""
+        line = (
+            json.dumps(
+                {
+                    "type": "system",
+                    "content": "Setup complete.",
+                }
+            )
+            + "\n"
+        )
+        assert not _jsonl_has_record_type(
+            line, frozenset({"system"}), completion_marker="%%ORDER_UP%%"
+        )
+
+    def test_assistant_null_message_no_crash(self):
+        """Assistant record with message=None must not crash, returns False with marker."""
+        line = json.dumps({"type": "assistant", "message": None}) + "\n"
+        assert not _jsonl_has_record_type(
+            line, frozenset({"assistant"}), completion_marker="%%ORDER_UP%%"
+        )
+
+    def test_marker_in_thinking_block_not_detected(self):
+        """Marker inside a thinking block must NOT trigger confirmation."""
+        line = (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {"type": "thinking", "thinking": "%%ORDER_UP%%"},
+                        ]
+                    },
+                }
+            )
+            + "\n"
+        )
+        assert not _jsonl_has_record_type(
+            line, frozenset({"assistant"}), completion_marker="%%ORDER_UP%%"
+        )
+
 
 class TestMarkerDiscrimination:
     """Regression guards: per-invocation markers are structurally incompatible with static ones."""

--- a/tests/execution/test_process_jsonl.py
+++ b/tests/execution/test_process_jsonl.py
@@ -412,12 +412,24 @@ class TestJsonlHasRecordTypeResultContent:
             line, frozenset({"system"}), completion_marker="%%ORDER_UP%%"
         )
 
+    def test_fallback_record_type_no_content_not_confirmed(self):
+        """System record without content field must NOT confirm."""
+        line = json.dumps({"type": "system"}) + "\n"
+        assert not _jsonl_has_record_type(
+            line, frozenset({"system"}), completion_marker="%%ORDER_UP%%"
+        )
+
     def test_assistant_null_message_no_crash(self):
         """Assistant record with message=None must not crash, returns False with marker."""
         line = json.dumps({"type": "assistant", "message": None}) + "\n"
         assert not _jsonl_has_record_type(
             line, frozenset({"assistant"}), completion_marker="%%ORDER_UP%%"
         )
+
+    def test_assistant_null_message_no_marker_accepted(self):
+        """Assistant record with message=None and no marker configured must return True."""
+        line = json.dumps({"type": "assistant", "message": None}) + "\n"
+        assert _jsonl_has_record_type(line, frozenset({"assistant"}), completion_marker="")
 
     def test_marker_in_thinking_block_not_detected(self):
         """Marker inside a thinking block must NOT trigger confirmation."""

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -612,7 +612,8 @@ def test_merge_worktree_has_commit_guard_predecessor() -> None:
                     frontier.extend(ctx.predecessors.get(p, set()))
             assert has_guard, (
                 f"{yaml_path.name}: merge_worktree step '{step_name}' has no commit_guard "
-                f"in its predecessor chain. Predecessors: {sorted(ctx.predecessors.get(step_name, set()))}"
+                f"in its predecessor chain. "
+                f"Predecessors: {sorted(ctx.predecessors.get(step_name, set()))}"
             )
 
 


### PR DESCRIPTION
## Summary

`_jsonl_has_record_type()` in `src/autoskillit/execution/process/_process_jsonl.py` has a control-flow bug: the `return True` sits outside the `if record_type == "result":` block, so any non-result record type (e.g. `"assistant"`) that passes the type filter immediately returns `True` without checking `completion_marker`. The fix restructures the loop body to extract text from every record type using the same branching as `_jsonl_contains_marker`, then applies `_marker_is_standalone` for all record types when `completion_marker` is non-empty.

To avoid duplicating the non-trivial text-extraction logic, a shared `_extract_record_text()` helper is extracted and used by both `_jsonl_contains_marker` and `_jsonl_has_record_type`.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260518-124709-513273/.autoskillit/temp/make-plan/p3_a3_wp1_fix_jsonl_has_record_type_fallthrough_plan_2026-05-18_125900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 60 | 10.3k | 686.9k | 67.0k | 115 | 57.2k | 7m 5s |
| verify | claude-opus-4-6 | 1 | 35 | 5.6k | 278.4k | 56.1k | 40 | 75.2k | 3m 23s |
| implement* | MiniMax-M2.7-highspeed | 1 | 443.5k | 6.4k | 662.5k | 50.7k | 57 | 64.0k | 2m 33s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 82.2k | 3.3k | 202.2k | 28.9k | 19 | 41.7k | 1m 6s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 92.5k | 2.0k | 286.0k | 28.9k | 21 | 15.4k | 53s |
| review_pr | claude-sonnet-4-6 | 3 | 260 | 45.8k | 1.2M | 55.9k | 97 | 125.0k | 10m 43s |
| resolve_review | claude-sonnet-4-6 | 2 | 364 | 19.1k | 2.1M | 65.9k | 102 | 92.1k | 11m 32s |
| **Total** | | | 619.0k | 92.5k | 5.4M | 67.0k | | 470.7k | 37m 18s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 185 | 3581.1 | 345.9 | 34.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 176109.2 | 7674.9 | 1593.6 |
| **Total** | **197** | 27480.5 | 2389.2 | 469.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 3.0k | 10.6k | 722.3k | 56.8k | 6m 26s |