### PR TITLE
fix: introduce SidecarReadResult to distinguish missing vs empty sidecar and add ORCHESTRATOR label sweep

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -48,6 +48,20 @@ logger = get_logger(__name__)
 ENVELOPE_STDERR_MAX = 2000
 
 
+def resolve_dispatch_timeout(
+    timeout_sec: int | None,
+    default_timeout_sec: int,
+) -> float:
+    """Resolve dispatch timeout to a concrete float.
+
+    Single source of truth for all three timeout surfaces (prompt, process kill,
+    session deadline). Uses ``is not None`` to correctly handle ``timeout_sec=0``.
+    """
+    if timeout_sec is not None:
+        return float(timeout_sec)
+    return float(default_timeout_sec)
+
+
 class CaptureCompletenessError(RuntimeError):
     """Raised when a capture spec extracts zero fields from the payload."""
 
@@ -757,13 +771,16 @@ async def _run_dispatch(
 
     dispatch_sidecar_path = str(compute_sidecar_path(dispatch_id, tool_ctx.project_dir))
 
+    resolved_timeout = resolve_dispatch_timeout(
+        timeout_sec, tool_ctx.config.fleet.default_timeout_sec
+    )
     prompt = prompt_builder(
         recipe=recipe,
         task=task,
         ingredients=effective_ingredients,
         dispatch_id=dispatch_id,
         campaign_id=campaign_id,
-        l3_timeout_sec=timeout_sec or 1800,
+        l3_timeout_sec=int(resolved_timeout),
         capture=capture,
     )
 
@@ -856,7 +873,7 @@ async def _run_dispatch(
                     project_dir=str(tool_ctx.project_dir),
                     marker_dir=marker_dir,
                     session_id=caller_session_id,
-                    timeout=float(timeout_sec) if timeout_sec else None,
+                    timeout=resolved_timeout,
                     idle_output_timeout=float(idle_output_timeout)
                     if idle_output_timeout is not None
                     else None,
@@ -864,14 +881,7 @@ async def _run_dispatch(
                         "AUTOSKILLIT_PROJECT_DIR": str(tool_ctx.project_dir),
                         "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
                         "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
-                        "AUTOSKILLIT_SESSION_DEADLINE": str(
-                            started_at
-                            + (
-                                float(timeout_sec)
-                                if timeout_sec is not None
-                                else float(tool_ctx.config.fleet.default_timeout_sec)
-                            )
-                        ),
+                        "AUTOSKILLIT_SESSION_DEADLINE": str(started_at + resolved_timeout),
                     },
                     requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
                     on_spawn=_on_spawn,

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -903,7 +903,7 @@ async def _run_dispatch(
         from autoskillit.fleet._checkpoint_bridge import checkpoint_from_sidecar  # noqa: PLC0415
         from autoskillit.fleet.sidecar import read_sidecar_from_path  # noqa: PLC0415
 
-        sidecar_entries = read_sidecar_from_path(sidecar_file)
+        sidecar_entries = read_sidecar_from_path(sidecar_file).entries
         if sidecar_entries:
             dispatch_checkpoint = checkpoint_from_sidecar(sidecar_entries)
 

--- a/src/autoskillit/fleet/_label_cleanup.py
+++ b/src/autoskillit/fleet/_label_cleanup.py
@@ -16,7 +16,7 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.fleet._liveness import is_dispatch_session_alive
-from autoskillit.fleet.sidecar import read_sidecar_from_path
+from autoskillit.fleet.sidecar import SidecarReadStatus, read_sidecar_from_path
 from autoskillit.fleet.state import (
     TERMINAL_UNCLEANED_STATUSES,
     CampaignStateMutator,
@@ -58,7 +58,7 @@ async def cleanup_orphaned_labels(
         return True
 
     try:
-        entries = read_sidecar_from_path(Path(sidecar_path))
+        sidecar_result = read_sidecar_from_path(Path(sidecar_path))
     except Exception:
         logger.warning(
             "infra_label_cleanup_sidecar_read_failed",
@@ -67,11 +67,19 @@ async def cleanup_orphaned_labels(
         )
         return False
 
-    if not entries:
+    if sidecar_result.source != SidecarReadStatus.FOUND:
+        logger.warning(
+            "infra_label_cleanup_sidecar_unavailable",
+            sidecar_path=sidecar_path,
+            source=sidecar_result.source,
+        )
+        return False
+
+    if not sidecar_result.entries:
         return True
 
     all_succeeded = True
-    for entry in entries:
+    for entry in sidecar_result.entries:
         try:
             owner, repo, number = _parse_issue_ref(entry.issue_url)
         except ValueError:

--- a/src/autoskillit/fleet/sidecar.py
+++ b/src/autoskillit/fleet/sidecar.py
@@ -3,12 +3,19 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
+from enum import StrEnum
 from pathlib import Path
-from typing import Literal
+from typing import Literal, NamedTuple
 
 from autoskillit.core import ensure_project_temp, get_logger
 
 logger = get_logger()
+
+
+class SidecarReadStatus(StrEnum):
+    FOUND = "found"
+    MISSING = "missing"
+    ERROR = "error"
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +25,11 @@ class IssueSidecarEntry:
     ts: str
     pr_url: str | None = None
     reason: str | None = None
+
+
+class SidecarReadResult(NamedTuple):
+    entries: list[IssueSidecarEntry]
+    source: SidecarReadStatus
 
 
 def sidecar_path(dispatch_id: str, project_dir: Path) -> Path:
@@ -58,13 +70,18 @@ def read_sidecar(dispatch_id: str, project_dir: Path) -> list[IssueSidecarEntry]
     return entries
 
 
-def read_sidecar_from_path(path: Path) -> list[IssueSidecarEntry]:
-    """Read and parse a sidecar JSONL at path; skips corrupt lines; returns [] on OSError."""
+def read_sidecar_from_path(path: Path) -> SidecarReadResult:
+    """Read and parse a sidecar JSONL at path.
+
+    Returns a SidecarReadResult with source indicating whether the file was
+    found, missing, or unreadable. Callers must inspect source to distinguish
+    'file missing' from 'file empty'.
+    """
     entries: list[IssueSidecarEntry] = []
     try:
         lines = path.read_text().splitlines()
     except OSError:
-        return []
+        return SidecarReadResult(entries=[], source=SidecarReadStatus.MISSING)
     for line in lines:
         line = line.strip()
         if not line:
@@ -83,7 +100,7 @@ def read_sidecar_from_path(path: Path) -> list[IssueSidecarEntry]:
         except (json.JSONDecodeError, KeyError) as exc:
             logger.debug("sidecar: skipping corrupt JSONL line", path=str(path), error=str(exc))
             continue
-    return entries
+    return SidecarReadResult(entries=entries, source=SidecarReadStatus.FOUND)
 
 
 def compute_remaining_issues(

--- a/src/autoskillit/fleet/sidecar.py
+++ b/src/autoskillit/fleet/sidecar.py
@@ -80,8 +80,11 @@ def read_sidecar_from_path(path: Path) -> SidecarReadResult:
     entries: list[IssueSidecarEntry] = []
     try:
         lines = path.read_text().splitlines()
-    except OSError:
+    except FileNotFoundError:
         return SidecarReadResult(entries=[], source=SidecarReadStatus.MISSING)
+    except OSError as exc:
+        logger.warning("sidecar: failed to read file", path=str(path), error=str(exc))
+        return SidecarReadResult(entries=[], source=SidecarReadStatus.ERROR)
     for line in lines:
         line = line.strip()
         if not line:

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -130,7 +130,10 @@ def classify_stale_dispatch(
 
     Returns (new_status, sidecar_path_or_empty).
     """
-    from autoskillit.fleet.sidecar import read_sidecar_from_path  # noqa: PLC0415
+    from autoskillit.fleet.sidecar import (  # noqa: PLC0415
+        SidecarReadStatus,
+        read_sidecar_from_path,
+    )
 
     sidecar = Path(dispatch.sidecar_path) if dispatch.sidecar_path else None
     sidecar_path_str = ""
@@ -142,7 +145,10 @@ def classify_stale_dispatch(
         else:
             sidecar_path_str = str(sidecar)
             try:
-                has_entries = bool(read_sidecar_from_path(sidecar).entries)
+                sidecar_result = read_sidecar_from_path(sidecar)
+                has_entries = sidecar_result.source == SidecarReadStatus.FOUND and bool(
+                    sidecar_result.entries
+                )
             except Exception:
                 logger.warning(
                     "classify_stale_dispatch: read_sidecar_from_path failed for %s",

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -142,7 +142,7 @@ def classify_stale_dispatch(
         else:
             sidecar_path_str = str(sidecar)
             try:
-                has_entries = bool(read_sidecar_from_path(sidecar))
+                has_entries = bool(read_sidecar_from_path(sidecar).entries)
             except Exception:
                 logger.warning(
                     "classify_stale_dispatch: read_sidecar_from_path failed for %s",
@@ -305,7 +305,7 @@ def find_dispatch_for_issue(
             if d.sidecar_path is None:
                 continue
             if d.status == DispatchStatus.RUNNING:
-                entries = read_sidecar_from_path(Path(d.sidecar_path))
+                entries = read_sidecar_from_path(Path(d.sidecar_path)).entries
                 if any(e.issue_url == issue_url for e in entries):
                     return d
             elif (
@@ -313,7 +313,7 @@ def find_dispatch_for_issue(
                 and d.status in TERMINAL_UNCLEANED_STATUSES
                 and not d.labels_cleaned
             ):
-                entries = read_sidecar_from_path(Path(d.sidecar_path))
+                entries = read_sidecar_from_path(Path(d.sidecar_path)).entries
                 if any(e.issue_url == issue_url for e in entries):
                     terminal_match = d
     return terminal_match

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -740,7 +740,7 @@
         "review_loop_count",
         "review_verdict"
       ],
-      "note": "Compound iteration + blocking guard. Routes back to annotate_pr_diff only when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds), ensuring local review rounds are fully exhausted before exiting to CI.\n"
+      "note": "Compound iteration + blocking guard. Routes back to annotate_pr_diff only when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS). approved_with_comments yields had_blocking=false unconditionally because its resolve pass is one-shot, regardless of local_review_rounds.\n"
     },
     "check_repo_ci_event": {
       "tool": "check_repo_merge_state",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -708,8 +708,9 @@ steps:
     note: >
       Compound iteration + blocking guard. Routes back to annotate_pr_diff only when
       had_blocking=true AND max_exceeded=false. had_blocking is true when
-      previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds),
-      ensuring local review rounds are fully exhausted before exiting to CI.
+      previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds
+      AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS). approved_with_comments yields had_blocking=false
+      unconditionally because its resolve pass is one-shot, regardless of local_review_rounds.
 
   check_repo_ci_event:
     tool: check_repo_merge_state

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -304,6 +304,21 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
     except Exception:
         logger.warning("food_truck_auto_gate_boot_registry_failed", exc_info=True)
 
+    try:
+        from autoskillit.fleet import (  # noqa: PLC0415
+            discover_campaign_state_files,
+            sweep_stale_dispatch_labels,
+        )
+
+        _campaign_state_paths = discover_campaign_state_files(ctx.project_dir)
+        if _campaign_state_paths and ctx.github_client is not None:
+            create_background_task(
+                sweep_stale_dispatch_labels(_campaign_state_paths, ctx.github_client),
+                label="startup_label_recovery_sweep",
+            )
+    except Exception:
+        logger.warning("food_truck_auto_gate_boot_label_recovery_failed", exc_info=True)
+
 
 _LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | None] = {
     SessionType.FLEET: _fleet_auto_gate_boot,

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -311,13 +311,17 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         )
 
         _campaign_state_paths = discover_campaign_state_files(ctx.project_dir)
+    except Exception:
+        logger.warning("food_truck_auto_gate_boot_state_discovery_failed", exc_info=True)
+        return
+    try:
         if _campaign_state_paths and ctx.github_client is not None:
             create_background_task(
                 sweep_stale_dispatch_labels(_campaign_state_paths, ctx.github_client),
                 label="startup_label_recovery_sweep",
             )
     except Exception:
-        logger.warning("food_truck_auto_gate_boot_label_recovery_failed", exc_info=True)
+        logger.warning("food_truck_auto_gate_boot_label_sweep_failed", exc_info=True)
 
 
 _LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | None] = {

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -163,6 +163,19 @@ def annotate_pr_diff(
     }
 
 
+LOCAL_ROUND_EXEMPT_VERDICTS: frozenset[str] = frozenset(
+    {
+        "approved_with_comments",
+    }
+)
+"""Verdicts exempt from local_review_rounds re-review.
+
+Verdicts in this set yield ``had_blocking=false`` unconditionally regardless
+of ``local_review_rounds``. ``approved_with_comments`` is exempt because its
+resolve pass is one-shot — re-reviewing after resolved warnings adds no value.
+"""
+
+
 def check_review_loop(
     pr_number: str,
     current_iteration: str = "",
@@ -178,10 +191,12 @@ def check_review_loop(
     ``had_blocking`` is true when:
     - ``previous_verdict == "changes_requested"`` (always blocking), OR
     - ``local_review_rounds > 0`` and ``current_iteration < local_review_rounds``
-      (any verdict, including ``approved``, must re-review until local rounds exhausted)
+      AND verdict is not in ``LOCAL_ROUND_EXEMPT_VERDICTS``
+      (``approved`` must re-review until local rounds exhausted;
+      ``approved_with_comments`` is exempt — its resolve pass is one-shot)
 
-    ``approved_with_comments`` intentionally yields ``had_blocking=false`` when
-    ``local_review_rounds`` is absent or exhausted — the resolve_review pass is
+    ``approved_with_comments`` intentionally yields ``had_blocking=false``
+    regardless of ``local_review_rounds`` — the resolve_review pass is
     one-shot and does not trigger a re-review cycle.
     """
     current_iteration = current_iteration or ""
@@ -200,8 +215,13 @@ def check_review_loop(
         )
         local_rounds = 0
 
-    is_blocking_verdict = previous_verdict.strip() == "changes_requested"
-    local_rounds_not_exhausted = local_rounds > 0 and iteration < local_rounds
+    verdict = previous_verdict.strip()
+    is_blocking_verdict = verdict == "changes_requested"
+    local_rounds_not_exhausted = (
+        local_rounds > 0
+        and iteration < local_rounds
+        and verdict not in LOCAL_ROUND_EXEMPT_VERDICTS
+    )
     had_blocking = "true" if (is_blocking_verdict or local_rounds_not_exhausted) else "false"
 
     return {

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -163,17 +163,15 @@ def annotate_pr_diff(
     }
 
 
+# Verdicts exempt from local_review_rounds re-review.
+# Verdicts in this set yield ``had_blocking=false`` unconditionally regardless
+# of ``local_review_rounds``. ``approved_with_comments`` is exempt because its
+# resolve pass is one-shot — re-reviewing after resolved warnings adds no value.
 LOCAL_ROUND_EXEMPT_VERDICTS: frozenset[str] = frozenset(
     {
         "approved_with_comments",
     }
 )
-"""Verdicts exempt from local_review_rounds re-review.
-
-Verdicts in this set yield ``had_blocking=false`` unconditionally regardless
-of ``local_review_rounds``. ``approved_with_comments`` is exempt because its
-resolve pass is one-shot — re-reviewing after resolved warnings adds no value.
-"""
 
 
 def check_review_loop(

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -24,6 +24,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_channel_b_timeout_guard.py` | AST guard: Channel B tests must use timeout >= TimeoutTier.CHANNEL_B |
 | `test_dataclass_slots.py` | Architectural invariant: every @dataclass(frozen=True) must also have slots=True |
 | `test_cli_decomposition.py` | AST-level tests enforcing CLI decomposition and hook security hardening |
+| `test_dispatch_timeout_guard.py` | AST guard: _run_dispatch must call resolve_dispatch_timeout with no hardcoded 'or 1800' or falsy timeout patterns |
 | `test_doctor_readonly.py` | AST guard: run_doctor() must not perform filesystem mutations (REQ-DOCTOR-READONLY) |
 | `test_execution_source_split.py` | Arch guards for execution layer source splits (P8-F1, F3, F4 audit fixes) |
 | `test_feature_markers.py` | Marker completeness: fleet test files carry feature('fleet'), infra tests do not |

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -18,6 +18,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_backend_command_path.py` | AST tests enforcing ctx.backend usage for command construction in headless path |
 | `test_backend_protocol_completeness.py` | Protocol completeness tests for CodingAgentBackend command builders |
 | `test_audit_feature_gates_skill.py` | Structural integrity tests for the audit-feature-gates skill |
+| `test_boot_step_symmetry.py` | AST guard: both boot functions (_fleet_auto_gate_boot, _food_truck_auto_gate_boot) must call sweep_stale_dispatch_labels |
 | `test_bundled_recipes_split.py` | Enforcement: test_bundled_recipes.py split structure guard |
 | `test_cascade_map_guard.py` | REQ-GUARD-001..003, 005: CI guard validating cascade maps against AST-derived reverse import graph |
 | `test_channel_b_timeout_guard.py` | AST guard: Channel B tests must use timeout >= TimeoutTier.CHANNEL_B |

--- a/tests/arch/test_boot_step_symmetry.py
+++ b/tests/arch/test_boot_step_symmetry.py
@@ -1,0 +1,41 @@
+"""AST guard: both boot functions must call sweep_stale_dispatch_labels."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+LIFESPAN_PATH = Path(__file__).parents[2] / "src" / "autoskillit" / "server" / "_lifespan.py"
+
+_SWEEP_SYMBOL = "sweep_stale_dispatch_labels"
+_BOOT_FUNCTIONS = ("_fleet_auto_gate_boot", "_food_truck_auto_gate_boot")
+
+
+def _function_body_contains_symbol(tree: ast.Module, func_name: str, symbol: str) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == func_name:
+            for child in ast.walk(node):
+                if isinstance(child, ast.Name) and child.id == symbol:
+                    return True
+    return False
+
+
+class TestBootStepSymmetry:
+    def test_boot_functions_both_run_label_sweep(self) -> None:
+        assert LIFESPAN_PATH.exists(), f"Production file not found: {LIFESPAN_PATH}"
+        tree = ast.parse(LIFESPAN_PATH.read_text())
+
+        missing: list[str] = []
+        for func_name in _BOOT_FUNCTIONS:
+            if not _function_body_contains_symbol(tree, func_name, _SWEEP_SYMBOL):
+                missing.append(func_name)
+
+        assert not missing, (
+            f"Boot function(s) missing '{_SWEEP_SYMBOL}' call: {missing}. "
+            "Both _fleet_auto_gate_boot and _food_truck_auto_gate_boot must call "
+            "sweep_stale_dispatch_labels to maintain boot step symmetry."
+        )

--- a/tests/arch/test_dispatch_timeout_guard.py
+++ b/tests/arch/test_dispatch_timeout_guard.py
@@ -22,7 +22,7 @@ def _collect_function_source(tree: ast.Module, func_name: str) -> str:
 
 
 def test_run_dispatch_uses_resolve_dispatch_timeout() -> None:
-    """_run_dispatch must call resolve_dispatch_timeout and use its result for all timeout surfaces.
+    """_run_dispatch must use resolve_dispatch_timeout for all timeout surfaces.
 
     Prevents future regressions where a new timeout surface is added with its own
     hardcoded fallback.

--- a/tests/arch/test_dispatch_timeout_guard.py
+++ b/tests/arch/test_dispatch_timeout_guard.py
@@ -1,0 +1,51 @@
+"""AST guard: _run_dispatch must use resolve_dispatch_timeout for all timeout surfaces."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_API_PATH = Path(__file__).parents[2] / "src" / "autoskillit" / "fleet" / "_api.py"
+_RUN_DISPATCH = "_run_dispatch"
+_RESOLVE_SYMBOL = "resolve_dispatch_timeout"
+
+
+def _collect_function_source(tree: ast.Module, func_name: str) -> str:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == func_name:
+            return ast.unparse(node)
+    return ""
+
+
+def test_run_dispatch_uses_resolve_dispatch_timeout() -> None:
+    """_run_dispatch must call resolve_dispatch_timeout and use its result for all timeout surfaces.
+
+    Prevents future regressions where a new timeout surface is added with its own
+    hardcoded fallback.
+    """
+    assert _API_PATH.exists(), f"Production file not found: {_API_PATH}"
+    source = _API_PATH.read_text()
+    tree = ast.parse(source)
+
+    func_source = _collect_function_source(tree, _RUN_DISPATCH)
+    assert func_source, f"Function '{_RUN_DISPATCH}' not found in {_API_PATH}"
+
+    assert _RESOLVE_SYMBOL in func_source, (
+        f"'{_RUN_DISPATCH}' must call '{_RESOLVE_SYMBOL}' but no call was found. "
+        "All three timeout surfaces (prompt, process kill, session deadline) must use "
+        "a single resolved value from resolve_dispatch_timeout."
+    )
+
+    assert "or 1800" not in func_source, (
+        f"'{_RUN_DISPATCH}' contains hardcoded 'or 1800' fallback. "
+        "Use resolve_dispatch_timeout instead."
+    )
+
+    assert "if timeout_sec else None" not in func_source, (
+        f"'{_RUN_DISPATCH}' contains falsy 'if timeout_sec else None' timeout check. "
+        "Use resolve_dispatch_timeout which correctly handles timeout_sec=0."
+    )

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -550,3 +550,26 @@ class TestWriteDispatchToCampaignStateRefusal:
         assert len(refused) == 1
         assert refused[0].diagnostic_message == ""
         assert refused[0].reason == "fleet_unknown_ingredient"
+
+
+class TestResolveDispatchTimeout:
+    def test_uses_config_when_none(self) -> None:
+        """resolve_dispatch_timeout must use fleet.default_timeout_sec when timeout_sec is None."""
+        from autoskillit.fleet._api import resolve_dispatch_timeout
+
+        result = resolve_dispatch_timeout(None, default_timeout_sec=3600)
+        assert result == 3600.0
+
+    def test_uses_explicit_when_provided(self) -> None:
+        """resolve_dispatch_timeout must use the explicit value when provided."""
+        from autoskillit.fleet._api import resolve_dispatch_timeout
+
+        result = resolve_dispatch_timeout(1200, default_timeout_sec=3600)
+        assert result == 1200.0
+
+    def test_handles_zero(self) -> None:
+        """resolve_dispatch_timeout must treat 0 as an explicit value, not as None."""
+        from autoskillit.fleet._api import resolve_dispatch_timeout
+
+        result = resolve_dispatch_timeout(0, default_timeout_sec=3600)
+        assert result == 0.0

--- a/tests/fleet/test_label_cleanup.py
+++ b/tests/fleet/test_label_cleanup.py
@@ -457,7 +457,7 @@ class TestCleanupOrphanedLabelsUnit:
     async def test_cleanup_returns_false_when_sidecar_file_missing_on_disk(
         self, tmp_path: Path
     ) -> None:
-        """cleanup_orphaned_labels must return False when sidecar_path points to nonexistent file."""
+        """cleanup_orphaned_labels returns False when sidecar_path points to nonexistent file."""
         from autoskillit.fleet._label_cleanup import cleanup_orphaned_labels
 
         missing_path = str(tmp_path / "deleted_issues.jsonl")

--- a/tests/fleet/test_label_cleanup.py
+++ b/tests/fleet/test_label_cleanup.py
@@ -452,3 +452,19 @@ class TestCleanupOrphanedLabelsUnit:
         result = await cleanup_orphaned_labels(str(sidecar), github_client)
 
         assert result is False
+
+    @pytest.mark.anyio
+    async def test_cleanup_returns_false_when_sidecar_file_missing_on_disk(
+        self, tmp_path: Path
+    ) -> None:
+        """cleanup_orphaned_labels must return False when sidecar_path points to nonexistent file."""
+        from autoskillit.fleet._label_cleanup import cleanup_orphaned_labels
+
+        missing_path = str(tmp_path / "deleted_issues.jsonl")
+        github_client = AsyncMock()
+        github_client.swap_labels = AsyncMock(return_value={"success": True})
+
+        result = await cleanup_orphaned_labels(missing_path, github_client)
+
+        assert result is False
+        github_client.swap_labels.assert_not_called()

--- a/tests/fleet/test_label_cleanup.py
+++ b/tests/fleet/test_label_cleanup.py
@@ -462,7 +462,6 @@ class TestCleanupOrphanedLabelsUnit:
 
         missing_path = str(tmp_path / "deleted_issues.jsonl")
         github_client = AsyncMock()
-        github_client.swap_labels = AsyncMock(return_value={"success": True})
 
         result = await cleanup_orphaned_labels(missing_path, github_client)
 

--- a/tests/fleet/test_sidecar.py
+++ b/tests/fleet/test_sidecar.py
@@ -5,7 +5,6 @@ import pytest
 
 from autoskillit.fleet.sidecar import (
     IssueSidecarEntry,
-    SidecarReadResult,
     SidecarReadStatus,
     append_sidecar_entry,
     compute_remaining_issues,
@@ -165,11 +164,6 @@ class TestReadSidecarFromPath:
         assert result.source == SidecarReadStatus.MISSING
         assert result.entries == []
 
-    def test_read_sidecar_from_path_returns_missing_when_file_absent(self) -> None:
-        result = read_sidecar_from_path(Path("/nonexistent/dir/issues.jsonl"))
-        assert result.source == SidecarReadStatus.MISSING
-        assert result.entries == []
-
     def test_read_sidecar_from_path_returns_found_when_file_empty(self, tmp_path: Path) -> None:
         sidecar = tmp_path / "empty.jsonl"
         sidecar.write_text("")
@@ -185,12 +179,6 @@ class TestReadSidecarFromPath:
         result = read_sidecar_from_path(sidecar)
         assert result.source == SidecarReadStatus.FOUND
         assert len(result.entries) == 1
-
-    def test_result_is_sidecar_read_result_type(self, tmp_path: Path) -> None:
-        p = tmp_path / "issues.jsonl"
-        p.write_text("")
-        result = read_sidecar_from_path(p)
-        assert isinstance(result, SidecarReadResult)
 
     def test_valid_jsonl_parsed_correctly(self, tmp_path: Path) -> None:
         p = tmp_path / "issues.jsonl"

--- a/tests/fleet/test_sidecar.py
+++ b/tests/fleet/test_sidecar.py
@@ -5,6 +5,8 @@ import pytest
 
 from autoskillit.fleet.sidecar import (
     IssueSidecarEntry,
+    SidecarReadResult,
+    SidecarReadStatus,
     append_sidecar_entry,
     compute_remaining_issues,
     merge_sidecar_chain,
@@ -160,7 +162,35 @@ class TestComputeRemainingIssues:
 class TestReadSidecarFromPath:
     def test_nonexistent_parent_returns_empty(self) -> None:
         result = read_sidecar_from_path(Path("/nonexistent/dir/issues.jsonl"))
-        assert result == []
+        assert result.source == SidecarReadStatus.MISSING
+        assert result.entries == []
+
+    def test_read_sidecar_from_path_returns_missing_when_file_absent(self) -> None:
+        result = read_sidecar_from_path(Path("/nonexistent/dir/issues.jsonl"))
+        assert result.source == SidecarReadStatus.MISSING
+        assert result.entries == []
+
+    def test_read_sidecar_from_path_returns_found_when_file_empty(self, tmp_path: Path) -> None:
+        sidecar = tmp_path / "empty.jsonl"
+        sidecar.write_text("")
+        result = read_sidecar_from_path(sidecar)
+        assert result.source == SidecarReadStatus.FOUND
+        assert result.entries == []
+
+    def test_read_sidecar_from_path_returns_found_with_entries(self, tmp_path: Path) -> None:
+        sidecar = tmp_path / "issues.jsonl"
+        sidecar.write_text(
+            '{"issue_url":"https://github.com/o/r/issues/1","status":"completed","ts":"t"}\n'
+        )
+        result = read_sidecar_from_path(sidecar)
+        assert result.source == SidecarReadStatus.FOUND
+        assert len(result.entries) == 1
+
+    def test_result_is_sidecar_read_result_type(self, tmp_path: Path) -> None:
+        p = tmp_path / "issues.jsonl"
+        p.write_text("")
+        result = read_sidecar_from_path(p)
+        assert isinstance(result, SidecarReadResult)
 
     def test_valid_jsonl_parsed_correctly(self, tmp_path: Path) -> None:
         p = tmp_path / "issues.jsonl"
@@ -172,12 +202,13 @@ class TestReadSidecarFromPath:
         ]
         p.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-        entries = read_sidecar_from_path(p)
+        result = read_sidecar_from_path(p)
 
-        assert len(entries) == 2
-        assert all(isinstance(e, IssueSidecarEntry) for e in entries)
-        assert entries[0].issue_url == URL1
-        assert entries[1].issue_url == URL2
+        assert result.source == SidecarReadStatus.FOUND
+        assert len(result.entries) == 2
+        assert all(isinstance(e, IssueSidecarEntry) for e in result.entries)
+        assert result.entries[0].issue_url == URL1
+        assert result.entries[1].issue_url == URL2
 
 
 class TestMergeSidecarChain:

--- a/tests/fleet/test_startup_label_recovery.py
+++ b/tests/fleet/test_startup_label_recovery.py
@@ -338,7 +338,7 @@ class TestStartupLabelRecoverySweep:
     async def test_sweep_does_not_mark_cleaned_when_sidecar_file_missing_on_disk(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Dispatch with sidecar_path pointing to a deleted file must NOT get labels_cleaned=True."""
+        """Dispatch with deleted sidecar file must NOT get labels_cleaned=True."""
         from autoskillit.fleet import DispatchRecord, read_state, write_initial_state
         from autoskillit.fleet._label_cleanup import sweep_stale_dispatch_labels
         from autoskillit.fleet.state import upsert_dispatch_record_by_name

--- a/tests/fleet/test_startup_label_recovery.py
+++ b/tests/fleet/test_startup_label_recovery.py
@@ -333,3 +333,48 @@ class TestStartupLabelRecoverySweep:
         await sweep_stale_dispatch_labels([state_path], github_client)
 
         swap_labels_mock.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_sweep_does_not_mark_cleaned_when_sidecar_file_missing_on_disk(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dispatch with sidecar_path pointing to a deleted file must NOT get labels_cleaned=True."""
+        from autoskillit.fleet import DispatchRecord, read_state, write_initial_state
+        from autoskillit.fleet._label_cleanup import sweep_stale_dispatch_labels
+        from autoskillit.fleet.state import upsert_dispatch_record_by_name
+
+        monkeypatch.setattr(
+            "autoskillit.fleet._label_cleanup.is_dispatch_session_alive",
+            lambda record: False,
+        )
+
+        state_path = tmp_path / "campaign_missing_sidecar.json"
+        deleted_sidecar = str(tmp_path / "deleted_issues.jsonl")
+
+        write_initial_state(
+            state_path,
+            campaign_id="test",
+            campaign_name="test",
+            manifest_path="/m.yaml",
+            dispatches=[DispatchRecord(name="d1")],
+        )
+        upsert_dispatch_record_by_name(
+            state_path,
+            DispatchRecord(
+                name="d1",
+                status=DispatchStatus.FAILURE,
+                sidecar_path=deleted_sidecar,
+                labels_cleaned=False,
+            ),
+        )
+
+        swap_labels_mock = AsyncMock(return_value={"success": True})
+        github_client = AsyncMock()
+        github_client.swap_labels = swap_labels_mock
+
+        await sweep_stale_dispatch_labels([state_path], github_client)
+
+        swap_labels_mock.assert_not_called()
+        state = read_state(state_path)
+        assert state is not None
+        assert state.dispatches[0].labels_cleaned is False

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -144,16 +144,16 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # eval resolved/manifest/scorecard/eval_context
     ("src/autoskillit/smoke_utils.py", 71),
     ("src/autoskillit/smoke_utils.py", 140),
-    # Lines 157 and 440 are list-payload write sites (dual membership: also in list_sites
+    # Lines 157 and 438 are list-payload write sites (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches
     # them because it cannot distinguish list vs dict return types — intentional.
     ("src/autoskillit/smoke_utils.py", 157),
-    ("src/autoskillit/smoke_utils.py", 440),
-    ("src/autoskillit/smoke_utils.py", 522),
-    ("src/autoskillit/smoke_utils.py", 533),
-    ("src/autoskillit/smoke_utils.py", 626),
-    ("src/autoskillit/smoke_utils.py", 702),
-    ("src/autoskillit/smoke_utils.py", 797),
+    ("src/autoskillit/smoke_utils.py", 438),
+    ("src/autoskillit/smoke_utils.py", 520),
+    ("src/autoskillit/smoke_utils.py", 531),
+    ("src/autoskillit/smoke_utils.py", 624),
+    ("src/autoskillit/smoke_utils.py", 700),
+    ("src/autoskillit/smoke_utils.py", 795),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 315),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
@@ -223,7 +223,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 157),
-            ("src/autoskillit/smoke_utils.py", 440),
+            ("src/autoskillit/smoke_utils.py", 438),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -144,16 +144,16 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # eval resolved/manifest/scorecard/eval_context
     ("src/autoskillit/smoke_utils.py", 71),
     ("src/autoskillit/smoke_utils.py", 140),
-    # Lines 157 and 420 are list-payload write sites (dual membership: also in list_sites
+    # Lines 157 and 440 are list-payload write sites (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches
     # them because it cannot distinguish list vs dict return types — intentional.
     ("src/autoskillit/smoke_utils.py", 157),
-    ("src/autoskillit/smoke_utils.py", 420),
-    ("src/autoskillit/smoke_utils.py", 502),
-    ("src/autoskillit/smoke_utils.py", 513),
-    ("src/autoskillit/smoke_utils.py", 606),
-    ("src/autoskillit/smoke_utils.py", 682),
-    ("src/autoskillit/smoke_utils.py", 777),
+    ("src/autoskillit/smoke_utils.py", 440),
+    ("src/autoskillit/smoke_utils.py", 522),
+    ("src/autoskillit/smoke_utils.py", 533),
+    ("src/autoskillit/smoke_utils.py", 626),
+    ("src/autoskillit/smoke_utils.py", 702),
+    ("src/autoskillit/smoke_utils.py", 797),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 315),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
@@ -223,7 +223,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 157),
-            ("src/autoskillit/smoke_utils.py", 420),
+            ("src/autoskillit/smoke_utils.py", 440),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -775,6 +775,52 @@ class TestFoodTruckAutoGateBoot:
         result = json.loads(await run_skill("/some-skill", "/tmp"))
         assert result.get("success") is True
 
+    @pytest.mark.anyio
+    async def test_food_truck_auto_gate_boot_runs_label_sweep(
+        self, tool_ctx, monkeypatch, tmp_path
+    ) -> None:
+        """ORCHESTRATOR boot must call sweep_stale_dispatch_labels when campaign state files exist."""
+        import json as _json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.core import FOOD_TRUCK_TOOL_TAGS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _food_truck_auto_gate_boot
+
+        dispatches_dir = tmp_path / ".autoskillit" / "temp" / "dispatches"
+        dispatches_dir.mkdir(parents=True)
+        (dispatches_dir / "campaign1.json").write_text(_json.dumps({}))
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+        tool_ctx.project_dir = tmp_path
+        tool_ctx.github_client = AsyncMock()
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core")
+
+        mock_create_bg_task = MagicMock(return_value=MagicMock())
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.pipeline.create_background_task", mock_create_bg_task):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        with patch(
+                            "autoskillit.fleet.sweep_stale_dispatch_labels",
+                            new_callable=AsyncMock,
+                        ):
+                            with patch(
+                                "autoskillit.fleet.discover_campaign_state_files",
+                                return_value=[dispatches_dir / "campaign1.json"],
+                            ):
+                                await _food_truck_auto_gate_boot(tool_ctx)
+
+        sweep_call_labels = [
+            call_args.kwargs.get("label") for call_args in mock_create_bg_task.call_args_list
+        ]
+        assert "startup_label_recovery_sweep" in sweep_call_labels, (
+            "label sweep background task not scheduled; "
+            f"create_background_task labels: {sweep_call_labels}"
+        )
+
 
 @pytest.mark.feature("fleet")
 class TestFeatureGateVisibility:

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -779,7 +779,7 @@ class TestFoodTruckAutoGateBoot:
     async def test_food_truck_auto_gate_boot_runs_label_sweep(
         self, tool_ctx, monkeypatch, tmp_path
     ) -> None:
-        """ORCHESTRATOR boot must call sweep_stale_dispatch_labels when campaign state files exist."""
+        """ORCHESTRATOR boot must schedule label sweep when campaign state files exist."""
         import json as _json
         from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -253,6 +253,49 @@ def test_crl_needs_human_non_blocking_when_local_rounds_exhausted() -> None:
 
 
 # ---------------------------------------------------------------------------
+# T_CRL19–T_CRL21: approved_with_comments exemption from local_review_rounds
+# ---------------------------------------------------------------------------
+
+
+def test_crl_approved_with_comments_non_blocking_when_local_rounds_active() -> None:
+    """approved_with_comments must NOT trigger re-review even when local_rounds are not exhausted.
+
+    The resolve_review pass for approved_with_comments is one-shot. Re-reviewing
+    after resolved warnings adds no value and wastes time budget.
+    """
+    result = check_review_loop(
+        pr_number="42",
+        current_iteration="1",
+        max_iterations="6",
+        previous_verdict="approved_with_comments",
+        local_review_rounds="2",
+    )
+    assert result["had_blocking"] == "false"
+    assert result["next_iteration"] == "2"
+
+
+def test_crl_approved_with_comments_non_blocking_at_first_local_round() -> None:
+    """approved_with_comments at iteration 0 with local_review_rounds > 0 is still non-blocking."""
+    result = check_review_loop(
+        pr_number="42",
+        current_iteration="0",
+        max_iterations="6",
+        previous_verdict="approved_with_comments",
+        local_review_rounds="3",
+    )
+    assert result["had_blocking"] == "false"
+
+
+def test_local_round_exempt_verdicts_constant_exists() -> None:
+    """LOCAL_ROUND_EXEMPT_VERDICTS must exist and contain approved_with_comments."""
+    from autoskillit.smoke_utils import LOCAL_ROUND_EXEMPT_VERDICTS
+
+    assert "approved_with_comments" in LOCAL_ROUND_EXEMPT_VERDICTS
+    assert "changes_requested" not in LOCAL_ROUND_EXEMPT_VERDICTS
+    assert "approved" not in LOCAL_ROUND_EXEMPT_VERDICTS
+
+
+# ---------------------------------------------------------------------------
 # T_SU_LI1–T_SU_LI5: check_loop_iteration tests (generic loop iteration guard)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Introduce `SidecarReadResult` to distinguish "file missing" (unverifiable state) from "file genuinely empty" (verified no-op), so `cleanup_orphaned_labels` correctly returns `False` when a sidecar path is recorded but the file no longer exists on disk. Fix the boot-path asymmetry where `sweep_stale_dispatch_labels` ran only on FLEET session startup but not ORCHESTRATOR, leaving corrupted label records unswept in food-truck-only environments. Also fix `check_review_loop` to yield `had_blocking="false"` for `approved_with_comments` regardless of `local_review_rounds` position, and align L3 prompt timeout derivation with `fleet.default_timeout_sec`.

## Requirements

- REQ-REM-001: `cleanup_orphaned_labels` must return `False` when `sidecar_path` is set but the file does not exist on disk
- REQ-REM-002: `check_review_loop` must return `had_blocking="false"` when `previous_verdict` is `approved_with_comments`, regardless of `local_review_rounds` position. `approved` verdicts continue to force re-review until local rounds are exhausted (existing behavior, per docstring and test).
- REQ-REM-003: The L3 prompt timeout (`l3_timeout_sec`), `AUTOSKILLIT_SESSION_DEADLINE` env var, and subprocess kill timeout must all derive from the same source (`fleet.default_timeout_sec` or explicit `timeout_sec` override)
- REQ-REM-004: `sweep_stale_dispatch_labels` must run on ORCHESTRATOR session startup, not only FLEET sessions
- REQ-REM-005: Tests must cover: (a) missing-sidecar cleanup returns `False`, (b) `check_review_loop` with `approved_with_comments` + configured `local_review_rounds` + non-exhausted iteration, (c) L3 prompt timeout consistency with config default
- REQ-REM-006: `check_review_loop` docstring (`smoke_utils.py:183-185`) and recipe note (`implementation.yaml:699-701`) must be updated to reflect that `approved_with_comments` yields `had_blocking=false` unconditionally, not only when `local_review_rounds` is absent or exhausted

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_sidecar_result_integrity_label_recovery_2026-05-22_220537.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 4.5k | 23.7k | 1.3M | 123.3k | 163 | 84.7k | 12m 52s |
| dry_walkthrough | claude-opus-4-6 | 2 | 113 | 21.0k | 3.1M | 98.1k | 179 | 162.8k | 10m 48s |
| implement | claude-sonnet-4-6 | 2 | 806 | 44.6k | 6.0M | 109.5k | 305 | 247.2k | 17m 10s |
| prepare_pr* | MiniMax-M2.7 | 1 | 75.9k | 3.6k | 379.8k | 29.8k | 25 | 42.8k | 1m 21s |
| compose_pr* | MiniMax-M2.7 | 1 | 55.2k | 1.9k | 264.6k | 0 | 20 | 0 | 51s |
| review_pr | claude-opus-4-6 | 3 | 129 | 84.6k | 2.2M | 95.2k | 107 | 219.6k | 23m 38s |
| resolve_review | claude-sonnet-4-6 | 2 | 798 | 65.9k | 6.5M | 121.6k | 248 | 160.0k | 24m 49s |
| **Total** | | | 137.4k | 245.3k | 19.7M | 123.3k | | 917.1k | 1h 31m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 443 | 13533.5 | 558.0 | 100.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 60 | 108383.1 | 2666.0 | 1098.9 |
| **Total** | **503** | 39210.7 | 1823.2 | 487.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 6.1k | 134.2k | 13.8M | 491.9k | 54m 52s |
| claude-opus-4-6 | 2 | 242 | 105.5k | 5.2M | 382.4k | 34m 27s |
| MiniMax-M2.7 | 2 | 131.1k | 5.6k | 644.4k | 42.8k | 2m 12s |