### PR TITLE
Add 6 narrow cascade entries for uncovered core/types/ modules

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -222,6 +222,12 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
         }
     ),
     "_type_results_execution": frozenset({"core", "execution", "server", "pipeline"}),
+    "_type_backend": frozenset({"core"}),
+    "_type_dispatch_identity": frozenset({"core", "fleet", "execution"}),
+    "_type_figure_spec": frozenset({"core", "report"}),
+    "_type_session_env": frozenset({"core", "cli"}),
+    "_type_capture": frozenset({"core", "fleet", "recipe", "cli"}),
+    "_type_token": frozenset({"core"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -187,6 +187,7 @@ class TestBuildTestScopeCoreCascade:
         "hooks",
         "skills",
         "planner",
+        "report",
         "arch",
         "contracts",
         "infra",
@@ -441,6 +442,65 @@ class TestBuildTestScopeCoreCascade:
         for pkg in ["core", "fleet", "recipe", "cli"]:
             assert pkg in dir_names, f"narrow cascade should include {pkg}"
         for excluded in ["execution", "pipeline", "hooks", "migration", "workspace"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
+
+    def test_type_dispatch_identity_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_dispatch_identity → narrow cascade of {"core", "fleet", "execution"}."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_dispatch_identity.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "fleet", "execution"]:
+            assert pkg in dir_names, f"narrow cascade should include {pkg}"
+        for excluded in ["config", "pipeline", "migration", "workspace", "report", "hooks"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
+
+    def test_type_figure_spec_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_figure_spec → narrow cascade of {"core", "report"}."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_figure_spec.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "report"]:
+            assert pkg in dir_names, f"narrow cascade should include {pkg}"
+        for excluded in ["config", "execution", "pipeline", "fleet", "migration", "workspace"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
+
+    def test_type_session_env_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_session_env → narrow cascade of {"core", "cli"}."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_session_env.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "cli"]:
+            assert pkg in dir_names, f"narrow cascade should include {pkg}"
+        for excluded in ["config", "execution", "pipeline", "fleet", "migration", "workspace"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
+
+    def test_type_token_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_token → narrow cascade of {"core"} only."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_token.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "core" in dir_names
+        for excluded in ["config", "execution", "pipeline", "fleet", "migration", "workspace"]:
             assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
 

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -92,6 +92,12 @@ class TestModuleCascadeCore:
             "_type_checkpoint",
             "_type_results",
             "_type_results_execution",
+            "_type_backend",
+            "_type_dispatch_identity",
+            "_type_figure_spec",
+            "_type_session_env",
+            "_type_capture",
+            "_type_token",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
 
@@ -134,6 +140,28 @@ class TestModuleCascadeCore:
                 "smoke_utils",
             }
         )
+
+    def test_type_backend_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_backend"] == frozenset({"core"})
+
+    def test_type_dispatch_identity_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_dispatch_identity"] == frozenset(
+            {"core", "fleet", "execution"}
+        )
+
+    def test_type_figure_spec_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_figure_spec"] == frozenset({"core", "report"})
+
+    def test_type_session_env_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_session_env"] == frozenset({"core", "cli"})
+
+    def test_type_capture_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_capture"] == frozenset(
+            {"core", "fleet", "recipe", "cli"}
+        )
+
+    def test_type_token_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_token"] == frozenset({"core"})
 
 
 class TestBuildTestScopeCoreCascade:
@@ -385,6 +413,35 @@ class TestBuildTestScopeCoreCascade:
             assert excluded not in dir_names, (
                 f"_type_results cascade should not include {excluded}"
             )
+
+    def test_type_backend_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_backend → narrow cascade of {"core"} only."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_backend.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "core" in dir_names
+        for excluded in ["config", "execution", "pipeline", "fleet", "migration", "workspace"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
+
+    def test_type_capture_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_capture → narrow cascade of {"core", "fleet", "recipe", "cli"}."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_capture.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "fleet", "recipe", "cli"]:
+            assert pkg in dir_names, f"narrow cascade should include {pkg}"
+        for excluded in ["execution", "pipeline", "hooks", "migration", "workspace"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
 
 class TestClosureCoreNarrowCascade:


### PR DESCRIPTION
## Summary

Add 6 narrow cascade entries to `MODULE_CASCADE_CORE` in `tests/_test_filter.py` so that changes to `_type_backend`, `_type_dispatch_identity`, `_type_figure_spec`, `_type_session_env`, `_type_capture`, and `_type_token` trigger only their verified consumer test directories instead of the full 18-directory `LAYER_CASCADE_CONSERVATIVE["core"]` cascade. Update the guard test `test_all_entries_present` and add per-entry value tests. The `.autoskillit/skills/` manifest pattern (REQ-MNFST-001) is already satisfied by existing entries in `.autoskillit/test-filter-manifest.yaml` (lines 145-149).

Validated Cascades (Corrected from Issue):
- `_type_backend`: `{"core"}` — zero production consumers outside core/
- `_type_dispatch_identity`: `{"core", "fleet", "execution"}` — verified via import analysis
- `_type_figure_spec`: `{"core", "report"}` — verified via import analysis
- `_type_session_env`: `{"core", "cli"}` — verified via import analysis
- `_type_capture`: `{"core", "fleet", "recipe", "cli"}` — verified via import analysis
- `_type_token`: `{"core"}` — zero production consumers outside core/

## Requirements

### Group: CASC (Cascade Map Entries)

**REQ-CASC-001:** `MODULE_CASCADE_CORE` in `tests/_test_filter.py` must contain an entry for `_type_backend` with cascade `{"core"}`. *(Note: Issue claimed `{"core", "config"}` — corrected to `{"core"}` after import validation)*

**REQ-CASC-002:** `MODULE_CASCADE_CORE` in `tests/_test_filter.py` must contain an entry for `_type_dispatch_identity` with cascade `{"core", "fleet", "execution"}`. *(Note: Issue missed `execution` — corrected)*

**REQ-CASC-003:** `MODULE_CASCADE_CORE` in `tests/_test_filter.py` must contain an entry for `_type_figure_spec` with cascade `{"core", "report"}`.

**REQ-CASC-004:** `MODULE_CASCADE_CORE` in `tests/_test_filter.py` must contain an entry for `_type_session_env` with cascade `{"core", "cli"}`.

**REQ-CASC-005:** `MODULE_CASCADE_CORE` in `tests/_test_filter.py` must contain an entry for `_type_capture` with cascade `{"core", "fleet", "recipe", "cli"}`. *(Note: Issue claimed 6 packages — corrected after import validation)*

**REQ-CASC-006:** `MODULE_CASCADE_CORE` in `tests/_test_filter.py` must include `_type_token` with cascade `{"core"}`. *(Note: Issue suggested `_CORE_UNIVERSAL_MODULES` — corrected to narrow cascade after import validation)*

### Group: MNFST (Manifest Pattern)

**REQ-MNFST-001:** The non-Python manifest in `tests/_test_filter.py` must map `.autoskillit/skills/` paths (including `SKILL.md` files) to the `skills` test directory. — PRE-SATISFIED by existing `.autoskillit/test-filter-manifest.yaml` lines 145-149.

### Group: GUARD (Guard Tests)

**REQ-GUARD-001:** The cascade entries added in CASC-001 through CASC-005 must be validated by the existing arch guard tests in `tests/test_test_filter_core_cascade.py` (extend if needed).

**REQ-GUARD-002:** All existing tests must continue to pass after all changes.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

N/A — no conflicts

## Changed Files

### Modified (●):
- `tests/_test_filter.py` — Added 6 narrow cascade entries to `MODULE_CASCADE_CORE`
- `tests/test_test_filter_core_cascade.py` — Extended guard tests for new entries

Closes #2598

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260518-154420-726333/.autoskillit/temp/make-plan/add_cascade_entries_plan_2026-05-18_155300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.8k | 19.9k | 1.8M | 89.8k | 349 | 80.8k | 15m 16s |
| verify | claude-opus-4-6 | 1 | 1.2k | 8.9k | 358.3k | 56.9k | 72 | 42.0k | 4m 9s |
| implement* | MiniMax-M2.7 | 1 | 154.3k | 4.4k | 692.9k | 30.2k | 42 | 30.2k | 4m 29s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.8k | 2.7k | 198.2k | 0 | 17 | 0 | 43s |
| compose_pr* | MiniMax-M2.7 | 1 | 38.1k | 2.2k | 308.0k | 0 | 20 | 0 | 46s |
| review_pr | claude-opus-4-6 | 3 | 113 | 28.4k | 1.2M | 49.9k | 83 | 100.7k | 8m 33s |
| resolve_review | claude-opus-4-6 | 1 | 57 | 8.4k | 1.6M | 64.3k | 59 | 49.6k | 3m 47s |
| **Total** | | | 239.4k | 75.0k | 6.1M | 89.8k | | 303.4k | 37m 44s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 63 | 10998.4 | 479.8 | 70.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 60 | 25958.9 | 826.5 | 140.8 |
| **Total** | **123** | 49371.6 | 2466.6 | 609.8 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 5.7k | 3.6k | 164.3k | 45.5k | 3m 42s |