### PR TITLE
Rectify: Recipe Validation Version Skew Immunity

### DIFF
--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -7,6 +7,7 @@ from autoskillit.core import get_logger
 logger = get_logger(__name__)
 
 # Rule registration — import triggers @semantic_rule registration.
+from autoskillit.recipe import registry as _reg  # noqa: E402, PLC0415
 from autoskillit.recipe._api import (  # noqa: E402
     format_recipe_list_response,
     list_all,
@@ -158,6 +159,9 @@ from autoskillit.recipe.validator import (  # noqa: E402
     run_semantic_rules,
     validate_recipe_structure,
 )
+
+_reg._finalize_registry()  # pyright: ignore[reportAttributeAccessIssue]
+del _reg
 
 __all__ = [
     "GROUP_LABELS",

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -180,7 +180,8 @@ def _clear_stale_caches() -> None:
     _block_budgets.cache_clear()
     load_bundled_manifest.cache_clear()
     load_ml_sub_area_folding.cache_clear()
-    _LOAD_CACHE.clear()
+    with _LOAD_CACHE_LOCK:
+        _LOAD_CACHE.clear()
 
 
 def format_recipe_list_response(result: LoadResult[RecipeInfo]) -> dict[str, object]:

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -142,8 +142,8 @@ _LOAD_CACHE: dict[tuple, _LoadCacheEntry] = {}
 _LOAD_CACHE_LOCK = threading.Lock()
 
 _PROCESS_START_PKG_MTIME: int | None = None
-_staleness_last_check: float = 0.0
-_staleness_is_stale: bool = False
+_STALENESS_LAST_CHECK: float = 0.0
+_STALENESS_IS_STALE: bool = False
 _STALENESS_TTL: float = 30.0
 
 
@@ -156,17 +156,17 @@ def _get_process_start_mtime() -> int:
 
 def _check_process_staleness() -> bool:
     """Return True if the package directory was modified after process start."""
-    global _staleness_last_check, _staleness_is_stale  # noqa: PLW0603
+    global _STALENESS_LAST_CHECK, _STALENESS_IS_STALE  # noqa: PLW0603
     now = time.monotonic()
-    if now - _staleness_last_check < _STALENESS_TTL:
-        return _staleness_is_stale
-    _staleness_last_check = now
+    if now - _STALENESS_LAST_CHECK < _STALENESS_TTL:
+        return _STALENESS_IS_STALE
+    _STALENESS_LAST_CHECK = now
     try:
-        _staleness_is_stale = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
+        _STALENESS_IS_STALE = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
     except (OSError, RuntimeError):
         logger.warning("pkg_root() unavailable during staleness check; assuming non-stale")
-        _staleness_is_stale = False
-    return _staleness_is_stale
+        _STALENESS_IS_STALE = False
+    return _STALENESS_IS_STALE
 
 
 def _clear_stale_caches() -> None:

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -134,11 +134,46 @@ class _LoadCacheEntry:
     project_dir_mtime: int
     builtin_dir_mtime: int
     pkg_version: str
+    rule_registry_hash: str
     result: LoadRecipeResult
 
 
 _LOAD_CACHE: dict[tuple, _LoadCacheEntry] = {}
 _LOAD_CACHE_LOCK = threading.Lock()
+
+# ---------------------------------------------------------------------------
+# Process staleness guard
+# ---------------------------------------------------------------------------
+
+_PROCESS_START_PKG_MTIME: int = _path_mtime_ns(pkg_root())
+_staleness_last_check: float = 0.0
+_staleness_is_stale: bool = False
+_STALENESS_TTL: float = 30.0
+
+
+def _check_process_staleness() -> bool:
+    """Return True if the package directory was modified after process start."""
+    global _staleness_last_check, _staleness_is_stale  # noqa: PLW0603
+    now = time.monotonic()
+    if now - _staleness_last_check < _STALENESS_TTL:
+        return _staleness_is_stale
+    _staleness_last_check = now
+    _staleness_is_stale = _path_mtime_ns(pkg_root()) != _PROCESS_START_PKG_MTIME
+    return _staleness_is_stale
+
+
+def _clear_stale_caches() -> None:
+    """Clear all lru_cache helpers and the load cache when staleness is detected."""
+    from autoskillit.recipe.contracts import load_bundled_manifest  # noqa: PLC0415
+    from autoskillit.recipe.methodology_venue_appendix import (  # noqa: PLC0415
+        load_ml_sub_area_folding,
+    )
+    from autoskillit.recipe.rules.rules_blocks import _block_budgets  # noqa: PLC0415
+
+    _block_budgets.cache_clear()
+    load_bundled_manifest.cache_clear()
+    load_ml_sub_area_folding.cache_clear()
+    _LOAD_CACHE.clear()
 
 
 def format_recipe_list_response(result: LoadResult[RecipeInfo]) -> dict[str, object]:
@@ -357,6 +392,16 @@ def load_and_validate(
         {"content": str, "suggestions": list, "valid": bool}
         On not-found: {"error": str}
     """
+    if _check_process_staleness():
+        _clear_stale_caches()
+        return {
+            "error": (
+                "Process is running stale code — package directory was modified on disk "
+                "since server startup. Restart the MCP server via reload_session."
+            ),
+            "valid": False,
+        }
+
     _pdir = project_dir if project_dir is not None else Path.cwd()
     pkg_version = _get_pkg_version()
     project_recipes_dir = _pdir / ".autoskillit" / "recipes"
@@ -390,7 +435,14 @@ def load_and_validate(
     with _LOAD_CACHE_LOCK:
         cached = _LOAD_CACHE.get(cache_key)
 
-    if cached is not None and cached.pkg_version == pkg_version:
+    from autoskillit.recipe import registry as _registry  # noqa: PLC0415
+
+    _rule_hash: str = _registry.RULE_REGISTRY_HASH  # pyright: ignore[reportAttributeAccessIssue]
+    if (
+        cached is not None
+        and cached.pkg_version == pkg_version
+        and cached.rule_registry_hash == _rule_hash
+    ):
         pm = _path_mtime_ns(project_recipes_dir)
         bm = _path_mtime_ns(_builtin_dir)
         rm = _path_mtime_ns(cached.recipe_path)
@@ -619,6 +671,7 @@ def load_and_validate(
             project_dir_mtime=_path_mtime_ns(project_recipes_dir),
             builtin_dir_mtime=_path_mtime_ns(_builtin_dir),
             pkg_version=pkg_version,
+            rule_registry_hash=_rule_hash,
             result=result,
         )
         with _LOAD_CACHE_LOCK:

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -450,6 +450,8 @@ def load_and_validate(
     from autoskillit.recipe import registry as _registry  # noqa: PLC0415
 
     _rule_hash: str = _registry.RULE_REGISTRY_HASH  # pyright: ignore[reportAttributeAccessIssue]
+    if not _rule_hash:
+        logger.warning("RULE_REGISTRY_HASH is empty — _finalize_registry() was never called")
     if (
         cached is not None
         and cached.pkg_version == pkg_version

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -144,6 +144,7 @@ _LOAD_CACHE_LOCK = threading.Lock()
 _PROCESS_START_PKG_MTIME: int | None = None
 _STALENESS_LAST_CHECK: float = 0.0
 _STALENESS_IS_STALE: bool = False
+_STALENESS_CACHES_CLEARED: bool = False
 _STALENESS_TTL: float = 30.0
 
 
@@ -171,6 +172,7 @@ def _check_process_staleness() -> bool:
 
 def _clear_stale_caches() -> None:
     """Clear all lru_cache helpers and the load cache when staleness is detected."""
+    global _STALENESS_CACHES_CLEARED  # noqa: PLW0603
     from autoskillit.recipe.contracts import load_bundled_manifest  # noqa: PLC0415
     from autoskillit.recipe.methodology_venue_appendix import (  # noqa: PLC0415
         load_ml_sub_area_folding,
@@ -182,6 +184,7 @@ def _clear_stale_caches() -> None:
     load_ml_sub_area_folding.cache_clear()
     with _LOAD_CACHE_LOCK:
         _LOAD_CACHE.clear()
+    _STALENESS_CACHES_CLEARED = True
 
 
 def format_recipe_list_response(result: LoadResult[RecipeInfo]) -> dict[str, object]:
@@ -401,7 +404,8 @@ def load_and_validate(
         On not-found: {"error": str}
     """
     if _check_process_staleness():
-        _clear_stale_caches()
+        if not _STALENESS_CACHES_CLEARED:
+            _clear_stale_caches()
         return {
             "error": (
                 "Process is running stale code — package directory was modified on disk "

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -145,10 +145,17 @@ _LOAD_CACHE_LOCK = threading.Lock()
 # Process staleness guard
 # ---------------------------------------------------------------------------
 
-_PROCESS_START_PKG_MTIME: int = _path_mtime_ns(pkg_root())
+_PROCESS_START_PKG_MTIME: int | None = None
 _staleness_last_check: float = 0.0
 _staleness_is_stale: bool = False
 _STALENESS_TTL: float = 30.0
+
+
+def _get_process_start_mtime() -> int:
+    global _PROCESS_START_PKG_MTIME  # noqa: PLW0603
+    if _PROCESS_START_PKG_MTIME is None:
+        _PROCESS_START_PKG_MTIME = _path_mtime_ns(pkg_root())
+    return _PROCESS_START_PKG_MTIME
 
 
 def _check_process_staleness() -> bool:
@@ -158,7 +165,7 @@ def _check_process_staleness() -> bool:
     if now - _staleness_last_check < _STALENESS_TTL:
         return _staleness_is_stale
     _staleness_last_check = now
-    _staleness_is_stale = _path_mtime_ns(pkg_root()) != _PROCESS_START_PKG_MTIME
+    _staleness_is_stale = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
     return _staleness_is_stale
 
 

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -141,10 +141,6 @@ class _LoadCacheEntry:
 _LOAD_CACHE: dict[tuple, _LoadCacheEntry] = {}
 _LOAD_CACHE_LOCK = threading.Lock()
 
-# ---------------------------------------------------------------------------
-# Process staleness guard
-# ---------------------------------------------------------------------------
-
 _PROCESS_START_PKG_MTIME: int | None = None
 _staleness_last_check: float = 0.0
 _staleness_is_stale: bool = False

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -161,7 +161,11 @@ def _check_process_staleness() -> bool:
     if now - _staleness_last_check < _STALENESS_TTL:
         return _staleness_is_stale
     _staleness_last_check = now
-    _staleness_is_stale = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
+    try:
+        _staleness_is_stale = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
+    except (OSError, RuntimeError):
+        logger.warning("pkg_root() unavailable during staleness check; assuming non-stale")
+        _staleness_is_stale = False
     return _staleness_is_stale
 
 

--- a/src/autoskillit/recipe/registry.py
+++ b/src/autoskillit/recipe/registry.py
@@ -89,6 +89,8 @@ def semantic_rule(
         fn: Callable[[ValidationContext], list[RuleFinding]],
     ) -> Callable[[ValidationContext], list[RuleFinding]]:
         if _REGISTRY_FINALIZED:
+            if any(r.name == name for r in _RULE_REGISTRY):
+                return fn
             raise RuntimeError(f"Cannot register rule {name!r} after registry finalization")
         _RULE_REGISTRY.append(
             RuleDef(name=name, description=description, severity=severity, check=fn)
@@ -114,6 +116,8 @@ def block_rule(
         fn: Callable[[BlockContext], list[RuleFinding]],
     ) -> Callable[[BlockContext], list[RuleFinding]]:
         if _REGISTRY_FINALIZED:
+            if any(r.name == name for r in _BLOCK_RULE_REGISTRY):
+                return fn
             raise RuntimeError(f"Cannot register block rule {name!r} after registry finalization")
         _BLOCK_RULE_REGISTRY.append(
             BlockRuleDef(name=name, description=description, severity=severity, check=fn)

--- a/src/autoskillit/recipe/registry.py
+++ b/src/autoskillit/recipe/registry.py
@@ -7,6 +7,8 @@ prevents that file from exceeding the 1000-line architecture limit.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -86,6 +88,8 @@ def semantic_rule(
     def decorator(
         fn: Callable[[ValidationContext], list[RuleFinding]],
     ) -> Callable[[ValidationContext], list[RuleFinding]]:
+        if _REGISTRY_FINALIZED:
+            raise RuntimeError(f"Cannot register rule {name!r} after registry finalization")
         _RULE_REGISTRY.append(
             RuleDef(name=name, description=description, severity=severity, check=fn)
         )
@@ -109,12 +113,36 @@ def block_rule(
     def decorator(
         fn: Callable[[BlockContext], list[RuleFinding]],
     ) -> Callable[[BlockContext], list[RuleFinding]]:
+        if _REGISTRY_FINALIZED:
+            raise RuntimeError(f"Cannot register block rule {name!r} after registry finalization")
         _BLOCK_RULE_REGISTRY.append(
             BlockRuleDef(name=name, description=description, severity=severity, check=fn)
         )
         return fn
 
     return decorator
+
+
+_REGISTRY_FINALIZED: bool = False
+RULE_REGISTRY_HASH: str = ""
+
+
+def compute_rule_registry_hash() -> str:
+    """Compute a stable sha256 over _RULE_REGISTRY + _BLOCK_RULE_REGISTRY."""
+    rows = sorted(
+        [(r.name, r.severity.value) for r in _RULE_REGISTRY]
+        + [(r.name, r.severity.value) for r in _BLOCK_RULE_REGISTRY],
+        key=lambda t: t[0],
+    )
+    payload = json.dumps(rows, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _finalize_registry() -> None:
+    """Compute RULE_REGISTRY_HASH after all rule modules have been imported."""
+    global _REGISTRY_FINALIZED, RULE_REGISTRY_HASH  # noqa: PLW0603
+    RULE_REGISTRY_HASH = compute_rule_registry_hash()
+    _REGISTRY_FINALIZED = True
 
 
 def run_semantic_rules(wf: Recipe | ValidationContext) -> list[RuleFinding]:

--- a/tests/arch/test_recipe_rule_registration.py
+++ b/tests/arch/test_recipe_rule_registration.py
@@ -74,3 +74,4 @@ def test_rule_registry_hash_nonempty_after_recipe_import() -> None:
         "RULE_REGISTRY_HASH is empty — _finalize_registry() may have been removed or "
         "called before rules registered"
     )
+    assert len(RULE_REGISTRY_HASH) == 64, "RULE_REGISTRY_HASH must be a sha256 hex digest"

--- a/tests/arch/test_recipe_rule_registration.py
+++ b/tests/arch/test_recipe_rule_registration.py
@@ -34,3 +34,43 @@ def test_every_rules_module_imported_by_recipe_init() -> None:
         f"recipe/__init__.py must import these rules modules so their "
         f"@semantic_rule decorators register: {missing}"
     )
+
+
+def test_load_cache_entry_has_rule_registry_hash_guard() -> None:
+    """_LoadCacheEntry must have a rule_registry_hash field and the cache hit
+    validation must reference it — prevents silent removal in future refactors."""
+    import dataclasses
+
+    src = Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "recipe"
+    api_src = src / "_api.py"
+
+    from autoskillit.recipe._api import _LoadCacheEntry
+
+    field_names = {f.name for f in dataclasses.fields(_LoadCacheEntry)}
+    assert "rule_registry_hash" in field_names, (
+        "_LoadCacheEntry must have a rule_registry_hash field"
+    )
+
+    api_text = api_src.read_text()
+    tree = ast.parse(api_text)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "load_and_validate":
+            fn_src = ast.get_source_segment(api_text, node) or ""
+            assert "rule_registry_hash" in fn_src, (
+                "load_and_validate must reference rule_registry_hash in cache hit validation"
+            )
+            break
+    else:
+        raise AssertionError("load_and_validate not found in _api.py")
+
+
+def test_rule_registry_hash_nonempty_after_recipe_import() -> None:
+    """RULE_REGISTRY_HASH must be non-empty after `import autoskillit.recipe`."""
+    from autoskillit.recipe.registry import (
+        RULE_REGISTRY_HASH,  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+    assert RULE_REGISTRY_HASH, (
+        "RULE_REGISTRY_HASH is empty — _finalize_registry() may have been removed or "
+        "called before rules registered"
+    )

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -964,6 +964,7 @@ def test_load_and_validate_cache_invalidated_on_rule_registry_change(tmp_path, m
 
     monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
     monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+    monkeypatch.setattr(api_mod, "_STALENESS_CACHES_CLEARED", False)
     monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
@@ -997,6 +998,7 @@ def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):
     monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
     monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+    monkeypatch.setattr(api_mod, "_STALENESS_CACHES_CLEARED", False)
 
     real_mtime = api_mod._path_mtime_ns
 
@@ -1038,6 +1040,7 @@ def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
     monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
     monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+    monkeypatch.setattr(api_mod, "_STALENESS_CACHES_CLEARED", False)
 
     real_mtime = api_mod._path_mtime_ns
 

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -956,3 +956,145 @@ def test_load_and_validate_skips_list_recipes_when_recipe_list_provided(tmp_path
 
     assert "error" not in result
     assert result.get("content_hash") is not None
+
+
+# ---------------------------------------------------------------------------
+# Rule registry hash cache invalidation tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_and_validate_cache_invalidated_on_rule_registry_change(tmp_path, monkeypatch):
+    """Changing the rule registry hash invalidates the cache."""
+    import autoskillit.recipe._api as api_mod
+
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(api_mod, "_staleness_is_stale", False)
+    monkeypatch.setattr(api_mod, "_staleness_last_check", 0.0)
+
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    (recipes_dir / "myrecipe.yaml").write_text(MINIMAL_RECIPE_YAML)
+
+    calls: list[int] = []
+    real_validate = api_mod.validate_recipe_structure
+
+    def counting_validate(recipe):
+        calls.append(1)
+        return real_validate(recipe)
+
+    monkeypatch.setattr(api_mod, "validate_recipe_structure", counting_validate)
+
+    api_mod.load_and_validate("myrecipe", tmp_path)
+
+    from autoskillit.recipe import registry as reg_mod
+
+    monkeypatch.setattr(reg_mod, "RULE_REGISTRY_HASH", "changed-hash-value")
+    api_mod.load_and_validate("myrecipe", tmp_path)
+
+    assert len(calls) == 2
+
+
+def test_load_cache_entry_includes_rule_registry_hash():
+    """_LoadCacheEntry dataclass has a rule_registry_hash field."""
+    import dataclasses
+
+    from autoskillit.recipe._api import _LoadCacheEntry
+
+    field_names = {f.name for f in dataclasses.fields(_LoadCacheEntry)}
+    assert "rule_registry_hash" in field_names
+
+
+def test_load_cache_entry_rule_registry_hash_checked_in_hit_path():
+    """The cache hit validation block references rule_registry_hash."""
+    import ast
+    from pathlib import Path
+
+    api_src = Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "recipe" / "_api.py"
+    tree = ast.parse(api_src.read_text())
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "load_and_validate":
+            src_lines = ast.get_source_segment(api_src.read_text(), node) or ""
+            assert "rule_registry_hash" in src_lines, (
+                "load_and_validate must reference rule_registry_hash in cache validation"
+            )
+            break
+    else:
+        raise AssertionError("load_and_validate function not found")
+
+
+# ---------------------------------------------------------------------------
+# Process staleness detection tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):
+    """Stale process returns error result instead of evaluating recipes."""
+    import autoskillit.recipe._api as api_mod
+
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
+    monkeypatch.setattr(api_mod, "_staleness_last_check", 0.0)
+    monkeypatch.setattr(api_mod, "_staleness_is_stale", False)
+
+    real_mtime = api_mod._path_mtime_ns
+
+    def fake_mtime(path):
+        from autoskillit.core import pkg_root
+
+        if path == pkg_root():
+            return 2000
+        return real_mtime(path)
+
+    monkeypatch.setattr(api_mod, "_path_mtime_ns", fake_mtime)
+
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    (recipes_dir / "myrecipe.yaml").write_text(MINIMAL_RECIPE_YAML)
+
+    result = api_mod.load_and_validate("myrecipe", tmp_path)
+
+    assert result.get("valid") is False
+    assert "stale" in result.get("error", "").lower()
+
+
+def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
+    """Staleness detection clears lru_cache helpers."""
+    import autoskillit.recipe._api as api_mod
+    from autoskillit.recipe.contracts import load_bundled_manifest
+    from autoskillit.recipe.methodology_venue_appendix import load_ml_sub_area_folding
+    from autoskillit.recipe.rules.rules_blocks import _block_budgets
+
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
+
+    _block_budgets()
+    load_bundled_manifest()
+    load_ml_sub_area_folding()
+    assert _block_budgets.cache_info().currsize > 0
+    assert load_bundled_manifest.cache_info().currsize > 0
+    assert load_ml_sub_area_folding.cache_info().currsize > 0
+
+    monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
+    monkeypatch.setattr(api_mod, "_staleness_last_check", 0.0)
+    monkeypatch.setattr(api_mod, "_staleness_is_stale", False)
+
+    real_mtime = api_mod._path_mtime_ns
+
+    def fake_mtime(path):
+        from autoskillit.core import pkg_root
+
+        if path == pkg_root():
+            return 2000
+        return real_mtime(path)
+
+    monkeypatch.setattr(api_mod, "_path_mtime_ns", fake_mtime)
+
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    (recipes_dir / "myrecipe.yaml").write_text(MINIMAL_RECIPE_YAML)
+
+    api_mod.load_and_validate("myrecipe", tmp_path)
+
+    assert _block_budgets.cache_info().currsize == 0
+    assert load_bundled_manifest.cache_info().currsize == 0
+    assert load_ml_sub_area_folding.cache_info().currsize == 0

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -989,35 +989,6 @@ def test_load_and_validate_cache_invalidated_on_rule_registry_change(tmp_path, m
     assert len(calls) == 2
 
 
-def test_load_cache_entry_includes_rule_registry_hash():
-    """_LoadCacheEntry dataclass has a rule_registry_hash field."""
-    import dataclasses
-
-    from autoskillit.recipe._api import _LoadCacheEntry
-
-    field_names = {f.name for f in dataclasses.fields(_LoadCacheEntry)}
-    assert "rule_registry_hash" in field_names
-
-
-def test_load_cache_entry_rule_registry_hash_checked_in_hit_path():
-    """The cache hit validation block references rule_registry_hash."""
-    import ast
-    from pathlib import Path
-
-    api_src = Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "recipe" / "_api.py"
-    tree = ast.parse(api_src.read_text())
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "load_and_validate":
-            src_lines = ast.get_source_segment(api_src.read_text(), node) or ""
-            assert "rule_registry_hash" in src_lines, (
-                "load_and_validate must reference rule_registry_hash in cache validation"
-            )
-            break
-    else:
-        raise AssertionError("load_and_validate function not found")
-
-
 def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):
     """Stale process returns error result instead of evaluating recipes."""
     import autoskillit.recipe._api as api_mod

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -963,8 +963,8 @@ def test_load_and_validate_cache_invalidated_on_rule_registry_change(tmp_path, m
     import autoskillit.recipe._api as api_mod
 
     monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
-    monkeypatch.setattr(api_mod, "_staleness_is_stale", False)
-    monkeypatch.setattr(api_mod, "_staleness_last_check", 0.0)
+    monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -1024,8 +1024,8 @@ def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):
 
     monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
     monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
-    monkeypatch.setattr(api_mod, "_staleness_last_check", 0.0)
-    monkeypatch.setattr(api_mod, "_staleness_is_stale", False)
+    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
 
     real_mtime = api_mod._path_mtime_ns
 
@@ -1065,8 +1065,8 @@ def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
     assert load_ml_sub_area_folding.cache_info().currsize > 0
 
     monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
-    monkeypatch.setattr(api_mod, "_staleness_last_check", 0.0)
-    monkeypatch.setattr(api_mod, "_staleness_is_stale", False)
+    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
 
     real_mtime = api_mod._path_mtime_ns
 

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -958,11 +958,6 @@ def test_load_and_validate_skips_list_recipes_when_recipe_list_provided(tmp_path
     assert result.get("content_hash") is not None
 
 
-# ---------------------------------------------------------------------------
-# Rule registry hash cache invalidation tests
-# ---------------------------------------------------------------------------
-
-
 def test_load_and_validate_cache_invalidated_on_rule_registry_change(tmp_path, monkeypatch):
     """Changing the rule registry hash invalidates the cache."""
     import autoskillit.recipe._api as api_mod
@@ -1021,11 +1016,6 @@ def test_load_cache_entry_rule_registry_hash_checked_in_hit_path():
             break
     else:
         raise AssertionError("load_and_validate function not found")
-
-
-# ---------------------------------------------------------------------------
-# Process staleness detection tests
-# ---------------------------------------------------------------------------
 
 
 def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):

--- a/tests/recipe/test_rules_registry.py
+++ b/tests/recipe/test_rules_registry.py
@@ -38,6 +38,58 @@ def test_rule_finding_to_dict() -> None:
     }
 
 
+def test_rule_registry_hash_changes_on_rule_addition(monkeypatch) -> None:
+    """Adding a rule to the registry changes the computed hash."""
+    from autoskillit.recipe.registry import (
+        _RULE_REGISTRY,
+        RuleDef,
+        compute_rule_registry_hash,
+    )
+
+    h1 = compute_rule_registry_hash()
+
+    dummy = RuleDef(
+        name="test-dummy-rule",
+        description="dummy",
+        severity=Severity.WARNING,
+        check=lambda ctx: [],
+    )
+    monkeypatch.setattr(
+        "autoskillit.recipe.registry._RULE_REGISTRY",
+        list(_RULE_REGISTRY) + [dummy],
+    )
+
+    h2 = compute_rule_registry_hash()
+    assert h1 != h2
+
+
+def test_rule_registry_hash_stable_across_calls() -> None:
+    """Hash is deterministic — same input produces same output."""
+    from autoskillit.recipe.registry import compute_rule_registry_hash
+
+    assert compute_rule_registry_hash() == compute_rule_registry_hash()
+
+
+def test_rule_registry_hash_nonempty_after_import() -> None:
+    """RULE_REGISTRY_HASH is non-empty after import autoskillit.recipe."""
+    from autoskillit.recipe.registry import RULE_REGISTRY_HASH
+
+    assert RULE_REGISTRY_HASH, "RULE_REGISTRY_HASH must be non-empty after finalization"
+    assert len(RULE_REGISTRY_HASH) == 64  # sha256 hex digest length
+
+
+def test_semantic_rule_after_finalization_raises() -> None:
+    """Registering a rule after finalization raises RuntimeError."""
+    from autoskillit.recipe.registry import _REGISTRY_FINALIZED, semantic_rule
+
+    assert _REGISTRY_FINALIZED, "Registry should be finalized after import"
+    with pytest.raises(RuntimeError, match="after registry finalization"):
+
+        @semantic_rule(name="post-finalize-test", description="should fail")
+        def _check(ctx):
+            return []
+
+
 def test_old_rule_removed() -> None:
     from autoskillit.recipe.validator import _RULE_REGISTRY
 

--- a/tests/recipe/test_rules_registry.py
+++ b/tests/recipe/test_rules_registry.py
@@ -70,14 +70,6 @@ def test_rule_registry_hash_stable_across_calls() -> None:
     assert compute_rule_registry_hash() == compute_rule_registry_hash()
 
 
-def test_rule_registry_hash_nonempty_after_import() -> None:
-    """RULE_REGISTRY_HASH is non-empty after import autoskillit.recipe."""
-    from autoskillit.recipe.registry import RULE_REGISTRY_HASH
-
-    assert RULE_REGISTRY_HASH, "RULE_REGISTRY_HASH must be non-empty after finalization"
-    assert len(RULE_REGISTRY_HASH) == 64  # sha256 hex digest length
-
-
 def test_semantic_rule_after_finalization_raises() -> None:
     """Registering a rule after finalization raises RuntimeError."""
     from autoskillit.recipe.registry import _REGISTRY_FINALIZED, semantic_rule


### PR DESCRIPTION
## Summary

The recipe validation pipeline has a structural asymmetry: YAML data hot-reloads via mtime-based `_LOAD_CACHE` invalidation, but Python rule logic (`_RULE_REGISTRY`, `_BLOCK_RULE_REGISTRY`) and `lru_cache`-pinned helpers are frozen at import time for the process lifetime. When on-disk code changes while the MCP server is running, freshly-read YAML is evaluated against stale rules, producing false validation errors that block fleet dispatch.

The fix applies the hook registry drift detection pattern — already proven in `hook_registry.py` + `_lifespan.py` — to the rule registry: a content hash of `_RULE_REGISTRY` is embedded in `_LoadCacheEntry` and validated on every cache hit. A complementary process-level staleness guard compares `pkg_root()` directory mtime at call time against the mtime captured at module load time, catching all forms of code drift. Four new tests and an arch test enforce the guarantees.

## Requirements

- **Problem Summary:** Recipe YAML files hot-reload from disk via mtime-based cache invalidation, but Python validation rules are loaded once at import time and never reloaded. When a commit changes both recipe YAML and validation rules while the MCP server is running, only the YAML change is picked up — the rule change requires a server restart. This causes false validation errors that block dispatches.
- **Observed Failure:** Commit `d4002070c` added `route_ci_applicable` to `implementation.yaml` and extended `rules_ci.py` to recognize `action: route` steps. The MCP server running v0.10.152 re-read the YAML (now v0.10.158 content) but evaluated it against v0.10.152 `rules_ci.py` (no `_CI_APPLICABLE_RE`), resulting in 3 `enqueue-missing-ci-gate` errors blocking all further dispatches.
- **Test Suite Blind Spot:** All tests run at HEAD — no test simulates cross-version evaluation where cached YAML is validated by stale rules.
- **Related Risks:** `_block_budgets()`, `load_bundled_manifest()`, and `load_ml_sub_area_folding()` are `@lru_cache`-pinned helpers reading YAML that could change on disk.

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_recipe_validation_version_skew_immunity_2026-05-20_083554.md`

## Changed Files

**Modified:**
- `src/autoskillit/recipe/__init__.py` — call `_finalize_registry()` after all rule imports
- `src/autoskillit/recipe/_api.py` — add `rule_registry_hash` to `_LoadCacheEntry`, cache hit validation, process staleness guard, lru_cache cleanup
- `src/autoskillit/recipe/registry.py` — add `compute_rule_registry_hash()`, `RULE_REGISTRY_HASH`, `_finalize_registry()`, finalization guard in decorators
- `tests/arch/test_recipe_rule_registration.py` — arch tests for rule registry hash presence
- `tests/recipe/test_api.py` — tests for cache invalidation on rule change, staleness detection, lru_cache clearing
- `tests/recipe/test_rules_registry.py` — tests for hash stability and change detection

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 49 | 10.6k | 1.2M | 100.6k | 248 | 84.7k | 10m 6s |
| rectify | claude-sonnet-4-6 | 1 | 53 | 12.0k | 908.0k | 81.1k | 112 | 72.4k | 7m 1s |
| dry_walkthrough | claude-opus-4-6 | 1 | 1.7k | 21.8k | 2.8M | 87.4k | 145 | 72.6k | 9m 24s |
| implement | claude-opus-4-6 | 1 | 144 | 17.4k | 4.8M | 113.3k | 122 | 98.5k | 7m 37s |
| prepare_pr* | MiniMax-M2.7 | 1 | 66.9k | 3.4k | 245.7k | 0 | 20 | 29.2k | 2m 45s |
| compose_pr* | MiniMax-M2.7 | 1 | 104.3k | 3.0k | 313.9k | 26.3k | 27 | 2.9k | 2m 25s |
| review_pr | claude-opus-4-6 | 3 | 117 | 88.5k | 1.9M | 85.6k | 100 | 188.4k | 20m 56s |
| resolve_review | claude-opus-4-6 | 3 | 183 | 47.1k | 6.6M | 105.1k | 197 | 209.8k | 21m 19s |
| **Total** | | | 173.4k | 203.8k | 18.7M | 113.3k | | 758.5k | 1h 21m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 321 | 14887.4 | 306.9 | 54.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 98 | 67643.8 | 2140.6 | 480.1 |
| **Total** | **419** | 44703.4 | 1810.2 | 486.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 102 | 22.6k | 2.1M | 157.1k | 17m 8s |
| claude-opus-4-6 | 4 | 2.1k | 174.8k | 16.1M | 569.3k | 59m 18s |
| MiniMax-M2.7 | 2 | 171.2k | 6.4k | 559.5k | 32.1k | 5m 10s |