### PR TITLE
Fix weak and incorrect assertions in execution tests

### DIFF
--- a/tests/execution/test_github_api_tracking_http.py
+++ b/tests/execution/test_github_api_tracking_http.py
@@ -107,7 +107,8 @@ async def test_no_tracker_still_works(mock_http_server, _reset_mock):
     )
     fetcher = DefaultGitHubFetcher(token="test-token", tracker=None, base_url=mock_http_server.url)
     result = await fetcher.fetch_issue("owner", "repo", 1)
-    assert result is not None
+    assert result["success"] is True
+    assert result["issue_number"] == 1
 
 
 async def test_make_tracked_httpx_client_without_tracker_is_normal_client():

--- a/tests/execution/test_session_adjudication_outcome.py
+++ b/tests/execution/test_session_adjudication_outcome.py
@@ -388,9 +388,8 @@ class TestEarlyStop:
             channel_confirmation=ChannelConfirmation.UNMONITORED,
             completion_marker="%%ORDER_UP%%",
         )
-        # is_error sessions may trigger API-level retry via needs_retry property,
-        # but EARLY_STOP specifically should not fire for non-success subtypes
-        assert reason != RetryReason.EARLY_STOP
+        assert needs_retry is False
+        assert reason == RetryReason.NONE
 
     def test_early_stop_not_triggered_for_empty_result(self) -> None:
         """Empty result should be classified as kill anomaly, not EARLY_STOP."""

--- a/tests/execution/test_session_adjudication_retry.py
+++ b/tests/execution/test_session_adjudication_retry.py
@@ -396,18 +396,6 @@ class TestComputeRetrySuccessEmptyResult:
         assert reason == RetryReason.RESUME  # infrastructure kill — progress existed
 
 
-class TestComputeRetryCompletedPath:
-    """_compute_retry unique test: COMPLETED termination + unparseable."""
-
-    def test_unparseable_on_completed_returns_resume(self):
-        s = ClaudeSessionResult(
-            subtype="unparseable", is_error=True, result="garbled", session_id=""
-        )
-        needs, reason = _compute_retry(s, -15, TerminationReason.COMPLETED)
-        assert needs is True
-        assert reason == RetryReason.RESUME
-
-
 @pytest.mark.parametrize("termination", list(TerminationReason))
 def test_compute_retry_handles_all_termination_reasons_without_raising(
     termination: TerminationReason,


### PR DESCRIPTION
## Summary

Fix three validated audit findings ([2.3], [2.4], [3.9]) in execution test files:

1. Replace tautological `assert result is not None` with field-specific assertions in `test_no_tracker_still_works` — the mock returns `{"number": 1, ...}` but `fetch_issue` maps this to `"issue_number"` in its return dict (the issue's suggested fix `result.get("number")` references the wrong key)
2. Replace weak inequality `assert reason != RetryReason.EARLY_STOP` with exact equality `assert reason == RetryReason.NONE` plus `assert needs_retry is False` in `test_early_stop_not_triggered_for_errors`
3. Delete redundant `TestComputeRetryCompletedPath` class — its single test exercises the identical code path as `TestComputeRetryUnparseable.test_unparseable_subtype_with_nonzero_returncode_should_retry`

No production code changes. Total test count decreases by exactly 1 (the deleted duplicate).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-205433-493941/.autoskillit/temp/make-plan/fix_weak_incorrect_assertions_execution_tests_plan_2026-05-22_210500.md`

Closes #2752

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 81 | 13.1k | 880.1k | 80.8k | 141 | 68.9k | 8m 57s |
| verify | claude-opus-4-6 | 1 | 36 | 4.8k | 287.9k | 41.5k | 48 | 26.3k | 2m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 136.0k | 2.8k | 389.6k | 34.9k | 34 | 25.1k | 1m 27s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 59.7k | 3.1k | 205.7k | 29.8k | 22 | 15.1k | 1m 24s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 36.0k | 1.2k | 175.9k | 29.8k | 13 | 14.8k | 35s |
| review_pr | claude-sonnet-4-6 | 3 | 374 | 31.7k | 1.4M | 44.1k | 120 | 96.4k | 10m 56s |
| resolve_review | claude-sonnet-4-6 | 1 | 173 | 7.7k | 827.8k | 58.5k | 45 | 49.0k | 3m 6s |
| **Total** | | | 232.4k | 64.5k | 4.1M | 80.8k | | 295.6k | 29m 22s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 20 | 19481.5 | 1254.3 | 138.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **20** | 206913.4 | 14782.1 | 3222.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 628 | 52.5k | 3.1M | 214.4k | 23m 1s |
| claude-opus-4-6 | 1 | 36 | 4.8k | 287.9k | 26.3k | 2m 54s |
| MiniMax-M2.7-highspeed | 3 | 231.7k | 7.1k | 771.3k | 55.0k | 3m 26s |