### PR TITLE
Replace hardcoded BUNDLED_SKILLS constant with dynamic resolver

### DIFF
--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import re
 from pathlib import Path
 
@@ -71,7 +72,16 @@ AUDIT_SKILL_NAMES = [
     "audit-review-decisions",
 ]
 
-BUNDLED_SKILL_NAMES = {s.name for s in DefaultSkillResolver().list_all()} | INTERNAL_SKILLS
+
+@functools.lru_cache(maxsize=1)
+def _get_bundled_skill_names() -> frozenset[str]:
+    """Return the set of all bundled skill names (public + internal).
+
+    Lazy and cached to defer and isolate initialization failures — a broken
+    DefaultSkillResolver will only affect tests that call this function, not
+    the entire module at import time.
+    """
+    return frozenset({s.name for s in DefaultSkillResolver().list_all()} | INTERNAL_SKILLS)
 
 
 def _all_skill_roots() -> list[Path]:
@@ -148,7 +158,7 @@ class TestSkillResolver:
                     # Skip placeholder filesystem paths like {{AUTOSKILLIT_TEMP}}/skill-name/
                     if start >= 1 and content[start - 1] == "}":
                         continue
-                    if name in BUNDLED_SKILL_NAMES:
+                    if name in _get_bundled_skill_names():
                         skill_file = f"{skill_md.parent.name}/SKILL.md"
                         assert False, f"{skill_file}: /{name} should be /autoskillit:{name}"
 
@@ -377,8 +387,9 @@ class TestSkillResolver:
             if entry.is_dir()
             and (entry / "SKILL.md").is_file()
             and entry.name not in RETIRED_SKILL_NAMES
+            and entry.name not in INTERNAL_SKILLS
         }
-        assert filesystem_names == BUNDLED_SKILL_NAMES
+        assert filesystem_names == _get_bundled_skill_names() - INTERNAL_SKILLS
 
 
 class TestSkillCategories:

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -18,138 +18,6 @@ from autoskillit.workspace.skills import (
 
 pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
-BUNDLED_SKILLS = [
-    "analyze-prs",
-    "arch-lens-c4-container",
-    "arch-lens-concurrency",
-    "arch-lens-data-lineage",
-    "arch-lens-deployment",
-    "arch-lens-development",
-    "arch-lens-error-resilience",
-    "arch-lens-module-dependency",
-    "arch-lens-operational",
-    "arch-lens-process-flow",
-    "arch-lens-repository-access",
-    "arch-lens-scenarios",
-    "arch-lens-security",
-    "arch-lens-state-lifecycle",
-    "audit-arch",
-    "audit-bugs",
-    "audit-claims",
-    "audit-cohesion",
-    "audit-defense-standards",
-    "audit-docs",
-    "audit-friction",
-    "audit-impl",
-    "audit-review-decisions",
-    "audit-tests",
-    "build-execution-map",
-    "bundle-local-report",
-    "close-kitchen",
-    "collapse-issues",
-    "compose-pr",
-    "compose-research-pr",
-    "design-guards",
-    "diagnose-ci",
-    "dry-walkthrough",
-    "elaborate-phase",
-    "enrich-issues",
-    "exp-lens-benchmark-representativeness",
-    "exp-lens-causal-assumptions",
-    "exp-lens-comparator-construction",
-    "exp-lens-error-budget",
-    "exp-lens-estimand-clarity",
-    "exp-lens-exploratory-confirmatory",
-    "exp-lens-fair-comparison",
-    "exp-lens-governance-risk",
-    "exp-lens-iterative-learning",
-    "exp-lens-measurement-validity",
-    "exp-lens-pipeline-integrity",
-    "exp-lens-randomization-blocking",
-    "exp-lens-reproducibility-artifacts",
-    "exp-lens-sensitivity-robustness",
-    "exp-lens-severity-testing",
-    "exp-lens-unit-interference",
-    "exp-lens-validity-threats",
-    "exp-lens-variance-stability",
-    "generate-report",
-    "implement-experiment",
-    "implement-worktree",
-    "implement-worktree-no-merge",
-    "investigate",
-    "issue-splitter",
-    "make-arch-diag",
-    "make-campaign",
-    "make-experiment-diag",
-    "make-groups",
-    "make-plan",
-    "make-req",
-    "merge-pr",
-    "mermaid",
-    "migrate-recipes",
-    "open-integration-pr",
-    "open-kitchen",
-    "pipeline-summary",
-    "plan-experiment",
-    "plan-visualization",
-    "planner-analyze",
-    "planner-assess-review-approach",
-    "planner-consolidate-wps",
-    "planner-elaborate-assignments",
-    "planner-elaborate-phase",
-    "planner-elaborate-wps",
-    "planner-extract-domain",
-    "planner-generate-phases",
-    "planner-reconcile-deps",
-    "planner-refine",
-    "planner-refine-assignments",
-    "planner-refine-phases",
-    "planner-refine-wps",
-    "prepare-issue",
-    "prepare-pr",
-    "prepare-research-pr",
-    "process-issues",
-    "promote-to-main",
-    "rectify",
-    "reload-session",
-    "report-bug",
-    "resolve-claims-review",
-    "resolve-design-review",
-    "resolve-failures",
-    "resolve-merge-conflicts",
-    "resolve-research-review",
-    "resolve-review",
-    "retry-worktree",
-    "review-pr",
-    "review-approach",
-    "review-design",
-    "review-research-pr",
-    "run-experiment",
-    "scope",
-    "setup-project",
-    "smoke-task",
-    "sous-chef",
-    "stage-data",
-    "triage-issues",
-    "troubleshoot-experiment",
-    "validate-audit",
-    "validate-review-decisions",
-    "verify-diag",
-    "vis-lens-always-on",
-    "vis-lens-antipattern",
-    "vis-lens-caption-annot",
-    "vis-lens-chart-select",
-    "vis-lens-color-access",
-    "vis-lens-methodology-norms",
-    "vis-lens-figure-table",
-    "vis-lens-multi-compare",
-    "vis-lens-reproducibility",
-    "vis-lens-story-arc",
-    "vis-lens-temporal",
-    "vis-lens-uncertainty",
-    "write-recipe",
-]
-
 # Internal-only skill documents: injected programmatically, never invocable as slash commands.
 # They have no YAML frontmatter and do not follow the user-facing SKILL.md structural contract.
 INTERNAL_SKILLS: frozenset[str] = frozenset({"sous-chef"})
@@ -203,7 +71,7 @@ AUDIT_SKILL_NAMES = [
     "audit-review-decisions",
 ]
 
-BUNDLED_SKILL_NAMES = set(BUNDLED_SKILLS)
+BUNDLED_SKILL_NAMES = {s.name for s in DefaultSkillResolver().list_all()} | INTERNAL_SKILLS
 
 
 def _all_skill_roots() -> list[Path]:
@@ -497,6 +365,20 @@ class TestSkillResolver:
         names = {s.name for s in DefaultSkillResolver().list_all()}
         surfaced = RETIRED_SKILL_NAMES & names
         assert not surfaced, f"list_all() returned retired skill name(s): {sorted(surfaced)}"
+
+    def test_bundled_skill_names_covers_filesystem(self) -> None:
+        """BUNDLED_SKILL_NAMES must cover every skill directory with a SKILL.md."""
+        from autoskillit.core import RETIRED_SKILL_NAMES
+
+        filesystem_names = {
+            entry.name
+            for root in _all_skill_roots()
+            for entry in root.iterdir()
+            if entry.is_dir()
+            and (entry / "SKILL.md").is_file()
+            and entry.name not in RETIRED_SKILL_NAMES
+        }
+        assert filesystem_names == BUNDLED_SKILL_NAMES
 
 
 class TestSkillCategories:


### PR DESCRIPTION
## Summary

Replace the hardcoded `BUNDLED_SKILLS` list (129 entries, lines 21–151 of `tests/workspace/test_skills.py`) and its derivative `BUNDLED_SKILL_NAMES` set (line 206) with a dynamically computed set using `DefaultSkillResolver().list_all()`. The constant has drifted (missing 6 skills confirmed on disk) and will continue drifting as skills are added. The resolver is already proven in `test_bundled_skills_list_matches_filesystem` (line 370). The dynamic set is unioned with the existing `INTERNAL_SKILLS` frozenset (line 155) to preserve cross-reference guard coverage for internal skills like `sous-chef`.

Closes #2754

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-205435-399258/.autoskillit/temp/make-plan/replace_bundled_skills_constant_plan_2026-05-22_210500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 81 | 14.0k | 948.3k | 86.7k | 129 | 76.3k | 9m 22s |
| verify | claude-opus-4-6 | 1 | 62 | 10.5k | 1.8M | 63.8k | 104 | 48.6k | 5m 58s |
| implement* | MiniMax-M2.7-highspeed | 1 | 360.5k | 4.6k | 563.5k | 29.8k | 40 | 15.6k | 2m 5s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 112.2k | 3.8k | 235.6k | 29.8k | 24 | 15.1k | 1m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 44.1k | 1.3k | 205.8k | 29.8k | 14 | 14.9k | 37s |
| review_pr | claude-sonnet-4-6 | 2 | 240 | 21.0k | 902.9k | 42.5k | 68 | 69.3k | 6m 56s |
| resolve_review | claude-sonnet-4-6 | 1 | 255 | 14.5k | 1.3M | 58.3k | 68 | 48.9k | 4m 59s |
| **Total** | | | 517.4k | 69.7k | 5.9M | 86.7k | | 288.6k | 31m 20s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 148 | 3807.3 | 105.7 | 31.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 17 | 77889.8 | 2873.7 | 855.0 |
| **Total** | **165** | 36031.4 | 1748.8 | 422.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 576 | 49.5k | 3.2M | 194.4k | 21m 18s |
| claude-opus-4-6 | 1 | 62 | 10.5k | 1.8M | 48.6k | 5m 58s |
| MiniMax-M2.7-highspeed | 3 | 516.8k | 9.7k | 1.0M | 45.6k | 4m 3s |