### PR TITLE
PX2 P2-A4-WP1 — Rename ClaudeCodeBackend.build_skill_session_cmd

### DIFF
--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -31,6 +31,7 @@ from autoskillit.core import (
     ResumeSpec,
     SessionCheckpoint,
     SessionEvent,
+    SkillSessionConfig,
     ValidatedAddDir,
     build_agent_env,
     extract_skill_name,
@@ -80,7 +81,7 @@ _SESSION_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
     }
 )
 
-# Variables that build_skill_session_cmd controls exclusively. They must not
+# Variables that _build_skill_session_cmd_impl controls exclusively. They must not
 # leak from the host process environment — the caller opts in via explicit
 # parameters (exit_after_stop_delay_ms, scenario_step_name, allowed_write_prefix, etc.).
 # Note: CLAUDE_CODE_EXIT_AFTER_STOP_DELAY, SCENARIO_STEP_NAME, and
@@ -570,6 +571,68 @@ class ClaudeCodeBackend:
         )
 
     def build_skill_session_cmd(
+        self,
+        skill_command: str,
+        cwd: str = "",
+        config: SkillSessionConfig | None = None,
+        *,
+        completion_marker: str = "",
+        model: str | None = None,
+        plugin_source: PluginSource | None = None,
+        output_format: OutputFormat = OutputFormat.JSON,
+        add_dirs: Sequence[ValidatedAddDir] = (),
+        exit_after_stop_delay_ms: int = 0,
+        stream_idle_timeout_ms: int = 0,
+        scenario_step_name: str = "",
+        temp_dir_relpath: str | None = None,
+        allowed_write_prefix: str = "",
+        provider_extras: Mapping[str, str] | None = None,
+        profile_name: str = "",
+        resume_session_id: str = "",
+        resume_checkpoint: SessionCheckpoint | None = None,
+        resume_message: str | None = None,
+    ) -> CmdSpec:
+        if config is not None:
+            return self._build_skill_session_cmd_impl(
+                skill_command,
+                cwd=cwd,
+                completion_marker=config.completion_marker,
+                model=config.model,
+                plugin_source=config.plugin_source,
+                output_format=config.output_format,
+                add_dirs=config.add_dirs,
+                exit_after_stop_delay_ms=config.exit_after_stop_delay_ms,
+                stream_idle_timeout_ms=config.stream_idle_timeout_ms,
+                scenario_step_name=config.scenario_step_name,
+                temp_dir_relpath=config.temp_dir_relpath,
+                allowed_write_prefix=config.allowed_write_prefix,
+                provider_extras=config.provider_extras,
+                profile_name=config.profile_name,
+                resume_session_id=config.resume_session_id,
+                resume_checkpoint=config.resume_checkpoint,
+                resume_message=config.resume_message,
+            )
+        return self._build_skill_session_cmd_impl(
+            skill_command,
+            cwd=cwd,
+            completion_marker=completion_marker,
+            model=model,
+            plugin_source=plugin_source,
+            output_format=output_format,
+            add_dirs=add_dirs,
+            exit_after_stop_delay_ms=exit_after_stop_delay_ms,
+            stream_idle_timeout_ms=stream_idle_timeout_ms,
+            scenario_step_name=scenario_step_name,
+            temp_dir_relpath=temp_dir_relpath,
+            allowed_write_prefix=allowed_write_prefix,
+            provider_extras=provider_extras,
+            profile_name=profile_name,
+            resume_session_id=resume_session_id,
+            resume_checkpoint=resume_checkpoint,
+            resume_message=resume_message,
+        )
+
+    def _build_skill_session_cmd_impl(
         self,
         skill_command: str,
         *,

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -137,7 +137,7 @@ def build_skill_session_cmd(
     resume_message: str | None = None,
 ) -> ClaudeHeadlessCmd:
     """Build the complete headless command spec for a skill session."""
-    spec = ClaudeCodeBackend().build_skill_session_cmd(
+    spec = ClaudeCodeBackend()._build_skill_session_cmd_impl(
         skill_command,
         cwd=cwd,
         completion_marker=completion_marker,

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -137,7 +137,7 @@ def build_skill_session_cmd(
     resume_message: str | None = None,
 ) -> ClaudeHeadlessCmd:
     """Build the complete headless command spec for a skill session."""
-    spec = ClaudeCodeBackend()._build_skill_session_cmd_impl(
+    spec = ClaudeCodeBackend().build_skill_session_cmd(
         skill_command,
         cwd=cwd,
         completion_marker=completion_marker,

--- a/tests/execution/backends/test_claude_backend.py
+++ b/tests/execution/backends/test_claude_backend.py
@@ -418,10 +418,6 @@ class TestBuildSkillSessionCmdConfigAdapter:
         assert isinstance(spec, CmdSpec)
         assert any("/plan" in s or "plan" in s for s in spec.cmd)
 
-    def test_impl_method_exists(self) -> None:
-        assert hasattr(ClaudeCodeBackend, "_build_skill_session_cmd_impl")
-        assert callable(getattr(ClaudeCodeBackend, "_build_skill_session_cmd_impl"))
-
     def test_config_path_returns_cmdspec(self) -> None:
         backend = ClaudeCodeBackend()
         config = SkillSessionConfig(completion_marker="%%DONE%%", output_format=OutputFormat.JSON)

--- a/tests/execution/backends/test_claude_backend.py
+++ b/tests/execution/backends/test_claude_backend.py
@@ -12,6 +12,7 @@ from autoskillit.core import (
     MarketplaceInstall,
     NamedResume,
     OutputFormat,
+    SessionCheckpoint,
     SkillSessionConfig,
 )
 from autoskillit.execution import commands
@@ -372,6 +373,7 @@ class TestBuildSkillSessionCmdConfigAdapter:
 
     def test_config_adapter_forwards_all_fields(self) -> None:
         backend = ClaudeCodeBackend()
+        chk = SessionCheckpoint(step_name="chk")
         config = SkillSessionConfig(
             completion_marker="%%MARKER%%",
             model="sonnet",
@@ -385,6 +387,8 @@ class TestBuildSkillSessionCmdConfigAdapter:
             provider_extras={"KEY": "val"},
             profile_name="my-profile",
             resume_session_id="s1",
+            resume_checkpoint=chk,
+            resume_message="resume-msg",
         )
         via_config = backend.build_skill_session_cmd("/plan", cwd="/tmp", config=config)
         via_impl = backend._build_skill_session_cmd_impl(
@@ -402,6 +406,8 @@ class TestBuildSkillSessionCmdConfigAdapter:
             provider_extras={"KEY": "val"},
             profile_name="my-profile",
             resume_session_id="s1",
+            resume_checkpoint=chk,
+            resume_message="resume-msg",
         )
         assert via_config.cmd == via_impl.cmd
         assert via_config.env == via_impl.env

--- a/tests/execution/backends/test_claude_backend.py
+++ b/tests/execution/backends/test_claude_backend.py
@@ -7,10 +7,12 @@ import pytest
 
 from autoskillit.core import (
     BareResume,
+    CmdSpec,
     DirectInstall,
     MarketplaceInstall,
     NamedResume,
     OutputFormat,
+    SkillSessionConfig,
 )
 from autoskillit.execution import commands
 from autoskillit.execution.backends import ClaudeCodeBackend
@@ -345,3 +347,77 @@ class TestBuildFoodTruckCmdEquivalence:
         shim = commands.build_food_truck_cmd(**kwargs)
         assert spec.cmd == tuple(shim.cmd)
         assert spec.env == shim.env
+
+
+class TestBuildSkillSessionCmdConfigAdapter:
+    def test_config_adapter_matches_impl(self) -> None:
+        backend = ClaudeCodeBackend()
+        config = SkillSessionConfig(
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_source=None,
+            output_format=OutputFormat.JSON,
+        )
+        via_config = backend.build_skill_session_cmd("/plan", cwd="/tmp", config=config)
+        via_impl = backend._build_skill_session_cmd_impl(
+            "/plan",
+            cwd="/tmp",
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_source=None,
+            output_format=OutputFormat.JSON,
+        )
+        assert via_config.cmd == via_impl.cmd
+        assert via_config.env == via_impl.env
+
+    def test_config_adapter_forwards_all_fields(self) -> None:
+        backend = ClaudeCodeBackend()
+        config = SkillSessionConfig(
+            completion_marker="%%MARKER%%",
+            model="sonnet",
+            plugin_source=DirectInstall(plugin_dir=Path("/p")),
+            output_format=OutputFormat.STREAM_JSON,
+            exit_after_stop_delay_ms=120000,
+            stream_idle_timeout_ms=30000,
+            scenario_step_name="step1",
+            temp_dir_relpath=".autoskillit/temp",
+            allowed_write_prefix="/tmp/test",
+            provider_extras={"KEY": "val"},
+            profile_name="my-profile",
+            resume_session_id="s1",
+        )
+        via_config = backend.build_skill_session_cmd("/plan", cwd="/tmp", config=config)
+        via_impl = backend._build_skill_session_cmd_impl(
+            "/plan",
+            cwd="/tmp",
+            completion_marker="%%MARKER%%",
+            model="sonnet",
+            plugin_source=DirectInstall(plugin_dir=Path("/p")),
+            output_format=OutputFormat.STREAM_JSON,
+            exit_after_stop_delay_ms=120000,
+            stream_idle_timeout_ms=30000,
+            scenario_step_name="step1",
+            temp_dir_relpath=".autoskillit/temp",
+            allowed_write_prefix="/tmp/test",
+            provider_extras={"KEY": "val"},
+            profile_name="my-profile",
+            resume_session_id="s1",
+        )
+        assert via_config.cmd == via_impl.cmd
+        assert via_config.env == via_impl.env
+
+    def test_legacy_flat_params_still_work(self) -> None:
+        backend = ClaudeCodeBackend()
+        spec = backend.build_skill_session_cmd("/plan", **SKILL_BASE)
+        assert isinstance(spec, CmdSpec)
+        assert any("/plan" in s or "plan" in s for s in spec.cmd)
+
+    def test_impl_method_exists(self) -> None:
+        assert hasattr(ClaudeCodeBackend, "_build_skill_session_cmd_impl")
+        assert callable(getattr(ClaudeCodeBackend, "_build_skill_session_cmd_impl"))
+
+    def test_config_path_returns_cmdspec(self) -> None:
+        backend = ClaudeCodeBackend()
+        config = SkillSessionConfig(completion_marker="%%DONE%%", output_format=OutputFormat.JSON)
+        result = backend.build_skill_session_cmd("/plan", cwd="/tmp", config=config)
+        assert isinstance(result, CmdSpec)


### PR DESCRIPTION
## Summary

Rename `ClaudeCodeBackend.build_skill_session_cmd` to `_build_skill_session_cmd_impl` (private), add a dual-path adapter that accepts either a `SkillSessionConfig` object or the existing flat keyword arguments, update the `commands.py` shim to call the renamed private method directly, and update the stale comment at `claude.py` line 83.

The new public `build_skill_session_cmd` is a dual-path adapter: when `config` is provided it destructures `SkillSessionConfig` fields and forwards to `_build_skill_session_cmd_impl`; when `config` is `None` (legacy callers) it forwards flat kwargs. This preserves backward compatibility with all existing production call sites (`headless/__init__.py:711`) and tests, while exposing the new config-based interface for downstream WPs (P2-A5-WP1, P2-A8-WP1, P3-A2-WP3).

The `CodingAgentBackend` protocol is not modified — the adapter's signature is a superset of the protocol's required flat-param signature, so structural subtyping conformance is preserved.

**Key design decision — dual-path adapter:** The production call site at `headless/__init__.py:711` calls `backend.build_skill_session_cmd(skill_command, cwd=cwd, completion_marker=..., ...)` with flat kwargs via the `CodingAgentBackend` protocol. If the public method only accepted `SkillSessionConfig`, this call would fail at runtime. The dual-path adapter preserves backward compatibility by accepting both calling conventions.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-110441-682250/.autoskillit/temp/make-plan/px2_p2_a4_wp1_rename_claudecodebackend_plan_2026-05-22_111200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.7k | 33.1k | 1.5M | 106.9k | 210 | 91.7k | 14m 58s |
| verify | claude-opus-4-6 | 1 | 42 | 14.1k | 678.7k | 61.7k | 72 | 46.5k | 6m 45s |
| implement* | MiniMax-M2.7-highspeed | 1 | 585.8k | 7.4k | 886.0k | 29.6k | 78 | 39.2k | 3m 19s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.4k | 3.2k | 245.2k | 0 | 19 | 0 | 58s |
| compose_pr* | MiniMax-M2.7 | 1 | 118.0k | 3.6k | 488.9k | 29.7k | 39 | 15.5k | 1m 30s |
| review_pr | claude-sonnet-4-6 | 2 | 144 | 36.9k | 607.7k | 54.5k | 51 | 87.9k | 9m 11s |
| resolve_review | claude-sonnet-4-6 | 2 | 506 | 31.2k | 3.5M | 77.5k | 157 | 114.7k | 13m 45s |
| **Total** | | | 749.5k | 129.5k | 8.0M | 106.9k | | 395.5k | 50m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 143 | 6195.9 | 274.0 | 51.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 292087.4 | 9562.3 | 2596.4 |
| **Total** | **155** | 51320.1 | 2551.5 | 835.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 2.4k | 101.2k | 5.7M | 294.3k | 37m 55s |
| claude-opus-4-6 | 1 | 42 | 14.1k | 678.7k | 46.5k | 6m 45s |
| MiniMax-M2.7-highspeed | 1 | 585.8k | 7.4k | 886.0k | 39.2k | 3m 19s |
| MiniMax-M2.7 | 2 | 161.4k | 6.8k | 734.1k | 15.5k | 2m 28s |