### PR TITLE
PX4 P4-A6-WP1 — Add Codex NDJSON pipeline tests to test_headless_result.py

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -42,7 +42,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_headless_provider_forwarding.py` | Tests verifying provider_extras and profile_name forwarding through the headless call chain |
 | `test_headless_result_write_reconciliation.py` | Integration tests for EMPTY_OUTPUT + write-evidence reconciliation gate in _build_skill_result |
 | `test_headless_synthesis.py` | Tests for headless.py synthesis helpers: output path extraction, validation, contamination |
-| `test_headless_result.py` | Tests for _build_skill_result idle_stall lifespan_started propagation |
+| `test_headless_result.py` | Tests for _build_skill_result: idle_stall lifespan_started, kill_reason propagation, backend delegation, write evidence, and Codex NDJSON pipeline (happy path, turn failed, termination branches) |
 | `test_idle_output_env.py` | Group G (execution part): AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env variable injection tests |
 | `test_linux_tracing.py` | Tests for Linux-only process tracing via psutil and /proc filesystem |
 | `test_linux_tracing_pty_integration.py` | Integration test: PTY-wrapped command is traced at the workload level, not the wrapper |

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -13,12 +13,18 @@ from autoskillit.core import AGENT_BACKEND_CLAUDE_CODE
 from autoskillit.core.types import (
     AgentSessionResult,
     KillReason,
+    SkillResult,
     SubprocessResult,
     TerminationReason,
     WriteEvidence,
 )
-from autoskillit.execution.headless import _build_skill_result
+from autoskillit.execution.backends.codex import CodexBackend
+from autoskillit.execution.headless import _build_skill_result, _parse_stdout
+from autoskillit.execution.headless._headless_result import _adapt_agent_result
+from autoskillit.execution.session import ClaudeSessionResult
+from autoskillit.execution.session._session_outcome import _compute_outcome
 from tests.execution.conftest import _make_tool_use_line, _sr, _success_session_json
+from tests.fixtures.codex import HAPPY_PATH_SINGLE_TURN, TURN_FAILED_ERROR, fixture_path
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -123,6 +129,62 @@ def _stale_result_with_token_usage(
         kill_reason=kill_reason,
         pid=12345,
         session_id="sess-stale-token",
+        channel_b_session_id="",
+    )
+
+
+def _adapt_codex_result(agent_result: AgentSessionResult) -> ClaudeSessionResult:
+    return _adapt_agent_result(agent_result)
+
+
+def _make_codex_parse_stdout() -> object:
+    """Return a _parse_stdout replacement that delegates to CodexResultParser.
+
+    Simulates Phase C wiring: parses Codex NDJSON via CodexResultParser,
+    adapts via _adapt_codex_result, and extracts error codes from turn.failed
+    events into session.errors for API error detection.
+
+    The ``backend`` parameter is accepted for signature compatibility with
+    _parse_stdout (called as ``_parse_stdout(stdout, backend=backend)`` inside
+    _build_skill_result) but is intentionally ignored — this monkeypatch
+    unconditionally routes through CodexResultParser.
+    """
+
+    def _patched(stdout: str, backend: object = None) -> ClaudeSessionResult:  # noqa: ARG001
+        agent_result = CodexBackend().result_parser().parse_stdout(stdout)
+        session = _adapt_codex_result(agent_result)
+        for line in stdout.strip().splitlines():
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") == "turn.failed":
+                error = obj.get("error", {})
+                if isinstance(error, dict):
+                    code = error.get("code", "")
+                    if code:
+                        session.errors.append(code)
+        return session
+
+    return _patched  # type: ignore[return-value]
+
+
+def _codex_subprocess_result(
+    stdout: str,
+    *,
+    returncode: int = 0,
+    stderr: str = "",
+    termination: TerminationReason = TerminationReason.NATURAL_EXIT,
+    kill_reason: KillReason = KillReason.NATURAL_EXIT,
+) -> SubprocessResult:
+    return SubprocessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        termination=termination,
+        kill_reason=kill_reason,
+        pid=12345,
+        session_id="",
         channel_b_session_id="",
     )
 
@@ -253,7 +315,6 @@ class TestBackendDelegatedWriteToolNames:
 
     def test_codex_backend_produces_zero_write_count(self):
         """CodexBackend.write_tool_names() is empty — write_call_count must be 0."""
-        from autoskillit.execution.backends.codex import CodexBackend
 
         stdout = (
             _make_tool_use_line("Write", {"file_path": "/a/b.py", "content": "x"})
@@ -377,7 +438,6 @@ class TestBackendDelegatedWriteToolNames:
 class TestParseStdout:
     def test_backend_none_calls_parse_session_result(self):
         """_parse_stdout with backend=None returns the same result as parse_session_result."""
-        from autoskillit.execution.headless import _parse_stdout
         from autoskillit.execution.session import parse_session_result
 
         stdout = _success_session_json("test result")
@@ -389,8 +449,6 @@ class TestParseStdout:
 
     def test_default_backend_returns_claude_session_result(self):
         """_parse_stdout with no backend arg returns a ClaudeSessionResult."""
-        from autoskillit.execution.headless import _parse_stdout
-        from autoskillit.execution.session import ClaudeSessionResult
 
         stdout = _success_session_json("test result")
         result = _parse_stdout(stdout)
@@ -399,9 +457,6 @@ class TestParseStdout:
 
     def test_parse_stdout_accepts_backend_kwarg(self):
         """_parse_stdout accepts an optional backend keyword argument."""
-
-        from autoskillit.execution.headless import _parse_stdout
-        from autoskillit.execution.session import ClaudeSessionResult
 
         mock_backend = Mock()
         mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
@@ -412,8 +467,6 @@ class TestParseStdout:
 
     def test_parse_stdout_with_backend_matches_fallback(self):
         """_parse_stdout with backend produces same result as without."""
-
-        from autoskillit.execution.headless import _parse_stdout
 
         mock_backend = Mock()
         mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
@@ -427,7 +480,6 @@ class TestParseStdout:
     def test_parse_stdout_claude_code_backend_falls_through(self):
         """ClaudeCodeBackend backend falls through to parse_session_result."""
         from autoskillit.execution.backends.claude import ClaudeCodeBackend
-        from autoskillit.execution.headless import _parse_stdout
         from autoskillit.execution.session import parse_session_result
 
         stdout = _success_session_json("test result")
@@ -439,8 +491,6 @@ class TestParseStdout:
 
     def test_parse_stdout_non_claude_backend_dispatches_through_result_parser(self):
         """Non-Claude backend dispatches through result_parser().parse_stdout()."""
-        from autoskillit.execution.headless import _parse_stdout
-        from autoskillit.execution.session import ClaudeSessionResult
 
         mock_backend = Mock()
         mock_backend.name = "not-claude-code"
@@ -464,7 +514,6 @@ class TestParseStdout:
 
     def test_parse_stdout_backend_none_unchanged(self):
         """_parse_stdout with backend=None matches parse_session_result (regression guard)."""
-        from autoskillit.execution.headless import _parse_stdout
         from autoskillit.execution.session import parse_session_result
 
         stdout = _success_session_json("test result")
@@ -476,10 +525,8 @@ class TestParseStdout:
 
     def test_parse_stdout_codex_backend_dispatches_through_adapter(self, monkeypatch):
         """CodexBackend dispatches through _adapt_agent_result (non-Claude path)."""
-        from autoskillit.execution.backends.codex import CodexBackend
         from autoskillit.execution.headless import _headless_result
         from autoskillit.execution.headless._headless_result import _parse_stdout
-        from autoskillit.execution.session import ClaudeSessionResult
 
         spy = Mock(wraps=_headless_result._adapt_agent_result)
         monkeypatch.setattr(_headless_result, "_adapt_agent_result", spy)
@@ -560,3 +607,178 @@ class TestWriteEvidenceCrossCheck:
             and "write_call_count_cross_check_mismatch" in call.args[0]
             for call in cap.calls
         ), "Cross-check must warn when count=0 but stdout contains write tool names"
+
+
+class TestCodexPipelineHappyPath:
+    """Codex NDJSON happy-path through _parse_stdout and _build_skill_result."""
+
+    def test_parse_stdout_with_codex_backend(self):
+        content = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+        session = _parse_stdout(content, backend=CodexBackend())
+        assert session.session_id == "thread_hp_abc123"
+        assert session.token_usage is not None
+        assert session.token_usage["input_tokens"] == 150
+        assert session.token_usage["output_tokens"] == 75
+        assert session.token_usage["cache_read_tokens"] == 30
+
+    def test_happy_path_pipeline(self):
+        content = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+        result = _codex_subprocess_result(content)
+        sr = _build_skill_result(
+            result,
+            backend=CodexBackend(),
+            supports_claude_format_stdout=False,
+        )
+        assert sr.success is True
+        assert sr.session_id == "thread_hp_abc123"
+        assert sr.is_error is False
+        assert sr.token_usage is not None
+
+    def test_subtype_via_compute_outcome(self):
+        content = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+        result = _codex_subprocess_result(content)
+        sr = _build_skill_result(
+            result,
+            backend=CodexBackend(),
+            supports_claude_format_stdout=False,
+        )
+        session = _parse_stdout(content, backend=CodexBackend())
+        outcome, _ = _compute_outcome(session, 0, TerminationReason.NATURAL_EXIT)
+        expected_subtype = session.normalize_subtype(outcome, "")
+        assert sr.subtype == expected_subtype
+
+    def test_parse_stdout_directly_with_codex_backend(self):
+        content = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+        session = _parse_stdout(content, backend=CodexBackend())
+        assert session.session_id == "thread_hp_abc123"
+        assert session.is_error is False
+        assert "input_tokens" in (session.token_usage or {})
+        assert "output_tokens" in (session.token_usage or {})
+
+
+class TestCodexPipelineTurnFailed:
+    """Codex NDJSON turn_failed_error through _build_skill_result."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_parse_stdout(self, monkeypatch):
+        from autoskillit.execution.headless import _headless_result
+
+        monkeypatch.setattr(_headless_result, "_parse_stdout", _make_codex_parse_stdout())
+        self._content = fixture_path(TURN_FAILED_ERROR).read_text()
+        self._result = _codex_subprocess_result(
+            self._content,
+            returncode=1,
+            termination=TerminationReason.NATURAL_EXIT,
+            kill_reason=KillReason.NATURAL_EXIT,
+        )
+
+    def _build(self) -> SkillResult:
+        return _build_skill_result(self._result, supports_claude_format_stdout=False)
+
+    def test_failure_success_is_false(self):
+        sr = self._build()
+        assert sr.success is False
+
+    def test_failure_session_id(self):
+        sr = self._build()
+        assert sr.session_id == "thread_fail_001"
+
+    def test_failure_is_error(self):
+        sr = self._build()
+        assert sr.is_error is True
+
+    def test_failure_subtype(self):
+        sr = self._build()
+        assert sr.subtype == "error_during_execution"
+
+    def test_failure_needs_retry(self):
+        sr = self._build()
+        assert sr.needs_retry is True
+
+    def test_failure_token_usage_none(self):
+        sr = self._build()
+        assert sr.token_usage is None
+
+
+class TestCodexPipelineTerminationBranches:
+    """STALE and IDLE_STALL branches with Codex NDJSON fixtures."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_parse_stdout(self, monkeypatch):
+        from autoskillit.execution.headless import _headless_result
+
+        monkeypatch.setattr(_headless_result, "_parse_stdout", _make_codex_parse_stdout())
+
+    def _happy_content(self) -> str:
+        return fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+
+    def _error_content(self) -> str:
+        return fixture_path(TURN_FAILED_ERROR).read_text()
+
+    def test_stale_codex_happy_path_with_backend_succeeds(self):
+        result = _codex_subprocess_result(
+            self._happy_content(),
+            returncode=-1,
+            termination=TerminationReason.STALE,
+            kill_reason=KillReason.INFRA_KILL,
+        )
+        sr = _build_skill_result(
+            result,
+            completion_marker="%%ORDER_UP%%",
+            supports_claude_format_stdout=False,
+        )
+        assert sr.success is True
+
+    def test_stale_codex_empty_stdout_fails(self):
+        result = _codex_subprocess_result(
+            "",
+            returncode=-1,
+            termination=TerminationReason.STALE,
+            kill_reason=KillReason.INFRA_KILL,
+        )
+        sr = _build_skill_result(result, supports_claude_format_stdout=False)
+        assert sr.success is False
+
+    def test_stale_codex_error_fixture_fails(self):
+        result = _codex_subprocess_result(
+            self._error_content(),
+            returncode=-1,
+            termination=TerminationReason.STALE,
+            kill_reason=KillReason.INFRA_KILL,
+        )
+        sr = _build_skill_result(result, supports_claude_format_stdout=False)
+        assert sr.success is False
+
+    def test_idle_stall_codex_happy_path_with_backend_succeeds(self):
+        result = _codex_subprocess_result(
+            self._happy_content(),
+            returncode=-1,
+            termination=TerminationReason.IDLE_STALL,
+            kill_reason=KillReason.INFRA_KILL,
+        )
+        sr = _build_skill_result(
+            result,
+            completion_marker="%%ORDER_UP%%",
+            supports_claude_format_stdout=False,
+        )
+        assert sr.success is True
+
+    def test_idle_stall_codex_empty_stdout_fails(self):
+        result = _codex_subprocess_result(
+            "",
+            returncode=-1,
+            termination=TerminationReason.IDLE_STALL,
+            kill_reason=KillReason.INFRA_KILL,
+        )
+        sr = _build_skill_result(result, supports_claude_format_stdout=False)
+        assert sr.success is False
+
+    def test_idle_stall_codex_error_fixture_fails(self):
+        result = _codex_subprocess_result(
+            self._error_content(),
+            returncode=-1,
+            termination=TerminationReason.IDLE_STALL,
+            kill_reason=KillReason.INFRA_KILL,
+        )
+        sr = _build_skill_result(result, supports_claude_format_stdout=False)
+        assert sr.success is False

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -616,7 +616,10 @@ class TestCodexPipelineHappyPath:
         content = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
         session = _parse_stdout(content, backend=CodexBackend())
         assert session.session_id == "thread_hp_abc123"
+        assert session.is_error is False
         assert session.token_usage is not None
+        assert "input_tokens" in session.token_usage
+        assert "output_tokens" in session.token_usage
         assert session.token_usage["input_tokens"] == 150
         assert session.token_usage["output_tokens"] == 75
         assert session.token_usage["cache_read_tokens"] == 30
@@ -646,14 +649,6 @@ class TestCodexPipelineHappyPath:
         outcome, _ = _compute_outcome(session, 0, TerminationReason.NATURAL_EXIT)
         expected_subtype = session.normalize_subtype(outcome, "")
         assert sr.subtype == expected_subtype
-
-    def test_parse_stdout_directly_with_codex_backend(self):
-        content = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
-        session = _parse_stdout(content, backend=CodexBackend())
-        assert session.session_id == "thread_hp_abc123"
-        assert session.is_error is False
-        assert "input_tokens" in (session.token_usage or {})
-        assert "output_tokens" in (session.token_usage or {})
 
 
 class TestCodexPipelineTurnFailed:

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -639,13 +639,14 @@ class TestCodexPipelineHappyPath:
 
     def test_subtype_via_compute_outcome(self):
         content = fixture_path(HAPPY_PATH_SINGLE_TURN).read_text()
+        backend = CodexBackend()
+        session = _parse_stdout(content, backend=backend)
         result = _codex_subprocess_result(content)
         sr = _build_skill_result(
             result,
-            backend=CodexBackend(),
+            backend=backend,
             supports_claude_format_stdout=False,
         )
-        session = _parse_stdout(content, backend=CodexBackend())
         outcome, _ = _compute_outcome(session, 0, TerminationReason.NATURAL_EXIT)
         expected_subtype = session.normalize_subtype(outcome, "")
         assert sr.subtype == expected_subtype


### PR DESCRIPTION
## Summary

Add three test classes to `tests/execution/test_headless_result.py` that exercise the Codex NDJSON pipeline: `TestCodexPipelineHappyPath` (4 methods), `TestCodexPipelineTurnFailed` (6 methods), and `TestCodexPipelineTerminationBranches` (6 methods). Tests feed Codex NDJSON fixtures through `_parse_stdout` with `CodexBackend` and `_build_skill_result`, asserting correctness of `SkillResult` fields (success, session_id, token_usage, subtype, is_error, needs_retry). A shared `_adapt_codex_result` helper and a `_make_codex_parse_stdout` factory function provide the monkeypatch plumbing that simulates Phase C error-code propagation. All 16 test methods are marked `small` with `layer('execution')`. Update the `tests/execution/CLAUDE.md` file description to reflect expanded scope.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-000230-516798/.autoskillit/temp/make-plan/px4_p4_a6_wp1_codex_pipeline_tests_plan_2026-05-23_001600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.7k | 43.2k | 1.8M | 130.4k | 189 | 173.3k | 25m 27s |
| verify | claude-sonnet-4-6 | 1 | 1.6k | 15.2k | 702.0k | 77.5k | 145 | 62.3k | 8m 43s |
| implement* | MiniMax-M2.7 | 1 | 72.7k | 10.0k | 2.4M | 20.8k | 103 | 0 | 4m 21s |
| prepare_pr* | MiniMax-M2.7 | 1 | 50.0k | 4.1k | 438.8k | 0 | 28 | 0 | 58s |
| compose_pr* | MiniMax-M2.7 | 1 | 45.0k | 1.2k | 243.4k | 0 | 16 | 0 | 45s |
| review_pr | claude-opus-4-6 | 2 | 91 | 62.3k | 1.4M | 83.4k | 67 | 185.2k | 14m 36s |
| resolve_review | claude-opus-4-6 | 1 | 60 | 12.6k | 1.4M | 70.1k | 57 | 55.4k | 7m 47s |
| **Total** | | | 172.1k | 148.6k | 8.3M | 130.4k | | 476.1k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 256 | 9308.0 | 0.0 | 39.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 88037.6 | 3460.3 | 789.9 |
| **Total** | **272** | 30642.1 | 1750.3 | 546.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 4.3k | 58.4k | 2.5M | 235.6k | 34m 10s |
| MiniMax-M2.7 | 3 | 167.7k | 15.3k | 3.1M | 0 | 6m 4s |
| claude-opus-4-6 | 2 | 151 | 74.9k | 2.8M | 240.5k | 22m 23s |