### PR TITLE
Set mcp_config_capable=True in CodexBackend capabilities

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -384,7 +384,7 @@ class CodexBackend:
             supports_thinking_blocks=False,
             supports_claude_format_stdout=False,
             exit_code_is_terminal=True,
-            mcp_config_capable=False,
+            mcp_config_capable=True,
             completion_record_types=frozenset({"turn.completed", "turn.failed", "error"}),
             session_record_types=frozenset(),
         )

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -87,8 +87,8 @@ class TestCodexBackend:
     def test_capabilities_exit_code_is_terminal_true(self) -> None:
         assert CodexBackend().capabilities.exit_code_is_terminal is True
 
-    def test_capabilities_mcp_config_capable_false(self) -> None:
-        assert CodexBackend().capabilities.mcp_config_capable is False
+    def test_capabilities_mcp_config_capable_true(self) -> None:
+        assert CodexBackend().capabilities.mcp_config_capable is True
 
     def test_capabilities_completion_record_types(self) -> None:
         expected = frozenset({"turn.completed", "turn.failed", "error"})
@@ -274,7 +274,7 @@ class TestCodexBackendProtocol:
             ("pty_required", False),
             ("session_resume_capable", True),
             ("skill_injection_capable", False),
-            ("mcp_config_capable", False),
+            ("mcp_config_capable", True),
         ],
     )
     def test_capability_flag(self, attr: str, expected: bool) -> None:


### PR DESCRIPTION
## Summary

Set `mcp_config_capable=True` in `CodexBackend.capabilities` to declare that Codex supports global MCP server registration. This is a single-field override in the `BackendCapabilities` literal inside `codex.py`, plus two test assertion updates to match.

## Requirements

### Goal

Override the default mcp_config_capable=False by setting it True in CodexBackend's capabilities property, declaring that Codex supports global MCP server registration.

### Context

- Phase: MCP Server Registration & Kitchen Gating (Milestone: 5-mcp-server-registration-kitchen-gating)
- Assignment: P5-A3 (Set mcp_config_capable=True in CodexBackend.capabilities property)
- Depends on: P5-A2-WP1
- Depended on by: P5-A10-WP1, P5-A7-WP1

### Deliverables

- `codex.py: BackendCapabilities(...) literal inside CodexBackend.capabilities set to mcp_config_capable=True`

### Technical Steps

1. Open src/autoskillit/execution/backends/codex.py
2. Locate the CodexBackend.capabilities property at lines 359-371
3. Inside the BackendCapabilities(...) constructor call, change mcp_config_capable=False to mcp_config_capable=True
4. Ensure no other fields are changed

### Acceptance Criteria

- CodexBackend().capabilities.mcp_config_capable is True
- All other capability flags on CodexBackend remain unchanged
- ClaudeCodeBackend().capabilities.mcp_config_capable remains False
- Existing unit tests for CodexBackend.capabilities continue to pass
- No other files are modified by this work package

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

(None)

Closes #2695

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-075641-824606/.autoskillit/temp/make-plan/px5_p5_a3_wp1_override_mcp_config_capable_plan_2026-05-23_080100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 58 | 4.0k | 489.9k | 49.0k | 35 | 37.1k | 2m 37s |
| verify | claude-opus-4-6 | 1 | 45 | 3.9k | 315.7k | 46.1k | 33 | 32.6k | 2m 19s |
| implement* | MiniMax-M2.7-highspeed | 1 | 311.9k | 3.6k | 503.7k | 29.8k | 43 | 15.5k | 1m 45s |
| prepare_pr* | MiniMax-M2.7 | 1 | 39.6k | 2.1k | 194.0k | 0 | 15 | 0 | 1m 28s |
| compose_pr* | MiniMax-M2.7 | 1 | 40.3k | 1.7k | 191.4k | 29.8k | 16 | 42.5k | 57s |
| review_pr | claude-sonnet-4-6 | 3 | 316 | 23.3k | 1.4M | 44.8k | 105 | 107.6k | 7m 4s |
| **Total** | | | 392.1k | 38.6k | 3.1M | 49.0k | | 235.4k | 16m 12s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 8 | 62963.1 | 1940.2 | 449.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **8** | 384210.5 | 29424.2 | 4820.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 103 | 7.8k | 805.7k | 69.7k | 4m 56s |
| MiniMax-M2.7-highspeed | 1 | 311.9k | 3.6k | 503.7k | 15.5k | 1m 45s |
| MiniMax-M2.7 | 2 | 79.8k | 3.8k | 385.4k | 42.5k | 2m 25s |
| claude-sonnet-4-6 | 1 | 316 | 23.3k | 1.4M | 107.6k | 7m 4s |