### PR TITLE
test: add 9 unit tests for _adapt_agent_result field mapping gaps

### DIFF
--- a/tests/execution/test_adapt_agent_result.py
+++ b/tests/execution/test_adapt_agent_result.py
@@ -199,3 +199,116 @@ def test_assistant_messages_from_raw() -> None:
 def test_assistant_messages_default_empty() -> None:
     result = _adapt_agent_result(_make_agent_result())
     assert result.assistant_messages == []
+
+
+def test_success_false_maps_is_error_true_when_raw_absent() -> None:
+    result = _adapt_agent_result(_make_agent_result(success=False))
+    assert result.is_error is True
+
+
+def test_errors_field_defaults_to_empty_list() -> None:
+    result = _adapt_agent_result(_make_agent_result())
+    assert result.errors == []
+
+
+def test_context_exhaustion_error_max_turns() -> None:
+    result = _adapt_agent_result(
+        _make_agent_result(
+            raw={"subtype": "error_max_turns"},
+            error="API error: context_length_exceeded",
+        )
+    )
+    assert result.jsonl_context_exhausted is True
+
+
+def test_context_exhaustion_unknown_subtype() -> None:
+    result = _adapt_agent_result(
+        _make_agent_result(
+            error="context_length_exceeded",
+        )
+    )
+    assert result.jsonl_context_exhausted is True
+
+
+def test_context_exhaustion_error_is_none() -> None:
+    result = _adapt_agent_result(
+        _make_agent_result(
+            raw={"subtype": "error_during_execution"},
+            error=None,
+        )
+    )
+    assert result.jsonl_context_exhausted is False
+
+
+def test_unused_agent_fields_do_not_affect_output() -> None:
+    base = _adapt_agent_result(
+        _make_agent_result(exit_code=0, backend_name="a", elapsed_seconds=1.0)
+    )
+    varied = _adapt_agent_result(
+        _make_agent_result(exit_code=99, backend_name="b", elapsed_seconds=999.0)
+    )
+    assert base.subtype == varied.subtype
+    assert base.is_error == varied.is_error
+    assert base.result == varied.result
+    assert base.session_id == varied.session_id
+    assert base.errors == varied.errors
+    assert base.token_usage == varied.token_usage
+    assert base.assistant_messages == varied.assistant_messages
+    assert base.tool_uses == varied.tool_uses
+    assert base.jsonl_context_exhausted == varied.jsonl_context_exhausted
+    assert base.stop_reasons == varied.stop_reasons
+    assert base.has_thinking_only_turn == varied.has_thinking_only_turn
+    assert base.seen_block_types == varied.seen_block_types
+
+
+def test_canonical_token_usage_none_falls_through_to_token_usage() -> None:
+    result = _adapt_agent_result(
+        _make_agent_result(raw={"canonical_token_usage": None, "token_usage": {"input": 42}})
+    )
+    assert result.token_usage == {"input": 42}
+
+
+def test_empty_output_maps_to_empty_result() -> None:
+    result = _adapt_agent_result(_make_agent_result(output=""))
+    assert result.result == ""
+
+
+def test_full_round_trip_all_fields() -> None:
+    agent = _make_agent_result(
+        success=True,
+        exit_code=42,
+        backend_name="codex",
+        elapsed_seconds=5.5,
+        session_id="sess-abc",
+        output="final output",
+        error="some warning",
+        raw={
+            "is_error": False,
+            "subtype": "success",
+            "stop_reasons": ["end_turn"],
+            "canonical_token_usage": {"input": 200, "output": 50},
+            "token_usage": {"input": 100},
+            "command_executions": [{"name": "bash", "cmd": "ls"}],
+            "mcp_tool_calls": [{"name": "read", "path": "/tmp"}],
+            "file_changes": ["main.py"],
+            "agent_messages": ["I updated the file."],
+        },
+    )
+    result = _adapt_agent_result(agent)
+
+    assert result.subtype == CliSubtype.SUCCESS
+    assert result.is_error is False
+    assert result.result == "final output"
+    assert result.session_id == "sess-abc"
+    assert result.errors == []
+    assert result.token_usage == {"input": 200, "output": 50}
+    assert result.assistant_messages == ["I updated the file."]
+    assert result.tool_uses == [
+        {"name": "bash", "cmd": "ls"},
+        {"name": "read", "path": "/tmp"},
+        {"name": "file_change", "type": "file_change", "path": "main.py"},
+    ]
+    assert result.jsonl_context_exhausted is False
+    assert result.stop_reasons == ["end_turn"]
+    assert result.has_thinking_only_turn is False
+    assert result.seen_block_types == frozenset()

--- a/tests/execution/test_adapt_agent_result.py
+++ b/tests/execution/test_adapt_agent_result.py
@@ -260,6 +260,10 @@ def test_unused_agent_fields_do_not_affect_output() -> None:
     assert base.has_thinking_only_turn == varied.has_thinking_only_turn
     assert base.seen_block_types == varied.seen_block_types
 
+    assert not hasattr(base, "exit_code")
+    assert not hasattr(base, "backend_name")
+    assert not hasattr(base, "elapsed_seconds")
+
 
 def test_canonical_token_usage_none_falls_through_to_token_usage() -> None:
     result = _adapt_agent_result(


### PR DESCRIPTION
## Summary

Add 9 new unit tests to `tests/execution/test_adapt_agent_result.py` that close coverage gaps in the field mapping from `AgentSessionResult` to `ClaudeSessionResult` via `_adapt_agent_result`. The existing 20 tests cover individual behaviors well but miss: the `success=False` → `is_error=True` fallback path, the `errors` field default, context exhaustion with `ERROR_MAX_TURNS` and `UNKNOWN` subtypes, `error=None` edge case, `canonical_token_usage=None` fallthrough, empty output, unused input fields, and a full round-trip assertion proving every output field is set correctly when all inputs are populated.

## Changed Files

- **●** `tests/execution/test_adapt_agent_result.py`

Closes #2690

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/px4_p4_a4_wp1_adapt_agent_result_tests_plan_2026-05-23_002600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 59 | 13.5k | 621.2k | 80.4k | 84 | 106.8k | 9m 40s |
| verify | claude-opus-4-6 | 1 | 37 | 6.3k | 472.6k | 65.5k | 47 | 50.3k | 3m 50s |
| implement* | MiniMax-M2.7 | 1 | 56.0k | 3.2k | 621.6k | 0 | 29 | 0 | 49s |
| prepare_pr* | MiniMax-M2.7 | 1 | 50.1k | 2.9k | 569.1k | 26.9k | 29 | 8.3k | 1m 11s |
| compose_pr* | MiniMax-M2.7 | 1 | 93.1k | 2.2k | 373.3k | 26.9k | 27 | 2.9k | 1m 12s |
| review_pr | claude-opus-4-6 | 2 | 810 | 30.4k | 920.0k | 62.9k | 65 | 93.3k | 10m 20s |
| resolve_review | claude-opus-4-6 | 1 | 42 | 5.1k | 782.2k | 62.3k | 32 | 47.1k | 2m 54s |
| **Total** | | | 200.2k | 63.5k | 4.4M | 80.4k | | 308.8k | 29m 58s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 113 | 5500.9 | 0.0 | 27.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 195541.5 | 11780.5 | 1273.8 |
| **Total** | **117** | 37264.4 | 2638.9 | 543.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 59 | 13.5k | 621.2k | 106.8k | 9m 40s |
| claude-opus-4-6 | 3 | 889 | 41.8k | 2.2M | 190.7k | 17m 5s |
| MiniMax-M2.7 | 3 | 199.2k | 8.3k | 1.6M | 11.2k | 3m 12s |