### PR TITLE
Add provider field to CoreRunConfig end-to-end

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -129,6 +129,7 @@ class RunSkillConfig:
 class CoreRunConfig:
     default_model: str = "sonnet"
     model_override: str | None = None
+    provider: str = "anthropic"
 
     def __post_init__(self) -> None:
         if not self.default_model:

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -52,6 +52,7 @@ run_skill:
 model:
   default: sonnet
   override: null
+  provider: anthropic
 
 worktree_setup:
   command: null

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -404,6 +404,7 @@ class AutomationConfig:
                 if (_d := val(mc, "default", None)) is not None
                 else _mc["default_model"],
                 model_override=val(mc, "override", _mc["model_override"]) or None,
+                provider=str(val(mc, "provider", _mc["provider"])),
             ),
             worktree_setup=WorktreeSetupConfig(
                 command=_to_optional_list(val(ws, "command", _ws["command"])),
@@ -565,7 +566,7 @@ def _build_config_schema() -> dict[str, frozenset[str]]:
         # YAML uses short keys ('default', 'override') to keep user config concise;
         # the Python fields use explicit names to avoid shadowing builtins.
         if f.name == "model":
-            schema["model"] = frozenset({"default", "override"})
+            schema["model"] = frozenset({"default", "override", "provider"})
             continue
         # Skip the scalar experimental_enabled field — it is handled under the features section
         if f.name == "experimental_enabled":

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,6 +1,7 @@
 """Tests for configuration loading and resolution."""
 
 from dataclasses import fields as dc_fields
+from pathlib import Path
 
 import pytest
 import yaml
@@ -43,6 +44,16 @@ class TestDefaultConfig:
         cfg = AutomationConfig()
         assert cfg.model.default_model == "sonnet"
         assert cfg.model.model_override is None
+        assert cfg.model.provider == "anthropic"
+
+    def test_model_provider_custom(self):
+        """MOD_C4: CoreRunConfig accepts custom provider."""
+        from autoskillit.config import CoreRunConfig
+
+        cfg = CoreRunConfig(provider="openai")
+        assert cfg.provider == "openai"
+        assert cfg.default_model == "sonnet"
+        assert cfg.model_override is None
 
 
 class TestLoadConfig:
@@ -196,6 +207,17 @@ class TestLoadConfig:
         cfg = load_config(tmp_path)
         assert cfg.model.default_model == "sonnet"
         assert cfg.model.model_override is None
+        assert cfg.model.provider == "anthropic"
+
+    def test_yaml_loads_model_provider(self, tmp_path):
+        """MOD_C5: YAML model.provider loads into CoreRunConfig.provider."""
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {"model": {"provider": "openai"}}
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.model.provider == "openai"
+        assert cfg.model.default_model == "sonnet"
 
     def test_partial_model_config(self, tmp_path):
         """MOD_C3: YAML key 'override' maps to Python field model_override;
@@ -207,6 +229,24 @@ class TestLoadConfig:
         cfg = load_config(tmp_path)
         assert cfg.model.model_override == "haiku"
         assert cfg.model.default_model == "sonnet"
+        assert cfg.model.provider == "anthropic"
+
+    def test_validate_layer_keys_accepts_model_provider(self):
+        """MOD_C6: validate_layer_keys does not reject model.provider."""
+        from autoskillit.config import validate_layer_keys
+
+        validate_layer_keys(
+            {"model": {"provider": "openai"}},
+            layer_path=Path("test"),
+            is_secrets_layer=False,
+        )
+
+    def test_model_provider_defaults_match_yaml(self, tmp_path):
+        """MOD_C7: CoreRunConfig.provider default matches defaults.yaml loaded value."""
+        from autoskillit.config import CoreRunConfig
+
+        cfg = load_config(tmp_path)
+        assert cfg.model.provider == CoreRunConfig().provider
 
     def test_yaml_loads_worktree_setup_config(self, tmp_path):
         """WS_C2: YAML with worktree_setup section populates WorktreeSetupConfig."""


### PR DESCRIPTION
## Summary

Add `provider: str = 'anthropic'` field to `CoreRunConfig` dataclass and wire it end-to-end through `defaults.yaml`, the Dynaconf loader (`from_dynaconf()`), and the `_build_config_schema()` validation whitelist. This is a prerequisite for P4-A7-WP1.

Key insight: the `model` section in `_build_config_schema()` uses a **hardcoded frozenset** (not auto-discovery from dataclass fields), so adding the field to `CoreRunConfig` alone is insufficient — three sites must be updated in lockstep: the dataclass, the schema frozenset, and the `from_dynaconf()` constructor call.

## Requirements

## Goal

Add provider field to ModelConfig dataclass, wire it through the Dynaconf loader, and set the default in defaults.yaml.

## Context

- Phase: Provider Config and Quota Abstraction (Milestone: 4-provider-config-and-quota-abstraction)
- Assignment: P4-A3 (Add `provider: str = 'anthropic'` field to `ModelConfig` and wire through Dynaconf loader)
- Depends on: None
- Depended on by: P4-A7-WP1

## Deliverables

- `ModelConfig.provider field added: `provider: str = 'anthropic'` inserted after the `override` field at line 132. No other changes to the file.`
- `settings.py ModelConfig constructor updated: `provider=str(val(mc, 'provider', _mc['provider']))` added as third argument to ModelConfig() call at lines 397-400.`
- `defaults.yaml model section updated: `provider: anthropic` added after `override: null` within the `model:` block. Result reads: model:\n  default: sonnet\n  override: null\n  provider: anthropic`

## Technical Steps

1. Open src/autoskillit/config/_config_dataclasses.py at line 128-131 (the ModelConfig class).
2. Insert `provider: str = 'anthropic'` on line 132, immediately after `override: str | None = None`.
3. No __post_init__, no ClassVar, no import changes required.
4. Verify no existing test asserts on ModelConfig field count or structure — confirmed none exist.
5. Open `src/autoskillit/config/settings.py` and locate the `model=ModelConfig(...)` block inside `from_dynaconf()` (currently lines 397-400).
6. After WP1 lands, `_mc = _field_defaults(ModelConfig)` will automatically include `'provider': 'anthropic'` — no change needed to _mc line.
7. Add third argument to ModelConfig constructor: `provider=str(val(mc, 'provider', _mc['provider']))`. Follow existing str(val(...)) wrapping pattern.
8. Run `pre-commit run --all-files` and `task test-check` to confirm no regressions.
9. Open `src/autoskillit/config/defaults.yaml` at the `model:` block (lines 52-54).
10. Append `  provider: anthropic` as a new line after `  override: null`, maintaining 2-space indentation.
11. Verify no trailing whitespace, no extra blank lines, and YAML parses cleanly.
12. Confirm P4-A3-WP1 and P4-A3-WP2 are prerequisites so this YAML key is consumed.

## Acceptance Criteria

- ModelConfig() instantiates without arguments and sets provider='anthropic'.
- ModelConfig(provider='openai') sets provider='openai'.
- Existing fields ModelConfig.default and ModelConfig.override are unaffected.
- All existing tests pass without modification.
- pre-commit run --all-files passes.
- from_dynaconf() passes provider to ModelConfig(...).
- When no provider key in config, model.provider resolves to 'anthropic'.
- When model.provider set to 'openai' in config YAML, model.provider resolves to 'openai'.
- When AUTOSKILLIT_MODEL__PROVIDER=openai env var is set, model.provider resolves to 'openai'.
- task test-check passes with no regressions.
- validate_layer_keys() accepts provider as valid sub-key of model section automatically.
- defaults.yaml YAML parses without error.
- model: block contains exactly three keys: default, override, and provider, each indented 2 spaces.
- provider value is the string `anthropic` (unquoted).
- No other sections in defaults.yaml are modified.
- P4-A4-WP1 (providers section) does NOT conflict.
- config.model.provider == 'anthropic' when no override is set.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-084014-811263/.autoskillit/temp/make-plan/p4-a3-wp1-add-provider-field-to-modelconfig-end-to-end_plan_2026-05-20_084500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.3k | 12.1k | 911.8k | 81.7k | 202 | 59.5k | 9m 41s |
| verify | claude-opus-4-6 | 1 | 60 | 11.4k | 1.7M | 61.9k | 111 | 47.1k | 5m 20s |
| implement* | MiniMax-M2.7 | 1 | 433.2k | 8.7k | 1.4M | 29.2k | 94 | 2.9k | 12m 45s |
| prepare_pr* | MiniMax-M2.7 | 1 | 59.4k | 3.9k | 268.3k | 0 | 22 | 0 | 1m 42s |
| compose_pr* | MiniMax-M2.7 | 1 | 106.7k | 2.8k | 257.0k | 29.2k | 22 | 2.9k | 1m 45s |
| review_pr | claude-opus-4-6 | 3 | 112 | 27.8k | 1.1M | 49.1k | 80 | 99.0k | 7m 19s |
| **Total** | | | 603.7k | 66.6k | 5.7M | 81.7k | | 211.4k | 38m 35s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 45 | 31611.8 | 64.7 | 193.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **45** | 126002.5 | 4697.5 | 1479.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 4.3k | 12.1k | 911.8k | 59.5k | 9m 41s |
| claude-opus-4-6 | 2 | 172 | 39.2k | 2.8M | 146.1k | 12m 39s |
| MiniMax-M2.7 | 3 | 599.3k | 15.4k | 1.9M | 5.8k | 16m 13s |