### PR TITLE
[FEATURE] Add MODULE_CASCADE_CORE entries for _json and _type_protocols_backend

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -164,6 +164,7 @@ _CORE_UNIVERSAL_EXCLUSIONS: dict[str, frozenset[str]] = {
 }
 
 MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
+    "_json": frozenset({"core", "execution", "pipeline", "recipe"}),
     "feature_flags": frozenset(
         {"core", "cli", "config", "execution", "recipe", "server", "workspace"}
     ),
@@ -195,6 +196,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_resume": frozenset({"core", "cli", "execution", "fleet"}),
     "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
     "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "workspace"}),
+    "_type_protocols_backend": frozenset({"core", "execution", "pipeline"}),
     "_install_detect": frozenset({"core", "cli", "config"}),
     "_linux_proc": frozenset({"core", "execution", "fleet", "cli"}),
     "_type_plugin_source": frozenset({"core", "execution", "pipeline", "server", "cli"}),

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -529,7 +529,7 @@ class TestBuildTestScopeCoreCascade:
         dir_names = {p.name for p in result}
         for pkg in ["core", "execution", "pipeline"]:
             assert pkg in dir_names, f"narrow cascade should include {pkg}"
-        for excluded in ["config", "fleet", "migration", "workspace", "recipe", "cli"]:
+        for excluded in ["config", "fleet", "migration", "workspace", "recipe", "cli", "planner"]:
             assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
     def test_json_narrow_cascade(self, tmp_path: Path) -> None:

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -68,6 +68,7 @@ class TestModuleCascadeCore:
 
     def test_all_entries_present(self) -> None:
         expected_stems = {
+            "_json",
             "feature_flags",
             "branch_guard",
             "_plugin_ids",
@@ -81,6 +82,7 @@ class TestModuleCascadeCore:
             "_type_resume",
             "_type_helpers",
             "_type_protocols_workspace",
+            "_type_protocols_backend",
             "_install_detect",
             "_linux_proc",
             "_type_plugin_source",
@@ -162,6 +164,16 @@ class TestModuleCascadeCore:
 
     def test_type_token_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_token"] == frozenset({"core", "execution"})
+
+    def test_type_protocols_backend_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_protocols_backend"] == frozenset(
+            {"core", "execution", "pipeline"}
+        )
+
+    def test_json_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_json"] == frozenset(
+            {"core", "execution", "pipeline", "recipe"}
+        )
 
 
 class TestBuildTestScopeCoreCascade:
@@ -503,6 +515,36 @@ class TestBuildTestScopeCoreCascade:
         for pkg in ["core", "execution"]:
             assert pkg in dir_names, f"narrow cascade should include {pkg}"
         for excluded in ["config", "pipeline", "fleet", "migration", "workspace"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
+
+    def test_type_protocols_backend_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_protocols_backend -> cascade of {"core", "execution", "pipeline"} only."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_protocols_backend.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "execution", "pipeline"]:
+            assert pkg in dir_names, f"narrow cascade should include {pkg}"
+        for excluded in ["config", "fleet", "migration", "workspace", "recipe", "cli"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
+
+    def test_json_narrow_cascade(self, tmp_path: Path) -> None:
+        """_json -> cascade of {"core", "execution", "pipeline", "recipe"} only."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/_json.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "execution", "pipeline", "recipe"]:
+            assert pkg in dir_names, f"narrow cascade should include {pkg}"
+        for excluded in ["config", "fleet", "migration", "workspace", "cli", "planner"]:
             assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
 


### PR DESCRIPTION
## Summary

Add two missing entries to the `MODULE_CASCADE_CORE` dict in `tests/_test_filter.py` so that changes to `core/_json.py` and `core/types/_type_protocols_backend.py` use narrow test cascades instead of falling through to the full `cascade_map["core"]` fail-open path (line 1275). Extend tests in `tests/test_test_filter_core_cascade.py` to cover the new entries.

**Issue corrections (verified via grep and adversarial audit):**

1. The issue proposes `frozenset({"core", "execution", "planner", "cli"})` for `_json`, citing `write_versioned_json` and `read_versioned_json` as downstream consumers. However, those functions live in `core/io.py` (a separate module stem `io` already in `_CORE_UNIVERSAL_MODULES`), not in `_json.py`. The actual direct consumers of `_json.py` symbols (`fast_dumps`, `fast_loads`) are:

   | Package | Files | Symbol |
   |---------|-------|--------|
   | `core` | `io.py`, `runtime/session_provenance.py`, `runtime/session_registry.py` | `fast_dumps` |
   | `execution` | `session_log.py`, `linux_tracing.py`, `session/_session_state.py`, `process/_process_jsonl.py`, `process/_process_race.py`, `backends/claude.py`, `backends/codex.py` | `fast_dumps`, `fast_loads` |
   | `pipeline` | `background.py` | `fast_dumps` |
   | `recipe` | `io.py` | `fast_loads` |

   Correct cascade: `frozenset({"core", "execution", "pipeline", "recipe"})`.

2. The issue proposes `frozenset({"core", "execution"})` for `_type_protocols_backend`. However, `pipeline/context.py:22` imports `CodingAgentBackend` from `autoskillit.core` (re-exported from `_type_protocols_backend`), making `pipeline` a direct consumer. The arch guard `test_module_cascade_core_is_superset_of_ast_consumers` in `tests/arch/test_cascade_map_guard.py` would fail without `pipeline`. Correct cascade: `frozenset({"core", "execution", "pipeline"})`.

## Requirements

- REQ-FILT-001: Add `_type_protocols_backend` to `MODULE_CASCADE_CORE` with cascade `frozenset({"core", "execution", "pipeline"})` — the `CodingAgentBackend` protocol is consumed by `execution/backends/__init__.py`, `execution/headless/_headless_result.py`, and `pipeline/context.py`
- REQ-FILT-002: Add `_json` to `MODULE_CASCADE_CORE` with cascade `frozenset({"core", "execution", "pipeline", "recipe"})` — covers downstream consumers of `fast_dumps` and `fast_loads` (verified via grep)

Closes #2721

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-185527-034331/.autoskillit/temp/make-plan/add_module_cascade_core_entries_plan_2026-05-22_185527.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 2.6k | 18.6k | 1.2M | 79.5k | 154 | 69.9k | 11m 35s |
| verify | claude-opus-4-6 | 1 | 42 | 7.0k | 584.2k | 51.5k | 69 | 38.0k | 4m 43s |
| implement* | MiniMax-M2.7-highspeed | 1 | 309.0k | 4.1k | 447.0k | 29.8k | 41 | 42.4k | 1m 46s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 79.9k | 3.8k | 300.2k | 34.9k | 25 | 21.4k | 1m 26s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.5k | 1.6k | 205.7k | 29.8k | 15 | 14.8k | 41s |
| review_pr | claude-sonnet-4-6 | 2 | 192 | 23.2k | 848.5k | 51.6k | 69 | 86.4k | 6m 20s |
| resolve_review | claude-sonnet-4-6 | 1 | 133 | 10.3k | 682.7k | 55.9k | 44 | 42.8k | 4m 11s |
| **Total** | | | 439.3k | 68.6k | 4.2M | 79.5k | | 315.7k | 30m 44s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 44 | 10159.1 | 963.4 | 93.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 341336.5 | 21418.5 | 5154.5 |
| **Total** | **46** | 92231.5 | 6863.5 | 1490.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 2.6k | 25.6k | 1.8M | 107.9k | 16m 19s |
| MiniMax-M2.7-highspeed | 3 | 436.4k | 9.5k | 953.0k | 78.6k | 3m 53s |
| claude-sonnet-4-6 | 2 | 325 | 33.5k | 1.5M | 129.2k | 10m 31s |