### PR TITLE
[P5-A11-WP1] Create tests/fixtures/codex Package and All NDJSON Fixture Files

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -127,6 +127,9 @@ src/autoskillit/assets/**/*:
 tests/recipe/fixtures/*:
   - recipe/
 
+tests/fixtures/codex/*.ndjson:
+  - execution/
+
 # Local .autoskillit/ config and state files
 .autoskillit/test-source-map.json:
   - infra/

--- a/tests/execution/backends/test_codex_fixtures.py
+++ b/tests/execution/backends/test_codex_fixtures.py
@@ -1,0 +1,233 @@
+"""Codex fixture integrity tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.execution.backends.codex import _scan_codex_ndjson
+from autoskillit.execution.process import _marker_is_standalone
+from tests.fixtures.codex import (
+    CODEX_SCHEMA_VERSION,
+    HAPPY_PATH_SINGLE_TURN,
+    MULTI_TURN_WITH_COMPACTION,
+    SESSION_WITH_MCP_TOOL_CALL,
+    SESSION_WITH_REASONING,
+    TURN_FAILED_ERROR,
+    fixture_path,
+)
+from tests.fixtures.codex import (
+    __all__ as CODEX_ALL,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+ALL_FIXTURE_NAMES = [
+    HAPPY_PATH_SINGLE_TURN,
+    MULTI_TURN_WITH_COMPACTION,
+    TURN_FAILED_ERROR,
+    SESSION_WITH_REASONING,
+    SESSION_WITH_MCP_TOOL_CALL,
+]
+
+
+def _load_events(name: str) -> list[dict]:
+    """Read a fixture and return parsed JSON objects."""
+    text = fixture_path(name).read_text()
+    return [json.loads(line) for line in text.strip().splitlines() if line.strip()]
+
+
+class TestCodexFixturePackage:
+    def test_schema_version_is_one(self) -> None:
+        assert CODEX_SCHEMA_VERSION == 1
+
+    def test_all_filename_constants_end_in_ndjson(self) -> None:
+        for name in CODEX_ALL:
+            if name.endswith(".ndjson"):
+                assert name.endswith(".ndjson")
+
+    def test_fixture_path_returns_existing_file(self) -> None:
+        for name in ALL_FIXTURE_NAMES:
+            assert fixture_path(name).is_file()
+
+    def test_all_exports_count(self) -> None:
+        assert len(CODEX_ALL) == 7
+
+
+class TestCodexFixtureValidity:
+    def test_every_line_is_valid_json(self, name: str = "") -> None:
+        name = "happy_path_single_turn.ndjson"
+        text = fixture_path(name).read_text()
+        for line in text.strip().splitlines():
+            if line.strip():
+                json.loads(line)
+
+    def test_first_line_is_thread_started(self, name: str = "") -> None:
+        name = "happy_path_single_turn.ndjson"
+        events = _load_events(name)
+        assert events[0]["type"] == "thread.started"
+        assert isinstance(events[0]["thread_id"], str)
+        assert events[0]["thread_id"]
+
+    def test_all_lines_are_dicts(self, name: str = "") -> None:
+        name = "happy_path_single_turn.ndjson"
+        events = _load_events(name)
+        for event in events:
+            assert isinstance(event, dict)
+
+
+class TestHappyPathFixture:
+    def test_contains_order_up_marker_standalone(self) -> None:
+        events = _load_events(HAPPY_PATH_SINGLE_TURN)
+        for event in events:
+            if (
+                event.get("type") == "item.completed"
+                and event.get("item", {}).get("type") == "message"
+            ):
+                for block in event.get("item", {}).get("content", []):
+                    if block.get("type") == "text":
+                        text = block.get("text", "")
+                        if "%%ORDER_UP%%" in text:
+                            assert _marker_is_standalone(text, "%%ORDER_UP%%")
+                            return
+
+    def test_turn_completed_has_nonzero_usage(self) -> None:
+        events = _load_events(HAPPY_PATH_SINGLE_TURN)
+        for event in events:
+            if event.get("type") == "turn.completed":
+                usage = event.get("usage", {})
+                assert usage.get("input_tokens", 0) > 0
+                assert usage.get("output_tokens", 0) > 0
+                return
+
+    def test_reasoning_output_tokens_zero(self) -> None:
+        events = _load_events(HAPPY_PATH_SINGLE_TURN)
+        for event in events:
+            if event.get("type") == "turn.completed":
+                usage = event.get("usage", {})
+                assert usage.get("reasoning_output_tokens", -1) == 0
+                return
+
+    def test_has_three_item_types(self) -> None:
+        events = _load_events(HAPPY_PATH_SINGLE_TURN)
+        item_types = set()
+        for event in events:
+            if event.get("type") == "item.completed":
+                item_types.add(event.get("item", {}).get("type"))
+        assert "function_call" in item_types
+        assert "file_change" in item_types
+        assert "message" in item_types
+
+
+class TestMultiTurnFixture:
+    def test_turn2_input_tokens_greater_than_turn1(self) -> None:
+        events = _load_events(MULTI_TURN_WITH_COMPACTION)
+        turn_completed_tokens = [
+            e.get("usage", {}).get("input_tokens")
+            for e in events
+            if e.get("type") == "turn.completed"
+        ]
+        assert len(turn_completed_tokens) == 2
+        assert turn_completed_tokens[1] > turn_completed_tokens[0]
+
+    def test_has_two_turn_completed_events(self) -> None:
+        events = _load_events(MULTI_TURN_WITH_COMPACTION)
+        count = sum(1 for e in events if e.get("type") == "turn.completed")
+        assert count == 2
+
+    def test_todo_list_item_present(self) -> None:
+        events = _load_events(MULTI_TURN_WITH_COMPACTION)
+        has_todo = any(
+            e.get("type") == "item.completed" and e.get("item", {}).get("type") == "todo_list"
+            for e in events
+        )
+        assert has_todo
+
+
+class TestTurnFailedFixture:
+    def test_has_nonempty_error_message(self) -> None:
+        events = _load_events(TURN_FAILED_ERROR)
+        for event in events:
+            if event.get("type") == "turn.failed":
+                assert event.get("error", {}).get("message")
+                return
+
+    def test_has_partial_item_started(self) -> None:
+        events = _load_events(TURN_FAILED_ERROR)
+        has_item_started = any(e.get("type") == "item.started" for e in events)
+        assert has_item_started
+
+    def test_no_turn_completed(self) -> None:
+        events = _load_events(TURN_FAILED_ERROR)
+        has_completed = any(e.get("type") == "turn.completed" for e in events)
+        assert not has_completed
+
+
+class TestReasoningFixture:
+    def test_reasoning_output_tokens_positive(self) -> None:
+        events = _load_events(SESSION_WITH_REASONING)
+        for event in events:
+            if event.get("type") == "turn.completed":
+                assert event.get("usage", {}).get("reasoning_output_tokens", 0) > 0
+                return
+
+    def test_has_reasoning_item(self) -> None:
+        events = _load_events(SESSION_WITH_REASONING)
+        has_reasoning = any(
+            e.get("type") == "item.completed"
+            and e.get("item", {}).get("type") == "reasoning"
+            and e.get("item", {}).get("text")
+            for e in events
+        )
+        assert has_reasoning
+
+    def test_contains_order_up_marker(self) -> None:
+        events = _load_events(SESSION_WITH_REASONING)
+        for event in events:
+            if (
+                event.get("type") == "item.completed"
+                and event.get("item", {}).get("type") == "message"
+            ):
+                for block in event.get("item", {}).get("content", []):
+                    if block.get("type") == "text":
+                        text = block.get("text", "")
+                        if "%%ORDER_UP%%" in text:
+                            assert _marker_is_standalone(text, "%%ORDER_UP%%")
+                            return
+
+
+class TestMcpToolCallFixture:
+    def test_has_all_three_status_transitions(self) -> None:
+        events = _load_events(SESSION_WITH_MCP_TOOL_CALL)
+        mcp_events = [
+            e.get("type") for e in events if e.get("item", {}).get("type") == "mcp_tool_call"
+        ]
+        assert "item.started" in mcp_events
+        assert "item.updated" in mcp_events
+        assert "item.completed" in mcp_events
+
+    def test_mcp_result_content_populated(self) -> None:
+        events = _load_events(SESSION_WITH_MCP_TOOL_CALL)
+        for event in events:
+            if (
+                event.get("type") == "item.completed"
+                and event.get("item", {}).get("type") == "mcp_tool_call"
+            ):
+                result = event.get("item", {}).get("result", {})
+                assert result.get("content")
+                return
+
+
+class TestCodexFixturesParseWithBackend:
+    def test_happy_path_parses_successfully(self) -> None:
+        text = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+        acc = _scan_codex_ndjson(text)
+        assert acc.success is True
+        assert acc.session_id
+
+    def test_failed_parses_as_failure(self) -> None:
+        text = fixture_path(TURN_FAILED_ERROR).read_text()
+        acc = _scan_codex_ndjson(text)
+        assert acc.success is False
+        assert acc.error_message

--- a/tests/execution/backends/test_codex_fixtures.py
+++ b/tests/execution/backends/test_codex_fixtures.py
@@ -43,9 +43,8 @@ class TestCodexFixturePackage:
         assert CODEX_SCHEMA_VERSION == 1
 
     def test_all_filename_constants_end_in_ndjson(self) -> None:
-        for name in CODEX_ALL:
-            if name.endswith(".ndjson"):
-                assert name.endswith(".ndjson")
+        for name in ALL_FIXTURE_NAMES:
+            assert name.endswith(".ndjson")
 
     def test_fixture_path_returns_existing_file(self) -> None:
         for name in ALL_FIXTURE_NAMES:
@@ -56,21 +55,21 @@ class TestCodexFixturePackage:
 
 
 class TestCodexFixtureValidity:
-    def test_every_line_is_valid_json(self, name: str = "") -> None:
+    def test_every_line_is_valid_json(self) -> None:
         name = "happy_path_single_turn.ndjson"
         text = fixture_path(name).read_text()
         for line in text.strip().splitlines():
             if line.strip():
                 json.loads(line)
 
-    def test_first_line_is_thread_started(self, name: str = "") -> None:
+    def test_first_line_is_thread_started(self) -> None:
         name = "happy_path_single_turn.ndjson"
         events = _load_events(name)
         assert events[0]["type"] == "thread.started"
         assert isinstance(events[0]["thread_id"], str)
         assert events[0]["thread_id"]
 
-    def test_all_lines_are_dicts(self, name: str = "") -> None:
+    def test_all_lines_are_dicts(self) -> None:
         name = "happy_path_single_turn.ndjson"
         events = _load_events(name)
         for event in events:
@@ -91,6 +90,7 @@ class TestHappyPathFixture:
                         if "%%ORDER_UP%%" in text:
                             assert _marker_is_standalone(text, "%%ORDER_UP%%")
                             return
+        pytest.fail("%%ORDER_UP%% marker not found in any item.completed message event")
 
     def test_turn_completed_has_nonzero_usage(self) -> None:
         events = _load_events(HAPPY_PATH_SINGLE_TURN)
@@ -100,6 +100,7 @@ class TestHappyPathFixture:
                 assert usage.get("input_tokens", 0) > 0
                 assert usage.get("output_tokens", 0) > 0
                 return
+        pytest.fail("No turn.completed event found in fixture")
 
     def test_reasoning_output_tokens_zero(self) -> None:
         events = _load_events(HAPPY_PATH_SINGLE_TURN)
@@ -108,6 +109,7 @@ class TestHappyPathFixture:
                 usage = event.get("usage", {})
                 assert usage.get("reasoning_output_tokens", -1) == 0
                 return
+        pytest.fail("No turn.completed event found in fixture")
 
     def test_has_three_item_types(self) -> None:
         events = _load_events(HAPPY_PATH_SINGLE_TURN)
@@ -124,7 +126,7 @@ class TestMultiTurnFixture:
     def test_turn2_input_tokens_greater_than_turn1(self) -> None:
         events = _load_events(MULTI_TURN_WITH_COMPACTION)
         turn_completed_tokens = [
-            e.get("usage", {}).get("input_tokens")
+            e.get("usage", {}).get("input_tokens", 0)
             for e in events
             if e.get("type") == "turn.completed"
         ]
@@ -152,6 +154,7 @@ class TestTurnFailedFixture:
             if event.get("type") == "turn.failed":
                 assert event.get("error", {}).get("message")
                 return
+        pytest.fail("No turn.failed event found in fixture")
 
     def test_has_partial_item_started(self) -> None:
         events = _load_events(TURN_FAILED_ERROR)
@@ -171,6 +174,7 @@ class TestReasoningFixture:
             if event.get("type") == "turn.completed":
                 assert event.get("usage", {}).get("reasoning_output_tokens", 0) > 0
                 return
+        pytest.fail("No turn.completed event found in fixture")
 
     def test_has_reasoning_item(self) -> None:
         events = _load_events(SESSION_WITH_REASONING)
@@ -195,6 +199,7 @@ class TestReasoningFixture:
                         if "%%ORDER_UP%%" in text:
                             assert _marker_is_standalone(text, "%%ORDER_UP%%")
                             return
+        pytest.fail("%%ORDER_UP%% marker not found in any item.completed message event")
 
 
 class TestMcpToolCallFixture:
@@ -217,6 +222,7 @@ class TestMcpToolCallFixture:
                 result = event.get("item", {}).get("result", {})
                 assert result.get("content")
                 return
+        pytest.fail("No item.completed mcp_tool_call event found in fixture")
 
 
 class TestCodexFixturesParseWithBackend:

--- a/tests/execution/backends/test_codex_fixtures.py
+++ b/tests/execution/backends/test_codex_fixtures.py
@@ -56,21 +56,21 @@ class TestCodexFixturePackage:
 
 class TestCodexFixtureValidity:
     def test_every_line_is_valid_json(self) -> None:
-        name = "happy_path_single_turn.ndjson"
+        name = HAPPY_PATH_SINGLE_TURN
         text = fixture_path(name).read_text()
         for line in text.strip().splitlines():
             if line.strip():
                 json.loads(line)
 
     def test_first_line_is_thread_started(self) -> None:
-        name = "happy_path_single_turn.ndjson"
+        name = HAPPY_PATH_SINGLE_TURN
         events = _load_events(name)
         assert events[0]["type"] == "thread.started"
         assert isinstance(events[0]["thread_id"], str)
         assert events[0]["thread_id"]
 
     def test_all_lines_are_dicts(self) -> None:
-        name = "happy_path_single_turn.ndjson"
+        name = HAPPY_PATH_SINGLE_TURN
         events = _load_events(name)
         for event in events:
             assert isinstance(event, dict)
@@ -107,7 +107,7 @@ class TestHappyPathFixture:
         for event in events:
             if event.get("type") == "turn.completed":
                 usage = event.get("usage", {})
-                assert usage.get("reasoning_output_tokens", -1) == 0
+                assert usage.get("reasoning_output_tokens", 0) == 0
                 return
         pytest.fail("No turn.completed event found in fixture")
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixture data files."""

--- a/tests/fixtures/codex/__init__.py
+++ b/tests/fixtures/codex/__init__.py
@@ -1,0 +1,29 @@
+"""Codex CLI NDJSON test fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CODEX_SCHEMA_VERSION: int = 1
+
+HAPPY_PATH_SINGLE_TURN: str = "happy_path_single_turn.ndjson"
+MULTI_TURN_WITH_COMPACTION: str = "multi_turn_with_compaction.ndjson"
+TURN_FAILED_ERROR: str = "turn_failed_error.ndjson"
+SESSION_WITH_REASONING: str = "session_with_reasoning.ndjson"
+SESSION_WITH_MCP_TOOL_CALL: str = "session_with_mcp_tool_call.ndjson"
+
+
+def fixture_path(name: str) -> Path:
+    """Return the absolute path to a fixture file in this directory."""
+    return Path(__file__).parent / name
+
+
+__all__ = [
+    "CODEX_SCHEMA_VERSION",
+    "HAPPY_PATH_SINGLE_TURN",
+    "MULTI_TURN_WITH_COMPACTION",
+    "SESSION_WITH_MCP_TOOL_CALL",
+    "SESSION_WITH_REASONING",
+    "TURN_FAILED_ERROR",
+    "fixture_path",
+]

--- a/tests/fixtures/codex/happy_path_single_turn.ndjson
+++ b/tests/fixtures/codex/happy_path_single_turn.ndjson
@@ -1,0 +1,12 @@
+{"type":"thread.started","thread_id":"thread_hp_abc123"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"type":"function_call","id":"fc_001","name":"shell","args":"{\"command\":\"ls -la\"}"}}
+{"type":"item.updated","item":{"type":"function_call","id":"fc_001","name":"shell","status":"in_progress"}}
+{"type":"item.completed","item":{"type":"function_call","id":"fc_001","name":"shell","args":"{\"command\":\"ls -la\"}","output":"file1.py\nfile2.py"}}
+{"type":"item.started","item":{"type":"file_change","id":"fch_001","path":"/src/main.py"}}
+{"type":"item.updated","item":{"type":"file_change","id":"fch_001","path":"/src/main.py","status":"in_progress"}}
+{"type":"item.completed","item":{"type":"file_change","id":"fch_001","path":"/src/main.py"}}
+{"type":"item.started","item":{"type":"message","id":"msg_001","content":[]}}
+{"type":"item.updated","item":{"type":"message","id":"msg_001","content":[{"type":"text","text":"Working on it..."}]}}
+{"type":"item.completed","item":{"type":"message","id":"msg_001","content":[{"type":"text","text":"Task completed successfully.\n\n%%ORDER_UP%%"}]}}
+{"type":"turn.completed","usage":{"input_tokens":150,"output_tokens":75,"cached_input_tokens":30,"reasoning_output_tokens":0}}

--- a/tests/fixtures/codex/multi_turn_with_compaction.ndjson
+++ b/tests/fixtures/codex/multi_turn_with_compaction.ndjson
@@ -1,0 +1,14 @@
+{"type":"thread.started","thread_id":"thread_mt_001"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"type":"message","id":"msg_001","content":[]}}
+{"type":"item.completed","item":{"type":"message","id":"msg_001","content":[{"type":"text","text":"Starting work on the task."}]}}
+{"type":"item.started","item":{"type":"function_call","id":"fc_001","name":"shell","args":"{\"command\":\"echo hello\"}"}}
+{"type":"item.completed","item":{"type":"function_call","id":"fc_001","name":"shell","args":"{\"command\":\"echo hello\"}","output":"hello"}}
+{"type":"turn.completed","usage":{"input_tokens":200,"output_tokens":80,"cached_input_tokens":50,"reasoning_output_tokens":0}}
+{"type":"turn.started"}
+{"type":"item.started","item":{"type":"todo_list","id":"todo_001"}}
+{"type":"item.updated","item":{"type":"todo_list","id":"todo_001","items":[{"text":"Step 1","completed":true}]}}
+{"type":"item.completed","item":{"type":"todo_list","id":"todo_001","items":[{"text":"Step 1","completed":true},{"text":"Step 2","completed":true}]}}
+{"type":"item.started","item":{"type":"message","id":"msg_002","content":[]}}
+{"type":"item.completed","item":{"type":"message","id":"msg_002","content":[{"type":"text","text":"All tasks completed.\n\n%%ORDER_UP%%"}]}}
+{"type":"turn.completed","usage":{"input_tokens":450,"output_tokens":120,"cached_input_tokens":100,"reasoning_output_tokens":0}}

--- a/tests/fixtures/codex/session_with_mcp_tool_call.ndjson
+++ b/tests/fixtures/codex/session_with_mcp_tool_call.ndjson
@@ -1,0 +1,8 @@
+{"type":"thread.started","thread_id":"thread_mcp_001"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"type":"mcp_tool_call","id":"mcp_001","tool_name":"read_file","args":"{\"path\":\"/src/main.py\"}"}}
+{"type":"item.updated","item":{"type":"mcp_tool_call","id":"mcp_001","tool_name":"read_file","status":"in_progress"}}
+{"type":"item.completed","item":{"type":"mcp_tool_call","id":"mcp_001","tool_name":"read_file","result":{"content":"def main():\n    print('hello')"}}}
+{"type":"item.started","item":{"type":"message","id":"msg_001","content":[]}}
+{"type":"item.completed","item":{"type":"message","id":"msg_001","content":[{"type":"text","text":"File contents retrieved successfully.\n\n%%ORDER_UP%%"}]}}
+{"type":"turn.completed","usage":{"input_tokens":250,"output_tokens":100,"cached_input_tokens":40,"reasoning_output_tokens":0}}

--- a/tests/fixtures/codex/session_with_reasoning.ndjson
+++ b/tests/fixtures/codex/session_with_reasoning.ndjson
@@ -1,0 +1,7 @@
+{"type":"thread.started","thread_id":"thread_reason_001"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"type":"reasoning","id":"reason_001"}}
+{"type":"item.completed","item":{"type":"reasoning","id":"reason_001","text":"Let me analyze the codebase structure to determine the best approach for this refactoring task."}}
+{"type":"item.started","item":{"type":"message","id":"msg_001","content":[]}}
+{"type":"item.completed","item":{"type":"message","id":"msg_001","content":[{"type":"text","text":"I have analyzed the code and completed the refactoring.\n\n%%ORDER_UP%%"}]}}
+{"type":"turn.completed","usage":{"input_tokens":300,"output_tokens":150,"cached_input_tokens":60,"reasoning_output_tokens":45}}

--- a/tests/fixtures/codex/turn_failed_error.ndjson
+++ b/tests/fixtures/codex/turn_failed_error.ndjson
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"thread_fail_001"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"type":"message","id":"msg_001","content":[]}}
+{"type":"turn.failed","error":{"message":"Rate limit exceeded. Please retry after 30 seconds.","code":"rate_limit_exceeded"}}

--- a/tests/infra/test_ci_shard_config.py
+++ b/tests/infra/test_ci_shard_config.py
@@ -17,6 +17,7 @@ KNOWN_GENERAL_SHARD_DIRS = {
     "cli",
     "config",
     "docs",
+    "fixtures",
     "fleet",
     "hooks",
     "infra",


### PR DESCRIPTION
## Summary

Create a new `tests/fixtures/codex/` package containing five NDJSON fixture files representing Codex CLI session output scenarios (happy path, multi-turn, failure, reasoning, MCP tool calls). The package provides a `fixture_path()` helper and filename constants for downstream consumption by `tests/execution/backends/` test suites. A dedicated fixture integrity test file validates all acceptance criteria. The test-filter manifest is updated to route `.ndjson` file changes to the `execution/` test directory.

**Critical commit constraint:** All new files (NDJSON fixtures + `__init__.py` files + test file) and the manifest update MUST land in a single commit. The `test_manifest_pattern_matches_real_file` orphan check in `tests/infra/test_manifest_completeness.py` runs `git ls-files --cached` and will fail if the manifest pattern `tests/fixtures/codex/*.ndjson` is present but the NDJSON files are not yet tracked.

## Requirements

### Goal
Scaffold the fixture directory with constants, then create all five NDJSON fixtures.

### Context
- Phase: Codex CLI Backend Implementation (Milestone: 5-codex-cli-backend-implementation)
- Assignment: P5-A11 (Create Codex NDJSON test fixtures for happy-path, error, multi-turn, and edge cases)
- Depends on: None
- Depended on by: P5-A12-WP1

### Deliverables
- `tests/fixtures/__init__.py`
- `tests/fixtures/codex/__init__.py`
- `tests/fixtures/codex/happy_path_single_turn.ndjson`
- `tests/fixtures/codex/multi_turn_with_compaction.ndjson`
- `tests/fixtures/codex/turn_failed_error.ndjson`
- `tests/fixtures/codex/session_with_reasoning.ndjson`
- `tests/fixtures/codex/session_with_mcp_tool_call.ndjson`

### Acceptance Criteria
- CODEX_SCHEMA_VERSION == 1
- fixture_path returns correct Path
- All filename constants end in .ndjson
- Every line is valid JSON
- First line is thread.started with thread_id
- agent_message contains %%ORDER_UP%% as standalone line
- turn.completed has non-zero usage
- turn2 input_tokens > turn1 input_tokens (cumulative invariant)
- turn_failed has non-empty error.message
- reasoning fixture has reasoning_output_tokens>0
- mcp fixture has all 3 status transitions
- Both are valid NDJSON

### Architecture

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph Fixtures ["tests/fixtures/codex/"]
        direction TB
        INIT["__init__.py<br/>━━━━━━━━━━<br/>CODEX_SCHEMA_VERSION=1<br/>5 filename constants<br/>fixture_path helper"]
        HP["happy_path_single_turn.ndjson<br/>━━━━━━━━━━<br/>Full lifecycle + ORDER_UP"]
        MT["multi_turn_with_compaction.ndjson<br/>━━━━━━━━━━<br/>2 turns + cumulative tokens"]
        TF["turn_failed_error.ndjson<br/>━━━━━━━━━━<br/>Partial item + turn.failed"]
        SR["session_with_reasoning.ndjson<br/>━━━━━━━━━━<br/>reasoning item + tokens>0"]
        MCP["session_with_mcp_tool_call.ndjson<br/>━━━━━━━━━━<br/>started/updated/completed"]
    end

    subgraph Tests ["tests/execution/backends/"]
        direction TB
        TFIX["test_codex_fixtures.py<br/>━━━━━━━━━━<br/>Fixture integrity validation"]
    end

    subgraph Manifest [".autoskillit/"]
        direction TB
        MANIF["test-filter-manifest.yaml<br/>━━━━━━━━━━<br/>+ tests/fixtures/codex/*.ndjson"]
    end

    subgraph Consumers ["Existing Consumers"]
        direction TB
        PARSER["test_codex_result_parser.py<br/>━━━━━━━━━━<br/>_scan_codex_ndjson tests"]
        BACKEND["test_codex_backend.py<br/>━━━━━━━━━━<br/>CodexStreamParser tests"]
    end

    INIT --> TFIX
    HP --> TFIX
    MT --> TFIX
    TF --> TFIX
    SR --> TFIX
    MCP --> TFIX
    MANIF -.->|routes changes to| Tests
    TFIX -.->|validates| Fixtures
    HP -.->|future: consumed by| PARSER
    HP -.->|future: consumed by| BACKEND

    class INIT,HP,MT,TF,SR,MCP newComponent;
    class TFIX newComponent;
    class MANIF phase;
    class PARSER,BACKEND handler;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Green | New Component | New files created by this task |
| Purple | Modified | Existing files with additions |
| Orange | Consumer | Existing test files that will consume fixtures |

Closes #2509

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260521-075117-926197/.autoskillit/temp/make-plan/p5_a11_wp1_create_tests_fixtures_codex_plan_2026-05-21_081000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.6k | 25.1k | 1.4M | 101.1k | 341 | 83.1k | 13m 35s |
| verify | claude-opus-4-6 | 1 | 37 | 6.9k | 864.3k | 58.6k | 73 | 43.4k | 4m 24s |
| implement* | MiniMax-M2.7-highspeed | 1 | 762.1k | 10.5k | 863.4k | 34.7k | 104 | 60.9k | 7m 14s |
| prepare_pr* | MiniMax-M2.7 | 1 | 45.3k | 4.0k | 207.9k | 0 | 17 | 0 | 1m 11s |
| compose_pr* | MiniMax-M2.7 | 1 | 126.0k | 3.5k | 407.7k | 26.7k | 31 | 2.9k | 2m 34s |
| review_pr | claude-sonnet-4-6 | 3 | 677 | 106.8k | 2.1M | 90.4k | 118 | 229.6k | 21m 50s |
| resolve_review | claude-sonnet-4-6 | 2 | 414 | 31.1k | 2.9M | 77.2k | 116 | 119.4k | 13m 36s |
| **Total** | | | 939.3k | 187.8k | 8.7M | 101.1k | | 539.4k | 1h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 312 | 2767.4 | 195.1 | 33.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 28 | 102307.7 | 4265.0 | 1110.7 |
| **Total** | **340** | 25510.6 | 1586.4 | 552.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 5.7k | 163.1k | 6.3M | 432.2k | 49m 3s |
| claude-opus-4-6 | 1 | 37 | 6.9k | 864.3k | 43.4k | 4m 24s |
| MiniMax-M2.7-highspeed | 1 | 762.1k | 10.5k | 863.4k | 60.9k | 7m 14s |
| MiniMax-M2.7 | 2 | 171.4k | 7.4k | 615.7k | 2.9k | 3m 46s |