### PR TITLE
Fleet Dispatch Staleness: Exception Errors + Deep Detection

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -226,10 +226,13 @@ from .types import OutputPatternResolver as OutputPatternResolver
 from .types import PackDef as PackDef
 from .types import PluginSource as PluginSource
 from .types import PRState as PRState
+from .types import ProcessStaleError as ProcessStaleError
 from .types import PromptContractError as PromptContractError
 from .types import QuotaRefreshTask as QuotaRefreshTask
 from .types import ReadOnlyResolver as ReadOnlyResolver
 from .types import RecipePackDef as RecipePackDef
+from .types import RecipeLoadError as RecipeLoadError
+from .types import RecipeNotFoundError as RecipeNotFoundError
 from .types import RecipeRepository as RecipeRepository
 from .types import RecipeSource as RecipeSource
 from .types import RestartScope as RestartScope

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -8,6 +8,7 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 |------|---------|
 | `__init__.py` | Re-export hub — aggregates `__all__` from all `_type_*.py` modules |
 | `_type_enums.py` | All `StrEnum` discriminators (`RetryReason`, `KillReason`, `Severity`, etc.) |
+| `_type_exceptions.py` | Exception hierarchy for recipe loading: `RecipeLoadError`, `ProcessStaleError`, `RecipeNotFoundError` |
 | `_type_figure_spec.py` | `FigureSpec` TypedDict and consumer/producer field sets for `yaml:figure-spec` contracts |
 | `_type_constants.py` | Shared constants: tool lists, env var names, env var sets for session kinds |
 | `_type_session_env.py` | Typed env spec dataclasses for session launch boundaries (`FleetSessionEnv`) |

--- a/src/autoskillit/core/types/__init__.py
+++ b/src/autoskillit/core/types/__init__.py
@@ -18,6 +18,8 @@ from ._type_dispatch_identity import *  # noqa: F401, F403
 from ._type_dispatch_identity import __all__ as _dispatch_identity_all
 from ._type_enums import *  # noqa: F401, F403
 from ._type_enums import __all__ as _enums_all
+from ._type_exceptions import *  # noqa: F401, F403
+from ._type_exceptions import __all__ as _exceptions_all
 from ._type_figure_spec import *  # noqa: F401, F403
 from ._type_figure_spec import __all__ as _figure_spec_all
 from ._type_helpers import *  # noqa: F401, F403
@@ -58,6 +60,7 @@ __all__ = (
     + _constants_all
     + _dispatch_identity_all
     + _enums_all
+    + _exceptions_all
     + _figure_spec_all
     + _helpers_all
     + _plugin_source_all

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -414,6 +414,7 @@ class FleetErrorCode(StrEnum):
     FLEET_GATE_NO_CAMPAIGN = "fleet_gate_no_campaign"
     FLEET_ACQUIRE_TIMEOUT = "fleet_acquire_timeout"
     FLEET_RECIPE_INVALID = "fleet_recipe_invalid"
+    FLEET_PROCESS_STALE = "fleet_process_stale"
     FLEET_DISPATCH_SKIPPED = "fleet_dispatch_skipped"
 
 

--- a/src/autoskillit/core/types/_type_exceptions.py
+++ b/src/autoskillit/core/types/_type_exceptions.py
@@ -1,0 +1,21 @@
+"""Exception types for recipe loading failures."""
+
+from __future__ import annotations
+
+__all__ = [
+    "RecipeLoadError",
+    "ProcessStaleError",
+    "RecipeNotFoundError",
+]
+
+
+class RecipeLoadError(Exception):
+    """Base exception for load_and_validate failures."""
+
+
+class ProcessStaleError(RecipeLoadError):
+    """MCP server process is running stale code — restart required."""
+
+
+class RecipeNotFoundError(RecipeLoadError):
+    """Named recipe could not be found in any scan directory."""

--- a/src/autoskillit/core/types/_type_protocols_recipe.py
+++ b/src/autoskillit/core/types/_type_protocols_recipe.py
@@ -36,7 +36,12 @@ class RecipeRepository(Protocol):
         ingredient_overrides: dict[str, str] | None = None,
         temp_dir: Path | None = None,
         temp_dir_relpath: str | None = None,
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        """Load and validate a recipe.
+
+        Raises ProcessStaleError or RecipeNotFoundError on failure.
+        """
+        ...
 
     def validate_from_path(
         self, script_path: Any, temp_dir_relpath: str = ".autoskillit/temp"

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -20,6 +20,7 @@ from autoskillit.core import (
     CaptureValueTypeError,
     FleetErrorCode,
     InfraExitCategory,
+    ProcessStaleError,
     RetryReason,
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
@@ -583,6 +584,14 @@ async def _run_dispatch(
             tool_ctx.project_dir,
             suppressed=tool_ctx.config.migration.suppressed if tool_ctx.config else None,
             temp_dir=tool_ctx.temp_dir,
+        )
+    except ProcessStaleError as exc:
+        return DispatchResult(
+            DispatchRejected(
+                error_code=FleetErrorCode.FLEET_PROCESS_STALE,
+                message=str(exc),
+            ),
+            per_dispatch_state_path=None,
         )
     except Exception as exc:
         logger.warning("load_and_validate failed for '%s'", recipe, exc_info=True)

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -63,6 +63,7 @@ _ERROR_CODE_CATEGORIES: dict[str, ErrorCodeCategory] = {
     FleetErrorCode.FLEET_MANIFEST_CORRUPTED: ErrorCodeCategory.INFRASTRUCTURE,
     FleetErrorCode.FLEET_LOCK_NOT_INITIALIZED: ErrorCodeCategory.INFRASTRUCTURE,
     FleetErrorCode.FLEET_RECIPE_INVALID: ErrorCodeCategory.INFRASTRUCTURE,
+    FleetErrorCode.FLEET_PROCESS_STALE: ErrorCodeCategory.INFRASTRUCTURE,
     FleetErrorCode.FLEET_FEATURE_DISABLED: ErrorCodeCategory.INFRASTRUCTURE,
     FleetErrorCode.FLEET_DISPATCH_SKIPPED: ErrorCodeCategory.INFRASTRUCTURE,
     FleetErrorCode.FLEET_GATE_ALREADY_RECORDED: ErrorCodeCategory.INFRASTRUCTURE,

--- a/src/autoskillit/hooks/formatters/_fmt_recipe.py
+++ b/src/autoskillit/hooks/formatters/_fmt_recipe.py
@@ -25,7 +25,6 @@ _FMT_LOAD_RECIPE_RENDERED: frozenset[str] = frozenset(
     {
         "valid",
         "suggestions",
-        "error",
         "content",
         "ingredients_table",
         "orchestration_rules",
@@ -160,7 +159,6 @@ _FMT_OPEN_KITCHEN_RENDERED: frozenset[str] = frozenset(
     {
         "valid",
         "suggestions",
-        "error",
         "content",
         "ingredients_table",
         "orchestration_rules",

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -13,6 +13,8 @@ from typing import Any
 
 from autoskillit.core import (
     LoadResult,
+    ProcessStaleError,
+    RecipeNotFoundError,
     RecipeSource,
     SkillLister,
     YAMLError,
@@ -146,6 +148,26 @@ _STALENESS_LAST_CHECK: float = 0.0
 _STALENESS_IS_STALE: bool = False
 _STALENESS_CACHES_CLEARED: bool = False
 _STALENESS_TTL: float = 30.0
+_STALENESS_SCAN_DIRS: tuple[str, ...] = ("recipe/rules",)
+_DEEP_MTIME_BASELINE: int | None = None
+
+
+def _compute_deep_mtime() -> int:
+    """Return max mtime_ns across all .py files in staleness-scanned subdirectories."""
+    root = pkg_root()
+    max_mt = 0
+    for subdir in _STALENESS_SCAN_DIRS:
+        d = root / subdir
+        if d.is_dir():
+            for f in d.iterdir():
+                if f.suffix == ".py" and f.is_file():
+                    try:
+                        mt = f.stat().st_mtime_ns
+                        if mt > max_mt:
+                            max_mt = mt
+                    except OSError:
+                        continue
+    return max_mt
 
 
 def _get_process_start_mtime() -> int:
@@ -156,14 +178,20 @@ def _get_process_start_mtime() -> int:
 
 
 def _check_process_staleness() -> bool:
-    """Return True if the package directory was modified after process start."""
-    global _STALENESS_LAST_CHECK, _STALENESS_IS_STALE  # noqa: PLW0603
+    """Return True if the package directory or rule files were modified after process start."""
+    global _STALENESS_LAST_CHECK, _STALENESS_IS_STALE, _DEEP_MTIME_BASELINE  # noqa: PLW0603
     now = time.monotonic()
     if now - _STALENESS_LAST_CHECK < _STALENESS_TTL:
         return _STALENESS_IS_STALE
     _STALENESS_LAST_CHECK = now
     try:
-        _STALENESS_IS_STALE = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
+        pkg_stale = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
+        if not pkg_stale:
+            current_deep = _compute_deep_mtime()
+            if _DEEP_MTIME_BASELINE is None:
+                _DEEP_MTIME_BASELINE = current_deep
+            pkg_stale = current_deep != _DEEP_MTIME_BASELINE
+        _STALENESS_IS_STALE = pkg_stale
     except (OSError, RuntimeError):
         logger.warning("pkg_root() unavailable during staleness check; assuming non-stale")
         _STALENESS_IS_STALE = False
@@ -400,19 +428,19 @@ def load_and_validate(
             recipe defaults. Used to activate hidden features (e.g., sprint_mode).
 
     Returns:
-        {"content": str, "suggestions": list, "valid": bool}
-        On not-found: {"error": str}
+        ``LoadRecipeResult`` dict on success (always has ``valid``, ``suggestions``).
+
+    Raises:
+        ProcessStaleError: Package directory was modified since server startup.
+        RecipeNotFoundError: Named recipe could not be found.
     """
     if _check_process_staleness():
         if not _STALENESS_CACHES_CLEARED:
             _clear_stale_caches()
-        return {
-            "error": (
-                "Process is running stale code — package directory was modified on disk "
-                "since server startup. Restart the MCP server via reload_session."
-            ),
-            "valid": False,
-        }
+        raise ProcessStaleError(
+            "Process is running stale code — package directory was modified on disk "
+            "since server startup. Restart the MCP server via reload_session."
+        )
 
     _pdir = project_dir if project_dir is not None else Path.cwd()
     pkg_version = _get_pkg_version()
@@ -482,7 +510,7 @@ def load_and_validate(
     t0 = _t("find_recipe", t0, name)
 
     if match is None:
-        return {"error": f"No recipe named '{name}' found"}
+        raise RecipeNotFoundError(f"No recipe named '{name}' found")
 
     raw = match.content if match.content is not None else match.path.read_text()
     raw = substitute_temp_placeholder(raw, _temp_relpath)

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -171,15 +171,16 @@ def _compute_deep_mtime() -> int:
 
 
 def _get_process_start_mtime() -> int:
-    global _PROCESS_START_PKG_MTIME  # noqa: PLW0603
+    global _PROCESS_START_PKG_MTIME, _DEEP_MTIME_BASELINE  # noqa: PLW0603
     if _PROCESS_START_PKG_MTIME is None:
         _PROCESS_START_PKG_MTIME = _path_mtime_ns(pkg_root())
+        _DEEP_MTIME_BASELINE = _compute_deep_mtime()
     return _PROCESS_START_PKG_MTIME
 
 
 def _check_process_staleness() -> bool:
     """Return True if the package directory or rule files were modified after process start."""
-    global _STALENESS_LAST_CHECK, _STALENESS_IS_STALE, _DEEP_MTIME_BASELINE  # noqa: PLW0603
+    global _STALENESS_LAST_CHECK, _STALENESS_IS_STALE  # noqa: PLW0603
     now = time.monotonic()
     if now - _STALENESS_LAST_CHECK < _STALENESS_TTL:
         return _STALENESS_IS_STALE
@@ -188,8 +189,6 @@ def _check_process_staleness() -> bool:
         pkg_stale = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
         if not pkg_stale:
             current_deep = _compute_deep_mtime()
-            if _DEEP_MTIME_BASELINE is None:
-                _DEEP_MTIME_BASELINE = current_deep
             pkg_stale = current_deep != _DEEP_MTIME_BASELINE
         _STALENESS_IS_STALE = pkg_stale
     except (OSError, RuntimeError):

--- a/src/autoskillit/recipe/_recipe_ingredients.py
+++ b/src/autoskillit/recipe/_recipe_ingredients.py
@@ -111,7 +111,6 @@ class LoadRecipeResult(TypedDict, total=False):
     kitchen_rules: list[str]
     requires_packs: list[str]
     requires_features: list[str]
-    error: str
     greeting: str
     ingredients_table: str
     orchestration_rules: str
@@ -127,7 +126,7 @@ class OpenKitchenResult(TypedDict, total=False):
     Extends LoadRecipeResult with three post-return keys injected by the handler.
     """
 
-    # Inherited from LoadRecipeResult (15 keys)
+    # Inherited from LoadRecipeResult (14 keys)
     content: str
     diagram: str | None
     suggestions: list[dict[str, Any]]
@@ -135,7 +134,6 @@ class OpenKitchenResult(TypedDict, total=False):
     kitchen_rules: list[str]
     requires_packs: list[str]
     requires_features: list[str]
-    error: str
     greeting: str
     ingredients_table: str | None
     orchestration_rules: str

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -18,6 +18,7 @@ from autoskillit import __version__
 from autoskillit.config import iter_display_categories, resolve_ingredient_defaults
 from autoskillit.core import (
     PIPELINE_FORBIDDEN_TOOLS,
+    ProcessStaleError,
     _collect_disabled_feature_tags,
     atomic_write,
     find_latest_session_id,
@@ -416,6 +417,9 @@ async def open_kitchen(
                     resolved_defaults=_defaults,
                     ingredient_overrides=overrides,
                 )
+            except ProcessStaleError as exc:
+                logger.warning("open_kitchen_failure", stage="process_stale", exc_info=True)
+                return _kitchen_failure_envelope(exc, stage="process_stale")
             except Exception as exc:
                 logger.warning("open_kitchen_failure", stage="load_and_validate", exc_info=True)
                 return _kitchen_failure_envelope(exc, stage="load_and_validate")

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -40,6 +40,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_layer_enforcement.py` | MCP tool registry + import layer contracts + cross-package rules |
 | `test_layer_markers.py` | Enforce pytestmark layer markers on all in-scope test files |
 | `test_never_raises_contracts.py` | Structural enforcement of 'Never raises' docstring contracts in server/ |
+| `test_no_error_dict_return.py` | AST guard: load_and_validate must not return dicts with 'error' key — errors flow via exceptions |
 | `test_no_inline_jsonl_request_id_dedup.py` | AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py |
 | `test_protocol_names.py` | T5-T6: Protocol naming and DefaultSkillResolver export smoke tests |
 | `test_python_no_hardcoded_temp.py` | Architectural invariant: no literal `.autoskillit/temp` outside the whitelist |

--- a/tests/arch/test_no_error_dict_return.py
+++ b/tests/arch/test_no_error_dict_return.py
@@ -1,0 +1,49 @@
+"""AST guard: load_and_validate must never return a dict containing an 'error' key.
+
+Errors flow via exceptions (ProcessStaleError, RecipeNotFoundError).
+Returning {"error": ...} re-introduces the silent-drop bug that callers
+cannot reliably detect at the type level.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+RECIPE_API = SRC / "recipe" / "_api.py"
+
+
+def _find_function_node(
+    tree: ast.Module, name: str
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    return None
+
+
+def _has_error_key_in_dict(node: ast.Dict) -> bool:
+    for key in node.keys:
+        if isinstance(key, ast.Constant) and key.value == "error":
+            return True
+    return False
+
+
+def test_load_and_validate_has_no_error_dict_return():
+    """No return statement in load_and_validate may contain a dict literal with 'error' key."""
+    tree = ast.parse(RECIPE_API.read_text())
+    func = _find_function_node(tree, "load_and_validate")
+    assert func is not None, "load_and_validate function not found in recipe/_api.py"
+
+    violations: list[int] = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Return) and node.value is not None:
+            for child in ast.walk(node.value):
+                if isinstance(child, ast.Dict) and _has_error_key_in_dict(child):
+                    violations.append(node.lineno)
+
+    assert violations == [], (
+        f"load_and_validate has return statements with 'error' dict keys at lines {violations}. "
+        "Use ProcessStaleError or RecipeNotFoundError exceptions instead."
+    )

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -769,7 +769,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         constant for backend capability declarations (IL-0), bringing the count to 21.
         _type_token.py adds CanonicalTokenUsage frozen dataclass for provider-agnostic
         token usage normalization (IL-0), bringing the count to 22.
-        Exempt at 34 files (core/types: 22).
+        _type_exceptions.py adds RecipeLoadError hierarchy (ProcessStaleError,
+        RecipeNotFoundError) for exception-based error propagation from
+        load_and_validate, bringing the count to 23.
+        Exempt at 35 files (core/types: 23).
       cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
         for backward-compatible cli/ imports; canonical implementation lives in
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -825,7 +828,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 31,
         "execution": 18,
         "core": 20,
-        "core/types": 23,
+        "core/types": 24,
         "cli": 20,
         "hooks": 10,
         "pipeline": 12,

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -18,6 +18,7 @@ class TestCoreSubpackages:
             "_type_dispatch_identity",
             "_type_enums",
             "_type_constants",
+            "_type_exceptions",
             "_type_results",
             "_type_subprocess",
             "_type_helpers",

--- a/tests/contracts/test_package_gateways.py
+++ b/tests/contracts/test_package_gateways.py
@@ -100,10 +100,11 @@ def test_recipe_facades_in_all():
 
 
 def test_recipe_load_and_validate_not_found(tmp_path):
+    from autoskillit.core import RecipeNotFoundError
     from autoskillit.recipe import load_and_validate
 
-    result = load_and_validate("__nonexistent__", project_dir=tmp_path)
-    assert "error" in result
+    with pytest.raises(RecipeNotFoundError):
+        load_and_validate("__nonexistent__", project_dir=tmp_path)
 
 
 def test_recipe_load_and_validate_found_returns_required_keys(tmp_path):

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -19,6 +19,8 @@ from autoskillit.core.types import (
     DatabaseReader,
     HeadlessExecutor,
     MergeQueueWatcher,
+    ProcessStaleError,
+    RecipeNotFoundError,
     RecipeRepository,
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
@@ -326,6 +328,7 @@ class InMemoryRecipeRepository(RecipeRepository):
         self._validated: dict[str, dict[str, Any]] = {}
         self._path_validated: dict[str, dict[str, Any]] = {}
         self._all_recipes: dict[str, Any] = {}
+        self._stale: bool = False
         self.calls: list[dict[str, Any]] = []
 
     # -- test setup helpers --
@@ -352,6 +355,9 @@ class InMemoryRecipeRepository(RecipeRepository):
 
     def set_all(self, data: dict[str, Any]) -> None:
         self._all_recipes = data
+
+    def set_stale(self, stale: bool) -> None:
+        self._stale = stale
 
     # -- protocol methods --
 
@@ -395,6 +401,13 @@ class InMemoryRecipeRepository(RecipeRepository):
                 "temp_dir_relpath": temp_dir_relpath,
             }
         )
+        if self._stale:
+            raise ProcessStaleError(
+                "Process is running stale code — package directory was modified on disk "
+                "since server startup. Restart the MCP server via reload_session."
+            )
+        if name not in self._validated and name not in self._recipes:
+            raise RecipeNotFoundError(f"No recipe named '{name}' found")
         return self._validated.get(name, {"valid": True, "suggestions": []})
 
     def validate_from_path(

--- a/tests/fleet/CLAUDE.md
+++ b/tests/fleet/CLAUDE.md
@@ -44,6 +44,7 @@ Fleet campaign dispatch, state persistence, and sidecar tests.
 | `test_sidecar.py` | Sidecar tests |
 | `test_startup_label_recovery.py` | Tests for sweep_stale_dispatch_labels — dead dispatch label cleanup, alive dispatch skip, missing sidecar, multi-campaign |
 | `test_find_dispatch_for_issue.py` | Tests for find_dispatch_for_issue — running dispatch sidecar lookup, non-running skip, missing sidecar, empty state, corrupt state |
+| `test_staleness_propagation.py` | Tests for ProcessStaleError propagation through fleet dispatch — FLEET_PROCESS_STALE error code |
 | `test_state.py` | Tests for fleet state module (Group J) |
 | `test_state_lock_contract.py` | Locking contract tests — AST scan for flock targets, flock acquisition per mutation, cross-caller concurrency |
 | `test_state_protection.py` | Tests for fleet.state.build_protected_campaign_ids (PROT_1–PROT_9) |

--- a/tests/fleet/test_error_envelope.py
+++ b/tests/fleet/test_error_envelope.py
@@ -49,6 +49,7 @@ class TestFleetErrorCodeEnum:
             "fleet_acquire_timeout",
             "fleet_recipe_invalid",
             "fleet_dispatch_skipped",
+            "fleet_process_stale",
         }
         assert {c.value for c in FleetErrorCode} == expected_values
 

--- a/tests/fleet/test_staleness_propagation.py
+++ b/tests/fleet/test_staleness_propagation.py
@@ -1,0 +1,64 @@
+"""Tests for staleness error propagation through fleet dispatch."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.core import FleetErrorCode
+from autoskillit.fleet import FleetSemaphore
+from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+from tests.server._helpers import _make_recipe_info, _make_standard_recipe
+
+pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+async def _no_sleep_quota_checker(config, **kwargs) -> dict:
+    return {
+        "should_sleep": False,
+        "sleep_seconds": 0,
+        "utilization": None,
+        "resets_at": None,
+        "window_name": None,
+    }
+
+
+async def _noop_quota_refresher(config, **kwargs) -> None:
+    pass
+
+
+def _simple_prompt_builder(**kwargs) -> str:
+    return f"prompt-for-{kwargs.get('recipe', 'unknown')}"
+
+
+class TestStalenessErrorPropagation:
+    @pytest.mark.anyio
+    async def test_stale_process_returns_fleet_process_stale(self, tool_ctx):
+        """ProcessStaleError from load_and_validate → FLEET_PROCESS_STALE rejection."""
+        from autoskillit.fleet._api import execute_dispatch
+
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        repo = InMemoryRecipeRepository()
+        recipe_info = _make_recipe_info("test-recipe")
+        repo.add_recipe("test-recipe", recipe_info)
+        repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe", ["task"]))
+        repo.set_stale(True)
+        tool_ctx.recipes = repo
+        tool_ctx.executor = InMemoryHeadlessExecutor()
+
+        dispatch_result = await execute_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="t",
+            ingredients=None,
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=_simple_prompt_builder,
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+        result = json.loads(dispatch_result.outcome.to_envelope())
+        assert result["success"] is False
+        assert result["error"] == FleetErrorCode.FLEET_PROCESS_STALE
+        assert "stale" in result["user_visible_message"].lower()

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -117,9 +117,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 63),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools/tools_kitchen.py", 118),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 137),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 592),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 119),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 138),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 596),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 486),
     # tools_github.py — bug report dict

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -28,6 +28,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_callable_contracts.py` | Contract tests for run_python callable inputs and outputs |
 | `test_campaign_loader.py` | Tests for campaign recipe loading |
 | `test_create_worktree_functional.py` | Functional tests for scripts/recipe/create_worktree.sh — actually executes the script against real git repos |
+| `test_deep_staleness.py` | Tests for deep staleness detection — rule file mtime scan in _check_process_staleness |
 | `test_check_ci_already_passed_routing.py` | Tests for check_ci_already_passed routing logic |
 | `test_check_repo_merge_state_routing.py` | Tests for check_repo_merge_state routing logic |
 | `test_cmd_rpc.py` | Tests for recipe/_cmd_rpc.py run_python callables |

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -1036,6 +1036,7 @@ def test_load_and_validate_raises_on_not_found(tmp_path, monkeypatch):
 def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
     """Staleness detection clears lru_cache helpers."""
     import autoskillit.recipe._api as api_mod
+    from autoskillit.core import ProcessStaleError
     from autoskillit.recipe.contracts import load_bundled_manifest
     from autoskillit.recipe.methodology_venue_appendix import load_ml_sub_area_folding
     from autoskillit.recipe.rules.rules_blocks import _block_budgets
@@ -1069,7 +1070,8 @@ def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
     recipes_dir.mkdir(parents=True)
     (recipes_dir / "myrecipe.yaml").write_text(MINIMAL_RECIPE_YAML)
 
-    api_mod.load_and_validate("myrecipe", tmp_path)
+    with pytest.raises(ProcessStaleError):
+        api_mod.load_and_validate("myrecipe", tmp_path)
 
     assert _block_budgets.cache_info().currsize == 0
     assert load_bundled_manifest.cache_info().currsize == 0

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -991,8 +991,9 @@ def test_load_and_validate_cache_invalidated_on_rule_registry_change(tmp_path, m
 
 
 def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):
-    """Stale process returns error result instead of evaluating recipes."""
+    """Stale process raises ProcessStaleError instead of evaluating recipes."""
     import autoskillit.recipe._api as api_mod
+    from autoskillit.core import ProcessStaleError
 
     monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
     monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
@@ -1015,10 +1016,21 @@ def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):
     recipes_dir.mkdir(parents=True)
     (recipes_dir / "myrecipe.yaml").write_text(MINIMAL_RECIPE_YAML)
 
-    result = api_mod.load_and_validate("myrecipe", tmp_path)
+    with pytest.raises(ProcessStaleError, match="stale"):
+        api_mod.load_and_validate("myrecipe", tmp_path)
 
-    assert result.get("valid") is False
-    assert "stale" in result.get("error", "").lower()
+
+def test_load_and_validate_raises_on_not_found(tmp_path, monkeypatch):
+    """load_and_validate raises RecipeNotFoundError for nonexistent recipes."""
+    import autoskillit.recipe._api as api_mod
+    from autoskillit.core import RecipeNotFoundError
+
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+
+    with pytest.raises(RecipeNotFoundError, match="nonexistent_recipe"):
+        api_mod.load_and_validate("nonexistent_recipe", tmp_path)
 
 
 def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -33,24 +33,13 @@ def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
     assert api_mod._check_process_staleness() is True
 
 
-def test_deep_staleness_baseline_initialized_on_first_check(tmp_path, monkeypatch):
-    """First call to _check_process_staleness sets the deep mtime baseline."""
+def test_deep_staleness_baseline_initialized_eagerly(tmp_path, monkeypatch):
+    """_get_process_start_mtime eagerly sets the deep mtime baseline."""
     import autoskillit.recipe._api as api_mod
 
-    monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
-    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
-    monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+    monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", None)
     monkeypatch.setattr(api_mod, "_DEEP_MTIME_BASELINE", None)
-
-    def fake_mtime(path):
-        from autoskillit.core import pkg_root
-
-        if path == pkg_root():
-            return 1000
-        return 0
-
-    monkeypatch.setattr(api_mod, "_path_mtime_ns", fake_mtime)
     monkeypatch.setattr(api_mod, "_compute_deep_mtime", lambda: 5000)
 
-    assert api_mod._check_process_staleness() is False
+    api_mod._get_process_start_mtime()
     assert api_mod._DEEP_MTIME_BASELINE == 5000

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
-    """Changes to .py files in recipe/rules/ trigger staleness even when pkg_root() mtime is unchanged."""
+    """Rule file changes trigger staleness even when pkg_root() mtime is unchanged."""
     import autoskillit.recipe._api as api_mod
 
     monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -1,0 +1,56 @@
+"""Tests for deep staleness detection in recipe/_api.py."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
+    """Changes to .py files in recipe/rules/ trigger staleness even when pkg_root() mtime is unchanged."""
+    import autoskillit.recipe._api as api_mod
+
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
+    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+    monkeypatch.setattr(api_mod, "_STALENESS_CACHES_CLEARED", False)
+    monkeypatch.setattr(api_mod, "_DEEP_MTIME_BASELINE", 5000)
+
+    real_mtime = api_mod._path_mtime_ns
+
+    def fake_mtime(path):
+        from autoskillit.core import pkg_root
+
+        if path == pkg_root():
+            return 1000
+        return real_mtime(path)
+
+    monkeypatch.setattr(api_mod, "_path_mtime_ns", fake_mtime)
+    monkeypatch.setattr(api_mod, "_compute_deep_mtime", lambda: 9999)
+
+    assert api_mod._check_process_staleness() is True
+
+
+def test_deep_staleness_baseline_initialized_on_first_check(tmp_path, monkeypatch):
+    """First call to _check_process_staleness sets the deep mtime baseline."""
+    import autoskillit.recipe._api as api_mod
+
+    monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1000)
+    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+    monkeypatch.setattr(api_mod, "_DEEP_MTIME_BASELINE", None)
+
+    def fake_mtime(path):
+        from autoskillit.core import pkg_root
+
+        if path == pkg_root():
+            return 1000
+        return 0
+
+    monkeypatch.setattr(api_mod, "_path_mtime_ns", fake_mtime)
+    monkeypatch.setattr(api_mod, "_compute_deep_mtime", lambda: 5000)
+
+    assert api_mod._check_process_staleness() is False
+    assert api_mod._DEEP_MTIME_BASELINE == 5000

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -74,6 +74,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_kitchen_gate.py` | Tests for tools_kitchen.py: gate mechanics, hook config, recipe packs, refresh, misc |
 | `test_tools_kitchen_visibility.py` | Tests for tools_kitchen.py: visibility, component management, sous-chef, redisable_subsets |
 | `test_no_path_cwd_in_tools.py` | Regression guard: Path.cwd() must not appear in server tool handlers |
+| `test_open_kitchen_staleness.py` | Tests for ProcessStaleError propagation through open_kitchen — failure envelope with staleness context |
 | `test_tools_label_validation.py` | Tests for label whitelist validation in server tool handlers |
 | `test_tools_list_recipes.py` | Tests for autoskillit server list_recipes tool |
 | `test_tools_load_recipe.py` | Tests for autoskillit server load_recipe tool |

--- a/tests/server/test_open_kitchen_staleness.py
+++ b/tests/server/test_open_kitchen_staleness.py
@@ -1,0 +1,38 @@
+"""Tests for ProcessStaleError propagation through open_kitchen."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from autoskillit.core import ProcessStaleError
+from tests.server.conftest import _make_mock_ctx
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_stale_returns_failure_envelope():
+    """ProcessStaleError from load_and_validate → failure envelope with staleness context."""
+    from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.side_effect = ProcessStaleError(
+        "Process is running stale code"
+    )
+
+    with (
+        patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+        patch("autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()),
+        patch("autoskillit.server.tools.tools_kitchen._write_hook_config"),
+    ):
+        result = await open_kitchen(name="test-recipe", ctx=mock_ctx)
+
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert "stale" in parsed["error"].lower()
+    assert parsed["stage"] == "process_stale"

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -743,22 +743,25 @@ async def test_open_kitchen_uses_project_dir_for_recipe_lookup(tmp_path, monkeyp
     Regression test: when project_dir differs from cwd, recipes must be found
     in project_dir's .autoskillit/recipes/ directory.
     """
-    import yaml
-
     monkeypatch.chdir(tmp_path)  # Ensure cwd != project_dir
     different_dir = tmp_path / "project_root"
     different_dir.mkdir()
 
     # Create a recipe only in project_dir, not in cwd
-    recipe_yaml = {
-        "name": "test-project-dir-recipe",
-        "description": "Test recipe for project_dir propagation",
-        "ingredients": [],
-        "steps": [{"tool": "run_skill", "name": "s1", "with": {"skill": "test"}}],
-    }
+    recipe_yaml_text = (
+        "name: test-project-dir-recipe\n"
+        "description: Test recipe for project_dir propagation\n"
+        "autoskillit_version: '0.2.0'\n"
+        "kitchen_rules:\n"
+        "  - Never use native tools\n"
+        "steps:\n"
+        "  stop:\n"
+        "    action: stop\n"
+        "    message: done\n"
+    )
     recipes_dir = different_dir / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
-    (recipes_dir / "test-project-dir-recipe.yaml").write_text(yaml.dump(recipe_yaml))
+    (recipes_dir / "test-project-dir-recipe.yaml").write_text(recipe_yaml_text)
 
     # Build context with project_dir = different_dir, recipes = RealRecipeRepository
     from autoskillit.config.settings import AutomationConfig

--- a/tests/test_fakes_conformance.py
+++ b/tests/test_fakes_conformance.py
@@ -241,6 +241,7 @@ def test_recipe_repository_list_records_call():
 
 def test_recipe_repository_load_and_validate_records_call():
     repo = InMemoryRecipeRepository()
+    repo.set_validated("my-recipe", {"valid": True, "suggestions": []})
     repo.load_and_validate(
         "my-recipe",
         Path("/proj"),
@@ -280,6 +281,7 @@ def test_recipe_repository_list_all_records_call_with_none_project_dir():
 
 def test_recipe_repository_calls_accumulate():
     repo = InMemoryRecipeRepository()
+    repo.set_validated("r1", {"valid": True, "suggestions": []})
     repo.find("r1", Path("/a"))
     repo.list_all()
     repo.load_and_validate("r1", Path("/a"))


### PR DESCRIPTION
## Summary

Fleet dispatch sessions break when autoskillit code changes on disk during a campaign, because `load_and_validate()` in `recipe/_api.py` communicates errors via optional dict keys instead of exceptions — allowing callers to silently ignore errors — while the staleness guard checks only the top-level `pkg_root()` directory mtime, missing changes to files in subdirectories like `recipe/rules/`.

This PR converts all error return paths in `load_and_validate()` to exceptions (`ProcessStaleError`, `RecipeNotFoundError`) — making it structurally impossible for any caller to silently ignore errors — and deepens staleness detection to scan file-level mtimes in validation-critical subdirectories.

## Requirements

## Problem Summary

Fleet Dispatch sessions break when autoskillit code changes on disk during a campaign, while order and cook sessions are operationally immune. The root cause is an architectural asymmetry: `dispatch_food_truck` performs recipe validation **in-process** within a long-lived MCP server — and calls it **repeatedly** (once per dispatch, many times per campaign). In contrast, `run_skill` (used by order sessions) delegates all work to fresh subprocesses, and `open_kitchen` (which also validates in-process) is called only **once** at session start when the MCP server is still fresh.

### Two Failure Modes

**Mode A: Staleness Guard Fires (Explicit Block)** — `pkg_root()` directory mtime changes. `_check_process_staleness()` returns `True`, `_clear_stale_caches()` runs, `load_and_validate()` returns `{"error": "Process is running stale code...", "valid": False}`. Bug: `fleet/_api.py:597-608` reads `suggestions` key but never reads `error` — LLM sees `"Recipe 'X' has validation errors: "` (empty).

**Mode B: Stale Rules Produce False Errors (Silent Corruption)** — Rule `.py` files edited in-place, YAML also modified. `_LOAD_CACHE` misses and re-validates against stale in-memory rules. `pkg_root()` directory mtime doesn't change for subpackage edits, so Mode A guard doesn't fire.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    START([MCP Tool Call])

    subgraph Entry ["Entry Points"]
        direction TB
        DISPATCH["dispatch_food_truck<br/>━━━━━━━━━━<br/>fleet/_api.py:580"]
        KITCHEN["open_kitchen<br/>━━━━━━━━━━<br/>tools_kitchen.py:412"]
        LOADTOOL["load_recipe<br/>━━━━━━━━━━<br/>tools_recipe.py:201"]
    end

    subgraph Validation ["● load_and_validate — recipe/_api.py"]
        direction TB
        STALE{"★ Deep Staleness<br/>Check<br/>━━━━━━━━━━<br/>pkg_root + rules/*.py<br/>file-level mtime scan"}
        STALE_YES["★ raise ProcessStaleError<br/>━━━━━━━━━━<br/>Exception, not dict return"]
        NOTFOUND["★ raise RecipeNotFoundError<br/>━━━━━━━━━━<br/>Exception, not dict return"]
        CACHE{"Cache Hit?<br/>━━━━━━━━━━<br/>_LOAD_CACHE check"}
        VALIDATE["Run Validation<br/>━━━━━━━━━━<br/>Schema + Rules + Contracts"]
        RESULT["Return LoadRecipeResult<br/>━━━━━━━━━━<br/>Success dict only"]
    end

    subgraph ErrorHandling ["★ Exception-Based Error Handling"]
        direction TB
        DISPATCH_CATCH["★ except ProcessStaleError<br/>━━━━━━━━━━<br/>DispatchRejected with<br/>FLEET_PROCESS_STALE"]
        DISPATCH_CATCH_OTHER["except RecipeLoadError<br/>━━━━━━━━━━<br/>DispatchRejected with<br/>FLEET_RECIPE_INVALID"]
        KITCHEN_CATCH["except ProcessStaleError<br/>━━━━━━━━━━<br/>_kitchen_failure_envelope<br/>stage=process_stale"]
    end

    subgraph Outcomes ["Outcomes"]
        direction TB
        SUCCESS_D(["Dispatch Proceeds"])
        SUCCESS_K(["Kitchen Opens"])
        REJECT(["DispatchRejected<br/>with actionable message"])
        FAIL(["Kitchen Failure<br/>with staleness context"])
    end

    START --> DISPATCH & KITCHEN & LOADTOOL

    DISPATCH --> STALE
    KITCHEN --> STALE
    LOADTOOL --> STALE

    STALE -->|"stale"| STALE_YES
    STALE -->|"fresh"| CACHE
    CACHE -->|"not found"| NOTFOUND
    CACHE -->|"miss"| VALIDATE
    CACHE -->|"hit"| RESULT
    VALIDATE --> RESULT

    STALE_YES -.->|"raises"| DISPATCH_CATCH & KITCHEN_CATCH
    NOTFOUND -.->|"raises"| DISPATCH_CATCH_OTHER & KITCHEN_CATCH

    RESULT -->|"valid=True"| SUCCESS_D & SUCCESS_K
    RESULT -->|"valid=False"| DISPATCH_CATCH_OTHER

    DISPATCH_CATCH --> REJECT
    DISPATCH_CATCH_OTHER --> REJECT
    KITCHEN_CATCH --> FAIL

    class START terminal;
    class DISPATCH,KITCHEN,LOADTOOL handler;
    class STALE,CACHE stateNode;
    class STALE_YES,NOTFOUND,DISPATCH_CATCH,DISPATCH_CATCH_OTHER,KITCHEN_CATCH newComponent;
    class VALIDATE,RESULT phase;
    class SUCCESS_D,SUCCESS_K terminal;
    class REJECT,FAIL detector;
```

Closes #2735

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260522-171102-557869/.autoskillit/temp/rectify/rectify_fleet_dispatch_staleness_asymmetry_2026-05-22_171500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 51 | 18.6k | 832.8k | 115.6k | 145 | 66.7k | 9m 35s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 1.1k | 18.8k | 690.5k | 75.9k | 141 | 51.8k | 12m 13s |
| implement | claude-opus-4-6 | 1 | 160 | 30.6k | 9.1M | 139.1k | 210 | 123.9k | 11m 49s |
| prepare_pr* | MiniMax-M2.7 | 1 | 85.8k | 4.3k | 408.3k | 29.8k | 25 | 42.7k | 1m 38s |
| compose_pr* | MiniMax-M2.7 | 1 | 42.9k | 2.8k | 362.8k | 0 | 23 | 0 | 29s |
| review_pr | claude-opus-4-6 | 3 | 120 | 98.5k | 1.5M | 91.7k | 86 | 260.0k | 24m 53s |
| resolve_review | claude-opus-4-6 | 1 | 57 | 16.1k | 1.2M | 72.7k | 82 | 60.1k | 11m 32s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 30 | 2.4k | 405.6k | 40.4k | 22 | 26.6k | 1m 17s |
| diagnose_ci* | MiniMax-M2.7 | 1 | 56.7k | 4.3k | 803.8k | 0 | 42 | 0 | 43s |
| resolve_ci | claude-opus-4-6 | 1 | 35 | 4.3k | 686.9k | 49.6k | 33 | 36.2k | 9m 4s |
| **Total** | | | 186.9k | 200.9k | 15.9M | 139.1k | | 668.0k | 1h 23m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 352 | 25757.4 | 352.1 | 87.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 26 | 45026.7 | 2309.8 | 620.6 |
| ci_conflict_fix | 1235 | 328.4 | 21.5 | 2.0 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 2 | 343448.0 | 18095.5 | 2167.0 |
| **Total** | **1615** | 9862.8 | 413.6 | 124.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 1.1k | 37.4k | 1.5M | 118.5k | 21m 48s |
| claude-opus-4-6 | 5 | 402 | 152.1k | 12.8M | 506.8k | 58m 36s |
| MiniMax-M2.7 | 3 | 185.4k | 11.5k | 1.6M | 42.7k | 2m 49s |