### PR TITLE
Change test-smoke-codex desc and precondition

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -208,7 +208,7 @@ tasks:
         exit $PYTEST_EXIT
 
   test-smoke-codex:
-    desc: Run Codex CLI smoke tests (requires OPENAI_API_KEY)
+    desc: Run Codex CLI smoke tests (requires Codex authentication)
     deps: [_tmpdir-setup]
     env:
       PYTHONDONTWRITEBYTECODE: "1"
@@ -216,8 +216,8 @@ tasks:
       CODEX_SMOKE_TEST: "1"
       TMPDIR: "{{.PYTEST_TMPDIR}}"
     preconditions:
-      - sh: test -n "$OPENAI_API_KEY"
-        msg: "OPENAI_API_KEY must be set"
+      - sh: test -n "$OPENAI_API_KEY" || test -n "$CODEX_API_KEY" || test -f "$HOME/.codex/auth.json"
+        msg: "Codex authentication required: set OPENAI_API_KEY or CODEX_API_KEY, or run 'codex login'"
     cmds:
       - |
         mkdir -p .autoskillit/temp


### PR DESCRIPTION
## Summary

Update the `test-smoke-codex` task in `Taskfile.yml` to reflect widened Codex authentication support:
1. Change the `desc` field to say "requires Codex authentication" instead of "requires OPENAI_API_KEY"
2. Replace the single `OPENAI_API_KEY` precondition with a three-way OR accepting `OPENAI_API_KEY`, `CODEX_API_KEY`, or `~/.codex/auth.json`
3. Update the precondition failure message to list all three auth paths

**Known downstream mismatch (out of scope):** The pytest skip decorator in `tests/execution/test_smoke_codex.py:22` hard-gates on `OPENAI_API_KEY` via `pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), ...)`. After this change, a user authenticating via `CODEX_API_KEY` or `codex login` will pass the Taskfile precondition (pytest launches) but all tests will skip because the Python-level gate still requires `OPENAI_API_KEY`. The issue scopes this WP to Taskfile-only changes; the test file skip condition and its docstrings (lines 3, 19, 33) are a separate follow-up.

Closes #2669

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-060211-285161/.autoskillit/temp/make-plan/px1_p1-a4-wp1_change_test_smoke_codex_desc_plan_2026-05-22_060600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 69 | 10.1k | 560.1k | 51.0k | 95 | 38.4k | 6m 10s |
| verify | claude-opus-4-6 | 1 | 25 | 2.8k | 198.2k | 34.8k | 28 | 19.8k | 2m 0s |
| implement* | MiniMax-M2.7 | 1 | 43.8k | 2.2k | 615.6k | 0 | 34 | 0 | 42s |
| prepare_pr* | MiniMax-M2.7 | 3 | 252.9k | 8.4k | 716.2k | 29.7k | 65 | 67.6k | 4m 46s |
| compose_pr* | MiniMax-M2.7 | 1 | 42.5k | 1.9k | 339.6k | 29.7k | 23 | 15.5k | 1m 13s |
| review_pr | claude-opus-4-6 | 3 | 98 | 19.8k | 1.3M | 45.7k | 87 | 85.0k | 7m 22s |
| **Total** | | | 339.4k | 45.2k | 3.7M | 51.0k | | 226.3k | 22m 14s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 6 | 102602.7 | 0.0 | 370.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **6** | 619207.7 | 37713.7 | 7540.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 192 | 32.7k | 2.0M | 143.1k | 15m 32s |
| MiniMax-M2.7 | 3 | 339.2k | 12.5k | 1.7M | 83.1k | 6m 42s |