### PR TITLE
Remove -a/never from smoke test, add compound auth boolean

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -95,7 +95,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_session_model_peak_context.py` | Tests for peak_context and turn_count extraction from extract_token_usage |
 | `test_session_parsing.py` | L1 unit tests for execution/session.py — token extraction, parsing, and SkillResult |
 | `test_session_result.py` | L1 unit tests for ClaudeSessionResult and parse_session_result — result types and policies |
-| `test_smoke_codex.py` | Codex CLI smoke test: gated E2E validation of codex exec NDJSON output (CODEX_SMOKE_TEST=1) |
+| `test_smoke_codex.py` | Codex CLI smoke test: gated E2E validation of codex exec NDJSON output (CODEX_SMOKE_TEST=1 + CODEX_API_KEY/OPENAI_API_KEY/auth.json) |
 | `test_termination_action.py` | Unit tests for decide_termination_action — pure decision function |
 | `test_termination_executor.py` | Integration tests for execute_termination_action |
 | `test_testing.py` | L1 unit tests for execution/testing.py — pytest output parsing |

--- a/tests/execution/test_smoke_codex.py
+++ b/tests/execution/test_smoke_codex.py
@@ -1,6 +1,7 @@
 """Codex CLI smoke test: gated E2E validation of codex exec NDJSON output.
 
-Gated E2E tests run only when CODEX_SMOKE_TEST=1 and OPENAI_API_KEY are set
+Gated E2E tests run only when CODEX_SMOKE_TEST=1 and one of: CODEX_API_KEY env var,
+OPENAI_API_KEY env var, or ~/.codex/auth.json (CLI-managed auth) are set
 (via ``task test-smoke-codex``).
 """
 
@@ -8,6 +9,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -16,10 +18,18 @@ from autoskillit.execution.backends.codex import CodexResultParser, CodexStreamP
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.large]
 
-_SKIP_REASON = "Set CODEX_SMOKE_TEST=1 and OPENAI_API_KEY to run Codex smoke tests"
+_SKIP_REASON = (
+    "Set CODEX_SMOKE_TEST=1 and one of: CODEX_API_KEY, OPENAI_API_KEY,"
+    " or ~/.codex/auth.json to run Codex smoke tests"
+)
 
 _skip_unless_codex_smoke = pytest.mark.skipif(
-    not os.environ.get("CODEX_SMOKE_TEST") or not os.environ.get("OPENAI_API_KEY"),
+    not os.environ.get("CODEX_SMOKE_TEST")
+    or (
+        not os.environ.get("CODEX_API_KEY")
+        and not os.environ.get("OPENAI_API_KEY")
+        and not Path("~/.codex/auth.json").expanduser().exists()
+    ),
     reason=_SKIP_REASON,
 )
 
@@ -30,8 +40,9 @@ class TestCodexSmokeExecution:
     """Full end-to-end Codex CLI smoke execution.
 
     Run via ``task test-smoke-codex`` which sets CODEX_SMOKE_TEST=1 and
-    requires OPENAI_API_KEY. Executes ``codex exec --json`` with a trivial
-    prompt and validates NDJSON output parsing.
+    requires one of: CODEX_API_KEY, OPENAI_API_KEY, or ~/.codex/auth.json.
+    Executes ``codex exec --json`` with a trivial prompt and validates
+    NDJSON output parsing.
     """
 
     def test_codex_exec_ndjson_parseable(self) -> None:
@@ -42,8 +53,6 @@ class TestCodexSmokeExecution:
                 "--json",
                 "--sandbox",
                 "workspace-write",
-                "-a",
-                "never",
                 "Respond with exactly: hello",
             ],
             capture_output=True,


### PR DESCRIPTION
## Summary

Modify `tests/execution/test_smoke_codex.py` to: (1) remove the `-a`/`never` flags from the `codex exec` subprocess command, (2) widen the skip condition from a single `OPENAI_API_KEY` check to a compound boolean accepting `CODEX_API_KEY`, `OPENAI_API_KEY`, or `~/.codex/auth.json`, and (3) update all docstrings and `_SKIP_REASON` to describe the widened auth gate.

**Issue contradictions resolved:** The issue body contains conflicting acceptance criteria — some lines defer `_SKIP_REASON` and skip-condition changes to sibling WPs (P1-A3-WP1, P1-A3-WP2), while the Deliverables section and Technical Steps 7–16 explicitly include them in this WP's scope. This plan follows the **Deliverables section** as the authoritative scope, since it is the most internally consistent and matches the issue title.

**Out of scope:** `Taskfile.yml` lines 211, 219–220 are NOT modified by this WP. Specifically: line 211 (`desc: Run Codex CLI smoke tests (requires OPENAI_API_KEY)`), line 219 (`test -n "$OPENAI_API_KEY"` precondition), and line 220 (`msg: "OPENAI_API_KEY must be set"`). These Taskfile entries will block `task test-smoke-codex` for users authenticating via `CODEX_API_KEY` or `~/.codex/auth.json` only. The Taskfile guard is a shell-level concern owned separately — a follow-up WP should widen it to match the test-level compound auth gate.

## Requirements

### Goal

Remove -a/never from the smoke test subprocess call, add the compound auth boolean accepting CODEX_API_KEY/OPENAI_API_KEY/~/.codex/auth.json, and update all docstrings and _SKIP_REASON to describe the widened auth gate.

### Deliverables

- `tests/execution/test_smoke_codex.py` with lines 45-46 (`-a` and `never`) deleted from the subprocess.run command list
- `from pathlib import Path` added to the import block
- Lines 21-24 replaced with compound skip condition covering CODEX_API_KEY, OPENAI_API_KEY, and ~/.codex/auth.json
- Module docstring updated to enumerate all three valid auth methods
- `_SKIP_REASON` string updated to enumerate all three valid auth methods
- TestCodexSmokeExecution class docstring updated to remove 'requires OPENAI_API_KEY' language
- `tests/execution/CLAUDE.md` updated to reflect widened auth gate

### Acceptance Criteria

- The subprocess.run command list reads exactly `['codex', 'exec', '--json', '--sandbox', 'workspace-write', 'Respond with exactly: hello']` with no `-a` or `never` entries
- Skip condition evaluates to False when CODEX_SMOKE_TEST=1 and at least one auth method is present
- Skip condition evaluates to True when CODEX_SMOKE_TEST is unset
- Skip condition evaluates to True when CODEX_SMOKE_TEST=1 but all three auth methods are absent
- _SKIP_REASON enumerates CODEX_API_KEY, OPENAI_API_KEY, and ~/.codex/auth.json
- No other lines in the file are modified

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([pytest collection])

    subgraph Before ["BEFORE — Current Skip Logic"]
        direction TB
        B1{"CODEX_SMOKE_TEST<br/>━━━━━━━━━━<br/>set?"}
        B2{"OPENAI_API_KEY<br/>━━━━━━━━━━<br/>set?"}
        B3["RUN test<br/>━━━━━━━━━━<br/>codex exec --json<br/>--sandbox workspace-write<br/>-a never 'prompt'"]
        B4([SKIP])
    end

    subgraph After ["AFTER — ● Widened Auth Gate"]
        direction TB
        A1{"CODEX_SMOKE_TEST<br/>━━━━━━━━━━<br/>set?"}
        A2{"● CODEX_API_KEY<br/>━━━━━━━━━━<br/>set?"}
        A3{"● OPENAI_API_KEY<br/>━━━━━━━━━━<br/>set?"}
        A4{"★ ~/.codex/auth.json<br/>━━━━━━━━━━<br/>exists?"}
        A5["● RUN test<br/>━━━━━━━━━━<br/>codex exec --json<br/>--sandbox workspace-write<br/>'prompt'"]
        A6([SKIP])
    end

    START --> B1
    B1 -->|"no"| B4
    B1 -->|"yes"| B2
    B2 -->|"no"| B4
    B2 -->|"yes"| B3

    START --> A1
    A1 -->|"no"| A6
    A1 -->|"yes"| A2
    A2 -->|"yes"| A5
    A2 -->|"no"| A3
    A3 -->|"yes"| A5
    A3 -->|"no"| A4
    A4 -->|"yes"| A5
    A4 -->|"no"| A6

    class START terminal;
    class B1,B2 stateNode;
    class B3 handler;
    class B4 terminal;
    class A1 stateNode;
    class A2,A3,A4 newComponent;
    class A5 handler;
    class A6 terminal;
```

**Color Legend:**

| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Start/skip/end states |
| Teal | State | Existing decision nodes |
| Green | New | New/modified decision nodes in compound auth |
| Orange | Handler | Test execution (subprocess call) |

**Lens Used:** Process Flow — the core change is decision logic (skip condition branching) and command construction (removing CLI flags).

Closes #2668

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-060210-295609/.autoskillit/temp/make-plan/px1_p1_a2_wp1_remove_a_never_plan_2026-05-22_061500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 74 | 14.8k | 939.7k | 69.7k | 144 | 54.9k | 12m 7s |
| verify | claude-opus-4-6 | 1 | 35 | 4.1k | 286.9k | 48.3k | 43 | 33.2k | 2m 35s |
| implement* | MiniMax-M2.7 | 1 | 76.1k | 7.6k | 1.9M | 29.7k | 82 | 8.3k | 4m 57s |
| prepare_pr* | MiniMax-M2.7 | 1 | 44.3k | 2.9k | 295.4k | 0 | 22 | 0 | 54s |
| compose_pr* | MiniMax-M2.7 | 1 | 43.5k | 3.0k | 322.7k | 26.7k | 21 | 8.3k | 1m 43s |
| review_pr | claude-opus-4-6 | 3 | 106 | 23.8k | 1.3M | 47.1k | 82 | 94.2k | 7m 5s |
| **Total** | | | 164.1k | 56.1k | 5.0M | 69.7k | | 199.0k | 29m 23s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 25 | 76646.3 | 332.2 | 303.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **25** | 200997.2 | 7959.4 | 2243.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 74 | 14.8k | 939.7k | 54.9k | 12m 7s |
| claude-opus-4-6 | 2 | 141 | 27.9k | 1.6M | 127.4k | 9m 41s |
| MiniMax-M2.7 | 3 | 163.9k | 13.4k | 2.5M | 16.6k | 7m 34s |