### PR TITLE
test_backend_protocol.py — Protocol conformance for CodingAgentBackend and sub-protocols

### DIFF
--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -13,6 +13,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_activate_deps_completeness.py` | Contracts: SKILL.md activate_deps must cover invoked Skill tool calls |
 | `test_advisory_coverage.py` | Contracts: SKILL_FILE_ADVISORY_MAP advisory hook coverage |
 | `test_api_surface_alignment.py` | REQ-C8-01 / C2-01: API surface alignment tests |
+| `test_backend_protocol.py` | Protocol conformance for CodingAgentBackend, StreamParser, ResultParser, and ClaudeCodeBackend |
 | `test_claim_issue_contracts.py` | Contract tests for claim_issue and release_issue MCP tools |
 | `test_claude_code_interface_contracts.py` | Contract tests for Claude Code external interface conventions |
 | `test_collapse_issues_contracts.py` | Contract tests for the collapse-issues skill SKILL.md |

--- a/tests/contracts/test_backend_protocol.py
+++ b/tests/contracts/test_backend_protocol.py
@@ -1,0 +1,74 @@
+"""Protocol conformance for CodingAgentBackend and sub-protocols.
+
+Contract tests verifying @runtime_checkable decoration and isinstance
+conformance for CodingAgentBackend, StreamParser, ResultParser, and
+ClaudeCodeBackend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+
+# -- Importability ----------------------------------------------------------
+
+
+def test_backend_protocols_importable_from_core():
+    from autoskillit.core import (  # noqa: F401
+        CodingAgentBackend,
+        ResultParser,
+        StreamParser,
+    )
+
+
+# -- @runtime_checkable -----------------------------------------------------
+
+
+def test_stream_parser_is_runtime_checkable():
+    from autoskillit.core import StreamParser
+
+    assert getattr(StreamParser, "_is_runtime_protocol", False), (
+        "StreamParser not decorated with @runtime_checkable"
+    )
+
+
+def test_result_parser_is_runtime_checkable():
+    from autoskillit.core import ResultParser
+
+    assert getattr(ResultParser, "_is_runtime_protocol", False), (
+        "ResultParser not decorated with @runtime_checkable"
+    )
+
+
+def test_coding_agent_backend_is_runtime_checkable():
+    from autoskillit.core import CodingAgentBackend
+
+    assert getattr(CodingAgentBackend, "_is_runtime_protocol", False), (
+        "CodingAgentBackend not decorated with @runtime_checkable"
+    )
+
+
+# -- isinstance conformance: ClaudeCodeBackend ------------------------------
+
+
+def test_claude_code_backend_satisfies_coding_agent_backend():
+    from autoskillit.core import CodingAgentBackend
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    assert isinstance(ClaudeCodeBackend(), CodingAgentBackend)
+
+
+def test_claude_code_backend_stream_parser_satisfies_protocol():
+    from autoskillit.core import StreamParser
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    assert isinstance(ClaudeCodeBackend().stream_parser(), StreamParser)
+
+
+def test_claude_code_backend_result_parser_satisfies_protocol():
+    from autoskillit.core import ResultParser
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    assert isinstance(ClaudeCodeBackend().result_parser(), ResultParser)


### PR DESCRIPTION
## Summary

Add `tests/contracts/test_backend_protocol.py` with 7 test functions that verify protocol conformance for `CodingAgentBackend`, `StreamParser`, and `ResultParser` from `autoskillit.core`. The tests confirm `@runtime_checkable` decoration, importability, and `isinstance` conformance of `ClaudeCodeBackend` against the backend protocol and its sub-protocol factory returns.

## Requirements

### Goal

Contract test file enforcing @runtime_checkable decoration and isinstance conformance for CodingAgentBackend, StreamParser, ResultParser, and ClaudeCodeBackend.

### Context

- Phase: CodingAgentBackend Protocol and ClaudeCodeBackend Extraction (Milestone: 3-codingagentbackend-protocol-and-claudecodebackend-extraction)
- Assignment: P3-A7 (Add new tests for P3 types and implementations)
- Depends on: P3-A1-WP1, P3-A2-WP1, P3-A8-WP2
- Depended on by: None

### Deliverables

- `tests/contracts/test_backend_protocol.py — 7 test functions`

### Acceptance Criteria

- pytestmark layer('contracts') and small
- Importability test passes
- _is_runtime_protocol True for all 3 Protocols
- isinstance checks pass for ClaudeCodeBackend
- No subprocess invocations
- Concrete imports deferred inside function bodies
- ruff format/check pass

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260519-221858-889965/.autoskillit/temp/make-plan/test_backend_protocol_plan_2026-05-19_222500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 74 | 10.9k | 1.1M | 86.3k | 220 | 71.8k | 8m 26s |
| verify | claude-opus-4-6 | 1 | 1.7k | 5.4k | 535.6k | 48.4k | 77 | 37.3k | 5m 18s |
| implement* | MiniMax-M2.7 | 1 | 48.0k | 3.6k | 858.3k | 0 | 44 | 0 | 3m 49s |
| prepare_pr* | MiniMax-M2.7 | 1 | 41.9k | 2.7k | 192.3k | 29.2k | 20 | 42.0k | 1m 35s |
| compose_pr* | MiniMax-M2.7 | 1 | 37.6k | 1.4k | 229.9k | 0 | 18 | 0 | 32s |
| review_pr | claude-opus-4-6 | 3 | 177 | 20.7k | 948.9k | 45.2k | 70 | 92.4k | 7m 5s |
| **Total** | | | 129.4k | 44.8k | 3.9M | 86.3k | | 243.5k | 26m 46s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 75 | 11444.1 | 0.0 | 47.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **75** | 51866.7 | 3246.1 | 596.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 74 | 10.9k | 1.1M | 71.8k | 8m 26s |
| claude-opus-4-6 | 2 | 1.9k | 26.1k | 1.5M | 129.7k | 12m 24s |
| MiniMax-M2.7 | 3 | 127.4k | 7.7k | 1.3M | 42.0k | 5m 56s |