### PR TITLE
fix: route check_pr_state CONFLICTING directly to ci_conflict_fix

### DIFF
--- a/src/autoskillit/recipe/rules/rules_ci.py
+++ b/src/autoskillit/recipe/rules/rules_ci.py
@@ -78,24 +78,20 @@ _CONFLICT_RESOLUTION_SKILLS: frozenset[str] = frozenset({"resolve-merge-conflict
 _CODE_RESOLUTION_SKILLS: frozenset[str] = frozenset({"resolve-failures"})
 
 
-def _is_conflict_gate_step(step: object) -> bool:
-    """Return True if step is a stale-base conflict-detection gate.
+def _is_exit_code_conflict_gate(step: object) -> bool:
+    """Return True if step is a run_cmd stale-base exit-code gate (merge-base/is-ancestor)."""
+    if getattr(step, "tool", None) != "run_cmd":
+        return False
+    cmd = (getattr(step, "with_args", {}) or {}).get("cmd", "")
+    return isinstance(cmd, str) and any(kw in cmd for kw in _CONFLICT_GATE_KEYWORDS)
 
-    A gate is either:
-    - run_cmd with a 'cmd' containing 'merge-base' or 'is-ancestor'
-    - run_skill with a skill_command referencing 'resolve-merge-conflicts'
-    """
-    tool = getattr(step, "tool", None)
-    with_args = getattr(step, "with_args", {}) or {}
-    if tool == "run_cmd":
-        cmd = with_args.get("cmd", "")
-        return isinstance(cmd, str) and any(kw in cmd for kw in _CONFLICT_GATE_KEYWORDS)
-    if tool == "run_skill":
-        skill_cmd = with_args.get("skill_command", "")
-        return isinstance(skill_cmd, str) and any(
-            s in skill_cmd for s in _CONFLICT_RESOLUTION_SKILLS
-        )
-    return False
+
+def _is_conflict_resolution_step(step: object) -> bool:
+    """Return True if step invokes resolve-merge-conflicts via run_skill."""
+    if getattr(step, "tool", None) != "run_skill":
+        return False
+    skill_cmd = (getattr(step, "with_args", {}) or {}).get("skill_command", "")
+    return isinstance(skill_cmd, str) and any(s in skill_cmd for s in _CONFLICT_RESOLUTION_SKILLS)
 
 
 def _is_code_resolution_step(step: object) -> bool:
@@ -135,7 +131,9 @@ def _bfs_without_barrier(graph: dict[str, set[str]], start: str, barriers: set[s
 def _check_ci_failure_conflict_gate(ctx: ValidationContext) -> list[RuleFinding]:
     # Identify all conflict-gate and code-resolution steps by name
     conflict_gates: set[str] = {
-        name for name, step in ctx.recipe.steps.items() if _is_conflict_gate_step(step)
+        name
+        for name, step in ctx.recipe.steps.items()
+        if _is_exit_code_conflict_gate(step) or _is_conflict_resolution_step(step)
     }
     code_resolution_steps: set[str] = {
         name for name, step in ctx.recipe.steps.items() if _is_code_resolution_step(step)
@@ -173,6 +171,53 @@ def _check_ci_failure_conflict_gate(ctx: ValidationContext) -> list[RuleFinding]
                     ),
                 )
             )
+    return findings
+
+
+@semantic_rule(
+    name="mergeability-conflicting-direct-to-resolution",
+    description=(
+        "check_pr_mergeable CONFLICTING arm reaches a stale-base exit-code gate "
+        "(run_cmd with merge-base) before reaching conflict resolution "
+        "(resolve-merge-conflicts). Route CONFLICTING directly to resolution."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_mergeability_conflicting_direct(ctx: ValidationContext) -> list[RuleFinding]:
+    exit_code_gates: set[str] = {
+        name for name, step in ctx.recipe.steps.items() if _is_exit_code_conflict_gate(step)
+    }
+    resolution_steps: set[str] = {
+        name for name, step in ctx.recipe.steps.items() if _is_conflict_resolution_step(step)
+    }
+    if not exit_code_gates:
+        return []
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "check_pr_mergeable":
+            continue
+        if step.on_result is None:
+            continue
+        for cond in step.on_result.conditions:
+            if not cond.when or "CONFLICTING" not in cond.when:
+                continue
+            reachable = _bfs_without_barrier(ctx.step_graph, cond.route, resolution_steps)
+            unguarded_gates = reachable & exit_code_gates
+            if unguarded_gates:
+                findings.append(
+                    RuleFinding(
+                        rule="mergeability-conflicting-direct-to-resolution",
+                        severity=Severity.ERROR,
+                        step_name=name,
+                        message=(
+                            f"Step '{name}' routes CONFLICTING to '{cond.route}' which "
+                            f"reaches exit-code gate(s) "
+                            f"({', '.join(sorted(unguarded_gates))}) "
+                            f"before conflict resolution. GitHub's CONFLICTING status is "
+                            f"authoritative — route directly to resolve-merge-conflicts."
+                        ),
+                    )
+                )
     return findings
 
 

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -773,7 +773,7 @@
       "on_result": [
         {
           "when": "${{ result.mergeable_status }} == 'CONFLICTING'",
-          "route": "detect_ci_conflict"
+          "route": "ci_conflict_fix"
         },
         {
           "route": "ci_watch"
@@ -781,7 +781,7 @@
       ],
       "on_failure": "ci_watch",
       "skip_when_false": "inputs.open_pr",
-      "note": "Pre-CI-watch gate: checks PR mergeable state before entering the CI polling loop. CONFLICTING PRs cannot trigger pull_request workflows (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would produce a guaranteed no_runs. Routes CONFLICTING to detect_ci_conflict (which handles conflict resolution) and MERGEABLE/UNKNOWN to ci_watch.\n"
+      "note": "Pre-CI-watch gate: checks PR mergeable state before entering the CI polling loop. CONFLICTING PRs cannot trigger pull_request workflows (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would produce a guaranteed no_runs. Routes CONFLICTING directly to ci_conflict_fix (resolve-merge-conflicts) — GitHub's CONFLICTING status is authoritative, no stale-base exit-code discrimination needed (mirrors merge-prs.yaml check_mergeability pattern). Routes MERGEABLE/UNKNOWN to ci_watch.\n"
     },
     "ci_watch": {
       "tool": "wait_for_ci",
@@ -1779,7 +1779,7 @@
       "on_failure": "diagnose_ci",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Detects whether the CI failure originates from a stale integration base rather than a code-level test failure. Exit 0 (fetch succeeded AND base is NOT an ancestor of HEAD) signals a stale base — routes to ci_conflict_fix. Exit 1 (fetch failed OR base is already an ancestor) signals a real code failure or an unresolvable state — falls through to diagnose_ci. This step insulates resolve_ci from being invoked for merge-conflict failures.\n"
+      "note": "Stale-base triage gate for CI FAILURE paths only. Do NOT route check_pr_mergeable CONFLICTING here — GitHub's CONFLICTING status is authoritative and should route directly to ci_conflict_fix. Valid callers: ci_watch, check_ci_timed_out_loop, check_ci_already_passed, ci_watch_post_queue_fix. Exit 0 (base NOT ancestor) → ci_conflict_fix. Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.\n"
     },
     "ci_conflict_fix": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -730,7 +730,7 @@ steps:
       cwd: "${{ context.work_dir }}"
     on_result:
       - when: "${{ result.mergeable_status }} == 'CONFLICTING'"
-        route: detect_ci_conflict
+        route: ci_conflict_fix
       - route: ci_watch
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
@@ -738,8 +738,10 @@ steps:
       Pre-CI-watch gate: checks PR mergeable state before entering the CI
       polling loop. CONFLICTING PRs cannot trigger pull_request workflows
       (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would
-      produce a guaranteed no_runs. Routes CONFLICTING to detect_ci_conflict
-      (which handles conflict resolution) and MERGEABLE/UNKNOWN to ci_watch.
+      produce a guaranteed no_runs. Routes CONFLICTING directly to ci_conflict_fix
+      (resolve-merge-conflicts) — GitHub's CONFLICTING status is authoritative,
+      no stale-base exit-code discrimination needed (mirrors merge-prs.yaml
+      check_mergeability pattern). Routes MERGEABLE/UNKNOWN to ci_watch.
 
   ci_watch:
     tool: wait_for_ci
@@ -1651,11 +1653,12 @@ steps:
     optional: true
     skip_when_false: "inputs.open_pr"
     note: >
-      Detects whether the CI failure originates from a stale integration base rather than
-      a code-level test failure. Exit 0 (fetch succeeded AND base is NOT an ancestor of HEAD)
-      signals a stale base — routes to ci_conflict_fix. Exit 1 (fetch failed OR base is already
-      an ancestor) signals a real code failure or an unresolvable state — falls through to
-      diagnose_ci. This step insulates resolve_ci from being invoked for merge-conflict failures.
+      Stale-base triage gate for CI FAILURE paths only. Do NOT route
+      check_pr_mergeable CONFLICTING here — GitHub's CONFLICTING status is
+      authoritative and should route directly to ci_conflict_fix.
+      Valid callers: ci_watch, check_ci_timed_out_loop, check_ci_already_passed,
+      ci_watch_post_queue_fix. Exit 0 (base NOT ancestor) → ci_conflict_fix.
+      Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.
 
   ci_conflict_fix:
     tool: run_skill

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -776,7 +776,7 @@
       "on_result": [
         {
           "when": "${{ result.mergeable_status }} == 'CONFLICTING'",
-          "route": "detect_ci_conflict"
+          "route": "ci_conflict_fix"
         },
         {
           "route": "ci_watch"
@@ -784,7 +784,7 @@
       ],
       "on_failure": "ci_watch",
       "skip_when_false": "inputs.open_pr",
-      "note": "Pre-CI-watch gate: checks PR mergeable state before entering the CI polling loop. CONFLICTING PRs cannot trigger pull_request workflows (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would produce a guaranteed no_runs. Routes CONFLICTING to detect_ci_conflict (which handles conflict resolution) and MERGEABLE/UNKNOWN to ci_watch.\n"
+      "note": "Pre-CI-watch gate: checks PR mergeable state before entering the CI polling loop. CONFLICTING PRs cannot trigger pull_request workflows (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would produce a guaranteed no_runs. Routes CONFLICTING directly to ci_conflict_fix (resolve-merge-conflicts) — GitHub's CONFLICTING status is authoritative, no stale-base exit-code discrimination needed (mirrors merge-prs.yaml check_mergeability pattern). Routes MERGEABLE/UNKNOWN to ci_watch.\n"
     },
     "ci_watch": {
       "tool": "wait_for_ci",
@@ -1766,7 +1766,7 @@
       "on_failure": "diagnose_ci",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Detects whether the CI failure originates from a stale integration base rather than a code-level test failure. Exit 0 (fetch succeeded AND base is NOT an ancestor of HEAD) signals a stale base — routes to ci_conflict_fix. Exit 1 (fetch failed OR base is already an ancestor) signals a real code failure or an unresolvable state — falls through to diagnose_ci. This step insulates resolve_ci from being invoked for merge-conflict failures.\n"
+      "note": "Stale-base triage gate for CI FAILURE paths only. Do NOT route check_pr_mergeable CONFLICTING here — GitHub's CONFLICTING status is authoritative and should route directly to ci_conflict_fix. Valid callers: ci_watch, check_ci_timed_out_loop, check_ci_already_passed, ci_watch_post_queue_fix. Exit 0 (base NOT ancestor) → ci_conflict_fix. Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.\n"
     },
     "ci_conflict_fix": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -738,7 +738,7 @@ steps:
       cwd: "${{ context.work_dir }}"
     on_result:
       - when: "${{ result.mergeable_status }} == 'CONFLICTING'"
-        route: detect_ci_conflict
+        route: ci_conflict_fix
       - route: ci_watch
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
@@ -746,8 +746,10 @@ steps:
       Pre-CI-watch gate: checks PR mergeable state before entering the CI
       polling loop. CONFLICTING PRs cannot trigger pull_request workflows
       (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would
-      produce a guaranteed no_runs. Routes CONFLICTING to detect_ci_conflict
-      (which handles conflict resolution) and MERGEABLE/UNKNOWN to ci_watch.
+      produce a guaranteed no_runs. Routes CONFLICTING directly to ci_conflict_fix
+      (resolve-merge-conflicts) — GitHub's CONFLICTING status is authoritative,
+      no stale-base exit-code discrimination needed (mirrors merge-prs.yaml
+      check_mergeability pattern). Routes MERGEABLE/UNKNOWN to ci_watch.
 
   ci_watch:
     tool: wait_for_ci
@@ -1632,11 +1634,12 @@ steps:
     optional: true
     skip_when_false: "inputs.open_pr"
     note: >
-      Detects whether the CI failure originates from a stale integration base rather than
-      a code-level test failure. Exit 0 (fetch succeeded AND base is NOT an ancestor of HEAD)
-      signals a stale base — routes to ci_conflict_fix. Exit 1 (fetch failed OR base is already
-      an ancestor) signals a real code failure or an unresolvable state — falls through to
-      diagnose_ci. This step insulates resolve_ci from being invoked for merge-conflict failures.
+      Stale-base triage gate for CI FAILURE paths only. Do NOT route
+      check_pr_mergeable CONFLICTING here — GitHub's CONFLICTING status is
+      authoritative and should route directly to ci_conflict_fix.
+      Valid callers: ci_watch, check_ci_timed_out_loop, check_ci_already_passed,
+      ci_watch_post_queue_fix. Exit 0 (base NOT ancestor) → ci_conflict_fix.
+      Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.
 
   ci_conflict_fix:
     tool: run_skill

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -804,7 +804,7 @@
       "on_result": [
         {
           "when": "${{ result.mergeable_status }} == 'CONFLICTING'",
-          "route": "detect_ci_conflict"
+          "route": "ci_conflict_fix"
         },
         {
           "route": "ci_watch"
@@ -812,7 +812,7 @@
       ],
       "on_failure": "ci_watch",
       "skip_when_false": "inputs.open_pr",
-      "note": "Pre-CI-watch gate: checks PR mergeable state before entering the CI polling loop. CONFLICTING PRs cannot trigger pull_request workflows (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would produce a guaranteed no_runs. Routes CONFLICTING to detect_ci_conflict (which handles conflict resolution) and MERGEABLE/UNKNOWN to ci_watch.\n"
+      "note": "Pre-CI-watch gate: checks PR mergeable state before entering the CI polling loop. CONFLICTING PRs cannot trigger pull_request workflows (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would produce a guaranteed no_runs. Routes CONFLICTING directly to ci_conflict_fix (resolve-merge-conflicts) — GitHub's CONFLICTING status is authoritative, no stale-base exit-code discrimination needed (mirrors merge-prs.yaml check_mergeability pattern). Routes MERGEABLE/UNKNOWN to ci_watch.\n"
     },
     "ci_watch": {
       "tool": "wait_for_ci",
@@ -1794,7 +1794,7 @@
       "on_failure": "diagnose_ci",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Detects whether the CI failure originates from a stale integration base rather than a code-level test failure. Exit 0 (fetch succeeded AND base is NOT an ancestor of HEAD) signals a stale base — routes to ci_conflict_fix. Exit 1 (fetch failed OR base is already an ancestor) signals a real code failure or an unresolvable state — falls through to diagnose_ci. This step insulates resolve_ci from being invoked for merge-conflict failures.\n"
+      "note": "Stale-base triage gate for CI FAILURE paths only. Do NOT route check_pr_mergeable CONFLICTING here — GitHub's CONFLICTING status is authoritative and should route directly to ci_conflict_fix. Valid callers: ci_watch, check_ci_timed_out_loop, check_ci_already_passed, ci_watch_post_queue_fix. Exit 0 (base NOT ancestor) → ci_conflict_fix. Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.\n"
     },
     "ci_conflict_fix": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -741,7 +741,7 @@ steps:
       cwd: "${{ context.work_dir }}"
     on_result:
       - when: "${{ result.mergeable_status }} == 'CONFLICTING'"
-        route: detect_ci_conflict
+        route: ci_conflict_fix
       - route: ci_watch
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
@@ -749,8 +749,10 @@ steps:
       Pre-CI-watch gate: checks PR mergeable state before entering the CI
       polling loop. CONFLICTING PRs cannot trigger pull_request workflows
       (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would
-      produce a guaranteed no_runs. Routes CONFLICTING to detect_ci_conflict
-      (which handles conflict resolution) and MERGEABLE/UNKNOWN to ci_watch.
+      produce a guaranteed no_runs. Routes CONFLICTING directly to ci_conflict_fix
+      (resolve-merge-conflicts) — GitHub's CONFLICTING status is authoritative,
+      no stale-base exit-code discrimination needed (mirrors merge-prs.yaml
+      check_mergeability pattern). Routes MERGEABLE/UNKNOWN to ci_watch.
 
   ci_watch:
     tool: wait_for_ci
@@ -1637,11 +1639,12 @@ steps:
     optional: true
     skip_when_false: "inputs.open_pr"
     note: >
-      Detects whether the CI failure originates from a stale integration base rather than
-      a code-level test failure. Exit 0 (fetch succeeded AND base is NOT an ancestor of HEAD)
-      signals a stale base — routes to ci_conflict_fix. Exit 1 (fetch failed OR base is already
-      an ancestor) signals a real code failure or an unresolvable state — falls through to
-      diagnose_ci. This step insulates resolve_ci from being invoked for merge-conflict failures.
+      Stale-base triage gate for CI FAILURE paths only. Do NOT route
+      check_pr_mergeable CONFLICTING here — GitHub's CONFLICTING status is
+      authoritative and should route directly to ci_conflict_fix.
+      Valid callers: ci_watch, check_ci_timed_out_loop, check_ci_already_passed,
+      ci_watch_post_queue_fix. Exit 0 (base NOT ancestor) → ci_conflict_fix.
+      Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.
 
   ci_conflict_fix:
     tool: run_skill

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -717,6 +717,9 @@ def test_pre_ci_watch_mergeable_check_exists(recipe_name: str) -> None:
     assert conflicting_routes, "CONFLICTING condition must be handled"
     assert "ci_watch" not in conflicting_routes, "CONFLICTING must not route to ci_watch"
     for route_name in conflicting_routes:
+        assert route_name in recipe.steps, (
+            f"CONFLICTING route '{route_name}' not found in recipe steps"
+        )
         target = recipe.steps[route_name]
         skill_cmd = (target.with_args or {}).get("skill_command", "")
         assert "resolve-merge-conflicts" in skill_cmd, (

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -716,6 +716,12 @@ def test_pre_ci_watch_mergeable_check_exists(recipe_name: str) -> None:
     }
     assert conflicting_routes, "CONFLICTING condition must be handled"
     assert "ci_watch" not in conflicting_routes, "CONFLICTING must not route to ci_watch"
+    for route_name in conflicting_routes:
+        target = recipe.steps[route_name]
+        skill_cmd = (target.with_args or {}).get("skill_command", "")
+        assert "resolve-merge-conflicts" in skill_cmd, (
+            f"CONFLICTING route '{route_name}' must invoke resolve-merge-conflicts"
+        )
     ci_event_step = recipe.steps["check_repo_ci_event"]
     next_step = ci_event_step.on_success
     if next_step == "route_ci_applicable":

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -196,6 +196,25 @@ class TestPipelineVariantInvariants:
         default_routes = [r for w, r in routes.items() if w is None]
         assert default_routes == ["re_push"]
 
+    def test_check_pr_state_conflicting_routes_directly_to_resolution(self, recipe) -> None:
+        """CONFLICTING mergeability must route directly to conflict resolution,
+        not through a stale-base exit-code gate."""
+        pr_state = recipe.steps["check_pr_state"]
+        conflicting_targets = {
+            c.route for c in pr_state.on_result.conditions if c.when and "CONFLICTING" in c.when
+        }
+        for target_name in conflicting_targets:
+            target_step = recipe.steps[target_name]
+            assert target_step.tool == "run_skill", (
+                f"CONFLICTING routes to '{target_name}' which is {target_step.tool}, "
+                f"not run_skill. CONFLICTING must route directly to conflict resolution."
+            )
+            skill_cmd = (target_step.with_args or {}).get("skill_command", "")
+            assert "resolve-merge-conflicts" in skill_cmd, (
+                f"CONFLICTING routes to '{target_name}' which does not invoke "
+                f"resolve-merge-conflicts. CONFLICTING must route to conflict resolution."
+            )
+
     def test_detect_ci_conflict_skip_when_false(self, recipe) -> None:
         step = recipe.steps["detect_ci_conflict"]
         assert step.skip_when_false == "inputs.open_pr"

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -204,6 +204,9 @@ class TestPipelineVariantInvariants:
             c.route for c in pr_state.on_result.conditions if c.when and "CONFLICTING" in c.when
         }
         for target_name in conflicting_targets:
+            assert target_name in recipe.steps, (
+                f"CONFLICTING route '{target_name}' not found in recipe steps"
+            )
             target_step = recipe.steps[target_name]
             assert target_step.tool == "run_skill", (
                 f"CONFLICTING routes to '{target_name}' which is {target_step.tool}, "

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -1105,6 +1105,80 @@ def test_ci_cwd_branch_context_mismatch_passes_for_batch_branch() -> None:
     assert len(matched) == 0
 
 
+# ---------------------------------------------------------------------------
+# mergeability-conflicting-direct-to-resolution rule tests
+# ---------------------------------------------------------------------------
+
+_CONFLICTING_DIRECT_RULE = "mergeability-conflicting-direct-to-resolution"
+
+
+def test_mergeability_conflicting_through_exit_code_gate_fires() -> None:
+    """Rule fires when check_pr_mergeable CONFLICTING routes through
+    a run_cmd merge-base gate before reaching resolution."""
+    wf = _make_workflow(
+        {
+            "check_state": {
+                "tool": "check_pr_mergeable",
+                "on_result": [
+                    {
+                        "when": "${{ result.mergeable_status }} == 'CONFLICTING'",
+                        "route": "stale_base_gate",
+                    },
+                    {"route": "ci_watch"},
+                ],
+            },
+            "stale_base_gate": {
+                "tool": "run_cmd",
+                "with": {"cmd": "! git merge-base --is-ancestor origin/main HEAD"},
+                "on_success": "fix_conflict",
+                "on_failure": "diagnose",
+            },
+            "fix_conflict": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:resolve-merge-conflicts work plan main"},
+                "on_success": "done",
+            },
+            "diagnose": {"tool": "run_skill", "on_success": "done"},
+            "ci_watch": {"tool": "wait_for_ci", "with": {"event": "push"}, "on_success": "done"},
+            "done": {"action": "stop", "message": "done"},
+        }
+    )
+    findings = run_semantic_rules(wf)
+    matched = [f for f in findings if f.rule == _CONFLICTING_DIRECT_RULE]
+    assert len(matched) >= 1, f"Expected rule to fire, got: {[f.rule for f in findings]}"
+    assert matched[0].severity == Severity.ERROR
+    assert matched[0].step_name == "check_state"
+
+
+def test_mergeability_conflicting_direct_to_resolution_passes() -> None:
+    """Rule passes when check_pr_mergeable CONFLICTING routes directly
+    to resolve-merge-conflicts without an intervening exit-code gate."""
+    wf = _make_workflow(
+        {
+            "check_state": {
+                "tool": "check_pr_mergeable",
+                "on_result": [
+                    {
+                        "when": "${{ result.mergeable_status }} == 'CONFLICTING'",
+                        "route": "fix_conflict",
+                    },
+                    {"route": "ci_watch"},
+                ],
+            },
+            "fix_conflict": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:resolve-merge-conflicts work plan main"},
+                "on_success": "done",
+            },
+            "ci_watch": {"tool": "wait_for_ci", "with": {"event": "push"}, "on_success": "done"},
+            "done": {"action": "stop", "message": "done"},
+        }
+    )
+    findings = run_semantic_rules(wf)
+    matched = [f for f in findings if f.rule == _CONFLICTING_DIRECT_RULE]
+    assert not matched, f"Rule should not fire for direct routing, got: {matched}"
+
+
 def test_bundled_recipes_pass_ci_cwd_branch_context_mismatch() -> None:
     """All bundled recipes must pass the ci-cwd-branch-context-mismatch rule."""
     for yaml_path in sorted(builtin_recipes_dir().glob("*.yaml")):


### PR DESCRIPTION
## Summary

`check_pr_state` routes all CONFLICTING PRs to `detect_ci_conflict`, which performs a stale-base check (`! git merge-base --is-ancestor origin/$base HEAD`). This check only detects one class of merge conflict — where the base branch has advanced past the feature branch's merge-base. When the base branch has NOT advanced (but the PR is still CONFLICTING per GitHub's API), the step exits 1 and misroutes to `diagnose_ci` (the CI failure diagnosis path) instead of `ci_conflict_fix` (the merge conflict resolution path).

The fix routes `check_pr_state` CONFLICTING directly to `ci_conflict_fix`, bypassing `detect_ci_conflict`. A new semantic rule `mergeability-conflicting-direct-to-resolution` validates this pattern. The `_is_conflict_gate_step` helper is split into two focused helpers (`_is_exit_code_conflict_gate` and `_is_conflict_resolution_step`) to support the rule.

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_conflicting_pr_misroute_2026-05-22_170500.md`

<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 73 | 13.5k | 980.1k | 139.9k | 177 | 66.0k | 8m 22s |
| dry_walkthrough | claude-opus-4-6 | 1 | 909 | 26.1k | 1.3M | 95.3k | 125 | 80.7k | 10m 6s |
| implement | claude-opus-4-6 | 1 | 77 | 7.4k | 1.2M | 86.2k | 83 | 72.3k | 4m 3s |
| prepare_pr* | MiniMax-M2.7 | 1 | 46.6k | 3.4k | 255.7k | 0 | 19 | 0 | 34s |
| compose_pr* | MiniMax-M2.7 | 1 | 37.8k | 1.1k | 192.4k | 0 | 15 | 0 | 16s |
| review_pr | claude-opus-4-6 | 3 | 100 | 58.4k | 1.3M | 76.3k | 92 | 168.0k | 16m 21s |
| resolve_review | claude-opus-4-6 | 1 | 44 | 4.7k | 799.6k | 54.4k | 34 | 39.4k | 3m 3s |
| **Total** | | | 85.7k | 114.5k | 6.0M | 139.9k | | 426.4k | 42m 47s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 99 | 12146.7 | 730.5 | 74.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 133272.0 | 6565.8 | 777.3 |
| **Total** | **105** | 57119.9 | 4060.9 | 1090.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 73 | 13.5k | 980.1k | 66.0k | 8m 22s |
| claude-opus-4-6 | 4 | 1.1k | 96.5k | 4.6M | 360.4k | 33m 35s |
| MiniMax-M2.7 | 2 | 84.5k | 4.5k | 448.1k | 0 | 50s |