### PR TITLE
Config-only per-recipe per-step model override

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -449,6 +449,7 @@ class ProvidersConfig:
     profiles: dict[str, dict[str, str | None]] = field(default_factory=dict)
     step_overrides: dict[str, str] = field(default_factory=dict)
     recipe_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
+    model_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
     provider_retry_limit: int = 2
 
     def __post_init__(self) -> None:
@@ -472,6 +473,17 @@ class ProvidersConfig:
                     raise ValueError(
                         f"recipe_overrides[{recipe!r}][{step!r}] must be a string, "
                         f"got {type(provider).__name__!r}"
+                    )
+        for recipe, overrides in self.model_overrides.items():
+            if not isinstance(overrides, dict):
+                raise ValueError(
+                    f"model_overrides[{recipe!r}] must be a dict, got {type(overrides).__name__!r}"
+                )
+            for step, model_val in overrides.items():
+                if not isinstance(model_val, str):
+                    raise ValueError(
+                        f"model_overrides[{recipe!r}][{step!r}] must be a string, "
+                        f"got {type(model_val).__name__!r}"
                     )
 
     @property

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -306,6 +306,7 @@ providers:
       context_window: null
   step_overrides: {}
   recipe_overrides: {}
+  model_overrides: {}
   provider_retry_limit: 2
 
 agent_backend:

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -542,6 +542,7 @@ class AutomationConfig:
                 profiles=val(pvd, "profiles", _pvd["profiles"]),
                 step_overrides=val(pvd, "step_overrides", _pvd["step_overrides"]),
                 recipe_overrides=val(pvd, "recipe_overrides", _pvd["recipe_overrides"]),
+                model_overrides=val(pvd, "model_overrides", _pvd["model_overrides"]),
                 provider_retry_limit=_parse_int_field(
                     val(pvd, "provider_retry_limit", _pvd["provider_retry_limit"]),
                     "providers.provider_retry_limit",

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -345,13 +345,14 @@ async def run_skill(
         if _cfg.model.model_override:
             effective_model = _cfg.model.model_override
         else:
-            _mo_recipe_map = _cfg.providers.model_overrides.get(tool_ctx.recipe_name or "")
-            if _mo_recipe_map:
-                _step_mo = _mo_recipe_map.get(step_name) if step_name else None
-                if _step_mo is None:
-                    _step_mo = _mo_recipe_map.get("*")
-                if _step_mo:
-                    effective_model = _step_mo
+            if tool_ctx.recipe_name:
+                _mo_recipe_map = _cfg.providers.model_overrides.get(tool_ctx.recipe_name)
+                if _mo_recipe_map:
+                    _step_mo = _mo_recipe_map.get(step_name) if step_name else None
+                    if _step_mo is None:
+                        _step_mo = _mo_recipe_map.get("*")
+                    if _step_mo:
+                        effective_model = _step_mo
 
         # Look up artifact validation patterns from skill contract
         expected_output_patterns: list[str] = []

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -342,13 +342,16 @@ async def run_skill(
                     provider_extras = prof_extras
                     profile_name_out = prof_name
 
-        _mo_recipe_map = _cfg.providers.model_overrides.get(tool_ctx.recipe_name or "")
-        if _mo_recipe_map:
-            _step_mo = _mo_recipe_map.get(step_name) if step_name else None
-            if _step_mo is None:
-                _step_mo = _mo_recipe_map.get("*")
-            if _step_mo:
-                effective_model = _step_mo
+        if _cfg.model.model_override:
+            effective_model = _cfg.model.model_override
+        else:
+            _mo_recipe_map = _cfg.providers.model_overrides.get(tool_ctx.recipe_name or "")
+            if _mo_recipe_map:
+                _step_mo = _mo_recipe_map.get(step_name) if step_name else None
+                if _step_mo is None:
+                    _step_mo = _mo_recipe_map.get("*")
+                if _step_mo:
+                    effective_model = _step_mo
 
         # Look up artifact validation patterns from skill contract
         expected_output_patterns: list[str] = []

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -342,6 +342,14 @@ async def run_skill(
                     provider_extras = prof_extras
                     profile_name_out = prof_name
 
+        _mo_recipe_map = _cfg.providers.model_overrides.get(tool_ctx.recipe_name or "")
+        if _mo_recipe_map:
+            _step_mo = _mo_recipe_map.get(step_name) if step_name else None
+            if _step_mo is None:
+                _step_mo = _mo_recipe_map.get("*")
+            if _step_mo:
+                effective_model = _step_mo
+
         # Look up artifact validation patterns from skill contract
         expected_output_patterns: list[str] = []
         if tool_ctx.output_pattern_resolver:

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -55,6 +55,7 @@ class TestProvidersConfig:
         }
         assert cfg.providers.step_overrides == {}
         assert cfg.providers.recipe_overrides == {}
+        assert cfg.providers.model_overrides == {}
         assert cfg.providers.provider_retry_limit == 2
 
     def test_providers_config_defaults(self) -> None:
@@ -65,6 +66,7 @@ class TestProvidersConfig:
         assert cfg.profiles == {}
         assert cfg.step_overrides == {}
         assert cfg.recipe_overrides == {}
+        assert cfg.model_overrides == {}
         assert cfg.provider_retry_limit == 2
 
     def test_providers_config_is_mutable(self) -> None:
@@ -85,6 +87,7 @@ class TestProvidersConfig:
             "profiles",
             "step_overrides",
             "recipe_overrides",
+            "model_overrides",
             "provider_retry_limit",
         }
 
@@ -124,6 +127,33 @@ class TestProvidersConfig:
         cfg = ProvidersConfig(profiles={"sentinel": {"base_url": None, "api_key_env": None}})  # type: ignore[arg-type]
         assert cfg.profiles["sentinel"]["base_url"] is None
         assert cfg.profiles["sentinel"]["api_key_env"] is None
+
+    def test_model_overrides_field_default(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig()
+        assert cfg.model_overrides == {}
+
+    def test_model_overrides_valid(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(
+            model_overrides={"implementation": {"implement": "opus", "plan": "opus"}}
+        )
+        assert cfg.model_overrides["implementation"]["implement"] == "opus"
+        assert cfg.model_overrides["implementation"]["plan"] == "opus"
+
+    def test_model_overrides_non_dict_recipe_raises(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        with pytest.raises(ValueError, match="model_overrides.*must be a dict"):
+            ProvidersConfig(model_overrides={"implementation": "opus"})  # type: ignore[arg-type]
+
+    def test_model_overrides_non_string_model_raises(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        with pytest.raises(ValueError, match="model_overrides.*must be a string"):
+            ProvidersConfig(model_overrides={"implementation": {"implement": 42}})  # type: ignore[arg-type]
 
 
 class TestProvidersConfigYaml:
@@ -226,6 +256,27 @@ class TestProvidersConfigYaml:
             "remediation": {"implement": "anthropic"},
             "implementation": {"implement": "minimax"},
         }
+
+    def test_defaults_yaml_has_model_overrides(self) -> None:
+        from autoskillit.core.io import load_yaml
+        from autoskillit.core.paths import pkg_root
+
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+        assert "model_overrides" in defaults["providers"]
+        assert defaults["providers"]["model_overrides"] == {}
+
+    def test_model_overrides_round_trip(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text(
+            yaml.dump(
+                {"providers": {"model_overrides": {"implementation": {"implement": "opus"}}}}
+            )
+        )
+        cfg = load_config(tmp_path)
+        assert cfg.providers.model_overrides == {"implementation": {"implement": "opus"}}
 
 
 class TestResolvedProfiles:

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -128,12 +128,6 @@ class TestProvidersConfig:
         assert cfg.profiles["sentinel"]["base_url"] is None
         assert cfg.profiles["sentinel"]["api_key_env"] is None
 
-    def test_model_overrides_field_default(self) -> None:
-        from autoskillit.config.settings import ProvidersConfig
-
-        cfg = ProvidersConfig()
-        assert cfg.model_overrides == {}
-
     def test_model_overrides_valid(self) -> None:
         from autoskillit.config.settings import ProvidersConfig
 

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -230,7 +230,6 @@ async def test_run_skill_model_as_profile_no_anthropic_model_falls_through(
 async def test_run_skill_model_overrides_applied(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    from autoskillit.config import AutomationConfig
     from autoskillit.config.settings import ProvidersConfig
     from tests.fakes import InMemoryHeadlessExecutor
 
@@ -239,11 +238,8 @@ async def test_run_skill_model_overrides_applied(
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
-    cfg = AutomationConfig()
-    cfg.providers = ProvidersConfig(model_overrides={"implementation": {"implement": "opus"}})
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution._get_config",
-        lambda: cfg,
+    tool_ctx_kitchen_open.config.providers = ProvidersConfig(
+        model_overrides={"implementation": {"implement": "opus"}}
     )
 
     captured: dict = {}
@@ -264,7 +260,6 @@ async def test_run_skill_model_overrides_applied(
 async def test_run_skill_model_overrides_wildcard_step(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    from autoskillit.config import AutomationConfig
     from autoskillit.config.settings import ProvidersConfig
     from tests.fakes import InMemoryHeadlessExecutor
 
@@ -273,11 +268,8 @@ async def test_run_skill_model_overrides_wildcard_step(
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
-    cfg = AutomationConfig()
-    cfg.providers = ProvidersConfig(model_overrides={"implementation": {"*": "opus"}})
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution._get_config",
-        lambda: cfg,
+    tool_ctx_kitchen_open.config.providers = ProvidersConfig(
+        model_overrides={"implementation": {"*": "opus"}}
     )
 
     captured: dict = {}
@@ -298,7 +290,6 @@ async def test_run_skill_model_overrides_wildcard_step(
 async def test_run_skill_model_overrides_exact_over_wildcard(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    from autoskillit.config import AutomationConfig
     from autoskillit.config.settings import ProvidersConfig
     from tests.fakes import InMemoryHeadlessExecutor
 
@@ -307,13 +298,8 @@ async def test_run_skill_model_overrides_exact_over_wildcard(
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
-    cfg = AutomationConfig()
-    cfg.providers = ProvidersConfig(
+    tool_ctx_kitchen_open.config.providers = ProvidersConfig(
         model_overrides={"implementation": {"implement": "opus", "*": "haiku"}}
-    )
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution._get_config",
-        lambda: cfg,
     )
 
     captured: dict = {}
@@ -334,7 +320,6 @@ async def test_run_skill_model_overrides_exact_over_wildcard(
 async def test_run_skill_model_overrides_without_providers_feature(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    from autoskillit.config import AutomationConfig
     from autoskillit.config.settings import ProvidersConfig
     from tests.fakes import InMemoryHeadlessExecutor
 
@@ -343,11 +328,8 @@ async def test_run_skill_model_overrides_without_providers_feature(
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
-    cfg = AutomationConfig()
-    cfg.providers = ProvidersConfig(model_overrides={"implementation": {"implement": "opus"}})
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution._get_config",
-        lambda: cfg,
+    tool_ctx_kitchen_open.config.providers = ProvidersConfig(
+        model_overrides={"implementation": {"implement": "opus"}}
     )
 
     captured: dict = {}
@@ -368,7 +350,6 @@ async def test_run_skill_model_overrides_without_providers_feature(
 async def test_run_skill_model_overrides_no_match_passthrough(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    from autoskillit.config import AutomationConfig
     from autoskillit.config.settings import ProvidersConfig
     from tests.fakes import InMemoryHeadlessExecutor
 
@@ -377,11 +358,8 @@ async def test_run_skill_model_overrides_no_match_passthrough(
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
-    cfg = AutomationConfig()
-    cfg.providers = ProvidersConfig(model_overrides={"remediation": {"implement": "opus"}})
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution._get_config",
-        lambda: cfg,
+    tool_ctx_kitchen_open.config.providers = ProvidersConfig(
+        model_overrides={"remediation": {"implement": "opus"}}
     )
 
     captured: dict = {}
@@ -402,7 +380,6 @@ async def test_run_skill_model_overrides_no_match_passthrough(
 async def test_run_skill_global_override_beats_model_overrides(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    from autoskillit.config import AutomationConfig
     from autoskillit.config.settings import ProvidersConfig
     from tests.fakes import InMemoryHeadlessExecutor
 
@@ -411,13 +388,10 @@ async def test_run_skill_global_override_beats_model_overrides(
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
-    cfg = AutomationConfig()
-    cfg.providers = ProvidersConfig(model_overrides={"implementation": {"implement": "opus"}})
-    cfg.model.model_override = "haiku"
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution._get_config",
-        lambda: cfg,
+    tool_ctx_kitchen_open.config.providers = ProvidersConfig(
+        model_overrides={"implementation": {"implement": "opus"}}
     )
+    tool_ctx_kitchen_open.config.model.model_override = "haiku"
 
     captured: dict = {}
     original_run = executor.run

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -224,3 +224,210 @@ async def test_run_skill_model_as_profile_no_anthropic_model_falls_through(
 
     assert captured.get("model") == ""
     assert captured.get("provider_extras") is None
+
+
+@pytest.mark.anyio
+async def test_run_skill_model_overrides_applied(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config.settings import ProvidersConfig
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.recipe_name = "implementation"
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    cfg = AutomationConfig()
+    cfg.providers = ProvidersConfig(model_overrides={"implementation": {"implement": "opus"}})
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution._get_config",
+        lambda: cfg,
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), step_name="implement")
+
+    assert captured.get("model") == "opus"
+
+
+@pytest.mark.anyio
+async def test_run_skill_model_overrides_wildcard_step(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config.settings import ProvidersConfig
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.recipe_name = "implementation"
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    cfg = AutomationConfig()
+    cfg.providers = ProvidersConfig(model_overrides={"implementation": {"*": "opus"}})
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution._get_config",
+        lambda: cfg,
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), step_name="plan")
+
+    assert captured.get("model") == "opus"
+
+
+@pytest.mark.anyio
+async def test_run_skill_model_overrides_exact_over_wildcard(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config.settings import ProvidersConfig
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.recipe_name = "implementation"
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    cfg = AutomationConfig()
+    cfg.providers = ProvidersConfig(
+        model_overrides={"implementation": {"implement": "opus", "*": "haiku"}}
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution._get_config",
+        lambda: cfg,
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), step_name="implement")
+
+    assert captured.get("model") == "opus"
+
+
+@pytest.mark.anyio
+async def test_run_skill_model_overrides_without_providers_feature(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config.settings import ProvidersConfig
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.recipe_name = "implementation"
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    cfg = AutomationConfig()
+    cfg.providers = ProvidersConfig(model_overrides={"implementation": {"implement": "opus"}})
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution._get_config",
+        lambda: cfg,
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), step_name="implement")
+
+    assert captured.get("model") == "opus"
+
+
+@pytest.mark.anyio
+async def test_run_skill_model_overrides_no_match_passthrough(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config.settings import ProvidersConfig
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.recipe_name = "implementation"
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    cfg = AutomationConfig()
+    cfg.providers = ProvidersConfig(model_overrides={"remediation": {"implement": "opus"}})
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution._get_config",
+        lambda: cfg,
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), model="sonnet", step_name="implement")
+
+    assert captured.get("model") == "sonnet"
+
+
+@pytest.mark.anyio
+async def test_run_skill_global_override_beats_model_overrides(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config.settings import ProvidersConfig
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.recipe_name = "implementation"
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    cfg = AutomationConfig()
+    cfg.providers = ProvidersConfig(model_overrides={"implementation": {"implement": "opus"}})
+    cfg.model.model_override = "haiku"
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution._get_config",
+        lambda: cfg,
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), step_name="implement")
+
+    assert captured.get("model") == "haiku"


### PR DESCRIPTION
## Summary

Add a `model_overrides` field to `ProvidersConfig` that allows operators to specify per-recipe per-step model selection from `.autoskillit/.secrets.yaml` or `config.yaml`, without editing recipe YAML files. The override is injected in the `run_skill` MCP tool handler after provider resolution but before the executor call, and is subordinate only to the global `config.model.model_override`. This requires changes in 4 production files across 2 modules (config, server).

Closes #2712

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-074004-619001/.autoskillit/temp/make-plan/config_only_per_recipe_per_step_model_override_plan_2026-05-23_074600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 99 | 17.6k | 2.4M | 101.6k | 191 | 88.3k | 13m 9s |
| verify | claude-sonnet-4-6 | 1 | 62 | 12.3k | 973.1k | 80.5k | 106 | 66.6k | 6m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 940.2k | 11.6k | 1.2M | 34.9k | 106 | 85.0k | 4m 43s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 83.3k | 3.6k | 270.4k | 34.9k | 24 | 23.2k | 1m 28s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.2k | 1.4k | 205.7k | 29.8k | 19 | 14.8k | 43s |
| review_pr | claude-sonnet-4-6 | 1 | 84 | 24.0k | 433.2k | 67.6k | 32 | 54.9k | 5m 30s |
| resolve_review | claude-sonnet-4-6 | 1 | 213 | 9.6k | 1.3M | 65.1k | 61 | 52.1k | 5m 59s |
| **Total** | | | 1.1M | 80.2k | 6.8M | 101.6k | | 384.9k | 38m 27s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 280 | 4168.1 | 303.5 | 41.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 21 | 63393.3 | 2482.0 | 456.3 |
| **Total** | **301** | 22563.4 | 1278.6 | 266.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 99 | 17.6k | 2.4M | 88.3k | 13m 9s |
| claude-sonnet-4-6 | 3 | 359 | 45.9k | 2.7M | 173.6k | 18m 24s |
| MiniMax-M2.7-highspeed | 3 | 1.1M | 16.7k | 1.6M | 123.0k | 6m 54s |