### PR TITLE
[P3-A4-WP1] Wire backend field into ToolContext and make_context()

### DIFF
--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -18,6 +18,7 @@ from autoskillit.execution.anomaly_detection import (
 )
 from autoskillit.execution.backends import (
     ClaudeCodeBackend,
+    get_backend,
 )
 from autoskillit.execution.ci import DefaultCIWatcher
 from autoskillit.execution.commands import (
@@ -223,4 +224,6 @@ __all__ = [
     "extract_linked_issues",
     "is_valid_fidelity_finding",
     "partition_files_by_domain",
+    # backends
+    "get_backend",
 ]

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -19,6 +19,7 @@ from autoskillit.core import (
     CIRunScope,
     CIWatcher,
     CloneManager,
+    CodingAgentBackend,
     DatabaseReader,
     FleetLock,
     GateState,
@@ -70,6 +71,10 @@ class ToolContext:
                           Encodes how autoskillit is loaded into Claude Code sessions.
     runner:               SubprocessRunner implementation (DefaultSubprocessRunner in production,
                           MockSubprocessRunner in tests)
+    backend:              CodingAgentBackend — the coding agent backend resolved from
+                          config.agent_backend. Provides command building, stream/result
+                          parsing, env policy, and session location. None in test
+                          ToolContext instances unless explicitly provided.
     executor:             HeadlessExecutor — runs headless Claude Code sessions
     tester:               TestRunner — runs the project test suite
     recipes:              RecipeRepository — loads and lists pipeline recipes
@@ -125,6 +130,7 @@ class ToolContext:
     output_pattern_resolver: OutputPatternResolver | None = field(default=None)
     write_expected_resolver: WriteExpectedResolver | None = field(default=None)
     read_only_resolver: ReadOnlyResolver | None = field(default=None)
+    backend: CodingAgentBackend | None = field(default=None)
     session_skill_manager: SessionSkillManager | None = field(default=None)
     skill_resolver: SkillResolver | None = field(default=None)
     recipe_name: str = field(default="")

--- a/src/autoskillit/server/CLAUDE.md
+++ b/src/autoskillit/server/CLAUDE.md
@@ -9,7 +9,7 @@ Sub-package: tools/ (see tools/CLAUDE.md).
 |------|---------|
 | `__init__.py` | Re-exports `mcp`, `ToolContext`, `make_context`; applies `mcp.disable(tags={'kitchen'})` at import |
 | `_editable_guard.py` | Pre-deletion editable install guard for `perform_merge()` — scans site-packages for PEP 610 direct_url.json links into the worktree |
-| `_factory.py` | Composition root — `make_context()` is the sole legal instantiation point for all 22 service contracts |
+| `_factory.py` | Composition root — `make_context()` is the sole legal instantiation point for all 23 service contracts |
 | `_guards.py` | Orchestration-level gate functions for MCP tool access control |
 | `_lifespan.py` | FastMCP lifespan context manager — deferred startup (recovery, audit loading, stale cleanup, drift check) |
 | `_misc.py` | Quota, hook-config, triage, and miscellaneous server utilities; re-exports selected execution/workspace symbols for tools |

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -314,9 +314,7 @@ def make_context(
     ephemeral_root = resolve_ephemeral_root()
     session_mgr = DefaultSessionSkillManager(provider, ephemeral_root)
 
-    from autoskillit.execution.backends import (
-        get_backend,
-    )  # lazy: avoids backends init on server import
+    from autoskillit.execution import get_backend  # lazy: avoids execution init on server import
     from autoskillit.fleet import (  # lazy: avoids fleet init on server import
         FleetSemaphore,
         build_protected_campaign_ids,

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -1,5 +1,5 @@
 """Composition Root: make_context() is the only location that legally instantiates
-all 22 service contracts simultaneously.
+all 23 service contracts simultaneously.
 
 server/ is IL-3 — the only layer permitted to import from both IL-1 (pipeline/)
 and IL-2 (recipe/, migration/) at the same time. This module is the canonical
@@ -167,7 +167,7 @@ def make_context(
     plugin_source: PluginSource = _UNSET,
     fleet_lock: FleetLock | None = None,
 ) -> ToolContext:
-    """Create a fully-wired ToolContext with all 22 service fields populated.
+    """Create a fully-wired ToolContext with all 23 service fields populated.
 
     This is the Composition Root — the only location that should instantiate
     all concrete service implementations simultaneously. Uses a three-step
@@ -196,8 +196,9 @@ def make_context(
         ToolContext with gate starting closed (enabled=False) in all contexts.
         Tag-based visibility (mcp.enable({'headless'}) or open_kitchen) controls
         tool reveal — the gate itself is never pre-enabled at startup.
-        All service fields are populated. When runner=None is passed explicitly,
-        tester is left as None.
+        All service fields are populated, including backend (resolved from
+        config.agent_backend via the BACKEND_REGISTRY). When runner=None is
+        passed explicitly, tester is left as None.
     """
     env_profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE")
     if env_profile and env_profile in config.providers.profiles:
@@ -313,10 +314,15 @@ def make_context(
     ephemeral_root = resolve_ephemeral_root()
     session_mgr = DefaultSessionSkillManager(provider, ephemeral_root)
 
+    from autoskillit.execution.backends import (
+        get_backend,
+    )  # lazy: avoids backends init on server import
     from autoskillit.fleet import (  # lazy: avoids fleet init on server import
         FleetSemaphore,
         build_protected_campaign_ids,
     )
+
+    backend = get_backend(config.agent_backend.backend)
 
     audit = DefaultAuditLog()
     github_api_log = DefaultGitHubApiLog()
@@ -329,6 +335,7 @@ def make_context(
         gate=gate,
         plugin_source=plugin_source,
         runner=runner,
+        backend=backend,
         temp_dir=temp_dir,
         project_dir=project_dir,
         tester=DefaultTestRunner(config=config, runner=runner) if runner is not None else None,

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -115,6 +115,27 @@ def test_toolcontext_new_optional_fields_default_none(tmp_path):
     assert ctx.workspace_mgr is None
     assert ctx.clone_mgr is None
     assert ctx.github_client is None
+    assert ctx.backend is None
+
+
+def test_tool_context_has_backend_field() -> None:
+    """ToolContext dataclass exposes backend as an optional CodingAgentBackend Protocol field."""
+    import dataclasses
+    import typing
+
+    from autoskillit.core import CodingAgentBackend
+    from autoskillit.pipeline.context import ToolContext
+
+    fields = {f.name: f for f in dataclasses.fields(ToolContext)}
+    assert "backend" in fields
+    assert fields["backend"].default is None
+
+    hints = typing.get_type_hints(ToolContext)
+    assert "backend" in hints
+    args = typing.get_args(hints["backend"])
+    assert CodingAgentBackend in args, (
+        f"backend type hint {hints['backend']} does not include CodingAgentBackend Protocol"
+    )
 
 
 def test_toolcontext_optional_fields_all_have_protocol_annotations() -> None:

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -120,15 +120,10 @@ def test_toolcontext_new_optional_fields_default_none(tmp_path):
 
 def test_tool_context_has_backend_field() -> None:
     """ToolContext dataclass exposes backend as an optional CodingAgentBackend Protocol field."""
-    import dataclasses
     import typing
 
     from autoskillit.core import CodingAgentBackend
     from autoskillit.pipeline.context import ToolContext
-
-    fields = {f.name: f for f in dataclasses.fields(ToolContext)}
-    assert "backend" in fields
-    assert fields["backend"].default is None
 
     hints = typing.get_type_hints(ToolContext)
     assert "backend" in hints

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -610,6 +610,10 @@ def test_make_context_skips_replay_runner_for_non_claude_backend(monkeypatch, tm
     mock_build = Mock()
     monkeypatch.setattr("autoskillit.server._factory.build_replay_runner", mock_build)
 
+    from autoskillit.execution.backends import BACKEND_REGISTRY, ClaudeCodeBackend
+
+    monkeypatch.setitem(BACKEND_REGISTRY, "aider", ClaudeCodeBackend)
+
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
     ctx = make_context(cfg, plugin_dir=str(tmp_path))
 
@@ -622,8 +626,35 @@ def test_make_context_skips_record_runner_for_non_claude_backend(monkeypatch, tm
     monkeypatch.setenv("RECORD_SCENARIO_DIR", str(tmp_path))
     monkeypatch.delenv("REPLAY_SCENARIO", raising=False)
 
+    from autoskillit.execution.backends import BACKEND_REGISTRY, ClaudeCodeBackend
+
+    monkeypatch.setitem(BACKEND_REGISTRY, "aider", ClaudeCodeBackend)
+
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
     ctx = make_context(cfg, plugin_dir=str(tmp_path))
 
     assert isinstance(ctx.runner, DefaultSubprocessRunner)
     assert not isinstance(ctx.runner, RecordingSubprocessRunner)
+
+
+def test_make_context_backend_is_coding_agent_backend() -> None:
+    """make_context() sets ctx.backend to a CodingAgentBackend instance."""
+    from autoskillit.core import CodingAgentBackend
+
+    ctx = make_context(AutomationConfig(), runner=_runner())
+    assert isinstance(ctx.backend, CodingAgentBackend)
+
+
+def test_make_context_default_backend_is_claude_code() -> None:
+    """Default config (agent_backend.backend='claude-code') produces ClaudeCodeBackend."""
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    ctx = make_context(AutomationConfig(), runner=_runner())
+    assert isinstance(ctx.backend, ClaudeCodeBackend)
+
+
+def test_make_context_unknown_backend_raises_value_error() -> None:
+    """Unknown agent_backend key raises ValueError with supported keys."""
+    cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="nonexistent"))
+    with pytest.raises(ValueError, match="nonexistent"):
+        make_context(cfg, runner=_runner())

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -602,17 +602,22 @@ def test_tool_ctx_kitchen_open_fixture_gate_starts_open(tool_ctx_kitchen_open) -
     assert tool_ctx_kitchen_open.gate.enabled is True
 
 
-def test_make_context_skips_replay_runner_for_non_claude_backend(monkeypatch, tmp_path):
+@pytest.fixture()
+def _register_aider_backend(monkeypatch):
+    from autoskillit.execution.backends import BACKEND_REGISTRY, ClaudeCodeBackend
+
+    monkeypatch.setitem(BACKEND_REGISTRY, "aider", ClaudeCodeBackend)
+
+
+def test_make_context_skips_replay_runner_for_non_claude_backend(
+    monkeypatch, tmp_path, _register_aider_backend
+):
     monkeypatch.setenv("REPLAY_SCENARIO", "1")
     monkeypatch.setenv("REPLAY_SCENARIO_DIR", str(tmp_path))
     monkeypatch.delenv("RECORD_SCENARIO", raising=False)
 
     mock_build = Mock()
     monkeypatch.setattr("autoskillit.server._factory.build_replay_runner", mock_build)
-
-    from autoskillit.execution.backends import BACKEND_REGISTRY, ClaudeCodeBackend
-
-    monkeypatch.setitem(BACKEND_REGISTRY, "aider", ClaudeCodeBackend)
 
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
     ctx = make_context(cfg, plugin_dir=str(tmp_path))
@@ -621,14 +626,12 @@ def test_make_context_skips_replay_runner_for_non_claude_backend(monkeypatch, tm
     assert isinstance(ctx.runner, DefaultSubprocessRunner)
 
 
-def test_make_context_skips_record_runner_for_non_claude_backend(monkeypatch, tmp_path):
+def test_make_context_skips_record_runner_for_non_claude_backend(
+    monkeypatch, tmp_path, _register_aider_backend
+):
     monkeypatch.setenv("RECORD_SCENARIO", "1")
     monkeypatch.setenv("RECORD_SCENARIO_DIR", str(tmp_path))
     monkeypatch.delenv("REPLAY_SCENARIO", raising=False)
-
-    from autoskillit.execution.backends import BACKEND_REGISTRY, ClaudeCodeBackend
-
-    monkeypatch.setitem(BACKEND_REGISTRY, "aider", ClaudeCodeBackend)
 
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
     ctx = make_context(cfg, plugin_dir=str(tmp_path))


### PR DESCRIPTION
## Summary

Add a `backend: CodingAgentBackend | None = field(default=None)` field to the `ToolContext` dataclass in `pipeline/context.py`, and wire it in `make_context()` in `server/_factory.py` using the existing `get_backend()` factory from `execution/backends/`. The backend is resolved from `config.agent_backend.backend` (default `"claude-code"`) and assigned as a keyword arg in the ToolContext constructor call (before `ctx.executor`). Unknown backend keys raise `ValueError` (already handled by `get_backend()`). The `get_backend` import is lazy inside the make_context body to avoid eagerly pulling in `execution/backends/` at module import time.

## Requirements

(Not available — gh issue fetch returned empty, or issue has no Requirements section)

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260518-211356-951010/.autoskillit/temp/make-plan/p3_a4_wp1_wire_backend_into_toolcontext_plan_2026-05-18_211500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 6.1k | 16.2k | 1.4M | 121.8k | 226 | 114.8k | 9m 36s |
| verify | claude-opus-4-6 | 1 | 608 | 15.0k | 709.5k | 86.4k | 55 | 71.7k | 5m 58s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.3M | 12.0k | 1.5M | 67.0k | 120 | 81.3k | 4m 53s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.8k | 2.6k | 286.8k | 0 | 20 | 0 | 2m 22s |
| compose_pr* | MiniMax-M2.7 | 1 | 41.7k | 1.6k | 235.4k | 0 | 18 | 0 | 1m 7s |
| review_pr | claude-opus-4-6 | 3 | 121 | 69.1k | 1.3M | 66.6k | 94 | 160.2k | 16m 27s |
| resolve_review | claude-opus-4-6 | 2 | 717 | 22.4k | 1.8M | 74.1k | 104 | 99.4k | 13m 23s |
| resolve_queue_merge_conflicts | claude-opus-4-6 | 1 | 33 | 3.7k | 539.5k | 43.0k | 29 | 28.8k | 1m 21s |
| **Total** | | | 1.4M | 142.6k | 7.7M | 121.8k | | 556.3k | 55m 11s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 75 | 19793.9 | 1084.4 | 159.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 28 | 63745.9 | 3550.6 | 798.8 |
| resolve_queue_merge_conflicts | 324 | 1665.0 | 88.9 | 11.5 |
| **Total** | **427** | 18051.3 | 1302.8 | 333.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 6.1k | 16.2k | 1.4M | 114.8k | 9m 36s |
| claude-opus-4-6 | 4 | 1.5k | 110.2k | 4.4M | 360.2k | 37m 10s |
| MiniMax-M2.7-highspeed | 1 | 1.3M | 12.0k | 1.5M | 81.3k | 4m 53s |
| MiniMax-M2.7 | 2 | 84.6k | 4.2k | 522.2k | 0 | 3m 30s |