### PR TITLE
[P5-A12-WP1] Full Test Suite for CodexStreamParser

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -118,6 +118,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_claude_session_locator.py` | Tests for ClaudeSessionLocator |
 | `test_claude_stream_parser.py` | Tests for ClaudeStreamParser |
 | `test_backend_registry.py` | Tests for backend registry |
-| `test_codex_backend.py` | Tests for CodexFlags, CodexBackend protocol conformance, headless/resume command builders, CodexStreamParser, CodexSessionLocator |
+| `test_codex_backend.py` | Tests for CodexFlags, CodexBackend protocol conformance, headless/resume command builders, CodexSessionLocator |
 | `test_codex_env_policy.py` | Tests for CodexEnvPolicy three-layer scrub |
+| `test_codex_stream_parser.py` | Full test suite for CodexStreamParser: happy-path, item parsing, degradation, fixture-driven integration, protocol conformance |
 | `test_codex_result_parser.py` | Tests for CodexResultParser |

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from enum import StrEnum
 
 import pytest
@@ -8,9 +7,7 @@ import pytest
 from autoskillit.core import (
     AGENT_BACKEND_CODEX,
     BackendCapabilities,
-    BackendEventKind,
     CmdSpec,
-    CodexEventData,
     CodingAgentBackend,
     EnvPolicy,
     OutputFormat,
@@ -212,140 +209,6 @@ class TestCodexBackendFactories:
         parser = CodexBackend().stream_parser()
         assert isinstance(parser, CodexStreamParser)
         assert parser.completion_marker == ""
-
-
-class TestCodexStreamParser:
-    def test_parse_line_empty_returns_none(self) -> None:
-        parser = CodexStreamParser()
-        assert parser.parse_line("") is None
-
-    def test_parse_line_invalid_json_returns_none(self) -> None:
-        parser = CodexStreamParser()
-        assert parser.parse_line("not json") is None
-
-    def test_parse_line_thread_started_yields_session_meta(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps({"type": "thread.started", "thread_id": "t1"})
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.SESSION_META
-        assert event.session_id == "t1"
-        assert event.is_terminal is False
-
-    def test_parse_line_turn_completed_yields_completion(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps({"type": "turn.completed", "usage": {}})
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.COMPLETION
-        assert event.is_terminal is True
-
-    def test_parse_line_turn_failed_yields_completion(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps({"type": "turn.failed", "error": {"message": "fail"}})
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.COMPLETION
-        assert event.is_terminal is True
-
-    def test_parse_line_error_yields_error_event(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps({"type": "error", "message": "crash"})
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.ERROR
-        assert event.is_terminal is True
-
-    def test_parse_line_item_completed_unknown_type_yields_ignored(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps({"type": "item.completed", "item": {"type": "reasoning"}})
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.IGNORED
-
-    def test_completion_marker_detection_in_message(self) -> None:
-        parser = CodexStreamParser(completion_marker="%%DONE%%")
-        msg_line = json.dumps(
-            {
-                "type": "item.completed",
-                "item": {
-                    "type": "message",
-                    "content": [{"type": "text", "text": "result\n%%DONE%%"}],
-                },
-            }
-        )
-        parser.parse_line(msg_line)
-        done_line = json.dumps({"type": "turn.completed", "usage": {}})
-        event = parser.parse_line(done_line)
-        assert event is not None
-        assert event.has_marker is True
-
-    def test_no_marker_when_completion_marker_empty(self) -> None:
-        parser = CodexStreamParser()
-        msg_line = json.dumps(
-            {
-                "type": "item.completed",
-                "item": {
-                    "type": "message",
-                    "content": [{"type": "text", "text": "%%DONE%%"}],
-                },
-            }
-        )
-        parser.parse_line(msg_line)
-        done_line = json.dumps({"type": "turn.completed", "usage": {}})
-        event = parser.parse_line(done_line)
-        assert event is not None
-        assert event.has_marker is False
-
-    def test_turn_completed_backend_data_is_codex_event_data(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10}})
-        event = parser.parse_line(line)
-        assert event is not None
-        assert isinstance(event.backend_data, CodexEventData)
-
-    def test_parse_line_item_completed_message(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps(
-            {
-                "type": "item.completed",
-                "item": {"type": "message", "content": [{"type": "text", "text": "hello"}]},
-            }
-        )
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.TOOL_OUTPUT
-        assert event.is_terminal is False
-        assert isinstance(event.backend_data, CodexEventData)
-        assert event.backend_data.record_type == "item.completed"
-        assert event.backend_data.item_type == "message"
-
-    def test_parse_line_item_completed_file_change(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps(
-            {"type": "item.completed", "item": {"type": "file_change", "path": "src/foo.py"}}
-        )
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.TOOL_OUTPUT
-        assert event.backend_data is not None
-        assert event.backend_data.item_type == "file_change"
-
-    def test_parse_line_item_completed_function_call(self) -> None:
-        parser = CodexStreamParser()
-        line = json.dumps(
-            {"type": "item.completed", "item": {"type": "function_call", "name": "Bash"}}
-        )
-        event = parser.parse_line(line)
-        assert event is not None
-        assert event.kind == BackendEventKind.TOOL_OUTPUT
-        assert event.backend_data is not None
-        assert event.backend_data.item_type == "function_call"
-
-
-class TestCodexStreamParserConformance:
-    def test_isinstance_stream_parser_protocol(self) -> None:
-        assert isinstance(CodexStreamParser(""), StreamParser)
 
 
 class TestCodexEnvPolicy:

--- a/tests/execution/backends/test_codex_stream_parser.py
+++ b/tests/execution/backends/test_codex_stream_parser.py
@@ -348,6 +348,8 @@ class TestCodexStreamParserFixtures:
         second_usage = completions[1].backend_data.usage
         assert first_usage is not None
         assert second_usage is not None
+        # Compaction causes cumulative input growth: turn 2 includes the compacted
+        # summary of turn 1, so input_tokens is monotonically increasing across turns.
         assert second_usage["input_tokens"] > first_usage["input_tokens"]
 
     def test_turn_failed_fixture_yields_terminal_event(self) -> None:
@@ -385,4 +387,4 @@ class TestCodexStreamParserFixtures:
 
 class TestCodexStreamParserConformance:
     def test_isinstance_stream_parser_protocol(self) -> None:
-        assert isinstance(CodexStreamParser(""), StreamParser)
+        assert isinstance(CodexStreamParser(), StreamParser)

--- a/tests/execution/backends/test_codex_stream_parser.py
+++ b/tests/execution/backends/test_codex_stream_parser.py
@@ -58,40 +58,6 @@ class TestCodexStreamParserHappyPath:
         assert usage.cache_write_tokens is None
         assert usage.provider == "codex"
 
-    def test_last_turn_completed_carries_accumulated_marker_state(self) -> None:
-        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
-        msg_with_marker = json.dumps(
-            {
-                "type": "item.completed",
-                "item": {
-                    "type": "message",
-                    "content": [{"type": "text", "text": "Done.\n\n%%ORDER_UP%%"}],
-                },
-            }
-        )
-        msg_without_marker = json.dumps(
-            {
-                "type": "item.completed",
-                "item": {
-                    "type": "message",
-                    "content": [{"type": "text", "text": "More work done."}],
-                },
-            }
-        )
-        turn_completed_line = json.dumps({"type": "turn.completed", "usage": {}})
-
-        parser.parse_line(msg_with_marker)
-        event1 = parser.parse_line(turn_completed_line)
-        assert event1 is not None
-        assert event1.kind == BackendEventKind.COMPLETION
-        assert event1.has_marker is True
-
-        parser.parse_line(msg_without_marker)
-        event2 = parser.parse_line(turn_completed_line)
-        assert event2 is not None
-        assert event2.kind == BackendEventKind.COMPLETION
-        assert event2.has_marker is True
-
     def test_turn_failed_yields_terminal_completion(self) -> None:
         parser = CodexStreamParser()
         line = json.dumps(
@@ -195,6 +161,44 @@ class TestCodexStreamParserItemCompleted:
         event = parser.parse_line(turn_completed_line)
         assert event is not None
         assert event.has_marker is False
+
+    def test_last_turn_completed_carries_accumulated_marker_state(self) -> None:
+        # _saw_marker is a permanent latch: once set True by any item.completed
+        # message in the session, it stays True for all subsequent turn.completed
+        # events. The second turn here feeds a message without the marker, but
+        # event2.has_marker is still True because the latch never resets.
+        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
+        msg_with_marker = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "Done.\n\n%%ORDER_UP%%"}],
+                },
+            }
+        )
+        msg_without_marker = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "More work done."}],
+                },
+            }
+        )
+        turn_completed_line = json.dumps({"type": "turn.completed", "usage": {}})
+
+        parser.parse_line(msg_with_marker)
+        event1 = parser.parse_line(turn_completed_line)
+        assert event1 is not None
+        assert event1.kind == BackendEventKind.COMPLETION
+        assert event1.has_marker is True
+
+        parser.parse_line(msg_without_marker)
+        event2 = parser.parse_line(turn_completed_line)
+        assert event2 is not None
+        assert event2.kind == BackendEventKind.COMPLETION
+        assert event2.has_marker is True
 
     def test_item_completed_message_yields_tool_output(self) -> None:
         parser = CodexStreamParser()
@@ -329,6 +333,7 @@ class TestCodexStreamParserFixtures:
         terminal_events = [e for e in events if e.is_terminal]
         assert len(terminal_events) == 1
         assert terminal_events[0].kind == BackendEventKind.COMPLETION
+        assert terminal_events[0].has_marker is True
 
     def test_multi_turn_last_turn_completed_has_final_usage(self) -> None:
         text = fixture_path(MULTI_TURN_WITH_COMPACTION).read_text()
@@ -369,20 +374,6 @@ class TestCodexStreamParserFixtures:
         assert terminal.is_terminal is True
         assert isinstance(terminal.backend_data, CodexEventData)
         assert terminal.backend_data.record_type == "turn.failed"
-
-    def test_happy_path_fixture_marker_detected(self) -> None:
-        text = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
-        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
-        events = [
-            ev
-            for line in text.strip().splitlines()
-            if line.strip()
-            for ev in [parser.parse_line(line)]
-            if ev is not None
-        ]
-        terminal_events = [e for e in events if e.is_terminal]
-        assert len(terminal_events) == 1
-        assert terminal_events[0].has_marker is True
 
 
 class TestCodexStreamParserConformance:

--- a/tests/execution/backends/test_codex_stream_parser.py
+++ b/tests/execution/backends/test_codex_stream_parser.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.core import (
+    BackendEventKind,
+    CanonicalTokenUsage,
+    CodexEventData,
+    StreamParser,
+)
+from autoskillit.execution.backends.codex import CodexStreamParser
+from tests.fixtures.codex import (
+    HAPPY_PATH_SINGLE_TURN,
+    MULTI_TURN_WITH_COMPACTION,
+    TURN_FAILED_ERROR,
+    fixture_path,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestCodexStreamParserHappyPath:
+    def test_thread_started_yields_session_meta(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "thread.started", "thread_id": "t1"})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.SESSION_META
+        assert event.is_terminal is False
+        assert event.has_marker is False
+        assert event.session_id == "t1"
+
+    def test_turn_completed_yields_terminal_completion_with_usage(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 150,
+                    "output_tokens": 75,
+                    "cached_input_tokens": 30,
+                },
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.COMPLETION
+        assert event.is_terminal is True
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.usage is not None
+        assert isinstance(event.backend_data.usage, dict)
+        usage = CanonicalTokenUsage.from_codex_dict(event.backend_data.usage)
+        assert usage.input_tokens == 150
+        assert usage.output_tokens == 75
+        assert usage.cache_read_tokens == 30
+        assert usage.cache_write_tokens is None
+        assert usage.provider == "codex"
+
+    def test_last_turn_completed_carries_accumulated_marker_state(self) -> None:
+        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
+        msg_with_marker = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "Done.\n\n%%ORDER_UP%%"}],
+                },
+            }
+        )
+        msg_without_marker = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "More work done."}],
+                },
+            }
+        )
+        turn_completed_line = json.dumps({"type": "turn.completed", "usage": {}})
+
+        parser.parse_line(msg_with_marker)
+        event1 = parser.parse_line(turn_completed_line)
+        assert event1 is not None
+        assert event1.kind == BackendEventKind.COMPLETION
+        assert event1.has_marker is True
+
+        parser.parse_line(msg_without_marker)
+        event2 = parser.parse_line(turn_completed_line)
+        assert event2 is not None
+        assert event2.kind == BackendEventKind.COMPLETION
+        assert event2.has_marker is True
+
+    def test_turn_failed_yields_terminal_completion(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "turn.failed",
+                "error": {"message": "Rate limit exceeded", "code": "rate_limit_exceeded"},
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.COMPLETION
+        assert event.is_terminal is True
+        assert event.has_marker is False
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.record_type == "turn.failed"
+
+    def test_thread_started_missing_thread_id_yields_none_session_id(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "thread.started"})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.SESSION_META
+        assert event.session_id is None
+
+    def test_error_yields_terminal_error(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "error", "message": "crash"})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.ERROR
+        assert event.is_terminal is True
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.record_type == "error"
+
+
+class TestCodexStreamParserItemCompleted:
+    def test_standalone_marker_detected_on_completion(self) -> None:
+        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
+        msg_line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "Done.\n\n%%ORDER_UP%%"}],
+                },
+            }
+        )
+        parser.parse_line(msg_line)
+        turn_completed_line = json.dumps({"type": "turn.completed", "usage": {}})
+        event = parser.parse_line(turn_completed_line)
+        assert event is not None
+        assert event.has_marker is True
+
+    def test_embedded_marker_not_detected(self) -> None:
+        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
+        msg_line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "The %%ORDER_UP%% token was emitted."}],
+                },
+            }
+        )
+        parser.parse_line(msg_line)
+        turn_completed_line = json.dumps({"type": "turn.completed", "usage": {}})
+        event = parser.parse_line(turn_completed_line)
+        assert event is not None
+        assert event.has_marker is False
+
+    def test_no_marker_in_message_yields_false(self) -> None:
+        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
+        msg_line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "All done, no marker here."}],
+                },
+            }
+        )
+        parser.parse_line(msg_line)
+        turn_completed_line = json.dumps({"type": "turn.completed", "usage": {}})
+        event = parser.parse_line(turn_completed_line)
+        assert event is not None
+        assert event.has_marker is False
+
+    def test_no_marker_when_completion_marker_empty(self) -> None:
+        parser = CodexStreamParser()
+        msg_line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "%%ORDER_UP%%"}],
+                },
+            }
+        )
+        parser.parse_line(msg_line)
+        turn_completed_line = json.dumps({"type": "turn.completed", "usage": {}})
+        event = parser.parse_line(turn_completed_line)
+        assert event is not None
+        assert event.has_marker is False
+
+    def test_item_completed_message_yields_tool_output(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "message", "content": [{"type": "text", "text": "hello"}]},
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
+        assert event.is_terminal is False
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.record_type == "item.completed"
+        assert event.backend_data.item_type == "message"
+
+    def test_item_completed_function_call_yields_tool_output(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {"type": "item.completed", "item": {"type": "function_call", "name": "Bash"}}
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
+        assert event.is_terminal is False
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.item_type == "function_call"
+
+    def test_file_change_with_path_populated(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "file_change",
+                    "id": "fch_1",
+                    "path": "/src/foo.py",
+                    "changes": [{"type": "add", "line": 10}],
+                },
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
+        assert event.is_terminal is False
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.item_type == "file_change"
+        assert event.backend_data.raw["item"]["changes"] == [{"type": "add", "line": 10}]
+
+    def test_file_change_with_status_failed(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "file_change",
+                    "id": "fch_2",
+                    "path": "/src/bar.py",
+                    "status": "failed",
+                },
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.raw["item"]["status"] == "failed"
+
+    def test_file_change_with_empty_changes(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "file_change",
+                    "id": "fch_3",
+                    "path": "/src/baz.py",
+                    "changes": [],
+                },
+            }
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.TOOL_OUTPUT
+        assert isinstance(event.backend_data, CodexEventData)
+        assert event.backend_data.raw["item"]["changes"] == []
+
+
+class TestCodexStreamParserDegradation:
+    def test_unknown_top_level_event_type_yields_ignored(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "something.unexpected", "data": 42})
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.IGNORED
+        assert event.is_terminal is False
+        assert event.has_marker is False
+
+    def test_item_completed_unknown_item_type_yields_ignored(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps(
+            {"type": "item.completed", "item": {"type": "reasoning", "text": "thinking..."}}
+        )
+        event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.IGNORED
+
+    def test_malformed_json_returns_none(self) -> None:
+        parser = CodexStreamParser()
+        event = parser.parse_line('{"type": "turn.comple')
+        assert event is None
+
+    def test_empty_string_returns_none(self) -> None:
+        parser = CodexStreamParser()
+        assert parser.parse_line("") is None
+        assert parser.parse_line("   ") is None
+
+
+class TestCodexStreamParserFixtures:
+    def test_happy_path_first_event_session_meta_last_completion(self) -> None:
+        text = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
+        events = [
+            ev
+            for line in text.strip().splitlines()
+            if line.strip()
+            for ev in [parser.parse_line(line)]
+            if ev is not None
+        ]
+        assert events[0].kind == BackendEventKind.SESSION_META
+        terminal_events = [e for e in events if e.is_terminal]
+        assert len(terminal_events) == 1
+        assert terminal_events[0].kind == BackendEventKind.COMPLETION
+
+    def test_multi_turn_last_turn_completed_has_final_usage(self) -> None:
+        text = fixture_path(MULTI_TURN_WITH_COMPACTION).read_text()
+        parser = CodexStreamParser()
+        events = [
+            ev
+            for line in text.strip().splitlines()
+            if line.strip()
+            for ev in [parser.parse_line(line)]
+            if ev is not None
+        ]
+        completions = [e for e in events if e.kind == BackendEventKind.COMPLETION]
+        assert len(completions) == 2
+        assert isinstance(completions[0].backend_data, CodexEventData)
+        assert isinstance(completions[1].backend_data, CodexEventData)
+        first_usage = completions[0].backend_data.usage
+        second_usage = completions[1].backend_data.usage
+        assert first_usage is not None
+        assert second_usage is not None
+        assert second_usage["input_tokens"] > first_usage["input_tokens"]
+
+    def test_turn_failed_fixture_yields_terminal_event(self) -> None:
+        text = fixture_path(TURN_FAILED_ERROR).read_text()
+        parser = CodexStreamParser()
+        events = [
+            ev
+            for line in text.strip().splitlines()
+            if line.strip()
+            for ev in [parser.parse_line(line)]
+            if ev is not None
+        ]
+        terminal_events = [e for e in events if e.is_terminal]
+        assert len(terminal_events) == 1
+        terminal = terminal_events[0]
+        assert terminal.kind == BackendEventKind.COMPLETION
+        assert terminal.is_terminal is True
+        assert isinstance(terminal.backend_data, CodexEventData)
+        assert terminal.backend_data.record_type == "turn.failed"
+
+    def test_happy_path_fixture_marker_detected(self) -> None:
+        text = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+        parser = CodexStreamParser(completion_marker="%%ORDER_UP%%")
+        events = [
+            ev
+            for line in text.strip().splitlines()
+            if line.strip()
+            for ev in [parser.parse_line(line)]
+            if ev is not None
+        ]
+        terminal_events = [e for e in events if e.is_terminal]
+        assert len(terminal_events) == 1
+        assert terminal_events[0].has_marker is True
+
+
+class TestCodexStreamParserConformance:
+    def test_isinstance_stream_parser_protocol(self) -> None:
+        assert isinstance(CodexStreamParser(""), StreamParser)


### PR DESCRIPTION
## Summary

Create `tests/execution/backends/test_codex_stream_parser.py` as a dedicated test file for `CodexStreamParser`, following the established pattern where each backend component has its own test file. The file contains five test classes totaling 24 test methods that exercise `CodexStreamParser.parse_line()` against inline JSON payloads and NDJSON fixture files. Existing `TestCodexStreamParser` (13 tests) and `TestCodexStreamParserConformance` (1 test) classes in `tests/execution/backends/test_codex_backend.py` are extracted into the new file and reorganized — 10 genuinely new test methods are added. No production code changes are required.

## Requirements

## Goal

Write all CodexStreamParser unit tests covering happy-path, item parsing, graceful degradation, and fixture-driven integration.

## Context

- Phase: Codex CLI Backend Implementation (Milestone: 5-codex-cli-backend-implementation)
- Assignment: P5-A12 (Write CodexStreamParser unit tests against NDJSON fixtures)
- Depends on: P5-A2-WP2, P5-A11-WP1
- Depended on by: None

## Deliverables

- `TestCodexStreamParserHappyPath class with 5 test methods`
- `TestCodexStreamParserItemCompleted class with 6 test methods`
- `TestCodexStreamParserDegradation class`
- `TestCodexStreamParserFixtures class with 4 test methods`

## Technical Steps

1. Create tests/execution/test_codex_stream_parser.py with pytestmark=[layer('execution'), small].
2. Write tests: thread.started->session_meta, turn.completed->completion with CanonicalTokenUsage, last-turn-wins, turn.failed->error.
3. Use inline JSON construction only.
4. Test agent_message with standalone %%ORDER_UP%% -> has_marker=True.
5. Test agent_message with embedded marker -> has_marker=False.
6. Test agent_message without marker -> has_marker=False.
7. Test file_change with changes populated.
8. Test file_change with status='failed'.
9. Test file_change with empty changes.
10. Test unknown top-level event types -> SessionEvent(kind='ignored').
11. Test item.completed with unknown item.type -> kind='ignored'.
12. Test malformed/truncated JSON -> parse_line() returns None.
13. Test empty string -> None.
14. No version-gating tests (owned by P5-A8).
15. Load happy_path_single_turn.ndjson and drive through parse_line() line-by-line.
16. Assert first event is session_meta, last is completion is_terminal=True.
17. Load multi_turn_with_compaction.ndjson, verify last-record-wins token semantics.
18. Load turn_failed_error.ndjson, verify error event with is_terminal=True.
19. Verify %%ORDER_UP%% marker detected in happy-path fixture.

## Acceptance Criteria

- thread.started returns session_meta
- turn.completed returns completion is_terminal=True
- Last turn.completed wins
- turn.failed returns error is_terminal=True
- Standalone marker -> has_marker=True
- Embedded marker -> has_marker=False
- file_change populates backend_data
- Unknown events return kind='ignored'
- Malformed JSON returns None
- Empty string returns None
- No exceptions raised
- Happy-path produces session_meta first and completion last
- Cumulative tokens are not summed
- turn.failed produces error
- Marker detected

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

<!-- conflict-resolution-table: empty -->

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260521-095245-248773/.autoskillit/temp/make-plan/p5_a12_wp1_full_test_suite_codex_stream_parser_plan_2026-05-21_095900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.5k | 18.1k | 1.5M | 96.1k | 180 | 102.1k | 10m 30s |
| verify | claude-opus-4-6 | 1 | 63 | 24.1k | 2.3M | 91.2k | 123 | 76.1k | 8m 21s |
| implement* | MiniMax-M2.7-highspeed | 1 | 930.5k | 11.4k | 893.0k | 34.7k | 96 | 67.5k | 12m 1s |
| prepare_pr* | MiniMax-M2.7 | 1 | 45.8k | 3.4k | 211.1k | 29.6k | 19 | 42.5k | 1m 17s |
| compose_pr* | MiniMax-M2.7 | 1 | 96.9k | 2.5k | 250.8k | 26.7k | 20 | 2.9k | 1m 22s |
| review_pr | claude-sonnet-4-6 | 3 | 262 | 104.7k | 1.4M | 81.4k | 103 | 200.3k | 22m 55s |
| resolve_review | claude-sonnet-4-6 | 2 | 434 | 27.0k | 2.8M | 81.2k | 126 | 116.2k | 12m 42s |
| **Total** | | | 1.1M | 191.2k | 9.4M | 96.1k | | 607.5k | 1h 9m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 528 | 1691.2 | 127.8 | 21.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 91 | 30987.3 | 1276.6 | 296.7 |
| **Total** | **619** | 15153.7 | 981.5 | 308.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 4.2k | 149.9k | 5.7M | 418.6k | 46m 8s |
| claude-opus-4-6 | 1 | 63 | 24.1k | 2.3M | 76.1k | 8m 21s |
| MiniMax-M2.7-highspeed | 1 | 930.5k | 11.4k | 893.0k | 67.5k | 12m 1s |
| MiniMax-M2.7 | 2 | 142.6k | 5.8k | 461.9k | 45.4k | 2m 39s |