### PR TITLE
[P3-A5-WP5] Decouple _headless_result.py parse_stdout delegation

### DIFF
--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -124,7 +124,7 @@ def _resolve_skill_session_id(
     return result.session_id or result.channel_b_session_id
 
 
-def _parse_stdout(stdout: str) -> ClaudeSessionResult:
+def _parse_stdout(stdout: str, backend: CodingAgentBackend | None = None) -> ClaudeSessionResult:
     return parse_session_result(stdout)
 
 
@@ -197,7 +197,7 @@ def _build_skill_result(
     )
     if result.termination == TerminationReason.STALE:
         # Attempt to recover from stdout before declaring stale failure.
-        stale_session = _parse_stdout(result.stdout)
+        stale_session = _parse_stdout(result.stdout, backend=backend)
         stale_returncode = result.returncode if result.returncode is not None else -1
         can_attempt_stale_recovery = (
             stale_session.subtype == CliSubtype.SUCCESS
@@ -252,7 +252,7 @@ def _build_skill_result(
         return _apply_budget_guard(stale_sr, skill_command, audit, max_consecutive_retries)
 
     if result.termination == TerminationReason.IDLE_STALL:
-        idle_session = _parse_stdout(result.stdout)
+        idle_session = _parse_stdout(result.stdout, backend=backend)
         idle_returncode = result.returncode if result.returncode is not None else -1
         can_attempt_idle_stall_recovery = (
             idle_session.subtype == CliSubtype.SUCCESS
@@ -311,7 +311,7 @@ def _build_skill_result(
     if result.termination == TerminationReason.TIMED_OUT:
         returncode = -1
         if result.stdout.strip():
-            session = _parse_stdout(result.stdout)
+            session = _parse_stdout(result.stdout, backend=backend)
             if session.subtype != CliSubtype.TIMEOUT:
                 session = dataclasses.replace(session, subtype=CliSubtype.TIMEOUT, is_error=True)
         else:
@@ -324,7 +324,7 @@ def _build_skill_result(
             )
     else:
         returncode = result.returncode if result.returncode is not None else -1
-        session = _parse_stdout(result.stdout)
+        session = _parse_stdout(result.stdout, backend=backend)
 
     write_names = (
         backend.write_tool_names() if backend is not None else frozenset({"Write", "Edit"})

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import Mock
 
 import pytest
 
@@ -215,7 +216,6 @@ class TestBackendDelegatedWriteToolNames:
 
     def test_backend_provides_custom_tool_names(self):
         """Custom backend.write_tool_names() overrides the tool name set."""
-        from unittest.mock import Mock
 
         mock_backend = Mock()
         mock_backend.write_tool_names.return_value = frozenset({"CustomWrite"})
@@ -243,7 +243,6 @@ class TestBackendDelegatedWriteToolNames:
 
     def test_build_skill_result_threads_backend_to_parse_stdout(self, monkeypatch):
         """_build_skill_result passes backend to _parse_stdout on normal exit."""
-        from unittest.mock import Mock
 
         from autoskillit.execution.headless import _headless_result
 
@@ -252,12 +251,11 @@ class TestBackendDelegatedWriteToolNames:
 
         def spy(stdout, backend=None):
             captured["backend"] = backend
-            return original_parse(stdout)
+            return original_parse(stdout, backend=backend)
 
         monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
 
         mock_backend = Mock()
-        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
         _build_skill_result(result, backend=mock_backend)
@@ -266,7 +264,6 @@ class TestBackendDelegatedWriteToolNames:
 
     def test_build_skill_result_stale_threads_backend_to_parse_stdout(self, monkeypatch):
         """_build_skill_result passes backend to _parse_stdout on stale branch."""
-        from unittest.mock import Mock
 
         from autoskillit.execution.headless import _headless_result
 
@@ -275,12 +272,11 @@ class TestBackendDelegatedWriteToolNames:
 
         def spy(stdout, backend=None):
             captured["backend"] = backend
-            return original_parse(stdout)
+            return original_parse(stdout, backend=backend)
 
         monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
 
         mock_backend = Mock()
-        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.STALE)
         _build_skill_result(result, backend=mock_backend)
@@ -289,7 +285,6 @@ class TestBackendDelegatedWriteToolNames:
 
     def test_build_skill_result_idle_stall_threads_backend_to_parse_stdout(self, monkeypatch):
         """_build_skill_result passes backend to _parse_stdout on idle_stall branch."""
-        from unittest.mock import Mock
 
         from autoskillit.execution.headless import _headless_result
 
@@ -298,12 +293,11 @@ class TestBackendDelegatedWriteToolNames:
 
         def spy(stdout, backend=None):
             captured["backend"] = backend
-            return original_parse(stdout)
+            return original_parse(stdout, backend=backend)
 
         monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
 
         mock_backend = Mock()
-        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.IDLE_STALL)
         _build_skill_result(result, backend=mock_backend)
@@ -312,7 +306,6 @@ class TestBackendDelegatedWriteToolNames:
 
     def test_build_skill_result_timed_out_threads_backend_to_parse_stdout(self, monkeypatch):
         """_build_skill_result passes backend to _parse_stdout on timed_out branch."""
-        from unittest.mock import Mock
 
         from autoskillit.execution.headless import _headless_result
 
@@ -321,12 +314,11 @@ class TestBackendDelegatedWriteToolNames:
 
         def spy(stdout, backend=None):
             captured["backend"] = backend
-            return original_parse(stdout)
+            return original_parse(stdout, backend=backend)
 
         monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
 
         mock_backend = Mock()
-        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.TIMED_OUT)
         _build_skill_result(result, backend=mock_backend)
@@ -359,7 +351,6 @@ class TestParseStdout:
 
     def test_parse_stdout_accepts_backend_kwarg(self):
         """_parse_stdout accepts an optional backend keyword argument."""
-        from unittest.mock import Mock
 
         from autoskillit.execution.headless import _parse_stdout
         from autoskillit.execution.session import ClaudeSessionResult
@@ -372,7 +363,6 @@ class TestParseStdout:
 
     def test_parse_stdout_with_backend_matches_fallback(self):
         """_parse_stdout with backend produces same result as without."""
-        from unittest.mock import Mock
 
         from autoskillit.execution.headless import _parse_stdout
 

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -261,6 +261,7 @@ class TestBackendDelegatedWriteToolNames:
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
         _build_skill_result(result, backend=mock_backend)
+        assert "backend" in captured, "_parse_stdout was not called"
         assert captured["backend"] is mock_backend
 
     def test_build_skill_result_stale_threads_backend_to_parse_stdout(self, monkeypatch):
@@ -283,6 +284,53 @@ class TestBackendDelegatedWriteToolNames:
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.STALE)
         _build_skill_result(result, backend=mock_backend)
+        assert "backend" in captured, "_parse_stdout was not called"
+        assert captured["backend"] is mock_backend
+
+    def test_build_skill_result_idle_stall_threads_backend_to_parse_stdout(self, monkeypatch):
+        """_build_skill_result passes backend to _parse_stdout on idle_stall branch."""
+        from unittest.mock import Mock
+
+        from autoskillit.execution.headless import _headless_result
+
+        captured: dict = {}
+        original_parse = _headless_result._parse_stdout
+
+        def spy(stdout, backend=None):
+            captured["backend"] = backend
+            return original_parse(stdout)
+
+        monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
+
+        mock_backend = Mock()
+        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
+        stdout = _success_session_json("Done")
+        result = _sr(0, stdout, "", TerminationReason.IDLE_STALL)
+        _build_skill_result(result, backend=mock_backend)
+        assert "backend" in captured, "_parse_stdout was not called"
+        assert captured["backend"] is mock_backend
+
+    def test_build_skill_result_timed_out_threads_backend_to_parse_stdout(self, monkeypatch):
+        """_build_skill_result passes backend to _parse_stdout on timed_out branch."""
+        from unittest.mock import Mock
+
+        from autoskillit.execution.headless import _headless_result
+
+        captured: dict = {}
+        original_parse = _headless_result._parse_stdout
+
+        def spy(stdout, backend=None):
+            captured["backend"] = backend
+            return original_parse(stdout)
+
+        monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
+
+        mock_backend = Mock()
+        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
+        stdout = _success_session_json("Done")
+        result = _sr(0, stdout, "", TerminationReason.TIMED_OUT)
+        _build_skill_result(result, backend=mock_backend)
+        assert "backend" in captured, "_parse_stdout was not called"
         assert captured["backend"] is mock_backend
 
 

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -241,6 +241,50 @@ class TestBackendDelegatedWriteToolNames:
         sr = _build_skill_result(result, backend=None)
         assert sr.write_call_count == 0
 
+    def test_build_skill_result_threads_backend_to_parse_stdout(self, monkeypatch):
+        """_build_skill_result passes backend to _parse_stdout on normal exit."""
+        from unittest.mock import Mock
+
+        from autoskillit.execution.headless import _headless_result
+
+        captured: dict = {}
+        original_parse = _headless_result._parse_stdout
+
+        def spy(stdout, backend=None):
+            captured["backend"] = backend
+            return original_parse(stdout)
+
+        monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
+
+        mock_backend = Mock()
+        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
+        stdout = _success_session_json("Done")
+        result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
+        _build_skill_result(result, backend=mock_backend)
+        assert captured["backend"] is mock_backend
+
+    def test_build_skill_result_stale_threads_backend_to_parse_stdout(self, monkeypatch):
+        """_build_skill_result passes backend to _parse_stdout on stale branch."""
+        from unittest.mock import Mock
+
+        from autoskillit.execution.headless import _headless_result
+
+        captured: dict = {}
+        original_parse = _headless_result._parse_stdout
+
+        def spy(stdout, backend=None):
+            captured["backend"] = backend
+            return original_parse(stdout)
+
+        monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
+
+        mock_backend = Mock()
+        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
+        stdout = _success_session_json("Done")
+        result = _sr(0, stdout, "", TerminationReason.STALE)
+        _build_skill_result(result, backend=mock_backend)
+        assert captured["backend"] is mock_backend
+
 
 class TestParseStdout:
     def test_backend_none_calls_parse_session_result(self):
@@ -264,3 +308,30 @@ class TestParseStdout:
         result = _parse_stdout(stdout)
         assert isinstance(result, ClaudeSessionResult)
         assert result.result == "test result"
+
+    def test_parse_stdout_accepts_backend_kwarg(self):
+        """_parse_stdout accepts an optional backend keyword argument."""
+        from unittest.mock import Mock
+
+        from autoskillit.execution.headless import _parse_stdout
+        from autoskillit.execution.session import ClaudeSessionResult
+
+        mock_backend = Mock()
+        stdout = _success_session_json("test result")
+        result = _parse_stdout(stdout, backend=mock_backend)
+        assert isinstance(result, ClaudeSessionResult)
+        assert result.result == "test result"
+
+    def test_parse_stdout_with_backend_matches_fallback(self):
+        """_parse_stdout with backend produces same result as without."""
+        from unittest.mock import Mock
+
+        from autoskillit.execution.headless import _parse_stdout
+
+        mock_backend = Mock()
+        stdout = _success_session_json("test result")
+        with_backend = _parse_stdout(stdout, backend=mock_backend)
+        without_backend = _parse_stdout(stdout)
+        assert with_backend.result == without_backend.result
+        assert with_backend.session_id == without_backend.session_id
+        assert with_backend.session_complete == without_backend.session_complete


### PR DESCRIPTION
## Summary

Thread `backend: CodingAgentBackend | None` through the `_parse_stdout` helper in `_headless_result.py` and update all 4 call sites within `_build_skill_result` to pass the backend parameter. This completes the decoupling seam started by WP4: WP4 added `backend` to `_build_skill_result` and used it for `write_tool_names()` delegation; WP5 extends that delegation to the stdout parsing path.

**Design rationale:** `_build_skill_result` deeply depends on `ClaudeSessionResult` (30+ field accesses). The `ResultParser` protocol defines only `parse_result(events) -> AgentSessionResult` — it does not include `parse_stdout`, and `AgentSessionResult` lacks these rich fields. Therefore `_parse_stdout` threads `backend` as a dispatch seam while continuing to return `ClaudeSessionResult` via `parse_session_result()`. When a future WP refactors `_build_skill_result` to work with `AgentSessionResult`, this seam enables backend-specific dispatch without re-touching call sites.

## Architecture Changes

### Modified Files

- `src/autoskillit/execution/headless/_headless_result.py`
- `tests/execution/test_headless_result.py`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260519-132558-651503/.autoskillit/temp/make-plan/p3_a5_wp5_decouple_headless_result_parse_stdout_plan_2026-05-19_134200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 71 | 29.0k | 945.1k | 95.1k | 275 | 105.2k | 13m 12s |
| verify | claude-opus-4-6 | 1 | 35 | 8.6k | 336.0k | 63.7k | 45 | 48.9k | 3m 53s |
| implement* | MiniMax-M2.7-highspeed | 1 | 590.5k | 8.8k | 641.5k | 29.2k | 69 | 42.9k | 5m 6s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 52.5k | 2.6k | 145.8k | 29.2k | 19 | 42.0k | 1m 6s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 81.5k | 2.3k | 288.8k | 29.2k | 24 | 15.5k | 1m 3s |
| review_pr | claude-sonnet-4-6 | 3 | 268 | 54.3k | 1.2M | 57.6k | 97 | 131.7k | 11m 58s |
| resolve_review | claude-sonnet-4-6 | 2 | 500 | 25.5k | 3.2M | 68.5k | 149 | 108.3k | 11m 45s |
| **Total** | | | 725.4k | 131.1k | 6.8M | 95.1k | | 494.5k | 48m 5s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 81 | 7919.5 | 529.9 | 108.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 68 | 47060.9 | 1592.6 | 375.5 |
| **Total** | **149** | 45559.1 | 3318.6 | 880.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 839 | 108.8k | 5.4M | 345.2k | 36m 55s |
| claude-opus-4-6 | 1 | 35 | 8.6k | 336.0k | 48.9k | 3m 53s |
| MiniMax-M2.7-highspeed | 3 | 724.5k | 13.7k | 1.1M | 100.4k | 7m 16s |