### PR TITLE
Micro-cleanups — parameterize SQL tests, remove duplicate, rename misleading test, update docs

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -172,6 +172,7 @@ tests/
 ├── _test_filter.py                      # Test filter manifest: glob-to-test-directory mapping
 ├── conftest.py                          # Shared fixtures: minimal_ctx, tool_ctx, _make_result, _make_timeout_result
 ├── fakes.py                             # Protocol-based test fakes: InMemory*, MockSubprocessRunner
+├── test_backend_gating_root.py
 ├── test_conftest.py                     # Tests for conftest fixtures
 ├── test_fakes_conformance.py
 ├── test_llm_triage.py
@@ -181,6 +182,7 @@ tests/
 ├── test_test_filter_cascade.py
 ├── test_test_filter_content_aware.py
 ├── test_test_filter_core_cascade.py
+├── test_test_filter_coverage_map.py
 ├── test_test_filter_execution_cascade.py
 ├── test_test_filter_plugin.py
 ├── test_test_filter_scope_extras.py
@@ -198,6 +200,7 @@ tests/
 ├── fleet/                               # Fleet campaign + dispatch tests (see fleet/CLAUDE.md)
 ├── hooks/                               # Hook script tests (see hooks/CLAUDE.md)
 ├── infra/                               # CI/CD and security configuration tests (see infra/CLAUDE.md)
+├── integration/                         # Cross-layer integration tests
 ├── migration/                           # Migration engine and store tests (see migration/CLAUDE.md)
 ├── pipeline/                            # Audit log, gate, fidelity, and PR-gate tests (see pipeline/CLAUDE.md)
 ├── planner/                             # Planner manifest, validation, and compilation tests (see planner/CLAUDE.md)

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -229,20 +229,6 @@ class TestProvidersConfigYaml:
 
 
 class TestResolvedProfiles:
-    def test_defaults_yaml_anthropic_sentinel(self) -> None:
-        from autoskillit.core.io import load_yaml
-        from autoskillit.core.paths import pkg_root
-
-        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
-        profile = defaults["providers"]["profiles"]["anthropic"]
-        assert set(profile.keys()) == {
-            "base_url",
-            "timeout_seconds",
-            "api_key_env",
-            "context_window",
-        }
-        assert all(v is None for v in profile.values())
-
     def test_resolved_profiles_empty(self) -> None:
         from autoskillit.config.settings import ProvidersConfig
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -41,7 +41,7 @@ def test_core_init_uses_lazy_getattr():
     assert callable(core.__getattr__)
 
 
-def test_core_init_has_no_eager_submodule_imports():
+def test_core_init_has_no_eager_relative_imports():
     import ast
 
     from autoskillit.core.paths import pkg_root

--- a/tests/execution/test_db.py
+++ b/tests/execution/test_db.py
@@ -36,41 +36,26 @@ class TestValidateSelectOnly:
     def test_accepts_leading_whitespace(self):
         _validate_select_only("  \n  SELECT 1")
 
-    def test_rejects_insert(self):
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "INSERT INTO users VALUES (1, 'a')",
+            "DROP TABLE foo",
+            "UPDATE users SET name = 'x'",
+            "DELETE FROM users",
+            "ALTER TABLE users ADD COLUMN x",
+            "ATTACH DATABASE 'other.db' AS other",
+            "CREATE TABLE evil (id INT)",
+            "PRAGMA table_info(users)",
+        ],
+    )
+    def test_rejects_forbidden_sql(self, sql):
         with pytest.raises(ValueError, match="forbidden"):
-            _validate_select_only("INSERT INTO users VALUES (1, 'a')")
+            _validate_select_only(sql)
 
     def test_whitespace_only_raises(self):
         with pytest.raises(ValueError, match="empty"):
             _validate_select_only("   ")
-
-    def test_drop_raises(self):
-        with pytest.raises(ValueError, match="forbidden"):
-            _validate_select_only("DROP TABLE foo")
-
-    def test_update_raises(self):
-        with pytest.raises(ValueError, match="forbidden"):
-            _validate_select_only("UPDATE users SET name = 'x'")
-
-    def test_rejects_delete(self):
-        with pytest.raises(ValueError, match="forbidden"):
-            _validate_select_only("DELETE FROM users")
-
-    def test_rejects_alter(self):
-        with pytest.raises(ValueError, match="forbidden"):
-            _validate_select_only("ALTER TABLE users ADD COLUMN x")
-
-    def test_rejects_attach(self):
-        with pytest.raises(ValueError, match="forbidden"):
-            _validate_select_only("ATTACH DATABASE 'other.db' AS other")
-
-    def test_rejects_create(self):
-        with pytest.raises(ValueError, match="forbidden"):
-            _validate_select_only("CREATE TABLE evil (id INT)")
-
-    def test_rejects_pragma(self):
-        with pytest.raises(ValueError, match="forbidden"):
-            _validate_select_only("PRAGMA table_info(users)")
 
     def test_rejects_non_select_start(self):
         with pytest.raises(ValueError, match="must begin with SELECT"):


### PR DESCRIPTION
## Summary

Four independent micro-cleanups from the validated tests audit (issue #2756):

1. **[3.5]** Parameterize the 8 identical "forbidden SQL" rejection tests in `TestValidateSelectOnly` into a single `@pytest.mark.parametrize` test.
2. **[3.10]** Delete the byte-for-byte duplicate `test_defaults_yaml_anthropic_sentinel` from `TestResolvedProfiles`.
3. **[3.14]** Rename `test_core_init_has_no_eager_submodule_imports` → `test_core_init_has_no_eager_relative_imports` to accurately reflect the check's scope (relative imports only).
4. **[3.25]** Add `test_backend_gating_root.py`, `test_test_filter_coverage_map.py`, and `tests/integration/` to the `tests/CLAUDE.md` inventory.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260522-235024-820433/.autoskillit/temp/make-plan/micro_cleanups_parameterize_sql_tests_plan_2026-05-22_235600.md`

Closes #2756

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 85 | 10.7k | 1.2M | 79.8k | 117 | 65.4k | 7m 34s |
| verify | claude-opus-4-6 | 1 | 44 | 13.1k | 943.7k | 77.6k | 44 | 63.4k | 4m 27s |
| implement* | MiniMax-M2.7-highspeed | 1 | 403.2k | 4.7k | 506.3k | 29.8k | 51 | 42.4k | 2m 6s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 100.8k | 3.0k | 295.0k | 29.8k | 23 | 15.0k | 1m 19s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 93.4k | 2.1k | 354.6k | 29.8k | 24 | 14.8k | 55s |
| review_pr | claude-sonnet-4-6 | 3 | 308 | 47.1k | 1.4M | 55.1k | 106 | 133.7k | 12m 29s |
| resolve_review | claude-sonnet-4-6 | 1 | 159 | 9.3k | 838.8k | 58.3k | 47 | 44.6k | 3m 53s |
| **Total** | | | 598.0k | 89.9k | 5.6M | 79.8k | | 379.3k | 32m 45s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 64 | 7911.4 | 662.3 | 72.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **64** | 87191.0 | 5926.9 | 1405.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 129 | 23.8k | 2.1M | 128.9k | 12m 1s |
| MiniMax-M2.7-highspeed | 3 | 597.4k | 9.8k | 1.2M | 72.2k | 4m 21s |
| claude-sonnet-4-6 | 2 | 467 | 56.4k | 2.3M | 178.2k | 16m 22s |