### PR TITLE
Remove the -a/--ask-for-approval flag from CodexBackend build_headless_cmd

### DIFF
--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -301,6 +301,7 @@ class TestCodexHeadlessCmd:
     def test_no_approval_never_in_headless_cmd(self) -> None:
         spec = CodexBackend().build_headless_cmd("do stuff")
         assert "-a" not in spec.cmd
+        assert "never" not in spec.cmd
 
     def test_model_flag(self) -> None:
         spec = CodexBackend().build_headless_cmd("x", model="o3")


### PR DESCRIPTION
## Summary

The `-a`/`--ask-for-approval` flag has already been removed from `build_headless_cmd` in `codex.py`. The only remaining gap is that `test_no_approval_never_in_headless_cmd` asserts `-a` absence but does not assert `"never"` absence — failing to fully validate acceptance criterion #3. This plan adds the missing assertion to complete the deliverable.

**Scope boundary:** `build_skill_session_cmd` intentionally retains `-a never` (it is out of scope per the issue's acceptance criteria: "only its use in build_headless_cmd is removed"). `CodexFlags.ASK_FOR_APPROVAL_SHORT` and `CodexFlags.ASK_FOR_APPROVAL` enum members are explicitly preserved per the issue.

## Requirements

### Goal

Remove the -a/--ask-for-approval flag from CodexBackend.build_headless_cmd entirely (it is redundant with --sandbox workspace-write which implies approval: never), and update the three tests that assert its presence so the test suite passes cleanly before build_skill_session_cmd is wired.

### Acceptance Criteria

- build_headless_cmd('do stuff') returns cmd == ('codex', 'exec', '--json', '--sandbox', 'workspace-write', 'do stuff')
- '-a' not in CodexBackend().build_headless_cmd('x').cmd
- 'never' not in CodexBackend().build_headless_cmd('x').cmd
- All existing tests in test_codex_backend.py pass with no new failures
- CodexFlags.ASK_FOR_APPROVAL_SHORT enum member is NOT removed (it may still be useful elsewhere or in future; only its use in build_headless_cmd is removed)

## Architecture Impact

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph CodexBackend ["CodexBackend Command Builders"]
        direction TB
        BHC["build_headless_cmd<br/>━━━━━━━━━━<br/>codex exec --json<br/>--sandbox workspace-write<br/>NO -a flag"]
        BSSC["build_skill_session_cmd<br/>━━━━━━━━━━<br/>codex exec --json<br/>--sandbox workspace-write<br/>-a never ← retained"]
        BRC["build_resume_cmd<br/>━━━━━━━━━━<br/>codex exec --json<br/>resume {id}<br/>NO -a flag"]
    end

    subgraph Tests ["Test Coverage"]
        direction TB
        T1["test_default_cmd_structure<br/>━━━━━━━━━━<br/>Exact 6-element tuple<br/>without -a/never ✓"]
        T2["test_no_approval_flag_in_headless_cmd<br/>━━━━━━━━━━<br/>assert '-a' not in cmd ✓"]
        T3["● test_no_approval_never_in_headless_cmd<br/>━━━━━━━━━━<br/>assert '-a' not in cmd ✓<br/>★ assert 'never' not in cmd"]
        T4["test_no_approval_flag_in_resume<br/>━━━━━━━━━━<br/>assert '-a' not in cmd ✓<br/>assert 'never' not in cmd ✓"]
        T5["test_minimal_config<br/>━━━━━━━━━━<br/>Asserts -a/never present<br/>in skill_session_cmd ✓"]
    end

    BHC --> T1
    BHC --> T2
    BHC --> T3
    BRC --> T4
    BSSC --> T5

    class BHC,BRC cli;
    class BSSC phase;
    class T1,T2,T4,T5 stateNode;
    class T3 newComponent;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | CLI | Command builders without -a flag |
| Purple | Phase | Command builder retaining -a flag (out of scope) |
| Teal | State | Existing tests (no changes) |
| Green | New | Test with added assertion |

**Lens Used:** Operational - The change affects CLI command construction and its test validation coverage.

Closes #2683

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/remove_approval_flag_plan_2026-05-22_171500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 80 | 11.2k | 1.2M | 64.3k | 118 | 51.2k | 8m 33s |
| verify | claude-opus-4-6 | 1 | 45 | 5.1k | 324.2k | 51.0k | 45 | 35.9k | 3m 9s |
| implement* | MiniMax-M2.7 | 1 | 41.6k | 1.6k | 402.2k | 29.8k | 24 | 43.2k | 52s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.0k | 2.2k | 277.4k | 0 | 20 | 0 | 37s |
| compose_pr* | MiniMax-M2.7 | 1 | 41.4k | 3.3k | 518.4k | 0 | 28 | 0 | 48s |
| review_pr | claude-opus-4-6 | 3 | 111 | 16.5k | 1.0M | 42.6k | 78 | 80.4k | 5m 58s |
| **Total** | | | 126.2k | 39.9k | 3.7M | 64.3k | | 210.6k | 19m 58s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 236 | 32.8k | 2.5M | 167.5k | 17m 41s |
| MiniMax-M2.7 | 3 | 126.0k | 7.1k | 1.2M | 43.2k | 2m 17s |