### PR TITLE
feat(core): add mcp_config_capable field to BackendCapabilities

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -32,6 +32,7 @@ class BackendCapabilities:
     supports_thinking_blocks: bool
     supports_claude_format_stdout: bool
     exit_code_is_terminal: bool
+    mcp_config_capable: bool
     completion_record_types: frozenset[str]
     session_record_types: frozenset[str]
 
@@ -44,6 +45,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     supports_thinking_blocks=True,
     supports_claude_format_stdout=True,
     exit_code_is_terminal=False,
+    mcp_config_capable=False,
     completion_record_types=frozenset({"result"}),
     session_record_types=frozenset({"assistant"}),
 )

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -384,6 +384,7 @@ class CodexBackend:
             supports_thinking_blocks=False,
             supports_claude_format_stdout=False,
             exit_code_is_terminal=True,
+            mcp_config_capable=False,
             completion_record_types=frozenset({"turn.completed", "turn.failed", "error"}),
             session_record_types=frozenset(),
         )

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -200,6 +200,7 @@ def test_skill_injection_disabled_omits_flags(monkeypatch: pytest.MonkeyPatch) -
         supports_thinking_blocks=True,
         supports_claude_format_stdout=True,
         exit_code_is_terminal=False,
+        mcp_config_capable=False,
         completion_record_types=frozenset({"result"}),
         session_record_types=frozenset({"assistant"}),
     )
@@ -264,6 +265,7 @@ def test_binary_name_from_backend_used_in_which(monkeypatch: pytest.MonkeyPatch)
                 supports_thinking_blocks=True,
                 supports_claude_format_stdout=True,
                 exit_code_is_terminal=False,
+                mcp_config_capable=False,
                 completion_record_types=frozenset({"result"}),
                 session_record_types=frozenset({"assistant"}),
             )

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -50,7 +50,7 @@ def test_backend_capabilities_slots():
 
 
 def test_backend_capabilities_field_count():
-    """9 fields: 7 bool + 2 frozenset[str]."""
+    """10 fields: 8 bool + 2 frozenset[str]."""
     from autoskillit.core import BackendCapabilities
 
     fields = dataclasses.fields(BackendCapabilities)
@@ -65,6 +65,7 @@ def test_backend_capabilities_field_count():
         "supports_thinking_blocks",
         "supports_claude_format_stdout",
         "exit_code_is_terminal",
+        "mcp_config_capable",
     }
     assert frozenset_fields == {"completion_record_types", "session_record_types"}
 
@@ -81,6 +82,7 @@ def test_backend_capabilities_field_names_locked():
         "supports_thinking_blocks",
         "supports_claude_format_stdout",
         "exit_code_is_terminal",
+        "mcp_config_capable",
         "completion_record_types",
         "session_record_types",
     }
@@ -99,6 +101,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.supports_thinking_blocks is True
     assert CLAUDE_CODE_CAPABILITIES.supports_claude_format_stdout is True
     assert CLAUDE_CODE_CAPABILITIES.exit_code_is_terminal is False
+    assert CLAUDE_CODE_CAPABILITIES.mcp_config_capable is False
     assert CLAUDE_CODE_CAPABILITIES.completion_record_types == frozenset({"result"})
     assert CLAUDE_CODE_CAPABILITIES.session_record_types == frozenset({"assistant"})
 

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -87,6 +87,9 @@ class TestCodexBackend:
     def test_capabilities_exit_code_is_terminal_true(self) -> None:
         assert CodexBackend().capabilities.exit_code_is_terminal is True
 
+    def test_capabilities_mcp_config_capable_false(self) -> None:
+        assert CodexBackend().capabilities.mcp_config_capable is False
+
     def test_capabilities_completion_record_types(self) -> None:
         expected = frozenset({"turn.completed", "turn.failed", "error"})
         assert CodexBackend().capabilities.completion_record_types == expected
@@ -271,6 +274,7 @@ class TestCodexBackendProtocol:
             ("pty_required", False),
             ("session_resume_capable", True),
             ("skill_injection_capable", False),
+            ("mcp_config_capable", False),
         ],
     )
     def test_capability_flag(self, attr: str, expected: bool) -> None:


### PR DESCRIPTION
## Summary

Add a new `mcp_config_capable: bool` field to the `BackendCapabilities` frozen dataclass in `core/types/_type_backend.py`, positioned after `exit_code_is_terminal`. This field declares whether a backend supports global MCP server registration — a prerequisite for the MCP Server Registration & Kitchen Gating milestone. Update the `CLAUDE_CODE_CAPABILITIES` constant and all three external constructor call sites to include `mcp_config_capable=False`, and extend the corresponding test suites to maintain exhaustive field-coverage.

## Requirements

- `BackendCapabilities` dataclass contains `mcp_config_capable: bool` inserted after `exit_code_is_terminal: bool` with no default value
- `CLAUDE_CODE_CAPABILITIES` instantiation updated to include `mcp_config_capable=False`
- `codex.py` BackendCapabilities call updated with `mcp_config_capable=False`
- `test_session_launch.py` BackendCapabilities call at line 195 updated with `mcp_config_capable=False`
- `test_session_launch.py` BackendCapabilities call at line 259 updated with `mcp_config_capable=False`

## Implementation Plan

Plan file: `make-plan/px5_p5_a2_mcp_config_capable_plan_2026-05-23_070100.md`

Closes #2694

## Test Plan

- `tests/core/test_backend_capabilities.py` updated: field-count test expects 10 fields (8 bool + 2 frozenset), field-names lock test updated
- `tests/execution/backends/test_codex_backend.py` updated: per-field capability test and parametrize entry added
- `tests/cli/test_session_launch.py` updated: both BackendCapabilities constructors include `mcp_config_capable=False`
- All three test files pass; pytest collection succeeds with zero TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 69 | 10.9k | 1.3M | 89.7k | 109 | 64.5k | 9m 22s |
| verify | claude-opus-4-6 | 1 | 61 | 7.4k | 497.2k | 69.4k | 25 | 55.8k | 2m 49s |
| implement* | MiniMax-M2.7-highspeed | 1 | 592.6k | 5.4k | 742.2k | 29.8k | 60 | 15.5k | 2m 24s |
| prepare_pr* | MiniMax-M2.7 | 1 | 58.6k | 4.0k | 286.2k | 0 | 21 | 29.8k | 2m 23s |
| compose_pr* | MiniMax-M2.7 | 1 | 53.8k | 1.7k | 262.3k | 0 | 23 | 0 | 59s |
| review_pr | claude-sonnet-4-6 | 3 | 308 | 73.8k | 1.6M | 68.0k | 116 | 151.0k | 14m 51s |
| **Total** | | | 705.4k | 103.2k | 4.7M | 89.7k | | 316.7k | 32m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 14 | 53014.4 | 1107.7 | 388.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **14** | 334002.1 | 22621.2 | 7371.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 377 | 84.7k | 2.9M | 215.5k | 24m 14s |
| claude-opus-4-6 | 1 | 61 | 7.4k | 497.2k | 55.8k | 2m 49s |
| MiniMax-M2.7-highspeed | 1 | 592.6k | 5.4k | 742.2k | 15.5k | 2m 24s |
| MiniMax-M2.7 | 2 | 112.4k | 5.7k | 548.5k | 29.8k | 3m 22s |