### PR TITLE
Configure build_skill_session_cmd Return Value and Relax Shim Contract AST Assertion

### DIFF
--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -499,7 +499,7 @@ _CLAUDE_ENV_RULE_ALLOWED: frozenset[tuple[str, str]] = frozenset(
         # marketplace registration + install: `claude plugin marketplace add` /
         # `claude plugin install`. Administrative ops invoked once during setup.
         ("_marketplace.py", "install"),
-        # run_headless_core and dispatch_food_truck pass `spec` (ClaudeHeadlessCmd)
+        # run_headless_core and dispatch_food_truck pass `spec` (CmdSpec)
         # to _execute_claude_headless, which internally uses `spec.env` at the
         # runner call site. The checker incorrectly treats _execute_claude_headless(spec, ...)
         # as a direct subprocess call because `spec` resolves to a builder return value.

--- a/tests/execution/test_commands_shim_contract.py
+++ b/tests/execution/test_commands_shim_contract.py
@@ -32,9 +32,13 @@ class TestCommandsShimContract:
         ]
         assert len(body_stmts) <= 3, f"{name} has {len(body_stmts)} body statements, expected <= 3"
 
+    # Names that indicate backend-dispatch: the builder resolves its backend
+    # via ctx.backend or get_backend() instead of instantiating ClaudeCodeBackend directly.
+    _BACKEND_DISPATCH_NAMES: frozenset[str] = frozenset({"backend", "ctx", "get_backend"})
+
     @pytest.mark.parametrize("name", BUILDERS)
     def test_builder_delegates_to_backend(self, name: str):
-        """Each builder body must reference ClaudeCodeBackend."""
+        """Each builder body must reference ClaudeCodeBackend or use backend dispatch."""
         source = inspect.getsource(getattr(commands, name))
         tree = ast.parse(source)
         func = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == name)
@@ -43,4 +47,8 @@ class TestCommandsShimContract:
             for node in ast.walk(func)
             if isinstance(node, (ast.Name, ast.Attribute))
         }
-        assert "ClaudeCodeBackend" in ast_names, f"{name} does not delegate to ClaudeCodeBackend"
+        # Direct ClaudeCodeBackend() instantiation OR backend-dispatch (ctx.backend,
+        # get_backend()) are both valid delegation patterns.
+        assert "ClaudeCodeBackend" in ast_names or ast_names & self._BACKEND_DISPATCH_NAMES, (
+            f"{name} does not delegate to ClaudeCodeBackend or use backend dispatch"
+        )


### PR DESCRIPTION
Three targeted test-infrastructure changes to support the P2 backend-dispatch migration:

1. **Verify** `build_skill_session_cmd.return_value` is configured on `_mock_backend` fixture (already done in prior work — no change needed).
2. **Update comment** in `tests/cli/test_subprocess_env_contracts.py` line 502 replacing `ClaudeHeadlessCmd` with `CmdSpec` to reflect the type alias change.
3. **Relax assertion** in `tests/execution/test_commands_shim_contract.py::test_builder_delegates_to_backend` to accept both direct `ClaudeCodeBackend()` instantiation and backend-dispatch patterns (`backend`, `ctx`, `get_backend`), with an inline comment explaining why both are valid.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-154037-019054/.autoskillit/temp/make-plan/configure_build_skill_session_cmd_plan_2026-05-22_154500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 75 | 12.5k | 1.0M | 75.8k | 173 | 61.0k | 10m 36s |
| verify | claude-opus-4-6 | 1 | 42 | 7.4k | 671.7k | 56.1k | 33 | 40.9k | 3m 46s |
| implement* | MiniMax-M2.7-highspeed | 1 | 76.0k | 1.9k | 235.1k | 29.8k | 18 | 15.5k | 55s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.0k | 2.9k | 230.4k | 26.9k | 18 | 8.3k | 1m 4s |
| compose_pr* | MiniMax-M2.7 | 1 | 40.9k | 1.6k | 280.9k | 0 | 20 | 0 | 36s |
| review_pr | claude-sonnet-4-6 | 3 | 342 | 26.7k | 1.3M | 46.7k | 97 | 113.3k | 8m 17s |
| **Total** | | | 159.3k | 53.0k | 3.8M | 75.8k | | 239.1k | 25m 14s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 14 | 16795.5 | 1106.4 | 136.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **14** | 269592.9 | 17075.3 | 3783.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 417 | 39.2k | 2.4M | 174.4k | 18m 53s |
| claude-opus-4-6 | 1 | 42 | 7.4k | 671.7k | 40.9k | 3m 46s |
| MiniMax-M2.7-highspeed | 1 | 76.0k | 1.9k | 235.1k | 15.5k | 55s |
| MiniMax-M2.7 | 2 | 82.9k | 4.4k | 511.3k | 8.3k | 1m 39s |