### PR TITLE
Scaffold execution/backends package and implement CodexBackend

### DIFF
--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -18,6 +18,7 @@ from autoskillit.execution.anomaly_detection import (
 )
 from autoskillit.execution.backends import (
     ClaudeCodeBackend,
+    CodexBackend,
     get_backend,
 )
 from autoskillit.execution.ci import DefaultCIWatcher
@@ -209,6 +210,7 @@ __all__ = [
     "start_linux_tracing",
     # backends
     "ClaudeCodeBackend",
+    "CodexBackend",
     # anomaly_detection
     "detect_anomalies",
     "AnomalyKind",

--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -8,4 +8,4 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 |------|---------|
 | `__init__.py` | `BACKEND_REGISTRY`, `get_backend()` factory, re-exports |
 | `claude.py` | `ClaudeCodeBackend`, `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` |
-| `codex.py` | `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson` |
+| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson` |

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -12,6 +12,7 @@ from .claude import (
 from .codex import (
     CodexBackend,
     CodexEnvPolicy,
+    CodexFlags,
     CodexResultParser,
     CodexSessionLocator,
     CodexStreamParser,
@@ -42,6 +43,7 @@ __all__ = [
     "ClaudeStreamParser",
     "CodexBackend",
     "CodexEnvPolicy",
+    "CodexFlags",
     "CodexResultParser",
     "CodexSessionLocator",
     "CodexStreamParser",

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -9,10 +9,17 @@ from .claude import (
     ClaudeSessionLocator,
     ClaudeStreamParser,
 )
-from .codex import CodexResultParser
+from .codex import (
+    CodexBackend,
+    CodexEnvPolicy,
+    CodexResultParser,
+    CodexSessionLocator,
+    CodexStreamParser,
+)
 
 BACKEND_REGISTRY: dict[str, type[CodingAgentBackend]] = {
     "claude-code": ClaudeCodeBackend,
+    "codex": CodexBackend,
 }
 
 
@@ -33,6 +40,10 @@ __all__ = [
     "ClaudeResultParser",
     "ClaudeSessionLocator",
     "ClaudeStreamParser",
+    "CodexBackend",
+    "CodexEnvPolicy",
     "CodexResultParser",
+    "CodexSessionLocator",
+    "CodexStreamParser",
     "get_backend",
 ]

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -253,6 +253,12 @@ class CodexStreamParser:
                 kind=BackendEventKind.ERROR,
                 is_terminal=True,
                 has_marker=False,
+                backend_data=CodexEventData(
+                    record_type="error",
+                    thread_id="",
+                    item_type="",
+                    raw=obj,
+                ),
             )
 
         return SessionEvent(

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -365,7 +365,10 @@ class CodexBackend:
         if not resume_session_id:
             msg = "resume_session_id must be a non-empty string"
             raise ValueError(msg)
-        cmd: list[str] = ["codex", "exec", CodexFlags.RESUME_SUBCOMMAND]
+        cmd: list[str] = ["codex", "exec"]
+        if output_format == OutputFormat.JSON:
+            cmd.append(CodexFlags.JSON)
+        cmd.append(CodexFlags.RESUME_SUBCOMMAND)
         cmd.append(resume_session_id)
         cmd.append(prompt)
         base: dict[str, str] = dict(os.environ)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum, unique
@@ -346,7 +347,7 @@ class CodexBackend:
         for d in add_dirs:
             cmd += [CodexFlags.ADD_DIR, d]
         cmd.append(prompt)
-        env = self.env_policy().build_env({})
+        env = self.env_policy().build_env(dict(os.environ))
         return CmdSpec(cmd=tuple(cmd), env=env)
 
     def build_interactive_cmd(self, **kwargs: object) -> CmdSpec:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -1,20 +1,53 @@
-"""Codex/OpenAI backend result parser."""
+"""Codex/OpenAI backend implementation."""
 
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from enum import StrEnum, unique
+from pathlib import Path
 from typing import Any
 
 from autoskillit.core import (
     AGENT_BACKEND_CODEX,
     AgentSessionResult,
+    BackendCapabilities,
     BackendEventKind,
     CanonicalTokenUsage,
     CliSubtype,
+    CmdSpec,
+    CodexEventData,
+    OutputFormat,
+    PluginSource,
     SessionEvent,
+    fast_loads,
 )
+from autoskillit.execution.process import _marker_is_standalone
+
+__all__ = [
+    "CodexBackend",
+    "CodexEnvPolicy",
+    "CodexFlags",
+    "CodexResultParser",
+    "CodexSessionLocator",
+    "CodexStreamParser",
+]
+
+
+@unique
+class CodexFlags(StrEnum):
+    JSON = "--json"
+    SANDBOX = "--sandbox"
+    ASK_FOR_APPROVAL = "--ask-for-approval"
+    ASK_FOR_APPROVAL_SHORT = "-a"
+    MODEL = "--model"
+    MODEL_SHORT = "-m"
+    ADD_DIR = "--add-dir"
+    IGNORE_USER_CONFIG = "--ignore-user-config"
+    EPHEMERAL = "--ephemeral"
+    RESUME_SUBCOMMAND = "resume"
+    LAST = "--last"
 
 
 @dataclass
@@ -143,3 +176,193 @@ class CodexResultParser:
                 "file_changes": acc.file_changes,
             },
         )
+
+
+@dataclass(slots=True)
+class CodexStreamParser:
+    completion_marker: str = ""
+    _saw_marker: bool = field(default=False, init=False, repr=False)
+
+    def parse_line(self, line: str) -> SessionEvent | None:
+        line = line.strip()
+        if not line:
+            return None
+        try:
+            obj = fast_loads(line)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(obj, dict):
+            return None
+
+        event_type = obj.get("type", "")
+
+        if event_type == "thread.started":
+            return SessionEvent(
+                kind=BackendEventKind.SESSION_META,
+                is_terminal=False,
+                has_marker=False,
+                session_id=obj.get("thread_id", "") or None,
+            )
+
+        if event_type == "item.completed":
+            item = obj.get("item", {})
+            if isinstance(item, dict) and item.get("type") == "message":
+                for block in item.get("content", []):
+                    if (
+                        isinstance(block, dict)
+                        and block.get("type") == "text"
+                        and self.completion_marker
+                        and _marker_is_standalone(block.get("text", ""), self.completion_marker)
+                    ):
+                        self._saw_marker = True
+            return SessionEvent(
+                kind=BackendEventKind.IGNORED,
+                is_terminal=False,
+                has_marker=False,
+            )
+
+        if event_type == "turn.completed":
+            return SessionEvent(
+                kind=BackendEventKind.COMPLETION,
+                is_terminal=True,
+                has_marker=self._saw_marker,
+                backend_data=CodexEventData(
+                    record_type="turn.completed",
+                    thread_id="",
+                    item_type="",
+                    raw=obj,
+                    usage=obj.get("usage"),
+                ),
+            )
+
+        if event_type == "turn.failed":
+            return SessionEvent(
+                kind=BackendEventKind.COMPLETION,
+                is_terminal=True,
+                has_marker=False,
+                backend_data=CodexEventData(
+                    record_type="turn.failed",
+                    thread_id="",
+                    item_type="",
+                    raw=obj,
+                ),
+            )
+
+        if event_type == "error":
+            return SessionEvent(
+                kind=BackendEventKind.ERROR,
+                is_terminal=True,
+                has_marker=False,
+            )
+
+        return SessionEvent(
+            kind=BackendEventKind.IGNORED,
+            is_terminal=False,
+            has_marker=False,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CodexEnvPolicy:
+    def build_env(self, base_env: Mapping[str, str]) -> dict[str, str]:
+        return dict(base_env)
+
+
+@dataclass(frozen=True, slots=True)
+class CodexSessionLocator:
+    def locate_session(self, session_id: str) -> Path | None:
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class CodexBackend:
+    @property
+    def name(self) -> str:
+        return AGENT_BACKEND_CODEX
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        return BackendCapabilities(
+            channel_b_capable=False,
+            pty_required=False,
+            session_resume_capable=True,
+            skill_injection_capable=False,
+            supports_thinking_blocks=False,
+            supports_claude_format_stdout=False,
+            exit_code_is_terminal=True,
+            completion_record_types=frozenset({"turn.completed", "turn.failed", "error"}),
+            session_record_types=frozenset(),
+        )
+
+    def build_cmd(self, skill_command: str, cwd: str) -> CmdSpec:
+        spec = self.build_headless_cmd(skill_command)
+        return CmdSpec(cmd=spec.cmd, env=spec.env, cwd=cwd)
+
+    def stream_parser(self) -> CodexStreamParser:
+        return CodexStreamParser()
+
+    def result_parser(self) -> CodexResultParser:
+        return CodexResultParser()
+
+    def env_policy(self) -> CodexEnvPolicy:
+        return CodexEnvPolicy()
+
+    def session_locator(self) -> CodexSessionLocator:
+        return CodexSessionLocator()
+
+    def write_tool_names(self) -> frozenset[str]:
+        return frozenset()
+
+    def binary_name(self) -> str:
+        return "codex"
+
+    def version_cmd(self) -> tuple[str, ...]:
+        return ("codex", "--version")
+
+    def build_headless_cmd(
+        self,
+        prompt: str,
+        *,
+        model: str | None = None,
+        add_dirs: Sequence[str] = (),
+    ) -> CmdSpec:
+        cmd: list[str] = [
+            "codex",
+            "exec",
+            CodexFlags.JSON,
+            CodexFlags.SANDBOX,
+            "workspace-write",
+            CodexFlags.ASK_FOR_APPROVAL_SHORT,
+            "never",
+        ]
+        if model:
+            cmd += [CodexFlags.MODEL, model]
+        for d in add_dirs:
+            cmd += [CodexFlags.ADD_DIR, d]
+        cmd.append(prompt)
+        env = self.env_policy().build_env({})
+        return CmdSpec(cmd=tuple(cmd), env=env)
+
+    def build_interactive_cmd(self, **kwargs: object) -> CmdSpec:
+        raise NotImplementedError("Codex CLI does not support interactive mode")
+
+    def build_resume_cmd(
+        self,
+        *,
+        resume_session_id: str,
+        prompt: str,
+        output_format: OutputFormat = OutputFormat.JSON,
+        plugin_source: PluginSource | None = None,
+        env_extras: Mapping[str, str] | None = None,
+    ) -> CmdSpec:
+        cmd: list[str] = ["codex", "exec", CodexFlags.RESUME_SUBCOMMAND]
+        if resume_session_id:
+            cmd.append(resume_session_id)
+        else:
+            cmd.append(CodexFlags.LAST)
+        cmd.append(prompt)
+        base: dict[str, str] = {}
+        if env_extras:
+            base.update(env_extras)
+        env = self.env_policy().build_env(base)
+        return CmdSpec(cmd=tuple(cmd), env=env)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -362,11 +362,11 @@ class CodexBackend:
         plugin_source: PluginSource | None = None,
         env_extras: Mapping[str, str] | None = None,
     ) -> CmdSpec:
+        if not resume_session_id:
+            msg = "resume_session_id must be a non-empty string"
+            raise ValueError(msg)
         cmd: list[str] = ["codex", "exec", CodexFlags.RESUME_SUBCOMMAND]
-        if resume_session_id:
-            cmd.append(resume_session_id)
-        else:
-            cmd.append(CodexFlags.LAST)
+        cmd.append(resume_session_id)
         cmd.append(prompt)
         base: dict[str, str] = {}
         if env_extras:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -368,7 +368,7 @@ class CodexBackend:
         cmd: list[str] = ["codex", "exec", CodexFlags.RESUME_SUBCOMMAND]
         cmd.append(resume_session_id)
         cmd.append(prompt)
-        base: dict[str, str] = {}
+        base: dict[str, str] = dict(os.environ)
         if env_extras:
             base.update(env_extras)
         env = self.env_policy().build_env(base)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -332,6 +332,7 @@ class CodexBackend:
         *,
         model: str | None = None,
         add_dirs: Sequence[str] = (),
+        env_extras: Mapping[str, str] | None = None,
     ) -> CmdSpec:
         cmd: list[str] = [
             "codex",
@@ -347,7 +348,10 @@ class CodexBackend:
         for d in add_dirs:
             cmd += [CodexFlags.ADD_DIR, d]
         cmd.append(prompt)
-        env = self.env_policy().build_env(dict(os.environ))
+        base: dict[str, str] = dict(os.environ)
+        if env_extras:
+            base.update(env_extras)
+        env = self.env_policy().build_env(base)
         return CmdSpec(cmd=tuple(cmd), env=env)
 
     def build_interactive_cmd(self, **kwargs: object) -> CmdSpec:

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -117,4 +117,5 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_claude_session_locator.py` | Tests for ClaudeSessionLocator |
 | `test_claude_stream_parser.py` | Tests for ClaudeStreamParser |
 | `test_backend_registry.py` | Tests for backend registry |
+| `test_codex_backend.py` | Tests for CodexFlags, CodexBackend, CodexStreamParser, CodexEnvPolicy, CodexSessionLocator |
 | `test_codex_result_parser.py` | Tests for CodexResultParser |

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -5,6 +5,7 @@ import pytest
 from autoskillit.execution.backends import (
     BACKEND_REGISTRY,
     ClaudeCodeBackend,
+    CodexBackend,
     get_backend,
 )
 
@@ -27,6 +28,13 @@ class TestBackendRegistry:
     def test_backend_registry_value_type(self) -> None:
         assert BACKEND_REGISTRY["claude-code"] is ClaudeCodeBackend
 
+    def test_registry_has_codex_key(self) -> None:
+        assert "codex" in BACKEND_REGISTRY
+
+    def test_get_backend_codex(self) -> None:
+        result = get_backend("codex")
+        assert isinstance(result, CodexBackend)
+
     def test_all_exports_complete(self) -> None:
         from autoskillit.execution.backends import __all__ as all_exports
 
@@ -37,7 +45,11 @@ class TestBackendRegistry:
             "ClaudeResultParser",
             "ClaudeSessionLocator",
             "ClaudeStreamParser",
+            "CodexBackend",
+            "CodexEnvPolicy",
             "CodexResultParser",
+            "CodexSessionLocator",
+            "CodexStreamParser",
             "get_backend",
         }
         assert set(all_exports) == expected

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -47,6 +47,7 @@ class TestBackendRegistry:
             "ClaudeStreamParser",
             "CodexBackend",
             "CodexEnvPolicy",
+            "CodexFlags",
             "CodexResultParser",
             "CodexSessionLocator",
             "CodexStreamParser",

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -136,6 +136,10 @@ class TestCodexBackendCommands:
         assert isinstance(spec, CmdSpec)
         assert isinstance(spec.cmd, tuple)
 
+    def test_build_headless_cmd_with_env_extras(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff", env_extras={"FOO": "bar"})
+        assert spec.env.get("FOO") == "bar"
+
     def test_build_cmd_delegates_to_headless(self) -> None:
         backend = CodexBackend()
         spec = backend.build_cmd("do stuff", "/work")

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -32,13 +32,10 @@ class TestCodexFlags:
     def test_is_str_enum(self) -> None:
         assert issubclass(CodexFlags, StrEnum)
 
-    def test_unique_decorator_enforced(self) -> None:
-        assert len(set(CodexFlags)) == 11
-
     def test_str_json_equals_double_dash_json(self) -> None:
         assert str(CodexFlags.JSON) == "--json"
 
-    def test_all_eleven_members_present(self) -> None:
+    def test_all_members_present(self) -> None:
         expected = {
             "JSON",
             "SANDBOX",
@@ -52,7 +49,9 @@ class TestCodexFlags:
             "RESUME_SUBCOMMAND",
             "LAST",
         }
-        assert {m.name for m in CodexFlags} == expected
+        actual = {m.name for m in CodexFlags}
+        assert actual == expected
+        assert len(set(CodexFlags)) == len(expected)
 
 
 class TestCodexBackend:
@@ -285,11 +284,6 @@ class TestCodexStreamParser:
 
 
 class TestCodexEnvPolicy:
-    def test_build_env_returns_dict(self) -> None:
-        policy = CodexEnvPolicy()
-        result = policy.build_env({"PATH": "/usr/bin"})
-        assert isinstance(result, dict)
-
     def test_build_env_passes_through_base(self) -> None:
         policy = CodexEnvPolicy()
         result = policy.build_env({"PATH": "/usr/bin", "HOME": "/root"})

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -164,6 +164,10 @@ class TestCodexBackendCommands:
         spec = CodexBackend().build_resume_cmd(resume_session_id="s1", prompt="go")
         assert "PATH" in spec.env
 
+    def test_build_resume_cmd_has_json_flag(self) -> None:
+        spec = CodexBackend().build_resume_cmd(resume_session_id="s1", prompt="go")
+        assert "--json" in spec.cmd
+
     def test_build_interactive_cmd_raises(self) -> None:
         with pytest.raises(NotImplementedError):
             CodexBackend().build_interactive_cmd()

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -317,12 +317,12 @@ class TestCodexImportContract:
     def test_import_codex_backend_from_package(self) -> None:
         from autoskillit.execution.backends import CodexBackend
 
-        assert issubclass(CodexBackend, CodingAgentBackend)
+        assert isinstance(CodexBackend(), CodingAgentBackend)
 
     def test_import_codex_backend_from_execution(self) -> None:
         from autoskillit.execution import CodexBackend
 
-        assert issubclass(CodexBackend, CodingAgentBackend)
+        assert isinstance(CodexBackend(), CodingAgentBackend)
 
     def test_codex_backend_not_in_core_types(self) -> None:
         from autoskillit.core.types import __all__ as core_all

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -160,6 +160,10 @@ class TestCodexBackendCommands:
         )
         assert spec.env.get("FOO") == "bar"
 
+    def test_build_resume_cmd_env_includes_os_environ(self) -> None:
+        spec = CodexBackend().build_resume_cmd(resume_session_id="s1", prompt="go")
+        assert "PATH" in spec.env
+
     def test_build_interactive_cmd_raises(self) -> None:
         with pytest.raises(NotImplementedError):
             CodexBackend().build_interactive_cmd()

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -9,8 +9,8 @@ from autoskillit.core import (
     AGENT_BACKEND_CODEX,
     BackendEventKind,
     CmdSpec,
-    CodingAgentBackend,
     CodexEventData,
+    CodingAgentBackend,
     EnvPolicy,
     ResultParser,
     SessionLocator,
@@ -144,20 +144,16 @@ class TestCodexBackendCommands:
         assert spec.cwd == "/work"
 
     def test_build_resume_cmd_with_session_id(self) -> None:
-        spec = CodexBackend().build_resume_cmd(
-            resume_session_id="sess-123", prompt="continue"
-        )
+        spec = CodexBackend().build_resume_cmd(resume_session_id="sess-123", prompt="continue")
         assert spec.cmd[0] == "codex"
         assert spec.cmd[1] == "exec"
         assert "resume" in spec.cmd
         assert "sess-123" in spec.cmd
         assert spec.cmd[-1] == "continue"
 
-    def test_build_resume_cmd_empty_id_uses_last(self) -> None:
-        spec = CodexBackend().build_resume_cmd(
-            resume_session_id="", prompt="continue"
-        )
-        assert "--last" in spec.cmd
+    def test_build_resume_cmd_empty_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            CodexBackend().build_resume_cmd(resume_session_id="", prompt="continue")
 
     def test_build_resume_cmd_with_env_extras(self) -> None:
         spec = CodexBackend().build_resume_cmd(

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import json
+from enum import StrEnum
+
+import pytest
+
+from autoskillit.core import (
+    AGENT_BACKEND_CODEX,
+    BackendEventKind,
+    CmdSpec,
+    CodingAgentBackend,
+    CodexEventData,
+    EnvPolicy,
+    ResultParser,
+    SessionLocator,
+    StreamParser,
+)
+from autoskillit.execution.backends.codex import (
+    CodexBackend,
+    CodexEnvPolicy,
+    CodexFlags,
+    CodexResultParser,
+    CodexSessionLocator,
+    CodexStreamParser,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestCodexFlags:
+    def test_is_str_enum(self) -> None:
+        assert issubclass(CodexFlags, StrEnum)
+
+    def test_unique_decorator_enforced(self) -> None:
+        assert len(set(CodexFlags)) == 11
+
+    def test_str_json_equals_double_dash_json(self) -> None:
+        assert str(CodexFlags.JSON) == "--json"
+
+    def test_all_eleven_members_present(self) -> None:
+        expected = {
+            "JSON",
+            "SANDBOX",
+            "ASK_FOR_APPROVAL",
+            "ASK_FOR_APPROVAL_SHORT",
+            "MODEL",
+            "MODEL_SHORT",
+            "ADD_DIR",
+            "IGNORE_USER_CONFIG",
+            "EPHEMERAL",
+            "RESUME_SUBCOMMAND",
+            "LAST",
+        }
+        assert {m.name for m in CodexFlags} == expected
+
+
+class TestCodexBackend:
+    def test_isinstance_coding_agent_backend(self) -> None:
+        assert isinstance(CodexBackend(), CodingAgentBackend)
+
+    def test_name_property(self) -> None:
+        assert CodexBackend().name == AGENT_BACKEND_CODEX
+
+    def test_capabilities_channel_b_false(self) -> None:
+        assert CodexBackend().capabilities.channel_b_capable is False
+
+    def test_capabilities_skill_injection_false(self) -> None:
+        assert CodexBackend().capabilities.skill_injection_capable is False
+
+    def test_capabilities_pty_required_false(self) -> None:
+        assert CodexBackend().capabilities.pty_required is False
+
+    def test_capabilities_session_resume_true(self) -> None:
+        assert CodexBackend().capabilities.session_resume_capable is True
+
+    def test_capabilities_supports_thinking_blocks_false(self) -> None:
+        assert CodexBackend().capabilities.supports_thinking_blocks is False
+
+    def test_capabilities_supports_claude_format_stdout_false(self) -> None:
+        assert CodexBackend().capabilities.supports_claude_format_stdout is False
+
+    def test_capabilities_exit_code_is_terminal_true(self) -> None:
+        assert CodexBackend().capabilities.exit_code_is_terminal is True
+
+    def test_capabilities_completion_record_types(self) -> None:
+        expected = frozenset({"turn.completed", "turn.failed", "error"})
+        assert CodexBackend().capabilities.completion_record_types == expected
+
+    def test_capabilities_session_record_types_empty(self) -> None:
+        assert CodexBackend().capabilities.session_record_types == frozenset()
+
+    def test_binary_name(self) -> None:
+        assert CodexBackend().binary_name() == "codex"
+
+    def test_version_cmd(self) -> None:
+        assert CodexBackend().version_cmd() == ("codex", "--version")
+
+
+class TestCodexBackendCommands:
+    def test_build_headless_cmd_codex_at_0(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff")
+        assert spec.cmd[0] == "codex"
+
+    def test_build_headless_cmd_exec_at_1(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff")
+        assert spec.cmd[1] == "exec"
+
+    def test_build_headless_cmd_has_json_flag(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff")
+        assert "--json" in spec.cmd
+
+    def test_build_headless_cmd_has_sandbox_flag(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff")
+        assert "--sandbox" in spec.cmd
+        idx = spec.cmd.index("--sandbox")
+        assert spec.cmd[idx + 1] == "workspace-write"
+
+    def test_build_headless_cmd_has_approval_never(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff")
+        assert "-a" in spec.cmd
+        idx = spec.cmd.index("-a")
+        assert spec.cmd[idx + 1] == "never"
+
+    def test_build_headless_cmd_prompt_is_last(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff")
+        assert spec.cmd[-1] == "do stuff"
+
+    def test_build_headless_cmd_with_model(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff", model="o3")
+        assert "--model" in spec.cmd
+        idx = spec.cmd.index("--model")
+        assert spec.cmd[idx + 1] == "o3"
+
+    def test_build_headless_cmd_returns_cmd_spec(self) -> None:
+        spec = CodexBackend().build_headless_cmd("x")
+        assert isinstance(spec, CmdSpec)
+        assert isinstance(spec.cmd, tuple)
+
+    def test_build_cmd_delegates_to_headless(self) -> None:
+        backend = CodexBackend()
+        spec = backend.build_cmd("do stuff", "/work")
+        assert spec.cmd[0] == "codex"
+        assert spec.cwd == "/work"
+
+    def test_build_resume_cmd_with_session_id(self) -> None:
+        spec = CodexBackend().build_resume_cmd(
+            resume_session_id="sess-123", prompt="continue"
+        )
+        assert spec.cmd[0] == "codex"
+        assert spec.cmd[1] == "exec"
+        assert "resume" in spec.cmd
+        assert "sess-123" in spec.cmd
+        assert spec.cmd[-1] == "continue"
+
+    def test_build_resume_cmd_empty_id_uses_last(self) -> None:
+        spec = CodexBackend().build_resume_cmd(
+            resume_session_id="", prompt="continue"
+        )
+        assert "--last" in spec.cmd
+
+    def test_build_resume_cmd_with_env_extras(self) -> None:
+        spec = CodexBackend().build_resume_cmd(
+            resume_session_id="s1", prompt="go", env_extras={"FOO": "bar"}
+        )
+        assert spec.env.get("FOO") == "bar"
+
+    def test_build_interactive_cmd_raises(self) -> None:
+        with pytest.raises(NotImplementedError):
+            CodexBackend().build_interactive_cmd()
+
+
+class TestCodexBackendFactories:
+    def test_stream_parser_returns_stream_parser(self) -> None:
+        assert isinstance(CodexBackend().stream_parser(), StreamParser)
+
+    def test_result_parser_returns_result_parser(self) -> None:
+        assert isinstance(CodexBackend().result_parser(), ResultParser)
+
+    def test_result_parser_is_codex_result_parser(self) -> None:
+        assert isinstance(CodexBackend().result_parser(), CodexResultParser)
+
+    def test_env_policy_returns_env_policy(self) -> None:
+        assert isinstance(CodexBackend().env_policy(), EnvPolicy)
+
+    def test_session_locator_returns_session_locator(self) -> None:
+        locator = CodexBackend().session_locator()
+        assert isinstance(locator, SessionLocator)
+
+    def test_session_locator_locate_returns_none(self) -> None:
+        locator = CodexBackend().session_locator()
+        assert locator.locate_session("any-id") is None
+
+    def test_write_tool_names_returns_frozenset(self) -> None:
+        assert isinstance(CodexBackend().write_tool_names(), frozenset)
+
+
+class TestCodexStreamParser:
+    def test_parse_line_empty_returns_none(self) -> None:
+        parser = CodexStreamParser()
+        assert parser.parse_line("") is None
+
+    def test_parse_line_invalid_json_returns_none(self) -> None:
+        parser = CodexStreamParser()
+        assert parser.parse_line("not json") is None
+
+    def test_parse_line_thread_started_yields_session_meta(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "thread.started", "thread_id": "t1"})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.SESSION_META
+        assert event.session_id == "t1"
+        assert event.is_terminal is False
+
+    def test_parse_line_turn_completed_yields_completion(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "turn.completed", "usage": {}})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.COMPLETION
+        assert event.is_terminal is True
+
+    def test_parse_line_turn_failed_yields_completion(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "turn.failed", "error": {"message": "fail"}})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.COMPLETION
+        assert event.is_terminal is True
+
+    def test_parse_line_error_yields_error_event(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "error", "message": "crash"})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.ERROR
+        assert event.is_terminal is True
+
+    def test_parse_line_item_completed_yields_ignored(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {"type": "item.completed", "item": {"type": "function_call", "name": "Bash"}}
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.IGNORED
+
+    def test_completion_marker_detection_in_message(self) -> None:
+        parser = CodexStreamParser(completion_marker="%%DONE%%")
+        msg_line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "result\n%%DONE%%"}],
+                },
+            }
+        )
+        parser.parse_line(msg_line)
+        done_line = json.dumps({"type": "turn.completed", "usage": {}})
+        event = parser.parse_line(done_line)
+        assert event is not None
+        assert event.has_marker is True
+
+    def test_no_marker_when_completion_marker_empty(self) -> None:
+        parser = CodexStreamParser()
+        msg_line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "%%DONE%%"}],
+                },
+            }
+        )
+        parser.parse_line(msg_line)
+        done_line = json.dumps({"type": "turn.completed", "usage": {}})
+        event = parser.parse_line(done_line)
+        assert event is not None
+        assert event.has_marker is False
+
+    def test_turn_completed_backend_data_is_codex_event_data(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10}})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert isinstance(event.backend_data, CodexEventData)
+
+
+class TestCodexEnvPolicy:
+    def test_build_env_returns_dict(self) -> None:
+        policy = CodexEnvPolicy()
+        result = policy.build_env({"PATH": "/usr/bin"})
+        assert isinstance(result, dict)
+
+    def test_build_env_passes_through_base(self) -> None:
+        policy = CodexEnvPolicy()
+        result = policy.build_env({"PATH": "/usr/bin", "HOME": "/root"})
+        assert result["PATH"] == "/usr/bin"
+        assert result["HOME"] == "/root"
+
+
+class TestCodexSessionLocator:
+    def test_locate_session_returns_none(self) -> None:
+        locator = CodexSessionLocator()
+        assert locator.locate_session("any-session-id") is None
+
+    def test_satisfies_session_locator_protocol(self) -> None:
+        assert isinstance(CodexSessionLocator(), SessionLocator)
+
+
+class TestCodexImportContract:
+    def test_import_codex_flags_from_module(self) -> None:
+        from autoskillit.execution.backends.codex import CodexFlags
+
+        assert CodexFlags is not None
+
+    def test_import_codex_backend_from_package(self) -> None:
+        from autoskillit.execution.backends import CodexBackend
+
+        assert CodexBackend is not None
+
+    def test_import_codex_backend_from_execution(self) -> None:
+        from autoskillit.execution import CodexBackend
+
+        assert CodexBackend is not None
+
+    def test_codex_backend_not_in_core_types(self) -> None:
+        from autoskillit.core.types import __all__ as core_all
+
+        assert "CodexBackend" not in core_all

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -312,17 +312,17 @@ class TestCodexImportContract:
     def test_import_codex_flags_from_module(self) -> None:
         from autoskillit.execution.backends.codex import CodexFlags
 
-        assert CodexFlags is not None
+        assert issubclass(CodexFlags, StrEnum)
 
     def test_import_codex_backend_from_package(self) -> None:
         from autoskillit.execution.backends import CodexBackend
 
-        assert CodexBackend is not None
+        assert issubclass(CodexBackend, CodingAgentBackend)
 
     def test_import_codex_backend_from_execution(self) -> None:
         from autoskillit.execution import CodexBackend
 
-        assert CodexBackend is not None
+        assert issubclass(CodexBackend, CodingAgentBackend)
 
     def test_codex_backend_not_in_core_types(self) -> None:
         from autoskillit.core.types import __all__ as core_all


### PR DESCRIPTION
## Summary

Add `CodexFlags` StrEnum (11 members), `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, and `CodexBackend` to the existing `execution/backends/codex.py`. Wire `CodexBackend` into `BACKEND_REGISTRY` as `"codex"`. Update `__init__.py` exports, `execution/__init__.py` re-exports, and `CLAUDE.md` documentation. The `CodexResultParser` and `_scan_codex_ndjson` already exist in `codex.py` from P5-A3-WP1 — this work package adds the remaining pieces to make the backend fully satisfy the `CodingAgentBackend` protocol.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-185425-813122/.autoskillit/temp/make-plan/P5-A1-WP1_scaffold_codex_backend_plan_2026-05-20_185500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.0k | 34.1k | 1.9M | 124.2k | 253 | 133.6k | 15m 16s |
| verify | claude-opus-4-6 | 1 | 530 | 15.1k | 1.2M | 97.5k | 88 | 82.6k | 5m 55s |
| implement* | MiniMax-M2.7-highspeed | 1 | 203.3k | 1.7k | 293.2k | 29.3k | 33 | 41.9k | 1m 38s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 152.7k | 4.3k | 269.0k | 34.3k | 25 | 64.6k | 1m 37s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 56.7k | 1.6k | 231.7k | 29.3k | 17 | 14.7k | 44s |
| review_pr | claude-sonnet-4-6 | 3 | 512 | 106.9k | 1.5M | 84.9k | 157 | 243.6k | 24m 45s |
| resolve_review | claude-opus-4-6 | 3 | 202 | 61.4k | 8.1M | 104.4k | 238 | 251.0k | 35m 5s |
| **Total** | | | 416.0k | 225.1k | 13.5M | 124.2k | | 832.0k | 1h 25m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 79 | 103070.2 | 3177.3 | 777.4 |
| **Total** | **79** | 171388.3 | 10531.5 | 2848.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 2.6k | 141.0k | 3.5M | 377.2k | 40m 1s |
| claude-opus-4-6 | 2 | 732 | 76.5k | 9.3M | 333.6k | 41m 1s |
| MiniMax-M2.7-highspeed | 3 | 412.7k | 7.6k | 793.9k | 121.2k | 4m 0s |