### PR TITLE
[FIX] Guard denial + CI timeout waste: context propagation immunity

### DIFF
--- a/src/autoskillit/execution/merge_queue/_merge_queue_repo_state.py
+++ b/src/autoskillit/execution/merge_queue/_merge_queue_repo_state.py
@@ -261,10 +261,12 @@ async def fetch_repo_merge_state(
                 has_push_trigger = True
 
     ci_event: Literal["push"] | None = "push" if has_push_trigger else None
+    ci_applicable: bool = has_push_trigger or merge_group_trigger
 
     return {
         "queue_available": queue_available,
         "merge_group_trigger": merge_group_trigger,
         "auto_merge_available": auto_merge_available,
         "ci_event": ci_event,
+        "ci_applicable": ci_applicable,
     }

--- a/src/autoskillit/hooks/guards/pr_create_guard.py
+++ b/src/autoskillit/hooks/guards/pr_create_guard.py
@@ -101,7 +101,7 @@ def main() -> None:
         if hook_data.get("recipe_allows_pr_create"):
             sys.exit(0)
     except (OSError, json.JSONDecodeError, AttributeError, TypeError) as exc:
-        print(f"pr_create_guard: config read error: {exc}", file=sys.stderr)
+        sys.stderr.write(f"pr_create_guard: config read error: {exc}\n")
 
     # Kitchen is open and command matches: deny
     payload = json.dumps(

--- a/src/autoskillit/hooks/guards/pr_create_guard.py
+++ b/src/autoskillit/hooks/guards/pr_create_guard.py
@@ -93,6 +93,16 @@ def main() -> None:
             sys.exit(0)  # kitchen not open; fail-open
     except OSError:
         sys.exit(0)
+
+    # Recipe-level authorization: recipes that legitimately create PRs set
+    # recipe_allows_pr_create=true in .hook_config.json after loading.
+    try:
+        hook_data = json.loads(cfg_path.read_text())
+        if hook_data.get("recipe_allows_pr_create"):
+            sys.exit(0)
+    except (OSError, json.JSONDecodeError, AttributeError, TypeError):
+        pass  # fail-closed: parse error → continue to deny
+
     # Kitchen is open and command matches: deny
     payload = json.dumps(
         {

--- a/src/autoskillit/hooks/guards/pr_create_guard.py
+++ b/src/autoskillit/hooks/guards/pr_create_guard.py
@@ -100,8 +100,8 @@ def main() -> None:
         hook_data = json.loads(cfg_path.read_text())
         if hook_data.get("recipe_allows_pr_create"):
             sys.exit(0)
-    except (OSError, json.JSONDecodeError, AttributeError, TypeError):
-        pass  # fail-closed: parse error → continue to deny
+    except (OSError, json.JSONDecodeError, AttributeError, TypeError) as exc:
+        print(f"pr_create_guard: config read error: {exc}", file=sys.stderr)
 
     # Kitchen is open and command matches: deny
     payload = json.dumps(

--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -484,6 +484,73 @@ def _check_ci_event_literal_merge_group(ctx: ValidationContext) -> list[RuleFind
     return findings
 
 
+_CI_APPLICABLE_RE = re.compile(r"ci_applicable")
+
+
+@semantic_rule(
+    name="ci-wait-requires-applicability-guard",
+    description=(
+        "A wait_for_ci step whose event comes from check_repo_merge_state must have "
+        "an upstream action:route step that checks ci_applicable to prevent timeout "
+        "waste when no CI workflows apply."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_ci_wait_requires_applicability_guard(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "wait_for_ci":
+            continue
+        event_val = (step.with_args or {}).get("event", "")
+        if not isinstance(event_val, str) or "ci_event" not in event_val:
+            continue
+        has_guard = False
+        for pred_name in ctx.predecessors.get(step_name, set()):
+            pred_step = ctx.recipe.steps.get(pred_name)
+            if pred_step is None:
+                continue
+            if getattr(pred_step, "action", None) == "route":
+                if pred_step.on_result and pred_step.on_result.conditions:
+                    for cond in pred_step.on_result.conditions:
+                        if cond.when and _CI_APPLICABLE_RE.search(cond.when):
+                            has_guard = True
+                            break
+            if has_guard:
+                break
+        if not has_guard:
+            for ancestor_name in ctx.predecessors.get(step_name, set()):
+                for grand_pred_name in ctx.predecessors.get(ancestor_name, set()):
+                    grand_pred_step = ctx.recipe.steps.get(grand_pred_name)
+                    if grand_pred_step is None:
+                        continue
+                    if getattr(grand_pred_step, "action", None) == "route":
+                        if grand_pred_step.on_result and grand_pred_step.on_result.conditions:
+                            for cond in grand_pred_step.on_result.conditions:
+                                if cond.when and _CI_APPLICABLE_RE.search(cond.when):
+                                    has_guard = True
+                                    break
+                    if has_guard:
+                        break
+                if has_guard:
+                    break
+        if not has_guard:
+            findings.append(
+                RuleFinding(
+                    rule="ci-wait-requires-applicability-guard",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' calls wait_for_ci with a ci_event from "
+                        f"check_repo_merge_state but has no upstream action:route step "
+                        f"that checks ci_applicable. When ci_applicable=false, "
+                        f"wait_for_ci will exhaust its timeout budget polling for CI runs "
+                        f"that will never appear."
+                    ),
+                )
+            )
+    return findings
+
+
 _CI_TIMEOUT_MINIMUM = 600
 
 

--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -528,7 +528,9 @@ def _check_ci_wait_requires_applicability_guard(ctx: ValidationContext) -> list[
                             has_guard = True
                             break
             if not has_guard:
-                queue.extend(ctx.predecessors.get(node, set()) - visited)
+                new_preds = ctx.predecessors.get(node, set()) - visited
+                visited.update(new_preds)
+                queue.extend(new_preds)
         if not has_guard:
             findings.append(
                 RuleFinding(

--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -498,6 +498,8 @@ _PRIMARY_CI_EVENT_RE = re.compile(r"context\.(conflict_)?ci_event\s*\}\}")
     severity=Severity.ERROR,
 )
 def _check_ci_wait_requires_applicability_guard(ctx: ValidationContext) -> list[RuleFinding]:
+    from collections import deque
+
     findings: list[RuleFinding] = []
     for step_name, step in ctx.recipe.steps.items():
         if step.tool != "wait_for_ci":
@@ -506,34 +508,27 @@ def _check_ci_wait_requires_applicability_guard(ctx: ValidationContext) -> list[
         if not isinstance(event_val, str) or not _PRIMARY_CI_EVENT_RE.search(event_val):
             continue
         has_guard = False
-        for pred_name in ctx.predecessors.get(step_name, set()):
-            pred_step = ctx.recipe.steps.get(pred_name)
+        visited: set[str] = set()
+        queue: deque[str] = deque(ctx.predecessors.get(step_name, set()))
+        while queue and not has_guard:
+            node = queue.popleft()
+            if node in visited:
+                continue
+            visited.add(node)
+            pred_step = ctx.recipe.steps.get(node)
             if pred_step is None:
                 continue
+            if pred_step.tool == "wait_for_ci":
+                has_guard = True
+                break
             if getattr(pred_step, "action", None) == "route":
                 if pred_step.on_result and pred_step.on_result.conditions:
                     for cond in pred_step.on_result.conditions:
                         if cond.when and _CI_APPLICABLE_RE.search(cond.when):
                             has_guard = True
                             break
-            if has_guard:
-                break
-        if not has_guard:
-            for ancestor_name in ctx.predecessors.get(step_name, set()):
-                for grand_pred_name in ctx.predecessors.get(ancestor_name, set()):
-                    grand_pred_step = ctx.recipe.steps.get(grand_pred_name)
-                    if grand_pred_step is None:
-                        continue
-                    if getattr(grand_pred_step, "action", None) == "route":
-                        if grand_pred_step.on_result and grand_pred_step.on_result.conditions:
-                            for cond in grand_pred_step.on_result.conditions:
-                                if cond.when and _CI_APPLICABLE_RE.search(cond.when):
-                                    has_guard = True
-                                    break
-                    if has_guard:
-                        break
-                if has_guard:
-                    break
+            if not has_guard:
+                queue.extend(ctx.predecessors.get(node, set()) - visited)
         if not has_guard:
             findings.append(
                 RuleFinding(

--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -508,13 +508,11 @@ def _check_ci_wait_requires_applicability_guard(ctx: ValidationContext) -> list[
         if not isinstance(event_val, str) or not _PRIMARY_CI_EVENT_RE.search(event_val):
             continue
         has_guard = False
-        visited: set[str] = set()
-        queue: deque[str] = deque(ctx.predecessors.get(step_name, set()))
+        initial_preds = ctx.predecessors.get(step_name, set())
+        visited: set[str] = set(initial_preds)
+        queue: deque[str] = deque(initial_preds)
         while queue and not has_guard:
             node = queue.popleft()
-            if node in visited:
-                continue
-            visited.add(node)
             pred_step = ctx.recipe.steps.get(node)
             if pred_step is None:
                 continue

--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -485,6 +485,7 @@ def _check_ci_event_literal_merge_group(ctx: ValidationContext) -> list[RuleFind
 
 
 _CI_APPLICABLE_RE = re.compile(r"ci_applicable")
+_PRIMARY_CI_EVENT_RE = re.compile(r"context\.(conflict_)?ci_event\s*\}\}")
 
 
 @semantic_rule(
@@ -502,7 +503,7 @@ def _check_ci_wait_requires_applicability_guard(ctx: ValidationContext) -> list[
         if step.tool != "wait_for_ci":
             continue
         event_val = (step.with_args or {}).get("event", "")
-        if not isinstance(event_val, str) or "ci_event" not in event_val:
+        if not isinstance(event_val, str) or not _PRIMARY_CI_EVENT_RE.search(event_val):
             continue
         has_guard = False
         for pred_name in ctx.predecessors.get(step_name, set()):

--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -705,6 +705,12 @@ def _check_enqueue_missing_ci_gate(ctx: ValidationContext) -> list[RuleFinding]:
     ci_gate_steps: set[str] = {
         name for name, step in ctx.recipe.steps.items() if step.tool == "wait_for_ci"
     }
+    for name, step in ctx.recipe.steps.items():
+        if getattr(step, "action", None) == "route" and step.on_result:
+            if step.on_result.conditions and any(
+                c.when and _CI_APPLICABLE_RE.search(c.when) for c in step.on_result.conditions
+            ):
+                ci_gate_steps.add(name)
 
     # Build a direct routing graph without skip_when_false bypass edges.
     # Bypass edges allow CI gates to be sidestepped in the compiled step_graph,

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -742,12 +742,27 @@
         "step_name": "check_repo_ci_event"
       },
       "capture": {
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
-      "on_success": "check_pr_state",
+      "on_success": "route_ci_applicable",
       "on_failure": "ci_watch",
       "skip_when_false": "inputs.open_pr",
       "note": "Derives ci_event for the feature branch BEFORE ci_watch runs. Uses context.merge_target (feature branch) so push.branches filter is evaluated against the actual branch being pushed, not the base branch. Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).\n"
+    },
+    "route_ci_applicable": {
+      "action": "route",
+      "on_result": [
+        {
+          "when": "${{ context.ci_applicable }} == false",
+          "route": "check_repo_merge_state"
+        },
+        {
+          "route": "check_pr_state"
+        }
+      ],
+      "skip_when_false": "inputs.open_pr",
+      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
     },
     "check_pr_state": {
       "tool": "check_pr_mergeable",

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -853,7 +853,8 @@
         "step_name": "handle_no_ci_runs"
       },
       "capture": {
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
       "on_success": "check_ci_loop",
       "on_failure": "release_issue_failure",
@@ -1104,7 +1105,8 @@
         "queue_available": "${{ result.queue_available }}",
         "merge_group_trigger": "${{ result.merge_group_trigger }}",
         "auto_merge_available": "${{ result.auto_merge_available }}",
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
       "on_success": "route_queue_mode",
       "on_failure": "immediate_merge",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -701,7 +701,8 @@ steps:
       step_name: "check_repo_ci_event"
     capture:
       ci_event: "${{ result.ci_event }}"
-    on_success: check_pr_state
+      ci_applicable: "${{ result.ci_applicable }}"
+    on_success: route_ci_applicable
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     note: >
@@ -709,6 +710,18 @@ steps:
       Uses context.merge_target (feature branch) so push.branches filter
       is evaluated against the actual branch being pushed, not the base branch.
       Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).
+
+  route_ci_applicable:
+    action: route
+    on_result:
+      - when: "${{ context.ci_applicable }} == false"
+        route: check_repo_merge_state
+      - route: check_pr_state
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Short-circuits CI wait when no workflow trigger matches the feature branch.
+      ci_applicable=false means neither push nor merge_group triggers apply,
+      so wait_for_ci would exhaust its timeout budget with zero CI runs.
 
   check_pr_state:
     tool: check_pr_mergeable

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -803,6 +803,7 @@ steps:
       step_name: "handle_no_ci_runs"
     capture:
       ci_event: "${{ result.ci_event }}"
+      ci_applicable: "${{ result.ci_applicable }}"
     on_success: check_ci_loop
     on_failure: release_issue_failure
     retries: 1
@@ -1048,6 +1049,7 @@ steps:
       merge_group_trigger: "${{ result.merge_group_trigger }}"
       auto_merge_available: "${{ result.auto_merge_available }}"
       ci_event: "${{ result.ci_event }}"
+      ci_applicable: "${{ result.ci_applicable }}"
     on_success: route_queue_mode
     on_failure: immediate_merge
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -856,7 +856,8 @@
         "step_name": "handle_no_ci_runs"
       },
       "capture": {
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
       "on_success": "check_ci_loop",
       "on_failure": "release_issue_failure",
@@ -998,7 +999,8 @@
         "queue_available": "${{ result.queue_available }}",
         "merge_group_trigger": "${{ result.merge_group_trigger }}",
         "auto_merge_available": "${{ result.auto_merge_available }}",
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
       "on_success": "route_queue_mode",
       "on_failure": "immediate_merge",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -745,12 +745,27 @@
         "step_name": "check_repo_ci_event"
       },
       "capture": {
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
-      "on_success": "check_pr_state",
+      "on_success": "route_ci_applicable",
       "on_failure": "ci_watch",
       "skip_when_false": "inputs.open_pr",
       "note": "Derives ci_event for the feature branch BEFORE ci_watch runs. Uses context.merge_target (feature branch) so push.branches filter is evaluated against the actual branch being pushed, not the base branch. Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).\n"
+    },
+    "route_ci_applicable": {
+      "action": "route",
+      "on_result": [
+        {
+          "when": "${{ context.ci_applicable }} == false",
+          "route": "check_repo_merge_state"
+        },
+        {
+          "route": "check_pr_state"
+        }
+      ],
+      "skip_when_false": "inputs.open_pr",
+      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
     },
     "check_pr_state": {
       "tool": "check_pr_mergeable",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -709,7 +709,8 @@ steps:
       step_name: "check_repo_ci_event"
     capture:
       ci_event: "${{ result.ci_event }}"
-    on_success: check_pr_state
+      ci_applicable: "${{ result.ci_applicable }}"
+    on_success: route_ci_applicable
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     note: >
@@ -717,6 +718,18 @@ steps:
       Uses context.merge_target (feature branch) so push.branches filter
       is evaluated against the actual branch being pushed, not the base branch.
       Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).
+
+  route_ci_applicable:
+    action: route
+    on_result:
+      - when: "${{ context.ci_applicable }} == false"
+        route: check_repo_merge_state
+      - route: check_pr_state
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Short-circuits CI wait when no workflow trigger matches the feature branch.
+      ci_applicable=false means neither push nor merge_group triggers apply,
+      so wait_for_ci would exhaust its timeout budget with zero CI runs.
 
   check_pr_state:
     tool: check_pr_mergeable

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -811,6 +811,7 @@ steps:
       step_name: "handle_no_ci_runs"
     capture:
       ci_event: "${{ result.ci_event }}"
+      ci_applicable: "${{ result.ci_applicable }}"
     on_success: check_ci_loop
     on_failure: release_issue_failure
     retries: 1
@@ -951,6 +952,7 @@ steps:
       merge_group_trigger: "${{ result.merge_group_trigger }}"
       auto_merge_available: "${{ result.auto_merge_available }}"
       ci_event: "${{ result.ci_event }}"
+      ci_applicable: "${{ result.ci_applicable }}"
     on_success: route_queue_mode
     on_failure: immediate_merge
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -85,11 +85,12 @@
       },
       "capture": {
         "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}",
         "auto_merge_available": "${{ result.auto_merge_available }}"
       },
       "on_success": "check_integration_exists",
       "on_failure": "check_integration_exists",
-      "note": "Detects whether the repository's CI triggers on push or merge_group events for the base branch. Each downstream wait_for_ci step re-derives ci_event for its own watched branch via a dedicated derive_*_ci_event step. The global ci_event captured here is used only by diagnose-ci skill invocations. Routes to check_integration_exists regardless of outcome — non-blocking gate: ci_event defaults to null (match-any) on failure.\n"
+      "note": "Detects whether the repository's CI triggers on push or merge_group events for the base branch. Each downstream wait_for_ci step re-derives ci_event for its own watched branch via a dedicated derive_*_ci_event step. The global ci_event and ci_applicable captured here are used by diagnostic skill invocations. Routes to check_integration_exists regardless of outcome — non-blocking gate: ci_event defaults to null (match-any) on failure.\n"
     },
     "check_integration_exists": {
       "tool": "run_cmd",

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -85,12 +85,11 @@
       },
       "capture": {
         "ci_event": "${{ result.ci_event }}",
-        "ci_applicable": "${{ result.ci_applicable }}",
         "auto_merge_available": "${{ result.auto_merge_available }}"
       },
       "on_success": "check_integration_exists",
       "on_failure": "check_integration_exists",
-      "note": "Detects whether the repository's CI triggers on push or merge_group events for the base branch. Each downstream wait_for_ci step re-derives ci_event for its own watched branch via a dedicated derive_*_ci_event step. The global ci_event and ci_applicable captured here are used by diagnostic skill invocations. Routes to check_integration_exists regardless of outcome — non-blocking gate: ci_event defaults to null (match-any) on failure.\n"
+      "note": "Detects whether the repository's CI triggers on push or merge_group events for the base branch. Each downstream wait_for_ci step re-derives ci_event for its own watched branch via a dedicated derive_*_ci_event step. The global ci_event captured here is used by diagnostic skill invocations. ci_applicable is captured per-branch by derive_conflict_ci_event instead. Routes to check_integration_exists regardless of outcome — non-blocking gate: ci_event defaults to null (match-any) on failure.\n"
     },
     "check_integration_exists": {
       "tool": "run_cmd",

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -970,13 +970,38 @@
       "on_result": [
         {
           "when": "${{ context.conflict_ci_applicable }} == false",
-          "route": "merge_conflict_pr"
+          "route": "guard_ci_skip_conflict"
         },
         {
           "route": "wait_for_conflict_ci"
         }
       ],
       "note": "Short-circuits CI wait when no workflow trigger matches the conflict resolution branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
+    },
+    "guard_ci_skip_conflict": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ci_skip_conflict_count }}",
+        "max_iterations": "50"
+      },
+      "capture": {
+        "ci_skip_conflict_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "register_clone_failure"
+        },
+        {
+          "route": "merge_conflict_pr"
+        }
+      ],
+      "on_failure": "register_clone_failure",
+      "optional_context_refs": [
+        "ci_skip_conflict_count"
+      ],
+      "note": "Structural bound for the ci_applicable=false shortcut path. Uses check_loop_iteration to satisfy the unbounded-cycle semantic rule — the on_result exit to register_clone_failure provides a structural termination guarantee. Cap of 50 matches check_pr_merge_loop budget; in practice never exceeded because the PR merge loop terminates when all PRs are processed.\n"
     },
     "wait_for_conflict_ci": {
       "tool": "wait_for_ci",
@@ -1042,7 +1067,8 @@
         "step_name": "handle_conflict_no_runs"
       },
       "capture": {
-        "conflict_ci_event": "${{ result.ci_event }}"
+        "conflict_ci_event": "${{ result.ci_event }}",
+        "conflict_ci_applicable": "${{ result.ci_applicable }}"
       },
       "on_success": "merge_conflict_pr",
       "on_failure": "register_clone_failure",

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -957,11 +957,25 @@
         "step_name": "derive_conflict_ci_event"
       },
       "capture": {
-        "conflict_ci_event": "${{ result.ci_event }}"
+        "conflict_ci_event": "${{ result.ci_event }}",
+        "conflict_ci_applicable": "${{ result.ci_applicable }}"
       },
-      "on_success": "wait_for_conflict_ci",
-      "on_failure": "wait_for_conflict_ci",
-      "note": "Re-derives ci_event for the ACTUAL conflict resolution branch, not inputs.base_branch. The original check_repo_ci_event evaluates CI triggers against main, but conflict PRs target pr-batch/* branches where different CI rules may apply. Non-blocking: on_failure routes to wait_for_conflict_ci with conflict_ci_event=null (match-any fallback).\n"
+      "on_success": "route_conflict_ci",
+      "on_failure": "route_conflict_ci",
+      "note": "Re-derives ci_event for the ACTUAL conflict resolution branch, not inputs.base_branch. The original check_repo_ci_event evaluates CI triggers against main, but conflict PRs target pr-batch/* branches where different CI rules may apply. Non-blocking: on_failure routes to route_conflict_ci with conflict_ci_event=null (match-any fallback).\n"
+    },
+    "route_conflict_ci": {
+      "action": "route",
+      "on_result": [
+        {
+          "when": "${{ context.conflict_ci_applicable }} == false",
+          "route": "merge_conflict_pr"
+        },
+        {
+          "route": "wait_for_conflict_ci"
+        }
+      ],
+      "note": "Short-circuits CI wait when no workflow trigger matches the conflict resolution branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
     },
     "wait_for_conflict_ci": {
       "tool": "wait_for_ci",

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -117,6 +117,7 @@ steps:
       step_name: "check_repo_ci_event"
     capture:
       ci_event: "${{ result.ci_event }}"
+      ci_applicable: "${{ result.ci_applicable }}"
       auto_merge_available: "${{ result.auto_merge_available }}"
     on_success: check_integration_exists
     on_failure: check_integration_exists
@@ -124,9 +125,9 @@ steps:
       Detects whether the repository's CI triggers on push or merge_group events
       for the base branch. Each downstream wait_for_ci step re-derives ci_event
       for its own watched branch via a dedicated derive_*_ci_event step. The global
-      ci_event captured here is used only by diagnose-ci skill invocations.
-      Routes to check_integration_exists regardless of outcome — non-blocking gate:
-      ci_event defaults to null (match-any) on failure.
+      ci_event and ci_applicable captured here are used by diagnostic skill
+      invocations. Routes to check_integration_exists regardless of outcome —
+      non-blocking gate: ci_event defaults to null (match-any) on failure.
 
   check_integration_exists:
     tool: run_cmd

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -942,13 +942,25 @@ steps:
       step_name: "derive_conflict_ci_event"
     capture:
       conflict_ci_event: "${{ result.ci_event }}"
-    on_success: wait_for_conflict_ci
-    on_failure: wait_for_conflict_ci
+      conflict_ci_applicable: "${{ result.ci_applicable }}"
+    on_success: route_conflict_ci
+    on_failure: route_conflict_ci
     note: >
       Re-derives ci_event for the ACTUAL conflict resolution branch, not inputs.base_branch.
       The original check_repo_ci_event evaluates CI triggers against main, but conflict PRs
       target pr-batch/* branches where different CI rules may apply. Non-blocking: on_failure
-      routes to wait_for_conflict_ci with conflict_ci_event=null (match-any fallback).
+      routes to route_conflict_ci with conflict_ci_event=null (match-any fallback).
+
+  route_conflict_ci:
+    action: route
+    on_result:
+      - when: "${{ context.conflict_ci_applicable }} == false"
+        route: merge_conflict_pr
+      - route: wait_for_conflict_ci
+    note: >
+      Short-circuits CI wait when no workflow trigger matches the conflict resolution
+      branch. ci_applicable=false means neither push nor merge_group triggers apply,
+      so wait_for_ci would exhaust its timeout budget with zero CI runs.
 
   wait_for_conflict_ci:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -117,7 +117,6 @@ steps:
       step_name: "check_repo_ci_event"
     capture:
       ci_event: "${{ result.ci_event }}"
-      ci_applicable: "${{ result.ci_applicable }}"
       auto_merge_available: "${{ result.auto_merge_available }}"
     on_success: check_integration_exists
     on_failure: check_integration_exists
@@ -125,8 +124,9 @@ steps:
       Detects whether the repository's CI triggers on push or merge_group events
       for the base branch. Each downstream wait_for_ci step re-derives ci_event
       for its own watched branch via a dedicated derive_*_ci_event step. The global
-      ci_event and ci_applicable captured here are used by diagnostic skill
-      invocations. Routes to check_integration_exists regardless of outcome —
+      ci_event captured here is used by diagnostic skill invocations.
+      ci_applicable is captured per-branch by derive_conflict_ci_event instead.
+      Routes to check_integration_exists regardless of outcome —
       non-blocking gate: ci_event defaults to null (match-any) on failure.
 
   check_integration_exists:

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -956,12 +956,34 @@ steps:
     action: route
     on_result:
       - when: "${{ context.conflict_ci_applicable }} == false"
-        route: merge_conflict_pr
+        route: guard_ci_skip_conflict
       - route: wait_for_conflict_ci
     note: >
       Short-circuits CI wait when no workflow trigger matches the conflict resolution
       branch. ci_applicable=false means neither push nor merge_group triggers apply,
       so wait_for_ci would exhaust its timeout budget with zero CI runs.
+
+  guard_ci_skip_conflict:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.ci_skip_conflict_count }}"
+      max_iterations: "50"
+    capture:
+      ci_skip_conflict_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: register_clone_failure
+      - route: merge_conflict_pr
+    on_failure: register_clone_failure
+    optional_context_refs:
+      - ci_skip_conflict_count
+    note: >
+      Structural bound for the ci_applicable=false shortcut path. Uses
+      check_loop_iteration to satisfy the unbounded-cycle semantic rule — the
+      on_result exit to register_clone_failure provides a structural termination
+      guarantee. Cap of 50 matches check_pr_merge_loop budget; in practice never
+      exceeded because the PR merge loop terminates when all PRs are processed.
 
   wait_for_conflict_ci:
     tool: wait_for_ci
@@ -1018,6 +1040,7 @@ steps:
       step_name: "handle_conflict_no_runs"
     capture:
       conflict_ci_event: "${{ result.ci_event }}"
+      conflict_ci_applicable: "${{ result.ci_applicable }}"
     on_success: merge_conflict_pr
     on_failure: register_clone_failure
     retries: 1

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -773,12 +773,27 @@
         "step_name": "check_repo_ci_event"
       },
       "capture": {
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
-      "on_success": "check_pr_state",
+      "on_success": "route_ci_applicable",
       "on_failure": "ci_watch",
       "skip_when_false": "inputs.open_pr",
       "note": "Derives ci_event for the feature branch BEFORE ci_watch runs. Uses context.merge_target (feature branch) so push.branches filter is evaluated against the actual branch being pushed, not the base branch. Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).\n"
+    },
+    "route_ci_applicable": {
+      "action": "route",
+      "on_result": [
+        {
+          "when": "${{ context.ci_applicable }} == false",
+          "route": "check_repo_merge_state"
+        },
+        {
+          "route": "check_pr_state"
+        }
+      ],
+      "skip_when_false": "inputs.open_pr",
+      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
     },
     "check_pr_state": {
       "tool": "check_pr_mergeable",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -884,7 +884,8 @@
         "step_name": "handle_no_ci_runs"
       },
       "capture": {
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
       "on_success": "check_ci_loop",
       "on_failure": "release_issue_failure",
@@ -1026,7 +1027,8 @@
         "queue_available": "${{ result.queue_available }}",
         "merge_group_trigger": "${{ result.merge_group_trigger }}",
         "auto_merge_available": "${{ result.auto_merge_available }}",
-        "ci_event": "${{ result.ci_event }}"
+        "ci_event": "${{ result.ci_event }}",
+        "ci_applicable": "${{ result.ci_applicable }}"
       },
       "on_success": "route_queue_mode",
       "on_failure": "immediate_merge",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -814,6 +814,7 @@ steps:
       step_name: "handle_no_ci_runs"
     capture:
       ci_event: "${{ result.ci_event }}"
+      ci_applicable: "${{ result.ci_applicable }}"
     on_success: check_ci_loop
     on_failure: release_issue_failure
     retries: 1
@@ -954,6 +955,7 @@ steps:
       merge_group_trigger: "${{ result.merge_group_trigger }}"
       auto_merge_available: "${{ result.auto_merge_available }}"
       ci_event: "${{ result.ci_event }}"
+      ci_applicable: "${{ result.ci_applicable }}"
     on_success: route_queue_mode
     on_failure: immediate_merge
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -712,7 +712,8 @@ steps:
       step_name: "check_repo_ci_event"
     capture:
       ci_event: "${{ result.ci_event }}"
-    on_success: check_pr_state
+      ci_applicable: "${{ result.ci_applicable }}"
+    on_success: route_ci_applicable
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     note: >
@@ -720,6 +721,18 @@ steps:
       Uses context.merge_target (feature branch) so push.branches filter
       is evaluated against the actual branch being pushed, not the base branch.
       Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).
+
+  route_ci_applicable:
+    action: route
+    on_result:
+      - when: "${{ context.ci_applicable }} == false"
+        route: check_repo_merge_state
+      - route: check_pr_state
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Short-circuits CI wait when no workflow trigger matches the feature branch.
+      ci_applicable=false means neither push nor merge_group triggers apply,
+      so wait_for_ci would exhaust its timeout budget with zero CI runs.
 
   check_pr_state:
     tool: check_pr_mergeable

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -39,6 +39,10 @@ from autoskillit.server._notify import track_response_size
 
 logger = get_logger(__name__)
 
+_PR_CREATE_RECIPES: frozenset[str] = frozenset(
+    {"merge-prs", "implementation", "implementation-groups", "remediation"}
+)
+
 
 def _kitchen_failure_envelope(
     exc: BaseException,
@@ -112,6 +116,25 @@ def _write_hook_config() -> None:
         atomic_write(hook_cfg_path, json.dumps(payload))
     except OSError:
         logger.warning("hook_config_write_failed", path=str(hook_cfg_path))
+
+
+def _update_hook_config_with_recipe() -> None:
+    """Enrich .hook_config.json with recipe-level authorization after recipe loading."""
+    from autoskillit.server import _get_ctx, logger
+
+    ctx = _get_ctx()
+    hook_cfg_path = _hook_config_path(ctx.project_dir)
+    try:
+        payload = json.loads(hook_cfg_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        logger.warning("hook_config_recipe_update_read_failed", path=str(hook_cfg_path))
+        return
+    if ctx.recipe_name in _PR_CREATE_RECIPES:
+        payload["recipe_allows_pr_create"] = True
+    try:
+        atomic_write(hook_cfg_path, json.dumps(payload))
+    except OSError:
+        logger.warning("hook_config_recipe_update_write_failed", path=str(hook_cfg_path))
 
 
 async def _open_kitchen_handler() -> str | None:
@@ -393,6 +416,13 @@ async def open_kitchen(
             tool_ctx.recipe_content_hash = result.get("content_hash", "")
             tool_ctx.recipe_composite_hash = result.get("composite_hash", "")
             tool_ctx.recipe_version = result.get("recipe_version") or ""
+
+            try:
+                _update_hook_config_with_recipe()
+            except Exception:
+                logger.warning(
+                    "open_kitchen_failure", stage="update_hook_config_recipe", exc_info=True
+                )
 
             composite = result.get("composite_hash", "")
             from autoskillit.server._state import _check_rerun  # noqa: PLC0415

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -363,3 +363,47 @@ async def test_push_trigger_branches_ignore_allows_feature_branch(httpx_mock):
         token=None,
     )
     assert result["ci_event"] == "push"
+
+
+# ---------------------------------------------------------------------------
+# ci_applicable field tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ci_applicable_true_when_push_trigger(httpx_mock):
+    """ci_applicable=True when push trigger matches the branch."""
+    workflow_text = "on:\n  push:\n    branches: [main]\n"
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(owner="o", repo="r", branch="main", token=None)
+    assert result["ci_applicable"] is True
+    assert result["ci_event"] == "push"
+
+
+@pytest.mark.anyio
+async def test_ci_applicable_true_when_merge_group_only(httpx_mock):
+    """ci_applicable=True when merge_group trigger exists but push doesn't match."""
+    workflow_text = "on:\n  merge_group:\n"
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(owner="o", repo="r", branch="feature/x", token=None)
+    assert result["ci_applicable"] is True
+    assert result["ci_event"] is None
+
+
+@pytest.mark.anyio
+async def test_ci_applicable_false_when_no_triggers(httpx_mock):
+    """ci_applicable=False when no push or merge_group triggers exist."""
+    workflow_text = "on:\n  schedule:\n    - cron: '0 0 * * *'\n"
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(owner="o", repo="r", branch="main", token=None)
+    assert result["ci_applicable"] is False
+    assert result["ci_event"] is None

--- a/tests/infra/test_pr_create_guard.py
+++ b/tests/infra/test_pr_create_guard.py
@@ -331,3 +331,89 @@ class TestOrchestratorSessionExemption:
             session_type=None,
         )
         assert _is_denied(out), "Missing session type must be denied"
+
+
+# ---------------------------------------------------------------------------
+# Interactive kitchen exemption via recipe authorization
+# ---------------------------------------------------------------------------
+
+
+class TestInteractiveKitchenExemption:
+    """Interactive kitchen sessions with recipe_allows_pr_create must be allowed."""
+
+    def test_interactive_kitchen_with_recipe_allows_pr_create(self, tmp_path) -> None:
+        """Kitchen open + recipe_allows_pr_create=true → allow."""
+        hook_cfg = tmp_path / _HOOK_CONFIG_RELPATH
+        hook_cfg.parent.mkdir(parents=True, exist_ok=True)
+        hook_cfg.write_text(
+            json.dumps(
+                {
+                    "recipe_allows_pr_create": True,
+                    "quota_guard": {"cache_max_age": 300},
+                    "kitchen_id": "test-kitchen-id",
+                }
+            )
+        )
+        from autoskillit.hooks.guards.pr_create_guard import main
+
+        stdin_content = json.dumps(
+            {
+                "tool_name": _TOOL_NAME,
+                "tool_input": {"cmd": "gh pr create --title foo --body bar"},
+            }
+        )
+        clean_env = _make_clean_env(skill_name=None, session_type=None)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with unittest.mock.patch.dict(os.environ, clean_env, clear=True):
+                with unittest.mock.patch("sys.stdin", io.StringIO(stdin_content)):
+                    with unittest.mock.patch("pathlib.Path.cwd", return_value=tmp_path):
+                        try:
+                            main()
+                        except SystemExit as exc:
+                            assert exc.code == 0
+
+        assert buf.getvalue().strip() == "", (
+            "Interactive kitchen with recipe_allows_pr_create must be allowed"
+        )
+
+    def test_interactive_kitchen_without_recipe_flag_still_denied(self, tmp_path) -> None:
+        """Kitchen open + no recipe_allows_pr_create → deny."""
+        out = _run_guard(
+            "gh pr create --title foo --body bar",
+            kitchen_open=True,
+            tmpdir=tmp_path,
+            skill_name=None,
+            session_type=None,
+        )
+        assert _is_denied(out), "Kitchen open without recipe flag must be denied"
+
+    def test_interactive_kitchen_recipe_flag_false_still_denied(self, tmp_path) -> None:
+        """Kitchen open + recipe_allows_pr_create=false → deny."""
+        hook_cfg = tmp_path / _HOOK_CONFIG_RELPATH
+        hook_cfg.parent.mkdir(parents=True, exist_ok=True)
+        hook_cfg.write_text(json.dumps({"recipe_allows_pr_create": False, "kitchen_id": "test"}))
+        from autoskillit.hooks.guards.pr_create_guard import main
+
+        stdin_content = json.dumps(
+            {
+                "tool_name": _TOOL_NAME,
+                "tool_input": {"cmd": "gh pr create --title foo"},
+            }
+        )
+        clean_env = _make_clean_env(skill_name=None, session_type=None)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with unittest.mock.patch.dict(os.environ, clean_env, clear=True):
+                with unittest.mock.patch("sys.stdin", io.StringIO(stdin_content)):
+                    with unittest.mock.patch("pathlib.Path.cwd", return_value=tmp_path):
+                        try:
+                            main()
+                        except SystemExit as exc:
+                            assert exc.code == 0
+
+        assert _is_denied(buf.getvalue()), (
+            "Kitchen open with recipe_allows_pr_create=false must be denied"
+        )

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -117,8 +117,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 63),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools/tools_kitchen.py", 112),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 555),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 116),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 135),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 585),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 486),
     # tools_github.py — bug report dict

--- a/tests/infra/test_session_type_exemption_enforcement.py
+++ b/tests/infra/test_session_type_exemption_enforcement.py
@@ -172,6 +172,21 @@ def test_pr_create_guard_exempt_session_types_matches_hookdef() -> None:
     )
 
 
+def test_pr_create_guard_has_interactive_kitchen_pass_case() -> None:
+    """test_pr_create_guard.py must have at least one test where kitchen_open=True,
+    no session type env var is set, and the guard allows via recipe authorization."""
+    test_file = _find_test_file("guards/pr_create_guard.py")
+    assert test_file is not None
+    source = test_file.read_text(encoding="utf-8")
+    assert "recipe_allows_pr_create" in source, (
+        "test_pr_create_guard.py must have at least one test exercising the "
+        "recipe_allows_pr_create authorization path (interactive kitchen session)."
+    )
+    assert "TestInteractiveKitchenExemption" in source, (
+        "test_pr_create_guard.py must have a TestInteractiveKitchenExemption test class."
+    )
+
+
 def test_canonical_registry_payload_includes_exempt_session_types() -> None:
     """exempt_session_types must be part of the canonical registry payload used for hashing.
 

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -71,6 +71,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_plan_visualization_step.py` | Tests for plan visualization step in recipes |
 | `test_planner_recipe.py` | Tests for the planner recipe structure |
 | `test_promote_to_main_wrapper.py` | Tests for the promote-to-main wrapper recipe |
+| `test_recipe_ci_applicable_routing.py` | Structural tests for ci_applicable routing guards across all wait_for_ci chains |
 | `test_recipe_ci_contracts.py` | Cross-recipe ci_event/branch coherence and remote_url structural tests |
 | `test_recipe_ci_watch_event.py` | Tests for CI watch event in recipe steps |
 | `test_recipe_order.py` | Tests for BUNDLED_RECIPE_ORDER stable display order registry |

--- a/tests/recipe/conftest.py
+++ b/tests/recipe/conftest.py
@@ -100,6 +100,87 @@ def _write_yaml(path: Path, data: dict) -> Path:
     return path
 
 
+PRIMARY_CI_EVENT_KEYS = {"ci_event", "conflict_ci_event"}
+
+
+def build_reverse_graph(steps: dict) -> dict[str, set[str]]:
+    """Build a reverse routing graph: step -> set of steps that route to it."""
+    reverse: dict[str, set[str]] = {}
+    for name, step in steps.items():
+        for key in ("on_success", "on_failure"):
+            target = step.get(key)
+            if target:
+                reverse.setdefault(target, set()).add(name)
+        on_result = step.get("on_result", [])
+        if isinstance(on_result, list):
+            for cond in on_result:
+                if isinstance(cond, dict):
+                    target = cond.get("route")
+                    if target:
+                        reverse.setdefault(target, set()).add(name)
+                elif isinstance(cond, str):
+                    reverse.setdefault(cond, set()).add(name)
+        elif isinstance(on_result, dict):
+            for target in on_result.get("routes", {}).values():
+                if target:
+                    reverse.setdefault(target, set()).add(name)
+    return reverse
+
+
+def has_wait_for_ci_predecessor(steps: dict, step_name: str, reverse_graph: dict) -> bool:
+    """Return True if a wait_for_ci step exists upstream of step_name."""
+    visited: set[str] = set()
+    queue = list(reverse_graph.get(step_name, set()))
+    while queue:
+        node = queue.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        node_step = steps.get(node, {})
+        if node_step.get("tool") == "wait_for_ci":
+            return True
+        queue.extend(reverse_graph.get(node, set()) - visited)
+    return False
+
+
+def reaches_wait_for_ci(steps: dict, start: str, depth: int = 5) -> bool:
+    """BFS from start to check if wait_for_ci is reachable within depth hops."""
+    visited: set[str] = set()
+    queue = [start]
+    for _ in range(depth):
+        next_queue: list[str] = []
+        for node in queue:
+            if node in visited:
+                continue
+            visited.add(node)
+            node_step = steps.get(node, {})
+            if node_step.get("tool") == "wait_for_ci":
+                return True
+            for key in ("on_success", "on_failure"):
+                target = node_step.get(key)
+                if target and target in steps and target not in visited:
+                    next_queue.append(target)
+            on_result = node_step.get("on_result", [])
+            if isinstance(on_result, list):
+                for cond in on_result:
+                    if isinstance(cond, dict):
+                        target = cond.get("route")
+                    elif isinstance(cond, str):
+                        target = cond
+                    else:
+                        continue
+                    if target and target in steps and target not in visited:
+                        next_queue.append(target)
+            elif isinstance(on_result, dict):
+                for target in on_result.get("routes", {}).values():
+                    if target and target in steps and target not in visited:
+                        next_queue.append(target)
+        queue = next_queue
+        if not queue:
+            break
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Audit trail test fixtures
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -717,7 +717,14 @@ def test_pre_ci_watch_mergeable_check_exists(recipe_name: str) -> None:
     assert conflicting_routes, "CONFLICTING condition must be handled"
     assert "ci_watch" not in conflicting_routes, "CONFLICTING must not route to ci_watch"
     ci_event_step = recipe.steps["check_repo_ci_event"]
-    assert ci_event_step.on_success == "check_pr_state"
+    next_step = ci_event_step.on_success
+    if next_step == "route_ci_applicable":
+        route_step = recipe.steps["route_ci_applicable"]
+        assert route_step.action == "route"
+        route_targets = {c.route for c in route_step.on_result.conditions}
+        assert "check_pr_state" in route_targets
+    else:
+        assert next_step == "check_pr_state"
 
 
 @pytest.mark.parametrize("recipe_name", ["remediation", "implementation", "implementation-groups"])

--- a/tests/recipe/test_recipe_ci_applicable_routing.py
+++ b/tests/recipe/test_recipe_ci_applicable_routing.py
@@ -27,18 +27,52 @@ def recipe_data(request):
         return request.param.stem, yaml.safe_load(f)
 
 
+_PRIMARY_CI_EVENT_KEYS = {"ci_event", "conflict_ci_event"}
+
+
 def _find_ci_event_capture_steps(steps: dict) -> list[tuple[str, dict]]:
-    """Find steps that capture ci_event from check_repo_merge_state."""
+    """Find steps that capture a primary ci_event from check_repo_merge_state.
+
+    Only matches ci_event and conflict_ci_event — not secondary variants like
+    pre_enqueue_ci_event, batch_ci_event, etc. which have independent derivation
+    chains.
+    """
     result = []
     for step_name, step in steps.items():
         tool = step.get("tool", "")
         if "check_repo_merge_state" not in tool:
             continue
         capture = step.get("capture") or {}
-        ci_event_vars = [k for k in capture if "ci_event" in k]
-        if ci_event_vars:
+        if capture.keys() & _PRIMARY_CI_EVENT_KEYS:
             result.append((step_name, step))
     return result
+
+
+def _reaches_wait_for_ci(steps: dict, start: str, depth: int = 5) -> bool:
+    """BFS from start to check if wait_for_ci is reachable within depth hops."""
+    visited: set[str] = set()
+    queue = [start]
+    for _ in range(depth):
+        next_queue: list[str] = []
+        for node in queue:
+            if node in visited:
+                continue
+            visited.add(node)
+            node_step = steps.get(node, {})
+            if node_step.get("tool") == "wait_for_ci":
+                return True
+            for key in ("on_success", "on_failure"):
+                target = node_step.get(key)
+                if target and target in steps and target not in visited:
+                    next_queue.append(target)
+            for cond in node_step.get("on_result", []):
+                target = cond.get("route")
+                if target and target in steps and target not in visited:
+                    next_queue.append(target)
+        queue = next_queue
+        if not queue:
+            break
+    return False
 
 
 def _has_ci_applicable_route(steps: dict, from_step: str) -> bool:
@@ -68,6 +102,8 @@ def test_ci_event_capture_steps_have_ci_applicable_routing(recipe_data) -> None:
 
     violations = []
     for step_name, _step in capture_steps:
+        if not _reaches_wait_for_ci(steps, step_name):
+            continue
         if not _has_ci_applicable_route(steps, step_name):
             violations.append(step_name)
 

--- a/tests/recipe/test_recipe_ci_applicable_routing.py
+++ b/tests/recipe/test_recipe_ci_applicable_routing.py
@@ -1,0 +1,116 @@
+"""Structural tests: ci_applicable routing guards for all wait_for_ci routing chains.
+
+Every recipe that captures ci_event from check_repo_merge_state must also capture
+ci_applicable and have an action:route step that checks it before reaching
+wait_for_ci. This prevents 600s timeout waste when no CI workflows apply.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import yaml
+
+from autoskillit.recipe.io import builtin_recipes_dir
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_CI_APPLICABLE_RE = re.compile(r"ci_applicable")
+
+RECIPE_FILES = sorted(builtin_recipes_dir().glob("*.yaml"))
+
+
+@pytest.fixture(params=RECIPE_FILES, ids=lambda p: p.stem)
+def recipe_data(request):
+    with open(request.param) as f:
+        return request.param.stem, yaml.safe_load(f)
+
+
+def _find_ci_event_capture_steps(steps: dict) -> list[tuple[str, dict]]:
+    """Find steps that capture ci_event from check_repo_merge_state."""
+    result = []
+    for step_name, step in steps.items():
+        tool = step.get("tool", "")
+        if "check_repo_merge_state" not in tool:
+            continue
+        capture = step.get("capture") or {}
+        ci_event_vars = [k for k in capture if "ci_event" in k]
+        if ci_event_vars:
+            result.append((step_name, step))
+    return result
+
+
+def _has_ci_applicable_route(steps: dict, from_step: str) -> bool:
+    """Check if there's an action:route step that checks ci_applicable on the path."""
+    step = steps.get(from_step, {})
+    for target_key in ("on_success", "on_failure"):
+        target = step.get(target_key)
+        if target and target in steps:
+            route_step = steps[target]
+            if route_step.get("action") == "route":
+                on_result = route_step.get("on_result", [])
+                for condition in on_result:
+                    when = condition.get("when", "")
+                    if _CI_APPLICABLE_RE.search(when):
+                        return True
+    return False
+
+
+def test_ci_event_capture_steps_have_ci_applicable_routing(recipe_data) -> None:
+    """Steps capturing ci_event must route through a ci_applicable guard."""
+    recipe_name, data = recipe_data
+    steps = data.get("steps") or {}
+
+    capture_steps = _find_ci_event_capture_steps(steps)
+    if not capture_steps:
+        pytest.skip(f"{recipe_name}: no check_repo_merge_state steps capturing ci_event")
+
+    violations = []
+    for step_name, _step in capture_steps:
+        if not _has_ci_applicable_route(steps, step_name):
+            violations.append(step_name)
+
+    assert not violations, (
+        f"{recipe_name}: check_repo_merge_state steps capturing ci_event lack "
+        f"ci_applicable routing guard: {violations}. Insert an action:route step "
+        f"that checks ci_applicable between the capture and wait_for_ci."
+    )
+
+
+def test_merge_prs_routes_around_ci_wait_when_not_applicable(recipe_data) -> None:
+    """merge-prs must have ci_applicable routing for conflict CI path."""
+    recipe_name, data = recipe_data
+    if recipe_name != "merge-prs":
+        pytest.skip("merge-prs only")
+    steps = data.get("steps") or {}
+    assert "route_conflict_ci" in steps, "merge-prs must have route_conflict_ci step"
+    route_step = steps["route_conflict_ci"]
+    assert route_step.get("action") == "route"
+    on_result = route_step.get("on_result", [])
+    has_false_guard = any(
+        "ci_applicable" in (c.get("when", "") or "") and "false" in (c.get("when", "") or "")
+        for c in on_result
+    )
+    assert has_false_guard, "route_conflict_ci must check ci_applicable == false"
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["implementation", "implementation-groups", "remediation"],
+)
+def test_impl_recipes_route_around_ci_wait_when_not_applicable(recipe_name) -> None:
+    """implementation/implementation-groups/remediation must have ci_applicable routing."""
+    recipe_path = builtin_recipes_dir() / f"{recipe_name}.yaml"
+    with open(recipe_path) as f:
+        data = yaml.safe_load(f)
+    steps = data.get("steps") or {}
+    assert "route_ci_applicable" in steps, f"{recipe_name} must have route_ci_applicable step"
+    route_step = steps["route_ci_applicable"]
+    assert route_step.get("action") == "route"
+    on_result = route_step.get("on_result", [])
+    has_false_guard = any(
+        "ci_applicable" in (c.get("when", "") or "") and "false" in (c.get("when", "") or "")
+        for c in on_result
+    )
+    assert has_false_guard, f"{recipe_name}: route_ci_applicable must check ci_applicable == false"

--- a/tests/recipe/test_recipe_ci_applicable_routing.py
+++ b/tests/recipe/test_recipe_ci_applicable_routing.py
@@ -67,6 +67,8 @@ def _has_ci_applicable_route(steps: dict, from_step: str) -> bool:
             if route_step.get("action") == "route":
                 on_result = route_step.get("on_result", [])
                 for condition in on_result:
+                    if isinstance(condition, str):
+                        continue
                     when = condition.get("when", "")
                     if _CI_APPLICABLE_RE.search(when):
                         return True

--- a/tests/recipe/test_recipe_ci_applicable_routing.py
+++ b/tests/recipe/test_recipe_ci_applicable_routing.py
@@ -30,21 +30,66 @@ def recipe_data(request):
 _PRIMARY_CI_EVENT_KEYS = {"ci_event", "conflict_ci_event"}
 
 
+def _build_reverse_graph(steps: dict) -> dict[str, set[str]]:
+    """Build a reverse routing graph: step → set of steps that route to it."""
+    reverse: dict[str, set[str]] = {}
+    for name, step in steps.items():
+        for key in ("on_success", "on_failure"):
+            target = step.get(key)
+            if target:
+                reverse.setdefault(target, set()).add(name)
+        on_result = step.get("on_result", [])
+        if isinstance(on_result, list):
+            for cond in on_result:
+                if isinstance(cond, dict):
+                    target = cond.get("route")
+                    if target:
+                        reverse.setdefault(target, set()).add(name)
+                elif isinstance(cond, str):
+                    reverse.setdefault(cond, set()).add(name)
+        elif isinstance(on_result, dict):
+            for target in on_result.get("routes", {}).values():
+                if target:
+                    reverse.setdefault(target, set()).add(name)
+    return reverse
+
+
+def _has_wait_for_ci_predecessor(steps: dict, step_name: str, reverse_graph: dict) -> bool:
+    """Return True if a wait_for_ci step exists upstream of step_name."""
+    visited: set[str] = set()
+    queue = list(reverse_graph.get(step_name, set()))
+    while queue:
+        node = queue.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        node_step = steps.get(node, {})
+        if node_step.get("tool") == "wait_for_ci":
+            return True
+        queue.extend(reverse_graph.get(node, set()) - visited)
+    return False
+
+
 def _find_ci_event_capture_steps(steps: dict) -> list[tuple[str, dict]]:
     """Find steps that capture a primary ci_event from check_repo_merge_state.
 
     Only matches ci_event and conflict_ci_event — not secondary variants like
     pre_enqueue_ci_event, batch_ci_event, etc. which have independent derivation
-    chains.
+    chains. Excludes re-derivation steps that are downstream of a wait_for_ci
+    step (e.g. handle_no_ci_runs).
     """
+    reverse_graph = _build_reverse_graph(steps)
     result = []
     for step_name, step in steps.items():
         tool = step.get("tool", "")
         if "check_repo_merge_state" not in tool:
             continue
         capture = step.get("capture") or {}
-        if capture.keys() & _PRIMARY_CI_EVENT_KEYS:
-            result.append((step_name, step))
+        if not (capture.keys() & _PRIMARY_CI_EVENT_KEYS):
+            continue
+        if _has_wait_for_ci_predecessor(steps, step_name, reverse_graph):
+            continue
+        result.append((step_name, step))
     return result
 
 
@@ -65,10 +110,21 @@ def _reaches_wait_for_ci(steps: dict, start: str, depth: int = 5) -> bool:
                 target = node_step.get(key)
                 if target and target in steps and target not in visited:
                     next_queue.append(target)
-            for cond in node_step.get("on_result", []):
-                target = cond.get("route")
-                if target and target in steps and target not in visited:
-                    next_queue.append(target)
+            on_result = node_step.get("on_result", [])
+            if isinstance(on_result, list):
+                for cond in on_result:
+                    if isinstance(cond, dict):
+                        target = cond.get("route")
+                    elif isinstance(cond, str):
+                        target = cond
+                    else:
+                        continue
+                    if target and target in steps and target not in visited:
+                        next_queue.append(target)
+            elif isinstance(on_result, dict):
+                for target in on_result.get("routes", {}).values():
+                    if target and target in steps and target not in visited:
+                        next_queue.append(target)
         queue = next_queue
         if not queue:
             break

--- a/tests/recipe/test_recipe_ci_applicable_routing.py
+++ b/tests/recipe/test_recipe_ci_applicable_routing.py
@@ -14,6 +14,13 @@ import yaml
 
 from autoskillit.recipe.io import builtin_recipes_dir
 
+from .conftest import (
+    PRIMARY_CI_EVENT_KEYS,
+    build_reverse_graph,
+    has_wait_for_ci_predecessor,
+    reaches_wait_for_ci,
+)
+
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _CI_APPLICABLE_RE = re.compile(r"ci_applicable")
@@ -27,49 +34,6 @@ def recipe_data(request):
         return request.param.stem, yaml.safe_load(f)
 
 
-_PRIMARY_CI_EVENT_KEYS = {"ci_event", "conflict_ci_event"}
-
-
-def _build_reverse_graph(steps: dict) -> dict[str, set[str]]:
-    """Build a reverse routing graph: step → set of steps that route to it."""
-    reverse: dict[str, set[str]] = {}
-    for name, step in steps.items():
-        for key in ("on_success", "on_failure"):
-            target = step.get(key)
-            if target:
-                reverse.setdefault(target, set()).add(name)
-        on_result = step.get("on_result", [])
-        if isinstance(on_result, list):
-            for cond in on_result:
-                if isinstance(cond, dict):
-                    target = cond.get("route")
-                    if target:
-                        reverse.setdefault(target, set()).add(name)
-                elif isinstance(cond, str):
-                    reverse.setdefault(cond, set()).add(name)
-        elif isinstance(on_result, dict):
-            for target in on_result.get("routes", {}).values():
-                if target:
-                    reverse.setdefault(target, set()).add(name)
-    return reverse
-
-
-def _has_wait_for_ci_predecessor(steps: dict, step_name: str, reverse_graph: dict) -> bool:
-    """Return True if a wait_for_ci step exists upstream of step_name."""
-    visited: set[str] = set()
-    queue = list(reverse_graph.get(step_name, set()))
-    while queue:
-        node = queue.pop()
-        if node in visited:
-            continue
-        visited.add(node)
-        node_step = steps.get(node, {})
-        if node_step.get("tool") == "wait_for_ci":
-            return True
-        queue.extend(reverse_graph.get(node, set()) - visited)
-    return False
-
-
 def _find_ci_event_capture_steps(steps: dict) -> list[tuple[str, dict]]:
     """Find steps that capture a primary ci_event from check_repo_merge_state.
 
@@ -78,57 +42,19 @@ def _find_ci_event_capture_steps(steps: dict) -> list[tuple[str, dict]]:
     chains. Excludes re-derivation steps that are downstream of a wait_for_ci
     step (e.g. handle_no_ci_runs).
     """
-    reverse_graph = _build_reverse_graph(steps)
+    reverse_graph = build_reverse_graph(steps)
     result = []
     for step_name, step in steps.items():
         tool = step.get("tool", "")
         if "check_repo_merge_state" not in tool:
             continue
         capture = step.get("capture") or {}
-        if not (capture.keys() & _PRIMARY_CI_EVENT_KEYS):
+        if not (capture.keys() & PRIMARY_CI_EVENT_KEYS):
             continue
-        if _has_wait_for_ci_predecessor(steps, step_name, reverse_graph):
+        if has_wait_for_ci_predecessor(steps, step_name, reverse_graph):
             continue
         result.append((step_name, step))
     return result
-
-
-def _reaches_wait_for_ci(steps: dict, start: str, depth: int = 5) -> bool:
-    """BFS from start to check if wait_for_ci is reachable within depth hops."""
-    visited: set[str] = set()
-    queue = [start]
-    for _ in range(depth):
-        next_queue: list[str] = []
-        for node in queue:
-            if node in visited:
-                continue
-            visited.add(node)
-            node_step = steps.get(node, {})
-            if node_step.get("tool") == "wait_for_ci":
-                return True
-            for key in ("on_success", "on_failure"):
-                target = node_step.get(key)
-                if target and target in steps and target not in visited:
-                    next_queue.append(target)
-            on_result = node_step.get("on_result", [])
-            if isinstance(on_result, list):
-                for cond in on_result:
-                    if isinstance(cond, dict):
-                        target = cond.get("route")
-                    elif isinstance(cond, str):
-                        target = cond
-                    else:
-                        continue
-                    if target and target in steps and target not in visited:
-                        next_queue.append(target)
-            elif isinstance(on_result, dict):
-                for target in on_result.get("routes", {}).values():
-                    if target and target in steps and target not in visited:
-                        next_queue.append(target)
-        queue = next_queue
-        if not queue:
-            break
-    return False
 
 
 def _has_ci_applicable_route(steps: dict, from_step: str) -> bool:
@@ -158,7 +84,7 @@ def test_ci_event_capture_steps_have_ci_applicable_routing(recipe_data) -> None:
 
     violations = []
     for step_name, _step in capture_steps:
-        if not _reaches_wait_for_ci(steps, step_name):
+        if not reaches_wait_for_ci(steps, step_name):
             continue
         if not _has_ci_applicable_route(steps, step_name):
             violations.append(step_name)

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -125,15 +125,55 @@ def test_wait_for_ci_steps_have_remote_url(recipe_data) -> None:
 _PRIMARY_CI_EVENT_KEYS = {"ci_event", "conflict_ci_event"}
 
 
+def _build_reverse_graph(steps: dict) -> dict[str, set[str]]:
+    """Build a reverse routing graph: step -> set of steps that route to it."""
+    reverse: dict[str, set[str]] = {}
+    for name, step in steps.items():
+        for key in ("on_success", "on_failure"):
+            target = step.get(key)
+            if target:
+                reverse.setdefault(target, set()).add(name)
+        on_result = step.get("on_result", [])
+        if isinstance(on_result, list):
+            for cond in on_result:
+                if isinstance(cond, dict):
+                    target = cond.get("route")
+                    if target:
+                        reverse.setdefault(target, set()).add(name)
+        elif isinstance(on_result, dict):
+            for target in on_result.get("routes", {}).values():
+                if target:
+                    reverse.setdefault(target, set()).add(name)
+    return reverse
+
+
+def _has_wait_for_ci_predecessor(steps: dict, step_name: str, reverse_graph: dict) -> bool:
+    """Return True if a wait_for_ci step exists upstream of step_name."""
+    visited: set[str] = set()
+    queue = list(reverse_graph.get(step_name, set()))
+    while queue:
+        node = queue.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        node_step = steps.get(node, {})
+        if node_step.get("tool") == "wait_for_ci":
+            return True
+        queue.extend(reverse_graph.get(node, set()) - visited)
+    return False
+
+
 def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
     """Steps capturing a primary ci_event from check_repo_merge_state must also
     capture the corresponding ci_applicable field.
 
     Only checks ci_event and conflict_ci_event — secondary variants like
     pre_enqueue_ci_event and batch_ci_event have independent derivation chains.
+    Excludes re-derivation steps downstream of a wait_for_ci step.
     """
     recipe_name, data = recipe_data
     steps = data.get("steps") or {}
+    reverse_graph = _build_reverse_graph(steps)
 
     ci_event_capture_steps = []
     for step_name, step in steps.items():
@@ -141,8 +181,11 @@ def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
         if "check_repo_merge_state" not in tool:
             continue
         capture = step.get("capture") or {}
-        if capture.keys() & _PRIMARY_CI_EVENT_KEYS:
-            ci_event_capture_steps.append(step_name)
+        if not (capture.keys() & _PRIMARY_CI_EVENT_KEYS):
+            continue
+        if _has_wait_for_ci_predecessor(steps, step_name, reverse_graph):
+            continue
+        ci_event_capture_steps.append(step_name)
 
     if not ci_event_capture_steps:
         pytest.skip(f"{recipe_name}: no check_repo_merge_state steps capturing primary ci_event")

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -120,3 +120,38 @@ def test_wait_for_ci_steps_have_remote_url(recipe_data) -> None:
             missing.append(step_name)
 
     assert not missing, f"{recipe_name}: wait_for_ci steps missing remote_url: {missing}"
+
+
+def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
+    """Steps capturing ci_event from check_repo_merge_state must have a ci_applicable guard.
+
+    Structural contract: every check_repo_merge_state step that captures ci_event
+    and routes to a wait_for_ci step (directly or via intermediaries) must also
+    capture ci_applicable and route through an action:route step that checks it.
+    """
+    recipe_name, data = recipe_data
+    steps = data.get("steps") or {}
+
+    ci_event_capture_steps = []
+    for step_name, step in steps.items():
+        tool = step.get("tool", "")
+        if "check_repo_merge_state" not in tool:
+            continue
+        capture = step.get("capture") or {}
+        if any("ci_event" in k for k in capture):
+            ci_event_capture_steps.append(step_name)
+
+    if not ci_event_capture_steps:
+        pytest.skip(f"{recipe_name}: no check_repo_merge_state steps capturing ci_event")
+
+    violations = []
+    for step_name in ci_event_capture_steps:
+        step = steps[step_name]
+        capture = step.get("capture") or {}
+        has_applicable_capture = any("ci_applicable" in k for k in capture)
+        if not has_applicable_capture:
+            violations.append(f"{step_name}: captures ci_event but not ci_applicable")
+
+    assert not violations, f"{recipe_name}: ci_event capture without ci_applicable:\n" + "\n".join(
+        f"  - {v}" for v in violations
+    )

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -122,12 +122,15 @@ def test_wait_for_ci_steps_have_remote_url(recipe_data) -> None:
     assert not missing, f"{recipe_name}: wait_for_ci steps missing remote_url: {missing}"
 
 
-def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
-    """Steps capturing ci_event from check_repo_merge_state must have a ci_applicable guard.
+_PRIMARY_CI_EVENT_KEYS = {"ci_event", "conflict_ci_event"}
 
-    Structural contract: every check_repo_merge_state step that captures ci_event
-    and routes to a wait_for_ci step (directly or via intermediaries) must also
-    capture ci_applicable and route through an action:route step that checks it.
+
+def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
+    """Steps capturing a primary ci_event from check_repo_merge_state must also
+    capture the corresponding ci_applicable field.
+
+    Only checks ci_event and conflict_ci_event — secondary variants like
+    pre_enqueue_ci_event and batch_ci_event have independent derivation chains.
     """
     recipe_name, data = recipe_data
     steps = data.get("steps") or {}
@@ -138,11 +141,11 @@ def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
         if "check_repo_merge_state" not in tool:
             continue
         capture = step.get("capture") or {}
-        if any("ci_event" in k for k in capture):
+        if capture.keys() & _PRIMARY_CI_EVENT_KEYS:
             ci_event_capture_steps.append(step_name)
 
     if not ci_event_capture_steps:
-        pytest.skip(f"{recipe_name}: no check_repo_merge_state steps capturing ci_event")
+        pytest.skip(f"{recipe_name}: no check_repo_merge_state steps capturing primary ci_event")
 
     violations = []
     for step_name in ci_event_capture_steps:

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -163,13 +163,48 @@ def _has_wait_for_ci_predecessor(steps: dict, step_name: str, reverse_graph: dic
     return False
 
 
+def _reaches_wait_for_ci(steps: dict, start: str, depth: int = 5) -> bool:
+    """BFS from start to check if wait_for_ci is reachable within depth hops."""
+    visited: set[str] = set()
+    queue = [start]
+    for _ in range(depth):
+        next_queue: list[str] = []
+        for node in queue:
+            if node in visited:
+                continue
+            visited.add(node)
+            node_step = steps.get(node, {})
+            if node_step.get("tool") == "wait_for_ci":
+                return True
+            for key in ("on_success", "on_failure"):
+                target = node_step.get(key)
+                if target and target in steps and target not in visited:
+                    next_queue.append(target)
+            on_result = node_step.get("on_result", [])
+            if isinstance(on_result, list):
+                for cond in on_result:
+                    if isinstance(cond, dict):
+                        target = cond.get("route")
+                        if target and target in steps and target not in visited:
+                            next_queue.append(target)
+            elif isinstance(on_result, dict):
+                for target in on_result.get("routes", {}).values():
+                    if target and target in steps and target not in visited:
+                        next_queue.append(target)
+        queue = next_queue
+        if not queue:
+            break
+    return False
+
+
 def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
     """Steps capturing a primary ci_event from check_repo_merge_state must also
-    capture the corresponding ci_applicable field.
+    capture the corresponding ci_applicable field when they route to wait_for_ci.
 
     Only checks ci_event and conflict_ci_event — secondary variants like
     pre_enqueue_ci_event and batch_ci_event have independent derivation chains.
-    Excludes re-derivation steps downstream of a wait_for_ci step.
+    Excludes re-derivation steps downstream of a wait_for_ci step and
+    diagnostic-only captures that don't feed into a CI wait chain.
     """
     recipe_name, data = recipe_data
     steps = data.get("steps") or {}
@@ -185,10 +220,12 @@ def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
             continue
         if _has_wait_for_ci_predecessor(steps, step_name, reverse_graph):
             continue
+        if not _reaches_wait_for_ci(steps, step_name):
+            continue
         ci_event_capture_steps.append(step_name)
 
     if not ci_event_capture_steps:
-        pytest.skip(f"{recipe_name}: no check_repo_merge_state steps capturing primary ci_event")
+        pytest.skip(f"{recipe_name}: no check_repo_merge_state steps feeding wait_for_ci")
 
     violations = []
     for step_name in ci_event_capture_steps:

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -15,6 +15,13 @@ import yaml
 
 from autoskillit.recipe.io import builtin_recipes_dir
 
+from .conftest import (
+    PRIMARY_CI_EVENT_KEYS,
+    build_reverse_graph,
+    has_wait_for_ci_predecessor,
+    reaches_wait_for_ci,
+)
+
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _TEMPLATE_RE = re.compile(r"\$\{\{\s*(.+?)\s*\}\}")
@@ -122,81 +129,6 @@ def test_wait_for_ci_steps_have_remote_url(recipe_data) -> None:
     assert not missing, f"{recipe_name}: wait_for_ci steps missing remote_url: {missing}"
 
 
-_PRIMARY_CI_EVENT_KEYS = {"ci_event", "conflict_ci_event"}
-
-
-def _build_reverse_graph(steps: dict) -> dict[str, set[str]]:
-    """Build a reverse routing graph: step -> set of steps that route to it."""
-    reverse: dict[str, set[str]] = {}
-    for name, step in steps.items():
-        for key in ("on_success", "on_failure"):
-            target = step.get(key)
-            if target:
-                reverse.setdefault(target, set()).add(name)
-        on_result = step.get("on_result", [])
-        if isinstance(on_result, list):
-            for cond in on_result:
-                if isinstance(cond, dict):
-                    target = cond.get("route")
-                    if target:
-                        reverse.setdefault(target, set()).add(name)
-        elif isinstance(on_result, dict):
-            for target in on_result.get("routes", {}).values():
-                if target:
-                    reverse.setdefault(target, set()).add(name)
-    return reverse
-
-
-def _has_wait_for_ci_predecessor(steps: dict, step_name: str, reverse_graph: dict) -> bool:
-    """Return True if a wait_for_ci step exists upstream of step_name."""
-    visited: set[str] = set()
-    queue = list(reverse_graph.get(step_name, set()))
-    while queue:
-        node = queue.pop()
-        if node in visited:
-            continue
-        visited.add(node)
-        node_step = steps.get(node, {})
-        if node_step.get("tool") == "wait_for_ci":
-            return True
-        queue.extend(reverse_graph.get(node, set()) - visited)
-    return False
-
-
-def _reaches_wait_for_ci(steps: dict, start: str, depth: int = 5) -> bool:
-    """BFS from start to check if wait_for_ci is reachable within depth hops."""
-    visited: set[str] = set()
-    queue = [start]
-    for _ in range(depth):
-        next_queue: list[str] = []
-        for node in queue:
-            if node in visited:
-                continue
-            visited.add(node)
-            node_step = steps.get(node, {})
-            if node_step.get("tool") == "wait_for_ci":
-                return True
-            for key in ("on_success", "on_failure"):
-                target = node_step.get(key)
-                if target and target in steps and target not in visited:
-                    next_queue.append(target)
-            on_result = node_step.get("on_result", [])
-            if isinstance(on_result, list):
-                for cond in on_result:
-                    if isinstance(cond, dict):
-                        target = cond.get("route")
-                        if target and target in steps and target not in visited:
-                            next_queue.append(target)
-            elif isinstance(on_result, dict):
-                for target in on_result.get("routes", {}).values():
-                    if target and target in steps and target not in visited:
-                        next_queue.append(target)
-        queue = next_queue
-        if not queue:
-            break
-    return False
-
-
 def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
     """Steps capturing a primary ci_event from check_repo_merge_state must also
     capture the corresponding ci_applicable field when they route to wait_for_ci.
@@ -208,7 +140,7 @@ def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
     """
     recipe_name, data = recipe_data
     steps = data.get("steps") or {}
-    reverse_graph = _build_reverse_graph(steps)
+    reverse_graph = build_reverse_graph(steps)
 
     ci_event_capture_steps = []
     for step_name, step in steps.items():
@@ -216,11 +148,11 @@ def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
         if "check_repo_merge_state" not in tool:
             continue
         capture = step.get("capture") or {}
-        if not (capture.keys() & _PRIMARY_CI_EVENT_KEYS):
+        if not (capture.keys() & PRIMARY_CI_EVENT_KEYS):
             continue
-        if _has_wait_for_ci_predecessor(steps, step_name, reverse_graph):
+        if has_wait_for_ci_predecessor(steps, step_name, reverse_graph):
             continue
-        if not _reaches_wait_for_ci(steps, step_name):
+        if not reaches_wait_for_ci(steps, step_name):
             continue
         ci_event_capture_steps.append(step_name)
 

--- a/tests/recipe/test_recipe_ci_watch_event.py
+++ b/tests/recipe/test_recipe_ci_watch_event.py
@@ -45,9 +45,10 @@ def test_check_repo_ci_event_step_exists_before_ci_watch(recipe_path: str) -> No
     assert "ci_event" in capture, (
         f"{recipe_path}: check_repo_ci_event must capture ci_event into context"
     )
-    assert early_step.get("on_success") in ("ci_watch", "check_pr_state"), (
-        f"{recipe_path}: check_repo_ci_event.on_success must route to ci_watch or check_pr_state"
+    assert early_step.get("on_success") in ("ci_watch", "check_pr_state", "route_ci_applicable"), (
+        f"{recipe_path}: check_repo_ci_event.on_success must route to ci_watch, check_pr_state, or route_ci_applicable"
     )
-    assert early_step.get("on_failure") == "ci_watch", (
-        f"{recipe_path}: check_repo_ci_event.on_failure must be ci_watch (non-blocking)"
+    on_failure = early_step.get("on_failure")
+    assert on_failure in ("ci_watch", "check_integration_exists"), (
+        f"{recipe_path}: check_repo_ci_event.on_failure must be ci_watch or check_integration_exists (non-blocking)"
     )

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -857,3 +857,74 @@ def test_get_recipe_uses_project_dir(tmp_path, monkeypatch):
     assert "test-get-recipe-project-dir" in result, (
         f"get_recipe did not return the recipe from project_dir. Result: {result}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _update_hook_config_with_recipe — recipe authorization in hook config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_update_hook_config_with_recipe_includes_recipe_allows_pr_create(
+    tmp_path, monkeypatch
+):
+    """_update_hook_config_with_recipe adds recipe_allows_pr_create for PR-creating recipes."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.recipe_name = "merge-prs"
+    mock_ctx.kitchen_id = "test-kitchen-id"
+    mock_ctx.config.quota_guard.cache_max_age = 300
+    mock_ctx.config.quota_guard.cache_path = "/p/q.json"
+    mock_ctx.config.quota_guard.buffer_seconds = 60
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                from autoskillit.server.tools.tools_kitchen import (
+                    _open_kitchen_handler,
+                    _update_hook_config_with_recipe,
+                )
+
+                await _open_kitchen_handler()
+                _update_hook_config_with_recipe()
+
+    hook_cfg = tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS)
+    data = json.loads(hook_cfg.read_text())
+    assert data["recipe_allows_pr_create"] is True
+    assert "quota_guard" in data
+    assert "kitchen_id" in data
+
+
+@pytest.mark.anyio
+async def test_update_hook_config_with_recipe_excludes_pr_create_for_non_pr_recipes(
+    tmp_path, monkeypatch
+):
+    """_update_hook_config_with_recipe does NOT set recipe_allows_pr_create for non-PR recipes."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.recipe_name = "smoke-test"
+    mock_ctx.kitchen_id = "test-kitchen-id"
+    mock_ctx.config.quota_guard.cache_max_age = 300
+    mock_ctx.config.quota_guard.cache_path = "/p/q.json"
+    mock_ctx.config.quota_guard.buffer_seconds = 60
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                from autoskillit.server.tools.tools_kitchen import (
+                    _open_kitchen_handler,
+                    _update_hook_config_with_recipe,
+                )
+
+                await _open_kitchen_handler()
+                _update_hook_config_with_recipe()
+
+    hook_cfg = tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS)
+    data = json.loads(hook_cfg.read_text())
+    assert "recipe_allows_pr_create" not in data


### PR DESCRIPTION
## Summary

Two independent but thematically related architectural weaknesses share the same root pattern: a signal is computed upstream but not propagated to the downstream decision point.

**Issue A:** `pr_create_guard.py` checks `.hook_config.json` existence (signaling "kitchen is open") but the file carries no recipe authorization context — so it cannot distinguish interactive kitchen orchestration (which needs `gh pr create`) from unauthorized ad-hoc calls. Fix: enrich `.hook_config.json` with `recipe_allows_pr_create: true` when a PR-creating recipe is loaded (`open_kitchen` side), and have the guard read this field instead of just checking file existence (guard side).

**Issue B:** `fetch_repo_merge_state` computes `ci_event=null` (meaning "no CI trigger matches this branch") but the recipe routes unconditionally into `wait_for_ci`, which polls with `event=None` for up to 600s per iteration before giving up. Fix: add `ci_applicable: bool` to `fetch_repo_merge_state` return dict, and add `action: route` steps in all 4 affected recipes (`merge-prs.yaml`, `implementation.yaml`, `implementation-groups.yaml`, `remediation.yaml`) that check `ci_applicable` and short-circuit around `wait_for_ci` when false. Also adds a semantic rule `ci-wait-requires-applicability-guard` to prevent future recipes from reintroducing the unconditional routing pattern.

Both gaps stem from the same testing philosophy: unit tests mirror the layered architecture with no cross-layer scenario tests.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260519-222741-323883/.autoskillit/temp/rectify/rectify_guard_ci_routing_immunity_2026-05-19_224500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 46 | 8.7k | 335.4k | 91.8k | 191 | 42.7k | 8m 2s |
| rectify | claude-sonnet-4-6 | 1 | 1.2k | 12.8k | 699.8k | 64.3k | 103 | 56.6k | 7m 49s |
| dry_walkthrough | claude-opus-4-6 | 1 | 2.8k | 19.1k | 2.8M | 97.8k | 207 | 118.0k | 12m 50s |
| implement | claude-opus-4-6 | 1 | 3.0k | 32.1k | 9.4M | 154.6k | 183 | 141.1k | 15m 25s |
| prepare_pr* | MiniMax-M2.7 | 1 | 51.3k | 4.8k | 367.7k | 0 | 25 | 0 | 3m 33s |
| compose_pr* | MiniMax-M2.7 | 1 | 81.3k | 2.8k | 323.9k | 39.4k | 30 | 41.8k | 3m 52s |
| review_pr | claude-opus-4-6 | 3 | 127 | 97.7k | 2.5M | 121.1k | 247 | 277.1k | 42m 31s |
| resolve_review | claude-opus-4-6 | 2 | 134 | 30.6k | 5.1M | 100.0k | 183 | 143.3k | 22m 18s |
| **Total** | | | 140.0k | 208.7k | 21.5M | 154.6k | | 820.7k | 1h 56m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 669 | 14078.3 | 210.9 | 48.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 285 | 17812.0 | 502.7 | 107.2 |
| **Total** | **954** | 22545.0 | 860.2 | 218.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 1.3k | 21.5k | 1.0M | 99.4k | 15m 51s |
| claude-opus-4-6 | 4 | 6.1k | 179.5k | 19.8M | 679.5k | 1h 33m |
| MiniMax-M2.7 | 2 | 132.6k | 7.7k | 691.6k | 41.8k | 7m 25s |