### PR TITLE
[P3-A2-WP5] Create the public registry and factory surface for execution/backends/

### DIFF
--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -26,3 +26,17 @@ class TestBackendRegistry:
 
     def test_backend_registry_value_type(self) -> None:
         assert BACKEND_REGISTRY["claude-code"] is ClaudeCodeBackend
+
+    def test_all_exports_complete(self) -> None:
+        from autoskillit.execution.backends import __all__ as all_exports
+
+        expected = {
+            "BACKEND_REGISTRY",
+            "ClaudeCodeBackend",
+            "ClaudeEnvPolicy",
+            "ClaudeResultParser",
+            "ClaudeSessionLocator",
+            "ClaudeStreamParser",
+            "get_backend",
+        }
+        assert set(all_exports) == expected

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -26,9 +26,7 @@ def _extract_ref(template: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _find_capture_source(
-    steps: dict, capture_name: str
-) -> tuple[str, dict] | None:
+def _find_capture_source(steps: dict, capture_name: str) -> tuple[str, dict] | None:
     """Find the step that captures a given context variable name."""
     for step_name, step_data in steps.items():
         capture = step_data.get("capture") or {}
@@ -54,9 +52,7 @@ def test_wait_for_ci_event_branch_coherence(recipe_data) -> None:
     steps = data.get("steps") or {}
 
     wait_steps = {
-        name: step
-        for name, step in steps.items()
-        if (step.get("tool") or "") == "wait_for_ci"
+        name: step for name, step in steps.items() if (step.get("tool") or "") == "wait_for_ci"
     }
 
     if not wait_steps:
@@ -83,7 +79,10 @@ def test_wait_for_ci_event_branch_coherence(recipe_data) -> None:
 
         source_name, source_step = source
         source_tool = source_step.get("tool") or source_step.get("python") or ""
-        if "check_repo_merge_state" not in source_tool and "fetch_repo_merge_state" not in source_tool:
+        if (
+            "check_repo_merge_state" not in source_tool
+            and "fetch_repo_merge_state" not in source_tool
+        ):
             continue
 
         source_with = source_step.get("with") or {}
@@ -97,9 +96,8 @@ def test_wait_for_ci_event_branch_coherence(recipe_data) -> None:
                 f"branch: {branch_ref}"
             )
 
-    assert not violations, (
-        f"{recipe_name}: ci_event/branch mismatch detected:\n"
-        + "\n".join(f"  - {v}" for v in violations)
+    assert not violations, f"{recipe_name}: ci_event/branch mismatch detected:\n" + "\n".join(
+        f"  - {v}" for v in violations
     )
 
 
@@ -109,9 +107,7 @@ def test_wait_for_ci_steps_have_remote_url(recipe_data) -> None:
     steps = data.get("steps") or {}
 
     wait_steps = {
-        name: step
-        for name, step in steps.items()
-        if (step.get("tool") or "") == "wait_for_ci"
+        name: step for name, step in steps.items() if (step.get("tool") or "") == "wait_for_ci"
     }
 
     if not wait_steps:
@@ -123,6 +119,4 @@ def test_wait_for_ci_steps_have_remote_url(recipe_data) -> None:
         if "remote_url" not in with_args:
             missing.append(step_name)
 
-    assert not missing, (
-        f"{recipe_name}: wait_for_ci steps missing remote_url: {missing}"
-    )
+    assert not missing, f"{recipe_name}: wait_for_ci steps missing remote_url: {missing}"


### PR DESCRIPTION
## Summary

Create the public API surface for `execution/backends/` consisting of: a `BACKEND_REGISTRY` dict mapping backend names to concrete `CodingAgentBackend` types, a `get_backend()` factory function, and re-exports of all five concrete sub-object classes (`ClaudeCodeBackend`, `ClaudeEnvPolicy`, `ClaudeResultParser`, `ClaudeSessionLocator`, `ClaudeStreamParser`). The `execution/__init__.py` is intentionally NOT updated (deferred to P3-A4-WP2).

**Current state:** The implementation in `src/autoskillit/execution/backends/__init__.py` and the test suite in `tests/execution/backends/test_backend_registry.py` already satisfy the deliverables and acceptance criteria. This plan documents the design, verifies completeness, and prescribes one additional test to explicitly cover the `__all__` re-export contract.

Closes #2481

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260518-192653-996860/.autoskillit/temp/make-plan/p3_a2_wp5_registry_factory_plan_2026-05-18_192900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 85 | 13.2k | 1.1M | 91.2k | 257 | 63.4k | 8m 15s |
| verify | claude-opus-4-6 | 1 | 35 | 4.1k | 275.8k | 47.8k | 39 | 38.5k | 2m 1s |
| implement* | MiniMax-M2.7-highspeed | 1 | 295.8k | 3.6k | 553.7k | 29.1k | 46 | 42.9k | 4m 26s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 91.7k | 3.6k | 259.4k | 29.1k | 26 | 15.7k | 1m 28s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 45.8k | 1.3k | 201.1k | 29.1k | 14 | 15.4k | 39s |
| review_pr | claude-sonnet-4-6 | 3 | 262 | 32.9k | 1.1M | 51.1k | 88 | 111.8k | 8m 50s |
| resolve_review | claude-sonnet-4-6 | 1 | 167 | 11.3k | 914.1k | 60.6k | 50 | 46.9k | 3m 51s |
| **Total** | | | 433.8k | 70.0k | 4.4M | 91.2k | | 334.6k | 29m 32s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 40 | 13842.9 | 1072.2 | 89.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **40** | 110012.2 | 8364.3 | 1749.7 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 21.0k | 475.9k | 18.6M | 1.4M | 4h 8m |