### PR TITLE
Replace ClaudeHeadlessCmd TYPE_CHECKING import with CmdSpec

### DIFF
--- a/docs/audit/surface-freeze-checklist.md
+++ b/docs/audit/surface-freeze-checklist.md
@@ -111,7 +111,7 @@ autoskillit.core
   │
   ├── execution/headless/__init__.py
   │     Line 50: build_food_truck_cmd, build_skill_session_cmd
-  │     Line 99: ClaudeHeadlessCmd (TYPE_CHECKING)
+  │     Line 96: CmdSpec (TYPE_CHECKING)
   │
   └── execution/backends/claude.py
         Deferred imports:

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -48,7 +48,6 @@ from autoskillit.execution.clone_guard import (
     is_worktree_skill,
     snapshot_clone_state,
 )
-from autoskillit.execution.commands import ClaudeHeadlessCmd
 from autoskillit.execution.headless._headless_git import (
     _capture_git_head_sha,
     _compute_loc_changed,
@@ -94,7 +93,7 @@ if TYPE_CHECKING:
     from autoskillit.config import (
         AutomationConfig,
     )
-    from autoskillit.core import SubprocessResult
+    from autoskillit.core import CmdSpec, SubprocessResult
     from autoskillit.pipeline.context import (
         ToolContext,
     )
@@ -208,7 +207,7 @@ def _compute_post_session_metrics(
 
 
 async def _execute_claude_headless(
-    spec: ClaudeHeadlessCmd,
+    spec: CmdSpec,
     cwd: str,
     ctx: ToolContext,
     *,
@@ -246,7 +245,7 @@ async def _execute_claude_headless(
 ) -> SkillResult:
     """Shared subprocess execution for headless Claude sessions.
 
-    Accepts an already-built ClaudeHeadlessCmd and handles runner invocation,
+    Accepts an already-built CmdSpec and handles runner invocation,
     exception handling, _build_skill_result, and session log flushing.
     Used by both run_headless_core (leaf path) and
     DefaultHeadlessExecutor.dispatch_food_truck (food truck path).

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -499,7 +499,7 @@ _CLAUDE_ENV_RULE_ALLOWED: frozenset[tuple[str, str]] = frozenset(
         # marketplace registration + install: `claude plugin marketplace add` /
         # `claude plugin install`. Administrative ops invoked once during setup.
         ("_marketplace.py", "install"),
-        # run_headless_core and dispatch_food_truck pass `spec` (ClaudeHeadlessCmd)
+        # run_headless_core and dispatch_food_truck pass `spec` (CmdSpec)
         # to _execute_claude_headless, which internally uses `spec.env` at the
         # runner call site. The checker incorrectly treats _execute_claude_headless(spec, ...)
         # as a direct subprocess call because `spec` resolves to a builder return value.


### PR DESCRIPTION
## Summary

Replace the runtime import of `ClaudeHeadlessCmd` (a type alias for `CmdSpec` defined in `execution/commands.py:48`) in `src/autoskillit/execution/headless/__init__.py` with a `TYPE_CHECKING`-guarded import of `CmdSpec` from `autoskillit.core`. Update the type annotation on `_execute_claude_headless` and its docstring. Since `from __future__ import annotations` is active (line 11), all annotations are lazy strings — `CmdSpec` only needs to resolve at type-check time, not runtime. Update two stale documentation references identified by adversarial review.

## Requirements

## Goal

Replace the TYPE_CHECKING import of ClaudeHeadlessCmd with CmdSpec from autoskillit.core in headless/__init__.py.

## Context

- Phase: Protocol & Type System Alignment (Milestone: 2-protocol-type-system-alignment)
- Assignment: P2-A9 (Update headless/__init__.py type annotations from ClaudeHeadlessCmd to CmdSpec)
- Depends on: P2-A8-WP1
- Depended on by: P3-A3-WP1

## Deliverables

- `TYPE_CHECKING block updated: ClaudeHeadlessCmd import removed, CmdSpec added to autoskillit.core import`
- `Line 213: spec: CmdSpec instead of spec: ClaudeHeadlessCmd`
- `Line 251: docstring references CmdSpec instead of ClaudeHeadlessCmd`

## Acceptance Criteria

- ClaudeHeadlessCmd import line deleted from TYPE_CHECKING block
- CmdSpec appears in the autoskillit.core TYPE_CHECKING import alongside SubprocessResult
- File passes static import check
- Existing runtime imports in lines 50-53 untouched
- _execute_claude_headless annotates spec as CmdSpec
- Docstring references CmdSpec
- No function body changes
- All existing tests pass without modification

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

**Modified:**
- `docs/audit/surface-freeze-checklist.md`
- `src/autoskillit/execution/headless/__init__.py`
- `tests/cli/test_subprocess_env_contracts.py`

Closes #2679

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-154037-593771/.autoskillit/temp/make-plan/replace_claudeheadlesscmd_with_cmdspec_plan_2026-05-22_155500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.6k | 10.3k | 801.4k | 68.3k | 171 | 46.1k | 9m 52s |
| verify | claude-opus-4-6 | 1 | 46 | 7.5k | 815.7k | 54.8k | 63 | 39.6k | 3m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 259.3k | 2.6k | 443.4k | 29.8k | 31 | 15.5k | 1m 16s |
| prepare_pr* | MiniMax-M2.7 | 1 | 41.5k | 3.2k | 349.5k | 26.9k | 24 | 8.3k | 56s |
| compose_pr* | MiniMax-M2.7 | 1 | 41.9k | 1.9k | 271.2k | 0 | 18 | 0 | 32s |
| review_pr | claude-sonnet-4-6 | 3 | 246 | 30.3k | 871.5k | 46.7k | 84 | 118.1k | 7m 46s |
| **Total** | | | 346.6k | 55.8k | 3.6M | 68.3k | | 227.6k | 24m 16s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 11 | 40313.6 | 1410.7 | 238.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **11** | 322982.9 | 20690.5 | 5069.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 3.9k | 40.6k | 1.7M | 164.1k | 17m 38s |
| claude-opus-4-6 | 1 | 46 | 7.5k | 815.7k | 39.6k | 3m 54s |
| MiniMax-M2.7-highspeed | 1 | 259.3k | 2.6k | 443.4k | 15.5k | 1m 16s |
| MiniMax-M2.7 | 2 | 83.3k | 5.1k | 620.8k | 8.3k | 1m 27s |