### PR TITLE
Implementation Plan: [P5-A7-WP1] Register codex_backend Feature Flag and Wire into make_context()

### DIFF
--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -449,6 +449,15 @@ class FeatureDef:
 
 
 FEATURE_REGISTRY: dict[str, FeatureDef] = {
+    "codex_backend": FeatureDef(
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="Codex CLI backend for headless sessions",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        tier=2,
+        default_enabled=False,
+    ),
     "fleet": FeatureDef(
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="L3 Fleet Orchestrator — multi-session campaign dispatch",

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -27,6 +27,7 @@ from autoskillit.core import (
     WriteBehaviorSpec,
     detect_autoskillit_mcp_prefix,
     get_logger,
+    is_feature_enabled,
     pkg_root,
     resolve_temp_dir,
     temp_dir_display_str,
@@ -321,6 +322,13 @@ def make_context(
     )
 
     backend = get_backend(config.agent_backend.backend)
+
+    if is_feature_enabled(
+        "codex_backend", config.features, experimental_enabled=config.experimental_enabled
+    ):
+        from autoskillit.execution.backends.codex import CodexBackend
+
+        backend = CodexBackend()
 
     audit = DefaultAuditLog()
     github_api_log = DefaultGitHubApiLog()

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -326,7 +326,7 @@ def make_context(
     if is_feature_enabled(
         "codex_backend", config.features, experimental_enabled=config.experimental_enabled
     ):
-        from autoskillit.execution.backends import CodexBackend
+        from autoskillit.execution import CodexBackend
 
         backend = CodexBackend()
 

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -326,7 +326,7 @@ def make_context(
     if is_feature_enabled(
         "codex_backend", config.features, experimental_enabled=config.experimental_enabled
     ):
-        from autoskillit.execution.backends.codex import CodexBackend
+        from autoskillit.execution.backends import CodexBackend
 
         backend = CodexBackend()
 

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -358,6 +358,22 @@ def test_providers_feature_default_disabled():
     assert FEATURE_REGISTRY["providers"].default_enabled is False
 
 
+# ── Codex backend feature registry tests ───────────────────────────────────────
+
+
+def test_codex_backend_in_feature_registry():
+    """codex_backend is registered with correct FeatureDef field values."""
+    from autoskillit.core.types._type_constants import FEATURE_REGISTRY
+    from autoskillit.core.types._type_enums import FeatureLifecycle
+
+    entry = FEATURE_REGISTRY["codex_backend"]
+    assert entry.lifecycle == FeatureLifecycle.EXPERIMENTAL
+    assert entry.tier == 2
+    assert entry.default_enabled is False
+    assert entry.tool_tags == frozenset()
+    assert entry.skill_categories == frozenset()
+
+
 # ── T1: DISABLED lifecycle ──────────────────────────────────────────────────
 
 

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -13,6 +13,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_editable_guard.py` | Unit tests for server/_editable_guard.py — scan_editable_installs_for_worktree |
 | `test_factory.py` | Tests for server/_factory.py make_context() composition root |
 | `test_factory_recording.py` | Tests for make_context recording/replay runner wiring |
+| `test_factory_codex_backend_gate.py` | Tests for codex_backend feature flag gating in make_context() |
 | `test_git.py` | Tests for server/git.py perform_merge() |
 | `test_git_merge_dirty_check.py` | Tests for the pre-merge dirty check in perform_merge (Layer 3) |
 | `test_guards_module.py` | Smoke test: all 6 guards are importable from _guards |

--- a/tests/server/test_factory_codex_backend_gate.py
+++ b/tests/server/test_factory_codex_backend_gate.py
@@ -1,0 +1,44 @@
+"""Tests for codex_backend feature flag gating in make_context()."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.config import AutomationConfig
+from autoskillit.core.types import SubprocessResult, TerminationReason
+from autoskillit.server._factory import make_context
+from tests.fakes import MockSubprocessRunner
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _runner() -> MockSubprocessRunner:
+    r = MockSubprocessRunner()
+    r.set_default(
+        SubprocessResult(
+            returncode=0,
+            stdout="",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=1,
+        )
+    )
+    return r
+
+
+def test_codex_backend_not_instantiated_when_disabled(monkeypatch):
+    """When codex_backend feature is disabled, CodexBackend is not the ctx.backend."""
+    monkeypatch.setattr("autoskillit.server._factory.is_feature_enabled", lambda *a, **kw: False)
+    from autoskillit.execution.backends.codex import CodexBackend
+
+    ctx = make_context(AutomationConfig(), runner=_runner())
+    assert not isinstance(ctx.backend, CodexBackend)
+
+
+def test_codex_backend_instantiated_when_enabled(monkeypatch):
+    """When codex_backend feature is enabled, ctx.backend is a CodexBackend instance."""
+    monkeypatch.setattr("autoskillit.server._factory.is_feature_enabled", lambda *a, **kw: True)
+    from autoskillit.execution.backends.codex import CodexBackend
+
+    ctx = make_context(AutomationConfig(), runner=_runner())
+    assert isinstance(ctx.backend, CodexBackend)

--- a/tests/server/test_factory_codex_backend_gate.py
+++ b/tests/server/test_factory_codex_backend_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.config import AutomationConfig
+from autoskillit.core import is_feature_enabled
 from autoskillit.core.types import SubprocessResult, TerminationReason
 from autoskillit.server._factory import make_context
 from tests.fakes import MockSubprocessRunner
@@ -28,7 +29,12 @@ def _runner() -> MockSubprocessRunner:
 
 def test_codex_backend_not_instantiated_when_disabled(monkeypatch):
     """When codex_backend feature is disabled, CodexBackend is not the ctx.backend."""
-    monkeypatch.setattr("autoskillit.server._factory.is_feature_enabled", lambda *a, **kw: False)
+    monkeypatch.setattr(
+        "autoskillit.server._factory.is_feature_enabled",
+        lambda name, *a, **kw: (
+            False if name == "codex_backend" else is_feature_enabled(name, *a, **kw)
+        ),
+    )
     from autoskillit.execution.backends.codex import CodexBackend
 
     ctx = make_context(AutomationConfig(), runner=_runner())
@@ -37,7 +43,12 @@ def test_codex_backend_not_instantiated_when_disabled(monkeypatch):
 
 def test_codex_backend_instantiated_when_enabled(monkeypatch):
     """When codex_backend feature is enabled, ctx.backend is a CodexBackend instance."""
-    monkeypatch.setattr("autoskillit.server._factory.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._factory.is_feature_enabled",
+        lambda name, *a, **kw: (
+            True if name == "codex_backend" else is_feature_enabled(name, *a, **kw)
+        ),
+    )
     from autoskillit.execution.backends.codex import CodexBackend
 
     ctx = make_context(AutomationConfig(), runner=_runner())


### PR DESCRIPTION
## Summary

Register a new `codex_backend` entry in `FEATURE_REGISTRY` (EXPERIMENTAL, tier 2, default disabled) and wire a feature-flag-gated `CodexBackend` construction path into `make_context()`. Add a registry structural test and a factory gate test.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
tests/server/test_factory_codex_backend_gate.py

### Modified (●):
src/autoskillit/core/types/_type_constants.py
src/autoskillit/server/_factory.py
tests/arch/test_feature_registry.py
tests/server/CLAUDE.md

Closes #2520

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260520-232152-080656/.autoskillit/temp/make-plan/p5_a7_wp1_register_codex_backend_feature_flag_plan_2026-05-20_233600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 87 | 32.4k | 2.5M | 111.0k | 253 | 100.4k | 15m 1s |
| verify | claude-opus-4-6 | 1 | 43 | 13.1k | 782.2k | 70.0k | 68 | 55.0k | 7m 13s |
| implement* | MiniMax-M2.7-highspeed | 1 | 609.5k | 5.4k | 879.0k | 29.4k | 70 | 37.9k | 2m 50s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 81.0k | 4.5k | 232.3k | 29.4k | 22 | 14.9k | 1m 28s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 117.8k | 3.3k | 320.5k | 29.4k | 26 | 14.7k | 1m 19s |
| review_pr | claude-sonnet-4-6 | 3 | 390 | 70.8k | 1.8M | 65.5k | 121 | 143.0k | 15m 45s |
| resolve_review | claude-sonnet-4-6 | 1 | 311 | 13.4k | 1.8M | 62.4k | 81 | 47.5k | 7m 54s |
| **Total** | | | 809.1k | 142.8k | 8.3M | 111.0k | | 413.4k | 51m 34s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 78 | 11269.8 | 485.8 | 69.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 15 | 117853.9 | 3163.9 | 890.5 |
| **Total** | **93** | 89488.5 | 4445.4 | 1535.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 788 | 116.5k | 6.1M | 290.9k | 38m 41s |
| claude-opus-4-6 | 1 | 43 | 13.1k | 782.2k | 55.0k | 7m 13s |
| MiniMax-M2.7-highspeed | 3 | 808.3k | 13.1k | 1.4M | 67.5k | 5m 39s |