### PR TITLE
Add 3 stream_parser injection tests for _execute_claude_headless

### DIFF
--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -709,3 +709,131 @@ async def test_dispatch_food_truck_marker_dir_none_when_no_channel_b(
     )
 
     assert execute_kwargs["marker_dir"] is None
+
+
+# ── stream_parser injection tests ────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_execute_claude_headless_passes_stream_parser_to_runner(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.execution.commands import ClaudeHeadlessCmd
+    from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
+    from tests.execution.conftest import _sr
+
+    spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
+    runner_kwargs: dict = {}
+
+    async def fake_runner(cmd, **kwargs):
+        runner_kwargs.update(kwargs)
+        return _sr()
+
+    minimal_ctx.runner = fake_runner
+
+    sentinel = object()
+    backend = _mock_backend()
+    backend.stream_parser.return_value = sentinel
+    minimal_ctx.backend = backend
+
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._build_skill_result",
+        lambda *a, **kw: _STUB_RESULT,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._compute_post_session_metrics",
+        lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._capture_git_head_sha",
+        lambda *a: "",
+    )
+
+    await _execute_claude_headless(
+        spec, str(tmp_path), minimal_ctx, timeout=60, stale_threshold=30
+    )
+
+    assert runner_kwargs["stream_parser"] is sentinel
+    backend.stream_parser.assert_called()
+
+
+@pytest.mark.anyio
+async def test_execute_claude_headless_stream_parser_none_when_no_backend(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.execution.commands import ClaudeHeadlessCmd
+    from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
+    from tests.execution.conftest import _sr
+
+    spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
+    runner_kwargs: dict = {}
+
+    async def fake_runner(cmd, **kwargs):
+        runner_kwargs.update(kwargs)
+        return _sr()
+
+    minimal_ctx.runner = fake_runner
+
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._build_skill_result",
+        lambda *a, **kw: _STUB_RESULT,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._compute_post_session_metrics",
+        lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._capture_git_head_sha",
+        lambda *a: "",
+    )
+
+    await _execute_claude_headless(
+        spec, str(tmp_path), minimal_ctx, timeout=60, stale_threshold=30
+    )
+
+    assert runner_kwargs.get("stream_parser") is None
+
+
+@pytest.mark.anyio
+async def test_execute_claude_headless_stream_parser_receives_completion_marker(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.execution.commands import ClaudeHeadlessCmd
+    from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
+    from tests.execution.conftest import _sr
+
+    spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
+    runner_kwargs: dict = {}
+
+    async def fake_runner(cmd, **kwargs):
+        runner_kwargs.update(kwargs)
+        return _sr()
+
+    minimal_ctx.runner = fake_runner
+
+    backend = _mock_backend()
+    minimal_ctx.backend = backend
+
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._build_skill_result",
+        lambda *a, **kw: _STUB_RESULT,
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._compute_post_session_metrics",
+        lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._capture_git_head_sha",
+        lambda *a: "",
+    )
+
+    await _execute_claude_headless(
+        spec,
+        str(tmp_path),
+        minimal_ctx,
+        timeout=60,
+        stale_threshold=30,
+        completion_marker="%%TEST_MARKER%%",
+    )
+
+    backend.stream_parser.assert_called_once_with(completion_marker="%%TEST_MARKER%%")


### PR DESCRIPTION
## Summary

Add three standalone test functions to `tests/execution/test_headless_provider_forwarding.py` proving that `_execute_claude_headless` correctly passes the sentinel `StreamParser` object returned by `ctx.backend.stream_parser()` as the `stream_parser` kwarg to the subprocess runner. The tests cover the three critical paths: backend present (sentinel forwarded), backend absent (`None` passed), and completion_marker propagation to the factory call.

## Requirements

### Goal
Add a test that proves _execute_claude_headless passes the sentinel object returned by backend.stream_parser() as the stream_parser kwarg to the subprocess runner when ctx.backend is set.

### Context
- Phase: Stream & Result Parsing Pipeline Wiring (Milestone: 4-stream-result-parsing-pipeline-wiring)
- Assignment: P4-A5 (Add integration test verifying stream_parser kwarg reaches runner via _execute_claude_headless)
- Depends on: P4-A1-WP1
- Depended on by: None

### Deliverables
- New class `TestStreamParserInjection` with `test_execute_claude_headless_passes_stream_parser_to_runner` in `tests/execution/test_headless_provider_forwarding.py`
- New test function `test_execute_claude_headless_stream_parser_none_when_no_backend` appended to `tests/execution/test_headless_provider_forwarding.py`
- New test function `test_execute_claude_headless_stream_parser_receives_completion_marker` in `tests/execution/test_headless_provider_forwarding.py`

### Acceptance Criteria
- Task test-filtered passes with the new test selected.
- The test fails (red) before _execute_claude_headless is wired to call ctx.backend.stream_parser() and pass the result to the runner.
- The test passes (green) after the P4-A1 production wiring is applied.
- No import of production backend classes (CodexBackend, ClaudeCodeBackend) is required — _mock_backend() from conftest is sufficient.
- The test uses only the established monkeypatch patterns from existing tests in test_headless_provider_forwarding.py.
- The pytestmark at file scope (layer('execution') + small) covers the new test.
- Test is decorated with @pytest.mark.anyio.
- Test does NOT set minimal_ctx.backend — relies on the default None value.
- The assertion is runner_kwargs.get('stream_parser') is None — enforcing that P4-A1 passes the kwarg explicitly.
- Test follows the identical boilerplate structure as test_execute_claude_headless_pty_mode_from_backend.
- No new imports needed beyond what the existing file already imports.
- Task test-check passes after adding the test.
- The test exists and is collected by pytest.
- The test fails (red) before P4-A1 injects stream_parser into the runner call.
- The test passes (green) after both P4-A1 and P2-A1 land.
- Uses _mock_backend(), monkeypatches _build_skill_result/_compute_post_session_metrics/_capture_git_head_sha.
- The test is xdist-safe (no shared state, uses monkeypatch and tmp_path).
- pytestmark includes pytest.mark.layer('execution') and pytest.mark.small.

Closes #2691

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/px4_p4_a5_wp1_stream_parser_injection_tests_plan_2026-05-23_015600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 6.2k | 8.8k | 735.0k | 70.2k | 104 | 61.0k | 5m 47s |
| verify | claude-opus-4-6 | 1 | 63 | 18.7k | 1.8M | 81.8k | 59 | 68.0k | 7m 5s |
| implement* | MiniMax-M2.7 | 1 | 54.7k | 3.9k | 559.4k | 0 | 27 | 0 | 44s |
| prepare_pr* | MiniMax-M2.7 | 1 | 94.0k | 2.7k | 161.6k | 0 | 17 | 29.8k | 1m 39s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.4k | 2.1k | 350.3k | 0 | 24 | 0 | 40s |
| review_pr | claude-opus-4-6 | 3 | 115 | 36.5k | 1.3M | 54.6k | 84 | 117.1k | 10m 45s |
| **Total** | | | 194.5k | 72.7k | 4.9M | 81.8k | | 275.9k | 26m 41s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 128 | 4370.5 | 0.0 | 30.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **128** | 38390.6 | 2155.2 | 567.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 6.2k | 8.8k | 735.0k | 61.0k | 5m 47s |
| claude-opus-4-6 | 2 | 178 | 55.2k | 3.1M | 185.0k | 17m 51s |
| MiniMax-M2.7 | 3 | 188.1k | 8.7k | 1.1M | 29.8k | 3m 2s |