### PR TITLE
[P5-A15-WP1] Gate recovery paths by backend capability and add tests

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -40,6 +40,8 @@ class ResultParser(Protocol):
         events: Sequence[SessionEvent],
     ) -> AgentSessionResult: ...
 
+    def parse_stdout(self, stdout: str) -> AgentSessionResult: ...
+
 
 @runtime_checkable
 class EnvPolicy(Protocol):

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -495,6 +495,7 @@ async def _execute_claude_headless(
                 cwd,
                 runner,
                 backend=ctx.backend,
+                result_parser=ctx.backend.result_parser() if ctx.backend else None,
                 provider_extras=provider_extras,
                 retry_reason=skill_result.retry_reason,
             )

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -174,7 +174,11 @@ def _extract_missing_token_hints(
     then matches them against path-capture patterns that are NOT satisfied in
     the result text. Returns the hints needed to build the nudge prompt.
     """
-    session = result_parser.parse_stdout(stdout)
+    try:
+        session = result_parser.parse_stdout(stdout)
+    except Exception:
+        logger.warning("nudge_parse_stdout_failed", exc_info=True)
+        return []
     hints: list[tuple[str, str]] = []
 
     for pattern in expected_output_patterns:
@@ -272,7 +276,11 @@ async def _attempt_contract_nudge(
         return None
 
     # Parse the nudge response and check for the missing patterns
-    nudge_session = result_parser.parse_stdout(nudge_result.stdout)
+    try:
+        nudge_session = result_parser.parse_stdout(nudge_result.stdout)
+    except Exception:
+        logger.warning("nudge_parse_stdout_failed", exc_info=True)
+        return None
     combined_result = skill_result.result + "\n" + nudge_session.output
 
     if retry_reason == RetryReason.EARLY_STOP:

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -185,7 +185,9 @@ def _extract_missing_token_hints(
         # Skip if already satisfied
         if re.search(pattern, session.output):
             continue
-        # Collect absolute Write/Edit paths; use the LAST one (final deliverable)
+        # Collect absolute Write/Edit paths; use the LAST one (final deliverable).
+        # tool_uses and token_usage live in .raw (not promoted to typed attrs) because
+        # they vary by backend and are absent from non-Claude AgentSessionResult payloads.
         candidate_paths = [
             t.get("file_path", "")
             for t in session.raw.get("tool_uses", [])
@@ -278,10 +280,10 @@ async def _attempt_contract_nudge(
         logger.warning("nudge_parse_stdout_failed", exc_info=True)
         return None
     combined_result = skill_result.result + "\n" + nudge_session.output
+    _nudge_usage = nudge_session.raw.get("token_usage")
 
     if retry_reason == RetryReason.EARLY_STOP:
         if completion_marker in nudge_session.output:
-            _nudge_usage = nudge_session.raw.get("token_usage")
             logger.info(
                 "nudge_recovery_success",
                 session_id=skill_result.session_id,
@@ -294,9 +296,7 @@ async def _attempt_contract_nudge(
                 subtype="success",
                 needs_retry=False,
                 retry_reason=RetryReason.NONE,
-                token_usage=_merge_token_usage(
-                    skill_result.token_usage, nudge_session.raw.get("token_usage")
-                ),
+                token_usage=_merge_token_usage(skill_result.token_usage, _nudge_usage),
             )
         logger.debug(
             "nudge_early_stop_marker_not_found", nudge_result_len=len(nudge_session.output)
@@ -310,7 +310,6 @@ async def _attempt_contract_nudge(
         )
         return None
 
-    _nudge_usage = nudge_session.raw.get("token_usage")
     logger.info(
         "nudge_recovery_success",
         session_id=skill_result.session_id,
@@ -323,9 +322,7 @@ async def _attempt_contract_nudge(
         subtype="success",
         needs_retry=False,
         retry_reason=RetryReason.NONE,
-        token_usage=_merge_token_usage(
-            skill_result.token_usage, nudge_session.raw.get("token_usage")
-        ),
+        token_usage=_merge_token_usage(skill_result.token_usage, _nudge_usage),
     )
 
 

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -108,8 +108,7 @@ def _recover_block_from_assistant_messages(
         "pattern_recovered_from_assistant_messages",
         patterns=list(expected_output_patterns),
     )
-    # Preserve any content already drained into session.result before appending
-    # the recovered assistant_messages block.
+    # Preserve any content already drained into session.result.
     recovered = (session.result + "\n\n" + combined) if session.result else combined
     return dataclasses.replace(session, result=recovered)
 
@@ -135,9 +134,7 @@ def _synthesize_from_write_artifacts(
     if write_call_count == 0:
         return None
 
-    # Only synthesize for path-capture patterns (token_name\s*=\s*/.+).
-    # Non-path patterns (verdict=, merged=) must remain text-compliance-only.
-
+    # Only synthesize path-capture patterns; non-path patterns must remain text-compliance-only.
     synthesized_lines: list[str] = []
     for pattern in expected_output_patterns:
         token_name = _is_path_capture_pattern(pattern)
@@ -275,7 +272,6 @@ async def _attempt_contract_nudge(
         logger.warning("nudge_runner_failed_unexpected", exc_info=True)
         return None
 
-    # Parse the nudge response and check for the missing patterns
     try:
         nudge_session = result_parser.parse_stdout(nudge_result.stdout)
     except Exception:
@@ -284,7 +280,6 @@ async def _attempt_contract_nudge(
     combined_result = skill_result.result + "\n" + nudge_session.output
 
     if retry_reason == RetryReason.EARLY_STOP:
-        # For EARLY_STOP, success is determined by the marker being present
         if completion_marker in nudge_session.output:
             _nudge_usage = nudge_session.raw.get("token_usage")
             logger.info(

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -15,11 +15,15 @@ from autoskillit.execution.process import _marker_is_standalone
 from autoskillit.execution.session import (
     ClaudeSessionResult,
     _check_expected_patterns,
-    parse_session_result,
 )
 
 if TYPE_CHECKING:
-    from autoskillit.core import CodingAgentBackend, SubprocessResult, SubprocessRunner
+    from autoskillit.core import (
+        CodingAgentBackend,
+        ResultParser,
+        SubprocessResult,
+        SubprocessRunner,
+    )
 
 logger = get_logger(__name__)
 
@@ -162,6 +166,7 @@ def _synthesize_from_write_artifacts(
 def _extract_missing_token_hints(
     stdout: str,
     expected_output_patterns: Sequence[str],
+    result_parser: ResultParser,
 ) -> list[tuple[str, str]]:
     """Extract (token_name, write_path) pairs for patterns missing from the result.
 
@@ -169,7 +174,7 @@ def _extract_missing_token_hints(
     then matches them against path-capture patterns that are NOT satisfied in
     the result text. Returns the hints needed to build the nudge prompt.
     """
-    session = parse_session_result(stdout)
+    session = result_parser.parse_stdout(stdout)
     hints: list[tuple[str, str]] = []
 
     for pattern in expected_output_patterns:
@@ -177,12 +182,12 @@ def _extract_missing_token_hints(
         if not token_name:
             continue
         # Skip if already satisfied
-        if re.search(pattern, session.result):
+        if re.search(pattern, session.output):
             continue
         # Collect absolute Write/Edit paths; use the LAST one (final deliverable)
         candidate_paths = [
             t.get("file_path", "")
-            for t in session.tool_uses
+            for t in session.raw.get("tool_uses", [])
             if t.get("name") in {"Write", "Edit"} and t.get("file_path", "").startswith("/")
         ]
         if candidate_paths:
@@ -200,6 +205,7 @@ async def _attempt_contract_nudge(
     runner: SubprocessRunner,
     *,
     backend: CodingAgentBackend | None = None,
+    result_parser: ResultParser | None = None,
     provider_extras: Mapping[str, str] | None = None,
     retry_reason: RetryReason = RetryReason.CONTRACT_RECOVERY,
 ) -> SkillResult | None:
@@ -215,7 +221,9 @@ async def _attempt_contract_nudge(
     Returns a patched SkillResult(success=True) on success, or None to indicate the
     nudge failed and the caller should fall through to the original path.
     """
-    if backend is None or not backend.capabilities.session_resume_capable:
+    if backend is None or not backend.capabilities.skill_injection_capable:
+        return None
+    if result_parser is None:
         return None
 
     if retry_reason == RetryReason.EARLY_STOP:
@@ -226,7 +234,9 @@ async def _attempt_contract_nudge(
         )
         patterns_to_check: Sequence[str] = []
     else:
-        hints = _extract_missing_token_hints(subprocess_result.stdout, expected_output_patterns)
+        hints = _extract_missing_token_hints(
+            subprocess_result.stdout, expected_output_patterns, result_parser
+        )
         if not hints:
             logger.debug("nudge_skip_no_hints")
             return None
@@ -262,18 +272,17 @@ async def _attempt_contract_nudge(
         return None
 
     # Parse the nudge response and check for the missing patterns
-    nudge_session = parse_session_result(nudge_result.stdout)
-    combined_result = skill_result.result + "\n" + nudge_session.result
+    nudge_session = result_parser.parse_stdout(nudge_result.stdout)
+    combined_result = skill_result.result + "\n" + nudge_session.output
 
     if retry_reason == RetryReason.EARLY_STOP:
         # For EARLY_STOP, success is determined by the marker being present
-        if completion_marker in nudge_session.result:
+        if completion_marker in nudge_session.output:
+            _nudge_usage = nudge_session.raw.get("token_usage")
             logger.info(
                 "nudge_recovery_success",
                 session_id=skill_result.session_id,
-                nudge_output_count=nudge_session.token_usage.get("output_tokens", 0)
-                if nudge_session.token_usage
-                else 0,
+                nudge_output_count=_nudge_usage.get("output_tokens", 0) if _nudge_usage else 0,
             )
             return dataclasses.replace(
                 skill_result,
@@ -283,27 +292,26 @@ async def _attempt_contract_nudge(
                 needs_retry=False,
                 retry_reason=RetryReason.NONE,
                 token_usage=_merge_token_usage(
-                    skill_result.token_usage, nudge_session.token_usage
+                    skill_result.token_usage, nudge_session.raw.get("token_usage")
                 ),
             )
         logger.debug(
-            "nudge_early_stop_marker_not_found", nudge_result_len=len(nudge_session.result)
+            "nudge_early_stop_marker_not_found", nudge_result_len=len(nudge_session.output)
         )
         return None
 
     if not _check_expected_patterns(combined_result, patterns_to_check):
         logger.debug(
             "nudge_patterns_not_found",
-            nudge_result_len=len(nudge_session.result),
+            nudge_result_len=len(nudge_session.output),
         )
         return None
 
+    _nudge_usage = nudge_session.raw.get("token_usage")
     logger.info(
         "nudge_recovery_success",
         session_id=skill_result.session_id,
-        nudge_output_count=nudge_session.token_usage.get("output_tokens", 0)
-        if nudge_session.token_usage
-        else 0,
+        nudge_output_count=_nudge_usage.get("output_tokens", 0) if _nudge_usage else 0,
     )
     return dataclasses.replace(
         skill_result,
@@ -312,7 +320,9 @@ async def _attempt_contract_nudge(
         subtype="success",
         needs_retry=False,
         retry_reason=RetryReason.NONE,
-        token_usage=_merge_token_usage(skill_result.token_usage, nudge_session.token_usage),
+        token_usage=_merge_token_usage(
+            skill_result.token_usage, nudge_session.raw.get("token_usage")
+        ),
     )
 
 

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -15,7 +15,7 @@ NEW_HEADLESS_MODULES = [
 ]
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 950,
-    "headless/_headless_recovery.py": 345,
+    "headless/_headless_recovery.py": 355,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 690,
 }

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -1114,29 +1114,47 @@ def _ndjson_with_write(result_text: str, file_paths: list[str], session_id: str 
 
 class TestExtractMissingTokenHints:
     def test_extracts_token_and_path(self):
+        from autoskillit.execution.backends.claude import ClaudeResultParser
+
         stdout = _ndjson_with_write("plan summary\n%%ORDER_UP%%", ["/tmp/out.md"])
-        hints = _extract_missing_token_hints(stdout, [r"plan_path\s*=\s*/.+"])
+        hints = _extract_missing_token_hints(
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser()
+        )
         assert hints == [("plan_path", "/tmp/out.md")]
 
     def test_returns_empty_when_pattern_satisfied(self):
+        from autoskillit.execution.backends.claude import ClaudeResultParser
+
         stdout = _ndjson_with_write("plan_path = /tmp/out.md\n%%ORDER_UP%%", ["/tmp/out.md"])
-        hints = _extract_missing_token_hints(stdout, [r"plan_path\s*=\s*/.+"])
+        hints = _extract_missing_token_hints(
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser()
+        )
         assert hints == []
 
     def test_returns_empty_for_non_path_patterns(self):
+        from autoskillit.execution.backends.claude import ClaudeResultParser
+
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/out.md"])
-        hints = _extract_missing_token_hints(stdout, [r"verdict\s*=\s*\w+"])
+        hints = _extract_missing_token_hints(stdout, [r"verdict\s*=\s*\w+"], ClaudeResultParser())
         assert hints == []
 
     def test_uses_last_write_path(self):
+        from autoskillit.execution.backends.claude import ClaudeResultParser
+
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/first.md", "/tmp/final.md"])
-        hints = _extract_missing_token_hints(stdout, [r"plan_path\s*=\s*/.+"])
+        hints = _extract_missing_token_hints(
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser()
+        )
         assert hints == [("plan_path", "/tmp/final.md")]
 
     def test_extracts_hints_for_backslash_s_plus_pattern(self):
         """_extract_missing_token_hints must work for \\S+-terminated patterns."""
+        from autoskillit.execution.backends.claude import ClaudeResultParser
+
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/out.md"])
-        hints = _extract_missing_token_hints(stdout, [r"elab_result_path\s*=\s*\S+"])
+        hints = _extract_missing_token_hints(
+            stdout, [r"elab_result_path\s*=\s*\S+"], ClaudeResultParser()
+        )
         assert hints == [("elab_result_path", "/tmp/out.md")]
 
 
@@ -1726,7 +1744,7 @@ class TestNudgeBackendGuard:
         assert len(tool_ctx.runner.call_args_list) == 1
 
     @pytest.mark.anyio
-    async def test_nudge_skips_when_not_session_resume_capable(self, tool_ctx):
+    async def test_nudge_skips_when_not_skill_injection_capable(self, tool_ctx):
         from dataclasses import replace
         from unittest.mock import Mock
 
@@ -1735,7 +1753,7 @@ class TestNudgeBackendGuard:
         from autoskillit.execution.headless import run_headless_core
 
         marker = tool_ctx.config.run_skill.completion_marker
-        caps = replace(CLAUDE_CODE_CAPABILITIES, session_resume_capable=False)
+        caps = replace(CLAUDE_CODE_CAPABILITIES, skill_injection_capable=False)
         mock_backend = Mock()
         mock_backend.capabilities = caps
         mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
@@ -1748,7 +1766,7 @@ class TestNudgeBackendGuard:
             ctx=tool_ctx,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
         )
-        # Without session_resume_capable, nudge is skipped
+        # Without skill_injection_capable, nudge is skipped
         assert result.retry_reason == RetryReason.CONTRACT_RECOVERY
         assert len(tool_ctx.runner.call_args_list) == 1
 
@@ -1758,6 +1776,7 @@ class TestNudgeBackendGuard:
         from unittest.mock import Mock
 
         from autoskillit.core import CLAUDE_CODE_CAPABILITIES, CmdSpec
+        from autoskillit.execution.backends.claude import ClaudeResultParser
         from autoskillit.execution.headless import run_headless_core
 
         marker = tool_ctx.config.run_skill.completion_marker
@@ -1770,6 +1789,7 @@ class TestNudgeBackendGuard:
         mock_backend.capabilities = caps
         mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
         mock_backend.build_resume_cmd.return_value = expected_cmd
+        mock_backend.result_parser.return_value = ClaudeResultParser()
         tool_ctx.backend = mock_backend
         tool_ctx.runner.push(self._main_subprocess_result(marker, session_id="sess-main"))
         tool_ctx.runner.push(self._nudge_response(marker))
@@ -1779,6 +1799,40 @@ class TestNudgeBackendGuard:
             ctx=tool_ctx,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
         )
+        mock_backend.build_resume_cmd.assert_called_once()
+        call_kwargs = mock_backend.build_resume_cmd.call_args
+        assert call_kwargs.kwargs["resume_session_id"] == "sess-main"
+
+    @pytest.mark.anyio
+    async def test_nudge_calls_build_resume_cmd_when_skill_injection_capable(self, tool_ctx):
+        from dataclasses import replace
+        from unittest.mock import Mock
+
+        from autoskillit.core import CLAUDE_CODE_CAPABILITIES, CmdSpec
+        from autoskillit.execution.backends.claude import ClaudeResultParser
+        from autoskillit.execution.headless import run_headless_core
+
+        marker = tool_ctx.config.run_skill.completion_marker
+        caps = replace(CLAUDE_CODE_CAPABILITIES, skill_injection_capable=True)
+        expected_cmd = CmdSpec(
+            cmd=("claude", "--resume", "sess-main", "--print", "emit marker"),
+            env={"TEST": "val"},
+        )
+        mock_backend = Mock()
+        mock_backend.capabilities = caps
+        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
+        mock_backend.build_resume_cmd.return_value = expected_cmd
+        mock_backend.result_parser.return_value = ClaudeResultParser()
+        tool_ctx.backend = mock_backend
+        tool_ctx.runner.push(self._main_subprocess_result(marker, session_id="sess-main"))
+        tool_ctx.runner.push(self._nudge_response(marker))
+        result = await run_headless_core(
+            "/autoskillit:make-plan foo",
+            cwd="/tmp",
+            ctx=tool_ctx,
+            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+        )
+        assert result.success is True
         mock_backend.build_resume_cmd.assert_called_once()
         call_kwargs = mock_backend.build_resume_cmd.call_args
         assert call_kwargs.kwargs["resume_session_id"] == "sess-main"

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -11,6 +11,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeResultParser
 from autoskillit.execution.headless import (
     _build_skill_result,
     _extract_missing_token_hints,
@@ -1114,7 +1115,6 @@ def _ndjson_with_write(result_text: str, file_paths: list[str], session_id: str 
 
 class TestExtractMissingTokenHints:
     def test_extracts_token_and_path(self):
-        from autoskillit.execution.backends.claude import ClaudeResultParser
 
         stdout = _ndjson_with_write("plan summary\n%%ORDER_UP%%", ["/tmp/out.md"])
         hints = _extract_missing_token_hints(
@@ -1123,7 +1123,6 @@ class TestExtractMissingTokenHints:
         assert hints == [("plan_path", "/tmp/out.md")]
 
     def test_returns_empty_when_pattern_satisfied(self):
-        from autoskillit.execution.backends.claude import ClaudeResultParser
 
         stdout = _ndjson_with_write("plan_path = /tmp/out.md\n%%ORDER_UP%%", ["/tmp/out.md"])
         hints = _extract_missing_token_hints(
@@ -1132,14 +1131,12 @@ class TestExtractMissingTokenHints:
         assert hints == []
 
     def test_returns_empty_for_non_path_patterns(self):
-        from autoskillit.execution.backends.claude import ClaudeResultParser
 
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/out.md"])
         hints = _extract_missing_token_hints(stdout, [r"verdict\s*=\s*\w+"], ClaudeResultParser())
         assert hints == []
 
     def test_uses_last_write_path(self):
-        from autoskillit.execution.backends.claude import ClaudeResultParser
 
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/first.md", "/tmp/final.md"])
         hints = _extract_missing_token_hints(
@@ -1149,7 +1146,6 @@ class TestExtractMissingTokenHints:
 
     def test_extracts_hints_for_backslash_s_plus_pattern(self):
         """_extract_missing_token_hints must work for \\S+-terminated patterns."""
-        from autoskillit.execution.backends.claude import ClaudeResultParser
 
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/out.md"])
         hints = _extract_missing_token_hints(
@@ -1771,12 +1767,39 @@ class TestNudgeBackendGuard:
         assert len(tool_ctx.runner.call_args_list) == 1
 
     @pytest.mark.anyio
+    async def test_nudge_skips_when_result_parser_is_none(self, tool_ctx):
+        from dataclasses import replace
+        from unittest.mock import Mock
+
+        from autoskillit.core import CLAUDE_CODE_CAPABILITIES
+        from autoskillit.core.types import RetryReason
+        from autoskillit.execution.headless import run_headless_core
+
+        marker = tool_ctx.config.run_skill.completion_marker
+        caps = replace(CLAUDE_CODE_CAPABILITIES, skill_injection_capable=True)
+        mock_backend = Mock()
+        mock_backend.capabilities = caps
+        mock_backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
+        mock_backend.result_parser.return_value = None
+        tool_ctx.backend = mock_backend
+        tool_ctx.runner.push(self._main_subprocess_result(marker))
+        tool_ctx.runner.push(self._nudge_response(marker))
+        result = await run_headless_core(
+            "/autoskillit:make-plan foo",
+            cwd="/tmp",
+            ctx=tool_ctx,
+            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+        )
+        # result_parser=None prevents nudge even when skill_injection_capable=True
+        assert result.retry_reason == RetryReason.CONTRACT_RECOVERY
+        assert len(tool_ctx.runner.call_args_list) == 1
+
+    @pytest.mark.anyio
     async def test_nudge_uses_backend_build_resume_cmd(self, tool_ctx):
         from dataclasses import replace
         from unittest.mock import Mock
 
         from autoskillit.core import CLAUDE_CODE_CAPABILITIES, CmdSpec
-        from autoskillit.execution.backends.claude import ClaudeResultParser
         from autoskillit.execution.headless import run_headless_core
 
         marker = tool_ctx.config.run_skill.completion_marker
@@ -1809,7 +1832,6 @@ class TestNudgeBackendGuard:
         from unittest.mock import Mock
 
         from autoskillit.core import CLAUDE_CODE_CAPABILITIES, CmdSpec
-        from autoskillit.execution.backends.claude import ClaudeResultParser
         from autoskillit.execution.headless import run_headless_core
 
         marker = tool_ctx.config.run_skill.completion_marker
@@ -1836,6 +1858,7 @@ class TestNudgeBackendGuard:
         mock_backend.build_resume_cmd.assert_called_once()
         call_kwargs = mock_backend.build_resume_cmd.call_args
         assert call_kwargs.kwargs["resume_session_id"] == "sess-main"
+        mock_backend.result_parser.assert_called_once()
 
 
 class TestEarlyStopDetection:


### PR DESCRIPTION
## Summary

Gate `_attempt_contract_nudge` by `skill_injection_capable` (replacing `session_resume_capable`), thread `ResultParser` through the two functions that call `parse_session_result`, add `parse_stdout` to the `ResultParser` protocol, update internal code to work with `AgentSessionResult`, and add/update tests. Update `TestExtractMissingTokenHints` to supply the new `result_parser` argument at all 5 call sites.

The Codex backend sets `skill_injection_capable=False` and has no concept of skill-level structured output tokens, so the contract nudge recovery path must not fire for it. The current guard on `session_resume_capable` is too permissive — Codex can resume sessions but cannot handle skill injection nudges.

## Requirements

**Goal**

Gate _attempt_contract_nudge by capability, thread ResultParser into recovery helpers, and add tests.

**Context**

- Phase: Codex CLI Backend Implementation (Milestone: 5-codex-cli-backend-implementation)
- Assignment: P5-A15 (Gate recovery/nudge paths behind backend capabilities check)
- Depends on: P3-A5-WP1
- Depended on by: None

**Deliverables**

- `Gated _attempt_contract_nudge with backend parameter`
- `Updated call site in __init__.py`
- `Updated _headless_recovery.py`
- `Updated type annotations`
- `Updated call sites`
- `Updated tests`
- `3 async test methods in TestContractNudge`

**Acceptance Criteria**

- skill_injection_capable=False causes immediate None return
- backend=None falls back to existing shim
- skill_injection_capable=True uses backend.build_resume_cmd()
- No import of parse_session_result or ClaudeSessionResult remains
- result_parser.parse_stdout used at both sites
- All tests pass
- skill_injection_capable=False -> None return, runner called once
- skill_injection_capable=True -> build_resume_cmd called
- backend=None -> shim path, runner called twice

## Changed Files

- `src/autoskillit/core/types/_type_protocols_backend.py` — Add `parse_stdout` to `ResultParser` protocol
- `src/autoskillit/execution/headless/__init__.py` — Thread `result_parser` through nudge call site
- `src/autoskillit/execution/headless/_headless_recovery.py` — Gate by `skill_injection_capable`, thread `ResultParser`, migrate to `AgentSessionResult`
- `tests/arch/test_execution_source_split.py` — Bump line budget for `_headless_recovery.py`
- `tests/execution/test_headless_path_validation.py` — Update/rename capability tests, add `result_parser` to all 5 `TestExtractMissingTokenHints` call sites, add new test

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260521-075120-825305/.autoskillit/temp/make-plan/p5_a15_wp1_gate_recovery_paths_plan_2026-05-21_080000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 8.4k | 36.0k | 2.7M | 122.4k | 344 | 107.5k | 17m 3s |
| verify | claude-opus-4-6 | 1 | 54 | 18.3k | 2.4M | 89.5k | 120 | 74.4k | 8m 21s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 13.0k | 1.2M | 64.8k | 100 | 58.8k | 4m 10s |
| prepare_pr* | MiniMax-M2.7 | 1 | 131.9k | 3.7k | 258.0k | 29.6k | 31 | 42.4k | 1m 47s |
| compose_pr* | MiniMax-M2.7 | 1 | 45.7k | 1.7k | 288.5k | 0 | 19 | 0 | 20s |
| review_pr | claude-sonnet-4-6 | 3 | 409 | 132.8k | 1.9M | 94.6k | 141 | 227.2k | 31m 18s |
| resolve_review | claude-sonnet-4-6 | 2 | 1.8k | 41.3k | 4.8M | 92.7k | 194 | 154.7k | 25m 6s |
| **Total** | | | 1.4M | 246.8k | 13.5M | 122.4k | | 665.0k | 1h 28m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 125 | 9737.2 | 470.5 | 104.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 73 | 65439.0 | 2119.4 | 566.3 |
| **Total** | **198** | 68330.9 | 3358.3 | 1246.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 10.7k | 210.1k | 9.3M | 489.3k | 1h 13m |
| claude-opus-4-6 | 1 | 54 | 18.3k | 2.4M | 74.4k | 8m 21s |
| MiniMax-M2.7-highspeed | 1 | 1.2M | 13.0k | 1.2M | 58.8k | 4m 10s |
| MiniMax-M2.7 | 2 | 177.6k | 5.4k | 546.5k | 42.4k | 2m 7s |