### PR TITLE
Harden BEM pre-step gate directives in fleet dispatch prompt

### DIFF
--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -123,14 +123,24 @@ issue context when the task involves a GitHub issue.
 - `ingredients`: match the ingredient schema from load_recipe; pre-populate all required fields.
 - Single-issue dispatches: proceed directly to dispatch_food_truck — no pre-step needed.
 
-## MULTI-ISSUE DISPATCH — BEM PRE-STEP GATE
+## MULTI-ISSUE DISPATCH — BEM PRE-STEP GATE — MANDATORY
 
-When the user requests 2 or more issues dispatched:
+**CRITICAL**: BEM (build-execution-map) is what determines whether issues are independent \
+or share overlapping files and semantic dependencies. You cannot assess this on your own — \
+only BEM can. Any time the user's request contains 2 or more issues — regardless of how \
+many individual dispatch_food_truck calls you plan to make — you MUST follow this section. \
+There are no exceptions.
+
+**NEVER:**
+- NEVER dispatch 2 or more issue-bearing food trucks without first completing the bem-wrapper pre-step.
+- NEVER assume issues are independent without running BEM — BEM is what determines independence.
+- NEVER call dispatch_food_truck for individual issues in parallel before the execution map \
+has been produced and read.
 
 1. Count total issues across all targets. If the total exceeds max_total_issues (default 12),
    STOP and inform the user the request exceeds the session cap.
 
-2. Dispatch bem-wrapper first as the conflict analysis pre-step:
+2. You MUST dispatch bem-wrapper first as the conflict analysis pre-step:
    {mcp_prefix}dispatch_food_truck(
        recipe="bem-wrapper",
        task="Build execution map for conflict analysis",

--- a/tests/contracts/test_fleet_dispatch_bem_gate.py
+++ b/tests/contracts/test_fleet_dispatch_bem_gate.py
@@ -79,7 +79,7 @@ def test_fleet_prompt_bem_gate_uses_must_directive(fleet_prompt: str) -> None:
     parts = fleet_prompt.split("## MULTI-ISSUE")
     assert len(parts) >= 2, "Fleet prompt must contain ## MULTI-ISSUE heading"
     bem_section = parts[1].split("## DISPATCHER DISCIPLINE")[0]
-    assert "MUST" in bem_section.upper(), (
+    assert "MUST" in bem_section, (
         "BEM gate section must contain at least one MUST directive — "
         "soft imperative language is insufficient for LLM compliance"
     )

--- a/tests/contracts/test_fleet_dispatch_bem_gate.py
+++ b/tests/contracts/test_fleet_dispatch_bem_gate.py
@@ -60,3 +60,34 @@ def test_fleet_prompt_references_max_total_issues_cap(fleet_prompt: str) -> None
     assert "max_total_issues" in fleet_prompt, (
         "Fleet dispatcher prompt must mention the total issues session cap"
     )
+
+
+def test_fleet_prompt_bem_gate_uses_mandatory_heading(fleet_prompt: str) -> None:
+    """BEM gate heading must include MANDATORY to match sous-chef standard."""
+    bem_to_discipline = fleet_prompt.split("## DISPATCHER DISCIPLINE")[0]
+    assert "MANDATORY" in bem_to_discipline, (
+        "BEM pre-step gate heading must include 'MANDATORY' — weak headings "
+        "allow the LLM to treat the gate as advisory documentation"
+    )
+
+
+def test_fleet_prompt_bem_gate_uses_must_directive(fleet_prompt: str) -> None:
+    """BEM gate must contain MUST directives for enforcement."""
+    parts = fleet_prompt.split("## MULTI-ISSUE")
+    assert len(parts) >= 2, "Fleet prompt must contain ## MULTI-ISSUE heading"
+    bem_section = parts[1].split("## DISPATCHER DISCIPLINE")[0]
+    assert "MUST" in bem_section.upper(), (
+        "BEM gate section must contain at least one MUST directive — "
+        "soft imperative language is insufficient for LLM compliance"
+    )
+
+
+def test_fleet_prompt_bem_gate_has_never_block(fleet_prompt: str) -> None:
+    """BEM gate must contain NEVER prohibitions to prevent bypass."""
+    parts = fleet_prompt.split("## MULTI-ISSUE")
+    assert len(parts) >= 2, "Fleet prompt must contain ## MULTI-ISSUE heading"
+    bem_section = parts[1].split("## DISPATCHER DISCIPLINE")[0]
+    assert "NEVER" in bem_section, (
+        "BEM gate section must contain NEVER directives prohibiting "
+        "multi-issue dispatch without prior BEM execution"
+    )

--- a/tests/contracts/test_fleet_dispatch_bem_gate.py
+++ b/tests/contracts/test_fleet_dispatch_bem_gate.py
@@ -64,6 +64,9 @@ def test_fleet_prompt_references_max_total_issues_cap(fleet_prompt: str) -> None
 
 def test_fleet_prompt_bem_gate_uses_mandatory_heading(fleet_prompt: str) -> None:
     """BEM gate heading must include MANDATORY to match sous-chef standard."""
+    assert "## DISPATCHER DISCIPLINE" in fleet_prompt, (
+        "Fleet prompt must contain ## DISPATCHER DISCIPLINE heading"
+    )
     bem_to_discipline = fleet_prompt.split("## DISPATCHER DISCIPLINE")[0]
     assert "MANDATORY" in bem_to_discipline, (
         "BEM pre-step gate heading must include 'MANDATORY' — weak headings "


### PR DESCRIPTION
## Summary

Rewrite the BEM pre-step gate section of `_build_fleet_dispatch_prompt()` in `src/autoskillit/cli/_prompts_kitchen.py` with strong directive language (MANDATORY, MUST, NEVER, CRITICAL) to prevent the LLM from bypassing conflict analysis when dispatching multiple issues. Add 3 contract tests to `tests/contracts/test_fleet_dispatch_bem_gate.py` to lock the directive strength and prevent regression to weak language.

This is a recurrence fix. The same gap was investigated on 2026-05-07 and fixed with a prompt-only patch in PR #2207 (commit `2bf96695`), but the directive language used was too weak and the LLM bypasses it. This fix hardens the BEM gate with enforceable directives that the LLM cannot rationalize around.

## Problem

When a user requests parallel dispatch of multiple GitHub issues via the fleet kitchen dispatcher, the LLM skips the `build-execution-map` (BEM) pre-step gate and calls `dispatch_food_truck` directly for each issue without conflict analysis.

## Root Cause

The BEM gate section in `_build_fleet_dispatch_prompt()` uses purely descriptive procedural language without strong enforcement directives. It also lacks the force to override the single-issue fast path when multiple issues are present — BEM is what determines whether issues are independent or dependent, and the LLM cannot make that determination on its own.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-100823-443584/.autoskillit/temp/make-plan/harden_bem_gate_directives_plan_2026-05-20_101600.md`

## Changed Files

- `src/autoskillit/cli/_prompts_kitchen.py` — Hardened BEM gate section with MANDATORY heading, CRITICAL preamble, NEVER block, and MUST directive on step 2
- `tests/contracts/test_fleet_dispatch_bem_gate.py` — 3 new contract tests locking directive strength

Closes #2634

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.4k | 11.4k | 748.7k | 65.1k | 216 | 50.1k | 7m 48s |
| verify | claude-sonnet-4-6 | 1 | 36 | 7.7k | 350.6k | 54.3k | 62 | 39.7k | 4m 48s |
| implement* | MiniMax-M2.7 | 1 | 104.7k | 4.6k | 752.5k | 29.2k | 46 | 42.5k | 5m 1s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.8k | 2.8k | 334.1k | 0 | 28 | 0 | 41s |
| compose_pr* | MiniMax-M2.7 | 1 | 44.3k | 1.8k | 276.3k | 0 | 21 | 0 | 36s |
| review_pr | claude-sonnet-4-6 | 3 | 260 | 38.2k | 1.1M | 52.9k | 98 | 106.7k | 11m 13s |
| resolve_review | claude-sonnet-4-6 | 2 | 438 | 19.3k | 2.3M | 60.2k | 115 | 86.5k | 9m 58s |
| **Total** | | | 194.9k | 85.8k | 5.9M | 65.1k | | 325.6k | 40m 6s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 47 | 16011.6 | 904.5 | 98.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 460140.4 | 17303.8 | 3856.4 |
| **Total** | **52** | 113327.5 | 6260.7 | 1649.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 2.1k | 76.5k | 4.5M | 283.0k | 33m 48s |
| MiniMax-M2.7 | 3 | 192.8k | 9.3k | 1.4M | 42.5k | 6m 17s |