### PR TITLE
Implementation Plan: [P5-A2-WP1] Define CodexEventData frozen dataclass and import _marker_is_standalone

### DIFF
--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -132,8 +132,8 @@ many individual dispatch_food_truck calls you plan to make — you MUST follow t
 There are no exceptions.
 
 **NEVER:**
-- NEVER dispatch 2 or more issue-bearing food trucks without first completing \
-the bem-wrapper pre-step.
+- NEVER dispatch 2 or more issue-bearing food trucks without first completing the
+  bem-wrapper pre-step.
 - NEVER assume issues are independent without running BEM — BEM is what determines independence.
 - NEVER call dispatch_food_truck for individual issues in parallel before the execution map \
 has been produced and read.

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -85,6 +85,9 @@ class CodexEventData:
     thread_id: str
     item_type: str
     raw: Mapping[str, Any] = field(default_factory=dict)
+    usage: Mapping[str, Any] | None = None
+    file_changes: tuple[Mapping[str, Any], ...] | None = None
+    command: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/core/test_backend_dataclasses.py
+++ b/tests/core/test_backend_dataclasses.py
@@ -71,6 +71,61 @@ def test_codex_event_data_raw_default():
     assert ev.raw == {}
 
 
+def test_codex_event_data_fields_exhaustive():
+    import dataclasses
+
+    from autoskillit.core import CodexEventData
+
+    fields = {f.name for f in dataclasses.fields(CodexEventData)}
+    assert fields == {
+        "record_type",
+        "thread_id",
+        "item_type",
+        "raw",
+        "usage",
+        "file_changes",
+        "command",
+    }
+
+
+def test_codex_event_data_new_fields_default_none():
+    from autoskillit.core import CodexEventData
+
+    ev = CodexEventData(record_type="item", thread_id="t1", item_type="msg")
+    assert ev.usage is None
+    assert ev.file_changes is None
+    assert ev.command is None
+
+
+def test_codex_event_data_new_fields_accept_values():
+    from autoskillit.core import CodexEventData
+
+    ev = CodexEventData(
+        record_type="item",
+        thread_id="t1",
+        item_type="msg",
+        raw={},
+        usage={"input_tokens": 100, "output_tokens": 50},
+        file_changes=({"path": "foo.py", "action": "edit"},),
+        command="python foo.py",
+    )
+    assert ev.usage == {"input_tokens": 100, "output_tokens": 50}
+    assert ev.file_changes == ({"path": "foo.py", "action": "edit"},)
+    assert ev.command == "python foo.py"
+
+
+def test_codex_event_data_field_types():
+    import typing
+    from collections.abc import Mapping
+
+    from autoskillit.core import CodexEventData
+
+    hints = typing.get_type_hints(CodexEventData)
+    assert hints["usage"] == Mapping[str, typing.Any] | None
+    assert hints["file_changes"] == tuple[Mapping[str, typing.Any], ...] | None
+    assert hints["command"] == str | None
+
+
 def test_session_event_frozen():
     from autoskillit.core import BackendEventKind, SessionEvent
 

--- a/tests/execution/test_quota_sleep.py
+++ b/tests/execution/test_quota_sleep.py
@@ -515,6 +515,7 @@ class TestIntegration:
             ),
         )
 
+        monkeypatch.delenv("AUTOSKILLIT_PROVIDER_PROFILE", raising=False)
         stdin_text = json.dumps({"tool_name": "run_skill"})
         buf = io.StringIO()
         with patch("sys.stdin", io.StringIO(stdin_text)):


### PR DESCRIPTION
## Summary

Add three optional fields (`usage`, `file_changes`, `command`) to the existing `CodexEventData` frozen dataclass in `src/autoskillit/core/types/_type_backend.py`. The type already exists with `record_type`, `thread_id`, `item_type`, and `raw` fields and is wired into `SessionEvent.backend_data` union. The new fields provide typed access to Codex-specific event payload data needed by the downstream `CodexStreamParser` (P5-A2-WP2). Verify `_marker_is_standalone` IL-1 accessibility (already confirmed accessible).

**Deviation from issue specification**: The issue specifies `_type_results_execution.py` as the target file, but `CodexEventData` already exists in `_type_backend.py` with tests (`test_backend_dataclasses.py`), `SessionEvent.backend_data` union membership, and `__all__` export. Creating a second `CodexEventData` in `_type_results_execution.py` would cause a name collision at the `core/types/__init__.py` star-import level (both modules are star-imported into `__init__.py`). The correct approach is to augment the existing type in its current location.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):

- `src/autoskillit/cli/_prompts_kitchen.py`
- `src/autoskillit/core/types/_type_backend.py`
- `tests/core/test_backend_dataclasses.py`
- `tests/execution/test_quota_sleep.py`

Closes #2515

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-163817-833830/.autoskillit/temp/make-plan/p5_a2_wp1_codex_event_data_plan_2026-05-20_170000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.1k | 22.1k | 1.2M | 80.0k | 265 | 103.3k | 13m 21s |
| verify | claude-sonnet-4-6 | 1 | 1.8k | 3.6k | 211.9k | 39.7k | 60 | 24.9k | 3m 1s |
| implement* | MiniMax-M2.7-highspeed | 1 | 189.8k | 3.4k | 440.3k | 34.3k | 35 | 25.8k | 1m 31s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 46.9k | 2.8k | 172.4k | 29.2k | 17 | 14.8k | 54s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 59.4k | 1.9k | 201.6k | 29.2k | 18 | 14.7k | 48s |
| review_pr | claude-sonnet-4-6 | 3 | 238 | 30.9k | 998.6k | 49.8k | 82 | 100.0k | 8m 56s |
| resolve_review | claude-opus-4-6 | 1 | 39 | 4.6k | 489.1k | 46.6k | 34 | 32.2k | 3m 30s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 34 | 5.3k | 588.7k | 46.2k | 29 | 31.5k | 2m 9s |
| **Total** | | | 300.3k | 74.6k | 4.3M | 80.0k | | 347.2k | 34m 13s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 58 | 7591.4 | 445.0 | 59.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 602 | 977.9 | 52.3 | 8.7 |
| **Total** | **660** | 6527.4 | 526.1 | 113.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 4.1k | 56.6k | 2.4M | 228.2k | 25m 19s |
| MiniMax-M2.7-highspeed | 3 | 296.1k | 8.1k | 814.3k | 55.3k | 3m 13s |
| claude-opus-4-6 | 2 | 73 | 9.9k | 1.1M | 63.7k | 5m 39s |