### PR TITLE
[P3-A3-WP2] Thread StreamParser through SubprocessRunner and session-ID extraction

### DIFF
--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -325,13 +325,13 @@ async def run_managed_async(
                     functools.partial(
                         _watch_heartbeat,
                         stream_parser=stream_parser,
+                        _poll_interval=_heartbeat_poll,
                     ),
                     stdout_path,
                     heartbeat_record_types,
                     completion_marker,
                     acc,
                     trigger,
-                    _heartbeat_poll,
                 )
                 if session_log_dir is not None:
                     tg.start_soon(

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -322,7 +322,10 @@ async def run_managed_async(
             async with anyio.create_task_group() as tg:
                 tg.start_soon(_watch_process, proc, acc, trigger)
                 tg.start_soon(
-                    _watch_heartbeat,
+                    functools.partial(
+                        _watch_heartbeat,
+                        stream_parser=stream_parser,
+                    ),
                     stdout_path,
                     heartbeat_record_types,
                     completion_marker,

--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -35,9 +35,9 @@ async def _heartbeat(
     stdout_path: Path,
     record_types: frozenset[str] = frozenset({"result"}),
     completion_marker: str = "",
+    stream_parser: StreamParser | None = None,
     _poll_interval: float = 0.5,
     _on_poll: Callable[[], None] | None = None,
-    stream_parser: StreamParser | None = None,
 ) -> str:
     """Poll session NDJSON output for a result-type record with non-empty content.
 

--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import anyio
 import psutil
@@ -16,6 +16,9 @@ from autoskillit.execution.process._process_jsonl import (
     _jsonl_has_record_type,
     _jsonl_last_record_type,
 )
+
+if TYPE_CHECKING:
+    from autoskillit.core import StreamParser
 
 logger = get_logger(__name__)
 
@@ -34,6 +37,7 @@ async def _heartbeat(
     completion_marker: str = "",
     _poll_interval: float = 0.5,
     _on_poll: Callable[[], None] | None = None,
+    stream_parser: StreamParser | None = None,
 ) -> str:
     """Poll session NDJSON output for a result-type record with non-empty content.
 
@@ -66,7 +70,15 @@ async def _heartbeat(
         new_raw = raw[scan_pos:]
         scan_pos = len(raw)
         new_content = new_raw.decode("utf-8", errors="replace")
-        if _jsonl_has_record_type(new_content, record_types, completion_marker=completion_marker):
+        if stream_parser is not None:
+            for line in new_content.splitlines():
+                event = stream_parser.parse_line(line)
+                if event is not None and event.is_terminal:
+                    if not completion_marker or event.has_marker:
+                        return "completion"
+        elif _jsonl_has_record_type(
+            new_content, record_types, completion_marker=completion_marker
+        ):
             return "completion"
 
 

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -129,8 +129,8 @@ async def _watch_heartbeat(
     completion_marker: str,
     acc: RaceAccumulator,
     trigger: anyio.Event,
-    _poll_interval: float,
     stream_parser: StreamParser | None = None,
+    _poll_interval: float = 0.5,
 ) -> None:
     """Poll stdout NDJSON for a result record and deposit the Channel A signal."""
     await _heartbeat(
@@ -268,9 +268,9 @@ async def _extract_stdout_session_id(
     stdout_path: Path,
     acc: RaceAccumulator,
     ready: anyio.Event,
+    stream_parser: StreamParser | None = None,
     _poll_interval: float = 0.3,
     _timeout: float = 10.0,
-    stream_parser: StreamParser | None = None,
 ) -> None:
     """Extract session ID from stdout type=system record and deposit on accumulator.
 

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -130,6 +130,7 @@ async def _watch_heartbeat(
     acc: RaceAccumulator,
     trigger: anyio.Event,
     _poll_interval: float,
+    stream_parser: StreamParser | None = None,
 ) -> None:
     """Poll stdout NDJSON for a result record and deposit the Channel A signal."""
     await _heartbeat(
@@ -137,6 +138,7 @@ async def _watch_heartbeat(
         heartbeat_record_types,
         completion_marker=completion_marker,
         _poll_interval=_poll_interval,
+        stream_parser=stream_parser,
     )
     logger.debug(
         "channel_a_confirmed",

--- a/tests/execution/test_process_heartbeat.py
+++ b/tests/execution/test_process_heartbeat.py
@@ -599,6 +599,126 @@ class TestOrphanedToolResultDetection:
         assert result.orphaned_tool_result is False
 
 
+class TestHeartbeatStreamParser:
+    """_heartbeat dual-path: StreamParser vs legacy _jsonl_has_record_type."""
+
+    @pytest.mark.anyio
+    async def test_stream_parser_detects_completion(self, tmp_path):
+        """StreamParser path fires when type=result with non-empty result is written."""
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        stdout_path = tmp_path / "stdout.tmp"
+        stdout_path.write_text('{"type":"result","result":"Done","session_id":"s1"}\n')
+
+        with anyio.fail_after(5.0):
+            result = await _heartbeat(
+                stdout_path,
+                stream_parser=ClaudeStreamParser(),
+                _poll_interval=0.05,
+            )
+        assert result == "completion"
+
+    @pytest.mark.anyio
+    async def test_none_stream_parser_uses_legacy_path(self, tmp_path):
+        """stream_parser=None falls back to _jsonl_has_record_type."""
+        import json
+
+        stdout_path = tmp_path / "stdout.tmp"
+        result_record = json.dumps(
+            {"type": "result", "result": "Done", "session_id": "s1"},
+            separators=(",", ":"),
+        )
+        stdout_path.write_text(result_record + "\n")
+
+        with anyio.fail_after(5.0):
+            result = await _heartbeat(
+                stdout_path,
+                stream_parser=None,
+                record_types=frozenset({"result"}),
+                _poll_interval=0.05,
+            )
+        assert result == "completion"
+
+    @pytest.mark.anyio
+    async def test_stream_parser_ignores_non_terminal_records(self, tmp_path):
+        """StreamParser ignores type=assistant (non-terminal) — heartbeat stays silent."""
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        stdout_path = tmp_path / "stdout.tmp"
+        stdout_path.write_text('{"type":"assistant","message":{"content":"thinking"}}\n')
+
+        with pytest.raises(TimeoutError):
+            with anyio.fail_after(0.3):
+                await _heartbeat(
+                    stdout_path,
+                    stream_parser=ClaudeStreamParser(),
+                    _poll_interval=0.05,
+                )
+
+    @pytest.mark.anyio
+    async def test_stream_parser_requires_marker_when_set(self, tmp_path):
+        """StreamParser respects completion_marker: result without marker does not fire."""
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        stdout_path = tmp_path / "stdout.tmp"
+        stdout_path.write_text('{"type":"result","result":"Partial","session_id":"s1"}\n')
+
+        with pytest.raises(TimeoutError):
+            with anyio.fail_after(0.3):
+                await _heartbeat(
+                    stdout_path,
+                    stream_parser=ClaudeStreamParser(completion_marker="%%DONE%%"),
+                    completion_marker="%%DONE%%",
+                    _poll_interval=0.05,
+                )
+
+        # Append a record WITH the marker — should fire immediately
+        stdout_path.write_text(
+            '{"type":"result","result":"Done.\\n%%DONE%%","session_id":"s1"}\n',
+            mode="a",
+        )
+        with anyio.fail_after(1.0):
+            result = await _heartbeat(
+                stdout_path,
+                stream_parser=ClaudeStreamParser(completion_marker="%%DONE%%"),
+                completion_marker="%%DONE%%",
+                _poll_interval=0.05,
+            )
+        assert result == "completion"
+
+    @pytest.mark.anyio
+    async def test_stream_parser_fires_without_marker_when_unset(self, tmp_path):
+        """StreamParser with no completion_marker fires on type=result regardless of content."""
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        stdout_path = tmp_path / "stdout.tmp"
+        stdout_path.write_text('{"type":"result","result":"Done","session_id":"s1"}\n')
+
+        with anyio.fail_after(5.0):
+            result = await _heartbeat(
+                stdout_path,
+                stream_parser=ClaudeStreamParser(),
+                _poll_interval=0.05,
+            )
+        assert result == "completion"
+
+    @pytest.mark.anyio
+    async def test_stream_parser_skips_empty_result(self, tmp_path):
+        """StreamParser skips type=result with empty result field — heartbeat stays silent."""
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        stdout_path = tmp_path / "stdout.tmp"
+        stdout_path.write_text('{"type":"result","result":"","session_id":"s1"}\n')
+
+        with pytest.raises(TimeoutError):
+            with anyio.fail_after(0.3):
+                await _heartbeat(
+                    stdout_path,
+                    stream_parser=ClaudeStreamParser(),
+                    _poll_interval=0.05,
+                )
+
+
 class TestHasActiveDispatchMarker:
     """Unit tests for _has_active_dispatch_marker."""
 

--- a/tests/execution/test_process_heartbeat.py
+++ b/tests/execution/test_process_heartbeat.py
@@ -673,10 +673,8 @@ class TestHeartbeatStreamParser:
                 )
 
         # Append a record WITH the marker — should fire immediately
-        stdout_path.write_text(
-            '{"type":"result","result":"Done.\\n%%DONE%%","session_id":"s1"}\n',
-            mode="a",
-        )
+        with stdout_path.open("a") as f:
+            f.write('{"type":"result","result":"Done.\\n%%DONE%%","session_id":"s1"}\n')
         with anyio.fail_after(1.0):
             result = await _heartbeat(
                 stdout_path,

--- a/tests/execution/test_process_heartbeat.py
+++ b/tests/execution/test_process_heartbeat.py
@@ -656,8 +656,8 @@ class TestHeartbeatStreamParser:
                 )
 
     @pytest.mark.anyio
-    async def test_stream_parser_requires_marker_when_set(self, tmp_path):
-        """StreamParser respects completion_marker: result without marker does not fire."""
+    async def test_stream_parser_rejects_terminal_without_marker(self, tmp_path):
+        """StreamParser with completion_marker rejects terminal event when marker is absent."""
         from autoskillit.execution.backends import ClaudeStreamParser
 
         stdout_path = tmp_path / "stdout.tmp"
@@ -672,30 +672,19 @@ class TestHeartbeatStreamParser:
                     _poll_interval=0.05,
                 )
 
-        # Append a record WITH the marker — should fire immediately
-        with stdout_path.open("a") as f:
-            f.write('{"type":"result","result":"Done.\\n%%DONE%%","session_id":"s1"}\n')
+    @pytest.mark.anyio
+    async def test_stream_parser_fires_when_marker_present(self, tmp_path):
+        """StreamParser fires when terminal event contains the required completion marker."""
+        from autoskillit.execution.backends import ClaudeStreamParser
+
+        stdout_path = tmp_path / "stdout.tmp"
+        stdout_path.write_text('{"type":"result","result":"Done.\\n%%DONE%%","session_id":"s1"}\n')
+
         with anyio.fail_after(1.0):
             result = await _heartbeat(
                 stdout_path,
                 stream_parser=ClaudeStreamParser(completion_marker="%%DONE%%"),
                 completion_marker="%%DONE%%",
-                _poll_interval=0.05,
-            )
-        assert result == "completion"
-
-    @pytest.mark.anyio
-    async def test_stream_parser_fires_without_marker_when_unset(self, tmp_path):
-        """StreamParser with no completion_marker fires on type=result regardless of content."""
-        from autoskillit.execution.backends import ClaudeStreamParser
-
-        stdout_path = tmp_path / "stdout.tmp"
-        stdout_path.write_text('{"type":"result","result":"Done","session_id":"s1"}\n')
-
-        with anyio.fail_after(5.0):
-            result = await _heartbeat(
-                stdout_path,
-                stream_parser=ClaudeStreamParser(),
                 _poll_interval=0.05,
             )
         assert result == "completion"


### PR DESCRIPTION
## Summary

Thread `StreamParser` through `_watch_heartbeat` and `_heartbeat` in the Channel A heartbeat monitoring path, adding dual-path detection (StreamParser-based vs legacy `_jsonl_has_record_type`). The SubprocessRunner Protocol, DefaultSubprocessRunner, `run_managed_async`, `_extract_stdout_session_id`, and recording runners already carry `stream_parser` from prior work (P3-A1-WP1). This plan covers the remaining deliverables: threading `stream_parser` into `_watch_heartbeat` → `_heartbeat`, implementing dual-path detection in `_heartbeat`, and adding tests for both paths.

### Already implemented (verified):
- `SubprocessRunner` Protocol: `stream_parser: Any | None = None` (`_type_subprocess.py:165`)
- `DefaultSubprocessRunner.__call__`: `stream_parser: StreamParser | None = None` (`process/__init__.py:606`)
- `run_managed_async`: `stream_parser: StreamParser | None = None` (`process/__init__.py:215`)
- `_extract_stdout_session_id`: dual-path with `stream_parser` (`_process_race.py:265-318`)
- `RecordingSubprocessRunner` / `ReplayingSubprocessRunner`: carry `stream_parser` (`recording.py`)
- Tests: `TestExtractStdoutSessionIdStreamParser` in `test_process_race.py` (5 tests)

### Remaining work (this plan):
- Step 3: Pass `stream_parser` from `run_managed_async` to `_watch_heartbeat`
- Step 4: Add `stream_parser` to `_watch_heartbeat`, forward to `_heartbeat`
- Step 5: Dual-path detection in `_heartbeat`
- Step 6: Legacy `_jsonl_has_record_type` fallback when `stream_parser is None`
- Step 12: Tests for `_heartbeat` dual-path

Closes #2483

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260519-074022-393464/.autoskillit/temp/make-plan/p3_a3_wp2_thread_streamparser_plan_2026-05-19_075500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.4k | 22.7k | 1.5M | 104.7k | 311 | 114.5k | 15m 9s |
| verify | claude-sonnet-4-6 | 1 | 34 | 8.2k | 325.0k | 81.6k | 85 | 66.9k | 5m 0s |
| implement* | MiniMax-M2.7 | 1 | 223.5k | 7.4k | 1.1M | 29.2k | 65 | 69.9k | 5m 55s |
| prepare_pr* | MiniMax-M2.7 | 2 | 110.3k | 6.0k | 405.0k | 29.2k | 38 | 44.9k | 3m 52s |
| compose_pr* | MiniMax-M2.7 | 1 | 51.8k | 2.3k | 329.0k | 29.2k | 25 | 15.5k | 1m 36s |
| review_pr | claude-opus-4-6 | 3 | 121 | 60.6k | 1.9M | 71.8k | 97 | 157.7k | 16m 36s |
| resolve_review | claude-opus-4-6 | 2 | 97 | 26.1k | 2.0M | 80.6k | 88 | 107.2k | 13m 57s |
| **Total** | | | 389.2k | 133.4k | 7.5M | 104.7k | | 576.6k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 143 | 7361.2 | 488.7 | 51.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 35 | 57557.8 | 3063.5 | 746.0 |
| **Total** | **178** | 42252.4 | 3239.4 | 749.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 3.4k | 31.0k | 1.9M | 181.4k | 20m 9s |
| MiniMax-M2.7 | 3 | 385.6k | 15.7k | 1.8M | 130.3k | 11m 24s |
| claude-opus-4-6 | 2 | 218 | 86.7k | 3.9M | 264.9k | 30m 33s |