### PR TITLE
Add _skill_auto_gate_boot handler for SKILL session auto-gating

### DIFF
--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -325,7 +325,7 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
 
 
 async def _skill_auto_gate_boot(ctx: Any) -> None:
-    """Auto-open gate for headless skill (L1) sessions.
+    """Auto-open gate for headless SKILL sessions.
 
     Runs at lifespan startup when AUTOSKILLIT_HEADLESS=1 and
     AUTOSKILLIT_HEADLESS_AUTO_GATE=1. No-ops for non-headless sessions.

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -324,10 +324,73 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         logger.warning("food_truck_auto_gate_boot_label_sweep_failed", exc_info=True)
 
 
+async def _skill_auto_gate_boot(ctx: Any) -> None:
+    """Auto-open gate for headless skill (L1) sessions.
+
+    Runs at lifespan startup when AUTOSKILLIT_HEADLESS=1 and
+    AUTOSKILLIT_HEADLESS_AUTO_GATE=1. No-ops for non-headless sessions.
+    Omits quota-refresh loop and campaign state recovery — SKILL sessions
+    are short-lived.
+    """
+    from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+
+    if os.environ.get(HEADLESS_ENV_VAR) != "1":
+        return
+    if os.environ.get(HEADLESS_AUTO_GATE_ENV_VAR) != "1":
+        return
+
+    ctx.kitchen_id = resolve_kitchen_id()
+    ctx.active_recipe_packs = frozenset()
+    ctx.active_recipe_features = frozenset()
+
+    if ctx.gate is None:
+        logger.warning("skill_auto_gate_boot_no_gate")
+        return
+
+    ctx.gate.enable()
+    logger.info(
+        "skill_auto_gate_boot",
+        gate_state="open",
+        kitchen_id=ctx.kitchen_id,
+    )
+
+    try:
+        from autoskillit.core import _collect_disabled_feature_tags
+        from autoskillit.server import mcp as _mcp
+
+        _features = ctx.config.features if ctx.config is not None else {}
+        _exp_enabled = ctx.config.experimental_enabled if ctx.config is not None else False
+        for _tag in _collect_disabled_feature_tags(_features, experimental_enabled=_exp_enabled):
+            _mcp.disable(tags={_tag})
+    except Exception:
+        logger.warning("skill_auto_gate_boot_feature_suppression_failed", exc_info=True)
+
+    try:
+        from autoskillit.server.tools.tools_kitchen import _write_hook_config
+
+        _write_hook_config()
+    except Exception:
+        logger.warning("skill_auto_gate_boot_hook_config_failed", exc_info=True)
+
+    try:
+        from autoskillit.server._misc import _prime_quota_cache
+
+        await _prime_quota_cache()
+    except Exception:
+        logger.warning("skill_auto_gate_boot_quota_cache_failed", exc_info=True)
+
+    try:
+        from autoskillit.core import register_active_kitchen
+
+        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+    except Exception:
+        logger.warning("skill_auto_gate_boot_registry_failed", exc_info=True)
+
+
 _LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | None] = {
     SessionType.FLEET: _fleet_auto_gate_boot,
     SessionType.ORCHESTRATOR: _food_truck_auto_gate_boot,
-    SessionType.SKILL: None,
+    SessionType.SKILL: _skill_auto_gate_boot,
 }
 
 

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -348,6 +348,8 @@ class TestFleetAutoGateBoot:
         expected_id = f"test-campaign-{boot_fn_name}"
         monkeypatch.setenv(CAMPAIGN_ID_ENV_VAR, expected_id)
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        # FOOD_TRUCK_TOOL_TAGS: only read by _food_truck_auto_gate_boot;
+        # harmless for fleet/skill paths.
         monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core")
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS_AUTO_GATE", "1")
         tool_ctx.gate = DefaultGateState(enabled=False)
@@ -1027,7 +1029,7 @@ class TestSkillAutoGateBoot:
         assert len(quota_loop_calls) == 0, (
             "quota_refresh_loop must not be created for SKILL sessions"
         )
-        assert tool_ctx.quota_refresh_task is None
+        mock_create_bg_task.assert_not_called()
 
     @pytest.mark.anyio
     async def test_skill_auto_gate_boot_uses_project_dir_for_registration(

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -335,7 +335,7 @@ class TestFleetAutoGateBoot:
     @pytest.mark.anyio
     @pytest.mark.parametrize(
         "boot_fn_name",
-        ["_fleet_auto_gate_boot", "_food_truck_auto_gate_boot"],
+        ["_fleet_auto_gate_boot", "_food_truck_auto_gate_boot", "_skill_auto_gate_boot"],
     )
     async def test_boot_paths_inherit_campaign_id(self, boot_fn_name, tool_ctx, monkeypatch):
         """All boot paths must resolve kitchen_id via resolve_kitchen_id()."""
@@ -349,6 +349,7 @@ class TestFleetAutoGateBoot:
         monkeypatch.setenv(CAMPAIGN_ID_ENV_VAR, expected_id)
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
         monkeypatch.setenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "kitchen-core")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS_AUTO_GATE", "1")
         tool_ctx.gate = DefaultGateState(enabled=False)
         tool_ctx.quota_refresh_task = None
 
@@ -820,6 +821,294 @@ class TestFoodTruckAutoGateBoot:
             "label sweep background task not scheduled; "
             f"create_background_task labels: {sweep_call_labels}"
         )
+
+
+@pytest.mark.feature("skill")
+class TestSkillAutoGateBoot:
+    """Skill lifespan auto-gate: _skill_auto_gate_boot opens gate."""
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_opens_gate(self, tool_ctx, monkeypatch):
+        """SKILL+HEADLESS+AUTO_GATE: gate is open after _skill_auto_gate_boot() runs."""
+        from unittest.mock import AsyncMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.core.register_active_kitchen"):
+                    await _skill_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is True
+        assert tool_ctx.kitchen_id is not None
+        assert tool_ctx.active_recipe_packs == frozenset()
+        assert tool_ctx.active_recipe_features == frozenset()
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_noop_when_headless_not_1(self, tool_ctx, monkeypatch):
+        """SKILL without HEADLESS=1: gate remains closed."""
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.delenv(HEADLESS_ENV_VAR, raising=False)
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        await _skill_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is False
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_noop_when_auto_gate_not_1(self, tool_ctx, monkeypatch):
+        """HEADLESS=1 without HEADLESS_AUTO_GATE=1: gate remains closed."""
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.delenv(HEADLESS_AUTO_GATE_ENV_VAR, raising=False)
+
+        await _skill_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is False
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_warns_and_returns_when_no_gate(
+        self, tool_ctx, monkeypatch
+    ):
+        """gate is None: warning logged and early return (gate stays closed)."""
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = None
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with structlog.testing.capture_logs() as logs:
+            await _skill_auto_gate_boot(tool_ctx)
+
+        assert any(entry.get("event") == "skill_auto_gate_boot_no_gate" for entry in logs)
+        assert tool_ctx.kitchen_id is not None
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_fails_open_on_feature_suppression_error(
+        self, tool_ctx, monkeypatch
+    ):
+        """Feature suppression failure: gate stays open."""
+        from unittest.mock import AsyncMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch(
+            "autoskillit.core._collect_disabled_feature_tags",
+            side_effect=RuntimeError("feature error"),
+        ):
+            with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        await _skill_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is True
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_fails_open_on_hook_config_error(
+        self, tool_ctx, monkeypatch
+    ):
+        """_write_hook_config failure: gate stays open."""
+        from unittest.mock import AsyncMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch(
+            "autoskillit.server.tools.tools_kitchen._write_hook_config",
+            side_effect=OSError("disk full"),
+        ):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.core.register_active_kitchen"):
+                    await _skill_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is True
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_fails_open_on_quota_cache_error(
+        self, tool_ctx, monkeypatch
+    ):
+        """_prime_quota_cache failure: gate stays open."""
+        from unittest.mock import AsyncMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch(
+                "autoskillit.server._misc._prime_quota_cache",
+                new=AsyncMock(side_effect=RuntimeError("quota cache error")),
+            ):
+                with patch("autoskillit.core.register_active_kitchen"):
+                    await _skill_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is True
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_fails_open_on_registry_error(self, tool_ctx, monkeypatch):
+        """register_active_kitchen failure: gate stays open."""
+        from unittest.mock import AsyncMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.core.register_active_kitchen",
+                    side_effect=OSError("registry write error"),
+                ):
+                    await _skill_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is True
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_no_quota_refresh_loop(self, tool_ctx, monkeypatch):
+        """_skill_auto_gate_boot does NOT create a quota_refresh_loop background task."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task",
+                    return_value=MagicMock(),
+                ) as mock_create_bg_task:
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        await _skill_auto_gate_boot(tool_ctx)
+
+        quota_loop_calls = [
+            call
+            for call in mock_create_bg_task.call_args_list
+            if call.kwargs.get("label") == "quota_refresh_loop"
+        ]
+        assert len(quota_loop_calls) == 0, (
+            "quota_refresh_loop must not be created for SKILL sessions"
+        )
+        assert tool_ctx.quota_refresh_task is None
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_uses_project_dir_for_registration(
+        self, build_ctx, tmp_path, monkeypatch
+    ):
+        """register_active_kitchen must be called with ctx.project_dir, not Path.cwd()."""
+        import os
+        from unittest.mock import AsyncMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        monkeypatch.chdir(tmp_path)
+        different_dir = tmp_path / "project_root"
+        different_dir.mkdir()
+
+        ctx = build_ctx(project_dir=different_dir)
+        ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.core.register_active_kitchen") as mock_register_kitchen:
+                    await _skill_auto_gate_boot(ctx)
+
+        mock_register_kitchen.assert_called_once_with(
+            ctx.kitchen_id, os.getpid(), str(different_dir)
+        )
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_emits_structured_log(self, tool_ctx, monkeypatch):
+        """_skill_auto_gate_boot emits info log with event name, gate_state, and kitchen_id."""
+        from unittest.mock import AsyncMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.core.register_active_kitchen"):
+                    with structlog.testing.capture_logs() as logs:
+                        await _skill_auto_gate_boot(tool_ctx)
+
+        assert any(
+            entry.get("event") == "skill_auto_gate_boot"
+            and entry.get("gate_state") == "open"
+            and entry.get("kitchen_id") is not None
+            for entry in logs
+        )
+
+
+@pytest.mark.feature("skill")
+class TestSkillAutoGateBootRegistry:
+    """SKILL session type registry wiring."""
+
+    def test_lifespan_boot_registry_maps_skill_to_handler(self):
+        """SessionType.SKILL maps to _skill_auto_gate_boot in _LIFESPAN_BOOT_REGISTRY."""
+        from autoskillit.core import SessionType
+        from autoskillit.server._lifespan import (
+            _LIFESPAN_BOOT_REGISTRY,
+            _skill_auto_gate_boot,
+        )
+
+        assert _LIFESPAN_BOOT_REGISTRY[SessionType.SKILL] is _skill_auto_gate_boot
+
+    def test_lifespan_boot_registry_covers_all_session_types(self):
+        """_LIFESPAN_BOOT_REGISTRY has no None values (all session types wired)."""
+        from autoskillit.core import SessionType
+        from autoskillit.server._lifespan import _LIFESPAN_BOOT_REGISTRY
+
+        for session_type in SessionType:
+            assert _LIFESPAN_BOOT_REGISTRY.get(session_type) is not None, (
+                f"{session_type} has no boot handler in _LIFESPAN_BOOT_REGISTRY"
+            )
 
 
 @pytest.mark.feature("fleet")


### PR DESCRIPTION
## Summary

Add `_skill_auto_gate_boot` async handler to `src/autoskillit/server/_lifespan.py` that auto-opens the kitchen gate for headless SKILL sessions (L1 workers). The handler follows the established pattern from `_food_truck_auto_gate_boot` but is simpler: dual env-var guards (`AUTOSKILLIT_HEADLESS` + `AUTOSKILLIT_HEADLESS_AUTO_GATE`), kitchen_id/packs/features assignment, gate-None warning+return, `gate.enable()`, info log, and four try/except-wrapped post-gate blocks (feature suppression, hook config, quota prime, kitchen registry). No quota refresh loop or campaign state recovery — SKILL sessions are short-lived. Register the handler in `_LIFESPAN_BOOT_REGISTRY` replacing `None`. Extend the existing `test_boot_paths_inherit_campaign_id` parametrize to cover the new boot path.

## Requirements

### Goal

Add the full _skill_auto_gate_boot handler with all post-gate optional steps and register it in _LIFESPAN_BOOT_REGISTRY for SKILL sessions.

### Context

- Phase: MCP Server Registration & Kitchen Gating (Milestone: 5-mcp-server-registration-kitchen-gating)
- Assignment: P5-A4 (Implement _skill_auto_gate_boot in _lifespan.py)
- Depends on: P5-A1-WP1
- Depended on by: P5-A11-WP1

### Deliverables

- `_skill_auto_gate_boot async function in _lifespan.py with dual env-var guards, kitchen_id assignment, gate-None warning+return, gate.enable(), and info log`
- `Four try/except-wrapped post-gate blocks added to _skill_auto_gate_boot with 'skill_auto_gate_boot_*' warning log keys`
- `Line 311 of _lifespan.py reads 'SessionType.SKILL: _skill_auto_gate_boot,' instead of 'SessionType.SKILL: None,'`

### Acceptance Criteria

- When both env vars are '1', _skill_auto_gate_boot runs and ctx.gate.enabled is True after boot
- When AUTOSKILLIT_HEADLESS is absent or != '1', function returns immediately
- When AUTOSKILLIT_HEADLESS_AUTO_GATE is absent or != '1', function returns immediately
- When ctx.gate is None, a warning is logged and function returns without error
- ctx.kitchen_id, ctx.active_recipe_packs, ctx.active_recipe_features are assigned before the gate-None guard
- All four post-gate blocks are present: feature suppression, hook config, quota prime, kitchen registry
- _quota_refresh_loop background task is NOT included
- All local imports are inside their respective try blocks
- All exception log keys are prefixed 'skill_auto_gate_boot_'
- Each try/except block is individually isolated so one failure does not prevent subsequent steps
- No new module-level imports are added to _lifespan.py
- _LIFESPAN_BOOT_REGISTRY contains SessionType.SKILL mapped to _skill_auto_gate_boot (not None)
- test_lifespan_boot_registry_covers_all_session_types passes without modification
- No new imports are added to _lifespan.py for this change

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([_autoskillit_lifespan])

    subgraph Dispatch ["● _LIFESPAN_BOOT_REGISTRY Dispatch"]
        direction TB
        RESOLVE["_resolve_session_type()<br/>━━━━━━━━━━<br/>Returns SessionType enum"]
        LOOKUP{"Registry lookup<br/>━━━━━━━━━━<br/>boot_fn = REGISTRY.get(type)"}
    end

    subgraph SkillBoot ["★ _skill_auto_gate_boot"]
        direction TB
        G1{"HEADLESS=1?"}
        G2{"AUTO_GATE=1?"}
        ASSIGN["ctx.kitchen_id = resolve_kitchen_id()<br/>ctx.active_recipe_packs = frozenset()<br/>ctx.active_recipe_features = frozenset()"]
        G3{"ctx.gate is None?"}
        ENABLE["ctx.gate.enable()<br/>━━━━━━━━━━<br/>logger.info skill_auto_gate_boot"]
        B1["try: feature tag suppression<br/>━━━━━━━━━━<br/>_collect_disabled_feature_tags + mcp.disable"]
        B2["try: _write_hook_config()"]
        B3["try: await _prime_quota_cache()"]
        B4["try: register_active_kitchen()"]
    end

    SKIP([return — no-op])
    WARN([warn + return — no gate])
    DONE([boot complete])

    START --> RESOLVE
    RESOLVE --> LOOKUP
    LOOKUP -->|"SKILL"| G1
    LOOKUP -->|"ORCHESTRATOR"| FT([_food_truck_auto_gate_boot])
    LOOKUP -->|"FLEET"| FL([_fleet_auto_gate_boot])

    G1 -->|"!= 1"| SKIP
    G1 -->|"== 1"| G2
    G2 -->|"!= 1"| SKIP
    G2 -->|"== 1"| ASSIGN
    ASSIGN --> G3
    G3 -->|"Yes"| WARN
    G3 -->|"No"| ENABLE
    ENABLE --> B1
    B1 --> B2
    B2 --> B3
    B3 --> B4
    B4 --> DONE

    class START terminal;
    class RESOLVE,LOOKUP stateNode;
    class G1,G2,G3 detector;
    class ASSIGN,ENABLE newComponent;
    class B1,B2,B3,B4 newComponent;
    class SKIP,WARN,DONE terminal;
    class FT,FL handler;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Entry/exit points |
| Teal | State | Dispatch and routing |
| Green | New Component | New `_skill_auto_gate_boot` nodes |
| Red | Detector | Guard/validation decision points |
| Orange | Handler | Existing boot handlers |

**Lens Used:** Process Flow — the change is a new workflow with sequential guards and post-gate steps wired into the existing boot dispatch.

Closes #2696

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-075642-838534/.autoskillit/temp/make-plan/px5_p5_a4_wp1_skill_auto_gate_boot_plan_2026-05-23_080600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 81 | 15.8k | 1.4M | 82.6k | 140 | 73.5k | 13m 29s |
| verify | claude-opus-4-6 | 1 | 59 | 16.3k | 1.5M | 86.7k | 70 | 72.9k | 7m 2s |
| implement* | MiniMax-M2.7-highspeed | 1 | 879.2k | 13.1k | 861.4k | 29.8k | 70 | 50.4k | 4m 7s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.7k | 2.9k | 201.2k | 0 | 16 | 0 | 1m 34s |
| compose_pr* | MiniMax-M2.7 | 1 | 43.7k | 3.5k | 519.3k | 0 | 32 | 0 | 1m 0s |
| review_pr | claude-sonnet-4-6 | 1 | 100 | 34.6k | 563.7k | 78.9k | 38 | 66.7k | 7m 54s |
| resolve_review | claude-opus-4-6 | 1 | 35 | 7.0k | 993.1k | 69.6k | 36 | 56.6k | 11m 13s |
| **Total** | | | 966.8k | 93.2k | 6.1M | 86.7k | | 320.0k | 46m 22s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 356 | 2419.7 | 141.4 | 36.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 248285.0 | 14159.0 | 1756.0 |
| **Total** | **360** | 16831.1 | 888.9 | 258.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 181 | 50.4k | 1.9M | 140.2k | 21m 24s |
| claude-opus-4-6 | 2 | 94 | 23.3k | 2.5M | 129.5k | 18m 16s |
| MiniMax-M2.7-highspeed | 1 | 879.2k | 13.1k | 861.4k | 50.4k | 4m 7s |
| MiniMax-M2.7 | 2 | 87.4k | 6.3k | 720.5k | 0 | 2m 34s |