### PR TITLE
feat(server): add HEADLESS_AUTO_GATE_ENV_VAR support to SKILL+headless session type

### DIFF
--- a/src/autoskillit/server/CLAUDE.md
+++ b/src/autoskillit/server/CLAUDE.md
@@ -46,7 +46,7 @@ Controls whether the tool appears in `tools/list` (whether the agent can see it)
 - `_apply_session_type_visibility()` selectively reveals tags per session type:
   - **FLEET** sessions: `fleet`-tagged tools revealed; `fleet-dispatch` revealed only in dispatch mode
   - **ORCHESTRATOR + HEADLESS**: `kitchen` (or `kitchen-core` + pack tags) revealed
-  - **SKILL + HEADLESS**: `headless`-tagged tools revealed (`test_check`)
+  - **SKILL + HEADLESS**: `headless`-tagged tools revealed (`test_check`); with `HEADLESS_AUTO_GATE=1`, `kitchen-core` also revealed
   - **Interactive** (no HEADLESS): nothing pre-revealed; `open_kitchen` reveals `kitchen` tag
 - Tags not disabled at startup (`kitchen-core`, `fleet-dispatch`, `fleet`, `headless`) remain
   visible unless a session-type or feature-gate transform explicitly disables them

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -15,7 +15,8 @@ See GATED_TOOLS and UNGATED_TOOLS in core/types/_type_constants.py.
 Startup tag visibility is determined by AUTOSKILLIT_SESSION_TYPE (3-branch dispatch):
   FLEET — fleet-tagged tools pre-revealed
   ORCHESTRATOR + HEADLESS=1 — all kitchen-tagged tools pre-revealed
-  SKILL + HEADLESS=1 — headless-tagged tools (test_check) pre-revealed
+  SKILL + HEADLESS=1 — headless-tagged tools (test_check) pre-revealed;
+  with AUTO_GATE=1, kitchen-core also revealed
   ORCHESTRATOR/SKILL (interactive) — no pre-reveal; open_kitchen unlocks
 
 Transport: stdio (default for FastMCP).

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -14,6 +14,7 @@ from autoskillit.core import (
     FLEET_DISPATCH_MODE,
     FLEET_MODE_ENV_VAR,
     FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
+    HEADLESS_AUTO_GATE_ENV_VAR,
     HEADLESS_ENV_VAR,
     SessionType,
     get_logger,
@@ -66,6 +67,10 @@ def _apply_session_type_visibility() -> None:
         else:
             mcp.enable(tags={"kitchen"})
     elif _session is SessionType.SKILL and _headless:
-        mcp.enable(tags={"headless"})
+        if os.environ.get(HEADLESS_AUTO_GATE_ENV_VAR) == "1":
+            mcp.enable(tags={"kitchen-core"})
+            mcp.enable(tags={"headless"})
+        else:
+            mcp.enable(tags={"headless"})
     # ORCHESTRATOR+interactive and SKILL+interactive: no pre-reveal.
     # Cook unlocks via open_kitchen (orchestrator) or stays minimal (skill session).

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -67,10 +67,8 @@ def _apply_session_type_visibility() -> None:
         else:
             mcp.enable(tags={"kitchen"})
     elif _session is SessionType.SKILL and _headless:
+        mcp.enable(tags={"headless"})
         if os.environ.get(HEADLESS_AUTO_GATE_ENV_VAR) == "1":
             mcp.enable(tags={"kitchen-core"})
-            mcp.enable(tags={"headless"})
-        else:
-            mcp.enable(tags={"headless"})
     # ORCHESTRATOR+interactive and SKILL+interactive: no pre-reveal.
     # Cook unlocks via open_kitchen (orchestrator) or stays minimal (skill session).

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -188,11 +188,10 @@ class TestSessionTypeVisibility:
         )
         kitchen_core_tools = {t.name for t in tools if "kitchen-core" in t.tags}
         assert kitchen_core_tools, "kitchen-core-tagged tools should be visible when AUTO_GATE=1"
-        for name in GATED_TOOLS:
-            if name in tool_names:
-                assert "kitchen-core" in tool_tags[name], (
-                    f"{name} visible without kitchen-core tag"
-                )
+        visible_gated = {name for name in GATED_TOOLS if name in tool_names}
+        assert visible_gated, "At least one GATED_TOOL should be visible via kitchen-core tag"
+        for name in visible_gated:
+            assert "kitchen-core" in tool_tags[name], f"{name} visible without kitchen-core tag"
 
     @pytest.mark.anyio
     async def test_skill_headless_without_auto_gate_only_headless(self, monkeypatch):

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -171,6 +171,62 @@ class TestSessionTypeVisibility:
             assert name not in tool_names, f"{name} (kitchen) should be hidden for skill+headless"
 
     @pytest.mark.anyio
+    async def test_skill_headless_auto_gate_enables_kitchen_core_and_headless(self, monkeypatch):
+        from autoskillit.core import GATED_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS_AUTO_GATE", "1")
+        _apply_session_type_visibility()
+
+        tools = list(await mcp.list_tools())
+        tool_names = {t.name for t in tools}
+        assert "test_check" in tool_names, (
+            "test_check should be visible for skill+headless+auto_gate"
+        )
+        kitchen_core_tools = {t.name for t in tools if "kitchen-core" in t.tags}
+        assert kitchen_core_tools, "kitchen-core-tagged tools should be visible when AUTO_GATE=1"
+        for name in GATED_TOOLS:
+            assert name not in tool_names, (
+                f"{name} (kitchen) should be hidden for skill+headless+auto_gate"
+            )
+
+    @pytest.mark.anyio
+    async def test_skill_headless_without_auto_gate_only_headless(self, monkeypatch):
+        from autoskillit.core import GATED_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS_AUTO_GATE", raising=False)
+        _apply_session_type_visibility()
+
+        tools = list(await mcp.list_tools())
+        tool_names = {t.name for t in tools}
+        assert "test_check" in tool_names, "test_check should be visible for skill+headless"
+        for name in GATED_TOOLS:
+            assert name not in tool_names, f"{name} (kitchen) should be hidden for skill+headless"
+
+    @pytest.mark.anyio
+    async def test_skill_headless_auto_gate_zero_only_headless(self, monkeypatch):
+        from autoskillit.core import GATED_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS_AUTO_GATE", "0")
+        _apply_session_type_visibility()
+
+        tools = list(await mcp.list_tools())
+        tool_names = {t.name for t in tools}
+        assert "test_check" in tool_names, "test_check should be visible for skill+headless+gate=0"
+        for name in GATED_TOOLS:
+            assert name not in tool_names, (
+                f"{name} (kitchen) should be hidden for skill+headless+gate=0"
+            )
+
+    @pytest.mark.anyio
     async def test_food_truck_with_tool_tags_sees_kitchen_core_plus_declared(self, monkeypatch):
         """ORCHESTRATOR+HEADLESS with FOOD_TRUCK_TOOL_TAGS sees kitchen-core + github only."""
         from autoskillit.server import _apply_session_type_visibility, mcp

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -182,15 +182,17 @@ class TestSessionTypeVisibility:
 
         tools = list(await mcp.list_tools())
         tool_names = {t.name for t in tools}
+        tool_tags = {t.name: t.tags for t in tools}
         assert "test_check" in tool_names, (
             "test_check should be visible for skill+headless+auto_gate"
         )
         kitchen_core_tools = {t.name for t in tools if "kitchen-core" in t.tags}
         assert kitchen_core_tools, "kitchen-core-tagged tools should be visible when AUTO_GATE=1"
         for name in GATED_TOOLS:
-            assert name not in tool_names, (
-                f"{name} (kitchen) should be hidden for skill+headless+auto_gate"
-            )
+            if name in tool_names:
+                assert "kitchen-core" in tool_tags[name], (
+                    f"{name} visible without kitchen-core tag"
+                )
 
     @pytest.mark.anyio
     async def test_skill_headless_without_auto_gate_only_headless(self, monkeypatch):


### PR DESCRIPTION
## Summary

Add `HEADLESS_AUTO_GATE_ENV_VAR` to `src/autoskillit/server/_session_type.py` and modify the `SKILL+HEADLESS` branch in `_apply_session_type_visibility()` to check this env var. When `AUTOSKILLIT_HEADLESS_AUTO_GATE= `, the branch enables both `kitchen-core` and `headless` tags; otherwise it enables only `headless` (preserving existing behavior). Update inline documentation in `server/__init__.py` and `server/CLAUDE.md` to reflect the new sub-branch. Add three tests covering the new gate behavior.

**Known dependency (out of scope):** `HEADLESS_AUTO_GATE_ENV_VAR` is in `AUTOSKILLIT_PRIVATE_ENV_VARS` (the scrub list applied by `build_agent_env`). The skill session builders in `execution/backends/claude.py` and `execution/backends/codex.py` do not currently re-inject this var via `extras`. A separate WP must add env forwarding in both backends for this feature to activate in production SKILL sessions.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START(["_apply_session_type_visibility()"])

    RESOLVE["Resolve session type<br/>━━━━━━━━━━<br/>_resolve_session_type()"]
    HEADLESS_CHECK["Read HEADLESS env var<br/>━━━━━━━━━━<br/>os.environ.get(HEADLESS_ENV_VAR)"]

    IS_FLEET{"SessionType.FLEET?"}
    IS_ORCH{"ORCHESTRATOR<br/>+ headless?"}
    IS_SKILL{"SKILL<br/>+ headless?"}

    FLEET_ENABLE["Enable fleet tags<br/>━━━━━━━━━━<br/>mcp.enable(tags=fleet_tags)"]

    ORCH_ENABLE["Enable kitchen/packs<br/>━━━━━━━━━━<br/>mcp.enable(tags=kitchen/packs)"]

    AUTO_GATE{"● AUTO_GATE=1?<br/>━━━━━━━━━━<br/>★ HEADLESS_AUTO_GATE_ENV_VAR"}

    SKILL_KC["★ Enable kitchen-core + headless<br/>━━━━━━━━━━<br/>mcp.enable(tags=kitchen-core)<br/>mcp.enable(tags=headless)"]

    SKILL_H["Enable headless only<br/>━━━━━━━━━━<br/>mcp.enable(tags=headless)"]

    NOOP["No pre-reveal<br/>━━━━━━━━━━<br/>Interactive session"]

    DONE([RETURN])

    START --> RESOLVE --> HEADLESS_CHECK --> IS_FLEET
    IS_FLEET -->|"Yes"| FLEET_ENABLE --> DONE
    IS_FLEET -->|"No"| IS_ORCH
    IS_ORCH -->|"Yes"| ORCH_ENABLE --> DONE
    IS_ORCH -->|"No"| IS_SKILL
    IS_SKILL -->|"Yes"| AUTO_GATE
    AUTO_GATE -->|"Yes"| SKILL_KC --> DONE
    AUTO_GATE -->|"No"| SKILL_H --> DONE
    IS_SKILL -->|"No"| NOOP --> DONE

    class START,DONE terminal;
    class RESOLVE,HEADLESS_CHECK handler;
    class IS_FLEET,IS_ORCH,IS_SKILL stateNode;
    class AUTO_GATE stateNode;
    class FLEET_ENABLE,ORCH_ENABLE,SKILL_H handler;
    class SKILL_KC newComponent;
    class NOOP phase;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Entry and exit points |
| Teal | State | Decision/routing nodes |
| Orange | Handler | Existing processing nodes |
| Green | New Component | New kitchen-core+headless enable path |
| Purple | Phase | No-op / interactive path |

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-075643-175997/.autoskillit/temp/make-plan/px5_p5_a6_wp1_add_headless_auto_gate_env_var_plan_2026-05-23_080300.md`

Closes #2697

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 72 | 12.2k | 869.6k | 75.2k | 98 | 61.0k | 10m 6s |
| verify | claude-sonnet-4-6 | 1 | 36 | 7.5k | 428.4k | 69.1k | 71 | 55.6k | 4m 46s |
| implement* | MiniMax-M2.7-highspeed | 1 | 368.8k | 5.1k | 479.0k | 34.9k | 48 | 41.4k | 1m 58s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.3k | 2.4k | 242.3k | 0 | 16 | 0 | 1m 26s |
| compose_pr* | MiniMax-M2.7 | 1 | 41.2k | 2.9k | 385.9k | 0 | 27 | 0 | 53s |
| review_pr | claude-sonnet-4-6 | 3 | 284 | 57.2k | 1.3M | 60.0k | 104 | 139.5k | 14m 2s |
| resolve_review | claude-opus-4-6 | 2 | 91 | 12.6k | 2.0M | 72.3k | 77 | 99.6k | 14m 50s |
| **Total** | | | 452.8k | 100.0k | 5.8M | 75.2k | | 397.1k | 48m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 68 | 7044.7 | 609.0 | 75.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 154803.4 | 7663.3 | 969.2 |
| **Total** | **81** | 71010.8 | 4902.3 | 1235.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 392 | 77.0k | 2.6M | 256.0k | 28m 55s |
| MiniMax-M2.7-highspeed | 1 | 368.8k | 5.1k | 479.0k | 41.4k | 1m 58s |
| MiniMax-M2.7 | 2 | 83.5k | 5.3k | 628.2k | 0 | 2m 18s |
| claude-opus-4-6 | 1 | 91 | 12.6k | 2.0M | 99.6k | 14m 50s |