### PR TITLE
Rectify: CI Watch cwd/branch SHA Consistency — PART A ONLY

### DIFF
--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -694,3 +694,91 @@ def _check_enqueue_missing_ci_gate(ctx: ValidationContext) -> list[RuleFinding]:
                 )
             )
     return findings
+
+
+# ---------------------------------------------------------------------------
+# ci-cwd-branch-context-mismatch rule
+# ---------------------------------------------------------------------------
+
+_WORKTREE_BRANCH_PATTERNS: frozenset[str] = frozenset(
+    {
+        "worktree_branch_name",
+        "worktree_branch",
+    }
+)
+
+_WORKTREE_CWD_PATTERNS: frozenset[str] = frozenset(
+    {
+        "worktree_path",
+        "worktree_dir",
+    }
+)
+
+_CLONE_CWD_PATTERNS: frozenset[str] = frozenset(
+    {
+        "work_dir",
+        "clone_path",
+        "clone_dir",
+    }
+)
+
+_CONTEXT_VAR_RE = re.compile(r"\$\{\{\s*context\.(\w+)\s*\}\}")
+
+
+def _extract_context_var(value: str) -> str | None:
+    m = _CONTEXT_VAR_RE.search(value)
+    return m.group(1) if m else None
+
+
+def _is_worktree_branch_ref(var_name: str) -> bool:
+    return any(pat in var_name for pat in _WORKTREE_BRANCH_PATTERNS)
+
+
+def _is_clone_cwd_ref(var_name: str) -> bool:
+    return any(pat in var_name for pat in _CLONE_CWD_PATTERNS)
+
+
+@semantic_rule(
+    name="ci-cwd-branch-context-mismatch",
+    description=(
+        "wait_for_ci step watches a worktree branch but cwd references the clone root. "
+        "git rev-parse HEAD in the clone root returns the wrong SHA, causing "
+        "_validate_run_matches_scope to silently reject valid CI runs."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_ci_cwd_branch_context_mismatch(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "wait_for_ci":
+            continue
+        with_args = step.with_args or {}
+
+        if with_args.get("head_sha"):
+            continue
+
+        branch_val = with_args.get("branch", "")
+        cwd_val = with_args.get("cwd", "")
+
+        branch_var = _extract_context_var(str(branch_val))
+        cwd_var = _extract_context_var(str(cwd_val))
+
+        if not branch_var or not cwd_var:
+            continue
+
+        if _is_worktree_branch_ref(branch_var) and _is_clone_cwd_ref(cwd_var):
+            findings.append(
+                RuleFinding(
+                    rule="ci-cwd-branch-context-mismatch",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' watches worktree branch "
+                        f"(context.{branch_var}) but cwd uses clone root "
+                        f"(context.{cwd_var}). git rev-parse HEAD in the clone root "
+                        f"returns the batch/base branch SHA, not the worktree branch SHA. "
+                        f"Use cwd: '${{{{ context.worktree_path }}}}' or pass head_sha explicitly."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -707,13 +707,6 @@ _WORKTREE_BRANCH_PATTERNS: frozenset[str] = frozenset(
     }
 )
 
-_WORKTREE_CWD_PATTERNS: frozenset[str] = frozenset(
-    {
-        "worktree_path",
-        "worktree_dir",
-    }
-)
-
 _CLONE_CWD_PATTERNS: frozenset[str] = frozenset(
     {
         "work_dir",

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -189,14 +189,28 @@
       "capture": {
         "current_pr_branch": "${{ result.stdout | trim }}"
       },
-      "on_success": "wait_ci_pre_enqueue",
+      "on_success": "capture_pr_head_sha",
       "on_failure": "register_clone_failure",
       "note": "Fetches the headRefName for the current PR to be enqueued. Captured as current_pr_branch for use by wait_ci_pre_enqueue. Follows the same pattern as get_ejected_pr_branch and get_next_pr_branch.\n"
+    },
+    "capture_pr_head_sha": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "gh pr view '${{ context.current_pr_number }}' --json headRefOid -q .headRefOid",
+        "cwd": "${{ context.work_dir }}",
+        "step_name": "capture_pr_head_sha"
+      },
+      "capture": {
+        "current_pr_head_sha": "${{ result.stdout | trim }}"
+      },
+      "on_success": "wait_ci_pre_enqueue",
+      "on_failure": "register_clone_failure"
     },
     "wait_ci_pre_enqueue": {
       "tool": "wait_for_ci",
       "with": {
         "branch": "${{ context.current_pr_branch }}",
+        "head_sha": "${{ context.current_pr_head_sha }}",
         "cwd": "${{ context.work_dir }}",
         "event": "${{ context.ci_event }}",
         "timeout_seconds": 600,
@@ -910,7 +924,7 @@
         "branch": "${{ context.worktree_branch_name }}",
         "event": "${{ context.ci_event }}",
         "timeout_seconds": 600,
-        "cwd": "${{ context.work_dir }}",
+        "cwd": "${{ context.worktree_path }}",
         "auto_trigger": true
       },
       "on_result": [

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -241,17 +241,29 @@ steps:
       step_name: "get_current_pr_branch"
     capture:
       current_pr_branch: "${{ result.stdout | trim }}"
-    on_success: wait_ci_pre_enqueue
+    on_success: capture_pr_head_sha
     on_failure: register_clone_failure
     note: >
       Fetches the headRefName for the current PR to be enqueued. Captured as
       current_pr_branch for use by wait_ci_pre_enqueue. Follows the same
       pattern as get_ejected_pr_branch and get_next_pr_branch.
 
+  capture_pr_head_sha:
+    tool: run_cmd
+    with:
+      cmd: "gh pr view '${{ context.current_pr_number }}' --json headRefOid -q .headRefOid"
+      cwd: "${{ context.work_dir }}"
+      step_name: "capture_pr_head_sha"
+    capture:
+      current_pr_head_sha: "${{ result.stdout | trim }}"
+    on_success: wait_ci_pre_enqueue
+    on_failure: register_clone_failure
+
   wait_ci_pre_enqueue:
     tool: wait_for_ci
     with:
       branch: "${{ context.current_pr_branch }}"
+      head_sha: "${{ context.current_pr_head_sha }}"
       cwd: "${{ context.work_dir }}"
       event: "${{ context.ci_event }}"
       timeout_seconds: 600
@@ -890,7 +902,7 @@ steps:
       branch: "${{ context.worktree_branch_name }}"
       event: "${{ context.ci_event }}"
       timeout_seconds: 600
-      cwd: "${{ context.work_dir }}"
+      cwd: "${{ context.worktree_path }}"
       auto_trigger: true
     on_result:
       - when: "${{ result.conclusion }} == 'success'"

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -326,6 +326,20 @@ async def _auto_trigger_ci(
             ),
         }
     current_branch = branch_out.strip()
+    if not current_branch:
+        logger.error(
+            "auto_trigger: detached HEAD — refusing to commit/push",
+            cwd=cwd,
+        )
+        return {
+            **result,
+            "conclusion": "detached_head",
+            "triggered": False,
+            "error": (
+                "cwd is in detached HEAD state (no branch checked out). "
+                "Refusing to commit/push without a named branch."
+            ),
+        }
     if current_branch != branch:
         logger.error(
             "auto_trigger: cwd branch mismatch — refusing to commit/push",

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -130,11 +130,11 @@ async def wait_for_ci(
         if head_sha and cwd:
             try:
                 rc_b, branch_out, _ = await _run_subprocess(
-                    ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd, timeout=5.0
+                    ["git", "branch", "--show-current"], cwd=cwd, timeout=5.0
                 )
                 if rc_b == 0:
                     cwd_branch = branch_out.strip()
-                    if cwd_branch != "HEAD" and cwd_branch != branch:
+                    if cwd_branch and cwd_branch != branch:
                         logger.warning(
                             "wait_for_ci: cwd branch does not match watched branch — "
                             "head_sha may be from wrong branch",

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -127,6 +127,25 @@ async def wait_for_ci(
             except Exception:
                 logger.warning("git rev-parse HEAD failed", exc_info=True)
 
+        if head_sha and cwd:
+            try:
+                rc_b, branch_out, _ = await _run_subprocess(
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd, timeout=5.0
+                )
+                if rc_b == 0:
+                    cwd_branch = branch_out.strip()
+                    if cwd_branch != "HEAD" and cwd_branch != branch:
+                        logger.warning(
+                            "wait_for_ci: cwd branch does not match watched branch — "
+                            "head_sha may be from wrong branch",
+                            cwd_branch=cwd_branch,
+                            watched_branch=branch,
+                            inferred_sha=head_sha[:12],
+                            cwd=cwd,
+                        )
+            except Exception:
+                pass
+
         scope = CIRunScope(
             workflow=workflow or tool_ctx.default_ci_scope.workflow,
             head_sha=head_sha,
@@ -287,6 +306,29 @@ async def _auto_trigger_ci(
     On any failure (merge conflict, push rejected, etc.) returns original
     no_runs result so the recipe routes to handle_no_ci_runs as fallback.
     """
+    rc_bg, branch_out, _ = await _run_subprocess(
+        ["git", "branch", "--show-current"], cwd=cwd, timeout=5.0
+    )
+    if rc_bg == 0:
+        current_branch = branch_out.strip()
+        if current_branch != branch:
+            logger.error(
+                "auto_trigger: cwd branch mismatch — refusing to commit/push",
+                cwd_branch=current_branch,
+                target_branch=branch,
+                cwd=cwd,
+            )
+            return {
+                **result,
+                "conclusion": "branch_mismatch",
+                "triggered": False,
+                "error": (
+                    f"cwd is on branch '{current_branch}' but target is '{branch}'. "
+                    f"Empty commit would land on the wrong branch. "
+                    f"Fix the recipe to pass the correct cwd for this branch."
+                ),
+            }
+
     rc_m, out_m, _ = await _run_subprocess(
         ["gh", "pr", "view", branch, "--json", "mergeable"],
         cwd=cwd,

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -144,7 +144,7 @@ async def wait_for_ci(
                             cwd=cwd,
                         )
             except Exception:
-                pass
+                logger.warning("wait_for_ci: failed to check cwd branch", exc_info=True)
 
         scope = CIRunScope(
             workflow=workflow or tool_ctx.default_ci_scope.workflow,

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -309,25 +309,39 @@ async def _auto_trigger_ci(
     rc_bg, branch_out, _ = await _run_subprocess(
         ["git", "branch", "--show-current"], cwd=cwd, timeout=5.0
     )
-    if rc_bg == 0:
-        current_branch = branch_out.strip()
-        if current_branch != branch:
-            logger.error(
-                "auto_trigger: cwd branch mismatch — refusing to commit/push",
-                cwd_branch=current_branch,
-                target_branch=branch,
-                cwd=cwd,
-            )
-            return {
-                **result,
-                "conclusion": "branch_mismatch",
-                "triggered": False,
-                "error": (
-                    f"cwd is on branch '{current_branch}' but target is '{branch}'. "
-                    f"Empty commit would land on the wrong branch. "
-                    f"Fix the recipe to pass the correct cwd for this branch."
-                ),
-            }
+    if rc_bg != 0:
+        logger.error(
+            "auto_trigger: git branch --show-current failed — refusing to commit/push",
+            rc=rc_bg,
+            cwd=cwd,
+        )
+        return {
+            **result,
+            "conclusion": "branch_check_failed",
+            "triggered": False,
+            "error": (
+                f"Could not determine current branch in cwd (rc={rc_bg}). "
+                f"Refusing to commit/push without branch verification."
+            ),
+        }
+    current_branch = branch_out.strip()
+    if current_branch != branch:
+        logger.error(
+            "auto_trigger: cwd branch mismatch — refusing to commit/push",
+            cwd_branch=current_branch,
+            target_branch=branch,
+            cwd=cwd,
+        )
+        return {
+            **result,
+            "conclusion": "branch_mismatch",
+            "triggered": False,
+            "error": (
+                f"cwd is on branch '{current_branch}' but target is '{branch}'. "
+                f"Empty commit would land on the wrong branch. "
+                f"Fix the recipe to pass the correct cwd for this branch."
+            ),
+        }
 
     rc_m, out_m, _ = await _run_subprocess(
         ["gh", "pr", "view", branch, "--json", "mergeable"],

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -117,7 +117,8 @@ async def wait_for_ci(
             )
 
         # Infer head_sha from cwd if not provided
-        if head_sha is None and cwd:
+        _sha_inferred = head_sha is None
+        if _sha_inferred and cwd:
             try:
                 rc, stdout, _ = await _run_subprocess(
                     ["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0
@@ -127,7 +128,7 @@ async def wait_for_ci(
             except Exception:
                 logger.warning("git rev-parse HEAD failed", exc_info=True)
 
-        if head_sha and cwd:
+        if _sha_inferred and head_sha and cwd:
             try:
                 rc_b, branch_out, _ = await _run_subprocess(
                     ["git", "branch", "--show-current"], cwd=cwd, timeout=5.0

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -651,6 +651,50 @@ def test_merge_pr_routes_merged_false_to_failure(recipe) -> None:
     )
 
 
+def test_wait_for_conflict_ci_uses_worktree_cwd(recipe) -> None:
+    """wait_for_conflict_ci must use worktree_path, not work_dir, for correct SHA inference."""
+    step = recipe.steps["wait_for_conflict_ci"]
+    cwd = step.with_args.get("cwd", "")
+    assert "worktree_path" in cwd, (
+        f"wait_for_conflict_ci cwd must reference worktree_path for correct SHA inference, "
+        f"got: {cwd}"
+    )
+    assert "work_dir" not in cwd, (
+        f"wait_for_conflict_ci cwd must NOT use work_dir (clone root has wrong branch), got: {cwd}"
+    )
+
+
+def test_wait_ci_pre_enqueue_has_explicit_head_sha_or_matching_cwd(recipe) -> None:
+    """wait_ci_pre_enqueue: cwd must match branch or head_sha must be explicit."""
+    step = recipe.steps["wait_ci_pre_enqueue"]
+    cwd = step.with_args.get("cwd", "")
+    head_sha = step.with_args.get("head_sha")
+    branch = step.with_args.get("branch", "")
+
+    if "current_pr_branch" in branch and "work_dir" in cwd:
+        assert head_sha is not None, (
+            "wait_ci_pre_enqueue watches current_pr_branch but uses work_dir as cwd. "
+            "The PR branch is not checked out in work_dir on the first-PR path. "
+            "Pass head_sha explicitly via a capture step."
+        )
+
+
+def test_capture_pr_head_sha_step_exists(recipe) -> None:
+    """capture_pr_head_sha step must exist and route to wait_ci_pre_enqueue."""
+    assert "capture_pr_head_sha" in recipe.steps
+    step = recipe.steps["capture_pr_head_sha"]
+    assert step.tool == "run_cmd"
+    assert step.on_success == "wait_ci_pre_enqueue"
+
+
+def test_get_current_pr_branch_routes_to_capture(recipe) -> None:
+    """get_current_pr_branch must route to capture_pr_head_sha."""
+    step = recipe.steps["get_current_pr_branch"]
+    assert step.on_success == "capture_pr_head_sha", (
+        f"get_current_pr_branch.on_success must be 'capture_pr_head_sha', got {step.on_success!r}"
+    )
+
+
 def test_wait_for_conflict_ci_has_auto_trigger(recipe) -> None:
     """wait_for_conflict_ci has auto_trigger: true."""
     step = recipe.steps["wait_for_conflict_ci"]

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -761,3 +761,19 @@ def test_check_ci_watch_pr_loop_exists_with_correct_pattern(recipe) -> None:
     ]
     assert max_exceeded_conds, "check_ci_watch_pr_loop must route max_exceeded==true"
     assert max_exceeded_conds[0].route == "register_clone_failure"
+
+
+def test_wait_for_ci_steps_have_consistent_cwd(recipe) -> None:
+    """Every wait_for_ci step's cwd must be consistent with its branch parameter."""
+    for step_name, step in recipe.steps.items():
+        if step.tool != "wait_for_ci":
+            continue
+        branch = step.with_args.get("branch", "")
+        cwd = step.with_args.get("cwd", "")
+        head_sha = step.with_args.get("head_sha")
+
+        if "worktree_branch" in branch and not head_sha:
+            assert "worktree" in cwd, (
+                f"{step_name}: watches worktree branch ({branch}) "
+                f"but cwd ({cwd}) is not a worktree path and no head_sha is explicit"
+            )

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -671,12 +671,14 @@ def test_wait_ci_pre_enqueue_has_explicit_head_sha_or_matching_cwd(recipe) -> No
     head_sha = step.with_args.get("head_sha")
     branch = step.with_args.get("branch", "")
 
-    if "current_pr_branch" in branch and "work_dir" in cwd:
-        assert head_sha is not None, (
-            "wait_ci_pre_enqueue watches current_pr_branch but uses work_dir as cwd. "
-            "The PR branch is not checked out in work_dir on the first-PR path. "
-            "Pass head_sha explicitly via a capture step."
-        )
+    cwd_matches_branch = (
+        branch and cwd and (branch.split(".")[-1] in cwd.split(".")[-1] or "worktree" in cwd)
+    )
+    assert cwd_matches_branch or head_sha is not None, (
+        f"wait_ci_pre_enqueue watches branch={branch!r} but cwd={cwd!r} does not "
+        f"reference the same context and head_sha is not explicit. "
+        f"Either cwd must check out the watched branch or head_sha must be provided."
+    )
 
 
 def test_capture_pr_head_sha_step_exists(recipe) -> None:

--- a/tests/recipe/test_merge_prs_queue_common.py
+++ b/tests/recipe/test_merge_prs_queue_common.py
@@ -808,10 +808,10 @@ class TestMergePrsPreEnqueueCiGate:
         assert step.capture is not None
         assert "current_pr_branch" in step.capture
 
-    def test_get_current_pr_branch_routes_to_wait_ci_pre_enqueue(self, pmp) -> None:
-        """get_current_pr_branch.on_success must route to wait_ci_pre_enqueue."""
+    def test_get_current_pr_branch_routes_to_capture_pr_head_sha(self, pmp) -> None:
+        """get_current_pr_branch.on_success must route to capture_pr_head_sha."""
         step = pmp.steps["get_current_pr_branch"]
-        assert step.on_success == "wait_ci_pre_enqueue"
+        assert step.on_success == "capture_pr_head_sha"
 
     def test_wait_ci_pre_enqueue_exists(self, pmp) -> None:
         """wait_ci_pre_enqueue step must exist."""

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -1014,3 +1014,104 @@ def test_timed_out_re_is_module_level_constant():
     assert hasattr(rules_ci, "_TIMED_OUT_RE")
     assert isinstance(rules_ci._TIMED_OUT_RE, regex.Pattern)
     assert rules_ci._TIMED_OUT_RE.pattern == r"""==\s*['"]?timed_out['"]?"""
+
+
+# ---------------------------------------------------------------------------
+# ci-cwd-branch-context-mismatch rule tests
+# ---------------------------------------------------------------------------
+
+_CWD_BRANCH_RULE = "ci-cwd-branch-context-mismatch"
+
+
+def test_ci_cwd_branch_context_mismatch_fires_on_worktree_branch_with_clone_cwd() -> None:
+    """Rule fires when wait_for_ci watches a worktree branch but cwd is the clone root."""
+    recipe = _make_workflow(
+        {
+            "wait_for_conflict_ci": {
+                "tool": "wait_for_ci",
+                "with": {
+                    "branch": "${{ context.worktree_branch_name }}",
+                    "cwd": "${{ context.work_dir }}",
+                    "event": "${{ context.ci_event }}",
+                    "auto_trigger": True,
+                },
+            },
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == _CWD_BRANCH_RULE]
+    assert len(matched) == 1
+    assert matched[0].severity == Severity.ERROR
+    assert "worktree" in matched[0].message.lower()
+
+
+def test_ci_cwd_branch_context_mismatch_passes_when_cwd_is_worktree() -> None:
+    """Rule passes when both branch and cwd reference worktree context."""
+    recipe = _make_workflow(
+        {
+            "wait_for_conflict_ci": {
+                "tool": "wait_for_ci",
+                "with": {
+                    "branch": "${{ context.worktree_branch_name }}",
+                    "cwd": "${{ context.worktree_path }}",
+                    "event": "${{ context.ci_event }}",
+                    "auto_trigger": True,
+                },
+            },
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == _CWD_BRANCH_RULE]
+    assert len(matched) == 0
+
+
+def test_ci_cwd_branch_context_mismatch_passes_with_explicit_head_sha() -> None:
+    """Rule passes when head_sha is explicit — cwd-based inference is bypassed."""
+    recipe = _make_workflow(
+        {
+            "wait_ci_pre_enqueue": {
+                "tool": "wait_for_ci",
+                "with": {
+                    "branch": "${{ context.current_pr_branch }}",
+                    "head_sha": "${{ context.current_pr_head_sha }}",
+                    "cwd": "${{ context.work_dir }}",
+                    "event": "${{ context.ci_event }}",
+                    "auto_trigger": True,
+                },
+            },
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == _CWD_BRANCH_RULE]
+    assert len(matched) == 0
+
+
+def test_ci_cwd_branch_context_mismatch_passes_for_batch_branch() -> None:
+    """Rule passes when both branch and cwd reference clone-root context."""
+    recipe = _make_workflow(
+        {
+            "ci_watch_pr": {
+                "tool": "wait_for_ci",
+                "with": {
+                    "branch": "${{ context.batch_branch }}",
+                    "cwd": "${{ context.work_dir }}",
+                    "event": "${{ context.ci_event }}",
+                },
+            },
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == _CWD_BRANCH_RULE]
+    assert len(matched) == 0
+
+
+def test_bundled_recipes_pass_ci_cwd_branch_context_mismatch() -> None:
+    """All bundled recipes must pass the ci-cwd-branch-context-mismatch rule."""
+    for yaml_path in sorted(builtin_recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(yaml_path)
+        findings = run_semantic_rules(recipe)
+        matched = [f for f in findings if f.rule == _CWD_BRANCH_RULE]
+        assert not matched, (
+            f"{yaml_path.stem}: ci-cwd-branch-context-mismatch fired: "
+            f"{[f.message for f in matched]}"
+        )

--- a/tests/server/test_tools_ci_watch.py
+++ b/tests/server/test_tools_ci_watch.py
@@ -120,8 +120,8 @@ class TestWaitForCiAutoTrigger:
         assert result["conclusion"] == "branch_mismatch"
         assert result["triggered"] is False
         commands = [call[0] for call in tool_ctx_kitchen_open.runner.call_args_list]
-        assert not any("commit" in " ".join(cmd) for cmd in commands)
-        assert not any("push" in " ".join(cmd) for cmd in commands)
+        assert not any(cmd[0] == "git" and cmd[1] == "commit" for cmd in commands if len(cmd) > 1)
+        assert not any(cmd[0] == "git" and cmd[1] == "push" for cmd in commands if len(cmd) > 1)
 
     @pytest.mark.anyio
     async def test_auto_trigger_proceeds_when_cwd_branch_matches(self, tool_ctx_kitchen_open):

--- a/tests/server/test_tools_ci_watch.py
+++ b/tests/server/test_tools_ci_watch.py
@@ -60,7 +60,7 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo"))
 
@@ -78,7 +78,7 @@ class TestWaitForCiAutoTrigger:
         )  # git rev-parse HEAD — wait_for_ci initial HEAD inference
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "feature-branch\n")
-        )  # git rev-parse --abbrev-ref HEAD (diagnostic)
+        )  # git branch --show-current (diagnostic)
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "feature-branch\n")
         )  # git branch --show-current (guard)
@@ -108,7 +108,7 @@ class TestWaitForCiAutoTrigger:
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "integration/batch-branch\n")
-        )  # git rev-parse --abbrev-ref HEAD (diagnostic)
+        )  # git branch --show-current (diagnostic)
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "integration/batch-branch\n")
         )  # git branch --show-current (guard)
@@ -131,7 +131,7 @@ class TestWaitForCiAutoTrigger:
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "feature/conflict-fix\n")
-        )  # git rev-parse --abbrev-ref HEAD (diagnostic)
+        )  # git branch --show-current (diagnostic)
         tool_ctx_kitchen_open.runner.push(_sub(1, ""))  # git branch --show-current (fails)
 
         result = json.loads(
@@ -152,7 +152,7 @@ class TestWaitForCiAutoTrigger:
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "feature-branch\n")
-        )  # git rev-parse --abbrev-ref HEAD (diagnostic)
+        )  # git branch --show-current (diagnostic)
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "feature-branch\n")
         )  # git branch --show-current (guard, matches)
@@ -174,7 +174,7 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"CONFLICTING"}\n'))  # gh pr view
 
@@ -191,7 +191,7 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD (initial)
-        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(1))  # gh pr view — CLI failure (no PR)
 
@@ -206,7 +206,7 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(
@@ -224,7 +224,7 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
@@ -265,7 +265,7 @@ class TestWaitForCiAutoTrigger:
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "abc123\n")
         )  # git rev-parse HEAD — wait_for_ci initial HEAD inference
-        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
@@ -289,7 +289,7 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
-        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty

--- a/tests/server/test_tools_ci_watch.py
+++ b/tests/server/test_tools_ci_watch.py
@@ -59,12 +59,13 @@ class TestWaitForCiAutoTrigger:
     async def test_auto_trigger_default_false_does_not_fire(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
-        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo"))
 
         assert len(watcher.wait_calls) == 1
-        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 1
+        assert len(tool_ctx_kitchen_open.runner.call_args_list) == 2
         assert result["conclusion"] == "no_runs"
         assert "triggered" not in result
 
@@ -75,6 +76,12 @@ class TestWaitForCiAutoTrigger:
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "abc123\n")
         )  # git rev-parse HEAD — wait_for_ci initial HEAD inference
+        tool_ctx_kitchen_open.runner.push(
+            _sub(0, "feature-branch\n")
+        )  # git rev-parse --abbrev-ref HEAD (diagnostic)
+        tool_ctx_kitchen_open.runner.push(
+            _sub(0, "feature-branch\n")
+        )  # git branch --show-current (guard)
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
         tool_ctx_kitchen_open.runner.push(
@@ -94,10 +101,60 @@ class TestWaitForCiAutoTrigger:
         assert result["head_sha"] == "def456"
 
     @pytest.mark.anyio
+    async def test_auto_trigger_rejects_cwd_branch_mismatch(self, tool_ctx_kitchen_open):
+        """auto_trigger must refuse to commit/push when cwd is on a different branch."""
+        watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(
+            _sub(0, "integration/batch-branch\n")
+        )  # git rev-parse --abbrev-ref HEAD (diagnostic)
+        tool_ctx_kitchen_open.runner.push(
+            _sub(0, "integration/batch-branch\n")
+        )  # git branch --show-current (guard)
+
+        result = json.loads(
+            await wait_for_ci("feature/conflict-fix", cwd="/repo", auto_trigger=True)
+        )
+
+        assert result["conclusion"] == "branch_mismatch"
+        assert result["triggered"] is False
+        commands = [call[0] for call in tool_ctx_kitchen_open.runner.call_args_list]
+        assert not any("commit" in " ".join(cmd) for cmd in commands)
+        assert not any("push" in " ".join(cmd) for cmd in commands)
+
+    @pytest.mark.anyio
+    async def test_auto_trigger_proceeds_when_cwd_branch_matches(self, tool_ctx_kitchen_open):
+        """auto_trigger proceeds when cwd's current branch matches the target branch."""
+        watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(
+            _sub(0, "feature-branch\n")
+        )  # git rev-parse --abbrev-ref HEAD (diagnostic)
+        tool_ctx_kitchen_open.runner.push(
+            _sub(0, "feature-branch\n")
+        )  # git branch --show-current (guard, matches)
+        tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx_kitchen_open.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
+        tool_ctx_kitchen_open.runner.push(
+            _sub(0, "https://github.com/org/repo\n")
+        )  # git remote get-url upstream
+        tool_ctx_kitchen_open.runner.push(_sub(0))  # git push --force-with-lease
+
+        result = json.loads(await wait_for_ci("feature-branch", cwd="/repo", auto_trigger=True))
+
+        assert result["conclusion"] == "success"
+        assert result["triggered"] is True
+
+    @pytest.mark.anyio
     async def test_auto_trigger_skips_on_conflicting_pr(self, tool_ctx_kitchen_open):
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"CONFLICTING"}\n'))  # gh pr view
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
@@ -113,6 +170,8 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD (initial)
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(1))  # gh pr view — CLI failure (no PR)
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
@@ -126,6 +185,8 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(
             _sub(128, stderr="error: pre-commit hook rejected commit")
@@ -142,6 +203,8 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
         tool_ctx_kitchen_open.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
@@ -181,6 +244,8 @@ class TestWaitForCiAutoTrigger:
         tool_ctx_kitchen_open.runner.push(
             _sub(0, "abc123\n")
         )  # git rev-parse HEAD — wait_for_ci initial HEAD inference
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
         tool_ctx_kitchen_open.runner.push(
@@ -203,6 +268,8 @@ class TestWaitForCiAutoTrigger:
         watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
         tool_ctx_kitchen_open.ci_watcher = watcher
         tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git rev-parse --abbrev-ref HEAD
+        tool_ctx_kitchen_open.runner.push(_sub(0, "branch\n"))  # git branch --show-current
         tool_ctx_kitchen_open.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx_kitchen_open.runner.push(_sub(0))  # git commit --allow-empty
         tool_ctx_kitchen_open.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD — new HEAD

--- a/tests/server/test_tools_ci_watch.py
+++ b/tests/server/test_tools_ci_watch.py
@@ -124,6 +124,27 @@ class TestWaitForCiAutoTrigger:
         assert not any(cmd[0] == "git" and cmd[1] == "push" for cmd in commands if len(cmd) > 1)
 
     @pytest.mark.anyio
+    async def test_auto_trigger_rejects_when_branch_check_fails(self, tool_ctx_kitchen_open):
+        """auto_trigger must refuse to commit/push when git branch --show-current fails."""
+        watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
+        tool_ctx_kitchen_open.ci_watcher = watcher
+        tool_ctx_kitchen_open.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx_kitchen_open.runner.push(
+            _sub(0, "feature/conflict-fix\n")
+        )  # git rev-parse --abbrev-ref HEAD (diagnostic)
+        tool_ctx_kitchen_open.runner.push(_sub(1, ""))  # git branch --show-current (fails)
+
+        result = json.loads(
+            await wait_for_ci("feature/conflict-fix", cwd="/repo", auto_trigger=True)
+        )
+
+        assert result["conclusion"] == "branch_check_failed"
+        assert result["triggered"] is False
+        commands = [call[0] for call in tool_ctx_kitchen_open.runner.call_args_list]
+        assert not any(cmd[0] == "git" and cmd[1] == "commit" for cmd in commands if len(cmd) > 1)
+        assert not any(cmd[0] == "git" and cmd[1] == "push" for cmd in commands if len(cmd) > 1)
+
+    @pytest.mark.anyio
     async def test_auto_trigger_proceeds_when_cwd_branch_matches(self, tool_ctx_kitchen_open):
         """auto_trigger proceeds when cwd's current branch matches the target branch."""
         watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])


### PR DESCRIPTION
## Summary

The `wait_for_ci` MCP tool infers `head_sha` from `git rev-parse HEAD` in the caller-supplied `cwd`, but never verifies that the branch checked out in `cwd` matches the `branch` parameter being watched. When a recipe step passes the wrong `cwd` (clone root instead of worktree), the inferred SHA belongs to a different branch. `_validate_run_matches_scope()` then silently rejects all valid CI runs due to SHA mismatch. Worse, when `auto_trigger=true`, `_auto_trigger_ci` creates an empty commit on the wrong branch and force-pushes it as the target branch — a data corruption vector.

Part A addresses the **tool-level runtime guard** and the **direct recipe fix** for the two confirmed-broken call sites, plus `_auto_trigger_ci` safety. Part B will cover the semantic rule and validator infrastructure that prevents recurrence.

## Requirements

## Conflict Resolution Decisions

No conflict report provided.

Closes #2600

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260518-161206-178113/.autoskillit/temp/rectify/rectify_ci_watch_cwd_branch_consistency_2026-05-18_161900_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 4.3k | 19.1k | 1.1M | 109.5k | 176 | 75.1k | 10m 39s |
| dry_walkthrough | claude-opus-4-6 | 2 | 800 | 27.1k | 3.7M | 96.7k | 194 | 159.2k | 12m 25s |
| implement | claude-opus-4-6 | 2 | 136 | 28.3k | 3.1M | 91.4k | 134 | 146.0k | 10m 38s |
| prepare_pr* | MiniMax-M2.7 | 1 | 57.9k | 3.5k | 251.6k | 29.2k | 22 | 42.0k | 1m 21s |
| compose_pr* | MiniMax-M2.7 | 1 | 53.7k | 1.5k | 241.1k | 0 | 16 | 0 | 54s |
| review_pr | claude-opus-4-6 | 3 | 107 | 109.6k | 2.0M | 96.2k | 100 | 282.5k | 25m 24s |
| resolve_review | claude-opus-4-6 | 2 | 138 | 22.7k | 3.6M | 80.0k | 145 | 129.1k | 10m 55s |
| **Total** | | | 117.2k | 211.8k | 13.9M | 109.5k | | 833.8k | 1h 12m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 396 | 7761.5 | 368.6 | 71.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 141 | 25418.8 | 915.7 | 161.1 |
| **Total** | **537** | 25917.9 | 1552.7 | 394.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 4.3k | 19.1k | 1.1M | 75.1k | 10m 39s |
| claude-opus-4-6 | 4 | 1.2k | 187.7k | 12.3M | 716.8k | 59m 24s |
| MiniMax-M2.7 | 2 | 111.6k | 5.0k | 492.8k | 42.0k | 2m 15s |