### PR TITLE
Delete ClaudeHeadlessCmd dataclass, replace with CmdSpec type alias

### DIFF
--- a/docs/audit/surface-freeze-checklist.md
+++ b/docs/audit/surface-freeze-checklist.md
@@ -33,7 +33,7 @@
 | # | Name | Fields | In `__init__.__all__`? | Production Importers | Test Importers |
 |---|------|--------|------------------------|---------------------|----------------|
 | 1 | `ClaudeInteractiveCmd` | `cmd: list[str]`, `env: Mapping[str, str]` | YES | `execution/__init__.py` | `test_commands.py` |
-| 2 | `ClaudeHeadlessCmd` | `cmd: list[str]`, `env: Mapping[str, str]` | YES | `execution/__init__.py`, `headless/__init__.py` (TYPE_CHECKING) | `test_commands.py`, `test_headless_provider_fallback.py` (4 deferred), `test_headless_provider_forwarding.py` (5 deferred), `test_idle_output_env.py`, `test_flush_provider_integration.py` (4 deferred), `test_process_env_boundary.py` |
+| 2 | `ClaudeHeadlessCmd` | Type alias for `CmdSpec` (`cmd: tuple[str, ...]`, `env: Mapping[str, str]`, `cwd: str`) | YES | `execution/__init__.py`, `headless/__init__.py` (TYPE_CHECKING) | `test_commands.py`, `test_headless_provider_fallback.py` (4 deferred), `test_headless_provider_forwarding.py` (5 deferred), `test_idle_output_env.py`, `test_flush_provider_integration.py` (4 deferred), `test_process_env_boundary.py` |
 
 ### 1c. Constants (3) — MUST PRESERVE
 
@@ -48,10 +48,11 @@
 - `AUTOSKILLIT_PRIVATE_ENV_VARS` in `core/types/_type_constants.py`
 - See block comment at `commands.py:163-171`: "All lists must be kept in sync when adding new exclusive variables."
 
-### 1d. Re-exported Type (via `# noqa: F401, TC001`)
+### 1d. Re-exported Types (via `# noqa: F401, TC001`)
 
 | Name | Source | Purpose |
 |------|--------|---------|
+| `CmdSpec` | `autoskillit.core` | Canonical command spec; `ClaudeHeadlessCmd` is a type alias for this |
 | `SessionCheckpoint` | `autoskillit.core` | Dual purpose: (1) re-export for downstream, (2) runtime dependency — `_build_resume_context` accesses `checkpoint.completed_items` and `checkpoint.step_name`. TC001 suppresses ruff's `TYPE_CHECKING` suggestion which would break runtime usage. |
 
 ---

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -5,7 +5,7 @@ All sub-modules depend only on autoskillit.core.* at runtime;
 execution/headless.py has TYPE_CHECKING-only references to pipeline/.
 """
 
-from autoskillit.core import SkillResult
+from autoskillit.core import CmdSpec, SkillResult
 from autoskillit.execution._recording_skills import (
     restore_skill_snapshot,
     scan_skill_snapshots,
@@ -130,6 +130,7 @@ __all__ = [
     "kill_process_tree",
     "async_kill_process_tree",
     # commands
+    "CmdSpec",
     "ClaudeInteractiveCmd",
     "ClaudeHeadlessCmd",
     "build_interactive_cmd",

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from autoskillit.core import (
+    CmdSpec,
     NoResume,
     OutputFormat,
     PluginSource,
@@ -44,17 +45,7 @@ class ClaudeInteractiveCmd:
     env: Mapping[str, str] = field(default_factory=dict)
 
 
-@dataclass(frozen=True, slots=True)
-class ClaudeHeadlessCmd:
-    """Resolved argv + env for a claude headless subprocess.
-
-    ``env`` is the fully resolved environment returned by
-    :func:`build_agent_env`, including any headless-only extras such as
-    ``AUTOSKILLIT_HEADLESS=1``. Pass directly to the subprocess runner.
-    """
-
-    cmd: list[str]
-    env: Mapping[str, str] = field(default_factory=dict)
+ClaudeHeadlessCmd = CmdSpec
 
 
 def build_interactive_cmd(
@@ -86,7 +77,7 @@ def build_headless_cmd(
     model: str | None = None,
     env_extras: Mapping[str, str] | None = None,
     base: Mapping[str, str] | None = None,
-) -> ClaudeHeadlessCmd:
+) -> CmdSpec:
     """Build a Claude headless session command for skill execution."""
     spec = ClaudeCodeBackend().build_headless_cmd(
         prompt,
@@ -94,7 +85,7 @@ def build_headless_cmd(
         env_extras=env_extras,
         base=base,
     )
-    return ClaudeHeadlessCmd(cmd=list(spec.cmd), env=spec.env)
+    return spec
 
 
 def build_headless_resume_cmd(
@@ -104,7 +95,7 @@ def build_headless_resume_cmd(
     output_format: OutputFormat = OutputFormat.JSON,
     plugin_source: PluginSource | None = None,
     env_extras: Mapping[str, str] | None = None,
-) -> ClaudeHeadlessCmd:
+) -> CmdSpec:
     """Build a headless resume command for contract recovery nudge."""
     spec = ClaudeCodeBackend().build_resume_cmd(
         resume_session_id=resume_session_id,
@@ -113,7 +104,7 @@ def build_headless_resume_cmd(
         plugin_source=plugin_source,
         env_extras=env_extras,
     )
-    return ClaudeHeadlessCmd(cmd=list(spec.cmd), env=spec.env)
+    return spec
 
 
 def build_skill_session_cmd(
@@ -135,7 +126,7 @@ def build_skill_session_cmd(
     resume_session_id: str = "",
     resume_checkpoint: SessionCheckpoint | None = None,
     resume_message: str | None = None,
-) -> ClaudeHeadlessCmd:
+) -> CmdSpec:
     """Build the complete headless command spec for a skill session."""
     spec = ClaudeCodeBackend().build_skill_session_cmd(
         skill_command,
@@ -156,7 +147,7 @@ def build_skill_session_cmd(
         resume_checkpoint=resume_checkpoint,
         resume_message=resume_message,
     )
-    return ClaudeHeadlessCmd(cmd=list(spec.cmd), env=spec.env)
+    return spec
 
 
 def build_food_truck_cmd(
@@ -177,7 +168,7 @@ def build_food_truck_cmd(
     allowed_write_prefix: str = "",
     sentinel_contract: str = "",
     resume_message: str | None = None,
-) -> ClaudeHeadlessCmd:
+) -> CmdSpec:
     """Build the complete headless command spec for an L2 food truck session."""
     spec = ClaudeCodeBackend().build_food_truck_cmd(
         orchestrator_prompt=orchestrator_prompt,
@@ -197,4 +188,4 @@ def build_food_truck_cmd(
         sentinel_contract=sentinel_contract,
         resume_message=resume_message,
     )
-    return ClaudeHeadlessCmd(cmd=list(spec.cmd), env=spec.env)
+    return spec

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -26,7 +26,6 @@ from autoskillit.core import (
     CAMPAIGN_ID_ENV_VAR,
     DISPATCH_ID_ENV_VAR,
     FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
-    CmdSpec,
     KillReason,
     ProviderOutcome,
     RecipeIdentity,
@@ -107,10 +106,6 @@ __all__ = [
 ]
 
 logger = get_logger(__name__)
-
-
-def _cmd_spec_to_headless(cmd_spec: CmdSpec) -> ClaudeHeadlessCmd:
-    return cmd_spec
 
 
 def _session_log_dir(cwd: str) -> Path:
@@ -727,7 +722,7 @@ async def run_headless_core(
             resume_checkpoint=resume_checkpoint,
             resume_message=resume_message,
         )
-        spec = _cmd_spec_to_headless(cmd_spec)
+        spec = cmd_spec
 
         effective_timeout = timeout if timeout is not None else cfg.timeout
         effective_stale = stale_threshold if stale_threshold is not None else cfg.stale_threshold
@@ -919,7 +914,7 @@ class DefaultHeadlessExecutor:
             sentinel_contract=sentinel_contract,
             resume_message=resume_message,
         )
-        spec = _cmd_spec_to_headless(cmd_spec)
+        spec = cmd_spec
 
         effective_timeout = timeout if timeout is not None else fleet_cfg.default_timeout_sec
         effective_stale = (

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -110,7 +110,7 @@ logger = get_logger(__name__)
 
 
 def _cmd_spec_to_headless(cmd_spec: CmdSpec) -> ClaudeHeadlessCmd:
-    return ClaudeHeadlessCmd(cmd=list(cmd_spec.cmd), env=cmd_spec.env)
+    return cmd_spec
 
 
 def _session_log_dir(cwd: str) -> Path:
@@ -332,7 +332,7 @@ async def _execute_claude_headless(
     while True:
         try:
             _result = await runner(
-                spec.cmd,
+                list(spec.cmd),
                 cwd=Path(cwd),
                 timeout=timeout,
                 env=spec.env,

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -1182,9 +1182,9 @@ def test_headless_builders_return_tuple_cmd(builder, kwargs) -> None:
 
 def test_cmdspec_importable_from_execution() -> None:
     """CmdSpec must be importable from the execution package gateway."""
-    from autoskillit.execution import CmdSpec
+    from autoskillit.execution import CmdSpec as execution_CmdSpec
 
-    assert CmdSpec is not None
+    assert execution_CmdSpec is CmdSpec
 
 
 def test_cmdspec_in_execution_all() -> None:

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -9,6 +9,7 @@ import pytest
 from autoskillit.core import (
     BareResume,
     ClaudeFlags,
+    CmdSpec,
     DirectInstall,
     MarketplaceInstall,
     NamedResume,
@@ -1157,3 +1158,37 @@ class TestCompletionReminderPositionInvariant:
             f"[{builder}] Completion marker must appear in the last two prompt blocks. "
             f"Last block: {blocks[-1][:100]!r}"
         )
+
+
+def test_headless_cmd_is_cmdspec_alias() -> None:
+    """ClaudeHeadlessCmd must be a type alias for CmdSpec, not a separate class."""
+    from autoskillit.execution.commands import ClaudeHeadlessCmd
+
+    assert ClaudeHeadlessCmd is CmdSpec
+
+
+@pytest.mark.parametrize(
+    "builder,kwargs",
+    [
+        (build_headless_cmd, {"prompt": "go"}),
+        (build_headless_resume_cmd, {"resume_session_id": "abc", "prompt": "go"}),
+    ],
+)
+def test_headless_builders_return_tuple_cmd(builder, kwargs) -> None:
+    """Builder return values must have cmd as tuple, not list."""
+    result = builder(**kwargs)
+    assert isinstance(result.cmd, tuple)
+
+
+def test_cmdspec_importable_from_execution() -> None:
+    """CmdSpec must be importable from the execution package gateway."""
+    from autoskillit.execution import CmdSpec
+
+    assert CmdSpec is not None
+
+
+def test_cmdspec_in_execution_all() -> None:
+    """CmdSpec must appear in execution.__all__."""
+    import autoskillit.execution as m
+
+    assert "CmdSpec" in m.__all__


### PR DESCRIPTION
## Summary

Remove the `ClaudeHeadlessCmd` `@dataclass(frozen=True, slots=True)` definition from `src/autoskillit/execution/commands.py` (lines 47-57) and replace it with a `ClaudeHeadlessCmd = CmdSpec` type alias. Update all four headless builder functions to return `CmdSpec` directly (eliminating the `list(spec.cmd)` conversion). Add `CmdSpec` to `execution/__init__.py` imports and `__all__`. Update the surface-freeze-checklist.

Key structural change: `CmdSpec.cmd` is `tuple[str, ...]` while the old `ClaudeHeadlessCmd.cmd` was `list[str]`. The four builder functions return objects with `cmd` as `tuple` instead of `list`. The `tuple → list` conversion for `SubprocessRunner` moves to the runner call site in `_execute_claude_headless`. `_cmd_spec_to_headless` becomes an identity function.

## Requirements

## Goal

Delete the ClaudeHeadlessCmd @dataclass definition (lines 47-57) and replace it with ClaudeHeadlessCmd = CmdSpec type alias plus deprecation comment. Add import of CmdSpec from autoskillit.core.

## Context

- Phase: Protocol & Type System Alignment (Milestone: 2-protocol-type-system-alignment)
- Assignment: P2-A8 (Generalize ClaudeHeadlessCmd to CmdSpec at commands.py public function boundary)

## Deliverables

- `commands.py: ClaudeHeadlessCmd @dataclass removed, replaced with ClaudeHeadlessCmd = CmdSpec type alias`
- `commands.py: CmdSpec added to from autoskillit.core import block`
- `All four builder functions return CmdSpec directly (no ClaudeHeadlessCmd wrapping)`
- `Return type annotations changed from ClaudeHeadlessCmd to CmdSpec`
- `No list(spec.cmd) conversion anywhere in return paths`
- `CmdSpec added to imports in execution/__init__.py`
- `CmdSpec added to __all__ in execution/__init__.py`
- `ClaudeHeadlessCmd re-export verified preserved`
- `surface-freeze-checklist.md updated`

## Acceptance Criteria

- ClaudeHeadlessCmd remains importable from autoskillit.execution.commands and autoskillit.execution
- ClaudeHeadlessCmd is CmdSpec evaluates to True
- dataclass and field imports retained for ClaudeInteractiveCmd
- execution/__init__.py re-export works unchanged
- CmdSpec is imported from autoskillit.core
- All four functions declare return type CmdSpec
- No ClaudeHeadlessCmd construction in return statements
- Each function returns spec directly
- No list(spec.cmd) conversion appears
- Existing callers in headless/__init__.py work correctly with tuple[str, ...]
- mypy/pyright passes on commands.py
- from autoskillit.execution import CmdSpec succeeds
- from autoskillit.execution import ClaudeHeadlessCmd still succeeds
- 'CmdSpec' appears in execution.__all__
- 'ClaudeHeadlessCmd' still appears in execution.__all__
- No existing test imports broken

Closes #2678

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-125712-724740/.autoskillit/temp/make-plan/delete_claudeheadlesscmd_dataclass_plan_2026-05-22_131500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 86 | 22.4k | 2.0M | 101.6k | 334 | 92.5k | 18m 47s |
| verify | claude-opus-4-6 | 1 | 46 | 29.8k | 1.6M | 115.2k | 147 | 106.7k | 12m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 945.6k | 7.3k | 897.1k | 70.2k | 73 | 56.6k | 6m 8s |
| prepare_pr* | MiniMax-M2.7 | 1 | 59.4k | 3.0k | 242.4k | 0 | 19 | 29.7k | 57s |
| compose_pr* | MiniMax-M2.7 | 1 | 87.9k | 1.9k | 218.2k | 26.7k | 18 | 2.9k | 53s |
| review_pr | claude-sonnet-4-6 | 2 | 176 | 51.8k | 869.1k | 70.4k | 70 | 109.2k | 10m 36s |
| resolve_review | claude-sonnet-4-6 | 1 | 289 | 15.7k | 2.0M | 72.6k | 100 | 59.4k | 9m 21s |
| **Total** | | | 1.1M | 131.9k | 7.9M | 115.2k | | 457.0k | 59m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 76 | 11804.6 | 744.6 | 95.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 153925.3 | 4567.5 | 1211.3 |
| **Total** | **89** | 88330.7 | 5134.3 | 1481.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 551 | 89.9k | 4.9M | 261.1k | 38m 45s |
| claude-opus-4-6 | 1 | 46 | 29.8k | 1.6M | 106.7k | 12m 54s |
| MiniMax-M2.7-highspeed | 1 | 945.6k | 7.3k | 897.1k | 56.6k | 6m 8s |
| MiniMax-M2.7 | 2 | 147.4k | 4.9k | 460.5k | 32.6k | 1m 49s |