### PR TITLE
PX1 P1-A1-WP1 — Delete the two list entries appending CodexFlags

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -411,8 +411,6 @@ class CodexBackend:
             CodexFlags.JSON,
             CodexFlags.SANDBOX,
             "workspace-write",
-            CodexFlags.ASK_FOR_APPROVAL_SHORT,
-            "never",
         ]
         if model:
             cmd += [CodexFlags.MODEL, model]

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -114,11 +114,9 @@ class TestCodexBackendCommands:
         idx = spec.cmd.index("--sandbox")
         assert spec.cmd[idx + 1] == "workspace-write"
 
-    def test_build_headless_cmd_has_approval_never(self) -> None:
+    def test_no_approval_flag_in_headless_cmd(self) -> None:
         spec = CodexBackend().build_headless_cmd("do stuff")
-        assert "-a" in spec.cmd
-        idx = spec.cmd.index("-a")
-        assert spec.cmd[idx + 1] == "never"
+        assert "-a" not in spec.cmd
 
     def test_build_headless_cmd_prompt_is_last(self) -> None:
         spec = CodexBackend().build_headless_cmd("do stuff")
@@ -290,8 +288,6 @@ class TestCodexHeadlessCmd:
             "--json",
             "--sandbox",
             "workspace-write",
-            "-a",
-            "never",
             "do stuff",
         )
 
@@ -301,11 +297,9 @@ class TestCodexHeadlessCmd:
         idx = spec.cmd.index("--sandbox")
         assert spec.cmd[idx + 1] == "workspace-write"
 
-    def test_approval_never(self) -> None:
+    def test_no_approval_never_in_headless_cmd(self) -> None:
         spec = CodexBackend().build_headless_cmd("do stuff")
-        assert "-a" in spec.cmd
-        idx = spec.cmd.index("-a")
-        assert spec.cmd[idx + 1] == "never"
+        assert "-a" not in spec.cmd
 
     def test_model_flag(self) -> None:
         spec = CodexBackend().build_headless_cmd("x", model="o3")


### PR DESCRIPTION
## Summary

Remove `CodexFlags.ASK_FOR_APPROVAL_SHORT` (`"-a"`) and `"never"` from the `cmd` list initializer in `CodexBackend.build_headless_cmd` (codex.py), then update 3 tests in `test_codex_backend.py` that assert on the presence of these values. The `CodexFlags` enum members are retained — only their usage in `build_headless_cmd` is removed.

Closes #2667

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-060209-318208/.autoskillit/temp/make-plan/px1_p1_a1_wp1_delete_codexflags_approval_plan_2026-05-22_061800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 68 | 9.3k | 561.1k | 59.0k | 134 | 47.3k | 6m 9s |
| verify | claude-opus-4-6 | 1 | 34 | 6.4k | 259.0k | 57.3k | 51 | 42.4k | 3m 31s |
| implement* | MiniMax-M2.7 | 1 | 86.2k | 4.5k | 676.8k | 29.7k | 51 | 35.0k | 2m 28s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.6k | 3.1k | 197.1k | 0 | 18 | 0 | 45s |
| compose_pr* | MiniMax-M2.7 | 1 | 50.2k | 1.8k | 209.5k | 29.6k | 20 | 15.5k | 1m 3s |
| review_pr | claude-opus-4-6 | 3 | 82 | 19.4k | 992.8k | 44.4k | 75 | 83.9k | 6m 35s |
| **Total** | | | 179.2k | 44.5k | 2.9M | 59.0k | | 224.2k | 20m 33s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 16 | 42298.9 | 2189.8 | 281.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **16** | 181017.5 | 14011.8 | 2781.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 68 | 9.3k | 561.1k | 47.3k | 6m 9s |
| claude-opus-4-6 | 2 | 116 | 25.8k | 1.3M | 126.3k | 10m 7s |
| MiniMax-M2.7 | 3 | 179.0k | 9.4k | 1.1M | 50.6k | 4m 16s |