### PR TITLE
[P5-A16-WP1] Add test-smoke-codex Taskfile task and smoke test file

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -220,8 +220,8 @@ tasks:
         msg: "OPENAI_API_KEY must be set"
     cmds:
       - |
-        mkdir -p temp
-        TEST_OUTPUT="temp/smoke-codex-$(date +%Y-%m-%d_%H%M%S).txt"
+        mkdir -p .autoskillit/temp
+        TEST_OUTPUT=".autoskillit/temp/smoke-codex-$(date +%Y-%m-%d_%H%M%S).txt"
         echo "Running Codex smoke tests"
         echo "Output: $TEST_OUTPUT"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -207,6 +207,41 @@ tasks:
         echo "Research smoke test output saved to: $TEST_OUTPUT"
         exit $PYTEST_EXIT
 
+  test-smoke-codex:
+    desc: Run Codex CLI smoke tests (requires OPENAI_API_KEY)
+    deps: [_tmpdir-setup]
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+      OMP_NUM_THREADS: "1"
+      CODEX_SMOKE_TEST: "1"
+      TMPDIR: "{{.PYTEST_TMPDIR}}"
+    preconditions:
+      - sh: test -n "$OPENAI_API_KEY"
+        msg: "OPENAI_API_KEY must be set"
+    cmds:
+      - |
+        mkdir -p temp
+        TEST_OUTPUT="temp/smoke-codex-$(date +%Y-%m-%d_%H%M%S).txt"
+        echo "Running Codex smoke tests"
+        echo "Output: $TEST_OUTPUT"
+
+        if [[ -d ".venv" ]]; then
+          PYTEST_CMD=".venv/bin/python -m pytest"
+        else
+          PYTEST_CMD="pytest"
+        fi
+
+        set -o pipefail
+        set +e
+        $PYTEST_CMD tests/execution/test_smoke_codex.py -m smoke -v --tb=short -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        PYTEST_EXIT=$?
+        set +o pipefail
+        set -e
+
+        echo ""
+        echo "Codex smoke test output saved to: $TEST_OUTPUT"
+        exit $PYTEST_EXIT
+
   test-smoke-record:
     desc: Record smoke test scenario by running autoskillit order with recording enabled
     env:

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -94,6 +94,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_session_model_peak_context.py` | Tests for peak_context and turn_count extraction from extract_token_usage |
 | `test_session_parsing.py` | L1 unit tests for execution/session.py — token extraction, parsing, and SkillResult |
 | `test_session_result.py` | L1 unit tests for ClaudeSessionResult and parse_session_result — result types and policies |
+| `test_smoke_codex.py` | Codex CLI smoke test: gated E2E validation of codex exec NDJSON output (CODEX_SMOKE_TEST=1) |
 | `test_termination_action.py` | Unit tests for decide_termination_action — pure decision function |
 | `test_termination_executor.py` | Integration tests for execute_termination_action |
 | `test_testing.py` | L1 unit tests for execution/testing.py — pytest output parsing |

--- a/tests/execution/test_smoke_codex.py
+++ b/tests/execution/test_smoke_codex.py
@@ -48,7 +48,7 @@ class TestCodexSmokeExecution:
             ],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=int(os.environ.get("CODEX_SMOKE_TIMEOUT", "30")),
         )
         assert result.returncode == 0, (
             f"codex exec failed with rc={result.returncode}: {result.stderr}"

--- a/tests/execution/test_smoke_codex.py
+++ b/tests/execution/test_smoke_codex.py
@@ -1,0 +1,78 @@
+"""Codex CLI smoke test: gated E2E validation of codex exec NDJSON output.
+
+Gated E2E tests run only when CODEX_SMOKE_TEST=1 and OPENAI_API_KEY are set
+(via ``task test-smoke-codex``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from autoskillit.core import BackendEventKind, SessionEvent
+from autoskillit.execution.backends.codex import CodexResultParser, CodexStreamParser
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.large]
+
+_SKIP_REASON = "Set CODEX_SMOKE_TEST=1 and OPENAI_API_KEY to run Codex smoke tests"
+
+_skip_unless_codex_smoke = pytest.mark.skipif(
+    not os.environ.get("CODEX_SMOKE_TEST") or not os.environ.get("OPENAI_API_KEY"),
+    reason=_SKIP_REASON,
+)
+
+
+@_skip_unless_codex_smoke
+@pytest.mark.smoke
+class TestCodexSmokeExecution:
+    """Full end-to-end Codex CLI smoke execution.
+
+    Run via ``task test-smoke-codex`` which sets CODEX_SMOKE_TEST=1 and
+    requires OPENAI_API_KEY. Executes ``codex exec --json`` with a trivial
+    prompt and validates NDJSON output parsing.
+    """
+
+    def test_codex_exec_ndjson_parseable(self) -> None:
+        result = subprocess.run(
+            [
+                "codex",
+                "exec",
+                "--json",
+                "--sandbox",
+                "workspace-write",
+                "-a",
+                "never",
+                "Respond with exactly: hello",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"codex exec failed with rc={result.returncode}: {result.stderr}"
+        )
+
+        # Parse individual NDJSON lines with CodexStreamParser
+        parser = CodexStreamParser()
+        events: list[SessionEvent] = []
+        for line in result.stdout.splitlines():
+            evt = parser.parse_line(line)
+            if evt is not None:
+                events.append(evt)
+
+        completion_events = [e for e in events if e.kind == BackendEventKind.COMPLETION]
+        assert len(completion_events) >= 1, (
+            f"Expected at least one COMPLETION event, got kinds: {[e.kind for e in events]}"
+        )
+
+        # Parse full stdout with CodexResultParser
+        result_parser = CodexResultParser()
+        agent_result = result_parser.parse_stdout(result.stdout, exit_code=result.returncode)
+        token_usage = agent_result.raw.get("token_usage")
+        assert token_usage is not None, (
+            f"token_usage is None; raw keys: {list(agent_result.raw.keys())}"
+        )
+        assert token_usage.get("input_tokens", -1) >= 0
+        assert token_usage.get("output_tokens", -1) >= 0


### PR DESCRIPTION
## Summary

Add a `test-smoke-codex` Taskfile task and create `tests/execution/test_smoke_codex.py` — a gated E2E smoke test for the Codex CLI backend. The Taskfile task follows the established `test-smoke-research` pattern (deps, env, precondition, PYTEST_CMD resolution, tee output, exit code mirroring). The test file runs `codex exec --json --sandbox workspace-write -a never` via `subprocess.run`, parses NDJSON output with `CodexStreamParser`, asserts at least one `COMPLETION` event, then parses full stdout with `CodexResultParser` and asserts `token_usage` is non-None with valid counts. The `tests/execution/CLAUDE.md` file table is updated to include the new test file.

## Requirements

### Goal

Add Taskfile task and create E2E smoke test file.

### Context

- Phase: Codex CLI Backend Implementation (Milestone: 5-codex-cli-backend-implementation)
- Assignment: P5-A16 (Add task test-smoke-codex entry to Taskfile.yml for end-to-end Codex smoke testing)
- Depends on: P5-A2-WP2, P5-A3-WP1
- Depended on by: None

### Deliverables

- `test-smoke-codex task block in Taskfile.yml`
- `tests/execution/test_smoke_codex.py`

### Technical Steps

1. Insert test-smoke-codex task after test-smoke-research in Taskfile.yml.
2. Set deps=[_tmpdir-setup], env CODEX_SMOKE_TEST=1.
3. Add precondition: test -n $OPENAI_API_KEY.
4. Shell block: resolve PYTEST_CMD, run pytest tests/execution/test_smoke_codex.py -m smoke, tee output, exit with pytest code.
5. Create tests/execution/test_smoke_codex.py with pytestmark=[layer('execution'), large].
6. Add skipif guard checking both CODEX_SMOKE_TEST and OPENAI_API_KEY.
7. Add @pytest.mark.smoke class TestCodexSmokeExecution.
8. Implement test_codex_exec_ndjson_parseable: subprocess.run codex exec --json, assert exit code 0, parse lines with CodexStreamParser, assert completion event, parse full stdout with CodexResultParser, assert token_usage non-None.

### Acceptance Criteria

- task test-smoke-codex fails without OPENAI_API_KEY
- Output saved to temp/smoke-codex-*.txt
- Exit code mirrors pytest
- Skipped when env vars absent
- Runs codex exec with 30s timeout
- Asserts exit code 0
- At least one completion SessionEvent
- token_usage has input_tokens>=0 and output_tokens>=0

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/p5_a16_wp1_add_test_smoke_codex_plan_2026-05-21_075500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 83 | 15.9k | 953.9k | 97.3k | 248 | 64.9k | 11m 18s |
| verify | claude-opus-4-6 | 1 | 2.6k | 8.4k | 903.3k | 57.6k | 60 | 42.5k | 4m 35s |
| implement* | MiniMax-M2.7-highspeed | 1 | 440.7k | 4.5k | 677.8k | 29.6k | 55 | 38.2k | 1m 58s |
| prepare_pr* | MiniMax-M2.7 | 1 | 62.9k | 2.3k | 160.4k | 29.6k | 15 | 15.8k | 60s |
| compose_pr* | MiniMax-M2.7 | 1 | 86.7k | 1.8k | 216.4k | 26.7k | 16 | 2.9k | 1m 1s |
| review_pr | claude-sonnet-4-6 | 3 | 292 | 53.8k | 1.4M | 61.6k | 99 | 135.1k | 13m 56s |
| resolve_review | claude-sonnet-4-6 | 2 | 1.1k | 25.0k | 2.1M | 68.9k | 120 | 98.2k | 11m 12s |
| **Total** | | | 594.3k | 111.8k | 6.4M | 97.3k | | 397.6k | 45m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 114 | 5945.7 | 334.7 | 39.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 353809.0 | 16365.0 | 4174.0 |
| **Total** | **120** | 53548.8 | 3312.9 | 931.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 1.4k | 94.8k | 4.5M | 298.2k | 36m 27s |
| claude-opus-4-6 | 1 | 2.6k | 8.4k | 903.3k | 42.5k | 4m 35s |
| MiniMax-M2.7-highspeed | 1 | 440.7k | 4.5k | 677.8k | 38.2k | 1m 58s |
| MiniMax-M2.7 | 2 | 149.6k | 4.1k | 376.8k | 18.7k | 2m 0s |