### PR TITLE
[P5-A4-WP2] Implement CodexEnvPolicy and Unit Tests

### DIFF
--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -8,4 +8,4 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 |------|---------|
 | `__init__.py` | `BACKEND_REGISTRY`, `get_backend()` factory, re-exports |
 | `claude.py` | `ClaudeCodeBackend`, `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` |
-| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson` |
+| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson`, `CODEX_ENV_DENYLIST`, `CODEX_ENV_PREFIX_DENYLIST` |

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -335,7 +335,7 @@ class CodexEnvPolicy:
             and k not in AUTOSKILLIT_PRIVATE_ENV_VARS
             and not any(k.startswith(p) for p in CODEX_ENV_PREFIX_DENYLIST)
         }
-        if extras:
+        if extras is not None:
             out.update(extras)
         if required is not None:
             missing = required - frozenset(out)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from autoskillit.core import (
     AGENT_BACKEND_CODEX,
+    AUTOSKILLIT_PRIVATE_ENV_VARS,
     AgentSessionResult,
     BackendCapabilities,
     BackendEventKind,
@@ -34,6 +35,16 @@ __all__ = [
     "CodexSessionLocator",
     "CodexStreamParser",
 ]
+
+CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+    }
+)
+
+CODEX_ENV_PREFIX_DENYLIST: tuple[str, ...] = ("CLAUDE_CODE_",)
 
 
 @unique
@@ -310,8 +321,27 @@ class CodexStreamParser:
 
 @dataclass(frozen=True, slots=True)
 class CodexEnvPolicy:
-    def build_env(self, base_env: Mapping[str, str]) -> dict[str, str]:
-        return dict(base_env)
+    def build_env(
+        self,
+        base_env: Mapping[str, str],
+        *,
+        extras: Mapping[str, str] | None = None,
+        required: frozenset[str] | None = None,
+    ) -> dict[str, str]:
+        out: dict[str, str] = {
+            k: v
+            for k, v in base_env.items()
+            if k not in CODEX_ENV_DENYLIST
+            and k not in AUTOSKILLIT_PRIVATE_ENV_VARS
+            and not any(k.startswith(p) for p in CODEX_ENV_PREFIX_DENYLIST)
+        }
+        if extras:
+            out.update(extras)
+        if required is not None:
+            missing = required - frozenset(out)
+            if missing:
+                raise ValueError(f"Required env vars missing from session env: {sorted(missing)}")
+        return out
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -117,5 +117,6 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_claude_session_locator.py` | Tests for ClaudeSessionLocator |
 | `test_claude_stream_parser.py` | Tests for ClaudeStreamParser |
 | `test_backend_registry.py` | Tests for backend registry |
-| `test_codex_backend.py` | Tests for CodexFlags, CodexBackend, CodexStreamParser, CodexEnvPolicy, CodexSessionLocator |
+| `test_codex_backend.py` | Tests for CodexFlags, CodexBackend, CodexStreamParser, CodexSessionLocator |
+| `test_codex_env_policy.py` | Tests for CodexEnvPolicy three-layer scrub |
 | `test_codex_result_parser.py` | Tests for CodexResultParser |

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -347,7 +347,7 @@ class TestCodexStreamParserConformance:
 
 
 class TestCodexEnvPolicy:
-    def test_build_env_passes_through_base(self) -> None:
+    def test_build_env_preserves_non_denied_vars(self) -> None:
         policy = CodexEnvPolicy()
         result = policy.build_env({"PATH": "/usr/bin", "HOME": "/root"})
         assert result["PATH"] == "/usr/bin"

--- a/tests/execution/backends/test_codex_env_policy.py
+++ b/tests/execution/backends/test_codex_env_policy.py
@@ -82,6 +82,9 @@ class TestCodexEnvPolicy:
         assert isinstance(CodexEnvPolicy(), EnvPolicy)
 
     def test_frozen(self) -> None:
+        # CodexEnvPolicy has no dataclass fields; any attribute assignment on a
+        # frozen+slots dataclass raises TypeError (CPython) or FrozenInstanceError
+        # depending on the Python version and slots interaction.
         policy = CodexEnvPolicy()
-        with pytest.raises((FrozenInstanceError, TypeError)):
+        with pytest.raises((FrozenInstanceError, TypeError, AttributeError)):
             policy.some_attr = "value"  # type: ignore[misc]

--- a/tests/execution/backends/test_codex_env_policy.py
+++ b/tests/execution/backends/test_codex_env_policy.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from autoskillit.core import EnvPolicy
+from autoskillit.execution.backends.codex import CodexEnvPolicy
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestCodexEnvPolicy:
+    def test_anthropic_credentials_stripped(self) -> None:
+        policy = CodexEnvPolicy()
+        base = {
+            "ANTHROPIC_API_KEY": "sk-ant-secret",
+            "ANTHROPIC_AUTH_TOKEN": "token-secret",
+            "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+            "PATH": "/usr/bin",
+        }
+        result = policy.build_env(base)
+        assert "ANTHROPIC_API_KEY" not in result
+        assert "ANTHROPIC_AUTH_TOKEN" not in result
+        assert "ANTHROPIC_BASE_URL" not in result
+        assert result["PATH"] == "/usr/bin"
+
+    def test_claude_code_prefix_vars_stripped(self) -> None:
+        policy = CodexEnvPolicy()
+        base = {
+            "CLAUDE_CODE_SSE_PORT": "9876",
+            "CLAUDE_CODE_IDE_FOO": "bar",
+            "CLAUDE_CODE_AUTO_CONNECT_IDE": "0",
+            "HOME": "/home/user",
+        }
+        result = policy.build_env(base)
+        assert "CLAUDE_CODE_SSE_PORT" not in result
+        assert "CLAUDE_CODE_IDE_FOO" not in result
+        assert "CLAUDE_CODE_AUTO_CONNECT_IDE" not in result
+        assert result["HOME"] == "/home/user"
+
+    def test_autoskillit_private_vars_stripped(self) -> None:
+        policy = CodexEnvPolicy()
+        base = {
+            "AUTOSKILLIT_HEADLESS": "1",
+            "AUTOSKILLIT_SESSION_TYPE": "skill",
+            "PATH": "/usr/bin",
+        }
+        result = policy.build_env(base)
+        assert "AUTOSKILLIT_HEADLESS" not in result
+        assert "AUTOSKILLIT_SESSION_TYPE" not in result
+        assert result["PATH"] == "/usr/bin"
+
+    def test_claude_code_auto_connect_ide_not_injected(self) -> None:
+        policy = CodexEnvPolicy()
+        result = policy.build_env({"PATH": "/usr/bin"})
+        assert "CLAUDE_CODE_AUTO_CONNECT_IDE" not in result
+
+    def test_openai_api_key_preserved(self) -> None:
+        policy = CodexEnvPolicy()
+        base = {"OPENAI_API_KEY": "sk-openai-secret", "PATH": "/usr/bin"}
+        result = policy.build_env(base)
+        assert result["OPENAI_API_KEY"] == "sk-openai-secret"
+
+    def test_extras_overlay_applied_after_scrub(self) -> None:
+        policy = CodexEnvPolicy()
+        base = {"PATH": "/usr/bin"}
+        result = policy.build_env(base, extras={"CUSTOM_VAR": "custom_value"})
+        assert result["CUSTOM_VAR"] == "custom_value"
+
+    def test_required_sentinel_raises_value_error(self) -> None:
+        policy = CodexEnvPolicy()
+        with pytest.raises(ValueError, match="MISSING_VAR"):
+            policy.build_env({"PATH": "/usr/bin"}, required=frozenset({"MISSING_VAR"}))
+
+    def test_isinstance_env_policy_protocol(self) -> None:
+        assert isinstance(CodexEnvPolicy(), EnvPolicy)
+
+    def test_frozen(self) -> None:
+        policy = CodexEnvPolicy()
+        with pytest.raises((FrozenInstanceError, TypeError)):
+            policy.some_attr = "value"  # type: ignore[misc]

--- a/tests/execution/backends/test_codex_env_policy.py
+++ b/tests/execution/backends/test_codex_env_policy.py
@@ -4,7 +4,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from autoskillit.core import EnvPolicy
+from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS, EnvPolicy
 from autoskillit.execution.backends.codex import CodexEnvPolicy
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -41,14 +41,11 @@ class TestCodexEnvPolicy:
 
     def test_autoskillit_private_vars_stripped(self) -> None:
         policy = CodexEnvPolicy()
-        base = {
-            "AUTOSKILLIT_HEADLESS": "1",
-            "AUTOSKILLIT_SESSION_TYPE": "skill",
-            "PATH": "/usr/bin",
-        }
+        base: dict[str, str] = {var: "sentinel" for var in AUTOSKILLIT_PRIVATE_ENV_VARS}
+        base["PATH"] = "/usr/bin"
         result = policy.build_env(base)
-        assert "AUTOSKILLIT_HEADLESS" not in result
-        assert "AUTOSKILLIT_SESSION_TYPE" not in result
+        for var in AUTOSKILLIT_PRIVATE_ENV_VARS:
+            assert var not in result
         assert result["PATH"] == "/usr/bin"
 
     def test_claude_code_auto_connect_ide_not_injected(self) -> None:

--- a/tests/execution/backends/test_codex_env_policy.py
+++ b/tests/execution/backends/test_codex_env_policy.py
@@ -68,6 +68,14 @@ class TestCodexEnvPolicy:
         result = policy.build_env(base, extras={"CUSTOM_VAR": "custom_value"})
         assert result["CUSTOM_VAR"] == "custom_value"
 
+    def test_extras_trusted_channel_bypasses_denylist(self) -> None:
+        # extras is a trusted-injection channel: callers can explicitly re-introduce
+        # denied vars (e.g. to forward credentials to a trusted subprocess).
+        policy = CodexEnvPolicy()
+        base = {"ANTHROPIC_API_KEY": "sk-from-base", "PATH": "/usr/bin"}
+        result = policy.build_env(base, extras={"ANTHROPIC_API_KEY": "sk-trusted-override"})
+        assert result["ANTHROPIC_API_KEY"] == "sk-trusted-override"
+
     def test_required_sentinel_raises_value_error(self) -> None:
         policy = CodexEnvPolicy()
         with pytest.raises(ValueError, match="MISSING_VAR"):


### PR DESCRIPTION
## Summary

Upgrade `CodexEnvPolicy` from a passthrough (`return dict(base_env)`) to a three-layer env scrub implementation tuned for the Codex (OpenAI) backend:

1. **Layer 1** — Strip Anthropic-specific credentials (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`) and all `CLAUDE_CODE_*` prefixed vars
2. **Layer 2** — Strip `AUTOSKILLIT_PRIVATE_ENV_VARS` (shared orchestration internals)
3. **Layer 3** — No Claude-specific always-inject (unlike `ClaudeEnvPolicy` which injects `CLAUDE_CODE_AUTO_CONNECT_IDE=0`). Apply caller `extras` overlay. Enforce `required` sentinel check raising `ValueError`.

Add two module-level constants (`CODEX_ENV_DENYLIST`, `CODEX_ENV_PREFIX_DENYLIST`) to `codex.py` as implementation-internal constants (not exported via `__all__`). Create a dedicated test file with 9 behavioral tests.

## Requirements

## Acceptance Criteria

- ANTHROPIC_API_KEY stripped
- CLAUDE_CODE_* prefix vars stripped
- OPENAI_API_KEY preserved
- CLAUDE_CODE_AUTO_CONNECT_IDE not injected
- ValueError raised when required key missing
- All 8 behavioral tests pass
- isinstance Protocol check passes
- xdist-safe with no shared state

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
- `tests/execution/backends/test_codex_env_policy.py`

### Modified (●):
- `src/autoskillit/execution/backends/CLAUDE.md`
- `src/autoskillit/execution/backends/codex.py`
- `tests/execution/CLAUDE.md`
- `tests/execution/backends/test_codex_backend.py`

Closes #2518

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-232150-745886/.autoskillit/temp/make-plan/p5_a4_wp2_implement_codex_env_policy_plan_2026-05-20_232500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.0k | 18.3k | 1.0M | 87.3k | 230 | 91.8k | 12m 26s |
| verify | claude-opus-4-6 | 1 | 51 | 9.3k | 1.2M | 62.7k | 106 | 47.7k | 5m 15s |
| implement* | MiniMax-M2.7-highspeed | 1 | 436.3k | 5.1k | 558.5k | 29.4k | 46 | 68.7k | 2m 33s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 112.7k | 3.8k | 294.0k | 29.4k | 25 | 41.4k | 1m 32s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 65.2k | 1.9k | 261.7k | 29.4k | 18 | 14.7k | 52s |
| review_pr | claude-sonnet-4-6 | 2 | 226 | 72.4k | 1.1M | 76.2k | 85 | 126.7k | 15m 8s |
| resolve_review | claude-sonnet-4-6 | 1 | 309 | 18.9k | 2.3M | 77.7k | 97 | 78.7k | 8m 4s |
| **Total** | | | 617.8k | 129.7k | 6.7M | 87.3k | | 469.8k | 45m 52s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 123 | 4540.7 | 558.9 | 41.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 28 | 80865.9 | 2811.0 | 676.5 |
| **Total** | **151** | 44082.8 | 3111.5 | 858.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 3.6k | 109.6k | 4.4M | 297.2k | 35m 39s |
| claude-opus-4-6 | 1 | 51 | 9.3k | 1.2M | 47.7k | 5m 15s |
| MiniMax-M2.7-highspeed | 3 | 614.2k | 10.8k | 1.1M | 124.9k | 4m 57s |