### PR TITLE
PX1 P1-A5-WP1 — Assert that CODEX_API_KEY passes through CodexEnvPolicy

### DIFF
--- a/tests/execution/backends/test_codex_env_policy.py
+++ b/tests/execution/backends/test_codex_env_policy.py
@@ -59,6 +59,12 @@ class TestCodexEnvPolicy:
         result = policy.build_env(base)
         assert result["OPENAI_API_KEY"] == "sk-openai-secret"
 
+    def test_codex_api_key_preserved(self) -> None:
+        policy = CodexEnvPolicy()
+        base = {"CODEX_API_KEY": "sk-codex-secret", "PATH": "/usr/bin"}
+        result = policy.build_env(base)
+        assert result["CODEX_API_KEY"] == "sk-codex-secret"
+
     def test_extras_overlay_applied_after_scrub(self) -> None:
         policy = CodexEnvPolicy()
         base = {"PATH": "/usr/bin"}


### PR DESCRIPTION
## Summary

Add a new test method `test_codex_api_key_preserved` to `TestCodexEnvPolicy` in `tests/execution/backends/test_codex_env_policy.py`. The test asserts that `CODEX_API_KEY` passes through `CodexEnvPolicy.build_env()` unchanged, mirroring the existing `test_openai_api_key_preserved` pattern at lines 56-60. This validates that the three-layer scrub (exact denylist, private vars set, prefix denylist) does not strip the Codex-specific API key.

**Note:** A second `TestCodexEnvPolicy` class exists in `test_codex_backend.py` (line 214) — that class tests backend protocol conformance, not env-policy scrub behavior. The target for this work is exclusively `test_codex_env_policy.py`.

## Requirements

## Goal

Assert that CODEX_API_KEY passes through CodexEnvPolicy.build_env() unchanged, mirroring the existing test_openai_api_key_preserved pattern at line 56-60.

## Context

- Phase: Auth Gate & Pre-Existing Bug Fixes (Milestone: 1-auth-gate-pre-existing-bug-fixes)
- Assignment: P1-A5 (Add test_codex_api_key_preserved to TestCodexEnvPolicy in test_codex_env_policy.py)
- Depends on: None
- Depended on by: None

## Deliverables

- `New test method test_codex_api_key_preserved inserted after line 60 in TestCodexEnvPolicy`

## Technical Steps

1. Open tests/execution/backends/test_codex_env_policy.py
2. Locate test_openai_api_key_preserved (lines 56-60) as the template
3. Insert a new method test_codex_api_key_preserved immediately after line 60 (before the blank line preceding test_extras_overlay_applied_after_scrub at line 62)
4. The method body must: instantiate CodexEnvPolicy(), build base dict {'CODEX_API_KEY': 'sk-codex-secret', 'PATH': '/usr/bin'}, call policy.build_env(base), assert result['CODEX_API_KEY'] == 'sk-codex-secret'
5. No imports, fixtures, or other test modifications are required

## Acceptance Criteria

- test_codex_api_key_preserved appears immediately after test_openai_api_key_preserved and before test_extras_overlay_applied_after_scrub
- Method constructs CodexEnvPolicy(), passes {'CODEX_API_KEY': 'sk-codex-secret', 'PATH': '/usr/bin'} to build_env, and asserts result['CODEX_API_KEY'] == 'sk-codex-secret'
- No new imports, fixtures, or changes to any existing test are introduced
- pytest -k test_codex_api_key_preserved passes
- All existing tests in TestCodexEnvPolicy continue to pass

## Changed Files

- **tests/execution/backends/test_codex_env_policy.py** (modified)

Closes #2670

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/px1_p1_a5_wp1_assert_codex_api_key_plan_2026-05-22_060700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 70 | 8.3k | 626.2k | 56.9k | 102 | 40.7k | 4m 55s |
| verify | claude-sonnet-4-6 | 1 | 24 | 2.7k | 179.6k | 42.2k | 33 | 27.5k | 2m 23s |
| implement* | MiniMax-M2.7 | 1 | 123.2k | 2.3k | 551.5k | 29.7k | 33 | 2.9k | 5m 3s |
| prepare_pr* | MiniMax-M2.7 | 1 | 39.2k | 2.5k | 193.9k | 0 | 15 | 0 | 2m 1s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.5k | 1.8k | 181.2k | 26.7k | 14 | 8.3k | 51s |
| review_pr | claude-opus-4-6 | 3 | 102 | 18.3k | 1.1M | 50.7k | 76 | 90.1k | 6m 4s |
| **Total** | | | 202.0k | 36.0k | 2.8M | 56.9k | | 169.5k | 21m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 6 | 91915.8 | 485.7 | 389.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **6** | 467676.5 | 28257.8 | 6002.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 94 | 11.1k | 805.8k | 68.2k | 7m 19s |
| MiniMax-M2.7 | 3 | 201.8k | 6.7k | 926.5k | 11.2k | 7m 55s |
| claude-opus-4-6 | 1 | 102 | 18.3k | 1.1M | 90.1k | 6m 4s |