### PR TITLE
[P3-A3-WP3] Replace hardcoded type=system/session_id polling with StreamParser.parse_line()

### DIFF
--- a/src/autoskillit/core/types/_type_subprocess.py
+++ b/src/autoskillit/core/types/_type_subprocess.py
@@ -162,4 +162,5 @@ class SubprocessRunner(Protocol):
         max_extension_seconds: float = 7200,
         marker_dir: Path | None = None,
         session_id: str | None = None,
+        stream_parser: Any | None = None,
     ) -> Awaitable[SubprocessResult]: ...

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     import structlog
 
     from autoskillit.config import LinuxTracingConfig
+    from autoskillit.core import StreamParser
     from autoskillit.execution.linux_tracing import TraceTarget
 
 logger = get_logger(__name__)
@@ -211,6 +212,7 @@ async def run_managed_async(
     _session_id_timeout: float = 1.0,
     marker_dir: Path | None = None,
     session_id: str | None = None,
+    stream_parser: StreamParser | None = None,
 ) -> SubprocessResult:
     """Async subprocess execution with temp file I/O and process tree cleanup.
 
@@ -330,7 +332,10 @@ async def run_managed_async(
                 )
                 if session_log_dir is not None:
                     tg.start_soon(
-                        _extract_stdout_session_id,
+                        functools.partial(
+                            _extract_stdout_session_id,
+                            stream_parser=stream_parser,
+                        ),
                         stdout_path,
                         acc,
                         stdout_session_id_ready,
@@ -598,6 +603,7 @@ class DefaultSubprocessRunner:
         max_extension_seconds: float = 7200,
         marker_dir: Path | None = None,
         session_id: str | None = None,
+        stream_parser: StreamParser | None = None,
     ) -> SubprocessResult:
         return await run_managed_async(
             cmd,
@@ -618,4 +624,5 @@ class DefaultSubprocessRunner:
             max_extension_seconds=max_extension_seconds,
             marker_dir=marker_dir,
             session_id=session_id,
+            stream_parser=stream_parser,
         )

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import assert_never
+from typing import TYPE_CHECKING, assert_never
 
 import anyio
 import anyio.abc
@@ -18,6 +18,9 @@ from autoskillit.execution.process._process_monitor import (
     _heartbeat,
     _session_log_monitor,
 )
+
+if TYPE_CHECKING:
+    from autoskillit.core import StreamParser
 
 logger = get_logger(__name__)
 
@@ -265,6 +268,7 @@ async def _extract_stdout_session_id(
     ready: anyio.Event,
     _poll_interval: float = 0.3,
     _timeout: float = 10.0,
+    stream_parser: StreamParser | None = None,
 ) -> None:
     """Extract session ID from stdout type=system record and deposit on accumulator.
 
@@ -291,17 +295,23 @@ async def _extract_stdout_session_id(
             line = line.strip()
             if not line:
                 continue
-            try:
-                obj = _fast_loads(line)
-            except ValueError:
-                continue
-            if isinstance(obj, dict) and obj.get("type") == "system":
-                sid = obj.get("session_id")
-                if sid:
-                    acc.stdout_session_id = sid
-                    logger.debug("stdout_session_id_extracted", session_id=sid)
-                    ready.set()
-                    return
+            sid: str | None = None
+            if stream_parser is not None:
+                event = stream_parser.parse_line(line)
+                if event is not None:
+                    sid = event.session_id
+            else:
+                try:
+                    obj = _fast_loads(line)
+                except ValueError:
+                    continue
+                if isinstance(obj, dict) and obj.get("type") == "system":
+                    sid = obj.get("session_id")
+            if sid:
+                acc.stdout_session_id = sid
+                logger.debug("stdout_session_id_extracted", session_id=sid)
+                ready.set()
+                return
     logger.debug("stdout_session_id_extraction_timeout", timeout=_timeout)
     ready.set()
 

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -306,7 +306,9 @@ async def _extract_stdout_session_id(
                 except ValueError:
                     continue
                 if isinstance(obj, dict) and obj.get("type") == "system":
-                    sid = obj.get("session_id")
+                    raw_sid = obj.get("session_id")
+                    if isinstance(raw_sid, str):
+                        sid = raw_sid
             if sid:
                 acc.stdout_session_id = sid
                 logger.debug("stdout_session_id_extracted", session_id=sid)

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -106,6 +106,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         max_extension_seconds: float = 7200,
         marker_dir: Path | None = None,
         session_id: str | None = None,
+        stream_parser: Any | None = None,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 
@@ -136,6 +137,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
             max_extension_seconds=max_extension_seconds,
             marker_dir=marker_dir,
             session_id=session_id,
+            stream_parser=stream_parser,
         )
 
         if step_name:
@@ -255,6 +257,7 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         max_extension_seconds: float = 7200,
         marker_dir: Path | None = None,
         session_id: str | None = None,
+        stream_parser: Any | None = None,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -28,6 +28,8 @@ from autoskillit.execution._recording_skills import (
 if TYPE_CHECKING:
     from api_simulator.claude import ScenarioPlayer, ScenarioRecorder
 
+    from autoskillit.core import StreamParser
+
 logger = get_logger(__name__)
 
 # Environment variable names for scenario recording activation.
@@ -106,7 +108,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         max_extension_seconds: float = 7200,
         marker_dir: Path | None = None,
         session_id: str | None = None,
-        stream_parser: Any | None = None,
+        stream_parser: StreamParser | None = None,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 
@@ -257,7 +259,7 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         max_extension_seconds: float = 7200,
         marker_dir: Path | None = None,
         session_id: str | None = None,
-        stream_parser: Any | None = None,
+        stream_parser: StreamParser | None = None,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -359,6 +359,7 @@ class TestGroupDApiContractPreservation:
             "max_extension_seconds",
             "marker_dir",
             "session_id",
+            "stream_parser",
         }
         assert expected == public_params, (
             f"run_managed_async public params changed.\n"
@@ -425,6 +426,7 @@ class TestGroupDApiContractPreservation:
             "max_extension_seconds",
             "marker_dir",
             "session_id",
+            "stream_parser",
         }
         assert expected == actual, (
             f"DefaultSubprocessRunner.__call__ params changed.\n"

--- a/tests/execution/test_process_race.py
+++ b/tests/execution/test_process_race.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import dataclasses
+from pathlib import Path
 
+import anyio
 import pytest
 
 from autoskillit.core.types import (
@@ -14,6 +16,7 @@ from autoskillit.core.types import (
 from autoskillit.execution.process._process_race import (
     RaceAccumulator,
     RaceSignals,
+    _extract_stdout_session_id,
     resolve_termination,
 )
 
@@ -273,8 +276,6 @@ class TestExitSnapshot:
         """_watch_process populates acc.exit_snapshot after process exits."""
         import sys
 
-        import anyio
-
         from autoskillit.execution.process._process_race import _watch_process
 
         acc = RaceAccumulator()
@@ -296,8 +297,6 @@ class TestExitSnapshot:
     async def test_watch_process_exit_snapshot_has_event_marker(self) -> None:
         """If exit_snapshot was captured, it carries event='exit_snapshot'."""
         import sys
-
-        import anyio
 
         from autoskillit.execution.process._process_race import _watch_process
 
@@ -323,8 +322,6 @@ class TestProcessExitedEvent:
         """_watch_process must set acc.process_exited=True AND process_exited_event."""
         import sys
 
-        import anyio
-
         from autoskillit.execution.process._process_race import _watch_process
 
         acc = RaceAccumulator()
@@ -347,8 +344,6 @@ class TestProcessExitedEvent:
     async def test_process_exited_event_fires_before_trigger(self, tmp_path) -> None:
         """When trigger fires due to process exit, process_exited_event must already be set."""
         import sys
-
-        import anyio
 
         from autoskillit.execution.process._process_race import _watch_process
 
@@ -380,3 +375,115 @@ class TestProcessExitedEvent:
         # After setting the event, it is set on both
         acc.process_exited_event.set()
         assert signals.process_exited_event.is_set()
+
+
+@pytest.mark.anyio
+class TestExtractStdoutSessionIdStreamParser:
+    """_extract_stdout_session_id branching: StreamParser path vs fallback."""
+
+    async def test_stream_parser_extracts_session_id(self, tmp_path: Path) -> None:
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        path = tmp_path / "stdout"
+        path.write_text('{"type": "system", "session_id": "sp-test-123"}\n')
+
+        acc = RaceAccumulator()
+        ready = anyio.Event()
+        parser = ClaudeStreamParser()
+
+        await _extract_stdout_session_id(
+            path,
+            acc,
+            ready,
+            _poll_interval=0.05,
+            _timeout=1.0,
+            stream_parser=parser,
+        )
+
+        assert acc.stdout_session_id == "sp-test-123"
+        assert ready.is_set()
+
+    async def test_none_stream_parser_uses_fallback(self, tmp_path: Path) -> None:
+        path = tmp_path / "stdout"
+        path.write_text('{"type": "system", "session_id": "fallback-456"}\n')
+
+        acc = RaceAccumulator()
+        ready = anyio.Event()
+
+        await _extract_stdout_session_id(
+            path,
+            acc,
+            ready,
+            _poll_interval=0.05,
+            _timeout=1.0,
+            stream_parser=None,
+        )
+
+        assert acc.stdout_session_id == "fallback-456"
+        assert ready.is_set()
+
+    async def test_stream_parser_timeout_no_system_record(self, tmp_path: Path) -> None:
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        path = tmp_path / "stdout"
+        path.write_text('{"type": "assistant", "message": "hello"}\n')
+
+        acc = RaceAccumulator()
+        ready = anyio.Event()
+        parser = ClaudeStreamParser()
+
+        await _extract_stdout_session_id(
+            path,
+            acc,
+            ready,
+            _poll_interval=0.05,
+            _timeout=0.2,
+            stream_parser=parser,
+        )
+
+        assert acc.stdout_session_id is None
+        assert ready.is_set()
+
+    async def test_stream_parser_skips_malformed_json(self, tmp_path: Path) -> None:
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        path = tmp_path / "stdout"
+        path.write_text("not json at all\n")
+
+        acc = RaceAccumulator()
+        ready = anyio.Event()
+        parser = ClaudeStreamParser()
+
+        await _extract_stdout_session_id(
+            path,
+            acc,
+            ready,
+            _poll_interval=0.05,
+            _timeout=0.2,
+            stream_parser=parser,
+        )
+
+        assert acc.stdout_session_id is None
+        assert ready.is_set()
+
+    async def test_stream_parser_empty_session_id_skipped(self, tmp_path: Path) -> None:
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        path = tmp_path / "stdout"
+        path.write_text('{"type": "system", "session_id": ""}\n')
+
+        acc = RaceAccumulator()
+        ready = anyio.Event()
+        parser = ClaudeStreamParser()
+
+        await _extract_stdout_session_id(
+            path,
+            acc,
+            ready,
+            _poll_interval=0.05,
+            _timeout=0.2,
+            stream_parser=parser,
+        )
+
+        assert acc.stdout_session_id is None
+        assert ready.is_set()


### PR DESCRIPTION
## Summary

Replace the inline `fast_loads` + `type=="system"` JSON parsing in `_extract_stdout_session_id` with `StreamParser.parse_line()` calls, falling back to the current logic when no parser is provided. Thread the `stream_parser` parameter from `run_managed_async` through the anyio task group down to `_extract_stdout_session_id`. Update the `SubprocessRunner` protocol and all its concrete implementations (`DefaultSubprocessRunner`, `RecordingSubprocessRunner`, `ReplayingSubprocessRunner`) to maintain the documented signature-mirroring invariant. Update contract tests that hardcode parameter sets.

## Requirements

## Goal

Replace hardcoded type=system/session_id polling in _extract_stdout_session_id with StreamParser.parse_line() calls, falling back to current logic when parser is None.

## Context

- Phase: CodingAgentBackend Protocol and ClaudeCodeBackend Extraction (Milestone: 3-codingagentbackend-protocol-and-claudecodebackend-extraction)
- Assignment: P3-A3 (Refactor race engine to use StreamParser)
- Depends on: P3-A1-WP1, P3-A3-WP2
- Depended on by: None

## Deliverables

- `Updated _extract_stdout_session_id with StreamParser support`
- `Updated run_managed_async threading stream_parser`
- `Tests for both paths`

## Technical Steps

1. Add stream_parser: StreamParser | None = None to _extract_stdout_session_id signature
2. Add branch: if stream_parser provided, call parse_line(line) and read event.session_id
3. Retain existing fast_loads + type==system logic as fallback when stream_parser is None
4. Thread stream_parser from run_managed_async to _extract_stdout_session_id in task group
5. Update imports with TYPE_CHECKING guard for StreamParser and SessionEvent
6. Add tests for both StreamParser path and None fallback path

## Acceptance Criteria

- With stream_parser: uses parse_line, reads session_id without fast_loads
- Without stream_parser: identical to pre-refactor behavior
- run_managed_async passes stream_parser to _extract_stdout_session_id
- Existing tests pass
- New tests for both branches added

## Changed Files

### Modified (●):

- `● src/autoskillit/core/types/_type_subprocess.py`
- `● src/autoskillit/execution/process/__init__.py`
- `● src/autoskillit/execution/process/_process_race.py`
- `● src/autoskillit/execution/recording.py`
- `● tests/contracts/test_protocol_satisfaction.py`
- `● tests/execution/test_process_race.py`

Closes #2484

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260518-234141-687008/.autoskillit/temp/make-plan/p3_a3_wp3_stream_parser_session_id_plan_2026-05-18_234500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.2k | 27.6k | 1.4M | 104.3k | 271 | 94.8k | 12m 24s |
| verify | claude-opus-4-6 | 1 | 35 | 8.9k | 1.3M | 98.1k | 112 | 96.5k | 5m 0s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.7M | 13.1k | 1.5M | 70.3k | 139 | 82.0k | 6m 15s |
| prepare_pr* | MiniMax-M2.7 | 1 | 66.1k | 3.3k | 178.1k | 29.2k | 19 | 42.0k | 2m 16s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.2k | 2.1k | 310.7k | 0 | 24 | 0 | 1m 15s |
| review_pr | claude-opus-4-6 | 2 | 67 | 51.8k | 1.1M | 70.2k | 71 | 113.1k | 11m 7s |
| resolve_review | claude-opus-4-6 | 1 | 56 | 12.8k | 1.0M | 61.1k | 69 | 46.9k | 7m 21s |
| **Total** | | | 1.8M | 119.7k | 6.9M | 104.3k | | 475.3k | 45m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 172 | 8886.3 | 476.8 | 76.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 102292.1 | 4688.8 | 1277.5 |
| **Total** | **182** | 37744.1 | 2611.6 | 657.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 2.2k | 27.6k | 1.4M | 94.8k | 12m 24s |
| claude-opus-4-6 | 3 | 158 | 73.5k | 3.4M | 256.5k | 23m 29s |
| MiniMax-M2.7-highspeed | 1 | 1.7M | 13.1k | 1.5M | 82.0k | 6m 15s |
| MiniMax-M2.7 | 2 | 105.2k | 5.4k | 488.8k | 42.0k | 3m 32s |