### PR TITLE
Add Adversarial Plan-Review Agents to Rectify Skill

### DIFF
--- a/src/autoskillit/agents/CLAUDE.md
+++ b/src/autoskillit/agents/CLAUDE.md
@@ -32,7 +32,7 @@ Agent(subagent_type="autoskillit:{agent-name}", prompt="...")
 Claude Code automatically applies tool restrictions, model, maxTurns, and the
 markdown body as the system prompt from the agent definition frontmatter.
 
-**Used by:** make-plan Steps 6-9
+**Used by:** make-plan Steps 6-9, rectify Steps 5-7
 
 ### MCP Resource path (available for programmatic access)
 
@@ -45,7 +45,7 @@ agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{nam
 
 | Pack | Tag | Agents | Used By |
 |------|-----|--------|---------|
-| `plan-review` | `plan-review` | 3 adversarial reviewers | make-plan Steps 6-9 |
+| `plan-review` | `plan-review` | 3 adversarial reviewers | make-plan Steps 6-9, rectify Steps 5-7 |
 
 ## Adding Agents
 

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -333,7 +333,7 @@ class AgentPackDef(NamedTuple):
 
 
 AGENT_PACK_REGISTRY: dict[str, AgentPackDef] = {
-    "plan-review": AgentPackDef(False, "Adversarial plan review agents for make-plan"),
+    "plan-review": AgentPackDef(False, "Adversarial plan review agents for make-plan and rectify"),
 }
 
 if any(k != k.lower() for k in AGENT_PACK_REGISTRY):

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -162,6 +162,40 @@ If the Skill tool cannot be used (disable-model-invocation) or refuses this invo
 
 Include the diagram in the plan document under a "## Proposed Architecture" section.
 
+### Step 5: Foundation Audit
+
+Spawn 1 Foundation Auditor via `Agent(subagent_type="autoskillit:plan-foundation-auditor")`. Pass the full draft immunity plan text and the codebase root. Prepend the contrastive frame to the prompt:
+
+> "A junior engineer reviewed this immunity plan and found no structural flaws. What did they miss?"
+
+The Foundation Auditor performs step-by-step control-flow analysis: enumerates functions, draws control flow with scope levels, builds reachability tables, audits guard coverage, and applies exploit-first verification. It must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
+
+After reading the agent's findings, revise the draft plan by incorporating all valid findings (real gaps, not hypotheticals) before proceeding to Step 6.
+
+### Step 6: Interface Mapping
+
+Spawn 1 Interface Mapper via `Agent(subagent_type="autoskillit:plan-interface-mapper")`. Pass the **revised** draft plan text (from Step 5) and the codebase root. Prepend the contrastive frame to the prompt:
+
+> "A junior engineer reviewed this plan's variable usage and found it correct. What did they miss?"
+
+The Interface Mapper traces variable SET/READ points with full hop-by-hop provenance, builds a Similar-Variable Confusion Matrix, and audits caller/callee contracts. It must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
+
+**RULES FOR APPLYING INTERFACE MAPPING FINDINGS:** When the interface mapper identifies the correct variable for a step, apply the correction to ALL fields that consume that variable — cwd, skill_command arguments, branch references, SHA captures, output paths. Do not split the correct variable across some fields while leaving other fields on the wrong variable.
+
+After reading the agent's findings, revise the draft plan by incorporating all valid findings before proceeding to Step 7.
+
+### Step 7: Registry Trace
+
+Spawn 1 Registry Tracer via `Agent(subagent_type="autoskillit:plan-registry-tracer")`. Pass the **revised** draft plan text (from Step 6) and the codebase root. Prepend the contrastive frame to the prompt:
+
+> "A junior engineer reviewed this plan's registry coverage and found it complete. What did they miss?"
+
+The Registry Tracer uses three-layer tracing (LSP primary, tree-sitter structural, grep fallback) to find every file referencing symbols the plan touches. It checks participation in registry-sync patterns (RETIRED NAME SETS, RE-EXPORT CHAINS, TOOL REGISTRIES, RULE REGISTRATION, DUAL-COPY CONSTANTS, IMPORT LAYER CONSTRAINTS, TYPED ALIASES, DERIVED ARTIFACTS), then performs a two-layer completeness check (source-code layer vs. test/fixture layer). It must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
+
+**RULES FOR APPLYING REGISTRY TRACE FINDINGS:** Verify BOTH fixture/test completeness AND registry completeness before finalizing. A plan that addresses only one interpretation of a rename (manifest-focused OR workspace-focused) and misses the cross-cutting update is incomplete. Apply the two-family check: if references appear in only one layer (source-code or test/fixture), perform targeted follow-up searches in the other layer before concluding.
+
+After reading the agent's findings, apply all valid findings. The plan is now fully reviewed and ready for file write.
+
 ---
 
 ## Skill Loading Checklist
@@ -174,6 +208,7 @@ Before writing the final plan, verify:
 - [ ] Diagram uses ONLY the classDef styles from the mermaid skill (no invented colors)
 - [ ] Diagram includes a color legend table
 - [ ] Every new component, class, or function is wired into the call chain — nothing is created but left unconnected
+- [ ] Adversarial review pass completed (Steps 5-7) — all 3 agents spawned and findings applied
 
 ## Output
 

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -186,6 +186,32 @@ def test_make_plan_subagent_type_refs_resolve():
         )
 
 
+# T11-rectify: rectify SKILL.md subagent_type references resolve to agent files
+def test_rectify_subagent_type_refs_resolve():
+    """Grep rectify SKILL.md for autoskillit:plan-* subagent_type refs.
+
+    Each must correspond to an agent definition file in agents/.
+    """
+    import re
+
+    from autoskillit.core import pkg_root
+
+    content = (pkg_root() / "skills_extended" / "rectify" / "SKILL.md").read_text()
+    refs = re.findall(r"autoskillit:(plan-[a-z-]+)", content)
+    unique_refs = set(refs)
+    assert len(unique_refs) >= 3, (
+        f"Expected >=3 unique autoskillit:plan-* refs in rectify SKILL.md, "
+        f"found {len(unique_refs)}"
+    )
+
+    agents_dir = pkg_root() / "agents"
+    for agent_name in set(refs):
+        agent_file = agents_dir / f"{agent_name}.md"
+        assert agent_file.exists(), (
+            f"rectify SKILL.md references autoskillit:{agent_name} but {agent_file} does not exist"
+        )
+
+
 # T11b: make-plan SKILL.md no longer has activate_agents frontmatter
 def test_make_plan_no_activate_agents():
     """SKILL.md frontmatter must not contain activate_agents."""

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -205,7 +205,7 @@ def test_rectify_subagent_type_refs_resolve():
     )
 
     agents_dir = pkg_root() / "agents"
-    for agent_name in set(refs):
+    for agent_name in unique_refs:
         agent_file = agents_dir / f"{agent_name}.md"
         assert agent_file.exists(), (
             f"rectify SKILL.md references autoskillit:{agent_name} but {agent_file} does not exist"

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -8,7 +8,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 |------|---------|
 | `__init__.py` | empty |
 | `conftest.py` | Skill test fixtures |
-| `test_adversarial_review_contracts.py` | Contract tests verifying adversarial review pass (Steps 6-9) exists in make-plan SKILL.md |
+| `test_adversarial_review_contracts.py` | Contract tests verifying adversarial review agents exist in make-plan and rectify SKILL.md files |
 | `test_analyze_prs_contracts.py` | Contract tests for analyze-prs SKILL.md batch branch naming convention |
 | `test_arch_lens_context_path.py` | Tests that all arch-lens skills have ## Arguments section and context_path handling |
 | `test_audit_arch_preflight_contracts.py` | Audit-arch skill preflight contract tests |

--- a/tests/skills/test_adversarial_review_contracts.py
+++ b/tests/skills/test_adversarial_review_contracts.py
@@ -1,4 +1,4 @@
-"""Contract tests verifying adversarial review pass (Steps 6-9) exists in make-plan SKILL.md."""
+"""Contract tests verifying adversarial review agents exist in make-plan and rectify."""
 
 import pytest
 
@@ -8,6 +8,12 @@ from autoskillit.core.paths import pkg_root
 @pytest.fixture(scope="module")
 def make_plan_text() -> str:
     p = pkg_root() / "skills_extended" / "make-plan" / "SKILL.md"
+    return p.read_text()
+
+
+@pytest.fixture(scope="module")
+def rectify_text() -> str:
+    p = pkg_root() / "skills_extended" / "rectify" / "SKILL.md"
     return p.read_text()
 
 
@@ -172,3 +178,123 @@ def test_make_plan_interface_mapping_and_registry_trace_responsibilities(
         "Step 8 (Registry Trace) must mention registry/symbol tracing"
     )
     assert "junior reviewer" in step8_section, "Step 8 must include contrastive prompt frame"
+
+
+# ---------------------------------------------------------------------------
+# Rectify adversarial review contract tests (T1–T8)
+# ---------------------------------------------------------------------------
+
+
+def test_rectify_foundation_audit_exists(rectify_text: str) -> None:
+    """Rectify SKILL.md must include Foundation Audit step with contrastive prompt."""
+    workflow_idx = rectify_text.find("## Rectify Workflow")
+    assert workflow_idx != -1
+    fa_idx = rectify_text.find("Foundation Audit", workflow_idx)
+    assert fa_idx != -1, "Rectify must include Foundation Audit step"
+    im_idx = rectify_text.find("Interface Mapping", fa_idx)
+    assert im_idx != -1
+    section = rectify_text[fa_idx:im_idx].lower()
+    assert "foundation auditor" in section or "plan-foundation-auditor" in section
+    assert "scope expansion" in section
+    assert "junior engineer" in section
+
+
+def test_rectify_interface_mapping_exists(rectify_text: str) -> None:
+    """Rectify SKILL.md must include Interface Mapping step with contrastive prompt."""
+    workflow_idx = rectify_text.find("## Rectify Workflow")
+    assert workflow_idx != -1
+    im_idx = rectify_text.find("Interface Mapping", workflow_idx)
+    assert im_idx != -1, "Rectify must include Interface Mapping step"
+    rt_idx = rectify_text.find("Registry Trace", im_idx)
+    assert rt_idx != -1
+    section = rectify_text[im_idx:rt_idx].lower()
+    assert "variable" in section or "set/read" in section
+    assert "junior engineer" in section
+
+
+def test_rectify_registry_trace_exists(rectify_text: str) -> None:
+    """Rectify SKILL.md must include Registry Trace step with sync pattern names."""
+    workflow_idx = rectify_text.find("## Rectify Workflow")
+    assert workflow_idx != -1
+    rt_idx = rectify_text.find("Registry Trace", workflow_idx)
+    assert rt_idx != -1, "Rectify must include Registry Trace step"
+    next_heading = rectify_text.find("\n## ", rt_idx)
+    end = next_heading if next_heading != -1 else len(rectify_text)
+    section = rectify_text[rt_idx:end].upper()
+    sync_patterns = [
+        "RETIRED",
+        "RE-EXPORT",
+        "RULE REGISTRATION",
+        "IMPORT LAYER",
+        "TYPED ALIASES",
+        "DERIVED ARTIFACTS",
+    ]
+    found = sum(1 for p in sync_patterns if p in section)
+    gated_tools = "GATED_TOOLS" in section or "TOOL REGISTRIES" in section
+    dual_copy = "DUAL-COPY" in section or "SKILL_FILE_ADVISORY_MAP" in section
+    found += int(gated_tools) + int(dual_copy)
+    assert found >= 7, (
+        f"Registry Trace must contain at least 7 of 8 sync pattern names, found {found}"
+    )
+
+
+def test_rectify_adversarial_steps_ordered(rectify_text: str) -> None:
+    """Foundation Audit, Interface Mapping, Registry Trace must appear in order."""
+    workflow_idx = rectify_text.find("## Rectify Workflow")
+    assert workflow_idx != -1
+    fa_idx = rectify_text.find("Foundation Audit", workflow_idx)
+    im_idx = rectify_text.find("Interface Mapping", workflow_idx)
+    rt_idx = rectify_text.find("Registry Trace", workflow_idx)
+    assert all(i != -1 for i in (fa_idx, im_idx, rt_idx)), (
+        "All three adversarial steps must exist in Rectify Workflow"
+    )
+    assert fa_idx < im_idx < rt_idx, (
+        "Adversarial steps must appear in order: "
+        "Foundation Audit < Interface Mapping < Registry Trace"
+    )
+
+
+def test_rectify_checklist_includes_adversarial_review(rectify_text: str) -> None:
+    """Rectify Skill Loading Checklist must include adversarial review item."""
+    checklist_idx = rectify_text.find("## Skill Loading Checklist")
+    assert checklist_idx != -1
+    next_heading = rectify_text.find("\n## ", checklist_idx + 1)
+    end = next_heading if next_heading != -1 else len(rectify_text)
+    section = rectify_text[checklist_idx:end].lower()
+    assert "adversarial" in section, (
+        "Skill Loading Checklist must include an adversarial review checklist item"
+    )
+
+
+def test_rectify_interface_mapping_rules(rectify_text: str) -> None:
+    """Interface Mapping step must contain RULES FOR APPLYING INTERFACE MAPPING FINDINGS."""
+    im_idx = rectify_text.find("Interface Mapping")
+    assert im_idx != -1
+    rt_idx = rectify_text.find("Registry Trace", im_idx)
+    assert rt_idx != -1
+    section = rectify_text[im_idx:rt_idx]
+    assert "RULES FOR APPLYING INTERFACE MAPPING FINDINGS" in section
+
+
+def test_rectify_registry_trace_rules(rectify_text: str) -> None:
+    """Registry Trace step must contain RULES FOR APPLYING REGISTRY TRACE FINDINGS."""
+    rt_idx = rectify_text.find("Registry Trace")
+    assert rt_idx != -1
+    next_heading = rectify_text.find("\n## ", rt_idx)
+    end = next_heading if next_heading != -1 else len(rectify_text)
+    section = rectify_text[rt_idx:end]
+    assert "RULES FOR APPLYING REGISTRY TRACE FINDINGS" in section
+
+
+def test_rectify_sequential_revision_pattern(rectify_text: str) -> None:
+    """Each adversarial step must instruct revision before the next step."""
+    workflow_idx = rectify_text.find("## Rectify Workflow")
+    assert workflow_idx != -1
+    fa_idx = rectify_text.find("Foundation Audit", workflow_idx)
+    im_idx = rectify_text.find("Interface Mapping", workflow_idx)
+    rt_idx = rectify_text.find("Registry Trace", workflow_idx)
+    assert all(i != -1 for i in (fa_idx, im_idx, rt_idx))
+    fa_section = rectify_text[fa_idx:im_idx].lower()
+    im_section = rectify_text[im_idx:rt_idx].lower()
+    assert "revis" in fa_section, "Foundation Audit step must include revision instruction"
+    assert "revis" in im_section, "Interface Mapping step must include revision instruction"

--- a/tests/skills/test_adversarial_review_contracts.py
+++ b/tests/skills/test_adversarial_review_contracts.py
@@ -268,7 +268,9 @@ def test_rectify_checklist_includes_adversarial_review(rectify_text: str) -> Non
 
 def test_rectify_interface_mapping_rules(rectify_text: str) -> None:
     """Interface Mapping step must contain RULES FOR APPLYING INTERFACE MAPPING FINDINGS."""
-    im_idx = rectify_text.find("Interface Mapping")
+    workflow_idx = rectify_text.find("## Rectify Workflow")
+    assert workflow_idx != -1
+    im_idx = rectify_text.find("Interface Mapping", workflow_idx)
     assert im_idx != -1
     rt_idx = rectify_text.find("Registry Trace", im_idx)
     assert rt_idx != -1
@@ -278,7 +280,9 @@ def test_rectify_interface_mapping_rules(rectify_text: str) -> None:
 
 def test_rectify_registry_trace_rules(rectify_text: str) -> None:
     """Registry Trace step must contain RULES FOR APPLYING REGISTRY TRACE FINDINGS."""
-    rt_idx = rectify_text.find("Registry Trace")
+    workflow_idx = rectify_text.find("## Rectify Workflow")
+    assert workflow_idx != -1
+    rt_idx = rectify_text.find("Registry Trace", workflow_idx)
     assert rt_idx != -1
     next_heading = rectify_text.find("\n## ", rt_idx)
     end = next_heading if next_heading != -1 else len(rectify_text)


### PR DESCRIPTION
## Summary

Add a 3-pass sequential adversarial review sequence to rectify's SKILL.md, inserting Steps 5–7 after the existing Step 4 (Architecture Lens) and before the plan file write. Each agent pass revises the draft incrementally — the next agent sees the revised draft, not the original. Add contract tests verifying the new steps exist, are ordered correctly, contain rectify-specific contrastive prompts ("junior engineer" / "immunity plan"), and include the required RULES FOR APPLYING FINDINGS sections.

**Scope:** 1 SKILL.md edited, 1 registry constant corrected, 2 documentation files corrected, 1 test file extended, 1 test resolution guard extended. No recipe or Python source logic changes.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

| File | Resolution |
|------|------------|
| None | No merge conflicts |


## Changed Files

**Modified:**
- `src/autoskillit/agents/CLAUDE.md`
- `src/autoskillit/core/types/_type_constants.py`
- `src/autoskillit/skills_extended/rectify/SKILL.md`
- `tests/server/test_tools_agents.py`
- `tests/skills/CLAUDE.md`
- `tests/skills/test_adversarial_review_contracts.py`

Closes #2741

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-074005-613457/.autoskillit/temp/make-plan/add_adversarial_plan_review_agents_to_rectify_skill_plan_2026-05-23_075200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 703 | 30.6k | 1.6M | 112.7k | 121 | 92.7k | 16m 35s |
| verify | claude-opus-4-6 | 1 | 40 | 9.4k | 676.4k | 70.7k | 70 | 56.8k | 5m 47s |
| implement* | MiniMax-M2.7-highspeed | 1 | 904.8k | 9.6k | 1.0M | 29.8k | 86 | 39.9k | 3m 56s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 66.9k | 3.0k | 149.0k | 29.8k | 17 | 41.9k | 1m 6s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 69.5k | 1.5k | 178.8k | 29.8k | 16 | 41.7k | 44s |
| review_pr | claude-sonnet-4-6 | 1 | 76 | 18.4k | 356.4k | 69.9k | 32 | 54.7k | 8m 3s |
| resolve_review | claude-sonnet-4-6 | 1 | 157 | 8.5k | 915.9k | 60.4k | 47 | 47.7k | 5m 49s |
| **Total** | | | 1.0M | 80.9k | 4.9M | 112.7k | | 375.3k | 42m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 197 | 5279.5 | 202.4 | 48.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 91594.0 | 4767.0 | 846.8 |
| **Total** | **207** | 23535.2 | 1812.9 | 390.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 936 | 57.4k | 2.8M | 195.1k | 30m 27s |
| claude-opus-4-6 | 1 | 40 | 9.4k | 676.4k | 56.8k | 5m 47s |
| MiniMax-M2.7-highspeed | 3 | 1.0M | 14.1k | 1.4M | 123.4k | 5m 46s |