### PR TITLE
feat: add build_skill_session_cmd protocol conformance tests

### DIFF
--- a/tests/contracts/test_backend_protocol.py
+++ b/tests/contracts/test_backend_protocol.py
@@ -178,6 +178,8 @@ def test_build_skill_session_cmd_config_delegates_to_impl():
 
     assert result is sentinel
     mock_impl.assert_called_once()
+    args = mock_impl.call_args.args
+    assert args == ("/test",), f"skill_command not forwarded: {args}"
     kw = mock_impl.call_args.kwargs
     assert kw["cwd"] == "/work"
     assert kw["completion_marker"] == config.completion_marker

--- a/tests/contracts/test_backend_protocol.py
+++ b/tests/contracts/test_backend_protocol.py
@@ -1,8 +1,8 @@
 """Protocol conformance for CodingAgentBackend and sub-protocols.
 
-Contract tests verifying @runtime_checkable decoration and isinstance
-conformance for CodingAgentBackend, StreamParser, ResultParser, and
-ClaudeCodeBackend.
+Contract tests verifying @runtime_checkable decoration, isinstance
+conformance, and build_skill_session_cmd signature/delegation contracts
+for CodingAgentBackend, StreamParser, ResultParser, and ClaudeCodeBackend.
 """
 
 from __future__ import annotations
@@ -87,3 +87,118 @@ def test_claude_code_backend_stream_parser_forwards_completion_marker():
 
     parser = ClaudeCodeBackend().stream_parser(completion_marker="%%ORDER_UP%%")
     assert parser.completion_marker == "%%ORDER_UP%%"
+
+
+# -- Signature conformance: build_skill_session_cmd ---------------------------
+
+
+def test_build_skill_session_cmd_positional_param_names_match_protocol():
+    import inspect
+
+    from autoskillit.core import CodingAgentBackend
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    proto_sig = inspect.signature(CodingAgentBackend.build_skill_session_cmd)
+    impl_sig = inspect.signature(ClaudeCodeBackend.build_skill_session_cmd)
+
+    proto_names = [
+        n
+        for n, p in proto_sig.parameters.items()
+        if n != "self" and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ]
+    impl_names = [
+        n
+        for n, p in impl_sig.parameters.items()
+        if n != "self" and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ][: len(proto_names)]
+
+    assert proto_names == impl_names, (
+        f"Positional param name mismatch: protocol={proto_names}, impl={impl_names}"
+    )
+
+
+def test_build_skill_session_cmd_return_annotation_is_cmdspec():
+    from typing import get_type_hints
+
+    from autoskillit.core import CmdSpec
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    hints = get_type_hints(ClaudeCodeBackend.build_skill_session_cmd)
+    assert hints["return"] is CmdSpec, (
+        f"Return annotation should be CmdSpec, got {hints['return']}"
+    )
+
+
+def test_build_skill_session_cmd_protocol_shape_call_succeeds():
+    from autoskillit.core import CmdSpec, SkillSessionConfig
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    result = ClaudeCodeBackend().build_skill_session_cmd(
+        "/test-skill", "/tmp", SkillSessionConfig()
+    )
+    assert isinstance(result, CmdSpec)
+
+
+def test_build_skill_session_cmd_config_delegates_to_impl():
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from autoskillit.core import (
+        CmdSpec,
+        DirectInstall,
+        OutputFormat,
+        SessionCheckpoint,
+        SkillSessionConfig,
+    )
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    config = SkillSessionConfig(
+        completion_marker="%%VERIFY%%",
+        model="sonnet",
+        plugin_source=DirectInstall(plugin_dir=Path("/p")),
+        output_format=OutputFormat.STREAM_JSON,
+        exit_after_stop_delay_ms=120000,
+        stream_idle_timeout_ms=30000,
+        scenario_step_name="step-verify",
+        temp_dir_relpath=".autoskillit/temp",
+        allowed_write_prefix="/tmp/verify",
+        provider_extras={"EXTRA": "val"},
+        profile_name="verify-profile",
+        resume_session_id="sess-1",
+        resume_checkpoint=SessionCheckpoint(step_name="chk"),
+        resume_message="resume-msg",
+    )
+    sentinel = CmdSpec(cmd=("sentinel",), env={})
+
+    with patch.object(
+        ClaudeCodeBackend, "_build_skill_session_cmd_impl", return_value=sentinel
+    ) as mock_impl:
+        backend = ClaudeCodeBackend()
+        result = backend.build_skill_session_cmd("/test", "/work", config)
+
+    assert result is sentinel
+    mock_impl.assert_called_once()
+    kw = mock_impl.call_args.kwargs
+    assert kw["cwd"] == "/work"
+    assert kw["completion_marker"] == config.completion_marker
+    assert kw["model"] == config.model
+    assert kw["plugin_source"] == config.plugin_source
+    assert kw["output_format"] == config.output_format
+    assert kw["add_dirs"] == config.add_dirs
+    assert kw["exit_after_stop_delay_ms"] == config.exit_after_stop_delay_ms
+    assert kw["stream_idle_timeout_ms"] == config.stream_idle_timeout_ms
+    assert kw["scenario_step_name"] == config.scenario_step_name
+    assert kw["temp_dir_relpath"] == config.temp_dir_relpath
+    assert kw["allowed_write_prefix"] == config.allowed_write_prefix
+    assert kw["provider_extras"] == config.provider_extras
+    assert kw["profile_name"] == config.profile_name
+    assert kw["resume_session_id"] == config.resume_session_id
+    assert kw["resume_checkpoint"] == config.resume_checkpoint
+    assert kw["resume_message"] == config.resume_message
+
+
+def test_build_skill_session_cmd_impl_exists():
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    assert hasattr(ClaudeCodeBackend, "_build_skill_session_cmd_impl")
+    assert callable(getattr(ClaudeCodeBackend, "_build_skill_session_cmd_impl"))


### PR DESCRIPTION
## Summary

Add conformance verification tests that structurally lock the `ClaudeCodeBackend.build_skill_session_cmd` signature to the `CodingAgentBackend` protocol slot. Runtime analysis confirms the parameter names match exactly (skill_command, cwd, config), the return type annotates `-> CmdSpec`, and isinstance checks pass. The existing implementation widens acceptably (contravariant-safe `config` param, default `cwd`) without violating protocol contract.

## Requirements

### Goal

After P2-A4 adds the SkillSessionConfig config adapter on ClaudeCodeBackend, verify that the new public `build_skill_session_cmd(self, skill_command: str, cwd: str, config: SkillSessionConfig) -> CmdSpec` method satisfies the CodingAgentBackend protocol slot added in P2-A3, with correct return type annotation and parameter shape, and that runtime_checkable isinstance checks pass.

### Deliverables

- Conformance verification report: `ClaudeCodeBackend.build_skill_session_cmd` signature matches `CodingAgentBackend` protocol (skill_command, cwd, config params, CmdSpec return type)
- `isinstance(ClaudeCodeBackend(), CodingAgentBackend)` confirmed `True` at runtime
- Confirmation that `_build_skill_session_cmd_impl` delegation chain is intact

### Technical Steps

1. Verify `CodingAgentBackend.build_skill_session_cmd` protocol stub exists in `_type_protocols_backend.py` with signature `(self, skill_command: str, cwd: str, config: SkillSessionConfig) -> CmdSpec`
2. Confirm parameter names match exactly between protocol and implementation — no divergence
3. Verify return type annotation on implementation is `CmdSpec`
4. Confirm `isinstance(ClaudeCodeBackend(), CodingAgentBackend)` returns `True` at runtime
5. Verify `_build_skill_session_cmd_impl` delegation chain is intact

### Acceptance Criteria

- `ClaudeCodeBackend.build_skill_session_cmd` has exactly the signature `(self, skill_command: str, cwd: str, config: SkillSessionConfig) -> CmdSpec`
- `isinstance(ClaudeCodeBackend(), CodingAgentBackend)` returns `True`
- Return type annotation on the adapter method is `CmdSpec`
- `ClaudeCodeBackend._build_skill_session_cmd_impl` still exists
- All existing unit tests for command building pass

Closes #2686

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-211511-325192/.autoskillit/temp/make-plan/verify_build_skill_session_cmd_conformance_plan_2026-05-22_211600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 78 | 18.5k | 1.4M | 97.1k | 141 | 85.9k | 9m 34s |
| verify | claude-opus-4-6 | 1 | 53 | 10.1k | 776.5k | 63.5k | 85 | 48.1k | 5m 18s |
| implement* | MiniMax-M2.7 | 1 | 74.2k | 3.6k | 542.4k | 29.8k | 33 | 43.2k | 1m 26s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.2k | 2.8k | 286.7k | 0 | 18 | 0 | 51s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.4k | 1.8k | 273.8k | 0 | 18 | 0 | 20s |
| review_pr | claude-opus-4-6 | 2 | 76 | 31.0k | 869.0k | 60.3k | 53 | 82.6k | 9m 0s |
| resolve_review | claude-opus-4-6 | 1 | 45 | 5.4k | 884.9k | 59.4k | 38 | 44.5k | 3m 17s |
| **Total** | | | 157.1k | 73.3k | 5.1M | 97.1k | | 304.4k | 29m 47s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 121 | 4482.8 | 357.2 | 29.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 442430.5 | 22254.0 | 2693.0 |
| **Total** | **123** | 41263.5 | 2474.6 | 595.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 4 | 252 | 65.0k | 4.0M | 261.1k | 27m 10s |
| MiniMax-M2.7 | 3 | 156.9k | 8.3k | 1.1M | 43.2k | 2m 37s |