### PR TITLE
[FEATURE] Create SkillSessionConfig Protocol Slot and Conform CodexBackend

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -11,12 +11,11 @@ from ._type_backend import (
     BackendCapabilities,
     CmdSpec,
     SessionEvent,
-    SkillSessionConfig,  # noqa: F401
+    SkillSessionConfig,
 )
 from ._type_checkpoint import SessionCheckpoint
 from ._type_enums import OutputFormat
 from ._type_plugin_source import PluginSource
-from ._type_results import ValidatedAddDir
 
 __all__ = [
     "StreamParser",
@@ -100,23 +99,8 @@ class CodingAgentBackend(Protocol):
     def build_skill_session_cmd(
         self,
         skill_command: str,
-        *,
         cwd: str,
-        completion_marker: str,
-        model: str | None,
-        plugin_source: PluginSource | None,
-        output_format: OutputFormat,
-        add_dirs: Sequence[ValidatedAddDir] = (),
-        exit_after_stop_delay_ms: int = 0,
-        stream_idle_timeout_ms: int = 0,
-        scenario_step_name: str = "",
-        temp_dir_relpath: str | None = None,
-        allowed_write_prefix: str = "",
-        provider_extras: Mapping[str, str] | None = None,
-        profile_name: str = "",
-        resume_session_id: str = "",
-        resume_checkpoint: SessionCheckpoint | None = None,
-        resume_message: str | None = None,
+        config: SkillSessionConfig,
     ) -> CmdSpec: ...
 
     def build_food_truck_cmd(

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -27,6 +27,7 @@ from autoskillit.core import (
     PluginSource,
     SessionCheckpoint,
     SessionEvent,
+    SkillSessionConfig,
     ValidatedAddDir,
     extract_skill_name,
     fast_loads,
@@ -441,12 +442,13 @@ class CodexBackend:
     def build_skill_session_cmd(
         self,
         skill_command: str,
+        cwd: str = "",
+        config: SkillSessionConfig | None = None,
         *,
-        cwd: str,
-        completion_marker: str,
-        model: str | None,
-        plugin_source: PluginSource | None,
-        output_format: OutputFormat,
+        completion_marker: str = "",
+        model: str | None = None,
+        plugin_source: PluginSource | None = None,
+        output_format: OutputFormat = OutputFormat.JSON,
         add_dirs: Sequence[ValidatedAddDir] = (),
         exit_after_stop_delay_ms: int = 0,
         stream_idle_timeout_ms: int = 0,
@@ -459,6 +461,22 @@ class CodexBackend:
         resume_checkpoint: SessionCheckpoint | None = None,
         resume_message: str | None = None,
     ) -> CmdSpec:
+        if config is not None:
+            completion_marker = config.completion_marker
+            model = config.model
+            plugin_source = config.plugin_source  # noqa: F841  # no-op: Codex has no --plugin-dir equivalent
+            output_format = config.output_format  # noqa: F841  # no-op: --json is unconditional for Codex
+            add_dirs = config.add_dirs
+            exit_after_stop_delay_ms = config.exit_after_stop_delay_ms  # noqa: F841  # no-op: Claude-only
+            stream_idle_timeout_ms = config.stream_idle_timeout_ms  # noqa: F841  # no-op: Claude-only
+            scenario_step_name = config.scenario_step_name
+            temp_dir_relpath = config.temp_dir_relpath
+            allowed_write_prefix = config.allowed_write_prefix
+            provider_extras = config.provider_extras
+            profile_name = config.profile_name
+            resume_session_id = config.resume_session_id
+            resume_checkpoint = config.resume_checkpoint
+            resume_message = config.resume_message
         _has_prefix = bool(profile_name) and skill_command.strip().startswith("/")
 
         if resume_session_id:

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from pathlib import Path
 
 import pytest
 
@@ -10,10 +11,13 @@ from autoskillit.core import (
     BackendCapabilities,
     CmdSpec,
     CodingAgentBackend,
+    DirectInstall,
     EnvPolicy,
     OutputFormat,
     ResultParser,
+    SessionCheckpoint,
     SessionLocator,
+    SkillSessionConfig,
     StreamParser,
     ValidatedAddDir,
 )
@@ -495,3 +499,97 @@ class TestCodexBuildSkillSessionCmd:
     def test_json_flag_always_present(self) -> None:
         spec = CodexBackend().build_skill_session_cmd(**self.BASE)
         assert "--json" in spec.cmd
+
+
+class TestCodexBuildSkillSessionCmdConfigAdapter:
+    def test_config_adapter_matches_flat_params(self) -> None:
+        config = SkillSessionConfig(
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_source=None,
+            output_format=OutputFormat.JSON,
+        )
+        via_config = CodexBackend().build_skill_session_cmd(
+            "/test-skill", cwd="/work", config=config
+        )
+        via_flat = CodexBackend().build_skill_session_cmd(
+            skill_command="/test-skill",
+            cwd="/work",
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_source=None,
+            output_format=OutputFormat.JSON,
+        )
+        assert via_config.cmd == via_flat.cmd
+        assert via_config.env == via_flat.env
+        assert via_config.cwd == via_flat.cwd
+
+    def test_config_adapter_forwards_all_fields(self) -> None:
+        chk = SessionCheckpoint(step_name="chk")
+        config = SkillSessionConfig(
+            completion_marker="%%MARKER%%",
+            model="o3",
+            plugin_source=None,
+            output_format=OutputFormat.STREAM_JSON,
+            exit_after_stop_delay_ms=120000,
+            stream_idle_timeout_ms=30000,
+            scenario_step_name="step1",
+            temp_dir_relpath=".autoskillit/temp",
+            allowed_write_prefix="/tmp/test",
+            provider_extras={"KEY": "val"},
+            profile_name="my-profile",
+            resume_session_id="s1",
+            resume_checkpoint=chk,
+            resume_message="resume-msg",
+        )
+        via_config = CodexBackend().build_skill_session_cmd("/test", cwd="/tmp", config=config)
+        via_flat = CodexBackend().build_skill_session_cmd(
+            skill_command="/test",
+            cwd="/tmp",
+            completion_marker="%%MARKER%%",
+            model="o3",
+            plugin_source=None,
+            output_format=OutputFormat.STREAM_JSON,
+            exit_after_stop_delay_ms=120000,
+            stream_idle_timeout_ms=30000,
+            scenario_step_name="step1",
+            temp_dir_relpath=".autoskillit/temp",
+            allowed_write_prefix="/tmp/test",
+            provider_extras={"KEY": "val"},
+            profile_name="my-profile",
+            resume_session_id="s1",
+            resume_checkpoint=chk,
+            resume_message="resume-msg",
+        )
+        assert via_config.cmd == via_flat.cmd
+        assert via_config.env == via_flat.env
+
+    def test_config_path_returns_cmdspec(self) -> None:
+        config = SkillSessionConfig(completion_marker="%%DONE%%", output_format=OutputFormat.JSON)
+        result = CodexBackend().build_skill_session_cmd("/test", cwd="/tmp", config=config)
+        assert isinstance(result, CmdSpec)
+        assert isinstance(result.cmd, tuple)
+
+    def test_config_noop_fields(self) -> None:
+        config = SkillSessionConfig(
+            completion_marker="%%DONE%%",
+            output_format=OutputFormat.STREAM_JSON,
+            plugin_source=DirectInstall(plugin_dir=Path("/p")),
+        )
+        spec = CodexBackend().build_skill_session_cmd("/test", cwd="/work", config=config)
+        cmd_str = " ".join(spec.cmd)
+        assert "--output-format" not in cmd_str
+        assert "--plugin-dir" not in cmd_str
+        assert "--json" in spec.cmd
+
+    def test_legacy_flat_params_still_work(self) -> None:
+        spec = CodexBackend().build_skill_session_cmd(
+            skill_command="/test-skill",
+            cwd="/work",
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_source=None,
+            output_format=OutputFormat.JSON,
+        )
+        assert isinstance(spec, CmdSpec)
+        assert any("/test-skill" in s for s in spec.cmd)


### PR DESCRIPTION
## Summary

`SkillSessionConfig` already exists as a frozen dataclass in `_type_backend.py` with all 15 fields and is importable via `autoskillit.core`. This plan:
1. Updates the `CodingAgentBackend` protocol's `build_skill_session_cmd` slot from flat parameters to `(self, skill_command: str, cwd: str, config: SkillSessionConfig) -> CmdSpec`
2. Adds config-path support to `CodexBackend.build_skill_session_cmd` (dual-mode like `ClaudeCodeBackend`)
3. Documents no-op handling for `output_format`, `plugin_source`, and `profile_name` in codex.py

**Intentional scope boundary:** The production caller in `headless/__init__.py` (lines 706-724) and the `commands.py` forwarding shim (lines 110-150) are NOT updated in this WP. They continue using flat keyword arguments, which both backends accept via the backward-compatible dual-mode signature. Caller migration to the config path is deferred to P3-A2-WP3.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-200521-567151/.autoskillit/temp/make-plan/p3_a2_wp1_skill_session_config_plan_2026-05-22_202000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.6k | 27.6k | 1.6M | 107.7k | 168 | 101.3k | 15m 11s |
| verify | claude-opus-4-6 | 1 | 62 | 17.4k | 1.5M | 86.6k | 125 | 72.7k | 9m 54s |
| implement* | MiniMax-M2.7 | 1 | 238.0k | 13.0k | 1.9M | 20.8k | 128 | 29.8k | 7m 18s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.6k | 2.8k | 194.4k | 0 | 17 | 0 | 47s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.2k | 1.8k | 432.7k | 0 | 24 | 0 | 1m 1s |
| review_pr | claude-opus-4-6 | 2 | 76 | 34.6k | 890.2k | 65.1k | 55 | 133.5k | 9m 45s |
| resolve_review | claude-opus-4-6 | 2 | 110 | 19.7k | 1.9M | 71.7k | 95 | 109.3k | 12m 28s |
| **Total** | | | 322.6k | 116.8k | 8.5M | 107.7k | | 446.6k | 56m 26s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 146 | 13344.7 | 204.3 | 88.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **146** | 58103.0 | 3059.2 | 800.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 2.6k | 27.6k | 1.6M | 101.3k | 15m 11s |
| claude-opus-4-6 | 3 | 248 | 71.7k | 4.3M | 315.5k | 32m 8s |
| MiniMax-M2.7 | 3 | 319.8k | 17.6k | 2.6M | 29.8k | 9m 6s |