### PR TITLE
[P3-A5-WP3] Add Group B migration annotation to _merge_token_usage

### DIFF
--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -316,6 +316,7 @@ async def _attempt_contract_nudge(
     )
 
 
+# Group B migration target: token aggregation to backend-agnostic layer.
 def _merge_token_usage(
     base: dict[str, object] | None,
     nudge: dict[str, object] | None,


### PR DESCRIPTION
## Summary

WP3 completes the final deliverable for P3-A5 in `_headless_recovery.py`: adding the Group B migration annotation to `_merge_token_usage`. The capability guard, backend delegation, import cleanup, call-site update, and test additions described in the issue were already landed in the prior WP1 commit (`3d06b3aa`). This plan addresses the single remaining acceptance criterion: the Group B migration comment on `_merge_token_usage`.

## Requirements

**Goal:** Add capability guard to _attempt_contract_nudge, replace build_headless_resume_cmd() with backend.build_resume_cmd(), and annotate _merge_token_usage for Group B migration.

**Acceptance Criteria:**
- `backend=None` returns `None` immediately
- `session_resume_capable=False` returns `None` immediately
- `session_resume_capable=True` uses `backend.build_resume_cmd()`
- `build_headless_resume_cmd` import removed
- Existing nudge tests pass with mock backend
- `_merge_token_usage` has Group B migration comment

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260519-021316-167139/.autoskillit/temp/make-plan/p3_a5_wp3_capability_guard_and_group_b_annotation_plan_2026-05-19_021900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.1k | 15.2k | 1.0M | 83.1k | 219 | 77.1k | 10m 1s |
| verify | claude-sonnet-4-6 | 1 | 25 | 3.1k | 216.4k | 41.3k | 42 | 26.8k | 3m 30s |
| implement* | MiniMax-M2.7-highspeed | 1 | 129.2k | 1.9k | 320.8k | 29.2k | 25 | 42.9k | 1m 5s |
| prepare_pr* | MiniMax-M2.7 | 1 | 61.6k | 3.2k | 143.1k | 0 | 19 | 29.2k | 2m 7s |
| compose_pr* | MiniMax-M2.7 | 1 | 40.6k | 1.8k | 438.5k | 0 | 24 | 0 | 1m 39s |
| review_pr | claude-opus-4-6 | 3 | 101 | 16.8k | 1.0M | 44.2k | 78 | 80.8k | 5m 30s |
| **Total** | | | 234.6k | 41.9k | 3.1M | 83.1k | | 256.8k | 23m 53s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 1 | 320815.0 | 42922.0 | 1862.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **1** | 3130511.0 | 256833.0 | 41916.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 3.1k | 18.3k | 1.2M | 103.9k | 13m 31s |
| MiniMax-M2.7-highspeed | 1 | 129.2k | 1.9k | 320.8k | 42.9k | 1m 5s |
| MiniMax-M2.7 | 2 | 102.2k | 4.9k | 581.6k | 29.2k | 3m 47s |
| claude-opus-4-6 | 1 | 101 | 16.8k | 1.0M | 80.8k | 5m 30s |