### PR TITLE
feat: add Rule 5 to wavefront scheduling — retry does not block sibling pipelines

### DIFF
--- a/src/autoskillit/cli/_prompts_orchestrator.py
+++ b/src/autoskillit/cli/_prompts_orchestrator.py
@@ -218,6 +218,12 @@ CONTEXT LIMIT ROUTING — run_skill only (check BEFORE on_failure):
   without consuming the retries budget. This is a one-shot retry — if the retry also
   goes stale, fall through to on_failure. Before re-executing, if worktree_path was
   captured from the stale result, remove it (git worktree remove --force <path>).
+- PARALLEL-AWARE RETRY: When running multiple pipelines in parallel and a batched round
+  returns a mix of successful and needs_retry results, issue the retry for the failing
+  pipeline(s) AND the next steps for the successful pipelines in the same response. A
+  retrying pipeline does not block sibling pipelines from advancing. Route the retry per
+  the rules above. The retrying pipeline rejoins the wavefront at whatever step boundary
+  the others have reached when its retry completes.
 
 HOOK DENIAL COMPLIANCE — ALL HOOKS:
 - When a PreToolUse hook DENIES a tool call (permissionDecision: "deny"), the denial

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -265,6 +265,14 @@ Any `run_skill` invocation (investigate, implement, audit, review, etc.)
    progressing. If a pipeline has completed all its `plan_parts` and only has finalization
    steps remaining (push, merge, close), it is still active and must be advanced.
 
+5. **A retrying pipeline does not block sibling pipelines.** When a batched round returns
+   with a mix of successful and `needs_retry` results, issue the retry for the failing
+   pipeline(s) AND the next steps for the successful pipelines in the same response.
+   Route the retry per CONTEXT LIMIT ROUTING (same rules apply — check `retry_reason`,
+   `subtype`, `on_context_limit`, etc.). The retrying pipeline rejoins the wavefront at
+   whatever step boundary the other pipelines have reached when its retry completes.
+   Never hold successful pipelines idle while waiting for a retry to finish.
+
 ### Rationale
 
 Batched rounds wait for the **slowest step** in the batch. If a slow `run_skill` is launched

--- a/tests/contracts/test_sous_chef_scheduling.py
+++ b/tests/contracts/test_sous_chef_scheduling.py
@@ -177,17 +177,19 @@ def test_sous_chef_wavefront_retry_does_not_block_siblings() -> None:
 
 def test_orchestrator_prompt_has_parallel_retry_note() -> None:
     """REQ-PROMPT-013: Orchestrator prompt must mirror parallel-aware retry note."""
+    import re
+
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
     prompt = _build_orchestrator_prompt("test-recipe", mcp_prefix=DIRECT_PREFIX)
     section_start = prompt.find("CONTEXT LIMIT ROUTING")
     assert section_start != -1, "Orchestrator prompt must contain CONTEXT LIMIT ROUTING"
-    next_section_marker = "\n\n"
-    search_start = section_start + len("CONTEXT LIMIT ROUTING") + 200
-    next_section = prompt.find(next_section_marker, search_start)
+    next_section = re.search(r"\n[A-Z][A-Z _]+—", prompt[section_start + 1 :])
     section_text = (
-        prompt[section_start:next_section] if next_section != -1 else prompt[section_start:]
+        prompt[section_start : section_start + 1 + next_section.start()]
+        if next_section
+        else prompt[section_start:]
     )
     lower = section_text.lower()
     has_parallel_note = "retry" in lower and (

--- a/tests/contracts/test_sous_chef_scheduling.py
+++ b/tests/contracts/test_sous_chef_scheduling.py
@@ -141,8 +141,8 @@ def test_sous_chef_wavefront_has_positive_advancement_mandate() -> None:
     )
 
 
-def test_sous_chef_wavefront_has_four_rules() -> None:
-    """REQ-PROMPT-010: Wavefront Scheduling Rule must contain exactly 4 numbered rules."""
+def test_sous_chef_wavefront_has_five_rules() -> None:
+    """REQ-PROMPT-011: Wavefront Scheduling Rule must contain exactly 5 numbered rules."""
     import re
 
     text = _sous_chef_text()
@@ -153,8 +153,49 @@ def test_sous_chef_wavefront_has_four_rules() -> None:
         text[section_start:next_subsection] if next_subsection != -1 else text[section_start:]
     )
     rules = re.findall(r"^\d+\.\s", subsection, re.MULTILINE)
-    assert len(rules) == 4, (
-        f"Wavefront Scheduling Rule must have exactly 4 numbered rules, found {len(rules)}"
+    assert len(rules) == 5, (
+        f"Wavefront Scheduling Rule must have exactly 5 numbered rules, found {len(rules)}"
+    )
+
+
+def test_sous_chef_wavefront_retry_does_not_block_siblings() -> None:
+    """REQ-PROMPT-012: Wavefront must address retry+parallel collision."""
+    text = _sous_chef_text()
+    section_start = text.find("PARALLEL STEP SCHEDULING")
+    assert section_start != -1
+    next_section = text.find("\n## ", section_start + 1)
+    section_text = text[section_start:next_section] if next_section != -1 else text[section_start:]
+    lower = section_text.lower()
+    has_retry_collision = "retry" in lower and (
+        "sibling" in lower or "successful pipelines" in lower or "does not block" in lower
+    )
+    assert has_retry_collision, (
+        "PARALLEL STEP SCHEDULING section must address retry+parallel collision: "
+        "a retrying pipeline must not block sibling pipelines from advancing"
+    )
+
+
+def test_orchestrator_prompt_has_parallel_retry_note() -> None:
+    """REQ-PROMPT-013: Orchestrator prompt must mirror parallel-aware retry note."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("test-recipe", mcp_prefix=DIRECT_PREFIX)
+    section_start = prompt.find("CONTEXT LIMIT ROUTING")
+    assert section_start != -1, "Orchestrator prompt must contain CONTEXT LIMIT ROUTING"
+    next_section_marker = "\n\n"
+    search_start = section_start + len("CONTEXT LIMIT ROUTING") + 200
+    next_section = prompt.find(next_section_marker, search_start)
+    section_text = (
+        prompt[section_start:next_section] if next_section != -1 else prompt[section_start:]
+    )
+    lower = section_text.lower()
+    has_parallel_note = "retry" in lower and (
+        "sibling" in lower or "parallel" in lower or "does not block" in lower
+    )
+    assert has_parallel_note, (
+        "CONTEXT LIMIT ROUTING section in orchestrator prompt must contain a "
+        "parallel-aware retry note about not blocking sibling pipelines"
     )
 
 


### PR DESCRIPTION
## Summary

When a parallel wavefront group returns a mix of successful and `needs_retry` results, the orchestrator serializes the entire group behind the single retry because no instruction addresses this collision. The fix adds a Rule 5 to the Wavefront Scheduling Rule in `sous-chef/SKILL.md`, mirrors a parallel-aware note in `_prompts_orchestrator.py`, adds a contract test for the new rule, and updates the existing rule-count assertion from 4 to 5.

## Changed Files

### Modified (●):

- `src/autoskillit/cli/_prompts_orchestrator.py`
- `src/autoskillit/skills/sous-chef/SKILL.md`
- `tests/contracts/test_sous_chef_scheduling.py`

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.



## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/wavefront_retry_collision_plan_2026-05-22_223500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.7k | 12.0k | 847.1k | 79.7k | 104 | 61.1k | 9m 45s |
| verify | claude-sonnet-4-6 | 1 | 49 | 8.0k | 499.2k | 55.9k | 101 | 33.3k | 6m 53s |
| implement* | MiniMax-M2.7 | 1 | 87.8k | 4.3k | 696.2k | 0 | 40 | 0 | 2m 25s |
| prepare_pr* | MiniMax-M2.7 | 1 | 44.3k | 3.1k | 366.7k | 0 | 25 | 0 | 55s |
| compose_pr* | MiniMax-M2.7 | 1 | 59.0k | 2.0k | 373.3k | 0 | 27 | 0 | 1m 9s |
| review_pr | claude-opus-4-6 | 2 | 76 | 22.0k | 839.3k | 50.1k | 51 | 69.8k | 6m 42s |
| resolve_review | claude-opus-4-6 | 1 | 47 | 5.9k | 1.1M | 65.2k | 38 | 50.4k | 3m 27s |
| **Total** | | | 195.0k | 57.4k | 4.7M | 79.7k | | 214.6k | 31m 18s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 105026.1 | 5041.9 | 590.0 |
| **Total** | **10** | 467206.9 | 21461.0 | 5740.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 3.8k | 20.1k | 1.3M | 94.4k | 16m 39s |
| MiniMax-M2.7 | 3 | 191.1k | 9.5k | 1.4M | 0 | 4m 29s |
| claude-opus-4-6 | 2 | 123 | 27.9k | 1.9M | 120.2k | 10m 10s |