### PR TITLE
[P5-A2-WP2] Implement CodexStreamParser Full Dispatch and Wire stream_parser() Factory

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -181,6 +181,12 @@ class CodexResultParser:
 
 @dataclass(slots=True)
 class CodexStreamParser:
+    """Stateful NDJSON stream parser for Codex CLI output.
+
+    One instance per session — accumulates marker detection state across
+    parse_line() calls. Not reusable across sessions.
+    """
+
     completion_marker: str = ""
     _saw_marker: bool = field(default=False, init=False, repr=False)
 
@@ -207,7 +213,15 @@ class CodexStreamParser:
 
         if event_type == "item.completed":
             item = obj.get("item", {})
-            if isinstance(item, dict) and item.get("type") == "message":
+            if not isinstance(item, dict):
+                return SessionEvent(
+                    kind=BackendEventKind.IGNORED,
+                    is_terminal=False,
+                    has_marker=False,
+                )
+            item_type = item.get("type", "")
+
+            if item_type == "message":
                 for block in item.get("content", []):
                     if (
                         isinstance(block, dict)
@@ -216,6 +230,31 @@ class CodexStreamParser:
                         and _marker_is_standalone(block.get("text", ""), self.completion_marker)
                     ):
                         self._saw_marker = True
+                return SessionEvent(
+                    kind=BackendEventKind.TOOL_OUTPUT,
+                    is_terminal=False,
+                    has_marker=False,
+                    backend_data=CodexEventData(
+                        record_type="item.completed",
+                        thread_id="",
+                        item_type="message",
+                        raw=obj,
+                    ),
+                )
+
+            if item_type in ("file_change", "function_call"):
+                return SessionEvent(
+                    kind=BackendEventKind.TOOL_OUTPUT,
+                    is_terminal=False,
+                    has_marker=False,
+                    backend_data=CodexEventData(
+                        record_type="item.completed",
+                        thread_id="",
+                        item_type=item_type,
+                        raw=obj,
+                    ),
+                )
+
             return SessionEvent(
                 kind=BackendEventKind.IGNORED,
                 is_terminal=False,
@@ -305,8 +344,8 @@ class CodexBackend:
         spec = self.build_headless_cmd(skill_command)
         return CmdSpec(cmd=spec.cmd, env=spec.env, cwd=cwd)
 
-    def stream_parser(self) -> CodexStreamParser:
-        return CodexStreamParser()
+    def stream_parser(self, completion_marker: str = "") -> CodexStreamParser:
+        return CodexStreamParser(completion_marker=completion_marker)
 
     def result_parser(self) -> CodexResultParser:
         return CodexResultParser()

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -254,7 +254,7 @@ class TestCodexStreamParser:
         assert event.kind == BackendEventKind.ERROR
         assert event.is_terminal is True
 
-    def test_parse_line_item_completed_yields_ignored(self) -> None:
+    def test_parse_line_item_completed_unknown_type_yields_ignored(self) -> None:
         parser = CodexStreamParser()
         line = json.dumps({"type": "item.completed", "item": {"type": "reasoning"}})
         event = parser.parse_line(line)

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -378,13 +378,6 @@ class TestCodexStreamParser:
         assert event is not None
         assert event.is_terminal is False
 
-    def test_parse_line_item_completed_unknown_subtype_yields_ignored(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps({"type": "item.completed", "item": {"type": "reasoning"}})
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.IGNORED
-
 
 class TestCodexStreamParserConformance:
     def test_isinstance_stream_parser_protocol(self) -> None:

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -201,6 +201,16 @@ class TestCodexBackendFactories:
     def test_write_tool_names_returns_frozenset(self) -> None:
         assert isinstance(CodexBackend().write_tool_names(), frozenset)
 
+    def test_stream_parser_factory_passes_completion_marker(self) -> None:
+        parser = CodexBackend().stream_parser(completion_marker="%%DONE%%")
+        assert isinstance(parser, CodexStreamParser)
+        assert parser.completion_marker == "%%DONE%%"
+
+    def test_stream_parser_factory_default_empty_marker(self) -> None:
+        parser = CodexBackend().stream_parser()
+        assert isinstance(parser, CodexStreamParser)
+        assert parser.completion_marker == ""
+
 
 class TestCodexStreamParser:
     def test_parse_line_empty_returns_none(self) -> None:
@@ -246,9 +256,7 @@ class TestCodexStreamParser:
 
     def test_parse_line_item_completed_yields_ignored(self) -> None:
         parser = CodexStreamParser()
-        line = json.dumps(
-            {"type": "item.completed", "item": {"type": "function_call", "name": "Bash"}}
-        )
+        line = json.dumps({"type": "item.completed", "item": {"type": "reasoning"}})
         event = parser.parse_line(line)
         assert event is not None
         assert event.kind == BackendEventKind.IGNORED
@@ -293,6 +301,94 @@ class TestCodexStreamParser:
         event = parser.parse_line(line)
         assert event is not None
         assert isinstance(event.backend_data, CodexEventData)
+
+    def test_parse_line_item_completed_message_yields_tool_output(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "message", "content": [{"type": "text", "text": "hello"}]},
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
+
+    def test_parse_line_item_completed_file_change_yields_tool_output(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {"type": "item.completed", "item": {"type": "file_change", "path": "src/foo.py"}}
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
+
+    def test_parse_line_item_completed_function_call_yields_tool_output(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {"type": "item.completed", "item": {"type": "function_call", "name": "Bash"}}
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
+
+    def test_parse_line_item_completed_message_has_backend_data(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "message", "content": [{"type": "text", "text": "hello"}]},
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.record_type == "item.completed"
+        assert event.backend_data.item_type == "message"
+
+    def test_parse_line_item_completed_file_change_backend_data_item_type(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {"type": "item.completed", "item": {"type": "file_change", "path": "src/foo.py"}}
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.backend_data is not None
+        assert event.backend_data.item_type == "file_change"
+
+    def test_parse_line_item_completed_function_call_backend_data_item_type(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {"type": "item.completed", "item": {"type": "function_call", "name": "Bash"}}
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.backend_data is not None
+        assert event.backend_data.item_type == "function_call"
+
+    def test_parse_line_item_completed_message_not_terminal(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "message", "content": [{"type": "text", "text": "hello"}]},
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.is_terminal is False
+
+    def test_parse_line_item_completed_unknown_subtype_yields_ignored(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "item.completed", "item": {"type": "reasoning"}})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.IGNORED
+
+
+class TestCodexStreamParserConformance:
+    def test_isinstance_stream_parser_protocol(self) -> None:
+        assert isinstance(CodexStreamParser(""), StreamParser)
 
 
 class TestCodexEnvPolicy:

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -302,7 +302,7 @@ class TestCodexStreamParser:
         assert event is not None
         assert isinstance(event.backend_data, CodexEventData)
 
-    def test_parse_line_item_completed_message_yields_tool_output(self) -> None:
+    def test_parse_line_item_completed_message(self) -> None:
         parser = CodexStreamParser()
         line = json.dumps(
             {
@@ -313,70 +313,32 @@ class TestCodexStreamParser:
         event = parser.parse_line(line)
         assert event is not None
         assert event.kind == BackendEventKind.TOOL_OUTPUT
-
-    def test_parse_line_item_completed_file_change_yields_tool_output(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps(
-            {"type": "item.completed", "item": {"type": "file_change", "path": "src/foo.py"}}
-        )
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.TOOL_OUTPUT
-
-    def test_parse_line_item_completed_function_call_yields_tool_output(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps(
-            {"type": "item.completed", "item": {"type": "function_call", "name": "Bash"}}
-        )
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.TOOL_OUTPUT
-
-    def test_parse_line_item_completed_message_has_backend_data(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps(
-            {
-                "type": "item.completed",
-                "item": {"type": "message", "content": [{"type": "text", "text": "hello"}]},
-            }
-        )
-        event = parser.parse_line(line)
-        assert event is not None
+        assert event.is_terminal is False
         assert isinstance(event.backend_data, CodexEventData)
         assert event.backend_data.record_type == "item.completed"
         assert event.backend_data.item_type == "message"
 
-    def test_parse_line_item_completed_file_change_backend_data_item_type(self) -> None:
+    def test_parse_line_item_completed_file_change(self) -> None:
         parser = CodexStreamParser()
         line = json.dumps(
             {"type": "item.completed", "item": {"type": "file_change", "path": "src/foo.py"}}
         )
         event = parser.parse_line(line)
         assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
         assert event.backend_data is not None
         assert event.backend_data.item_type == "file_change"
 
-    def test_parse_line_item_completed_function_call_backend_data_item_type(self) -> None:
+    def test_parse_line_item_completed_function_call(self) -> None:
         parser = CodexStreamParser()
         line = json.dumps(
             {"type": "item.completed", "item": {"type": "function_call", "name": "Bash"}}
         )
         event = parser.parse_line(line)
         assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
         assert event.backend_data is not None
         assert event.backend_data.item_type == "function_call"
-
-    def test_parse_line_item_completed_message_not_terminal(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps(
-            {
-                "type": "item.completed",
-                "item": {"type": "message", "content": [{"type": "text", "text": "hello"}]},
-            }
-        )
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.is_terminal is False
 
 
 class TestCodexStreamParserConformance:


### PR DESCRIPTION
## Summary

Expand `CodexStreamParser.parse_line()` to return `TOOL_OUTPUT` events for `item.completed` subtypes (message, file_change, function_call) instead of blanket `IGNORED`, wire `CodexBackend.stream_parser()` to accept a `completion_marker` parameter, and add the stateful/one-per-session docstring. The `CodexStreamParser` class and basic dispatch already exist from WP1 — this WP completes the event dispatch table and wires the factory parameter.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-205048-772647/.autoskillit/temp/make-plan/p5_a2_wp2_implement_codex_stream_parser_plan_2026-05-20_210500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 5.3k | 23.5k | 1.8M | 95.1k | 342 | 80.1k | 11m 43s |
| verify | claude-opus-4-6 | 1 | 38 | 11.2k | 538.2k | 67.0k | 57 | 52.1k | 4m 45s |
| implement* | MiniMax-M2.7-highspeed | 1 | 594.1k | 7.7k | 973.6k | 53.4k | 73 | 61.8k | 2m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 211.7k | 4.4k | 410.4k | 29.3k | 37 | 41.2k | 1m 41s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 44.1k | 1.0k | 202.3k | 29.3k | 14 | 14.6k | 35s |
| review_pr | claude-sonnet-4-6 | 3 | 328 | 48.0k | 1.2M | 49.2k | 93 | 121.3k | 11m 12s |
| resolve_review | claude-opus-4-6 | 3 | 127 | 20.9k | 2.4M | 65.8k | 106 | 137.4k | 12m 31s |
| **Total** | | | 855.7k | 116.8k | 7.5M | 95.1k | | 508.4k | 45m 14s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 147 | 6622.9 | 420.5 | 52.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 59 | 40034.7 | 2329.1 | 354.9 |
| **Total** | **206** | 36249.8 | 2468.1 | 567.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 5.6k | 71.6k | 3.0M | 201.3k | 22m 56s |
| claude-opus-4-6 | 2 | 165 | 32.1k | 2.9M | 189.5k | 17m 16s |
| MiniMax-M2.7-highspeed | 3 | 849.9k | 13.1k | 1.6M | 117.6k | 5m 0s |