### PR TITLE
[P4-A4-WP1] Insert anthropic sentinel profile into providers.profiles

### DIFF
--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -207,7 +207,9 @@ def cook(
     }
     if profile is not None:
         _cook_env_extras["AUTOSKILLIT_PROVIDER_PROFILE"] = profile
-        _cook_env_extras.update(config.providers.profiles[profile])
+        _cook_env_extras.update(
+            {k: v for k, v in config.providers.profiles[profile].items() if v is not None}
+        )
 
     current_resume_spec = resume_spec
     _current_first_run = _first_run

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -430,7 +430,7 @@ class ProvidersConfig:
     """
 
     default_provider: str | None = None
-    profiles: dict[str, dict[str, str]] = field(default_factory=dict)
+    profiles: dict[str, dict[str, str | None]] = field(default_factory=dict)
     step_overrides: dict[str, str] = field(default_factory=dict)
     recipe_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
     provider_retry_limit: int = 2
@@ -440,9 +440,10 @@ class ProvidersConfig:
             raise ValueError(f"provider_retry_limit must be >= 1, got {self.provider_retry_limit}")
         for name, profile in self.profiles.items():
             for k, v in profile.items():
-                if not isinstance(v, str):
+                if v is not None and not isinstance(v, str):
                     raise ValueError(
-                        f"profiles[{name!r}][{k!r}] must be a string, got {type(v).__name__!r}"
+                        f"profiles[{name!r}][{k!r}] must be a string or null, "
+                        f"got {type(v).__name__!r}"
                     )
         for recipe, overrides in self.recipe_overrides.items():
             if not isinstance(overrides, dict):
@@ -461,7 +462,7 @@ class ProvidersConfig:
     def resolved_profiles(self) -> dict[str, ProviderProfileDef]:
         result: dict[str, ProviderProfileDef] = {}
         for name, raw_dict in self.profiles.items():
-            copy = dict(raw_dict)
+            copy = {k: v for k, v in raw_dict.items() if v is not None}
             base_url = copy.pop("base_url", None)
             timeout_str = copy.pop("timeout_seconds", None)
             api_key_env = copy.pop("api_key_env", None)

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -295,7 +295,12 @@ fleet:
 
 providers:
   default_provider: null
-  profiles: {}
+  profiles:
+    anthropic:
+      base_url: null
+      timeout_seconds: null
+      api_key_env: null
+      context_window: null
   step_overrides: {}
   recipe_overrides: {}
   provider_retry_limit: 2

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -156,11 +156,12 @@ def _check_dry_walkthrough(skill_command: str, cwd: str) -> str | None:
 
 def _provider_result(
     provider: str,
-    profiles: dict[str, dict[str, str]],
+    profiles: dict[str, dict[str, str | None]],
 ) -> tuple[str, dict[str, str]]:
     if provider == "anthropic":
         return ("anthropic", {})
-    return (provider, profiles.get(provider, {}))
+    raw = profiles.get(provider, {})
+    return (provider, {k: v for k, v in raw.items() if v is not None})
 
 
 def _resolve_provider_profile(
@@ -205,7 +206,8 @@ def _resolve_provider_profile(
             )
             if step_override == "anthropic":
                 return ("anthropic", {})
-            return (step_override, config_providers.profiles.get(step_override, {}))
+            raw = config_providers.profiles.get(step_override, {})
+            return (step_override, {k: v for k, v in raw.items() if v is not None})
 
     # Tier 2: wildcard override (requires recipe context)
     if recipe_name:
@@ -218,21 +220,24 @@ def _resolve_provider_profile(
             )
             if wildcard == "anthropic":
                 return ("anthropic", {})
-            return (wildcard, config_providers.profiles.get(wildcard, {}))
+            raw = config_providers.profiles.get(wildcard, {})
+            return (wildcard, {k: v for k, v in raw.items() if v is not None})
 
     # Tier 3: step YAML provider field
     if step_name:
         logger.debug("provider_profile_resolved", tier="step_provider_field", profile=step_name)
         if step_name == "anthropic":
             return ("anthropic", {})
-        return (step_name, config_providers.profiles.get(step_name, {}))
+        raw = config_providers.profiles.get(step_name, {})
+        return (step_name, {k: v for k, v in raw.items() if v is not None})
 
     # Tier 4: default
     name = config_providers.default_provider or "anthropic"
     logger.debug("provider_profile_resolved", tier="default", profile=name)
     if name == "anthropic":
         return ("anthropic", {})
-    return (name, config_providers.profiles.get(name, {}))
+    raw = config_providers.profiles.get(name, {})
+    return (name, {k: v for k, v in raw.items() if v is not None})
 
 
 def _resolve_model_as_profile(
@@ -276,5 +281,5 @@ def _resolve_model_as_profile(
         resolved_model=actual_model,
         profile=model_value,
     )
-    env_dict = {k: v for k, v in profile.items() if k != "ANTHROPIC_MODEL"}
+    env_dict = {k: v for k, v in profile.items() if k != "ANTHROPIC_MODEL" and v is not None}
     return (actual_model, model_value, env_dict)

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -46,7 +46,13 @@ class TestProvidersConfig:
 
         cfg = load_config(tmp_path)
         assert cfg.providers.default_provider is None
-        assert cfg.providers.profiles == {}
+        assert "anthropic" in cfg.providers.profiles
+        assert cfg.providers.profiles["anthropic"] == {
+            "base_url": None,
+            "timeout_seconds": None,
+            "api_key_env": None,
+            "context_window": None,
+        }
         assert cfg.providers.step_overrides == {}
         assert cfg.providers.recipe_overrides == {}
         assert cfg.providers.provider_retry_limit == 2
@@ -97,7 +103,7 @@ class TestProvidersConfig:
     def test_providers_config_profiles_non_string_value_raises(self) -> None:
         from autoskillit.config.settings import ProvidersConfig
 
-        with pytest.raises(ValueError, match=r"profiles\[.+\]\[.+\] must be a string"):
+        with pytest.raises(ValueError, match=r"profiles\[.+\]\[.+\] must be a string or null"):
             ProvidersConfig(profiles={"my_profile": {"model": 42}})  # type: ignore[arg-type]
 
     def test_recipe_overrides_non_string_value_raises(self) -> None:
@@ -111,6 +117,13 @@ class TestProvidersConfig:
 
         with pytest.raises(ValueError, match=r"recipe_overrides\[.+\] must be a dict"):
             ProvidersConfig(recipe_overrides={"remediation": "not_a_dict"})  # type: ignore[arg-type]
+
+    def test_providers_config_profiles_none_value_accepted(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(profiles={"sentinel": {"base_url": None, "api_key_env": None}})  # type: ignore[arg-type]
+        assert cfg.profiles["sentinel"]["base_url"] is None
+        assert cfg.profiles["sentinel"]["api_key_env"] is None
 
 
 class TestProvidersConfigYaml:
@@ -146,9 +159,12 @@ class TestProvidersConfigYaml:
         }
         (config_dir / "config.yaml").write_text(yaml.dump(config_data))
         cfg = load_config(tmp_path)
-        assert cfg.providers.profiles == {
-            "fast": {"model": "gpt-4o-mini", "api_base": "https://api.openai.com"},
+        # Defaults (anthropic sentinel) are merged with user-provided profiles
+        assert cfg.providers.profiles["fast"] == {
+            "model": "gpt-4o-mini",
+            "api_base": "https://api.openai.com",
         }
+        assert "anthropic" in cfg.providers.profiles
 
     def test_load_config_provider_retry_limit_override(self, tmp_path) -> None:
         from autoskillit.config import load_config
@@ -170,6 +186,20 @@ class TestProvidersConfigYaml:
         (config_dir / "config.yaml").write_text(yaml.dump(config_data))
         cfg = load_config(tmp_path)
         assert cfg.providers.recipe_overrides == {"remediation": {"implement": "anthropic"}}
+
+    def test_defaults_yaml_anthropic_sentinel_profile(self) -> None:
+        from autoskillit.core.io import load_yaml
+        from autoskillit.core.paths import pkg_root
+
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+        profile = defaults["providers"]["profiles"]["anthropic"]
+        assert set(profile.keys()) == {
+            "base_url",
+            "timeout_seconds",
+            "api_key_env",
+            "context_window",
+        }
+        assert all(v is None for v in profile.values())
 
     def test_load_config_recipe_overrides_merges_across_layers(
         self, tmp_path, monkeypatch
@@ -282,3 +312,27 @@ class TestResolvedProfiles:
         assert result["fast"].raw_env == {"model": "gpt-4o-mini"}
         assert result["large"].context_window == 200000
         assert result["large"].raw_env == {"model": "gpt-4o"}
+
+    def test_resolved_profiles_null_sentinel(self) -> None:
+        from autoskillit.config._config_dataclasses import ProviderProfileDef
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(
+            profiles={
+                "anthropic": {
+                    "base_url": None,
+                    "timeout_seconds": None,
+                    "api_key_env": None,
+                    "context_window": None,
+                }
+            }  # type: ignore[arg-type]
+        )
+        result = cfg.resolved_profiles
+        assert "anthropic" in result
+        profile = result["anthropic"]
+        assert isinstance(profile, ProviderProfileDef)
+        assert profile.base_url is None
+        assert profile.timeout_seconds is None
+        assert profile.api_key_env is None
+        assert profile.context_window is None
+        assert profile.raw_env == {}

--- a/tests/server/test_resolve_model_as_profile.py
+++ b/tests/server/test_resolve_model_as_profile.py
@@ -99,3 +99,23 @@ def test_anthropic_as_model_value_no_profile():
     cfg = _make_config(profiles={"minimax": {"ANTHROPIC_MODEL": "M2.7"}})
     result = _resolve_model_as_profile("anthropic", cfg)
     assert result == ("anthropic", "", None)
+
+
+def test_resolve_model_as_profile_filters_none_values():
+    from autoskillit.server._guards import _resolve_model_as_profile
+
+    cfg = _make_config(
+        profiles={
+            "myprofile": {
+                "ANTHROPIC_MODEL": "claude-sonnet-4-6",
+                "base_url": None,
+                "api_key_env": None,
+            }
+        }
+    )
+    model, name, extras = _resolve_model_as_profile("myprofile", cfg)
+    assert model == "claude-sonnet-4-6"
+    assert name == "myprofile"
+    assert extras is not None
+    assert None not in extras.values()
+    assert "base_url" not in extras

--- a/tests/server/test_resolve_provider_profile.py
+++ b/tests/server/test_resolve_provider_profile.py
@@ -200,3 +200,26 @@ def test_recipe_override_requires_step_name_with_step_name():
     )
     result = _resolve_provider_profile("implement", "remediation", cfg)
     assert result == ("vertex", {"K": "V"})
+
+
+def test_provider_result_filters_none_values():
+    from autoskillit.server._guards import _provider_result
+
+    profiles = {"custom": {"base_url": None, "api_key_env": "MY_KEY", "timeout_seconds": None}}
+    name, extras = _provider_result("custom", profiles)
+    assert name == "custom"
+    assert None not in extras.values()
+    assert extras == {"api_key_env": "MY_KEY"}
+
+
+def test_resolve_provider_profile_filters_none_from_step_override():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        profiles={"custom": {"base_url": None, "api_key_env": "MY_KEY"}},
+        step_overrides={"fetch": "custom"},
+    )
+    name, extras = _resolve_provider_profile("fetch", "my_recipe", cfg)
+    assert name == "custom"
+    assert None not in extras.values()
+    assert extras == {"api_key_env": "MY_KEY"}


### PR DESCRIPTION
## Summary

Insert an `anthropic` sentinel profile entry into `providers.profiles` in `defaults.yaml` with four null fields (`base_url`, `timeout_seconds`, `api_key_env`, `context_window`) to document the expected `ProviderProfileDef` schema shape. This requires four coordinated changes:

1. Replace `profiles: {}` in `defaults.yaml` with the sentinel block
2. Relax `ProvidersConfig.__post_init__` to allow `None` values in profile dicts (YAML `null` deserializes to Python `None`, not `str`)
3. Update the type annotation on `profiles` from `dict[str, dict[str, str]]` to `dict[str, dict[str, str | None]]`
4. Guard ALL downstream consumers that read raw profile dicts against `None` values leaking into env-var dicts: `_provider_result`, `_resolve_provider_profile` inline paths, `_resolve_model_as_profile`, and `_cook.py`

## Requirements

- defaults.yaml parses as valid YAML.
- providers.profiles is a mapping with key 'anthropic'.
- The anthropic entry has exactly four keys: base_url, timeout_seconds, api_key_env, context_window — all null.
- All four field keys indented at 6 spaces.
- No other lines in defaults.yaml are modified.
- After P4-A2 lands, loading AutomationConfig does not raise ValueError.
- Field names match ProviderProfileDef fields from P4-A1.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-112929-662729/.autoskillit/temp/make-plan/P4-A4-WP1_insert_anthropic_sentinel_profile_plan_2026-05-20_113500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.1k | 19.9k | 1.6M | 92.0k | 318 | 75.6k | 16m 15s |
| verify | claude-opus-4-6 | 1 | 44 | 12.8k | 910.4k | 71.8k | 42 | 94.6k | 4m 48s |
| implement* | MiniMax-M2.7 | 1 | 478.5k | 14.8k | 3.2M | 29.2k | 143 | 59.9k | 8m 2s |
| prepare_pr* | MiniMax-M2.7 | 1 | 132.1k | 4.1k | 305.7k | 29.2k | 31 | 29.2k | 1m 57s |
| compose_pr* | MiniMax-M2.7 | 1 | 81.1k | 1.4k | 194.9k | 29.2k | 15 | 2.9k | 39s |
| review_pr | claude-opus-4-6 | 3 | 113 | 80.4k | 1.5M | 75.1k | 92 | 169.7k | 18m 37s |
| resolve_review | claude-opus-4-6 | 1 | 38 | 9.7k | 508.9k | 58.3k | 32 | 43.9k | 6m 40s |
| **Total** | | | 694.9k | 143.1k | 8.2M | 92.0k | | 475.9k | 57m 1s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 144 | 21955.5 | 416.2 | 102.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **144** | 57034.3 | 3305.2 | 993.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 3.1k | 19.9k | 1.6M | 75.6k | 16m 15s |
| claude-opus-4-6 | 3 | 195 | 103.0k | 2.9M | 308.2k | 30m 6s |
| MiniMax-M2.7 | 3 | 691.6k | 20.2k | 3.7M | 92.1k | 10m 39s |