### PR TITLE
Extend _type_backend

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -248,6 +248,7 @@ from .types import Severity as Severity
 from .types import SkillLister as SkillLister
 from .types import SkillResolver as SkillResolver
 from .types import SkillResult as SkillResult
+from .types import SkillSessionConfig as SkillSessionConfig
 from .types import SkillSource as SkillSource
 from .types import StreamParser as StreamParser
 from .types import SubprocessResult as SubprocessResult

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -23,7 +23,7 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 | `_type_protocols_infra.py` | Protocols: `GateState`, `BackgroundSupervisor`, `FleetLock`, `QuotaRefreshTask`, `TokenFactory`, `CampaignProtector` |
 | `_type_protocols_backend.py` | Protocols: `StreamParser`, `ResultParser`, `EnvPolicy`, `SessionLocator`, `CodingAgentBackend` |
 | `_type_checkpoint.py` | `SessionCheckpoint` frozen dataclass and `compute_remaining()` helper for session resume |
-| `_type_backend.py` | `BackendCapabilities` frozen dataclass, `CLAUDE_CODE_CAPABILITIES` constant, `CmdSpec`, `ClaudeEventData`, `CodexEventData`, `SessionEvent`, `AgentSessionResult` |
+| `_type_backend.py` | `BackendCapabilities` frozen dataclass, `CLAUDE_CODE_CAPABILITIES` constant, `CmdSpec`, `SkillSessionConfig`, `ClaudeEventData`, `CodexEventData`, `SessionEvent`, `AgentSessionResult` |
 | `_type_capture.py` | `CaptureEntrySpec` and `CaptureValueTypeError` for typed capture contract enforcement |
 | `_type_dispatch_identity.py` | `DispatchIdentity` frozen value object, `PromptContractError`, and `assert_prompt_sentinel` for sentinel contract enforcement |
 | `_type_helpers.py` | Text processing and skill-name extraction utilities |

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -6,12 +6,16 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
-from ._type_enums import BackendEventKind
+from ._type_checkpoint import SessionCheckpoint
+from ._type_enums import BackendEventKind, OutputFormat
+from ._type_plugin_source import PluginSource
+from ._type_results import ValidatedAddDir
 
 __all__ = [
     "BackendCapabilities",
     "CLAUDE_CODE_CAPABILITIES",
     "CmdSpec",
+    "SkillSessionConfig",
     "ClaudeEventData",
     "CodexEventData",
     "SessionEvent",
@@ -50,6 +54,25 @@ class CmdSpec:
     cmd: tuple[str, ...]
     env: Mapping[str, str]
     cwd: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class SkillSessionConfig:
+    completion_marker: str = ""
+    model: str | None = None
+    plugin_source: PluginSource | None = None
+    output_format: OutputFormat = OutputFormat.JSON
+    add_dirs: tuple[ValidatedAddDir, ...] = ()
+    exit_after_stop_delay_ms: int = 0
+    stream_idle_timeout_ms: int = 0
+    scenario_step_name: str = ""
+    temp_dir_relpath: str | None = None
+    allowed_write_prefix: str = ""
+    provider_extras: Mapping[str, str] | None = None
+    profile_name: str = ""
+    resume_session_id: str = ""
+    resume_checkpoint: SessionCheckpoint | None = None
+    resume_message: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -40,7 +40,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_tool_sequence_analysis.py` | Tool sequence analysis tests |
 | `test_backend_capabilities.py` | Tests for BackendCapabilities frozen invariants and CLAUDE_CODE_CAPABILITIES field values |
 | `test_backend_event_kind.py` | Tests for BackendEventKind StrEnum — member exhaustiveness, values, importability |
-| `test_backend_dataclasses.py` | Tests for CmdSpec, ClaudeEventData, CodexEventData, SessionEvent, AgentSessionResult — frozen invariants, field types, defaults |
+| `test_backend_dataclasses.py` | Tests for CmdSpec, SkillSessionConfig, ClaudeEventData, CodexEventData, SessionEvent, AgentSessionResult — frozen invariants, field types, defaults |
 | `test_backend_protocols.py` | Tests for StreamParser, ResultParser, EnvPolicy, SessionLocator, CodingAgentBackend — @runtime_checkable, isinstance conformance, IL-0 compliance |
 | `test_type_constants.py` | Tests for PACK_REGISTRY and related constants in core._type_constants |
 | `test_type_protocol_shards.py` | Type protocol shards guard |

--- a/tests/core/test_backend_dataclasses.py
+++ b/tests/core/test_backend_dataclasses.py
@@ -178,6 +178,7 @@ def test_backend_module_all_exhaustive():
         "BackendCapabilities",
         "CLAUDE_CODE_CAPABILITIES",
         "CmdSpec",
+        "SkillSessionConfig",
         "ClaudeEventData",
         "CodexEventData",
         "SessionEvent",
@@ -194,3 +195,119 @@ def test_no_autoskillit_imports_in_backend():
         stripped = line.strip()
         if stripped.startswith("from autoskillit") or stripped.startswith("import autoskillit"):
             pytest.fail(f"IL-0 violation: {stripped}")
+
+
+def test_skill_session_config_importable_from_core():
+    import dataclasses
+
+    from autoskillit.core import SkillSessionConfig
+
+    assert dataclasses.is_dataclass(SkillSessionConfig)
+
+
+def test_skill_session_config_frozen():
+    from dataclasses import FrozenInstanceError
+
+    from autoskillit.core import SkillSessionConfig
+
+    cfg = SkillSessionConfig()
+    with pytest.raises(FrozenInstanceError):
+        cfg.completion_marker = "x"  # type: ignore[misc]
+
+
+def test_skill_session_config_slots():
+    from autoskillit.core import SkillSessionConfig
+
+    assert hasattr(SkillSessionConfig, "__slots__")
+    cfg = SkillSessionConfig()
+    assert not hasattr(cfg, "__dict__")
+
+
+def test_skill_session_config_fields_exhaustive():
+    import dataclasses
+
+    from autoskillit.core import SkillSessionConfig
+
+    fields = {f.name for f in dataclasses.fields(SkillSessionConfig)}
+    assert fields == {
+        "completion_marker",
+        "model",
+        "plugin_source",
+        "output_format",
+        "add_dirs",
+        "exit_after_stop_delay_ms",
+        "stream_idle_timeout_ms",
+        "scenario_step_name",
+        "temp_dir_relpath",
+        "allowed_write_prefix",
+        "provider_extras",
+        "profile_name",
+        "resume_session_id",
+        "resume_checkpoint",
+        "resume_message",
+    }
+
+
+def test_skill_session_config_defaults():
+    from autoskillit.core import OutputFormat, SkillSessionConfig
+
+    cfg = SkillSessionConfig()
+    assert cfg.completion_marker == ""
+    assert cfg.model is None
+    assert cfg.plugin_source is None
+    assert cfg.output_format == OutputFormat.JSON
+    assert cfg.add_dirs == ()
+    assert cfg.exit_after_stop_delay_ms == 0
+    assert cfg.stream_idle_timeout_ms == 0
+    assert cfg.scenario_step_name == ""
+    assert cfg.temp_dir_relpath is None
+    assert cfg.allowed_write_prefix == ""
+    assert cfg.provider_extras is None
+    assert cfg.profile_name == ""
+    assert cfg.resume_session_id == ""
+    assert cfg.resume_checkpoint is None
+    assert cfg.resume_message is None
+
+
+def test_skill_session_config_field_types():
+    import typing
+    from collections.abc import Mapping
+
+    from autoskillit.core import SkillSessionConfig
+    from autoskillit.core.types._type_backend import (
+        OutputFormat,
+        PluginSource,
+        SessionCheckpoint,
+        ValidatedAddDir,
+    )
+
+    hints = typing.get_type_hints(SkillSessionConfig)
+    assert hints["completion_marker"] is str
+    assert hints["model"] == str | None
+    assert hints["plugin_source"] == PluginSource | None
+    assert hints["output_format"] is OutputFormat
+    assert hints["add_dirs"] == tuple[ValidatedAddDir, ...]
+    assert hints["exit_after_stop_delay_ms"] is int
+    assert hints["stream_idle_timeout_ms"] is int
+    assert hints["scenario_step_name"] is str
+    assert hints["temp_dir_relpath"] == str | None
+    assert hints["allowed_write_prefix"] is str
+    assert hints["provider_extras"] == Mapping[str, str] | None
+    assert hints["profile_name"] is str
+    assert hints["resume_session_id"] is str
+    assert hints["resume_checkpoint"] == SessionCheckpoint | None
+    assert hints["resume_message"] == str | None
+
+
+def test_skill_session_config_new_imports_accessible():
+    from autoskillit.core.types._type_backend import (
+        OutputFormat,
+        PluginSource,
+        SessionCheckpoint,
+        ValidatedAddDir,
+    )
+
+    assert OutputFormat is not None
+    assert SessionCheckpoint is not None
+    assert PluginSource is not None
+    assert ValidatedAddDir is not None

--- a/tests/core/test_backend_dataclasses.py
+++ b/tests/core/test_backend_dataclasses.py
@@ -273,11 +273,11 @@ def test_skill_session_config_field_types():
     import typing
     from collections.abc import Mapping
 
-    from autoskillit.core import SkillSessionConfig
-    from autoskillit.core.types._type_backend import (
+    from autoskillit.core import (
         OutputFormat,
         PluginSource,
         SessionCheckpoint,
+        SkillSessionConfig,
         ValidatedAddDir,
     )
 
@@ -297,17 +297,3 @@ def test_skill_session_config_field_types():
     assert hints["resume_session_id"] is str
     assert hints["resume_checkpoint"] == SessionCheckpoint | None
     assert hints["resume_message"] == str | None
-
-
-def test_skill_session_config_new_imports_accessible():
-    from autoskillit.core.types._type_backend import (
-        OutputFormat,
-        PluginSource,
-        SessionCheckpoint,
-        ValidatedAddDir,
-    )
-
-    assert OutputFormat is not None
-    assert SessionCheckpoint is not None
-    assert PluginSource is not None
-    assert ValidatedAddDir is not None


### PR DESCRIPTION
## Summary

Extend `src/autoskillit/core/types/_type_backend.py` with four new imports (`OutputFormat`, `SessionCheckpoint`, `PluginSource`, `ValidatedAddDir`) and a new `SkillSessionConfig` frozen dataclass with 15 fields. Update `__all__`, the `.pyi` stub, and tests.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-092445-386245/.autoskillit/temp/make-plan/extend_type_backend_plan_2026-05-22_093500.md`

## Architecture Impact

### Module Dependency Lens

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph TypesPackage ["core/types/ — IL-0 Type Sub-Package"]
        direction TB

        subgraph Sources ["Source Modules (unchanged)"]
            direction LR
            ENUMS["● _type_enums<br/>━━━━━━━━━━<br/>OutputFormat, BackendEventKind"]
            CHECKPOINT["_type_checkpoint<br/>━━━━━━━━━━<br/>SessionCheckpoint"]
            PLUGIN["_type_plugin_source<br/>━━━━━━━━━━<br/>PluginSource"]
            RESULTS["_type_results<br/>━━━━━━━━━━<br/>ValidatedAddDir"]
        end

        subgraph Target ["Modified Module"]
            BACKEND["● _type_backend<br/>━━━━━━━━━━<br/>BackendCapabilities<br/>CmdSpec<br/>★ SkillSessionConfig"]
        end

        subgraph Hub ["Re-export Chain"]
            TYPEINIT["__init__.py<br/>━━━━━━━━━━<br/>from ._type_backend import *"]
            COREPYI["● core/__init__.pyi<br/>━━━━━━━━━━<br/>lazy_loader stub"]
        end
    end

    ENUMS -->|"BackendEventKind, OutputFormat"| BACKEND
    CHECKPOINT -->|"SessionCheckpoint"| BACKEND
    PLUGIN -->|"PluginSource"| BACKEND
    RESULTS -->|"ValidatedAddDir"| BACKEND
    BACKEND -->|"__all__ auto-propagates"| TYPEINIT
    TYPEINIT -->|"must add explicit line"| COREPYI

    class ENUMS,CHECKPOINT,PLUGIN,RESULTS handler;
    class BACKEND phase;
    class TYPEINIT stateNode;
    class COREPYI newComponent;
```

Closes #2672

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.4k | 13.5k | 884.8k | 96.9k | 182 | 100.1k | 10m 21s |
| verify | claude-opus-4-6 | 1 | 973 | 5.1k | 320.4k | 59.3k | 58 | 44.1k | 2m 37s |
| implement* | MiniMax-M2.7-highspeed | 1 | 401.5k | 4.7k | 597.7k | 34.7k | 51 | 58.6k | 2m 0s |
| prepare_pr* | MiniMax-M2.7 | 1 | 45.2k | 3.0k | 204.2k | 0 | 17 | 0 | 38s |
| compose_pr* | MiniMax-M2.7 | 1 | 59.2k | 2.2k | 303.9k | 29.7k | 22 | 35.0k | 1m 12s |
| review_pr | claude-sonnet-4-6 | 3 | 302 | 75.8k | 1.4M | 67.7k | 113 | 168.7k | 16m 55s |
| resolve_review | claude-sonnet-4-6 | 1 | 215 | 9.7k | 1.2M | 60.6k | 67 | 45.8k | 5m 17s |
| **Total** | | | 511.9k | 113.9k | 5.0M | 96.9k | | 452.4k | 39m 1s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 147 | 4066.2 | 398.6 | 31.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 18 | 68373.7 | 2546.2 | 536.3 |
| **Total** | **165** | 30039.0 | 2741.8 | 690.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 5.0k | 99.0k | 3.5M | 314.6k | 32m 34s |
| claude-opus-4-6 | 1 | 973 | 5.1k | 320.4k | 44.1k | 2m 37s |
| MiniMax-M2.7-highspeed | 1 | 401.5k | 4.7k | 597.7k | 58.6k | 2m 0s |
| MiniMax-M2.7 | 2 | 104.4k | 5.2k | 508.1k | 35.0k | 1m 49s |