### PR TITLE
[P3-A5-WP2] _cook.py and _session_launch.py — use backend.binary_name() and backend.build_interactive_cmd()

### DIFF
--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -65,14 +65,17 @@ def cook(
     *, resume: bool = False, session_id: str | None = None, profile: str | None = None
 ) -> None:
     """Launch Claude with all bundled AutoSkillit skills as slash commands."""
+    from autoskillit.execution.backends import ClaudeCodeBackend
     from autoskillit.workspace import (
         DefaultSessionSkillManager,
         SkillsDirectoryProvider,
         resolve_ephemeral_root,
     )
 
-    if not shutil.which("claude"):
-        print("'claude' not found on PATH. Install Claude Code to use cook.")
+    backend = ClaudeCodeBackend()
+
+    if not shutil.which(backend.binary_name()):
+        print(f"'{backend.binary_name()}' not found on PATH. Install Claude Code to use cook.")
         raise SystemExit(1)
 
     from autoskillit import __version__
@@ -153,7 +156,6 @@ def cook(
     )
 
     logger = get_logger(__name__)
-    from autoskillit.execution import build_interactive_cmd
 
     configure_logging()
 
@@ -211,7 +213,7 @@ def cook(
     _max_reloads = 10
     seen_reload_ids: set[str] = set()
     while True:
-        spec = build_interactive_cmd(
+        spec = backend.build_interactive_cmd(
             plugin_source=plugin_source,
             add_dirs=[skills_dir],
             initial_prompt=_current_initial_prompt,
@@ -219,7 +221,7 @@ def cook(
             env_extras=_cook_env_extras,
         )
         reload_session_id = _run_cook_session(
-            cmd=spec.cmd,
+            cmd=list(spec.cmd),
             env=spec.env,
             _first_run=_current_first_run,
             initial_prompt=_current_initial_prompt,

--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -65,7 +65,7 @@ def cook(
     *, resume: bool = False, session_id: str | None = None, profile: str | None = None
 ) -> None:
     """Launch Claude with all bundled AutoSkillit skills as slash commands."""
-    from autoskillit.execution.backends import ClaudeCodeBackend
+    from autoskillit.execution import ClaudeCodeBackend
     from autoskillit.workspace import (
         DefaultSessionSkillManager,
         SkillsDirectoryProvider,
@@ -221,7 +221,7 @@ def cook(
             env_extras=_cook_env_extras,
         )
         reload_session_id = _run_cook_session(
-            cmd=list(spec.cmd),
+            cmd=[*spec.cmd],
             env=spec.env,
             _first_run=_current_first_run,
             initial_prompt=_current_initial_prompt,

--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -74,8 +74,11 @@ def cook(
 
     backend = ClaudeCodeBackend()
 
-    if not shutil.which(backend.binary_name()):
-        print(f"'{backend.binary_name()}' not found on PATH. Install Claude Code to use cook.")
+    if shutil.which(backend.binary_name()) is None:
+        print(
+            f"ERROR: '{backend.binary_name()}' not found. "
+            "Install: https://docs.anthropic.com/en/docs/claude-code"
+        )
         raise SystemExit(1)
 
     from autoskillit import __version__

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -37,8 +37,14 @@ def _run_interactive_session(
         _InfraExitSignal — when an infrastructure exit is detected
         None — clean exit
     """
-    if shutil.which("claude") is None:
-        print("ERROR: 'claude' not found. Install: https://docs.anthropic.com/en/docs/claude-code")
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    backend = ClaudeCodeBackend()
+    if shutil.which(backend.binary_name()) is None:
+        print(
+            f"ERROR: '{backend.binary_name()}' not found. "
+            "Install: https://docs.anthropic.com/en/docs/claude-code"
+        )
         sys.exit(1)
     from autoskillit.cli.session._reload import consume_reload_sentinel
     from autoskillit.cli.ui._terminal import terminal_guard
@@ -52,28 +58,31 @@ def _run_interactive_session(
         detect_autoskillit_mcp_prefix,
         pkg_root,
     )
-    from autoskillit.execution import build_interactive_cmd, read_session_state
+    from autoskillit.execution import read_session_state
 
     _project_dir = project_dir if project_dir is not None else Path.cwd()
-    spec = build_interactive_cmd(
+    spec = backend.build_interactive_cmd(
         initial_prompt=initial_message,
         resume_spec=resume_spec if resume_spec is not None else NoResume(),
         env_extras=extra_env,
         required_env=required_env,
     )
-    plugin_flags = (
-        []
-        if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX
-        else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
-    )
-    _is_resume = isinstance(resume_spec, (BareResume, NamedResume))
-    cmd = [
-        *spec.cmd,
-        *plugin_flags,
-        ClaudeFlags.TOOLS,
-        "AskUserQuestion",
-        *([] if _is_resume else [ClaudeFlags.APPEND_SYSTEM_PROMPT, system_prompt]),
-    ]
+    if backend.capabilities.skill_injection_capable:
+        plugin_flags = (
+            []
+            if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX
+            else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
+        )
+        _is_resume = isinstance(resume_spec, (BareResume, NamedResume))
+        cmd = [
+            *spec.cmd,
+            *plugin_flags,
+            ClaudeFlags.TOOLS,
+            "AskUserQuestion",
+            *([] if _is_resume else [ClaudeFlags.APPEND_SYSTEM_PROMPT, system_prompt]),
+        ]
+    else:
+        cmd = list(spec.cmd)
     with terminal_guard():
         result = subprocess.run(cmd, env=spec.env)
     reload_session_id = consume_reload_sentinel(_project_dir)

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -37,7 +37,7 @@ def _run_interactive_session(
         _InfraExitSignal — when an infrastructure exit is detected
         None — clean exit
     """
-    from autoskillit.execution import ClaudeCodeBackend
+    from autoskillit.execution import ClaudeCodeBackend, read_session_state
 
     backend = ClaudeCodeBackend()
     if shutil.which(backend.binary_name()) is None:
@@ -58,7 +58,6 @@ def _run_interactive_session(
         detect_autoskillit_mcp_prefix,
         pkg_root,
     )
-    from autoskillit.execution import read_session_state
 
     _project_dir = project_dir if project_dir is not None else Path.cwd()
     spec = backend.build_interactive_cmd(

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -37,7 +37,7 @@ def _run_interactive_session(
         _InfraExitSignal — when an infrastructure exit is detected
         None — clean exit
     """
-    from autoskillit.execution.backends import ClaudeCodeBackend
+    from autoskillit.execution import ClaudeCodeBackend
 
     backend = ClaudeCodeBackend()
     if shutil.which(backend.binary_name()) is None:
@@ -82,7 +82,7 @@ def _run_interactive_session(
             *([] if _is_resume else [ClaudeFlags.APPEND_SYSTEM_PROMPT, system_prompt]),
         ]
     else:
-        cmd = list(spec.cmd)
+        cmd = [*spec.cmd]
     with terminal_guard():
         result = subprocess.run(cmd, env=spec.env)
     reload_session_id = consume_reload_sentinel(_project_dir)

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -16,6 +16,9 @@ from autoskillit.execution.anomaly_detection import (
     AnomalySeverity,
     detect_anomalies,
 )
+from autoskillit.execution.backends import (
+    ClaudeCodeBackend,
+)
 from autoskillit.execution.ci import DefaultCIWatcher
 from autoskillit.execution.commands import (
     _MAX_MCP_OUTPUT_TOKENS_VALUE,  # noqa: F401
@@ -203,6 +206,8 @@ __all__ = [
     "read_boot_id",
     "read_starttime_ticks",
     "start_linux_tracing",
+    # backends
+    "ClaudeCodeBackend",
     # anomaly_detection
     "detect_anomalies",
     "AnomalyKind",

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -587,7 +587,7 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.backends.ClaudeCodeBackend", _MockBackend),
+            patch("autoskillit.execution.ClaudeCodeBackend", _MockBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
@@ -625,7 +625,7 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.backends.ClaudeCodeBackend", _MockBackend),
+            patch("autoskillit.execution.ClaudeCodeBackend", _MockBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
@@ -665,7 +665,7 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.backends.ClaudeCodeBackend", _CustomBackend),
+            patch("autoskillit.execution.ClaudeCodeBackend", _CustomBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
@@ -701,7 +701,7 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.backends.ClaudeCodeBackend", _CapturingBackend),
+            patch("autoskillit.execution.ClaudeCodeBackend", _CapturingBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -708,7 +708,7 @@ class TestCookInteractive:
 
             module.cook()
 
-        assert len(captured_kwargs) >= 1, "build_interactive_cmd must have been called"
+        assert len(captured_kwargs) == 1, "build_interactive_cmd must have been called"
         call_kwargs = captured_kwargs[0]
         assert "plugin_source" in call_kwargs
         assert "add_dirs" in call_kwargs

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -566,24 +566,28 @@ class TestCookInteractive:
         """cook() passes AUTOSKILLIT_SESSION_TYPE=cook in env_extras."""
         from unittest.mock import MagicMock, patch
 
+        from autoskillit.core import CmdSpec
+
         fake_skills_dir = tmp_path / "skills"
         fake_skills_dir.mkdir()
         mock_mgr = MagicMock()
         mock_mgr.init_session.return_value = fake_skills_dir
         captured_env_extras: list = []
 
-        from autoskillit.execution.commands import ClaudeInteractiveCmd
+        class _MockBackend:
+            def binary_name(self) -> str:
+                return "claude"
 
-        def fake_build_interactive_cmd(**kwargs):
-            captured_env_extras.append(kwargs.get("env_extras", {}))
-            return ClaudeInteractiveCmd(cmd=["claude", "--dangerously-skip-permissions"], env={})
+            def build_interactive_cmd(self, **kwargs):
+                captured_env_extras.append(kwargs.get("env_extras", {}))
+                return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
 
         with (
             patch("shutil.which", return_value="/usr/bin/claude"),
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.build_interactive_cmd", fake_build_interactive_cmd),
+            patch("autoskillit.execution.backends.ClaudeCodeBackend", _MockBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
@@ -600,24 +604,28 @@ class TestCookInteractive:
         """cook() passes AUTOSKILLIT_LAUNCH_ID in env_extras."""
         from unittest.mock import MagicMock, patch
 
+        from autoskillit.core import CmdSpec
+
         fake_skills_dir = tmp_path / "skills"
         fake_skills_dir.mkdir()
         mock_mgr = MagicMock()
         mock_mgr.init_session.return_value = fake_skills_dir
         captured_env_extras: list = []
 
-        from autoskillit.execution.commands import ClaudeInteractiveCmd
+        class _MockBackend:
+            def binary_name(self) -> str:
+                return "claude"
 
-        def fake_build_interactive_cmd(**kwargs):
-            captured_env_extras.append(kwargs.get("env_extras", {}))
-            return ClaudeInteractiveCmd(cmd=["claude", "--dangerously-skip-permissions"], env={})
+            def build_interactive_cmd(self, **kwargs):
+                captured_env_extras.append(kwargs.get("env_extras", {}))
+                return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
 
         with (
             patch("shutil.which", return_value="/usr/bin/claude"),
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.build_interactive_cmd", fake_build_interactive_cmd),
+            patch("autoskillit.execution.backends.ClaudeCodeBackend", _MockBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
@@ -626,3 +634,84 @@ class TestCookInteractive:
 
         assert captured_env_extras, "build_interactive_cmd must have been called"
         assert "AUTOSKILLIT_LAUNCH_ID" in captured_env_extras[0]
+
+    def test_cook_uses_backend_binary_name(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cook() calls shutil.which with the backend's binary_name()."""
+        from unittest.mock import MagicMock, patch
+
+        from autoskillit.core import CmdSpec
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_skills_dir.mkdir()
+        mock_mgr = MagicMock()
+        mock_mgr.init_session.return_value = fake_skills_dir
+        captured_which: list = []
+
+        class _CustomBackend:
+            def binary_name(self) -> str:
+                return "my-test-claude"
+
+            def build_interactive_cmd(self, **kwargs):
+                return CmdSpec(cmd=("my-test-claude", "--dangerously-skip-permissions"), env={})
+
+        def tracking_which(binary):
+            captured_which.append(binary)
+            return "/usr/bin/my-test-claude" if binary == "my-test-claude" else None
+
+        with (
+            patch("shutil.which", side_effect=tracking_which),
+            patch("builtins.input", return_value=""),
+            patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("autoskillit.execution.backends.ClaudeCodeBackend", _CustomBackend),
+            patch("autoskillit.core.write_registry_entry"),
+        ):
+            import autoskillit.cli.session._cook as module
+
+            module.cook()
+
+        assert "my-test-claude" in captured_which
+
+    def test_cook_calls_backend_build_interactive_cmd_with_expected_kwargs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cook() calls backend.build_interactive_cmd() with expected kwargs."""
+        from unittest.mock import MagicMock, patch
+
+        from autoskillit.core import CmdSpec
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_skills_dir.mkdir()
+        mock_mgr = MagicMock()
+        mock_mgr.init_session.return_value = fake_skills_dir
+        captured_kwargs: list = []
+
+        class _CapturingBackend:
+            def binary_name(self) -> str:
+                return "claude"
+
+            def build_interactive_cmd(self, **kwargs):
+                captured_kwargs.append(kwargs)
+                return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("builtins.input", return_value=""),
+            patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("autoskillit.execution.backends.ClaudeCodeBackend", _CapturingBackend),
+            patch("autoskillit.core.write_registry_entry"),
+        ):
+            import autoskillit.cli.session._cook as module
+
+            module.cook()
+
+        assert len(captured_kwargs) >= 1, "build_interactive_cmd must have been called"
+        call_kwargs = captured_kwargs[0]
+        assert "plugin_source" in call_kwargs
+        assert "add_dirs" in call_kwargs
+        assert "initial_prompt" in call_kwargs
+        assert "resume_spec" in call_kwargs
+        assert "env_extras" in call_kwargs

--- a/tests/cli/test_cook_profile.py
+++ b/tests/cli/test_cook_profile.py
@@ -7,19 +7,23 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import autoskillit.cli.session._cook as cook_module
-from autoskillit.execution.commands import ClaudeInteractiveCmd
+from autoskillit.core import CmdSpec
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
 
-def _fake_build_cmd():
+def _make_mock_backend_class():
     captured = []
 
-    def fake(**kwargs):
-        captured.append(kwargs.get("env_extras", {}))
-        return ClaudeInteractiveCmd(cmd=["claude"], env={})
+    class _MockBackend:
+        def binary_name(self) -> str:
+            return "claude"
 
-    return fake, captured
+        def build_interactive_cmd(self, **kwargs):
+            captured.append(kwargs.get("env_extras", {}))
+            return CmdSpec(cmd=("claude",), env={})
+
+    return _MockBackend, captured
 
 
 @pytest.fixture()
@@ -28,13 +32,13 @@ def _mock_mgr():
 
 
 def _run_cook(profile, cfg, mock_mgr):
-    fake_build, captured = _fake_build_cmd()
+    mock_backend_cls, captured = _make_mock_backend_class()
     with (
         patch("shutil.which", return_value="/usr/bin/claude"),
         patch("builtins.input", return_value=""),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
         patch("subprocess.run", return_value=MagicMock(returncode=0)),
-        patch("autoskillit.execution.build_interactive_cmd", fake_build),
+        patch("autoskillit.execution.backends.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.core.write_registry_entry"),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch(
@@ -88,11 +92,11 @@ def test_profile_feature_disabled_exits(capsys, _mock_mgr):
     cfg = MagicMock()
     cfg.experimental_enabled = False
     cfg.providers.profiles = {"minimax": {}}
-    fake_build, _ = _fake_build_cmd()
+    mock_backend_cls, _ = _make_mock_backend_class()
     with (
         patch("shutil.which", return_value="/usr/bin/claude"),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=_mock_mgr),
-        patch("autoskillit.execution.build_interactive_cmd", fake_build),
+        patch("autoskillit.execution.backends.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch("autoskillit.cli.session._cook.is_feature_enabled", return_value=False),
     ):
@@ -107,11 +111,11 @@ def test_profile_unknown_exits(capsys, _mock_mgr):
     cfg = MagicMock()
     cfg.experimental_enabled = True
     cfg.providers.profiles = {"anthropic": {}, "openai": {}}
-    fake_build, _ = _fake_build_cmd()
+    mock_backend_cls, _ = _make_mock_backend_class()
     with (
         patch("shutil.which", return_value="/usr/bin/claude"),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=_mock_mgr),
-        patch("autoskillit.execution.build_interactive_cmd", fake_build),
+        patch("autoskillit.execution.backends.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch("autoskillit.cli.session._cook.is_feature_enabled", return_value=True),
     ):

--- a/tests/cli/test_cook_profile.py
+++ b/tests/cli/test_cook_profile.py
@@ -38,7 +38,7 @@ def _run_cook(profile, cfg, mock_mgr):
         patch("builtins.input", return_value=""),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
         patch("subprocess.run", return_value=MagicMock(returncode=0)),
-        patch("autoskillit.execution.backends.ClaudeCodeBackend", mock_backend_cls),
+        patch("autoskillit.execution.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.core.write_registry_entry"),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch(
@@ -96,7 +96,7 @@ def test_profile_feature_disabled_exits(capsys, _mock_mgr):
     with (
         patch("shutil.which", return_value="/usr/bin/claude"),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=_mock_mgr),
-        patch("autoskillit.execution.backends.ClaudeCodeBackend", mock_backend_cls),
+        patch("autoskillit.execution.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch("autoskillit.cli.session._cook.is_feature_enabled", return_value=False),
     ):
@@ -115,7 +115,7 @@ def test_profile_unknown_exits(capsys, _mock_mgr):
     with (
         patch("shutil.which", return_value="/usr/bin/claude"),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=_mock_mgr),
-        patch("autoskillit.execution.backends.ClaudeCodeBackend", mock_backend_cls),
+        patch("autoskillit.execution.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch("autoskillit.cli.session._cook.is_feature_enabled", return_value=True),
     ):

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -144,7 +144,7 @@ def test_cook_reload_loop_uses_named_resume(
     monkeypatch.setattr("builtins.input", lambda _prompt="": "")
     monkeypatch.setattr("autoskillit.cli._onboarding.is_first_run", lambda _: False)
     monkeypatch.setattr("autoskillit.cli.session._cook._run_cook_session", fake_run_cook_session)
-    monkeypatch.setattr("autoskillit.execution.backends.ClaudeCodeBackend", _MockBackend)
+    monkeypatch.setattr("autoskillit.execution.ClaudeCodeBackend", _MockBackend)
 
     from autoskillit.workspace.session_skills import DefaultSessionSkillManager
 

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -119,7 +119,7 @@ def test_cook_session_sentinel_consumed_after_reload(
 def test_cook_reload_loop_uses_named_resume(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from autoskillit.execution.commands import ClaudeInteractiveCmd
+    from autoskillit.core import CmdSpec
 
     run_count = [0]
     captured_resume_specs: list = []
@@ -130,9 +130,13 @@ def test_cook_reload_loop_uses_named_resume(
             return "sess-001"
         return None
 
-    def fake_build_interactive_cmd(**kwargs):
-        captured_resume_specs.append(kwargs.get("resume_spec"))
-        return ClaudeInteractiveCmd(cmd=["claude"], env={})
+    class _MockBackend:
+        def binary_name(self) -> str:
+            return "claude"
+
+        def build_interactive_cmd(self, **kwargs):
+            captured_resume_specs.append(kwargs.get("resume_spec"))
+            return CmdSpec(cmd=("claude",), env={})
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/claude")
@@ -140,7 +144,7 @@ def test_cook_reload_loop_uses_named_resume(
     monkeypatch.setattr("builtins.input", lambda _prompt="": "")
     monkeypatch.setattr("autoskillit.cli._onboarding.is_first_run", lambda _: False)
     monkeypatch.setattr("autoskillit.cli.session._cook._run_cook_session", fake_run_cook_session)
-    monkeypatch.setattr("autoskillit.execution.build_interactive_cmd", fake_build_interactive_cmd)
+    monkeypatch.setattr("autoskillit.execution.backends.ClaudeCodeBackend", _MockBackend)
 
     from autoskillit.workspace.session_skills import DefaultSessionSkillManager
 

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -181,3 +181,106 @@ def test_run_interactive_session_appends_system_prompt_on_fresh_session(
     assert ClaudeFlags.APPEND_SYSTEM_PROMPT in captured["cmd"]
     idx = captured["cmd"].index(ClaudeFlags.APPEND_SYSTEM_PROMPT)
     assert captured["cmd"][idx + 1] == "my-prompt"
+
+
+# ---------------------------------------------------------------------------
+# New tests — backend binary_name() and capability gate
+# ---------------------------------------------------------------------------
+
+
+def test_skill_injection_disabled_omits_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When skill_injection_capable=False, no plugin/tools/system-prompt flags are injected."""
+    from autoskillit.core import BackendCapabilities, CmdSpec
+
+    no_inject_caps = BackendCapabilities(
+        channel_b_capable=True,
+        pty_required=True,
+        session_resume_capable=True,
+        skill_injection_capable=False,
+        supports_thinking_blocks=True,
+        supports_claude_format_stdout=True,
+        exit_code_is_terminal=False,
+        completion_record_types=frozenset({"result"}),
+        session_record_types=frozenset({"assistant"}),
+    )
+
+    class _NoInjectBackend:
+        def binary_name(self) -> str:
+            return "claude"
+
+        @property
+        def capabilities(self):
+            return no_inject_caps
+
+        def build_interactive_cmd(self, **kwargs):
+            return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+    from autoskillit.cli.session._session_launch import _run_interactive_session
+
+    captured: dict = {}
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/claude")
+
+    def mock_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = kwargs.get("env", {}) or {}
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    monkeypatch.setattr("autoskillit.execution.backends.ClaudeCodeBackend", _NoInjectBackend)
+    _run_interactive_session(system_prompt="test")
+    assert ClaudeFlags.PLUGIN_DIR not in captured["cmd"]
+    assert ClaudeFlags.TOOLS not in captured["cmd"]
+    assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in captured["cmd"]
+
+
+def test_skill_injection_enabled_preserves_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When skill_injection_capable=True, plugin/tools/system-prompt flags are present."""
+    _stub_plugin_installed(monkeypatch)
+    captured = _capture_subprocess(monkeypatch)
+    _run_interactive_session(system_prompt="test")
+    assert ClaudeFlags.TOOLS in captured["cmd"]
+    idx = captured["cmd"].index(ClaudeFlags.TOOLS)
+    assert captured["cmd"][idx + 1] == "AskUserQuestion"
+    assert ClaudeFlags.APPEND_SYSTEM_PROMPT in captured["cmd"]
+
+
+def test_binary_name_from_backend_used_in_which(monkeypatch: pytest.MonkeyPatch) -> None:
+    """shutil.which is called with the backend's binary_name(), not a hardcoded literal."""
+    from autoskillit.core import BackendCapabilities, CmdSpec
+
+    captured_which_arg: list = []
+
+    class _CustomBinaryBackend:
+        def binary_name(self) -> str:
+            return "test-agent-binary"
+
+        @property
+        def capabilities(self):
+            return BackendCapabilities(
+                channel_b_capable=True,
+                pty_required=True,
+                session_resume_capable=True,
+                skill_injection_capable=True,
+                supports_thinking_blocks=True,
+                supports_claude_format_stdout=True,
+                exit_code_is_terminal=False,
+                completion_record_types=frozenset({"result"}),
+                session_record_types=frozenset({"assistant"}),
+            )
+
+        def build_interactive_cmd(self, **kwargs):
+            return CmdSpec(cmd=("test-agent-binary", "--dangerously-skip-permissions"), env={})
+
+    def tracking_which(binary: str):
+        captured_which_arg.append(binary)
+        if binary == "test-agent-binary":
+            return "/usr/bin/test-agent-binary"
+        return None
+
+    monkeypatch.setattr(shutil, "which", tracking_which)
+    monkeypatch.setattr("autoskillit.execution.backends.ClaudeCodeBackend", _CustomBinaryBackend)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
+    from autoskillit.cli.session._session_launch import _run_interactive_session
+
+    _run_interactive_session(system_prompt="test")
+    assert "test-agent-binary" in captured_which_arg

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -226,7 +226,7 @@ def test_skill_injection_disabled_omits_flags(monkeypatch: pytest.MonkeyPatch) -
         return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     monkeypatch.setattr(subprocess, "run", mock_run)
-    monkeypatch.setattr("autoskillit.execution.backends.ClaudeCodeBackend", _NoInjectBackend)
+    monkeypatch.setattr("autoskillit.execution.ClaudeCodeBackend", _NoInjectBackend)
     _run_interactive_session(system_prompt="test")
     assert ClaudeFlags.PLUGIN_DIR not in captured["cmd"]
     assert ClaudeFlags.TOOLS not in captured["cmd"]
@@ -278,7 +278,7 @@ def test_binary_name_from_backend_used_in_which(monkeypatch: pytest.MonkeyPatch)
         return None
 
     monkeypatch.setattr(shutil, "which", tracking_which)
-    monkeypatch.setattr("autoskillit.execution.backends.ClaudeCodeBackend", _CustomBinaryBackend)
+    monkeypatch.setattr("autoskillit.execution.ClaudeCodeBackend", _CustomBinaryBackend)
     monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
     from autoskillit.cli.session._session_launch import _run_interactive_session
 


### PR DESCRIPTION
## Summary

Replace hardcoded `'claude'` binary references and direct `build_interactive_cmd()` calls in `_cook.py` and `_session_launch.py` with `ClaudeCodeBackend`-dispatched calls. Gate the ClaudeFlags skill-injection block in `_session_launch.py` behind `backend.capabilities.skill_injection_capable`. Update six existing test sites that patch the old import path.

## Requirements

## Goal

Replace hardcoded 'claude' binary references and direct build_interactive_cmd() calls with backend-dispatched calls, gate ClaudeFlags skill-injection block behind backend.capabilities.skill_injection_capable.

## Context

- Phase: CodingAgentBackend Protocol and ClaudeCodeBackend Extraction (Milestone: 3-codingagentbackend-protocol-and-claudecodebackend-extraction)
- Assignment: P3-A5 (Refactor consumer modules to use backend abstraction)
- Depends on: P3-A1-WP1, P3-A2-WP1
- Depended on by: None

## Deliverables

- `Modified _cook.py with backend-aware binary check and cmd construction`
- `Modified _session_launch.py with backend-aware binary check, cmd construction, and capability gate`
- `Tests for both files`

## Technical Steps

1. Replace shutil.which('claude') with shutil.which(backend.binary_name()) in _cook.py
2. Replace build_interactive_cmd() call with backend.build_interactive_cmd() in _cook.py
3. Replace shutil.which('claude') in _session_launch.py
4. Replace build_interactive_cmd() in _session_launch.py
5. Gate ClaudeFlags append block behind backend.capabilities.skill_injection_capable
6. Obtain backend via config-level helper or lightweight factory
7. Add tests for binary name substitution and skill_injection_capable=False path

## Acceptance Criteria

- No shutil.which('claude') literal in either file
- No direct build_interactive_cmd import from execution
- skill_injection_capable=False omits PLUGIN_DIR/TOOLS/APPEND_SYSTEM_PROMPT
- skill_injection_capable=True preserves existing behavior
- task test-check passes

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260518-211355-512427/.autoskillit/temp/make-plan/p3_a5_wp2_cook_session_launch_backend_plan_2026-05-18_213500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 9.0k | 35.6k | 1.9M | 124.0k | 303 | 131.0k | 18m 5s |
| verify | claude-opus-4-6 | 1 | 2.4k | 10.6k | 1.4M | 69.3k | 81 | 54.3k | 4m 41s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.3M | 23.1k | 1.7M | 70.0k | 144 | 113.5k | 7m 41s |
| prepare_pr* | MiniMax-M2.7 | 1 | 57.1k | 4.8k | 553.2k | 0 | 43 | 0 | 1m 46s |
| compose_pr* | MiniMax-M2.7 | 1 | 37.3k | 1.7k | 344.7k | 0 | 20 | 0 | 1m 6s |
| review_pr | claude-opus-4-6 | 2 | 82 | 53.1k | 909.0k | 77.5k | 64 | 123.0k | 12m 47s |
| resolve_review | claude-opus-4-6 | 1 | 61 | 15.2k | 938.4k | 70.4k | 47 | 56.1k | 7m 10s |
| **Total** | | | 2.4M | 144.1k | 7.8M | 124.0k | | 478.0k | 53m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 309 | 5631.1 | 367.4 | 74.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 78199.3 | 4675.3 | 1269.6 |
| **Total** | **321** | 24382.1 | 1489.0 | 448.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 9.0k | 35.6k | 1.9M | 131.0k | 18m 5s |
| claude-opus-4-6 | 3 | 2.5k | 78.9k | 3.3M | 233.5k | 24m 39s |
| MiniMax-M2.7-highspeed | 1 | 2.3M | 23.1k | 1.7M | 113.5k | 7m 41s |
| MiniMax-M2.7 | 2 | 94.4k | 6.6k | 897.9k | 0 | 2m 52s |