### PR TITLE
[P4-A7-WP4] Add TestProviderBypass integration tests for provider bypass and full blocking path

### DIFF
--- a/tests/execution/test_quota_sleep.py
+++ b/tests/execution/test_quota_sleep.py
@@ -727,4 +727,5 @@ class TestProviderBypass:
         result = await check_and_sleep_if_needed(config)
         assert result["should_sleep"] is True
         assert result["sleep_seconds"] > 0
+        # 2 calls: initial fetch (cache miss) + re-fetch for accurate resets_at
         assert len(fetch_called) == 2

--- a/tests/execution/test_quota_sleep.py
+++ b/tests/execution/test_quota_sleep.py
@@ -641,3 +641,90 @@ class TestFetchQuotaNovelWindowWarning:
         assert not novel_warnings, (
             f"Unexpected novel-window warnings for known windows: {novel_warnings}"
         )
+
+
+class TestProviderBypass:
+    """Integration tests: provider bypass with live cache and anthropic full-path exercise."""
+
+    @pytest.mark.anyio
+    async def test_non_anthropic_provider_bypasses_above_threshold_cache(
+        self, monkeypatch, tmp_path
+    ):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            _write_cache,
+            check_and_sleep_if_needed,
+        )
+
+        resets_at = datetime.now(UTC) + timedelta(hours=2)
+        cache_path = tmp_path / "cache.json"
+        _write_cache(
+            str(cache_path),
+            QuotaFetchResult(
+                windows={"five_hour": QuotaWindowEntry(utilization=95.0, resets_at=resets_at)},
+                binding=QuotaStatus(
+                    utilization=95.0,
+                    resets_at=resets_at,
+                    window_name="five_hour",
+                    should_block=True,
+                    effective_threshold=85.0,
+                ),
+            ),
+        )
+
+        config = make_quota_guard_config(
+            enabled=True,
+            credentials_path=str(tmp_path / ".credentials.json"),
+            cache_path=str(cache_path),
+        )
+        fetch_called = []
+
+        async def mock_fetch(*a, **kw):
+            fetch_called.append(1)
+            raise AssertionError("should not fetch")
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", mock_fetch)
+        result = await check_and_sleep_if_needed(config, provider="minimax")
+        assert result["should_sleep"] is False
+        assert result.get("provider_bypass") is True
+        assert fetch_called == []
+
+    @pytest.mark.anyio
+    async def test_anthropic_provider_default_exercises_full_blocking_path(
+        self, monkeypatch, tmp_path
+    ):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            check_and_sleep_if_needed,
+        )
+
+        resets_at = datetime.now(UTC) + timedelta(hours=2)
+        config = make_quota_guard_config(
+            enabled=True,
+            credentials_path=str(tmp_path / ".credentials.json"),
+            cache_path=str(tmp_path / "cache.json"),
+        )
+        fetch_called = []
+
+        async def mock_fetch(path, **kwargs):
+            fetch_called.append(1)
+            return QuotaFetchResult(
+                windows={"five_hour": QuotaWindowEntry(utilization=95.0, resets_at=resets_at)},
+                binding=QuotaStatus(
+                    utilization=95.0,
+                    resets_at=resets_at,
+                    window_name="five_hour",
+                    should_block=True,
+                    effective_threshold=85.0,
+                ),
+            )
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", mock_fetch)
+        result = await check_and_sleep_if_needed(config)
+        assert result["should_sleep"] is True
+        assert result["sleep_seconds"] > 0
+        assert len(fetch_called) == 2


### PR DESCRIPTION
## Summary

Add a `TestProviderBypass` integration test class to `tests/execution/test_quota_sleep.py` with two tests exercising the provider bypass path in `check_and_sleep_if_needed`. Test 1 writes a real above-threshold cache file and verifies non-Anthropic providers bypass all quota I/O (including cache reads). Test 2 exercises the full Anthropic blocking path with above-threshold utilization, verifying `should_sleep=True` and positive `sleep_seconds`. No source code modifications — test-only change.

## Requirements

Add integration-level `TestProviderBypass` class covering provider-bypass-with-live-cache and anthropic-default-round-trip scenarios not duplicated by P4-A5-WP3 unit tests.

## Architecture Impact

This is a test-only change to `tests/execution/test_quota_sleep.py`. The `TestProviderBypass` class exercises the integration between `check_and_sleep_if_needed` (from `execution/backend.py` or the quota module) and the cache file system used for above-threshold detection. The tests verify that non-Anthropic providers (`provider="openai"` etc.) bypass all quota I/O, while the Anthropic default path exercises the full blocking logic.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-154416-118326/.autoskillit/temp/make-plan/p4_a7_wp4_quota_bypass_plan_2026-05-20_155300.md`

Closes #2506

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 665 | 13.5k | 968.0k | 74.2k | 150 | 59.2k | 9m 24s |
| verify | claude-sonnet-4-6 | 1 | 33 | 4.5k | 214.9k | 62.2k | 53 | 48.3k | 3m 33s |
| implement* | MiniMax-M2.7 | 1 | 120.0k | 3.4k | 578.9k | 29.2k | 39 | 16.2k | 1m 38s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.5k | 2.7k | 327.0k | 0 | 27 | 0 | 33s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.6k | 1.5k | 227.0k | 0 | 18 | 0 | 42s |
| review_pr | claude-opus-4-6 | 3 | 112 | 25.2k | 1.1M | 47.5k | 81 | 95.6k | 7m 52s |
| resolve_review | claude-opus-4-6 | 1 | 41 | 4.0k | 655.0k | 54.5k | 32 | 40.4k | 2m 54s |
| **Total** | | | 203.0k | 54.8k | 4.1M | 74.2k | | 259.7k | 26m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 87 | 6653.5 | 186.6 | 39.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 655027.0 | 40357.0 | 4021.0 |
| **Total** | **88** | 46537.3 | 2951.5 | 623.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 698 | 18.0k | 1.2M | 107.5k | 12m 57s |
| MiniMax-M2.7 | 3 | 202.1k | 7.6k | 1.1M | 16.2k | 2m 52s |
| claude-opus-4-6 | 2 | 153 | 29.2k | 1.8M | 136.0k | 10m 47s |