### PR TITLE
[P4-A6-WP1] Implement _profile_to_env and update _resolve_provider_profile

### DIFF
--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -175,7 +175,7 @@ def _profile_to_env(profile: ProviderProfileDef) -> dict[str, str]:
         if val:
             env["ANTHROPIC_API_KEY"] = val
         else:
-            logger.warning("provider_api_key_env_missing", api_key_env=profile.api_key_env)
+            logger.warning("provider_api_key_env_missing", env_var_name=profile.api_key_env)
     env.update(profile.raw_env)
     return env
 

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -10,7 +10,7 @@ from autoskillit.core import SessionType, extract_path_arg, get_logger, session_
 from autoskillit.pipeline import gate_error_result, headless_error_result
 
 if TYPE_CHECKING:
-    from autoskillit.config._config_dataclasses import ProvidersConfig
+    from autoskillit.config._config_dataclasses import ProviderProfileDef, ProvidersConfig
 
 logger = get_logger(__name__)
 
@@ -164,6 +164,22 @@ def _provider_result(
     return (provider, {k: v for k, v in raw.items() if v is not None})
 
 
+def _profile_to_env(profile: ProviderProfileDef) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if profile.base_url:
+        env["ANTHROPIC_BASE_URL"] = profile.base_url
+    if profile.timeout_seconds is not None and profile.timeout_seconds > 0:
+        env["API_TIMEOUT_MS"] = str(profile.timeout_seconds * 1000)
+    if profile.api_key_env:
+        val = os.environ.get(profile.api_key_env)
+        if val:
+            env["ANTHROPIC_API_KEY"] = val
+        else:
+            logger.warning("provider_api_key_env_missing", api_key_env=profile.api_key_env)
+    env.update(profile.raw_env)
+    return env
+
+
 def _resolve_provider_profile(
     step_name: str,
     recipe_name: str,
@@ -206,8 +222,11 @@ def _resolve_provider_profile(
             )
             if step_override == "anthropic":
                 return ("anthropic", {})
-            raw = config_providers.profiles.get(step_override, {})
-            return (step_override, {k: v for k, v in raw.items() if v is not None})
+            profile = config_providers.resolved_profiles.get(step_override)
+            if profile is None:
+                logger.debug("provider_profile_not_found", provider=step_override)
+                return (step_override, {})
+            return (step_override, _profile_to_env(profile))
 
     # Tier 2: wildcard override (requires recipe context)
     if recipe_name:
@@ -220,24 +239,33 @@ def _resolve_provider_profile(
             )
             if wildcard == "anthropic":
                 return ("anthropic", {})
-            raw = config_providers.profiles.get(wildcard, {})
-            return (wildcard, {k: v for k, v in raw.items() if v is not None})
+            profile = config_providers.resolved_profiles.get(wildcard)
+            if profile is None:
+                logger.debug("provider_profile_not_found", provider=wildcard)
+                return (wildcard, {})
+            return (wildcard, _profile_to_env(profile))
 
     # Tier 3: step YAML provider field
     if step_name:
         logger.debug("provider_profile_resolved", tier="step_provider_field", profile=step_name)
         if step_name == "anthropic":
             return ("anthropic", {})
-        raw = config_providers.profiles.get(step_name, {})
-        return (step_name, {k: v for k, v in raw.items() if v is not None})
+        profile = config_providers.resolved_profiles.get(step_name)
+        if profile is None:
+            logger.debug("provider_profile_not_found", provider=step_name)
+            return (step_name, {})
+        return (step_name, _profile_to_env(profile))
 
     # Tier 4: default
     name = config_providers.default_provider or "anthropic"
     logger.debug("provider_profile_resolved", tier="default", profile=name)
     if name == "anthropic":
         return ("anthropic", {})
-    raw = config_providers.profiles.get(name, {})
-    return (name, {k: v for k, v in raw.items() if v is not None})
+    profile = config_providers.resolved_profiles.get(name)
+    if profile is None:
+        logger.debug("provider_profile_not_found", provider=name)
+        return (name, {})
+    return (name, _profile_to_env(profile))
 
 
 def _resolve_model_as_profile(

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -26,12 +26,13 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_misc_module.py` | Contract tests: server._misc module |
 | `test_no_raw_signal_handler.py` | AST guard: no raw signal.signal(SIGTERM, ...) in cli/app.py |
 | `test_perform_merge_editable_guard.py` | Integration tests verifying perform_merge() aborts before cleanup on poisoned installs |
+| `test_profile_to_env.py` | Tests for _profile_to_env — ProviderProfileDef to env dict conversion in _guards.py |
 | `test_quota_refresh_loop.py` | Tests for _quota_refresh_loop in server/_misc.py |
 | `test_release_issue_fail_label.py` | Tests for release_issue fail_label path and fail label cleanup |
 | `test_reload_session.py` | Tests for the reload_session MCP tool and supporting helpers |
 | `test_research_smoke_pipeline.py` | Research recipe smoke pipeline: gated E2E tests (RESEARCH_SMOKE_TEST=1) |
 | `test_resolve_model_as_profile.py` | Tests for _resolve_model_as_profile — model-value-as-provider-profile resolution in _guards.py |
-| `test_resolve_provider_profile.py` | Tests for _resolve_provider_profile four-tier provider resolution in _guards.py |
+| `test_resolve_provider_profile.py` | Tests for _resolve_provider_profile six-tier provider resolution in _guards.py |
 | `test_run_skill_add_dirs.py` | Contract tests: run_skill passes correct add_dirs to executor (T-OVR-014) |
 | `test_run_skill_resume.py` | Tests for resume_session_id threading from run_skill through executor |
 | `test_server_init_gate.py` | Tests for server init: gate access, visibility, subset management, wire format compliance |

--- a/tests/server/test_profile_to_env.py
+++ b/tests/server/test_profile_to_env.py
@@ -19,13 +19,18 @@ def test_all_fields_populated(monkeypatch):
 
     monkeypatch.setenv("MY_KEY", "secret")
     profile = _make_profile(
-        name="x", base_url="https://a.com", timeout_seconds=30, api_key_env="MY_KEY"
+        name="x",
+        base_url="https://a.com",
+        timeout_seconds=30,
+        api_key_env="MY_KEY",
+        raw_env={"CUSTOM_FLAG": "on"},
     )
     result = _profile_to_env(profile)
     assert result == {
         "ANTHROPIC_BASE_URL": "https://a.com",
         "API_TIMEOUT_MS": "30000",
         "ANTHROPIC_API_KEY": "secret",
+        "CUSTOM_FLAG": "on",
     }
 
 
@@ -98,3 +103,15 @@ def test_raw_env_merged_with_mapped_fields():
     profile = _make_profile(name="x", base_url="https://a.com", raw_env={"EXTRA": "e"})
     result = _profile_to_env(profile)
     assert result == {"ANTHROPIC_BASE_URL": "https://a.com", "EXTRA": "e"}
+
+
+def test_raw_env_overrides_mapped_field():
+    from autoskillit.server._guards import _profile_to_env
+
+    profile = _make_profile(
+        name="x",
+        base_url="https://a.com",
+        raw_env={"ANTHROPIC_BASE_URL": "https://override.com"},
+    )
+    result = _profile_to_env(profile)
+    assert result["ANTHROPIC_BASE_URL"] == "https://override.com"

--- a/tests/server/test_profile_to_env.py
+++ b/tests/server/test_profile_to_env.py
@@ -54,7 +54,7 @@ def test_api_key_env_absent_warns(monkeypatch):
         result = _profile_to_env(profile)
     assert "ANTHROPIC_API_KEY" not in result
     assert any(
-        log["event"] == "provider_api_key_env_missing" and log["api_key_env"] == "MISSING_KEY"
+        log["event"] == "provider_api_key_env_missing" and log["env_var_name"] == "MISSING_KEY"
         for log in logs
     )
 

--- a/tests/server/test_profile_to_env.py
+++ b/tests/server/test_profile_to_env.py
@@ -1,0 +1,100 @@
+"""Tests for _profile_to_env — ProviderProfileDef to env dict conversion."""
+
+from __future__ import annotations
+
+import pytest
+import structlog.testing
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _make_profile(**kwargs):
+    from autoskillit.config._config_dataclasses import ProviderProfileDef
+
+    return ProviderProfileDef(**kwargs)
+
+
+def test_all_fields_populated(monkeypatch):
+    from autoskillit.server._guards import _profile_to_env
+
+    monkeypatch.setenv("MY_KEY", "secret")
+    profile = _make_profile(
+        name="x", base_url="https://a.com", timeout_seconds=30, api_key_env="MY_KEY"
+    )
+    result = _profile_to_env(profile)
+    assert result == {
+        "ANTHROPIC_BASE_URL": "https://a.com",
+        "API_TIMEOUT_MS": "30000",
+        "ANTHROPIC_API_KEY": "secret",
+    }
+
+
+def test_empty_fields_returns_empty_dict():
+    from autoskillit.server._guards import _profile_to_env
+
+    profile = _make_profile(name="x")
+    result = _profile_to_env(profile)
+    assert result == {}
+
+
+def test_zero_timeout_returns_empty_dict():
+    from autoskillit.server._guards import _profile_to_env
+
+    profile = _make_profile(name="x", timeout_seconds=0)
+    result = _profile_to_env(profile)
+    assert result == {}
+
+
+def test_api_key_env_absent_warns(monkeypatch):
+    from autoskillit.server._guards import _profile_to_env
+
+    monkeypatch.delenv("MISSING_KEY", raising=False)
+    profile = _make_profile(name="x", api_key_env="MISSING_KEY")
+    with structlog.testing.capture_logs() as logs:
+        result = _profile_to_env(profile)
+    assert "ANTHROPIC_API_KEY" not in result
+    assert any(
+        log["event"] == "provider_api_key_env_missing" and log["api_key_env"] == "MISSING_KEY"
+        for log in logs
+    )
+
+
+def test_base_url_only():
+    from autoskillit.server._guards import _profile_to_env
+
+    profile = _make_profile(name="x", base_url="https://b.com")
+    result = _profile_to_env(profile)
+    assert result == {"ANTHROPIC_BASE_URL": "https://b.com"}
+
+
+def test_timeout_only():
+    from autoskillit.server._guards import _profile_to_env
+
+    profile = _make_profile(name="x", timeout_seconds=60)
+    result = _profile_to_env(profile)
+    assert result == {"API_TIMEOUT_MS": "60000"}
+
+
+def test_api_key_env_only(monkeypatch):
+    from autoskillit.server._guards import _profile_to_env
+
+    monkeypatch.setenv("K", "v")
+    profile = _make_profile(name="x", api_key_env="K")
+    result = _profile_to_env(profile)
+    assert result == {"ANTHROPIC_API_KEY": "v"}
+
+
+def test_raw_env_passthrough():
+    from autoskillit.server._guards import _profile_to_env
+
+    profile = _make_profile(name="x", raw_env={"AWS_REGION": "us-east-1", "CUSTOM": "val"})
+    result = _profile_to_env(profile)
+    assert result == {"AWS_REGION": "us-east-1", "CUSTOM": "val"}
+
+
+def test_raw_env_merged_with_mapped_fields():
+    from autoskillit.server._guards import _profile_to_env
+
+    profile = _make_profile(name="x", base_url="https://a.com", raw_env={"EXTRA": "e"})
+    result = _profile_to_env(profile)
+    assert result == {"ANTHROPIC_BASE_URL": "https://a.com", "EXTRA": "e"}

--- a/tests/server/test_resolve_provider_profile.py
+++ b/tests/server/test_resolve_provider_profile.py
@@ -212,7 +212,7 @@ def test_provider_result_filters_none_values():
     assert extras == {"api_key_env": "MY_KEY"}
 
 
-def test_resolve_provider_profile_filters_none_from_step_override(monkeypatch):
+def test_resolve_provider_profile_step_override_resolves_api_key(monkeypatch):
     from autoskillit.server._guards import _resolve_provider_profile
 
     monkeypatch.setenv("MY_KEY", "secret-value")

--- a/tests/server/test_resolve_provider_profile.py
+++ b/tests/server/test_resolve_provider_profile.py
@@ -212,9 +212,10 @@ def test_provider_result_filters_none_values():
     assert extras == {"api_key_env": "MY_KEY"}
 
 
-def test_resolve_provider_profile_filters_none_from_step_override():
+def test_resolve_provider_profile_filters_none_from_step_override(monkeypatch):
     from autoskillit.server._guards import _resolve_provider_profile
 
+    monkeypatch.setenv("MY_KEY", "secret-value")
     cfg = _make_config(
         profiles={"custom": {"base_url": None, "api_key_env": "MY_KEY"}},
         step_overrides={"fetch": "custom"},
@@ -222,4 +223,4 @@ def test_resolve_provider_profile_filters_none_from_step_override():
     name, extras = _resolve_provider_profile("fetch", "my_recipe", cfg)
     assert name == "custom"
     assert None not in extras.values()
-    assert extras == {"api_key_env": "MY_KEY"}
+    assert extras == {"ANTHROPIC_API_KEY": "secret-value"}


### PR DESCRIPTION
## Summary

Add a `_profile_to_env` helper function to `src/autoskillit/server/_guards.py` that converts a `ProviderProfileDef` into a `dict[str, str]` of environment variable overrides. Replace the four inline `profiles.get()` calls in `_resolve_provider_profile` (Tiers 1–4) with `config_providers.resolved_profiles.get()` + `_profile_to_env()`. When `resolved_profiles.get()` returns `None`, log at debug level and return `(name, {})`. Add unit tests for `_profile_to_env` covering all field mappings. Update one existing test whose assertion changes under the new semantics.

**Scope boundary:** `_provider_result` (used by Tiers 0/0W) is NOT modified. Only the four inline `profiles.get(name, {})` calls at current lines 209, 223, 231, 239 are replaced.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-125600-087608/.autoskillit/temp/make-plan/P4-A6-WP1_implement_profile_to_env_plan_2026-05-20_130100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 5.5k | 26.3k | 1.5M | 99.0k | 194 | 84.2k | 14m 59s |
| verify | claude-sonnet-4-6 | 1 | 30 | 7.2k | 589.1k | 70.0k | 102 | 70.6k | 4m 56s |
| implement* | MiniMax-M2.7 | 1 | 59.5k | 6.8k | 1.4M | 0 | 63 | 0 | 1m 30s |
| prepare_pr* | MiniMax-M2.7 | 1 | 45.8k | 3.1k | 246.4k | 0 | 21 | 0 | 37s |
| compose_pr* | MiniMax-M2.7 | 1 | 42.5k | 1.8k | 243.3k | 0 | 23 | 0 | 37s |
| review_pr | claude-opus-4-6 | 3 | 99 | 44.6k | 1.1M | 58.4k | 78 | 125.4k | 11m 12s |
| resolve_review | claude-opus-4-6 | 1 | 46 | 6.5k | 983.7k | 61.1k | 39 | 46.4k | 3m 15s |
| **Total** | | | 153.4k | 96.3k | 6.0M | 99.0k | | 326.6k | 37m 7s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 154 | 8880.6 | 0.0 | 43.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 21 | 46845.1 | 2208.9 | 309.8 |
| **Total** | **175** | 34477.0 | 1866.5 | 550.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 5.6k | 33.5k | 2.1M | 154.8k | 19m 55s |
| MiniMax-M2.7 | 3 | 147.7k | 11.6k | 1.9M | 0 | 2m 44s |
| claude-opus-4-6 | 2 | 145 | 51.1k | 2.1M | 171.8k | 14m 27s |