### PR TITLE
[FIX] CI Event Branch Mismatch in merge-prs Recipe

### DIFF
--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -89,7 +89,7 @@
       },
       "on_success": "check_integration_exists",
       "on_failure": "check_integration_exists",
-      "note": "Detects whether the repository's CI triggers on push or merge_group events. Captures ci_event for use by wait_for_ci steps (wait_for_conflict_ci, ci_watch_pr) and diagnose-ci skill invocations downstream. Routes to check_integration_exists regardless of outcome — non-blocking gate: ci_event defaults to null (match-any) on failure, which matches the ci.py scope.event=None behavior.\n"
+      "note": "Detects whether the repository's CI triggers on push or merge_group events for the base branch. Each downstream wait_for_ci step re-derives ci_event for its own watched branch via a dedicated derive_*_ci_event step. The global ci_event captured here is used only by diagnose-ci skill invocations. Routes to check_integration_exists regardless of outcome — non-blocking gate: ci_event defaults to null (match-any) on failure.\n"
     },
     "check_integration_exists": {
       "tool": "run_cmd",
@@ -203,8 +203,23 @@
       "capture": {
         "current_pr_head_sha": "${{ result.stdout | trim }}"
       },
-      "on_success": "wait_ci_pre_enqueue",
+      "on_success": "derive_pre_enqueue_ci_event",
       "on_failure": "register_clone_failure"
+    },
+    "derive_pre_enqueue_ci_event": {
+      "tool": "check_repo_merge_state",
+      "with": {
+        "branch": "${{ context.current_pr_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "remote_url": "${{ context.remote_url }}",
+        "step_name": "derive_pre_enqueue_ci_event"
+      },
+      "capture": {
+        "pre_enqueue_ci_event": "${{ result.ci_event }}"
+      },
+      "on_success": "wait_ci_pre_enqueue",
+      "on_failure": "wait_ci_pre_enqueue",
+      "note": "Re-derives ci_event for the actual PR branch before the pre-enqueue CI wait. The global check_repo_ci_event evaluates CI triggers against inputs.base_branch (main), but wait_ci_pre_enqueue watches context.current_pr_branch where different CI rules may apply. Non-blocking: on_failure routes to wait_ci_pre_enqueue with pre_enqueue_ci_event=null (match-any fallback).\n"
     },
     "wait_ci_pre_enqueue": {
       "tool": "wait_for_ci",
@@ -212,7 +227,7 @@
         "branch": "${{ context.current_pr_branch }}",
         "head_sha": "${{ context.current_pr_head_sha }}",
         "cwd": "${{ context.work_dir }}",
-        "event": "${{ context.ci_event }}",
+        "event": "${{ context.pre_enqueue_ci_event }}",
         "timeout_seconds": 600,
         "remote_url": "${{ context.remote_url }}",
         "auto_trigger": true,
@@ -418,8 +433,23 @@
       },
       "retries": 2,
       "on_exhausted": "register_clone_failure",
-      "on_success": "ci_watch_post_queue_fix",
+      "on_success": "derive_post_queue_ci_event",
       "on_failure": "classify_push_failure"
+    },
+    "derive_post_queue_ci_event": {
+      "tool": "check_repo_merge_state",
+      "with": {
+        "branch": "${{ context.ejected_pr_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "remote_url": "${{ context.remote_url }}",
+        "step_name": "derive_post_queue_ci_event"
+      },
+      "capture": {
+        "post_queue_ci_event": "${{ result.ci_event }}"
+      },
+      "on_success": "ci_watch_post_queue_fix",
+      "on_failure": "ci_watch_post_queue_fix",
+      "note": "Re-derives ci_event for the actual ejected PR branch before the post-queue-fix CI wait. The global check_repo_ci_event evaluates CI triggers against inputs.base_branch (main), but ci_watch_post_queue_fix watches context.ejected_pr_branch where different CI rules may apply. Non-blocking: on_failure routes to ci_watch_post_queue_fix with post_queue_ci_event=null (match-any fallback).\n"
     },
     "classify_push_failure": {
       "action": "route",
@@ -483,7 +513,7 @@
       "tool": "wait_for_ci",
       "with": {
         "branch": "${{ context.ejected_pr_branch }}",
-        "event": "${{ context.ci_event }}",
+        "event": "${{ context.post_queue_ci_event }}",
         "timeout_seconds": 600,
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
@@ -914,23 +944,43 @@
       "capture": {
         "conflict_pr_number": "${{ result.stdout | trim }}"
       },
-      "on_success": "wait_for_conflict_ci",
+      "on_success": "derive_conflict_ci_event",
       "on_failure": "register_clone_failure",
       "note": "Creates a GitHub PR from the worktree branch into the integration batch branch. Captures conflict_pr_number for the subsequent gh pr merge call. The --json number --jq '.number' flags constrain gh output to a bare integer, but if gh emits unexpected warnings to stdout the trimmed value may be malformed and propagate silently to merge_conflict_pr. Verify conflict_pr_number is a non-empty integer before use.\n"
+    },
+    "derive_conflict_ci_event": {
+      "tool": "check_repo_merge_state",
+      "with": {
+        "branch": "${{ context.worktree_branch_name }}",
+        "cwd": "${{ context.work_dir }}",
+        "remote_url": "${{ context.remote_url }}",
+        "step_name": "derive_conflict_ci_event"
+      },
+      "capture": {
+        "conflict_ci_event": "${{ result.ci_event }}"
+      },
+      "on_success": "wait_for_conflict_ci",
+      "on_failure": "wait_for_conflict_ci",
+      "note": "Re-derives ci_event for the ACTUAL conflict resolution branch, not inputs.base_branch. The original check_repo_ci_event evaluates CI triggers against main, but conflict PRs target pr-batch/* branches where different CI rules may apply. Non-blocking: on_failure routes to wait_for_conflict_ci with conflict_ci_event=null (match-any fallback).\n"
     },
     "wait_for_conflict_ci": {
       "tool": "wait_for_ci",
       "with": {
         "branch": "${{ context.worktree_branch_name }}",
-        "event": "${{ context.ci_event }}",
+        "event": "${{ context.conflict_ci_event }}",
         "timeout_seconds": 600,
         "cwd": "${{ context.worktree_path }}",
+        "remote_url": "${{ context.remote_url }}",
         "auto_trigger": true
       },
       "on_result": [
         {
           "when": "${{ result.conclusion }} == 'success'",
           "route": "merge_conflict_pr"
+        },
+        {
+          "when": "${{ result.conclusion }} == 'no_runs'",
+          "route": "handle_conflict_no_runs"
         },
         {
           "when": "${{ result.conclusion }} == 'timed_out'",
@@ -941,7 +991,7 @@
         }
       ],
       "on_failure": "register_clone_failure",
-      "note": "Waits for CI to pass on the worktree branch before merging. 600 second timeout matches the merge-pr skill poll timeout. Routes on result.conclusion: success → merge_conflict_pr, timed_out → check_conflict_ci_loop (iteration guard), no_runs/failure → register_clone_failure.\n"
+      "note": "Waits for CI to pass on the worktree branch before merging. 600 second timeout matches the merge-pr skill poll timeout. Uses conflict_ci_event (derived for the actual worktree branch) instead of the global ci_event (derived for inputs.base_branch). Routes on result.conclusion: success → merge_conflict_pr, no_runs → handle_conflict_no_runs (recovery path), timed_out → check_conflict_ci_loop (iteration guard), failure → register_clone_failure.\n"
     },
     "check_conflict_ci_loop": {
       "tool": "run_python",
@@ -967,6 +1017,23 @@
         "conflict_ci_loop_count"
       ],
       "note": "Caps the wait_for_conflict_ci re-poll loop at 2 iterations. After 2 timed_out results (1200s total), routes to register_clone_failure instead of spinning indefinitely.\n"
+    },
+    "handle_conflict_no_runs": {
+      "tool": "check_repo_merge_state",
+      "with": {
+        "branch": "${{ context.worktree_branch_name }}",
+        "cwd": "${{ context.work_dir }}",
+        "remote_url": "${{ context.remote_url }}",
+        "step_name": "handle_conflict_no_runs"
+      },
+      "capture": {
+        "conflict_ci_event": "${{ result.ci_event }}"
+      },
+      "on_success": "merge_conflict_pr",
+      "on_failure": "register_clone_failure",
+      "retries": 1,
+      "on_exhausted": "register_clone_failure",
+      "note": "Intercepts no_runs from wait_for_conflict_ci. Re-derives ci_event for the worktree branch. Since this step is reached only after auto_trigger has already attempted to trigger CI (empty commit + force-push) and wait_for_conflict_ci still saw no_runs, the branch genuinely has no applicable CI. Routes unconditionally to merge_conflict_pr on tool success — skipping CI is correct because all recovery options have been exhausted. retries: 1 bounds the tool-call retry for transient API failures.\n"
     },
     "merge_conflict_pr": {
       "tool": "run_cmd",
@@ -1311,19 +1378,19 @@
         },
         {
           "when": "${{ result.verdict }} == needs_human",
-          "route": "ci_watch_pr"
+          "route": "derive_batch_ci_event"
         },
         {
           "when": "${{ result.verdict }} == approved",
-          "route": "ci_watch_pr"
+          "route": "derive_batch_ci_event"
         },
         {
           "when": "true",
-          "route": "ci_watch_pr"
+          "route": "derive_batch_ci_event"
         }
       ],
       "on_failure": "resolve_review_integration",
-      "note": "Automated review of the integration PR (REQ-REVIEW-001). Invokes review-pr against context.batch_branch. All four verdicts have explicit routes: changes_requested → resolve_review_integration, approved_with_comments → resolve_review_integration, needs_human → ci_watch_pr (human reviews inline), approved → ci_watch_pr. On tool-level failure, routes to resolve_review_integration (matches implementation.yaml pattern). needs_human is explicitly routed to satisfy the unrouted-verdict-value semantic rule.\n"
+      "note": "Automated review of the integration PR (REQ-REVIEW-001). Invokes review-pr against context.batch_branch. All four verdicts have explicit routes: changes_requested → resolve_review_integration, approved_with_comments → resolve_review_integration, needs_human → derive_batch_ci_event (human reviews inline), approved → derive_batch_ci_event. On tool-level failure, routes to resolve_review_integration (matches implementation.yaml pattern). needs_human is explicitly routed to satisfy the unrouted-verdict-value semantic rule.\n"
     },
     "resolve_review_integration": {
       "tool": "run_skill",
@@ -1367,17 +1434,33 @@
         "remote_url": "${{ context.remote_url }}",
         "branch": "${{ context.batch_branch }}"
       },
-      "on_success": "ci_watch_pr",
+      "on_success": "derive_batch_ci_event",
       "on_failure": "register_clone_failure",
-      "note": "Pushes the review-fixed integration branch to the remote (REQ-REVIEW-003). Routes to ci_watch_pr for final CI validation. On push failure, escalates to register_clone_failure.\n"
+      "note": "Pushes the review-fixed integration branch to the remote (REQ-REVIEW-003). Routes to derive_batch_ci_event for branch-specific CI event derivation before final CI validation. On push failure, escalates to register_clone_failure.\n"
+    },
+    "derive_batch_ci_event": {
+      "tool": "check_repo_merge_state",
+      "with": {
+        "branch": "${{ context.batch_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "remote_url": "${{ context.remote_url }}",
+        "step_name": "derive_batch_ci_event"
+      },
+      "capture": {
+        "batch_ci_event": "${{ result.ci_event }}"
+      },
+      "on_success": "ci_watch_pr",
+      "on_failure": "ci_watch_pr",
+      "note": "Re-derives ci_event for the actual batch branch before the final CI watch. The global check_repo_ci_event evaluates CI triggers against inputs.base_branch (main), but ci_watch_pr watches context.batch_branch where different CI rules may apply. Non-blocking: on_failure routes to ci_watch_pr with batch_ci_event=null (match-any fallback).\n"
     },
     "ci_watch_pr": {
       "tool": "wait_for_ci",
       "with": {
         "branch": "${{ context.batch_branch }}",
-        "event": "${{ context.ci_event }}",
+        "event": "${{ context.batch_ci_event }}",
         "timeout_seconds": 600,
         "cwd": "${{ context.work_dir }}",
+        "remote_url": "${{ context.remote_url }}",
         "pr_url": "${{ context.pr_url }}",
         "auto_trigger": true
       },

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -121,11 +121,12 @@ steps:
     on_success: check_integration_exists
     on_failure: check_integration_exists
     note: >
-      Detects whether the repository's CI triggers on push or merge_group events.
-      Captures ci_event for use by wait_for_ci steps (wait_for_conflict_ci, ci_watch_pr)
-      and diagnose-ci skill invocations downstream. Routes to check_integration_exists
-      regardless of outcome — non-blocking gate: ci_event defaults to null (match-any)
-      on failure, which matches the ci.py scope.event=None behavior.
+      Detects whether the repository's CI triggers on push or merge_group events
+      for the base branch. Each downstream wait_for_ci step re-derives ci_event
+      for its own watched branch via a dedicated derive_*_ci_event step. The global
+      ci_event captured here is used only by diagnose-ci skill invocations.
+      Routes to check_integration_exists regardless of outcome — non-blocking gate:
+      ci_event defaults to null (match-any) on failure.
 
   check_integration_exists:
     tool: run_cmd
@@ -256,8 +257,26 @@ steps:
       step_name: "capture_pr_head_sha"
     capture:
       current_pr_head_sha: "${{ result.stdout | trim }}"
-    on_success: wait_ci_pre_enqueue
+    on_success: derive_pre_enqueue_ci_event
     on_failure: register_clone_failure
+
+  derive_pre_enqueue_ci_event:
+    tool: check_repo_merge_state
+    with:
+      branch: "${{ context.current_pr_branch }}"
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      step_name: "derive_pre_enqueue_ci_event"
+    capture:
+      pre_enqueue_ci_event: "${{ result.ci_event }}"
+    on_success: wait_ci_pre_enqueue
+    on_failure: wait_ci_pre_enqueue
+    note: >
+      Re-derives ci_event for the actual PR branch before the pre-enqueue CI wait.
+      The global check_repo_ci_event evaluates CI triggers against inputs.base_branch
+      (main), but wait_ci_pre_enqueue watches context.current_pr_branch where different
+      CI rules may apply. Non-blocking: on_failure routes to wait_ci_pre_enqueue with
+      pre_enqueue_ci_event=null (match-any fallback).
 
   wait_ci_pre_enqueue:
     tool: wait_for_ci
@@ -265,7 +284,7 @@ steps:
       branch: "${{ context.current_pr_branch }}"
       head_sha: "${{ context.current_pr_head_sha }}"
       cwd: "${{ context.work_dir }}"
-      event: "${{ context.ci_event }}"
+      event: "${{ context.pre_enqueue_ci_event }}"
       timeout_seconds: 600
       remote_url: "${{ context.remote_url }}"
       auto_trigger: true
@@ -432,8 +451,26 @@ steps:
       push_error_type: "${{ result.error_type }}"
     retries: 2
     on_exhausted: register_clone_failure
-    on_success: ci_watch_post_queue_fix
+    on_success: derive_post_queue_ci_event
     on_failure: classify_push_failure
+
+  derive_post_queue_ci_event:
+    tool: check_repo_merge_state
+    with:
+      branch: "${{ context.ejected_pr_branch }}"
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      step_name: "derive_post_queue_ci_event"
+    capture:
+      post_queue_ci_event: "${{ result.ci_event }}"
+    on_success: ci_watch_post_queue_fix
+    on_failure: ci_watch_post_queue_fix
+    note: >
+      Re-derives ci_event for the actual ejected PR branch before the post-queue-fix CI wait.
+      The global check_repo_ci_event evaluates CI triggers against inputs.base_branch
+      (main), but ci_watch_post_queue_fix watches context.ejected_pr_branch where different
+      CI rules may apply. Non-blocking: on_failure routes to ci_watch_post_queue_fix with
+      post_queue_ci_event=null (match-any fallback).
 
   classify_push_failure:
     action: route
@@ -473,7 +510,7 @@ steps:
     tool: wait_for_ci
     with:
       branch: "${{ context.ejected_pr_branch }}"
-      event: "${{ context.ci_event }}"
+      event: "${{ context.post_queue_ci_event }}"
       timeout_seconds: 600
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
@@ -886,7 +923,7 @@ steps:
       step_name: "create_conflict_pr"
     capture:
       conflict_pr_number: "${{ result.stdout | trim }}"
-    on_success: wait_for_conflict_ci
+    on_success: derive_conflict_ci_event
     on_failure: register_clone_failure
     note: >
       Creates a GitHub PR from the worktree branch into the integration batch branch.
@@ -896,17 +933,37 @@ steps:
       and propagate silently to merge_conflict_pr. Verify conflict_pr_number is a
       non-empty integer before use.
 
+  derive_conflict_ci_event:
+    tool: check_repo_merge_state
+    with:
+      branch: "${{ context.worktree_branch_name }}"
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      step_name: "derive_conflict_ci_event"
+    capture:
+      conflict_ci_event: "${{ result.ci_event }}"
+    on_success: wait_for_conflict_ci
+    on_failure: wait_for_conflict_ci
+    note: >
+      Re-derives ci_event for the ACTUAL conflict resolution branch, not inputs.base_branch.
+      The original check_repo_ci_event evaluates CI triggers against main, but conflict PRs
+      target pr-batch/* branches where different CI rules may apply. Non-blocking: on_failure
+      routes to wait_for_conflict_ci with conflict_ci_event=null (match-any fallback).
+
   wait_for_conflict_ci:
     tool: wait_for_ci
     with:
       branch: "${{ context.worktree_branch_name }}"
-      event: "${{ context.ci_event }}"
+      event: "${{ context.conflict_ci_event }}"
       timeout_seconds: 600
       cwd: "${{ context.worktree_path }}"
+      remote_url: "${{ context.remote_url }}"
       auto_trigger: true
     on_result:
       - when: "${{ result.conclusion }} == 'success'"
         route: merge_conflict_pr
+      - when: "${{ result.conclusion }} == 'no_runs'"
+        route: handle_conflict_no_runs
       - when: "${{ result.conclusion }} == 'timed_out'"
         route: check_conflict_ci_loop
       - route: register_clone_failure
@@ -914,8 +971,10 @@ steps:
     note: >
       Waits for CI to pass on the worktree branch before merging.
       600 second timeout matches the merge-pr skill poll timeout.
-      Routes on result.conclusion: success → merge_conflict_pr,
-      timed_out → check_conflict_ci_loop (iteration guard), no_runs/failure → register_clone_failure.
+      Uses conflict_ci_event (derived for the actual worktree branch) instead of
+      the global ci_event (derived for inputs.base_branch). Routes on result.conclusion:
+      success → merge_conflict_pr, no_runs → handle_conflict_no_runs (recovery path),
+      timed_out → check_conflict_ci_loop (iteration guard), failure → register_clone_failure.
 
   check_conflict_ci_loop:
     tool: run_python
@@ -936,6 +995,27 @@ steps:
       Caps the wait_for_conflict_ci re-poll loop at 2 iterations.
       After 2 timed_out results (1200s total), routes to register_clone_failure
       instead of spinning indefinitely.
+
+  handle_conflict_no_runs:
+    tool: check_repo_merge_state
+    with:
+      branch: "${{ context.worktree_branch_name }}"
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      step_name: "handle_conflict_no_runs"
+    capture:
+      conflict_ci_event: "${{ result.ci_event }}"
+    on_success: merge_conflict_pr
+    on_failure: register_clone_failure
+    retries: 1
+    on_exhausted: register_clone_failure
+    note: >
+      Intercepts no_runs from wait_for_conflict_ci. Re-derives ci_event for the worktree
+      branch. Since this step is reached only after auto_trigger has already attempted to
+      trigger CI (empty commit + force-push) and wait_for_conflict_ci still saw no_runs,
+      the branch genuinely has no applicable CI. Routes unconditionally to merge_conflict_pr
+      on tool success — skipping CI is correct because all recovery options have been
+      exhausted. retries: 1 bounds the tool-call retry for transient API failures.
 
   merge_conflict_pr:
     tool: run_cmd
@@ -1272,18 +1352,18 @@ steps:
       - when: "${{ result.verdict }} == approved_with_comments"
         route: resolve_review_integration
       - when: "${{ result.verdict }} == needs_human"
-        route: ci_watch_pr
+        route: derive_batch_ci_event
       - when: "${{ result.verdict }} == approved"
-        route: ci_watch_pr
+        route: derive_batch_ci_event
       - when: "true"
-        route: ci_watch_pr
+        route: derive_batch_ci_event
     on_failure: resolve_review_integration
     note: >
       Automated review of the integration PR (REQ-REVIEW-001). Invokes review-pr against
       context.batch_branch. All four verdicts have explicit routes: changes_requested
       → resolve_review_integration, approved_with_comments → resolve_review_integration,
-      needs_human → ci_watch_pr (human reviews inline), approved → ci_watch_pr. On
-      tool-level failure, routes to resolve_review_integration (matches implementation.yaml
+      needs_human → derive_batch_ci_event (human reviews inline), approved → derive_batch_ci_event.
+      On tool-level failure, routes to resolve_review_integration (matches implementation.yaml
       pattern). needs_human is explicitly routed to satisfy the unrouted-verdict-value
       semantic rule.
 
@@ -1322,19 +1402,39 @@ steps:
       clone_path: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.batch_branch }}"
-    on_success: ci_watch_pr
+    on_success: derive_batch_ci_event
     on_failure: register_clone_failure
     note: >
       Pushes the review-fixed integration branch to the remote (REQ-REVIEW-003). Routes to
-      ci_watch_pr for final CI validation. On push failure, escalates to register_clone_failure.
+      derive_batch_ci_event for branch-specific CI event derivation before final CI validation.
+      On push failure, escalates to register_clone_failure.
+
+  derive_batch_ci_event:
+    tool: check_repo_merge_state
+    with:
+      branch: "${{ context.batch_branch }}"
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      step_name: "derive_batch_ci_event"
+    capture:
+      batch_ci_event: "${{ result.ci_event }}"
+    on_success: ci_watch_pr
+    on_failure: ci_watch_pr
+    note: >
+      Re-derives ci_event for the actual batch branch before the final CI watch.
+      The global check_repo_ci_event evaluates CI triggers against inputs.base_branch
+      (main), but ci_watch_pr watches context.batch_branch where different CI rules
+      may apply. Non-blocking: on_failure routes to ci_watch_pr with
+      batch_ci_event=null (match-any fallback).
 
   ci_watch_pr:
     tool: wait_for_ci
     with:
       branch: "${{ context.batch_branch }}"
-      event: "${{ context.ci_event }}"
+      event: "${{ context.batch_ci_event }}"
       timeout_seconds: 600
       cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
       pr_url: "${{ context.pr_url }}"
       auto_trigger: true
     on_result:

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -319,6 +319,32 @@ async def test_push_trigger_branch_filter_matches_target_branch(httpx_mock):
 
 
 @pytest.mark.anyio
+async def test_main_only_push_returns_none_for_pr_batch_branch(httpx_mock):
+    """push: branches: [main] must return ci_event=None for pr-batch/* branches.
+
+    This documents the exact failure mode from issue #2599: the recipe called
+    fetch_repo_merge_state(branch="main") → ci_event="push", then reused that
+    value for pr-batch/pr-merge-* branches where CI never fires.
+    """
+    workflow_text = textwrap.dedent("""\
+        on:
+          push:
+            branches: [main]
+    """)
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(
+        owner="org",
+        repo="repo",
+        branch="pr-batch/pr-merge-20260518-194529",
+        token=None,
+    )
+    assert result["ci_event"] is None
+
+
+@pytest.mark.anyio
 async def test_push_trigger_branches_ignore_allows_feature_branch(httpx_mock):
     """branches-ignore: [main, stable] → push fires on feature branches → ci_event='push'."""
     workflow_text = textwrap.dedent("""\

--- a/tests/execution/test_push_trigger_applies.py
+++ b/tests/execution/test_push_trigger_applies.py
@@ -63,6 +63,23 @@ def test_yaml_parse_failure_falls_back_to_heuristic_safe():
     assert _push_trigger_applies_to_branch(": [\n", "main") is False
 
 
+def test_main_only_push_excludes_pr_batch_branch():
+    """push: branches: [main] must NOT fire for pr-batch/* branches.
+
+    This is the exact failure mode from issue #2599: the recipe derived
+    ci_event='push' for main, then reused it for pr-batch/pr-merge-* branches
+    where GitHub Actions never fires.
+    """
+    text = "on:\n  push:\n    branches:\n      - main\n"
+    assert _push_trigger_applies_to_branch(text, "pr-batch/pr-merge-20260518-194529") is False
+
+
+def test_main_only_push_excludes_worktree_branch():
+    """push: branches: [main] must NOT fire for impl-* worktree branches."""
+    text = "on:\n  push:\n    branches:\n      - main\n"
+    assert _push_trigger_applies_to_branch(text, "impl-rectify-ci-event-20260518-180226") is False
+
+
 # ---------------------------------------------------------------------------
 # _has_merge_group_trigger tests
 # ---------------------------------------------------------------------------

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -71,6 +71,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_plan_visualization_step.py` | Tests for plan visualization step in recipes |
 | `test_planner_recipe.py` | Tests for the planner recipe structure |
 | `test_promote_to_main_wrapper.py` | Tests for the promote-to-main wrapper recipe |
+| `test_recipe_ci_contracts.py` | Cross-recipe ci_event/branch coherence and remote_url structural tests |
 | `test_recipe_ci_watch_event.py` | Tests for CI watch event in recipe steps |
 | `test_recipe_order.py` | Tests for BUNDLED_RECIPE_ORDER stable display order registry |
 | `test_report_frontmatter_schema.py` | Tests for report.md YAML frontmatter audit-trail schema |

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -765,24 +765,6 @@ def test_check_ci_watch_pr_loop_exists_with_correct_pattern(recipe) -> None:
     assert max_exceeded_conds[0].route == "register_clone_failure"
 
 
-def test_wait_for_conflict_ci_has_remote_url(recipe) -> None:
-    """wait_for_conflict_ci must include remote_url to avoid file:// clone path fallback."""
-    step = recipe.steps["wait_for_conflict_ci"]
-    assert "remote_url" in step.with_args, (
-        "wait_for_conflict_ci must pass remote_url — without it, repo resolution falls back "
-        "to git remote get-url in the cwd, which may resolve to a file:// clone path"
-    )
-
-
-def test_ci_watch_pr_has_remote_url(recipe) -> None:
-    """ci_watch_pr must include remote_url to avoid file:// clone path fallback."""
-    step = recipe.steps["ci_watch_pr"]
-    assert "remote_url" in step.with_args, (
-        "ci_watch_pr must pass remote_url — without it, repo resolution falls back "
-        "to git remote get-url in the cwd, which may resolve to a file:// clone path"
-    )
-
-
 def test_all_wait_for_ci_steps_have_remote_url(recipe) -> None:
     """Every wait_for_ci step must include remote_url in its with_args."""
     for step_name, step in recipe.steps.items():
@@ -809,6 +791,10 @@ def test_wait_for_conflict_ci_uses_dedicated_ci_event(recipe) -> None:
         "inputs.base_branch (main), not the worktree branch being watched. "
         "Use a dedicated context.conflict_ci_event instead."
     )
+    assert "context.conflict_ci_event" in event, (
+        "wait_for_conflict_ci must use context.conflict_ci_event — "
+        "the ci_event derived for the actual worktree branch"
+    )
 
 
 def test_ci_watch_pr_uses_dedicated_ci_event(recipe) -> None:
@@ -819,6 +805,10 @@ def test_ci_watch_pr_uses_dedicated_ci_event(recipe) -> None:
         "ci_watch_pr must NOT use context.ci_event — it was derived for "
         "inputs.base_branch (main), not context.batch_branch being watched. "
         "Use a dedicated context.batch_ci_event instead."
+    )
+    assert "context.batch_ci_event" in event, (
+        "ci_watch_pr must use context.batch_ci_event — "
+        "the ci_event derived for the actual batch branch"
     )
 
 
@@ -831,6 +821,10 @@ def test_wait_ci_pre_enqueue_uses_dedicated_ci_event(recipe) -> None:
         "inputs.base_branch (main), not context.current_pr_branch being watched. "
         "Use a dedicated context.pre_enqueue_ci_event instead."
     )
+    assert "context.pre_enqueue_ci_event" in event, (
+        "wait_ci_pre_enqueue must use context.pre_enqueue_ci_event — "
+        "the ci_event derived for the actual PR branch"
+    )
 
 
 def test_ci_watch_post_queue_fix_uses_dedicated_ci_event(recipe) -> None:
@@ -841,6 +835,10 @@ def test_ci_watch_post_queue_fix_uses_dedicated_ci_event(recipe) -> None:
         "ci_watch_post_queue_fix must NOT use context.ci_event — it was derived for "
         "inputs.base_branch (main), not context.ejected_pr_branch being watched. "
         "Use a dedicated context.post_queue_ci_event instead."
+    )
+    assert "context.post_queue_ci_event" in event, (
+        "ci_watch_post_queue_fix must use context.post_queue_ci_event — "
+        "the ci_event derived for the actual ejected PR branch"
     )
 
 
@@ -855,11 +853,45 @@ def test_derive_conflict_ci_event_step_exists(recipe) -> None:
     assert "worktree_branch_name" in step.with_args.get("branch", "")
 
 
+def test_derive_pre_enqueue_ci_event_step_exists(recipe) -> None:
+    """derive_pre_enqueue_ci_event must exist to re-derive ci_event for the PR branch."""
+    assert "derive_pre_enqueue_ci_event" in recipe.steps, (
+        "derive_pre_enqueue_ci_event step is missing — needed to derive ci_event for the "
+        "actual PR branch before wait_ci_pre_enqueue runs"
+    )
+    step = recipe.steps["derive_pre_enqueue_ci_event"]
+    assert step.tool == "check_repo_merge_state"
+    assert "current_pr_branch" in step.with_args.get("branch", "")
+
+
+def test_derive_post_queue_ci_event_step_exists(recipe) -> None:
+    """derive_post_queue_ci_event must exist to re-derive ci_event for the ejected PR branch."""
+    assert "derive_post_queue_ci_event" in recipe.steps, (
+        "derive_post_queue_ci_event step is missing — needed to derive ci_event for the "
+        "actual ejected PR branch before ci_watch_post_queue_fix runs"
+    )
+    step = recipe.steps["derive_post_queue_ci_event"]
+    assert step.tool == "check_repo_merge_state"
+    assert "ejected_pr_branch" in step.with_args.get("branch", "")
+
+
+def test_derive_batch_ci_event_step_exists(recipe) -> None:
+    """derive_batch_ci_event must exist to re-derive ci_event for the batch branch."""
+    assert "derive_batch_ci_event" in recipe.steps, (
+        "derive_batch_ci_event step is missing — needed to derive ci_event for the "
+        "actual batch branch before ci_watch_pr runs"
+    )
+    step = recipe.steps["derive_batch_ci_event"]
+    assert step.tool == "check_repo_merge_state"
+    assert "batch_branch" in step.with_args.get("branch", "")
+
+
 def test_create_conflict_pr_routes_to_derive_conflict_ci_event(recipe) -> None:
-    """create_conflict_pr.on_success must route to derive_conflict_ci_event, not directly to wait_for_conflict_ci."""
+    """create_conflict_pr.on_success must route to derive_conflict_ci_event."""
     step = recipe.steps["create_conflict_pr"]
     assert step.on_success == "derive_conflict_ci_event", (
-        f"create_conflict_pr.on_success must be 'derive_conflict_ci_event', got {step.on_success!r}"
+        f"create_conflict_pr.on_success must be "
+        f"'derive_conflict_ci_event', got {step.on_success!r}"
     )
 
 
@@ -874,7 +906,7 @@ def test_handle_conflict_no_runs_step_exists(recipe) -> None:
 
 
 def test_wait_for_conflict_ci_routes_no_runs_to_handler(recipe) -> None:
-    """wait_for_conflict_ci must route no_runs to handle_conflict_no_runs, not register_clone_failure."""
+    """wait_for_conflict_ci must route no_runs to handle_conflict_no_runs."""
     step = recipe.steps["wait_for_conflict_ci"]
     assert step.on_result is not None
     no_runs_conds = [c for c in step.on_result.conditions if c.when and "no_runs" in c.when]

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -570,10 +570,10 @@ def test_pmp_re_push_review_integration_uses_batch_branch(recipe) -> None:
     assert "context.batch_branch" in step.with_args.get("branch", "")
 
 
-def test_pmp_re_push_review_integration_routes_to_ci_watch(recipe) -> None:
-    """B22: re_push_review_integration.on_success must route to ci_watch_pr."""
+def test_pmp_re_push_review_integration_routes_to_derive_batch_ci_event(recipe) -> None:
+    """B22: re_push_review_integration.on_success must route through derive_batch_ci_event."""
     step = recipe.steps["re_push_review_integration"]
-    assert step.on_success == "ci_watch_pr"
+    assert step.on_success == "derive_batch_ci_event"
 
 
 def test_pmp_setup_remote_uses_context_remote_url(recipe) -> None:
@@ -682,11 +682,11 @@ def test_wait_ci_pre_enqueue_has_explicit_head_sha_or_matching_cwd(recipe) -> No
 
 
 def test_capture_pr_head_sha_step_exists(recipe) -> None:
-    """capture_pr_head_sha step must exist and route to wait_ci_pre_enqueue."""
+    """capture_pr_head_sha step must exist and route to derive_pre_enqueue_ci_event."""
     assert "capture_pr_head_sha" in recipe.steps
     step = recipe.steps["capture_pr_head_sha"]
     assert step.tool == "run_cmd"
-    assert step.on_success == "wait_ci_pre_enqueue"
+    assert step.on_success == "derive_pre_enqueue_ci_event"
 
 
 def test_get_current_pr_branch_routes_to_capture(recipe) -> None:
@@ -763,6 +763,126 @@ def test_check_ci_watch_pr_loop_exists_with_correct_pattern(recipe) -> None:
     ]
     assert max_exceeded_conds, "check_ci_watch_pr_loop must route max_exceeded==true"
     assert max_exceeded_conds[0].route == "register_clone_failure"
+
+
+def test_wait_for_conflict_ci_has_remote_url(recipe) -> None:
+    """wait_for_conflict_ci must include remote_url to avoid file:// clone path fallback."""
+    step = recipe.steps["wait_for_conflict_ci"]
+    assert "remote_url" in step.with_args, (
+        "wait_for_conflict_ci must pass remote_url — without it, repo resolution falls back "
+        "to git remote get-url in the cwd, which may resolve to a file:// clone path"
+    )
+
+
+def test_ci_watch_pr_has_remote_url(recipe) -> None:
+    """ci_watch_pr must include remote_url to avoid file:// clone path fallback."""
+    step = recipe.steps["ci_watch_pr"]
+    assert "remote_url" in step.with_args, (
+        "ci_watch_pr must pass remote_url — without it, repo resolution falls back "
+        "to git remote get-url in the cwd, which may resolve to a file:// clone path"
+    )
+
+
+def test_all_wait_for_ci_steps_have_remote_url(recipe) -> None:
+    """Every wait_for_ci step must include remote_url in its with_args."""
+    for step_name, step in recipe.steps.items():
+        if step.tool != "wait_for_ci":
+            continue
+        assert "remote_url" in step.with_args, (
+            f"{step_name}: wait_for_ci step must pass remote_url to prevent "
+            f"file:// clone path fallback during repo resolution"
+        )
+
+
+def test_wait_for_conflict_ci_uses_dedicated_ci_event(recipe) -> None:
+    """wait_for_conflict_ci must use a branch-specific ci_event, not the global one.
+
+    The global context.ci_event is derived for inputs.base_branch (main), but
+    wait_for_conflict_ci watches context.worktree_branch_name — a completely
+    different branch. Using the global ci_event causes no_runs timeouts when
+    CI only triggers on main pushes.
+    """
+    step = recipe.steps["wait_for_conflict_ci"]
+    event = step.with_args.get("event", "")
+    assert "context.ci_event" not in event, (
+        "wait_for_conflict_ci must NOT use context.ci_event — it was derived for "
+        "inputs.base_branch (main), not the worktree branch being watched. "
+        "Use a dedicated context.conflict_ci_event instead."
+    )
+
+
+def test_ci_watch_pr_uses_dedicated_ci_event(recipe) -> None:
+    """ci_watch_pr must use a branch-specific ci_event, not the global one."""
+    step = recipe.steps["ci_watch_pr"]
+    event = step.with_args.get("event", "")
+    assert "context.ci_event" not in event, (
+        "ci_watch_pr must NOT use context.ci_event — it was derived for "
+        "inputs.base_branch (main), not context.batch_branch being watched. "
+        "Use a dedicated context.batch_ci_event instead."
+    )
+
+
+def test_wait_ci_pre_enqueue_uses_dedicated_ci_event(recipe) -> None:
+    """wait_ci_pre_enqueue must use a branch-specific ci_event."""
+    step = recipe.steps["wait_ci_pre_enqueue"]
+    event = step.with_args.get("event", "")
+    assert "context.ci_event" not in event, (
+        "wait_ci_pre_enqueue must NOT use context.ci_event — it was derived for "
+        "inputs.base_branch (main), not context.current_pr_branch being watched. "
+        "Use a dedicated context.pre_enqueue_ci_event instead."
+    )
+
+
+def test_ci_watch_post_queue_fix_uses_dedicated_ci_event(recipe) -> None:
+    """ci_watch_post_queue_fix must use a branch-specific ci_event."""
+    step = recipe.steps["ci_watch_post_queue_fix"]
+    event = step.with_args.get("event", "")
+    assert "context.ci_event" not in event, (
+        "ci_watch_post_queue_fix must NOT use context.ci_event — it was derived for "
+        "inputs.base_branch (main), not context.ejected_pr_branch being watched. "
+        "Use a dedicated context.post_queue_ci_event instead."
+    )
+
+
+def test_derive_conflict_ci_event_step_exists(recipe) -> None:
+    """derive_conflict_ci_event must exist to re-derive ci_event for the worktree branch."""
+    assert "derive_conflict_ci_event" in recipe.steps, (
+        "derive_conflict_ci_event step is missing — needed to derive ci_event for the "
+        "actual worktree branch before wait_for_conflict_ci runs"
+    )
+    step = recipe.steps["derive_conflict_ci_event"]
+    assert step.tool == "check_repo_merge_state"
+    assert "worktree_branch_name" in step.with_args.get("branch", "")
+
+
+def test_create_conflict_pr_routes_to_derive_conflict_ci_event(recipe) -> None:
+    """create_conflict_pr.on_success must route to derive_conflict_ci_event, not directly to wait_for_conflict_ci."""
+    step = recipe.steps["create_conflict_pr"]
+    assert step.on_success == "derive_conflict_ci_event", (
+        f"create_conflict_pr.on_success must be 'derive_conflict_ci_event', got {step.on_success!r}"
+    )
+
+
+def test_handle_conflict_no_runs_step_exists(recipe) -> None:
+    """handle_conflict_no_runs must exist for no_runs recovery in conflict CI path."""
+    assert "handle_conflict_no_runs" in recipe.steps, (
+        "handle_conflict_no_runs step is missing — needed to handle no_runs conclusion "
+        "from wait_for_conflict_ci (mirrors implementation.yaml's handle_no_ci_runs)"
+    )
+    step = recipe.steps["handle_conflict_no_runs"]
+    assert step.tool == "check_repo_merge_state"
+
+
+def test_wait_for_conflict_ci_routes_no_runs_to_handler(recipe) -> None:
+    """wait_for_conflict_ci must route no_runs to handle_conflict_no_runs, not register_clone_failure."""
+    step = recipe.steps["wait_for_conflict_ci"]
+    assert step.on_result is not None
+    no_runs_conds = [c for c in step.on_result.conditions if c.when and "no_runs" in c.when]
+    assert no_runs_conds, "wait_for_conflict_ci must have an explicit no_runs route"
+    assert no_runs_conds[0].route == "handle_conflict_no_runs", (
+        f"wait_for_conflict_ci no_runs must route to handle_conflict_no_runs, "
+        f"got {no_runs_conds[0].route!r}"
+    )
 
 
 def test_wait_for_ci_steps_have_consistent_cwd(recipe) -> None:

--- a/tests/recipe/test_merge_prs_queue_pmp.py
+++ b/tests/recipe/test_merge_prs_queue_pmp.py
@@ -307,10 +307,10 @@ def test_merge_prs_ci_watch_post_queue_fix_exists(pmp_recipe) -> None:
     assert "ci_watch_post_queue_fix" in pmp_recipe.steps
 
 
-def test_merge_prs_push_ejected_fix_routes_to_ci_watch(pmp_recipe) -> None:
-    """push_ejected_fix.on_success must route to ci_watch_post_queue_fix."""
+def test_merge_prs_push_ejected_fix_routes_to_derive_post_queue_ci_event(pmp_recipe) -> None:
+    """push_ejected_fix.on_success must route through derive_post_queue_ci_event."""
     step = pmp_recipe.steps["push_ejected_fix"]
-    assert step.on_success == "ci_watch_post_queue_fix"
+    assert step.on_success == "derive_post_queue_ci_event"
 
 
 def test_merge_prs_ci_watch_routes_to_reenter(pmp_recipe) -> None:

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -1,0 +1,128 @@
+"""Cross-recipe structural tests: ci_event/branch coherence for all wait_for_ci steps.
+
+Every wait_for_ci step must use a ci_event that was derived for the same branch
+it watches. This prevents the class of bug where ci_event is derived for
+inputs.base_branch (main) but reused for pr-batch/*, feature, or worktree branches
+where different CI trigger rules apply.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import yaml
+
+from autoskillit.recipe.io import builtin_recipes_dir
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_TEMPLATE_RE = re.compile(r"\$\{\{\s*(.+?)\s*\}\}")
+
+
+def _extract_ref(template: str) -> str | None:
+    """Extract the context/result reference from a ${{ ... }} template string."""
+    m = _TEMPLATE_RE.search(template)
+    return m.group(1) if m else None
+
+
+def _find_capture_source(
+    steps: dict, capture_name: str
+) -> tuple[str, dict] | None:
+    """Find the step that captures a given context variable name."""
+    for step_name, step_data in steps.items():
+        capture = step_data.get("capture") or {}
+        if capture_name in capture:
+            return step_name, step_data
+    return None
+
+
+RECIPE_FILES = sorted(builtin_recipes_dir().glob("*.yaml"))
+
+
+@pytest.fixture(params=RECIPE_FILES, ids=lambda p: p.stem)
+def recipe_data(request):
+    with open(request.param) as f:
+        return request.param.stem, yaml.safe_load(f)
+
+
+def test_wait_for_ci_event_branch_coherence(recipe_data) -> None:
+    """For each wait_for_ci step, the event: must come from a check_repo_merge_state
+    step that used the same branch variable as the wait_for_ci step's branch: field,
+    OR the step must have its own dedicated ci_event derivation step."""
+    recipe_name, data = recipe_data
+    steps = data.get("steps") or {}
+
+    wait_steps = {
+        name: step
+        for name, step in steps.items()
+        if (step.get("tool") or "") == "wait_for_ci"
+    }
+
+    if not wait_steps:
+        pytest.skip(f"{recipe_name}: no wait_for_ci steps")
+
+    violations = []
+
+    for step_name, step in wait_steps.items():
+        with_args = step.get("with") or {}
+        event_template = with_args.get("event", "")
+        branch_template = with_args.get("branch", "")
+
+        event_ref = _extract_ref(event_template)
+        branch_ref = _extract_ref(branch_template)
+
+        if not event_ref or not branch_ref:
+            continue
+
+        event_var = event_ref.split(".")[-1] if "." in event_ref else event_ref
+
+        source = _find_capture_source(steps, event_var)
+        if source is None:
+            continue
+
+        source_name, source_step = source
+        source_tool = source_step.get("tool") or source_step.get("python") or ""
+        if "check_repo_merge_state" not in source_tool and "fetch_repo_merge_state" not in source_tool:
+            continue
+
+        source_with = source_step.get("with") or {}
+        source_branch_template = source_with.get("branch", "")
+        source_branch_ref = _extract_ref(source_branch_template)
+
+        if source_branch_ref and source_branch_ref != branch_ref:
+            violations.append(
+                f"{step_name}: event '{event_var}' derived from {source_name} "
+                f"(branch: {source_branch_ref}) but wait_for_ci watches "
+                f"branch: {branch_ref}"
+            )
+
+    assert not violations, (
+        f"{recipe_name}: ci_event/branch mismatch detected:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+    )
+
+
+def test_wait_for_ci_steps_have_remote_url(recipe_data) -> None:
+    """Every wait_for_ci step should include remote_url to prevent file:// fallback."""
+    recipe_name, data = recipe_data
+    steps = data.get("steps") or {}
+
+    wait_steps = {
+        name: step
+        for name, step in steps.items()
+        if (step.get("tool") or "") == "wait_for_ci"
+    }
+
+    if not wait_steps:
+        pytest.skip(f"{recipe_name}: no wait_for_ci steps")
+
+    missing = []
+    for step_name, step in wait_steps.items():
+        with_args = step.get("with") or {}
+        if "remote_url" not in with_args:
+            missing.append(step_name)
+
+    assert not missing, (
+        f"{recipe_name}: wait_for_ci steps missing remote_url: {missing}"
+    )


### PR DESCRIPTION
## Summary

The merge-prs recipe derives `ci_event` once by inspecting GitHub workflow files against `inputs.base_branch` (always `main`), then reuses that value for CI-watch steps targeting different branches (conflict resolution worktree branches, ejected PR branches, integration batch branches). When a project's CI only fires on `main`-targeted pushes, `ci_event="push"` is correct for `main` but meaningless for `pr-batch/*` branches — GitHub Actions never fires, producing `no_runs` after 1200s of wasted polling.

Fix: derive per-branch `ci_event` immediately before each CI-watch step, add a `no_runs` skip path for conflict PRs, and add structural tests preventing this class of bug.

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_ci_event_branch_mismatch_2026-05-18_174438.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 55 | 12.1k | 956.3k | 75.7k | 84 | 56.9k | 5m 38s |
| dry_walkthrough | claude-opus-4-6 | 1 | 56 | 27.1k | 2.1M | 92.1k | 146 | 90.2k | 10m 50s |
| implement | claude-opus-4-6 | 1 | 2.7k | 6.5k | 680.2k | 94.0k | 68 | 81.8k | 3m 55s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.3k | 2.3k | 163.1k | 0 | 18 | 0 | 55s |
| compose_pr* | MiniMax-M2.7 | 1 | 37.1k | 1.6k | 306.7k | 0 | 21 | 0 | 1m 50s |
| review_pr | claude-opus-4-6 | 3 | 516 | 98.1k | 1.9M | 95.6k | 168 | 262.9k | 28m 43s |
| resolve_review | claude-opus-4-6 | 2 | 95 | 22.2k | 2.0M | 91.6k | 88 | 191.9k | 11m 0s |
| **Total** | | | 83.7k | 169.7k | 8.0M | 95.6k | | 683.6k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 163 | 4172.9 | 501.7 | 39.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 74 | 26925.3 | 2593.9 | 299.6 |
| **Total** | **237** | 33803.3 | 2884.5 | 716.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 55 | 12.1k | 956.3k | 56.9k | 5m 38s |
| claude-opus-4-6 | 4 | 3.3k | 153.8k | 6.6M | 626.8k | 54m 30s |
| MiniMax-M2.7 | 2 | 80.3k | 3.9k | 469.8k | 0 | 2m 45s |