### PR TITLE
[P5-A6-WP1] Extend Exit Classification with OpenAI Error Patterns

### DIFF
--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -33,7 +33,7 @@ _CODEX_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"model_not_found", re.IGNORECASE),
 )
 
-_ALL_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
+_KNOWN_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     _API_ERROR_PATTERNS + _CODEX_API_ERROR_PATTERNS
 )
 
@@ -50,7 +50,7 @@ def classify_infra_exit(
     """
     if session._is_context_exhausted():
         return InfraExitCategory.CONTEXT_EXHAUSTED
-    if session._has_api_error() or any(p.search(result.stderr) for p in _ALL_API_ERROR_PATTERNS):
+    if session._has_api_error() or any(p.search(result.stderr) for p in _KNOWN_API_ERROR_PATTERNS):
         return InfraExitCategory.API_ERROR
     if result.returncode is not None and result.returncode < 0:
         return InfraExitCategory.PROCESS_KILLED

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -27,7 +27,7 @@ _API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 _CODEX_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"rate_limit_exceeded", re.IGNORECASE),
-    re.compile(r"server_error", re.IGNORECASE),
+    re.compile(r"\bserver_error\b", re.IGNORECASE),
     re.compile(r"insufficient_quota", re.IGNORECASE),
     re.compile(r"context_length_exceeded", re.IGNORECASE),
     re.compile(r"model_not_found", re.IGNORECASE),

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -25,6 +25,18 @@ _API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"connection reset", re.IGNORECASE),
 )
 
+_CODEX_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"rate_limit_exceeded", re.IGNORECASE),
+    re.compile(r"server_error", re.IGNORECASE),
+    re.compile(r"insufficient_quota", re.IGNORECASE),
+    re.compile(r"context_length_exceeded", re.IGNORECASE),
+    re.compile(r"model_not_found", re.IGNORECASE),
+)
+
+_ALL_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
+    _API_ERROR_PATTERNS + _CODEX_API_ERROR_PATTERNS
+)
+
 
 def classify_infra_exit(
     session: ClaudeSessionResult,
@@ -38,7 +50,7 @@ def classify_infra_exit(
     """
     if session._is_context_exhausted():
         return InfraExitCategory.CONTEXT_EXHAUSTED
-    if session._has_api_error() or any(p.search(result.stderr) for p in _API_ERROR_PATTERNS):
+    if session._has_api_error() or any(p.search(result.stderr) for p in _ALL_API_ERROR_PATTERNS):
         return InfraExitCategory.API_ERROR
     if result.returncode is not None and result.returncode < 0:
         return InfraExitCategory.PROCESS_KILLED

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -118,14 +118,14 @@ class ClaudeSessionResult:
         Scans assistant_messages, errors, and result for API error patterns.
         This is the channel-agnostic counterpart to _is_context_exhausted().
         """
-        from autoskillit.execution.session._exit_classification import _API_ERROR_PATTERNS
+        from autoskillit.execution.session._exit_classification import _ALL_API_ERROR_PATTERNS
 
         searchable = "\n".join(self.assistant_messages)
         if self.errors:
             searchable += "\n" + "\n".join(self.errors)
         if self.result:
             searchable += "\n" + self.result
-        return any(p.search(searchable) for p in _API_ERROR_PATTERNS)
+        return any(p.search(searchable) for p in _ALL_API_ERROR_PATTERNS)
 
     @property
     def agent_result(self) -> str:

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -118,14 +118,14 @@ class ClaudeSessionResult:
         Scans assistant_messages, errors, and result for API error patterns.
         This is the channel-agnostic counterpart to _is_context_exhausted().
         """
-        from autoskillit.execution.session._exit_classification import _ALL_API_ERROR_PATTERNS
+        from autoskillit.execution.session._exit_classification import _KNOWN_API_ERROR_PATTERNS
 
         searchable = "\n".join(self.assistant_messages)
         if self.errors:
             searchable += "\n" + "\n".join(self.errors)
         if self.result:
             searchable += "\n" + self.result
-        return any(p.search(searchable) for p in _ALL_API_ERROR_PATTERNS)
+        return any(p.search(searchable) for p in _KNOWN_API_ERROR_PATTERNS)
 
     @property
     def agent_result(self) -> str:

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -18,6 +18,14 @@ from autoskillit.core.types import SubprocessResult, TerminationReason
 from autoskillit.execution.session import ClaudeSessionResult
 from tests._helpers import make_tracing_config
 
+CODEX_API_ERROR_SIGNAL_STRINGS: tuple[str, ...] = (
+    "rate_limit_exceeded",
+    "server_error",
+    "insufficient_quota",
+    "context_length_exceeded",
+    "model_not_found",
+)
+
 
 def _mock_backend(
     *,

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -16,14 +16,12 @@ import pytest
 from autoskillit.core import CLAUDE_CODE_CAPABILITIES, CmdSpec
 from autoskillit.core.types import SubprocessResult, TerminationReason
 from autoskillit.execution.session import ClaudeSessionResult
+from autoskillit.execution.session._exit_classification import _CODEX_API_ERROR_PATTERNS
 from tests._helpers import make_tracing_config
 
-CODEX_API_ERROR_SIGNAL_STRINGS: tuple[str, ...] = (
-    "rate_limit_exceeded",
-    "server_error",
-    "insufficient_quota",
-    "context_length_exceeded",
-    "model_not_found",
+# Strip regex metacharacters (e.g. \b word boundaries) to yield plain test signal strings.
+CODEX_API_ERROR_SIGNAL_STRINGS: tuple[str, ...] = tuple(
+    p.pattern.replace(r"\b", "") for p in _CODEX_API_ERROR_PATTERNS
 )
 
 

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -28,7 +28,7 @@ from tests.execution.conftest import (
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
-# All patterns that _ALL_API_ERROR_PATTERNS covers
+# All patterns that _KNOWN_API_ERROR_PATTERNS covers
 API_ERROR_SIGNALS: list[str] = [
     "overloaded",
     "529",

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -21,7 +21,10 @@ from autoskillit.core.types import (
 from autoskillit.execution.headless._headless_result import _build_skill_result
 from autoskillit.execution.session._exit_classification import classify_infra_exit
 from autoskillit.execution.session._session_model import ClaudeSessionResult, parse_session_result
-from tests.execution.conftest import _make_synthetic_api_error_ndjson
+from tests.execution.conftest import (
+    CODEX_API_ERROR_SIGNAL_STRINGS,
+    _make_synthetic_api_error_ndjson,
+)
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -36,11 +39,7 @@ API_ERROR_SIGNALS: list[str] = [
     "network error",
     "connection reset",
     # OpenAI/Codex API error types
-    "rate_limit_exceeded",
-    "server_error",
-    "insufficient_quota",
-    "context_length_exceeded",
-    "model_not_found",
+    *CODEX_API_ERROR_SIGNAL_STRINGS,
 ]
 
 

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -25,7 +25,7 @@ from tests.execution.conftest import _make_synthetic_api_error_ndjson
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
-# All patterns that _API_ERROR_PATTERNS covers
+# All patterns that _ALL_API_ERROR_PATTERNS covers
 API_ERROR_SIGNALS: list[str] = [
     "overloaded",
     "529",
@@ -35,6 +35,12 @@ API_ERROR_SIGNALS: list[str] = [
     "socket hang up",
     "network error",
     "connection reset",
+    # OpenAI/Codex API error types
+    "rate_limit_exceeded",
+    "server_error",
+    "insufficient_quota",
+    "context_length_exceeded",
+    "model_not_found",
 ]
 
 

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -12,14 +12,7 @@ from autoskillit.core.types import (
 )
 from autoskillit.execution.session._exit_classification import classify_infra_exit
 from autoskillit.execution.session._session_model import ClaudeSessionResult
-
-OPENAI_ERROR_SIGNALS: list[str] = [
-    "rate_limit_exceeded",
-    "server_error",
-    "insufficient_quota",
-    "context_length_exceeded",
-    "model_not_found",
-]
+from tests.execution.conftest import CODEX_API_ERROR_SIGNAL_STRINGS
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -151,7 +144,7 @@ class TestClassifyInfraExit:
         result = _sr(returncode=1, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.CONTEXT_EXHAUSTED
 
-    @pytest.mark.parametrize("signal", OPENAI_ERROR_SIGNALS)
+    @pytest.mark.parametrize("signal", CODEX_API_ERROR_SIGNAL_STRINGS)
     def test_api_error_openai_patterns_in_stderr(self, signal: str) -> None:
         """OpenAI/Codex error pattern in stderr → API_ERROR."""
         session = ClaudeSessionResult(
@@ -163,7 +156,7 @@ class TestClassifyInfraExit:
         result = _sr(returncode=1, stderr=f"Error: {signal}")
         assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
 
-    @pytest.mark.parametrize("signal", OPENAI_ERROR_SIGNALS)
+    @pytest.mark.parametrize("signal", CODEX_API_ERROR_SIGNAL_STRINGS)
     def test_api_error_openai_patterns_in_assistant_messages(self, signal: str) -> None:
         """OpenAI/Codex error pattern in assistant_messages → API_ERROR."""
         session = ClaudeSessionResult(

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -13,6 +13,14 @@ from autoskillit.core.types import (
 from autoskillit.execution.session._exit_classification import classify_infra_exit
 from autoskillit.execution.session._session_model import ClaudeSessionResult
 
+OPENAI_ERROR_SIGNALS: list[str] = [
+    "rate_limit_exceeded",
+    "server_error",
+    "insufficient_quota",
+    "context_length_exceeded",
+    "model_not_found",
+]
+
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
@@ -142,6 +150,33 @@ class TestClassifyInfraExit:
         )
         result = _sr(returncode=1, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.CONTEXT_EXHAUSTED
+
+    @pytest.mark.parametrize("signal", OPENAI_ERROR_SIGNALS)
+    def test_api_error_openai_patterns_in_stderr(self, signal: str) -> None:
+        """OpenAI/Codex error pattern in stderr → API_ERROR."""
+        session = ClaudeSessionResult(
+            subtype="empty_output",
+            is_error=True,
+            result="",
+            session_id="",
+        )
+        result = _sr(returncode=1, stderr=f"Error: {signal}")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
+    @pytest.mark.parametrize("signal", OPENAI_ERROR_SIGNALS)
+    def test_api_error_openai_patterns_in_assistant_messages(self, signal: str) -> None:
+        """OpenAI/Codex error pattern in assistant_messages → API_ERROR."""
+        session = ClaudeSessionResult(
+            subtype="empty_output",
+            is_error=True,
+            result="",
+            session_id="",
+            assistant_messages=[
+                f'OpenAI API Error: {{"type":"{signal}","message":"{signal}"}}',
+            ],
+        )
+        result = _sr(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
 
 
 @pytest.mark.parametrize("category", list(InfraExitCategory))


### PR DESCRIPTION
## Summary

Add 5 OpenAI/Codex API error patterns (`rate_limit_exceeded`, `server_error`, `insufficient_quota`, `context_length_exceeded`, `model_not_found`) to `_exit_classification.py`. Define `_CODEX_API_ERROR_PATTERNS` as a separate tuple, combine it with the existing `_API_ERROR_PATTERNS` into `_ALL_API_ERROR_PATTERNS`, update both consumption sites (`classify_infra_exit()` and `_has_api_error()`), add 10 new parametrized test items (5 patterns x 2 channels), and extend the invariant signal list with 5 new entries.

## Requirements

## Requirements

- `_CODEX_API_ERROR_PATTERNS + _ALL_API_ERROR_PATTERNS in _exit_classification.py`
- `Updated _has_api_error() import in _session_model.py`
- `2 new parametrized test methods in test_exit_classification.py`
- `Extended API_ERROR_SIGNALS in test_api_error_signal_invariants.py`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-232151-213412/.autoskillit/temp/make-plan/p5_a6_wp1_extend_exit_classification_openai_patterns_plan_2026-05-20_233000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 74 | 14.6k | 1.1M | 84.6k | 192 | 89.0k | 8m 39s |
| verify | claude-sonnet-4-6 | 1 | 34 | 6.1k | 288.3k | 67.1k | 75 | 52.2k | 4m 9s |
| implement* | MiniMax-M2.7-highspeed | 1 | 333.8k | 4.6k | 496.9k | 29.4k | 42 | 15.4k | 1m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 60.5k | 2.9k | 202.9k | 29.4k | 20 | 14.8k | 1m 1s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 36.8k | 1.5k | 173.5k | 29.4k | 13 | 14.7k | 39s |
| review_pr | claude-sonnet-4-6 | 2 | 232 | 45.0k | 1.0M | 67.6k | 74 | 95.0k | 10m 17s |
| resolve_review | claude-sonnet-4-6 | 2 | 524 | 35.3k | 3.8M | 90.0k | 164 | 134.4k | 17m 57s |
| **Total** | | | 431.9k | 110.1k | 7.1M | 90.0k | | 415.6k | 44m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 61 | 8145.4 | 253.0 | 76.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 54 | 70571.1 | 2489.6 | 653.9 |
| **Total** | **115** | 61471.7 | 3614.0 | 957.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 864 | 101.0k | 6.2M | 370.7k | 41m 4s |
| MiniMax-M2.7-highspeed | 3 | 431.0k | 9.0k | 873.3k | 44.9k | 3m 25s |