### PR TITLE
refactor: migrate make-plan adversarial agents from MCP resource reads to native subagent_type invocation

### DIFF
--- a/src/autoskillit/agents/CLAUDE.md
+++ b/src/autoskillit/agents/CLAUDE.md
@@ -1,6 +1,8 @@
 # agents/
 
-Bundled agent definition markdown files served as MCP resources.
+Bundled agent definition markdown files that serve as both **plugin agents**
+(discovered natively by Claude Code at session start) and **MCP resources**
+(available via `unlock_agent_pack`).
 
 ## Files
 
@@ -16,17 +18,35 @@ Bundled agent definition markdown files served as MCP resources.
 Each `.md` file defines one agent with YAML frontmatter (`name`, `description`,
 `tools`, `model`, `maxTurns`) and a markdown body containing the agent's system prompt.
 
+## Invocation
+
+### Native `subagent_type` (preferred)
+
+Agent definitions in this directory are discovered at session start by Claude Code's
+plugin agent system. They are registered as `autoskillit:{agent-name}` in the
+subagent registry and invoked via:
+
+```
+Agent(subagent_type="autoskillit:{agent-name}", prompt="...")
+```
+
+Claude Code automatically applies tool restrictions, model, maxTurns, and the
+markdown body as the system prompt from the agent definition frontmatter.
+
+**Used by:** make-plan Steps 6-7
+
+### MCP Resource path (available for programmatic access)
+
+Agent resources are hidden at startup via `mcp.disable(tags={pack_tag})`.
+Sessions unlock them by calling `unlock_agent_pack(pack_name)`, which calls
+`ctx.enable_components(tags={pack_tag})` — per-session, not global. Once unlocked,
+agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{name}`.
+
 ## Agent Packs
 
 | Pack | Tag | Agents | Used By |
 |------|-----|--------|---------|
 | `plan-review` | `plan-review` | 4 adversarial reviewers | make-plan Steps 6-8 |
-
-## Visibility
-
-Agent resources are hidden at startup via `mcp.disable(tags={pack_tag})`.
-Sessions unlock them by calling `unlock_agent_pack(pack_name)`, which calls
-`ctx.enable_components(tags={pack_tag})` — per-session, not global.
 
 ## Adding Agents
 

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: make-plan
 activate_deps: [arch-lens, write-recipe]
-activate_agents: [plan-review]
 description: Planning executor. ALWAYS invoke this skill when instructed to create, devise, or write an implementation plan. Do not explore the codebase or draft a plan directly — use this skill first to load the planning workflow.
 hooks:
   PreToolUse:
@@ -141,22 +140,16 @@ If the Skill tool cannot be used (disable-model-invocation) or refuses this invo
 Include the diagram in the plan document under a "## Proposed Architecture" section.
 More than one lens diagram is okay if it is complex plan (don't do more than 3, and make sure to load each appropriate skill).
 
-6. **Unlock and Read Agent Definitions** - After drafting the plan (Steps 1-5), call `unlock_agent_pack("plan-review")` to make agent resources visible for this session. Then read each agent definition via `ReadMcpResourceTool`:
-   - `agent://plan-review/plan-contract-verifier`
-   - `agent://plan-review/plan-completeness-auditor`
-   - `agent://plan-review/plan-assumption-challenger`
-   - `agent://plan-review/plan-registry-wire-tracer`
+6. **Adversarial Agent Review** - After drafting the plan (Steps 1-5), spawn 3 parallel adversarial agents. Each receives the full draft plan text and the codebase root. Each attempts to find concrete ways the plan, if implemented literally, would introduce a bug or regression. They must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
 
-   Parse each definition's YAML frontmatter for `tools`, `model`, `maxTurns`. Use the markdown body as the agent's system prompt.
+   Spawn using `Agent(subagent_type=...)`:
+   - `autoskillit:plan-contract-verifier` — Contract Verifier: traces downstream consumers of every function, field, or format the plan introduces or modifies
+   - `autoskillit:plan-completeness-auditor` — Completeness Auditor: finds entities missed by plan search operations
+   - `autoskillit:plan-assumption-challenger` — Assumption Challenger: verifies implicit assumptions against actual code
 
-7. **Adversarial Agent Review** - Spawn 3 parallel subagents using the definitions read in Step 6. Each receives the full draft plan text and the codebase root. Each attempts to find concrete ways the plan, if implemented literally, would introduce a bug or regression. They must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
-   - **Contract Verifier** — traces downstream consumers of every function, field, or format the plan introduces or modifies
-   - **Completeness Auditor** — finds entities missed by plan search operations
-   - **Assumption Challenger** — verifies implicit assumptions against actual code
+7. **Registry Wire Trace** - Spawn 1 Registry Wire Tracer via `Agent(subagent_type="autoskillit:plan-registry-wire-tracer")`. For every file the plan modifies, check if it participates in registry-sync patterns (RETIRED NAME SETS, RE-EXPORT CHAINS, TOOL REGISTRIES, RULE REGISTRATION, DUAL-COPY CONSTANTS, IMPORT LAYER CONSTRAINTS, TYPED ALIASES, DERIVED ARTIFACTS).
 
-8. **Registry Wire Trace** - Spawn 1 Registry Wire Tracer subagent. For every file the plan modifies, check if it participates in registry-sync patterns (RETIRED NAME SETS, RE-EXPORT CHAINS, TOOL REGISTRIES, RULE REGISTRATION, DUAL-COPY CONSTANTS, IMPORT LAYER CONSTRAINTS, TYPED ALIASES, DERIVED ARTIFACTS).
-
-9. **Plan Revision** - Read all 4 adversarial reports. For each valid finding (where the agent identified a real gap, not a hypothetical):
+8. **Plan Revision** - Read all 4 adversarial reports. For each valid finding (where the agent identified a real gap, not a hypothetical):
    - Add missing consumers to implementation steps
    - Add missing entity categories to search/update operations
    - Replace invalid assumptions with verified facts
@@ -208,7 +201,7 @@ Before writing the final plan, verify:
 - [ ] Diagram uses ONLY the classDef styles from the mermaid skill (no invented colors)
 - [ ] Diagram includes a color legend table
 - [ ] Every new component, class, or function is wired into the call chain — nothing is created but left unconnected
-- [ ] Adversarial review pass completed (Steps 7-9) and valid findings incorporated into the plan
+- [ ] Adversarial review pass completed (Steps 6-8) and valid findings incorporated into the plan
 
 ## Critical Constraints
 

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -157,24 +157,38 @@ def test_agent_defs_in_pyproject_artifacts():
     assert '"src/autoskillit/agents/**"' in content
 
 
-# T11: make-plan SKILL.md activate_agents references valid packs
-def test_make_plan_activate_agents_resolves():
-    """Parse activate_agents from make-plan SKILL.md.
+# T11: make-plan SKILL.md subagent_type references resolve to agent files
+def test_make_plan_subagent_type_refs_resolve():
+    """Grep SKILL.md for autoskillit:plan-* subagent_type refs.
 
-    All packs should exist in AGENT_PACK_REGISTRY.
+    Each must correspond to an agent definition file in agents/.
     """
     import re
 
     from autoskillit.core import pkg_root
 
     content = (pkg_root() / "skills_extended" / "make-plan" / "SKILL.md").read_text()
-    m = re.search(r"^activate_agents:\s*\[([^\]]*)\]", content, re.MULTILINE)
-    assert m is not None, "activate_agents not found in make-plan SKILL.md frontmatter"
-    packs = [p.strip() for p in m.group(1).split(",") if p.strip()]
-    for pack in packs:
-        assert pack in AGENT_PACK_REGISTRY, (
-            f"Pack '{pack}' from activate_agents not in AGENT_PACK_REGISTRY"
+    refs = re.findall(r"autoskillit:(plan-[a-z-]+)", content)
+    assert len(refs) >= 4, f"Expected >=4 autoskillit:plan-* refs in SKILL.md, found {len(refs)}"
+
+    agents_dir = pkg_root() / "agents"
+    for agent_name in set(refs):
+        agent_file = agents_dir / f"{agent_name}.md"
+        assert agent_file.exists(), (
+            f"SKILL.md references autoskillit:{agent_name} but {agent_file} does not exist"
         )
+
+
+# T11b: make-plan SKILL.md no longer has activate_agents frontmatter
+def test_make_plan_no_activate_agents():
+    """SKILL.md frontmatter must not contain activate_agents."""
+    import re
+
+    from autoskillit.core import pkg_root
+
+    content = (pkg_root() / "skills_extended" / "make-plan" / "SKILL.md").read_text()
+    m = re.search(r"^activate_agents:", content, re.MULTILINE)
+    assert m is None, "activate_agents found in SKILL.md frontmatter — should have been removed"
 
 
 # T12: Agent definition frontmatter has required fields


### PR DESCRIPTION
## Summary

Replace the MCP resource indirection path (Steps 6–9) in make-plan's SKILL.md with direct native `subagent_type` invocation (Steps 6–8). The current flow requires 5 MCP tool calls (`unlock_agent_pack` + 4 `ReadMcpResourceTool` reads + frontmatter parsing) before any agent spawns — all to replicate what Claude Code's native plugin agent system already does automatically. The native `Agent(subagent_type="autoskillit:plan-*")` path injects the agent definition's system prompt, tool restrictions, model, and maxTurns from frontmatter automatically with zero preparatory calls.

Three files change: `SKILL.md` (instruction rewrite), `agents/CLAUDE.md` (documentation update), `test_tools_agents.py` (replace T11). No runtime code changes. No agent definition changes. MCP resource infrastructure retained.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260518-183842-327854/.autoskillit/temp/make-plan/migrate_make_plan_adversarial_agents_plan_2026-05-18_191500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 846 | 19.9k | 1.9M | 100.8k | 226 | 156.7k | 14m 2s |
| verify | claude-opus-4-6 | 1 | 54 | 14.8k | 1.0M | 75.6k | 59 | 62.1k | 6m 29s |
| implement* | MiniMax-M2.7 | 1 | 104.6k | 5.0k | 595.7k | 29.2k | 41 | 42.9k | 4m 6s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.7k | 2.9k | 288.3k | 0 | 21 | 0 | 1m 8s |
| compose_pr* | MiniMax-M2.7 | 1 | 40.8k | 1.7k | 272.8k | 0 | 19 | 0 | 1m 26s |
| review_pr | claude-opus-4-6 | 3 | 88 | 30.5k | 939.7k | 53.0k | 69 | 113.2k | 9m 21s |
| **Total** | | | 190.1k | 74.9k | 5.0M | 100.8k | | 374.9k | 36m 34s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 91 | 6546.6 | 471.7 | 55.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **91** | 55086.5 | 4119.4 | 823.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 846 | 19.9k | 1.9M | 156.7k | 14m 2s |
| claude-opus-4-6 | 2 | 142 | 45.3k | 2.0M | 175.2k | 15m 51s |
| MiniMax-M2.7 | 3 | 189.1k | 9.7k | 1.2M | 42.9k | 6m 40s |