### PR TITLE
Implementation Plan: [P3-A2-WP3] ClaudeResultParser — ResultParser Protocol Implementation

### DIFF
--- a/tests/execution/backends/test_claude_result_parser.py
+++ b/tests/execution/backends/test_claude_result_parser.py
@@ -131,6 +131,12 @@ class TestClaudeResultParser:
             assert raw["is_error"] is False
             assert raw["token_usage"] == {"input_tokens": 100, "output_tokens": 50}
             assert raw["write_artifacts"] == ["/tmp/foo.py"]
+            assert raw["tool_uses"] == [{"name": "Write", "id": "1", "file_path": "/tmp/foo.py"}]
+            assert raw["assistant_messages"] == ['{"type": "assistant", "message": {}}']
+            assert raw["jsonl_context_exhausted"] is False
+            assert raw["stop_reasons"] == ["end_turn"]
+            assert raw["has_thinking_only_turn"] is False
+            assert set(raw["seen_block_types"]) == {"text", "tool_use"}
 
     def test_parse_stdout_empty_output_error(self) -> None:
         from autoskillit.execution.session import ClaudeSessionResult, CliSubtype
@@ -150,6 +156,9 @@ class TestClaudeResultParser:
             result = parser.parse_stdout("")
             assert result.success is False
             assert result.error == "empty output"
+            raw = dict(result.raw)
+            assert raw["subtype"] == "empty_output"
+            assert raw["is_error"] is True
 
     def test_parse_stdout_write_artifacts_in_raw(self) -> None:
         from autoskillit.execution.session import ClaudeSessionResult, CliSubtype
@@ -192,6 +201,42 @@ class TestClaudeResultParser:
             parser = ClaudeResultParser()
             parser.parse_stdout('{"type": "result"}')
             mock_parse.assert_called_once()
+
+    def test_parse_stdout_seen_block_types_is_list(self) -> None:
+        from autoskillit.execution.session import ClaudeSessionResult, CliSubtype
+
+        mock_result = ClaudeSessionResult(
+            subtype=CliSubtype.SUCCESS,
+            is_error=False,
+            result="done",
+            session_id="",
+            seen_block_types=frozenset({"text", "thinking"}),
+        )
+        with patch(
+            "autoskillit.execution.backends.claude.parse_session_result",
+            return_value=mock_result,
+        ):
+            parser = ClaudeResultParser()
+            result = parser.parse_stdout('{"type": "result"}')
+            assert isinstance(result.raw["seen_block_types"], list)
+            assert set(result.raw["seen_block_types"]) == {"text", "thinking"}
+
+    def test_extract_write_artifacts_filters_correctly(self) -> None:
+        from autoskillit.execution.backends.claude import _extract_write_artifacts
+
+        tool_uses = [
+            {"name": "Write", "id": "1", "file_path": "/a.py"},
+            {"name": "Bash", "id": "2"},
+            {"name": "Edit", "id": "3", "file_path": "/b.py"},
+            {"name": "Write", "id": "4"},
+            {"name": "Read", "id": "5", "file_path": "/c.py"},
+        ]
+        assert _extract_write_artifacts(tool_uses) == ["/a.py", "/b.py"]
+
+    def test_extract_write_artifacts_empty_list(self) -> None:
+        from autoskillit.execution.backends.claude import _extract_write_artifacts
+
+        assert _extract_write_artifacts([]) == []
 
     def test_structural_conformance_result_parser(self) -> None:
         assert isinstance(ClaudeResultParser(), ResultParser)

--- a/tests/execution/backends/test_claude_result_parser.py
+++ b/tests/execution/backends/test_claude_result_parser.py
@@ -227,8 +227,12 @@ class TestClaudeResultParser:
         tool_uses = [
             {"name": "Write", "id": "1", "file_path": "/a.py"},
             {"name": "Bash", "id": "2"},
-            {"name": "Edit", "id": "3", "file_path": "/b.py"},
-            {"name": "Write", "id": "4"},
+            {
+                "name": "Edit",
+                "id": "3",
+                "file_path": "/b.py",
+            },  # Edit modifies files — counts as write artifact
+            {"name": "Write", "id": "4"},  # no file_path — silently skipped
             {"name": "Read", "id": "5", "file_path": "/c.py"},
         ]
         assert _extract_write_artifacts(tool_uses) == ["/a.py", "/b.py"]


### PR DESCRIPTION
## Summary

Implement `ClaudeResultParser` in `execution/backends/claude.py` that satisfies the `ResultParser` protocol, with a bonus `parse_stdout()` method that delegates to `parse_session_result()` and wraps `ClaudeSessionResult` into `AgentSessionResult` with `write_artifacts` derived from `tool_uses`. Also implement `_extract_write_artifacts` module-private helper.

**Current state:** The core implementation was delivered as part of P3-A2-WP1 (commit `097f972d`). The `ClaudeResultParser` class (lines 158–210) and `_extract_write_artifacts` helper (lines 44–49) already exist in `src/autoskillit/execution/backends/claude.py`. Tests exist at `tests/execution/backends/test_claude_result_parser.py` with 10 test methods. However, test coverage against the acceptance criteria has gaps that must be closed.

**Work remaining:** Strengthen existing tests to assert all 10 `raw` dict fields and validate empty-output subtype/is_error in the `raw` dict, matching the acceptance criteria precisely. Add unit tests for the `_extract_write_artifacts` helper.

## Requirements

## Goal

Implement ClaudeResultParser implementing ResultParser protocol, delegating to parse_session_result() and wrapping ClaudeSessionResult into AgentSessionResult with write_artifacts derived from tool_uses.

## Acceptance Criteria

- parse_stdout returns AgentSessionResult with all 10 required fields
- write_artifacts contains only Write/Edit file_paths
- parse_stdout('') returns is_error=True subtype='empty_output'
- No second call to extract_token_usage
- IL-1 import compliance
- pre-commit and test-check pass

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
tests/execution/backends/test_claude_result_parser.py

### Modified (●):
None

Closes #2479

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/p3_a2_wp3_clauderesultparser_plan_2026-05-18_182700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 6.2k | 23.6k | 1.3M | 96.1k | 293 | 81.3k | 11m 59s |
| verify | claude-opus-4-6 | 1 | 196 | 7.8k | 579.5k | 57.0k | 37 | 42.4k | 3m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 270.0k | 3.5k | 501.7k | 29.5k | 43 | 43.3k | 1m 44s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 101.4k | 4.7k | 262.8k | 29.5k | 26 | 15.7k | 1m 42s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 86.8k | 1.8k | 262.8k | 29.5k | 22 | 15.5k | 51s |
| review_pr | claude-sonnet-4-6 | 3 | 276 | 36.7k | 1.2M | 49.2k | 96 | 123.3k | 8m 46s |
| resolve_review | claude-sonnet-4-6 | 1 | 143 | 9.8k | 772.7k | 60.9k | 47 | 61.9k | 3m 59s |
| **Total** | | | 465.0k | 88.0k | 4.8M | 96.1k | | 383.3k | 32m 12s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 45 | 11149.4 | 961.4 | 77.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 96582.6 | 7732.6 | 1226.4 |
| **Total** | **53** | 90804.6 | 7231.6 | 1660.0 |