### PR TITLE
Rectify: Optimistic `labels_cleaned` Flag Blocks Dispatch Recovery

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -932,8 +932,9 @@ async def _run_dispatch(
     if final_status not in (DispatchStatus.SUCCESS, DispatchStatus.RESUMABLE):
         from autoskillit.fleet._label_cleanup import cleanup_orphaned_labels  # noqa: PLC0415
 
-        await cleanup_orphaned_labels(dispatch_sidecar_path, tool_ctx.github_client)
-        _labels_cleaned = True
+        _labels_cleaned = await cleanup_orphaned_labels(
+            dispatch_sidecar_path, tool_ctx.github_client
+        )
 
     try:
         project_log_dir = str(claude_code_project_dir(str(tool_ctx.project_dir)))

--- a/src/autoskillit/fleet/_label_cleanup.py
+++ b/src/autoskillit/fleet/_label_cleanup.py
@@ -119,7 +119,7 @@ async def sweep_stale_dispatch_labels(
     state files are logged and skipped so one corrupt file cannot block recovery.
     """
     for state_path in campaign_state_paths:
-        stale_sidecar_paths: list[str | None] = []
+        stale_dispatches: list[tuple[str, str | None]] = []
         terminal_uncleaned: list[tuple[str, str | None]] = []
         try:
             with CampaignStateMutator(state_path) as m:
@@ -129,7 +129,7 @@ async def sweep_stale_dispatch_labels(
                     if d.status == DispatchStatus.RUNNING:
                         if is_dispatch_session_alive(d):
                             continue
-                        stale_sidecar_paths.append(d.sidecar_path)
+                        stale_dispatches.append((d.name, d.sidecar_path))
                         d.status = DispatchStatus.INTERRUPTED
                         m.mark_dirty()
                     elif (
@@ -145,26 +145,26 @@ async def sweep_stale_dispatch_labels(
                 exc_info=True,
             )
             continue
-        for sp in stale_sidecar_paths:
-            await cleanup_orphaned_labels(sp, github_client)
 
-        terminal_results: dict[str, bool] = {}
+        cleanup_results: dict[str, bool] = {}
+        for name, sp in stale_dispatches:
+            cleanup_results[name] = await cleanup_orphaned_labels(sp, github_client)
         for name, sp in terminal_uncleaned:
-            terminal_results[name] = await cleanup_orphaned_labels(sp, github_client)
+            cleanup_results[name] = await cleanup_orphaned_labels(sp, github_client)
 
-        if terminal_uncleaned:
+        if cleanup_results:
             try:
                 with CampaignStateMutator(state_path) as m:
                     if m.state is not None:
                         for d in m.state.dispatches:
-                            if d.name in terminal_results and terminal_results[d.name]:
+                            if d.name in cleanup_results and cleanup_results[d.name]:
                                 d.labels_cleaned = True
                                 m.mark_dirty()
             except Exception:
                 logger.warning(
                     "startup_label_sweep_mark_cleaned_failed",
                     state_path=str(state_path),
-                    cleaned_names=sorted(n for n, s in terminal_results.items() if s),
+                    cleaned_names=sorted(n for n, s in cleanup_results.items() if s),
                     exc_info=True,
                 )
 

--- a/src/autoskillit/fleet/_label_cleanup.py
+++ b/src/autoskillit/fleet/_label_cleanup.py
@@ -39,12 +39,15 @@ _ADD_LABELS: list[str] = [IssueLabelState.FAIL.value]
 async def cleanup_orphaned_labels(
     sidecar_path: str | None,
     github_client: GitHubFetcher | None,
-) -> None:
+) -> bool:
     """Remove in-progress labels for all issues in a dispatch sidecar.
 
     Safe to call unconditionally from a finally block — returns immediately when
-    sidecar_path or github_client is None, and swallows GitHub API errors so the
+    sidecar_path or github_client is None, and swallows all errors so the
     original exception is never suppressed.
+
+    Returns True when all swap_labels calls succeeded (or there was nothing to
+    clean). Returns False when any call failed or raised.
     """
     if sidecar_path is None or github_client is None:
         logger.debug(
@@ -52,12 +55,22 @@ async def cleanup_orphaned_labels(
             reason="no_sidecar_or_no_client",
             has_sidecar=sidecar_path is not None,
         )
-        return
+        return True
 
-    entries = read_sidecar_from_path(Path(sidecar_path))
+    try:
+        entries = read_sidecar_from_path(Path(sidecar_path))
+    except Exception:
+        logger.warning(
+            "infra_label_cleanup_sidecar_read_failed",
+            sidecar_path=sidecar_path,
+            exc_info=True,
+        )
+        return False
+
     if not entries:
-        return
+        return True
 
+    all_succeeded = True
     for entry in entries:
         try:
             owner, repo, number = _parse_issue_ref(entry.issue_url)
@@ -66,6 +79,7 @@ async def cleanup_orphaned_labels(
                 "infra_label_cleanup_skip_bad_url",
                 issue_url=entry.issue_url,
             )
+            all_succeeded = False
             continue
         try:
             result = await github_client.swap_labels(
@@ -75,17 +89,21 @@ async def cleanup_orphaned_labels(
                 remove_labels=_REMOVE_LABELS,
                 add_labels=_ADD_LABELS,
             )
+            if not result.get("success"):
+                all_succeeded = False
             logger.info(
                 "infra_label_cleanup",
                 issue_url=entry.issue_url,
                 success=result.get("success"),
             )
         except Exception:
+            all_succeeded = False
             logger.warning(
                 "infra_label_cleanup_swap_failed",
                 issue_url=entry.issue_url,
                 exc_info=True,
             )
+    return all_succeeded
 
 
 async def sweep_stale_dispatch_labels(
@@ -129,22 +147,24 @@ async def sweep_stale_dispatch_labels(
             continue
         for sp in stale_sidecar_paths:
             await cleanup_orphaned_labels(sp, github_client)
-        for _name, sp in terminal_uncleaned:
-            await cleanup_orphaned_labels(sp, github_client)
+
+        terminal_results: dict[str, bool] = {}
+        for name, sp in terminal_uncleaned:
+            terminal_results[name] = await cleanup_orphaned_labels(sp, github_client)
+
         if terminal_uncleaned:
             try:
                 with CampaignStateMutator(state_path) as m:
                     if m.state is not None:
-                        cleaned_names = {name for name, _ in terminal_uncleaned}
                         for d in m.state.dispatches:
-                            if d.name in cleaned_names:
+                            if d.name in terminal_results and terminal_results[d.name]:
                                 d.labels_cleaned = True
                                 m.mark_dirty()
             except Exception:
                 logger.warning(
                     "startup_label_sweep_mark_cleaned_failed",
                     state_path=str(state_path),
-                    cleaned_names=sorted(n for n, _ in terminal_uncleaned),
+                    cleaned_names=sorted(n for n, s in terminal_results.items() if s),
                     exc_info=True,
                 )
 

--- a/src/autoskillit/server/tools/_claim_helpers.py
+++ b/src/autoskillit/server/tools/_claim_helpers.py
@@ -89,9 +89,10 @@ async def _try_claim_with_liveness(
             ),
         )
     if dispatch.status in TERMINAL_UNCLEANED_STATUSES:
-        await cleanup_orphaned_labels(dispatch.sidecar_path, github_client)
-        _mark_dispatch_labels_cleaned(dispatch.name, campaign_state_paths)
-        return ClaimDecision(claimed=True, stale_label_cleaned=True)
+        cleaned = await cleanup_orphaned_labels(dispatch.sidecar_path, github_client)
+        if cleaned:
+            _mark_dispatch_labels_cleaned(dispatch.name, campaign_state_paths)
+        return ClaimDecision(claimed=True, stale_label_cleaned=cleaned)
     if is_dispatch_session_alive(dispatch):
         return ClaimDecision(
             claimed=False,
@@ -100,5 +101,5 @@ async def _try_claim_with_liveness(
                 " — owning dispatch session is still alive"
             ),
         )
-    await cleanup_orphaned_labels(dispatch.sidecar_path, github_client)
-    return ClaimDecision(claimed=True, stale_label_cleaned=True)
+    cleaned = await cleanup_orphaned_labels(dispatch.sidecar_path, github_client)
+    return ClaimDecision(claimed=True, stale_label_cleaned=cleaned)

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -1089,10 +1090,134 @@ class TestCrashPathDiagnosticPersistence:
 
 class TestLabelsCleanedFieldPersistence:
     @pytest.mark.anyio
-    async def test_labels_cleaned_true_on_failure_outcome(
+    async def test_labels_cleaned_true_when_cleanup_succeeds(
         self, tool_ctx, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """DispatchRecord persists labels_cleaned=True when outcome is FAILURE."""
+        """DispatchRecord persists labels_cleaned=True only when cleanup actually succeeds."""
+        import dataclasses
+
+        from autoskillit.fleet.sidecar import sidecar_path as make_sidecar_path
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        swap_labels_mock = AsyncMock(return_value={"success": True})
+        github_client = AsyncMock()
+        github_client.swap_labels = swap_labels_mock
+        tool_ctx.github_client = github_client
+
+        failure_result = dataclasses.replace(
+            _DEFAULT_SKILL_RESULT,
+            success=False,
+            result='{"success": false, "reason": "context_exhaustion"}',
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+        )
+
+        async def _return_failure(**kwargs):
+            sidecar = make_sidecar_path(kwargs["dispatch_id"], tool_ctx.project_dir)
+            sidecar.write_text(
+                json.dumps(
+                    {
+                        "issue_url": "https://github.com/owner/repo/issues/1",
+                        "status": "completed",
+                        "ts": "2026-01-01T00:00:00Z",
+                    }
+                )
+                + "\n"
+            )
+            if kwargs.get("on_spawn"):
+                kwargs["on_spawn"](12345, 1000)
+            return failure_result
+
+        tool_ctx.executor.dispatch_food_truck = _return_failure
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_no_sentinel(),
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["status"] == "failure"
+        assert record["labels_cleaned"] is True
+
+    @pytest.mark.anyio
+    async def test_labels_cleaned_false_when_cleanup_fails(
+        self, tool_ctx, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DispatchRecord persists labels_cleaned=False when cleanup fails."""
+        import dataclasses
+
+        from autoskillit.fleet.sidecar import sidecar_path as make_sidecar_path
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+        swap_labels_mock = AsyncMock(side_effect=Exception("rate limited"))
+        github_client = AsyncMock()
+        github_client.swap_labels = swap_labels_mock
+        tool_ctx.github_client = github_client
+
+        failure_result = dataclasses.replace(
+            _DEFAULT_SKILL_RESULT,
+            success=False,
+            result='{"success": false, "reason": "context_exhaustion"}',
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+        )
+
+        async def _return_failure(**kwargs):
+            sidecar = make_sidecar_path(kwargs["dispatch_id"], tool_ctx.project_dir)
+            sidecar.write_text(
+                json.dumps(
+                    {
+                        "issue_url": "https://github.com/owner/repo/issues/1",
+                        "status": "completed",
+                        "ts": "2026-01-01T00:00:00Z",
+                    }
+                )
+                + "\n"
+            )
+            if kwargs.get("on_spawn"):
+                kwargs["on_spawn"](12345, 1000)
+            return failure_result
+
+        tool_ctx.executor.dispatch_food_truck = _return_failure
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_no_sentinel(),
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["status"] == "failure"
+        assert record["labels_cleaned"] is False
+
+    @pytest.mark.anyio
+    async def test_labels_cleaned_false_on_success_outcome(
+        self, tool_ctx, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DispatchRecord persists labels_cleaned=False when outcome is SUCCESS."""
+        _setup_dispatch(tool_ctx, monkeypatch)
+        tool_ctx.github_client = None
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_completed_clean(True),
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["status"] == "success"
+        assert record["labels_cleaned"] is False
+
+    @pytest.mark.anyio
+    async def test_labels_cleaned_true_with_no_client_no_sidecar(
+        self, tool_ctx, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """labels_cleaned=True when github_client is None (vacuously true — nothing to clean)."""
         import dataclasses
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
@@ -1119,21 +1244,3 @@ class TestLabelsCleanedFieldPersistence:
         record = _read_dispatch_record(tool_ctx)
         assert record["status"] == "failure"
         assert record["labels_cleaned"] is True
-
-    @pytest.mark.anyio
-    async def test_labels_cleaned_false_on_success_outcome(
-        self, tool_ctx, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """DispatchRecord persists labels_cleaned=False when outcome is SUCCESS."""
-        _setup_dispatch(tool_ctx, monkeypatch)
-        tool_ctx.github_client = None
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.parse_l3_result_block",
-            lambda **_: _make_completed_clean(True),
-        )
-
-        await _run(tool_ctx)
-
-        record = _read_dispatch_record(tool_ctx)
-        assert record["status"] == "success"
-        assert record["labels_cleaned"] is False

--- a/tests/fleet/test_label_cleanup.py
+++ b/tests/fleet/test_label_cleanup.py
@@ -344,3 +344,111 @@ class TestCleanupOrphanedLabelsUnit:
         )
         assert sorted(call.kwargs["remove_labels"]) == expected_remove
         assert call.kwargs["add_labels"] == [IssueLabelState.FAIL.value]
+
+    @pytest.mark.anyio
+    async def test_cleanup_returns_false_when_swap_labels_raises(self, tmp_path: Path) -> None:
+        """cleanup_orphaned_labels returns False when swap_labels raises."""
+        from autoskillit.fleet._label_cleanup import cleanup_orphaned_labels
+
+        sidecar = tmp_path / "test_issues.jsonl"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "issue_url": "https://github.com/owner/repo/issues/1",
+                    "status": "completed",
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            )
+            + "\n"
+        )
+
+        github_client = AsyncMock()
+        github_client.swap_labels = AsyncMock(side_effect=Exception("rate limited"))
+
+        result = await cleanup_orphaned_labels(str(sidecar), github_client)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_cleanup_returns_true_when_all_succeed(self, tmp_path: Path) -> None:
+        """cleanup_orphaned_labels returns True when all swap_labels succeed."""
+        from autoskillit.fleet._label_cleanup import cleanup_orphaned_labels
+
+        sidecar = tmp_path / "test_issues.jsonl"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "issue_url": "https://github.com/owner/repo/issues/1",
+                    "status": "completed",
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            )
+            + "\n"
+        )
+
+        github_client = AsyncMock()
+        github_client.swap_labels = AsyncMock(return_value={"success": True})
+
+        result = await cleanup_orphaned_labels(str(sidecar), github_client)
+
+        assert result is True
+
+    @pytest.mark.anyio
+    async def test_cleanup_returns_false_on_partial_failure(self, tmp_path: Path) -> None:
+        """cleanup_orphaned_labels returns False when any swap_labels call fails."""
+        from autoskillit.fleet._label_cleanup import cleanup_orphaned_labels
+
+        sidecar = tmp_path / "test_issues.jsonl"
+        lines = [
+            json.dumps(
+                {
+                    "issue_url": f"https://github.com/owner/repo/issues/{i}",
+                    "status": "completed",
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            )
+            for i in [1, 2]
+        ]
+        sidecar.write_text("\n".join(lines) + "\n")
+
+        call_count = 0
+
+        async def _succeed_then_raise(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"success": True}
+            raise Exception("rate limited")
+
+        github_client = AsyncMock()
+        github_client.swap_labels = _succeed_then_raise
+
+        result = await cleanup_orphaned_labels(str(sidecar), github_client)
+
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_cleanup_returns_false_when_swap_returns_failure(self, tmp_path: Path) -> None:
+        """cleanup_orphaned_labels returns False when swap_labels returns success=False."""
+        from autoskillit.fleet._label_cleanup import cleanup_orphaned_labels
+
+        sidecar = tmp_path / "test_issues.jsonl"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "issue_url": "https://github.com/owner/repo/issues/1",
+                    "status": "completed",
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            )
+            + "\n"
+        )
+
+        github_client = AsyncMock()
+        github_client.swap_labels = AsyncMock(
+            return_value={"success": False, "error": "rate limited"}
+        )
+
+        result = await cleanup_orphaned_labels(str(sidecar), github_client)
+
+        assert result is False

--- a/tests/fleet/test_startup_label_recovery.py
+++ b/tests/fleet/test_startup_label_recovery.py
@@ -230,6 +230,60 @@ class TestStartupLabelRecoverySweep:
         assert state.dispatches[0].labels_cleaned is True
 
     @pytest.mark.anyio
+    async def test_startup_sweep_leaves_labels_uncleaned_when_cleanup_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sweep leaves labels_cleaned=False when cleanup_orphaned_labels fails."""
+        from autoskillit.fleet import DispatchRecord, read_state, write_initial_state
+        from autoskillit.fleet._label_cleanup import sweep_stale_dispatch_labels
+        from autoskillit.fleet.state import upsert_dispatch_record_by_name
+
+        monkeypatch.setattr(
+            "autoskillit.fleet._label_cleanup.is_dispatch_session_alive",
+            lambda record: False,
+        )
+
+        state_path = tmp_path / "campaign_fail_cleanup.json"
+        sidecar = tmp_path / "sidecar_fail_cleanup.jsonl"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "issue_url": "https://github.com/owner/repo/issues/7",
+                    "status": "completed",
+                    "ts": "2026-01-01T00:00:00Z",
+                }
+            )
+            + "\n"
+        )
+        write_initial_state(
+            state_path,
+            campaign_id="test",
+            campaign_name="test",
+            manifest_path="/m.yaml",
+            dispatches=[DispatchRecord(name="d1")],
+        )
+        upsert_dispatch_record_by_name(
+            state_path,
+            DispatchRecord(
+                name="d1",
+                status=DispatchStatus.FAILURE,
+                sidecar_path=str(sidecar),
+                labels_cleaned=False,
+            ),
+        )
+
+        swap_labels_mock = AsyncMock(side_effect=Exception("rate limited"))
+        github_client = AsyncMock()
+        github_client.swap_labels = swap_labels_mock
+
+        await sweep_stale_dispatch_labels([state_path], github_client)
+
+        swap_labels_mock.assert_called_once()
+        state = read_state(state_path)
+        assert state is not None
+        assert state.dispatches[0].labels_cleaned is False
+
+    @pytest.mark.anyio
     async def test_startup_sweep_skips_terminal_dispatch_with_labels_already_cleaned(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/server/test_claim_liveness.py
+++ b/tests/server/test_claim_liveness.py
@@ -49,7 +49,7 @@ class TestClaimIssueLiveness:
     async def test_claim_issue_proceeds_when_owning_session_is_dead(self, tool_ctx_kitchen_open):
         """When dispatch is dead, label is cleaned up and claimed=True is returned."""
         dead_dispatch = _make_dead_dispatch()
-        cleanup_mock = AsyncMock()
+        cleanup_mock = AsyncMock(return_value=True)
         tool_ctx_kitchen_open.github_client = _mock_client_with_in_progress_label()
 
         with (
@@ -117,7 +117,7 @@ class TestClaimAndResolveIssueLiveness:
     ):
         """claim_and_resolve_issue: dead dispatch → cleanup → claimed=True."""
         dead_dispatch = _make_dead_dispatch()
-        cleanup_mock = AsyncMock()
+        cleanup_mock = AsyncMock(return_value=True)
         tool_ctx_kitchen_open.github_client = _mock_client_with_in_progress_label()
 
         with (
@@ -159,7 +159,7 @@ class TestClaimHelperParity:
         from autoskillit.server.tools._claim_helpers import _try_claim_with_liveness
 
         dead_dispatch = _make_dead_dispatch()
-        cleanup_mock = AsyncMock()
+        cleanup_mock = AsyncMock(return_value=True)
 
         with (
             patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=dead_dispatch),
@@ -217,7 +217,7 @@ class TestClaimHelperTerminalDispatchRecovery:
             sidecar_path=str(tmp_path / "fail_sidecar.jsonl"),
             labels_cleaned=False,
         )
-        cleanup_mock = AsyncMock()
+        cleanup_mock = AsyncMock(return_value=True)
 
         with (
             patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
@@ -239,6 +239,42 @@ class TestClaimHelperTerminalDispatchRecovery:
         assert cleanup_mock.call_args[0][0] == failure_dispatch.sidecar_path
 
     @pytest.mark.anyio
+    async def test_claim_helper_failure_dispatch_cleanup_fails_leaves_flag_false(self, tmp_path):
+        """_try_claim_with_liveness: cleanup fails → claimed=True, stale_label_cleaned=False."""
+        from autoskillit.server.tools._claim_helpers import _try_claim_with_liveness
+
+        failure_dispatch = DispatchRecord(
+            name="task-fail",
+            status=DispatchStatus.FAILURE,
+            sidecar_path=str(tmp_path / "fail_sidecar.jsonl"),
+            labels_cleaned=False,
+        )
+        cleanup_mock = AsyncMock(return_value=False)
+        mark_cleaned_mock = AsyncMock()
+
+        with (
+            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
+            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", cleanup_mock),
+            patch(
+                "autoskillit.server.tools._claim_helpers._mark_dispatch_labels_cleaned",
+                mark_cleaned_mock,
+            ),
+        ):
+            decision = await _try_claim_with_liveness(
+                issue_url=_ISSUE_URL,
+                issue_number=42,
+                effective_label="in-progress",
+                current_labels=["in-progress"],
+                allow_reentry=False,
+                github_client=AsyncMock(),
+                campaign_state_paths=[],
+            )
+
+        assert decision.claimed is True
+        assert decision.stale_label_cleaned is False
+        mark_cleaned_mock.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_claim_helper_failure_dispatch_skips_liveness_check(self, tmp_path):
         """_try_claim_with_liveness: FAILURE dispatch does NOT call is_dispatch_session_alive."""
         from autoskillit.server.tools._claim_helpers import _try_claim_with_liveness
@@ -254,7 +290,7 @@ class TestClaimHelperTerminalDispatchRecovery:
         with (
             patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
             patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", liveness_mock),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", AsyncMock()),
+            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", AsyncMock(return_value=True)),
         ):
             decision = await _try_claim_with_liveness(
                 issue_url=_ISSUE_URL,


### PR DESCRIPTION
## Summary

`cleanup_orphaned_labels` swallows all GitHub API errors and returns `None`, giving callers no way to distinguish success from failure. All four callers unconditionally set `labels_cleaned = True` after the call. `find_dispatch_for_issue` trusts that flag to skip dispatches, causing `_try_claim_with_liveness` to hard-block with no recovery when cleanup actually failed. The architectural fix is to make `cleanup_orphaned_labels` return a truthful per-issue success result, and have all callers propagate that truth into `labels_cleaned`. This eliminates the entire class of "lying flag blocks retry" bugs across the four-layer cleanup pipeline.

## Requirements

## Summary

The orchestrator cannot restart or redispatch a food truck session after a previous attempt fails. When `dispatch_food_truck` is called for an issue and the session fails (quota exhaustion, crash, timeout, infra kill), the `in-progress` label can remain on the GitHub issue with no recovery path. On retry, the new L3 session's `claim_issue` sees the label, the claim guard (`_try_claim_with_liveness`) cannot find a dispatch with `labels_cleaned=False`, and hard-blocks with "another session may be processing it." The orchestrator has no mechanism to clean up the stale label, force a redispatch, or detect that the previous session is dead.

This is the **third occurrence** of the same "orphaned label blocks retry" pattern in 17 days (2026-05-05 issue #1887, 2026-05-21 cell-lab issue #31, 2026-05-22 issue #2721). Each prior fix closed one cleanup gap while leaving the structural issue intact.

## Root Cause

A three-layer design gap between the dispatch infrastructure, the label cleanup tracking, and the claim guard.

### Gap 1: `labels_cleaned` flag is optimistic — set `True` even when cleanup fails

In `fleet/_api.py:931-936`, after `cleanup_orphaned_labels` is called, the flag `_labels_cleaned = True` is set unconditionally:

```python
_labels_cleaned = False
if final_status not in (DispatchStatus.SUCCESS, DispatchStatus.RESUMABLE):
    await cleanup_orphaned_labels(dispatch_sidecar_path, tool_ctx.github_client)
    _labels_cleaned = True  # Set REGARDLESS of whether cleanup actually succeeded
```

But `cleanup_orphaned_labels` (`fleet/_label_cleanup.py:39-88`) swallows all GitHub API errors per-issue — each failed `swap_labels` call is caught and logged at WARNING level, then execution continues. The function never returns a success/failure signal. So when the GitHub API call fails (rate limit, network issue, auth problem), the label stays on the issue but `labels_cleaned=True` is recorded in the `DispatchRecord`.

### Gap 2: `find_dispatch_for_issue` skips dispatches with `labels_cleaned=True`

In `fleet/state_recovery.py:311-314`, the terminal-dispatch search explicitly filters on `not d.labels_cleaned`:

```python
elif (
    terminal_match is None
    and d.status in TERMINAL_UNCLEANED_STATUSES
    and not d.labels_cleaned  # Trusts the flag — if True, skips this dispatch
):
```

When Gap 1 sets `labels_cleaned=True` despite a failed cleanup, this filter causes the dispatch to be invisible to `find_dispatch_for_issue`. The function returns `None`.

### Gap 3: `dispatch is None` is a hard block with no recovery path

In `_claim_helpers.py:83-90`, when `find_dispatch_for_issue` returns `None`, `_try_claim_with_liveness` returns `ClaimDecision(claimed=False)` unconditionally. There is no fallback — no GitHub API liveness check, no label age check, no force parameter. The only escapes are:
- `allow_reentry=True` on `claim_issue` (but this is a `claim_issue` tool parameter, not a dispatch ingredient the orchestrator can pass through `dispatch_food_truck`)
- Manually removing the label via the GitHub UI

### Gap 4: The orchestrator has no redispatch primitive

`dispatch_food_truck` has no `force`, `override`, or `cleanup_stale` parameter. The `dispatch_name` + `reset_blocking_dispatch` mechanism only works within campaign context (`AUTOSKILLIT_CAMPAIGN_STATE_PATH` must be set). For ad-hoc orchestrator dispatches, the orchestrator cannot:
- Call `cleanup_orphaned_labels` (fleet-internal function, not an MCP tool)
- Call `release_issue` (would need to know the issue was claimed and in what state)
- Remove the `in-progress` label directly (no MCP tool exposes raw label removal)
- Pass `allow_reentry` through `dispatch_food_truck` (not a dispatch ingredient)

## Four-Layer Cleanup Pipeline Analysis

| Layer | Mechanism | File | Handles this case? | Why not? |
|-------|-----------|------|--------------------|----------|
| 1. Infrastructure finally block | `cleanup_orphaned_labels` in `_run_dispatch` | `fleet/_api.py:886-889` | Only fires on Python exception (CancelledError, RuntimeError) | Normal subprocess exit with FAILURE doesn't raise |
| 2. Startup sweep | `sweep_stale_dispatch_labels` | `fleet/_label_cleanup.py:91-149` | Only fires for `SessionType.FLEET` boot, not `ORCHESTRATOR` | `_lifespan.py:309` — only `_fleet_auto_gate_boot` is registered for FLEET |
| 3. Claim-time liveness check | `_try_claim_with_liveness` | `server/tools/_claim_helpers.py:56-104` | Skips dispatches with `labels_cleaned=True` | Trusts the `labels_cleaned` flag which may be lying (Gap 1) |
| 4. Outcome-driven cleanup | Post-classification `cleanup_orphaned_labels` | `fleet/_api.py:931-936` | Runs, but its success is not verified | Sets `_labels_cleaned=True` unconditionally after call |

Layer 4 is the primary cleanup path. When it fails silently, Layer 3 cannot detect the failure because the `labels_cleaned` flag lies. Layer 2 doesn't fire for orchestrator sessions. Layer 1 doesn't fire for normal subprocess exits. All four layers fail simultaneously.

## Affected Components

- `src/autoskillit/fleet/_api.py:931-936` — Sets `_labels_cleaned = True` unconditionally after `cleanup_orphaned_labels`, even if cleanup failed
- `src/autoskillit/fleet/_label_cleanup.py:39-88` — `cleanup_orphaned_labels` swallows GitHub API errors, provides no success/failure return value
- `src/autoskillit/fleet/state_recovery.py:311-314` — `find_dispatch_for_issue` trusts `labels_cleaned` flag and skips dispatches where it's `True`
- `src/autoskillit/server/tools/_claim_helpers.py:83-90` — `_try_claim_with_liveness` hard-blocks when `find_dispatch_for_issue` returns `None`
- `src/autoskillit/server/tools/tools_fleet_dispatch.py:185-219` — Campaign halt gate and `reset_blocking_dispatch` only fire when `campaign_state_path_str` is set
- `src/autoskillit/server/_lifespan.py:309` — Startup sweep only registered for `SessionType.FLEET`, not `ORCHESTRATOR`

## Recommendations

**R1: Make `labels_cleaned` truthful.** Have `cleanup_orphaned_labels` return a boolean indicating whether all `swap_labels` calls succeeded. Only set `_labels_cleaned = True` in `_api.py:936` when the return value confirms success. This makes Layer 3 (claim-time liveness) able to detect and recover from Layer 4 failures.

**R2: Add an orchestrator-level label cleanup tool.** A new MCP tool (e.g., `unclaim_issue` or a `force` parameter on `claim_issue`) to let the orchestrator clear stale labels before retrying. This gives the orchestrator a manual recovery path when all automatic layers fail.

**R3: Add `dispatch is None` fallback — check actual GitHub label state.** When `find_dispatch_for_issue` returns `None` but the label IS present, the claim guard could verify via the GitHub API whether any live session actually holds the label, rather than hard-blocking. This makes the claim guard self-healing for any label orphaning scenario, regardless of dispatch state file accuracy.

**R4: Register startup sweep for `ORCHESTRATOR` session type.** Add `sweep_stale_dispatch_labels` to `_food_truck_auto_gate_boot` (or register it for `ORCHESTRATOR` in `_LIFESPAN_BOOT_REGISTRY`). This would give orchestrator sessions the same startup recovery that fleet sessions have.

**R5: Add a `dispatch_food_truck` parameter for stale label cleanup.** A `cleanup_stale_labels: bool` or `force: bool` parameter that removes the `in-progress` label on the target issue before launching the L3 session. Single-call retry path for the orchestrator.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260522-120058-074597/.autoskillit/temp/rectify/rectify_optimistic_labels_cleaned_flag_2026-05-22_120500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 8.9k | 10.9k | 649.9k | 95.6k | 116 | 69.8k | 7m 42s |
| dry_walkthrough | claude-opus-4-6 | 1 | 1.4k | 22.7k | 1.3M | 81.0k | 89 | 67.6k | 8m 35s |
| implement | claude-opus-4-6 | 1 | 59 | 16.3k | 2.2M | 93.1k | 71 | 79.7k | 6m 58s |
| prepare_pr* | MiniMax-M2.7 | 1 | 52.2k | 4.9k | 219.2k | 0 | 18 | 0 | 43s |
| compose_pr* | MiniMax-M2.7 | 1 | 51.8k | 2.9k | 146.8k | 29.7k | 14 | 42.3k | 54s |
| review_pr | claude-opus-4-6 | 3 | 82 | 67.5k | 1.4M | 85.2k | 82 | 190.5k | 16m 20s |
| resolve_review | claude-opus-4-6 | 1 | 43 | 5.1k | 701.0k | 50.3k | 33 | 37.0k | 3m 19s |
| **Total** | | | 114.4k | 130.3k | 6.6M | 95.6k | | 486.8k | 44m 31s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 379 | 5751.7 | 210.3 | 43.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 18 | 38946.6 | 2053.4 | 283.9 |
| **Total** | **397** | 16528.4 | 1226.1 | 328.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 8.9k | 10.9k | 649.9k | 69.8k | 7m 42s |
| claude-opus-4-6 | 4 | 1.6k | 111.6k | 5.5M | 374.7k | 35m 12s |
| MiniMax-M2.7 | 2 | 104.0k | 7.9k | 366.0k | 42.3k | 1m 37s |