### PR TITLE
[FEATURE] Verify ClaudeHeadlessCmd isinstance Assertions and Convert cmd=[] to cmd=() Tuples

### DIFF
--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -1,4 +1,4 @@
-"""Tests for execution/commands.py — ClaudeInteractiveCmd / ClaudeHeadlessCmd builders."""
+"""Tests for execution/commands.py — CmdSpec / ClaudeHeadlessCmd alias builders."""
 
 from __future__ import annotations
 

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -74,7 +74,7 @@ class TestProviderFieldsReachFlush:
         minimal_ctx.runner = fake_runner  # type: ignore[assignment]
 
         await _execute_claude_headless(
-            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
             str(tmp_path),
             minimal_ctx,
             timeout=30.0,
@@ -149,7 +149,7 @@ class TestProviderFieldsReachFlush:
         minimal_ctx.runner = fake_runner  # type: ignore[assignment]
 
         result = await _execute_claude_headless(
-            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
             str(tmp_path),
             minimal_ctx,
             timeout=30.0,
@@ -192,7 +192,7 @@ class TestProviderFieldsReachFlush:
         minimal_ctx.runner = raising_runner  # type: ignore[assignment]
 
         result = await _execute_claude_headless(
-            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
             str(tmp_path),
             minimal_ctx,
             timeout=30.0,
@@ -234,7 +234,7 @@ class TestProviderFieldsReachFlush:
 
         with pytest.raises(anyio.get_cancelled_exc_class()):
             await _execute_claude_headless(
-                ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+                ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
                 str(tmp_path),
                 minimal_ctx,
                 timeout=30.0,

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -118,7 +118,7 @@ class TestProviderFallbackLoop:
         minimal_ctx.runner = fake_runner
 
         result = await _execute_claude_headless(
-            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
             str(tmp_path),
             minimal_ctx,
             timeout=30.0,
@@ -146,7 +146,7 @@ class TestProviderFallbackLoop:
         minimal_ctx.runner = fake_runner
 
         result = await _execute_claude_headless(
-            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
             str(tmp_path),
             minimal_ctx,
             timeout=30.0,
@@ -173,7 +173,7 @@ class TestProviderFallbackLoop:
         minimal_ctx.runner = fake_runner
 
         result = await _execute_claude_headless(
-            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
             str(tmp_path),
             minimal_ctx,
             timeout=30.0,
@@ -198,7 +198,7 @@ class TestProviderFallbackLoop:
         minimal_ctx.runner = fake_runner
 
         result = await _execute_claude_headless(
-            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
             str(tmp_path),
             minimal_ctx,
             timeout=30.0,

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -232,7 +232,7 @@ async def test_no_fallback_env_returns_empty_provider_used(
     from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
     from tests.execution.conftest import _sr
 
-    _spec = ClaudeHeadlessCmd(cmd=["echo", "test"], env={})
+    _spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
     _sub_result = _sr()
 
     async def fake_runner(cmd, **kwargs):  # noqa: ARG001
@@ -273,7 +273,7 @@ async def test_provider_name_stamps_provider_used_on_result(
     from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
     from tests.execution.conftest import _sr
 
-    _spec = ClaudeHeadlessCmd(cmd=["echo", "test"], env={})
+    _spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
     _sub_result = _sr()
 
     async def fake_runner(cmd, **kwargs):  # noqa: ARG001
@@ -527,7 +527,7 @@ async def test_execute_claude_headless_forwards_marker_dir_to_runner(
     from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
     from tests.execution.conftest import _sr
 
-    spec = ClaudeHeadlessCmd(cmd=["echo", "test"], env={})
+    spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
     runner_kwargs: dict = {}
 
     async def fake_runner(cmd, **kwargs):
@@ -581,7 +581,7 @@ async def test_execute_claude_headless_pty_mode_from_backend(
     from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
     from tests.execution.conftest import _sr
 
-    spec = ClaudeHeadlessCmd(cmd=["echo", "test"], env={})
+    spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
     runner_kwargs: dict = {}
 
     async def fake_runner(cmd, **kwargs):
@@ -630,7 +630,7 @@ async def test_execute_claude_headless_session_log_dir_none_when_no_channel_b(
     from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
     from tests.execution.conftest import _sr
 
-    spec = ClaudeHeadlessCmd(cmd=["echo", "test"], env={})
+    spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
     runner_kwargs: dict = {}
 
     async def fake_runner(cmd, **kwargs):

--- a/tests/execution/test_process_env_boundary.py
+++ b/tests/execution/test_process_env_boundary.py
@@ -101,6 +101,6 @@ def test_headless_cmd_with_mappingproxy_env() -> None:
     from autoskillit.execution.commands import ClaudeHeadlessCmd
 
     env = MappingProxyType({"PATH": "/usr/bin"})
-    cmd = ClaudeHeadlessCmd(cmd=["echo", "test"], env=env)
+    cmd = ClaudeHeadlessCmd(cmd=("echo", "test"), env=env)
     assert cmd.env["PATH"] == "/usr/bin"
     assert isinstance(cmd.env, MappingProxyType)


### PR DESCRIPTION
## Summary

Verify that all three `isinstance(x, ClaudeHeadlessCmd)` assertions in `test_commands.py` remain valid under the `CmdSpec` alias (they do, since `ClaudeHeadlessCmd is CmdSpec` at runtime), update the module docstring to reference the alias relationship, confirm no list-mutating `.cmd` operations exist, and convert all 14 `ClaudeHeadlessCmd(cmd=[...])` list literals to `cmd=(...)` tuple literals across 4 test files. `test_idle_output_env.py` already uses `CmdSpec` with tuple literals — no changes needed there.

## Requirements

## Goal

Verify ClaudeHeadlessCmd isinstance assertions remain valid under the CmdSpec alias and convert all cmd=[...] list literals to cmd=(...,) tuples across integration test files.

## Context

- Phase: Protocol & Type System Alignment (Milestone: 2-protocol-type-system-alignment)
- Assignment: P2-A10 (Update test assertions and fixtures for CmdSpec return types and widened protocol signatures)
- Depends on: P2-A8-WP1
- Depended on by: None

## Deliverables

- `Verification that all three isinstance assertions pass unchanged under the CmdSpec alias`
- `Module docstring updated to reference CmdSpec alias`
- `Confirmation that no list-mutating .cmd operations exist`
- `All 15 ClaudeHeadlessCmd(cmd=[...]) list literals converted to cmd=(...,) tuple literals across 5 test files`

## Technical Steps

1. Confirm isinstance(x, ClaudeHeadlessCmd) is identical to isinstance(x, CmdSpec) under alias — no test assertion change needed
2. Audit all .cmd accesses: .cmd[0], .cmd.index(...), 'in .cmd', .cmd.count(...) — all tuple-compatible
3. Verify no list-mutating methods (.append, .insert, .extend, .pop) are called on .cmd
4. Update module docstring to reference CmdSpec alias relationship
5. Verify all three isinstance assertions at lines 176, 259, 587 will pass with CmdSpec instances
6. In tests/execution/test_headless_provider_fallback.py: change cmd=[...] to cmd=(...,) in all 4 constructions
7. In tests/execution/test_headless_provider_forwarding.py: change cmd=[...] to cmd=(...,) in all 5 constructions
8. In tests/execution/test_flush_provider_integration.py: change cmd=[...] to cmd=(...,) in all 4 constructions
9. In tests/execution/test_process_env_boundary.py: change cmd=[...] to cmd=(...,) in the 1 construction
10. In tests/execution/test_idle_output_env.py: change cmd=[...] to cmd=(...,) in the 1 construction
11. Verify import paths unchanged (all import from autoskillit.execution.commands)

## Acceptance Criteria

- All three isinstance assertions at lines 176, 259, 587 pass without modification
- No list-mutating methods called on .cmd in test_commands.py
- All .cmd subscript and membership tests work with tuple[str, ...]
- test_commands.py pytest suite passes with zero failures after alias change
- grep for 'ClaudeHeadlessCmd(cmd=[' returns zero matches in the five target files
- All five test files pass pytest after CmdSpec.cmd is tuple[str, ...]
- Import statements remain unchanged
- No new imports or helper functions introduced

## Conflict Resolution Table

Closes #2681

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-154036-044715/.autoskillit/temp/make-plan/verify_cmdspec_isinstance_plan_2026-05-22_155600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.6k | 10.6k | 1.0M | 65.8k | 219 | 56.6k | 6m 25s |
| verify | claude-opus-4-6 | 1 | 49 | 6.8k | 458.6k | 43.0k | 55 | 27.6k | 3m 30s |
| implement* | MiniMax-M2.7-highspeed | 1 | 315.7k | 3.6k | 416.6k | 29.8k | 46 | 42.4k | 1m 36s |
| prepare_pr* | MiniMax-M2.7 | 1 | 59.1k | 4.2k | 305.9k | 29.8k | 27 | 42.6k | 1m 25s |
| compose_pr* | MiniMax-M2.7 | 1 | 44.5k | 2.7k | 321.7k | 0 | 26 | 0 | 40s |
| review_pr | claude-sonnet-4-6 | 2 | 210 | 51.5k | 972.1k | 67.4k | 81 | 115.4k | 10m 27s |
| resolve_review | claude-sonnet-4-6 | 1 | 173 | 9.4k | 793.8k | 52.6k | 45 | 43.8k | 3m 58s |
| **Total** | | | 424.4k | 88.8k | 4.3M | 67.4k | | 328.4k | 28m 4s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 30 | 13886.6 | 1411.7 | 118.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **30** | 142989.9 | 10945.3 | 2959.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 5.0k | 71.5k | 2.8M | 215.8k | 20m 51s |
| claude-opus-4-6 | 1 | 49 | 6.8k | 458.6k | 27.6k | 3m 30s |
| MiniMax-M2.7-highspeed | 1 | 315.7k | 3.6k | 416.6k | 42.4k | 1m 36s |
| MiniMax-M2.7 | 2 | 103.6k | 6.9k | 627.7k | 42.6k | 2m 5s |