### PR TITLE
PX2 P2-A3-WP1 — Extend the import block in _type_protocols_backend

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -11,6 +11,7 @@ from ._type_backend import (
     BackendCapabilities,
     CmdSpec,
     SessionEvent,
+    SkillSessionConfig,  # noqa: F401
 )
 from ._type_checkpoint import SessionCheckpoint
 from ._type_enums import OutputFormat

--- a/tests/core/test_backend_protocols.py
+++ b/tests/core/test_backend_protocols.py
@@ -121,3 +121,10 @@ def test_stub_class_satisfies_coding_agent_backend():
         ) -> CmdSpec: ...
 
     assert isinstance(_Backend(), CodingAgentBackend)
+
+
+def test_skill_session_config_importable_from_protocols_backend() -> None:
+    from autoskillit.core import SkillSessionConfig as SkillSessionConfigDirect
+    from autoskillit.core.types._type_protocols_backend import SkillSessionConfig
+
+    assert SkillSessionConfig is SkillSessionConfigDirect


### PR DESCRIPTION
## Summary

Add `SkillSessionConfig` to the `from ._type_backend import (...)` block in `src/autoskillit/core/types/_type_protocols_backend.py`. `SkillSessionConfig` is a frozen dataclass defined in `_type_backend.py` whose 15 fields mirror the keyword arguments of `build_skill_session_cmd`. Adding the import makes the symbol available in `_type_protocols_backend.py` for downstream WPs (P2-A5-WP1, P2-A10-WP1, P2-A10-WP4) that will refactor the method signature from flat kwargs to a config-object parameter.

Closes #2673

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/px2_p2_a3_wp1_extend_import_block_plan_2026-05-22_110900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.5k | 15.1k | 978.0k | 66.3k | 170 | 54.1k | 12m 56s |
| verify | claude-sonnet-4-6 | 1 | 38 | 8.6k | 474.2k | 57.3k | 89 | 42.2k | 4m 44s |
| implement* | MiniMax-M2.7-highspeed | 1 | 235.5k | 3.4k | 538.5k | 34.7k | 42 | 49.6k | 1m 45s |
| prepare_pr* | MiniMax-M2.7 | 1 | 39.4k | 2.0k | 235.8k | 0 | 16 | 0 | 1m 1s |
| compose_pr* | MiniMax-M2.7 | 1 | 74.3k | 1.5k | 228.9k | 29.7k | 22 | 42.3k | 49s |
| review_pr | claude-sonnet-4-6 | 3 | 300 | 24.8k | 1.2M | 45.4k | 96 | 122.3k | 7m 48s |
| **Total** | | | 352.1k | 55.3k | 3.7M | 66.3k | | 310.4k | 29m 6s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 8 | 67307.4 | 6197.5 | 421.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **8** | 461683.5 | 38804.6 | 6912.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 2.8k | 48.5k | 2.7M | 218.6k | 25m 30s |
| MiniMax-M2.7-highspeed | 1 | 235.5k | 3.4k | 538.5k | 49.6k | 1m 45s |
| MiniMax-M2.7 | 2 | 113.7k | 3.5k | 464.6k | 42.3k | 1m 50s |