### PR TITLE
test(types): add SessionEvent frozen dataclass tests

### DIFF
--- a/tests/core/types/test_session_event.py
+++ b/tests/core/types/test_session_event.py
@@ -93,6 +93,7 @@ def test_backend_data_accepts_claude_event_data() -> None:
         backend_data=data,
     )
     assert ev.backend_data is data
+    assert isinstance(ev.backend_data, ClaudeEventData)
     assert ev.backend_data.record_type == "assistant"
 
 
@@ -105,6 +106,7 @@ def test_backend_data_accepts_codex_event_data() -> None:
         backend_data=data,
     )
     assert ev.backend_data is data
+    assert isinstance(ev.backend_data, CodexEventData)
     assert ev.backend_data.thread_id == "t1"
 
 

--- a/tests/core/types/test_session_event.py
+++ b/tests/core/types/test_session_event.py
@@ -1,0 +1,111 @@
+"""SessionEvent frozen dataclass behavior."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from autoskillit.core.types._type_backend import (
+    ClaudeEventData,
+    CodexEventData,
+    SessionEvent,
+)
+from autoskillit.core.types._type_enums import BackendEventKind
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+def test_required_fields_present() -> None:
+    field_names = {f.name for f in dataclasses.fields(SessionEvent)}
+    assert field_names == {
+        "kind",
+        "is_terminal",
+        "has_marker",
+        "session_id",
+        "exit_code",
+        "backend_data",
+    }
+    claude_data = ClaudeEventData(record_type="assistant", subtype="text", session_id="s1")
+    ev = SessionEvent(
+        kind=BackendEventKind.COMPLETION,
+        is_terminal=True,
+        has_marker=True,
+        session_id="abc",
+        exit_code=0,
+        backend_data=claude_data,
+    )
+    assert ev.kind is BackendEventKind.COMPLETION
+    assert ev.is_terminal is True
+    assert ev.has_marker is True
+    assert ev.session_id == "abc"
+    assert ev.exit_code == 0
+    assert ev.backend_data is claude_data
+
+
+def test_mutation_raises_attribute_error() -> None:
+    ev = SessionEvent(kind=BackendEventKind.COMPLETION, is_terminal=False, has_marker=False)
+    with pytest.raises(AttributeError):
+        ev.kind = BackendEventKind.ERROR  # type: ignore[misc]
+
+
+def test_default_construction_succeeds() -> None:
+    ev = SessionEvent(kind=BackendEventKind.ERROR, is_terminal=True, has_marker=False)
+    assert ev.session_id is None
+    assert ev.exit_code is None
+    assert ev.backend_data is None
+
+
+def test_two_identical_instances_are_equal() -> None:
+    kwargs = dict(
+        kind=BackendEventKind.SESSION_META,
+        is_terminal=False,
+        has_marker=True,
+        session_id="s1",
+        exit_code=1,
+        backend_data=None,
+    )
+    a = SessionEvent(**kwargs)
+    b = SessionEvent(**kwargs)
+    assert a == b
+    assert a is not b
+
+
+def test_backend_data_accepts_none() -> None:
+    ev = SessionEvent(
+        kind=BackendEventKind.IGNORED,
+        is_terminal=False,
+        has_marker=False,
+        backend_data=None,
+    )
+    assert ev.backend_data is None
+
+
+def test_backend_data_accepts_claude_event_data() -> None:
+    data = ClaudeEventData(record_type="assistant", subtype="text", session_id="s1")
+    ev = SessionEvent(
+        kind=BackendEventKind.COMPLETION,
+        is_terminal=True,
+        has_marker=True,
+        backend_data=data,
+    )
+    assert ev.backend_data is data
+    assert ev.backend_data.record_type == "assistant"
+
+
+def test_backend_data_accepts_codex_event_data() -> None:
+    data = CodexEventData(record_type="item", thread_id="t1", item_type="msg")
+    ev = SessionEvent(
+        kind=BackendEventKind.TOOL_OUTPUT,
+        is_terminal=False,
+        has_marker=False,
+        backend_data=data,
+    )
+    assert ev.backend_data is data
+    assert ev.backend_data.thread_id == "t1"
+
+
+def test_session_event_importable_from_core_types() -> None:
+    from autoskillit.core.types import SessionEvent as PublicSessionEvent
+
+    assert PublicSessionEvent is SessionEvent

--- a/tests/core/types/test_session_event.py
+++ b/tests/core/types/test_session_event.py
@@ -26,6 +26,9 @@ def test_required_fields_present() -> None:
         "exit_code",
         "backend_data",
     }
+
+
+def test_construction_stores_all_fields() -> None:
     claude_data = ClaudeEventData(record_type="assistant", subtype="text", session_id="s1")
     ev = SessionEvent(
         kind=BackendEventKind.COMPLETION,


### PR DESCRIPTION
## Summary

Create `tests/core/types/test_session_event.py` with 8 test functions proving `SessionEvent` is a correctly-implemented frozen dataclass: immutable, equality-comparable, accepts the full `backend_data` discriminated-union range, and is importable from `autoskillit.core.types`.

**Overlap note:** `tests/core/test_backend_dataclasses.py` already contains 3 tests touching `SessionEvent` (`test_session_event_frozen`, `test_session_event_defaults`, `test_session_event_backend_data_union_type`). Those tests are broader (covering all `_type_backend.py` dataclasses) and remain in place. The new file provides focused, single-class coverage in the `tests/core/types/` subdirectory, matching the pattern set by `test_dispatch_identity.py`.

## Requirements

### Goal

Prove SessionEvent is correctly-implemented frozen dataclass: immutable, equality-comparable, accepts full backend_data discriminated-union range, importable from core.types.

### Deliverables

- `tests/core/types/test_session_event.py — 8 test functions`

### Acceptance Criteria

- All fields accessible with correct values
- Mutation raises AttributeError
- Default construction works
- Identical instances compare equal
- backend_data accepts None, ClaudeEventData, CodexEventData
- Importable from autoskillit.core.types
- pytestmark layer('core'), small
- xdist-safe

Closes #2497

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260519-221903-835230/.autoskillit/temp/make-plan/test_session_event_plan_2026-05-19_222500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.0k | 9.2k | 926.6k | 72.5k | 170 | 53.2k | 10m 23s |
| verify | claude-sonnet-4-6 | 1 | 29 | 3.8k | 382.7k | 44.7k | 71 | 29.9k | 3m 40s |
| implement* | MiniMax-M2.7 | 1 | 46.6k | 2.8k | 477.9k | 0 | 27 | 0 | 54s |
| prepare_pr* | MiniMax-M2.7 | 1 | 41.6k | 3.1k | 230.5k | 26.3k | 19 | 8.3k | 1m 49s |
| compose_pr* | MiniMax-M2.7 | 1 | 37.9k | 1.6k | 232.0k | 0 | 19 | 0 | 34s |
| review_pr | claude-opus-4-6 | 4 | 127 | 40.9k | 1.8M | 59.0k | 109 | 145.7k | 12m 35s |
| resolve_review | claude-opus-4-6 | 1 | 45 | 5.5k | 814.6k | 55.3k | 36 | 42.2k | 3m 45s |
| **Total** | | | 130.3k | 66.8k | 4.9M | 72.5k | | 279.2k | 33m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 111 | 4305.6 | 0.0 | 25.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 162918.0 | 8432.6 | 1105.8 |
| **Total** | **116** | 41842.8 | 2406.7 | 575.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 4.0k | 12.9k | 1.3M | 83.1k | 14m 3s |
| MiniMax-M2.7 | 3 | 126.1k | 7.4k | 940.4k | 8.3k | 3m 17s |
| claude-opus-4-6 | 2 | 172 | 46.4k | 2.6M | 187.9k | 16m 20s |