### PR TITLE
[P4-A2-WP1] Add resolved_profiles property to ProvidersConfig

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -412,6 +412,7 @@ class ProviderProfileDef:
     timeout_seconds: int | None = None
     api_key_env: str | None = None
     context_window: int | None = None
+    raw_env: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.timeout_seconds is not None and self.timeout_seconds < 0:
@@ -455,6 +456,25 @@ class ProvidersConfig:
                         f"recipe_overrides[{recipe!r}][{step!r}] must be a string, "
                         f"got {type(provider).__name__!r}"
                     )
+
+    @property
+    def resolved_profiles(self) -> dict[str, ProviderProfileDef]:
+        result: dict[str, ProviderProfileDef] = {}
+        for name, raw_dict in self.profiles.items():
+            copy = dict(raw_dict)
+            base_url = copy.pop("base_url", None)
+            timeout_str = copy.pop("timeout_seconds", None)
+            api_key_env = copy.pop("api_key_env", None)
+            context_str = copy.pop("context_window", None)
+            result[name] = ProviderProfileDef(
+                name=name,
+                base_url=base_url,
+                timeout_seconds=int(timeout_str) if timeout_str else None,
+                api_key_env=api_key_env,
+                context_window=int(context_str) if context_str else None,
+                raw_env=copy,
+            )
+        return result
 
 
 @dataclass

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -469,9 +469,13 @@ class ProvidersConfig:
             result[name] = ProviderProfileDef(
                 name=name,
                 base_url=base_url,
-                timeout_seconds=int(timeout_str) if timeout_str else None,
+                timeout_seconds=int(timeout_str)
+                if timeout_str is not None and timeout_str != ""
+                else None,
                 api_key_env=api_key_env,
-                context_window=int(context_str) if context_str else None,
+                context_window=int(context_str)
+                if context_str is not None and context_str != ""
+                else None,
                 raw_env=copy,
             )
         return result

--- a/tests/config/test_provider_profile_def.py
+++ b/tests/config/test_provider_profile_def.py
@@ -43,17 +43,18 @@ class TestProviderProfileDefImports:
 
 
 class TestProviderProfileDefFields:
-    def test_has_exactly_five_fields(self) -> None:
+    def test_has_exactly_six_fields(self) -> None:
         from autoskillit.config._config_dataclasses import ProviderProfileDef
 
         fields = dataclasses.fields(ProviderProfileDef)
-        assert len(fields) == 5
+        assert len(fields) == 6
         assert [f.name for f in fields] == [
             "name",
             "base_url",
             "timeout_seconds",
             "api_key_env",
             "context_window",
+            "raw_env",
         ]
 
     def test_defaults_with_name_only(self) -> None:
@@ -65,6 +66,7 @@ class TestProviderProfileDefFields:
         assert p.timeout_seconds is None
         assert p.api_key_env is None
         assert p.context_window is None
+        assert p.raw_env == {}
 
     def test_all_fields_populated(self) -> None:
         from autoskillit.config._config_dataclasses import ProviderProfileDef
@@ -75,12 +77,14 @@ class TestProviderProfileDefFields:
             timeout_seconds=30,
             api_key_env="OPENAI_API_KEY",
             context_window=128000,
+            raw_env={"custom_key": "custom_val"},
         )
         assert p.name == "openai"
         assert p.base_url == "https://api.openai.com"
         assert p.timeout_seconds == 30
         assert p.api_key_env == "OPENAI_API_KEY"
         assert p.context_window == 128000
+        assert p.raw_env == {"custom_key": "custom_val"}
 
 
 class TestProviderProfileDefFrozen:

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -196,3 +196,89 @@ class TestProvidersConfigYaml:
             "remediation": {"implement": "anthropic"},
             "implementation": {"implement": "minimax"},
         }
+
+
+class TestResolvedProfiles:
+    def test_resolved_profiles_empty(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig()
+        assert cfg.resolved_profiles == {}
+
+    def test_resolved_profiles_typed_fields(self) -> None:
+        from autoskillit.config._config_dataclasses import ProviderProfileDef
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(
+            profiles={
+                "openai": {
+                    "base_url": "https://api.openai.com",
+                    "api_key_env": "OPENAI_API_KEY",
+                }
+            }
+        )
+        result = cfg.resolved_profiles
+        assert "openai" in result
+        profile = result["openai"]
+        assert isinstance(profile, ProviderProfileDef)
+        assert profile.base_url == "https://api.openai.com"
+        assert profile.api_key_env == "OPENAI_API_KEY"
+        assert profile.timeout_seconds is None
+        assert profile.context_window is None
+        assert profile.raw_env == {}
+
+    def test_resolved_profiles_int_coercion_timeout(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(profiles={"fast": {"timeout_seconds": "30"}})
+        assert cfg.resolved_profiles["fast"].timeout_seconds == 30
+
+    def test_resolved_profiles_int_coercion_context_window(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(profiles={"large": {"context_window": "128000"}})
+        assert cfg.resolved_profiles["large"].context_window == 128000
+
+    def test_resolved_profiles_empty_string_numeric_is_none(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(profiles={"test": {"timeout_seconds": ""}})
+        assert cfg.resolved_profiles["test"].timeout_seconds is None
+
+    def test_resolved_profiles_extra_keys_in_raw_env(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(
+            profiles={
+                "test": {
+                    "base_url": "https://example.com",
+                    "model": "gpt-4",
+                    "extra_flag": "true",
+                }
+            }
+        )
+        raw = cfg.resolved_profiles["test"].raw_env
+        assert raw == {"model": "gpt-4", "extra_flag": "true"}
+
+    def test_resolved_profiles_no_mutation(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(profiles={"test": {"model": "gpt-4"}})
+        cfg.resolved_profiles
+        assert cfg.profiles == {"test": {"model": "gpt-4"}}
+
+    def test_resolved_profiles_multiple_profiles(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(
+            profiles={
+                "fast": {"timeout_seconds": "10", "model": "gpt-4o-mini"},
+                "large": {"context_window": "200000", "model": "gpt-4o"},
+            }
+        )
+        result = cfg.resolved_profiles
+        assert len(result) == 2
+        assert result["fast"].timeout_seconds == 10
+        assert result["fast"].raw_env == {"model": "gpt-4o-mini"}
+        assert result["large"].context_window == 200000
+        assert result["large"].raw_env == {"model": "gpt-4o"}


### PR DESCRIPTION
## Summary

Add a lazily-computed `resolved_profiles` property to `ProvidersConfig` that coerces each raw `profiles` entry (`dict[str, str]`) into a typed `ProviderProfileDef` instance. This requires first adding a `raw_env: dict[str, str]` field to `ProviderProfileDef` — a prerequisite gap from P4-A1-WP1, which shipped the frozen dataclass with 5 fields but the acceptance criteria for this issue explicitly require a `raw_env` catch-all field for unknown keys.

**Files modified:**
- `src/autoskillit/config/_config_dataclasses.py` — add `raw_env` field to `ProviderProfileDef`, add `resolved_profiles` property to `ProvidersConfig`
- `tests/config/test_provider_profile_def.py` — update field count/name assertions, add `raw_env` coverage
- `tests/config/test_providers_config.py` — add `TestResolvedProfiles` test class

**No changes to:** `__post_init__` on either class, `profiles` field, any other ProvidersConfig field, any downstream consumer (P4-A6-WP1 scope), any re-export chain or `__all__` list.

## Requirements

*(No ## Requirements section found in issue #2500)*

## Conflict Resolution Decisions

*(No conflict resolution report provided)*

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph Input ["Data Origin"]
        YAML["config.yaml<br/>━━━━━━━━━━<br/>providers.profiles<br/>dict of str→str dicts"]
    end

    subgraph Storage ["Primary Storage (Unchanged)"]
        PROFILES[("● ProvidersConfig.profiles<br/>━━━━━━━━━━<br/>dict‹str, dict‹str, str››<br/>Raw string key-value pairs")]
    end

    subgraph Transform ["★ New: Coercion Layer"]
        direction TB
        PROP["★ resolved_profiles<br/>━━━━━━━━━━<br/>@property on ProvidersConfig<br/>Iterates profiles.items()"]
        COPY["dict(raw_dict)<br/>━━━━━━━━━━<br/>Shallow copy to<br/>protect mutation"]
        EXTRACT["Pop known keys<br/>━━━━━━━━━━<br/>base_url, timeout_seconds<br/>api_key_env, context_window"]
        COERCE["int() coercion<br/>━━━━━━━━━━<br/>timeout_seconds: str→int<br/>context_window: str→int"]
    end

    subgraph Output ["★ Typed Output"]
        PPD["★ ProviderProfileDef<br/>━━━━━━━━━━<br/>frozen dataclass<br/>+ raw_env for remainders"]
        RESULT["dict‹str, ProviderProfileDef›<br/>━━━━━━━━━━<br/>Keyed by profile name"]
    end

    YAML -->|"Dynaconf load"| PROFILES
    PROFILES -->|"self.profiles.items()"| PROP
    PROP --> COPY
    COPY --> EXTRACT
    EXTRACT --> COERCE
    COERCE -->|"construct"| PPD
    PPD --> RESULT

    class YAML cli;
    class PROFILES stateNode;
    class PROP,COPY,EXTRACT,COERCE newComponent;
    class PPD,RESULT output;
```

**Color Legend:**

| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Input | YAML config file origin |
| Teal | Storage | Existing `profiles` field (unchanged) |
| Green | New | New coercion property and transformation steps |
| Dark Teal | Output | Typed `ProviderProfileDef` instances |

**Lens Used:** Data Lineage — the core change is a data transformation pipeline converting raw `dict[str, str]` into typed frozen dataclass instances.

Closes #2500

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-102428-671862/.autoskillit/temp/make-plan/p4_a2_wp1_add_resolved_profiles_property_plan_2026-05-20_102800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.0k | 19.0k | 690.4k | 96.7k | 306 | 62.8k | 16m 22s |
| verify | claude-opus-4-6 | 1 | 35 | 6.6k | 278.6k | 50.2k | 50 | 35.5k | 2m 54s |
| implement* | MiniMax-M2.7 | 1 | 203.0k | 5.6k | 802.9k | 29.2k | 56 | 29.2k | 3m 41s |
| prepare_pr* | MiniMax-M2.7 | 1 | 96.9k | 2.4k | 106.1k | 29.2k | 18 | 34.6k | 1m 41s |
| compose_pr* | MiniMax-M2.7 | 1 | 81.6k | 3.1k | 346.8k | 29.2k | 28 | 15.5k | 1m 24s |
| review_pr | claude-opus-4-6 | 3 | 104 | 36.9k | 1.3M | 55.8k | 87 | 115.4k | 9m 18s |
| resolve_review | claude-opus-4-6 | 1 | 61 | 12.6k | 1.4M | 67.3k | 52 | 52.9k | 8m 55s |
| **Total** | | | 385.7k | 86.2k | 4.9M | 96.7k | | 345.9k | 44m 17s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 114 | 7042.8 | 256.3 | 48.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 169396.8 | 6617.8 | 1576.5 |
| **Total** | **122** | 39855.6 | 2835.3 | 706.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 4.0k | 19.0k | 690.4k | 62.8k | 16m 22s |
| claude-opus-4-6 | 3 | 200 | 56.1k | 2.9M | 203.8k | 21m 7s |
| MiniMax-M2.7 | 3 | 381.5k | 11.1k | 1.3M | 79.3k | 6m 47s |