### PR TITLE
Import AGENT_BACKEND_CLAUDE_CODE and Wire _parse_stdout Dispatch

### DIFF
--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, assert_never
 
 from autoskillit.core import (
+    AGENT_BACKEND_CLAUDE_CODE,
     AgentSessionResult,
     ChannelConfirmation,
     CliSubtype,
@@ -128,6 +129,9 @@ def _resolve_skill_session_id(
 
 
 def _parse_stdout(stdout: str, backend: CodingAgentBackend | None = None) -> ClaudeSessionResult:
+    if backend is not None and backend.name != AGENT_BACKEND_CLAUDE_CODE:
+        agent_result = backend.result_parser().parse_stdout(stdout)
+        return _adapt_agent_result(agent_result)
     return parse_session_result(stdout)
 
 

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -129,10 +129,10 @@ def _resolve_skill_session_id(
 
 
 def _parse_stdout(stdout: str, backend: CodingAgentBackend | None = None) -> ClaudeSessionResult:
-    if backend is not None and backend.name != AGENT_BACKEND_CLAUDE_CODE:
-        agent_result = backend.result_parser().parse_stdout(stdout)
-        return _adapt_agent_result(agent_result)
-    return parse_session_result(stdout)
+    if backend is None or backend.name == AGENT_BACKEND_CLAUDE_CODE:
+        return parse_session_result(stdout)
+    agent_result = backend.result_parser().parse_stdout(stdout)
+    return _adapt_agent_result(agent_result)
 
 
 def _adapt_agent_result(agent_result: AgentSessionResult) -> ClaudeSessionResult:

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -457,7 +457,7 @@ class TestParseStdout:
 
         stdout = _success_session_json("test result")
         result = _parse_stdout(stdout, backend=mock_backend)
-        mock_backend.result_parser().parse_stdout.assert_called_once_with(stdout)
+        mock_backend.result_parser.return_value.parse_stdout.assert_called_once_with(stdout)
         assert isinstance(result, ClaudeSessionResult)
         assert result.result == "adapter output"
 
@@ -487,6 +487,7 @@ class TestParseStdout:
         result = _parse_stdout(stdout, backend=CodexBackend())
         spy.assert_called_once()
         assert isinstance(result, ClaudeSessionResult)
+        assert result.result is not None
 
 
 class TestStaleRecoveryWriteEvidence:

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -444,7 +444,8 @@ class TestParseStdout:
 
         mock_backend = Mock()
         mock_backend.name = "not-claude-code"
-        mock_backend.result_parser().parse_stdout.return_value = AgentSessionResult(
+        parser = mock_backend.result_parser.return_value
+        parser.parse_stdout.return_value = AgentSessionResult(
             success=True,
             exit_code=0,
             backend_name="not-claude-code",
@@ -486,6 +487,8 @@ class TestParseStdout:
         stdout = _success_session_json("test result")
         result = _parse_stdout(stdout, backend=CodexBackend())
         spy.assert_called_once()
+        (agent_result,), _ = spy.call_args
+        assert isinstance(agent_result, AgentSessionResult)
         assert isinstance(result, ClaudeSessionResult)
         assert result.result is not None
 

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -9,7 +9,14 @@ from unittest.mock import Mock
 import pytest
 import structlog.testing
 
-from autoskillit.core.types import KillReason, SubprocessResult, TerminationReason, WriteEvidence
+from autoskillit.core import AGENT_BACKEND_CLAUDE_CODE
+from autoskillit.core.types import (
+    AgentSessionResult,
+    KillReason,
+    SubprocessResult,
+    TerminationReason,
+    WriteEvidence,
+)
 from autoskillit.execution.headless import _build_skill_result
 from tests.execution.conftest import _make_tool_use_line, _sr, _success_session_json
 
@@ -220,6 +227,7 @@ class TestBackendDelegatedWriteToolNames:
         """Custom backend.write_tool_names() overrides the tool name set."""
 
         mock_backend = Mock()
+        mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
         mock_backend.write_tool_names.return_value = frozenset({"CustomWrite"})
         stdout = (
             _make_tool_use_line("CustomWrite", {"file_path": "/a/b.py", "content": "x"})
@@ -292,6 +300,7 @@ class TestBackendDelegatedWriteToolNames:
         monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
 
         mock_backend = Mock()
+        mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
         _build_skill_result(result, backend=mock_backend)
@@ -313,6 +322,7 @@ class TestBackendDelegatedWriteToolNames:
         monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
 
         mock_backend = Mock()
+        mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.STALE)
         _build_skill_result(result, backend=mock_backend)
@@ -334,6 +344,7 @@ class TestBackendDelegatedWriteToolNames:
         monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
 
         mock_backend = Mock()
+        mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.IDLE_STALL)
         _build_skill_result(result, backend=mock_backend)
@@ -355,6 +366,7 @@ class TestBackendDelegatedWriteToolNames:
         monkeypatch.setattr(_headless_result, "_parse_stdout", spy)
 
         mock_backend = Mock()
+        mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.TIMED_OUT)
         _build_skill_result(result, backend=mock_backend)
@@ -392,6 +404,7 @@ class TestParseStdout:
         from autoskillit.execution.session import ClaudeSessionResult
 
         mock_backend = Mock()
+        mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
         stdout = _success_session_json("test result")
         result = _parse_stdout(stdout, backend=mock_backend)
         assert isinstance(result, ClaudeSessionResult)
@@ -403,12 +416,77 @@ class TestParseStdout:
         from autoskillit.execution.headless import _parse_stdout
 
         mock_backend = Mock()
+        mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
         stdout = _success_session_json("test result")
         with_backend = _parse_stdout(stdout, backend=mock_backend)
         without_backend = _parse_stdout(stdout)
         assert with_backend.result == without_backend.result
         assert with_backend.session_id == without_backend.session_id
         assert with_backend.session_complete == without_backend.session_complete
+
+    def test_parse_stdout_claude_code_backend_falls_through(self):
+        """ClaudeCodeBackend backend falls through to parse_session_result."""
+        from autoskillit.execution.backends.claude import ClaudeCodeBackend
+        from autoskillit.execution.headless import _parse_stdout
+        from autoskillit.execution.session import parse_session_result
+
+        stdout = _success_session_json("test result")
+        result = _parse_stdout(stdout, backend=ClaudeCodeBackend())
+        expected = parse_session_result(stdout)
+        assert result.result == expected.result
+        assert result.session_id == expected.session_id
+        assert result.session_complete == expected.session_complete
+
+    def test_parse_stdout_non_claude_backend_dispatches_through_result_parser(self):
+        """Non-Claude backend dispatches through result_parser().parse_stdout()."""
+        from autoskillit.execution.headless import _parse_stdout
+        from autoskillit.execution.session import ClaudeSessionResult
+
+        mock_backend = Mock()
+        mock_backend.name = "not-claude-code"
+        mock_backend.result_parser().parse_stdout.return_value = AgentSessionResult(
+            success=True,
+            exit_code=0,
+            backend_name="not-claude-code",
+            elapsed_seconds=0.0,
+            session_id="s1",
+            output="adapter output",
+            error="",
+            raw={"subtype": "success", "is_error": False, "stop_reasons": []},
+        )
+
+        stdout = _success_session_json("test result")
+        result = _parse_stdout(stdout, backend=mock_backend)
+        mock_backend.result_parser().parse_stdout.assert_called_once_with(stdout)
+        assert isinstance(result, ClaudeSessionResult)
+        assert result.result == "adapter output"
+
+    def test_parse_stdout_backend_none_unchanged(self):
+        """_parse_stdout with backend=None matches parse_session_result (regression guard)."""
+        from autoskillit.execution.headless import _parse_stdout
+        from autoskillit.execution.session import parse_session_result
+
+        stdout = _success_session_json("test result")
+        result = _parse_stdout(stdout, backend=None)
+        expected = parse_session_result(stdout)
+        assert result.result == expected.result
+        assert result.session_id == expected.session_id
+        assert result.session_complete == expected.session_complete
+
+    def test_parse_stdout_codex_backend_dispatches_through_adapter(self, monkeypatch):
+        """CodexBackend dispatches through _adapt_agent_result (non-Claude path)."""
+        from autoskillit.execution.backends.codex import CodexBackend
+        from autoskillit.execution.headless import _headless_result
+        from autoskillit.execution.headless._headless_result import _parse_stdout
+        from autoskillit.execution.session import ClaudeSessionResult
+
+        spy = Mock(wraps=_headless_result._adapt_agent_result)
+        monkeypatch.setattr(_headless_result, "_adapt_agent_result", spy)
+
+        stdout = _success_session_json("test result")
+        result = _parse_stdout(stdout, backend=CodexBackend())
+        spy.assert_called_once()
+        assert isinstance(result, ClaudeSessionResult)
 
 
 class TestStaleRecoveryWriteEvidence:


### PR DESCRIPTION
## Summary

Wire `AGENT_BACKEND_CLAUDE_CODE` into `_parse_stdout` via a two-branch dispatch: non-Claude-Code backends route through `backend.result_parser().parse_stdout()` + `_adapt_agent_result()`; Claude-Code backends and `backend=None` fall through to `parse_session_result(stdout)`. This avoids the lossy round-trip that would silently drop assistant messages, tool uses, and parsed thinking/block data when a Claude-Code backend goes through `result_parser` + `_adapt_agent_result`.

## Requirements

- AGENT_BACKEND_CLAUDE_CODE added to the `from autoskillit.core import (...)` block in _headless_result.py
- Two-branch _parse_stdout body: non-claude-code backend dispatches through result_parser + adapter; else falls through to parse_session_result
- Called with backend=None returns parse_session_result(stdout)
- Called with ClaudeCodeBackend (name='claude-code') returns parse_session_result(stdout)
- Called with CodexBackend (name='codex') calls result_parser().parse_stdout() and _adapt_agent_result()
- Function signature unchanged
- Four call sites require zero modifications
- All existing unit tests continue to pass

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-125712-247467/.autoskillit/temp/make-plan/import_agent_backend_claude_code_plan_2026-05-22_130300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 5.9k | 17.5k | 983.5k | 86.8k | 152 | 78.8k | 10m 13s |
| verify | claude-sonnet-4-6 | 1 | 36 | 7.8k | 446.3k | 73.3k | 84 | 59.7k | 5m 34s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 9.7k | 1.1M | 29.6k | 92 | 45.0k | 6m 52s |
| prepare_pr* | MiniMax-M2.7 | 1 | 52.9k | 4.4k | 462.1k | 0 | 28 | 0 | 36s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.0k | 1.4k | 350.9k | 0 | 20 | 0 | 27s |
| review_pr | claude-sonnet-4-6 | 2 | 330 | 44.3k | 1.7M | 70.9k | 108 | 105.3k | 10m 56s |
| resolve_review | claude-sonnet-4-6 | 2 | 540 | 38.5k | 3.6M | 85.9k | 169 | 133.4k | 17m 33s |
| diagnose_ci* | MiniMax-M2.7 | 2 | 307.9k | 16.1k | 2.8M | 29.8k | 173 | 72.0k | 26m 19s |
| resolve_ci | claude-opus-4-6 | 2 | 70 | 5.7k | 469.2k | 40.9k | 41 | 80.0k | 7m 47s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 25 | 2.1k | 205.3k | 35.5k | 17 | 20.6k | 45s |
| **Total** | | | 1.6M | 147.4k | 12.1M | 86.8k | | 594.8k | 1h 27m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 84 | 13019.0 | 535.6 | 115.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 225312.8 | 8337.8 | 2404.9 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 0 | — | — | — |
| ci_conflict_fix | 96 | 2138.6 | 214.6 | 21.9 |
| **Total** | **196** | 61772.5 | 3034.7 | 752.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 6.8k | 108.1k | 6.7M | 377.2k | 44m 18s |
| MiniMax-M2.7-highspeed | 1 | 1.2M | 9.7k | 1.1M | 45.0k | 6m 52s |
| MiniMax-M2.7 | 3 | 399.8k | 21.9k | 3.6M | 72.0k | 27m 22s |
| claude-opus-4-6 | 2 | 95 | 7.8k | 674.5k | 100.6k | 8m 32s |