### PR TITLE
Surface API retry events in diagnostic logs and stale SkillResult

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -246,6 +246,7 @@ from .types import SessionOutcome as SessionOutcome
 from .types import SessionSkillManager as SessionSkillManager
 from .types import ProviderOutcome as ProviderOutcome
 from .types import InfraOutcome as InfraOutcome
+from .types import ApiRetryOutcome as ApiRetryOutcome
 from .types import RecipeIdentity as RecipeIdentity
 from .types import SessionTelemetry as SessionTelemetry
 from .types import SessionType as SessionType

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -487,6 +487,7 @@ class BackendEventKind(StrEnum):
 
     COMPLETION = "completion"
     SESSION_META = "session_meta"
+    API_RETRY = "api_retry"
     TOOL_OUTPUT = "tool_output"
     ERROR = "error"
     IGNORED = "ignored"

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -480,4 +480,6 @@ class SessionIndexEntry(TypedDict):
     caller_session_id: str
     api_retry_count: int
     api_retry_exhausted: bool
+    api_retry_last_error: str
+    api_retry_last_status: int | None
     schema_version: int

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -29,6 +29,7 @@ __all__ = [
     "FailureRecord",
     "ProviderOutcome",
     "InfraOutcome",
+    "ApiRetryOutcome",
     "SkillResult",
     "CleanupResult",
     "CloneSuccessResult",
@@ -198,6 +199,16 @@ class InfraOutcome:
 
 
 @dataclass(frozen=True, slots=True)
+class ApiRetryOutcome:
+    """API retry event accumulation bundle."""
+
+    count: int = 0
+    last_error: str = ""
+    last_status: int | None = None
+    exhausted: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class WriteEvidence:
     """Bundled write evidence signals — either explicitly constructed or absent."""
 
@@ -246,6 +257,8 @@ class SkillResult:
     """Provider execution outcome bundle."""
     infra: InfraOutcome = field(default_factory=InfraOutcome)
     """Infrastructure exit classification bundle."""
+    api_retry: ApiRetryOutcome = field(default_factory=ApiRetryOutcome)
+    """API retry event accumulation bundle."""
 
     def to_json(self) -> str:
         data: dict[str, Any] = {
@@ -271,6 +284,10 @@ class SkillResult:
             "provider_fallback": self.provider.fallback_activated,
             "provider_used": self.provider.provider_used,
             "infra_exit_category": self.infra.exit_category,
+            "api_retry_count": self.api_retry.count,
+            "api_retry_last_error": self.api_retry.last_error,
+            "api_retry_last_status": self.api_retry.last_status,
+            "api_retry_exhausted": self.api_retry.exhausted,
         }
         if self.worktree_path is not None:
             data["worktree_path"] = self.worktree_path
@@ -461,4 +478,6 @@ class SessionIndexEntry(TypedDict):
     provider_used: str
     provider_fallback: bool
     caller_session_id: str
+    api_retry_count: int
+    api_retry_exhausted: bool
     schema_version: int

--- a/src/autoskillit/execution/anomaly_detection.py
+++ b/src/autoskillit/execution/anomaly_detection.py
@@ -23,6 +23,7 @@ class AnomalyKind(StrEnum):
     IDENTITY_DRIFT = "identity_drift"
     EMPTY_RESULT_WITH_TOKENS = "empty_result_with_tokens"
     THINKING_ONLY_FINAL_TURN = "thinking_only_final_turn"
+    API_RETRY_EXHAUSTION = "api_retry_exhaustion"
 
 
 class AnomalySeverity(StrEnum):

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -295,7 +295,20 @@ class ClaudeStreamParser:
         record_type = obj.get("type", "")
 
         if record_type == "system":
+            subtype = obj.get("subtype", "")
             session_id = obj.get("session_id", "")
+            if subtype == "api_retry":
+                return SessionEvent(
+                    kind=BackendEventKind.API_RETRY,
+                    is_terminal=False,
+                    has_marker=False,
+                    backend_data=ClaudeEventData(
+                        record_type="system",
+                        subtype="api_retry",
+                        session_id=session_id,
+                        raw=obj,
+                    ),
+                )
             return SessionEvent(
                 kind=BackendEventKind.SESSION_META,
                 is_terminal=False,

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -394,10 +394,6 @@ async def _execute_claude_headless(
                     ),
                     max_sessions=ctx.config.linux_tracing.max_sessions,
                     telemetry=_build_error_path_telemetry(ctx.github_api_log),
-                    api_retry_count=0,
-                    api_retry_last_error="",
-                    api_retry_last_status=None,
-                    api_retry_exhausted=False,
                 )
             except Exception:
                 logger.debug("flush_session_log during crash failed", exc_info=True)
@@ -453,10 +449,6 @@ async def _execute_claude_headless(
                         ),
                         max_sessions=ctx.config.linux_tracing.max_sessions,
                         telemetry=_build_error_path_telemetry(ctx.github_api_log),
-                        api_retry_count=0,
-                        api_retry_last_error="",
-                        api_retry_last_status=None,
-                        api_retry_exhausted=False,
                     )
             except Exception:
                 logger.debug("flush_session_log during cancel failed", exc_info=True)

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -394,6 +394,10 @@ async def _execute_claude_headless(
                     ),
                     max_sessions=ctx.config.linux_tracing.max_sessions,
                     telemetry=_build_error_path_telemetry(ctx.github_api_log),
+                    api_retry_count=0,
+                    api_retry_last_error="",
+                    api_retry_last_status=None,
+                    api_retry_exhausted=False,
                 )
             except Exception:
                 logger.debug("flush_session_log during crash failed", exc_info=True)
@@ -449,6 +453,10 @@ async def _execute_claude_headless(
                         ),
                         max_sessions=ctx.config.linux_tracing.max_sessions,
                         telemetry=_build_error_path_telemetry(ctx.github_api_log),
+                        api_retry_count=0,
+                        api_retry_last_error="",
+                        api_retry_last_status=None,
+                        api_retry_exhausted=False,
                     )
             except Exception:
                 logger.debug("flush_session_log during cancel failed", exc_info=True)
@@ -597,6 +605,10 @@ async def _execute_claude_headless(
                     loc_insertions=_metrics.loc_insertions,
                     loc_deletions=_metrics.loc_deletions,
                 ),
+                api_retry_count=skill_result.api_retry.count,
+                api_retry_last_error=skill_result.api_retry.last_error,
+                api_retry_last_status=skill_result.api_retry.last_status,
+                api_retry_exhausted=skill_result.api_retry.exhausted,
                 write_path_warnings=skill_result.write_path_warnings,
                 write_call_count=skill_result.evidence.write_call_count,
                 fs_writes_detected=skill_result.evidence.fs_writes_detected,

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, assert_never
 from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
     AgentSessionResult,
+    ApiRetryOutcome,
     ChannelConfirmation,
     CliSubtype,
     FailureRecord,
@@ -202,6 +203,15 @@ def _stdout_mentions_write_tools(stdout: str) -> bool:
     return '"Edit"' in stdout or '"Write"' in stdout
 
 
+def _build_api_retry_outcome(session: ClaudeSessionResult) -> ApiRetryOutcome:
+    return ApiRetryOutcome(
+        count=session.api_retry_count,
+        last_error=session.api_retry_last_error,
+        last_status=session.api_retry_last_status,
+        exhausted=session.api_retry_exhausted,
+    )
+
+
 def _make_terminated_result(
     *,
     result: SubprocessResult,
@@ -213,6 +223,8 @@ def _make_terminated_result(
     retry_reason: RetryReason,
     evidence: WriteEvidence,
     provider_used: str = "",
+    infra: InfraOutcome = InfraOutcome(),
+    api_retry: ApiRetryOutcome = ApiRetryOutcome(),
 ) -> SkillResult:
     """Construct SkillResult for infrastructure-terminated sessions (stale/idle_stall)."""
     return SkillResult(
@@ -231,6 +243,8 @@ def _make_terminated_result(
         last_stop_reason=session.last_stop_reason,
         lifespan_started=session.lifespan_started,
         provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
+        infra=infra,
+        api_retry=api_retry,
     )
 
 
@@ -277,6 +291,7 @@ def _build_skill_result(
         stale_evidence = _compute_write_evidence(
             stale_session, fs_writes_detected, git_writes_detected, backend
         )
+        stale_api_retry = _build_api_retry_outcome(stale_session)
         stale_returncode = result.returncode if result.returncode is not None else -1
         can_attempt_stale_recovery = (
             stale_session.subtype == CliSubtype.SUCCESS
@@ -305,6 +320,7 @@ def _build_skill_result(
                     retry_reason=RetryReason.NONE,
                     evidence=stale_evidence,
                     provider_used=provider_used,
+                    api_retry=stale_api_retry,
                 )
         # No valid result in stdout — fall through to original stale response
         _capture_failure(
@@ -315,6 +331,11 @@ def _build_skill_result(
             retry_reason=RetryReason.STALE,
             stderr=result.stderr if result.stderr else "",
             audit=audit,
+        )
+        stale_infra = (
+            InfraOutcome(exit_category=InfraExitCategory.API_ERROR.value)
+            if stale_session.api_retry_exhausted
+            else InfraOutcome()
         )
         stale_sr = _make_terminated_result(
             result=result,
@@ -329,6 +350,8 @@ def _build_skill_result(
             retry_reason=RetryReason.STALE,
             evidence=stale_evidence,
             provider_used=provider_used,
+            infra=stale_infra,
+            api_retry=stale_api_retry,
         )
         return _apply_budget_guard(stale_sr, skill_command, audit, max_consecutive_retries)
 
@@ -337,6 +360,7 @@ def _build_skill_result(
         idle_evidence = _compute_write_evidence(
             idle_session, fs_writes_detected, git_writes_detected, backend
         )
+        idle_api_retry = _build_api_retry_outcome(idle_session)
         idle_returncode = result.returncode if result.returncode is not None else -1
         can_attempt_idle_stall_recovery = (
             idle_session.subtype == CliSubtype.SUCCESS
@@ -365,6 +389,7 @@ def _build_skill_result(
                     retry_reason=RetryReason.NONE,
                     evidence=idle_evidence,
                     provider_used=provider_used,
+                    api_retry=idle_api_retry,
                 )
         _capture_failure(
             skill_command,
@@ -377,6 +402,11 @@ def _build_skill_result(
         )
         logger.warning(
             "Headless session killed: stdout idle for configured threshold (IDLE_STALL)"
+        )
+        idle_infra = (
+            InfraOutcome(exit_category=InfraExitCategory.API_ERROR.value)
+            if idle_session.api_retry_exhausted
+            else InfraOutcome()
         )
         idle_sr = _make_terminated_result(
             result=result,
@@ -391,6 +421,8 @@ def _build_skill_result(
             retry_reason=RetryReason.IDLE_STALL,
             evidence=idle_evidence,
             provider_used=provider_used,
+            infra=idle_infra,
+            api_retry=idle_api_retry,
         )
         return _apply_budget_guard(idle_sr, skill_command, audit, max_consecutive_retries)
 
@@ -534,6 +566,7 @@ def _build_skill_result(
     needs_retry = outcome == SessionOutcome.RETRIABLE
 
     infra_category = classify_infra_exit(session, result)
+    api_retry = _build_api_retry_outcome(session)
 
     # API error override: when the session failed due to an API infrastructure error
     # (overload, 529, ECONNRESET), promote to RESUME so the orchestrator routes to
@@ -671,6 +704,7 @@ def _build_skill_result(
             lifespan_started=session.lifespan_started,
             provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
             infra=InfraOutcome(exit_category=infra_category.value),
+            api_retry=api_retry,
         )
     else:
         sr = SkillResult(
@@ -693,6 +727,7 @@ def _build_skill_result(
             lifespan_started=session.lifespan_started,
             provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
             infra=InfraOutcome(exit_category=infra_category.value),
+            api_retry=api_retry,
         )
     sr = _apply_budget_guard(sr, skill_command, audit, max_consecutive_retries)
 

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -52,6 +52,8 @@ def classify_infra_exit(
         return InfraExitCategory.CONTEXT_EXHAUSTED
     if session._has_api_error() or any(p.search(result.stderr) for p in _KNOWN_API_ERROR_PATTERNS):
         return InfraExitCategory.API_ERROR
+    if session.api_retry_exhausted:
+        return InfraExitCategory.API_ERROR
     if result.returncode is not None and result.returncode < 0:
         return InfraExitCategory.PROCESS_KILLED
     return InfraExitCategory.COMPLETED

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -52,6 +52,9 @@ def classify_infra_exit(
         return InfraExitCategory.CONTEXT_EXHAUSTED
     if session._has_api_error() or any(p.search(result.stderr) for p in _KNOWN_API_ERROR_PATTERNS):
         return InfraExitCategory.API_ERROR
+    # Separate guard: _has_api_error() scans message text for known patterns, but
+    # api_retry_last_error can be "unknown" or another value not in _KNOWN_API_ERROR_PATTERNS.
+    # In that case _has_api_error() returns False while api_retry_exhausted is still True.
     if session.api_retry_exhausted:
         return InfraExitCategory.API_ERROR
     if result.returncode is not None and result.returncode < 0:

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -350,8 +350,7 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
                 acc.api_retry_count += 1
                 acc.api_retry_last_error = str(obj.get("error", ""))
                 raw_status = obj.get("error_status")
-                if isinstance(raw_status, int):
-                    acc.api_retry_last_status = raw_status
+                acc.api_retry_last_status = raw_status if isinstance(raw_status, int) else None
                 attempt = obj.get("attempt", 0)
                 max_retries = obj.get("max_retries", 0)
                 if (

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -68,6 +68,10 @@ class ClaudeSessionResult:
     stop_reasons: list[str] = field(default_factory=list)
     has_thinking_only_turn: bool = False
     seen_block_types: frozenset[str] = field(default_factory=frozenset)
+    api_retry_count: int = 0
+    api_retry_last_error: str = ""
+    api_retry_last_status: int | None = None
+    api_retry_exhausted: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.result, str):
@@ -307,6 +311,10 @@ class _ParseAccumulator:
     stop_reasons: list[str] = field(default_factory=list)
     seen_block_types: set[str] = field(default_factory=set)
     has_thinking_only_turn: bool = False
+    api_retry_count: int = 0
+    api_retry_last_error: str = ""
+    api_retry_last_status: int | None = None
+    api_retry_exhausted: bool = False
 
 
 def parse_session_result(stdout: str) -> ClaudeSessionResult:
@@ -337,6 +345,24 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
             if not isinstance(obj, dict):
                 continue
             record_type = obj.get("type")
+
+            if record_type == "system" and obj.get("subtype") == "api_retry":
+                acc.api_retry_count += 1
+                acc.api_retry_last_error = str(obj.get("error", ""))
+                raw_status = obj.get("error_status")
+                if isinstance(raw_status, int):
+                    acc.api_retry_last_status = raw_status
+                attempt = obj.get("attempt", 0)
+                max_retries = obj.get("max_retries", 0)
+                if (
+                    isinstance(attempt, int)
+                    and isinstance(max_retries, int)
+                    and attempt >= max_retries
+                    and max_retries > 0
+                ):
+                    acc.api_retry_exhausted = True
+                continue
+
             if record_type == "result":
                 acc.result_obj = obj
             elif record_type == "assistant":
@@ -462,4 +488,8 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
         seen_block_types=frozenset(
             acc.seen_block_types
         ),  # accumulator uses set; result is immutable
+        api_retry_count=acc.api_retry_count,
+        api_retry_last_error=acc.api_retry_last_error,
+        api_retry_last_status=acc.api_retry_last_status,
+        api_retry_exhausted=acc.api_retry_exhausted,
     )

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -152,6 +152,10 @@ def flush_session_log(
     raw_stdout: str = "",
     last_stop_reason: str = "",
     has_thinking_only_turn: bool = False,
+    api_retry_count: int = 0,
+    api_retry_last_error: str = "",
+    api_retry_last_status: int | None = None,
+    api_retry_exhausted: bool = False,
     versions: dict[str, Any] | None = None,
     model_identifier: str = "",
     max_sessions: int | None = None,
@@ -280,6 +284,28 @@ def flush_session_log(
         )
         anomalies.extend(outcome_anomalies)
 
+    # API retry exhaustion anomaly — fires regardless of token_usage presence
+    if api_retry_exhausted:
+        from autoskillit.execution.anomaly_detection import (
+            OUTCOME_ANOMALY_PID_SENTINEL,
+            OUTCOME_ANOMALY_SEQ_SENTINEL,
+            AnomalyKind,
+            AnomalySeverity,
+        )
+
+        anomalies.append(
+            {
+                "ts": datetime.now(UTC).isoformat(),
+                "seq": OUTCOME_ANOMALY_SEQ_SENTINEL,
+                "event": "anomaly",
+                "kind": str(AnomalyKind.API_RETRY_EXHAUSTION),
+                "severity": str(AnomalySeverity.WARNING),
+                "pid": OUTCOME_ANOMALY_PID_SENTINEL,
+                "detail": {"subtype": subtype, "api_retry_count": api_retry_count},
+                "snapshot": {},
+            }
+        )
+
     # Write anomalies.jsonl (only if anomalies exist)
     if anomalies:
         anomalies_path = session_dir / "anomalies.jsonl"
@@ -355,6 +381,10 @@ def flush_session_log(
         "dispatch_id": dispatch_id,
         "github_api_requests": github_api_requests,
         "caller_session_id": caller_session_id,
+        "api_retry_count": api_retry_count,
+        "api_retry_last_error": api_retry_last_error,
+        "api_retry_last_status": api_retry_last_status,
+        "api_retry_exhausted": api_retry_exhausted,
     }
     if versions is not None:
         effective_model_id = model_identifier or _primary_model_identifier(token_usage)
@@ -474,6 +504,8 @@ def flush_session_log(
         "provider_used": provider_outcome.provider_used,
         "provider_fallback": provider_outcome.fallback_activated,
         "caller_session_id": caller_session_id,
+        "api_retry_count": api_retry_count,
+        "api_retry_exhausted": api_retry_exhausted,
         "schema_version": 2,
     }
     index_path = log_root / "sessions.jsonl"

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -17,7 +17,7 @@ HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 1005,
     "headless/_headless_recovery.py": 360,
     "headless/_headless_path_tokens.py": 175,
-    "headless/_headless_result.py": 800,
+    "headless/_headless_result.py": 835,
 }
 
 

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -14,7 +14,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_result.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 998,
+    "headless/__init__.py": 1005,
     "headless/_headless_recovery.py": 360,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 800,
@@ -71,7 +71,7 @@ NEW_MQ_MODULES = ["_merge_queue_classifier.py", "_merge_queue_repo_state.py"]
 
 SESSION_SIZE_BUDGETS = {
     "session/__init__.py": 65,  # was 420; facade is ~40 lines after P2
-    "session/_session_model.py": 465,
+    "session/_session_model.py": 500,
     "session/_session_content.py": 200,
 }
 NEW_SESSION_FSM_MODULES = ["_retry_fsm.py", "_session_outcome.py"]

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -900,15 +900,16 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "REQ-CNST-010-E1: canonical type registry — wide surface required to prevent "
         "circular imports; all enums/protocols/constants consolidated here",
     ),
-    "headless.py": (
-        1550,
+    "execution/headless/__init__.py": (
+        1005,
         "REQ-CNST-010-E2: headless session orchestration — Channel B drain-race "
         "recovery + IDLE_STALL routing + contract nudge resume tier "
         "+ DIR_MISSING late-bind recovery arm + RecordingSubprocessRunner "
         "step-name auto-derivation gate + recipe identity threading "
         "+ _execute_claude_headless extraction + dispatch_food_truck orchestration-L2 path "
         "+ campaign_id/dispatch_id propagation kwargs "
-        "+ fs-level write detection (pre/post temp-dir snapshot + _resolve_skill_temp_dir); "
+        "+ fs-level write detection (pre/post temp-dir snapshot + _resolve_skill_temp_dir) "
+        "+ api_retry field forwarding to flush_session_log; "
         "splitting would fragment the adjudication pipeline across modules",
     ),
     "session.py": (
@@ -949,7 +950,10 @@ def test_no_src_module_exceeds_line_limit() -> None:
     violations: list[str] = []
     for py_file in sorted(SRC_ROOT.rglob("*.py")):
         line_count = len(py_file.read_text().splitlines())
-        limit, _ = _LINE_LIMIT_EXEMPTIONS.get(py_file.name, (1000, ""))
+        rel = str(py_file.relative_to(SRC_ROOT))
+        limit, _ = _LINE_LIMIT_EXEMPTIONS.get(
+            rel, _LINE_LIMIT_EXEMPTIONS.get(py_file.name, (1000, ""))
+        )
         if line_count > limit:
             violations.append(
                 f"{py_file.relative_to(SRC_ROOT)}: {line_count} lines (limit {limit})"

--- a/tests/core/test_backend_event_kind.py
+++ b/tests/core/test_backend_event_kind.py
@@ -19,6 +19,7 @@ def test_backend_event_kind_members():
     assert set(BackendEventKind) == {
         BackendEventKind.COMPLETION,
         BackendEventKind.SESSION_META,
+        BackendEventKind.API_RETRY,
         BackendEventKind.TOOL_OUTPUT,
         BackendEventKind.ERROR,
         BackendEventKind.IGNORED,
@@ -30,6 +31,7 @@ def test_backend_event_kind_values():
 
     assert BackendEventKind.COMPLETION == "completion"
     assert BackendEventKind.SESSION_META == "session_meta"
+    assert BackendEventKind.API_RETRY == "api_retry"
     assert BackendEventKind.TOOL_OUTPUT == "tool_output"
     assert BackendEventKind.ERROR == "error"
     assert BackendEventKind.IGNORED == "ignored"

--- a/tests/core/test_session_index_schema.py
+++ b/tests/core/test_session_index_schema.py
@@ -17,6 +17,8 @@ _REQUIRED_INDEX_FIELDS = {
     "caller_session_id",
     "fs_writes_detected",
     "git_writes_detected",
+    "api_retry_count",
+    "api_retry_exhausted",
 }
 
 

--- a/tests/execution/backends/test_claude_stream_parser.py
+++ b/tests/execution/backends/test_claude_stream_parser.py
@@ -60,9 +60,10 @@ class TestClaudeStreamParser:
         assert result.backend_data.raw["error"] == "unknown"
         assert result.backend_data.raw["attempt"] == 5
 
-    def test_parse_line_system_non_retry_still_session_meta(self) -> None:
+    def test_parse_line_system_unknown_subtype_still_session_meta(self) -> None:
+        # Regression guard: non-api_retry subtypes must not be misrouted to API_RETRY.
         parser = ClaudeStreamParser()
-        line = '{"type": "system", "session_id": "s1"}'
+        line = json.dumps({"type": "system", "subtype": "other_subtype", "session_id": "s1"})
         result = parser.parse_line(line)
         assert result is not None
         assert result.kind == BackendEventKind.SESSION_META

--- a/tests/execution/backends/test_claude_stream_parser.py
+++ b/tests/execution/backends/test_claude_stream_parser.py
@@ -38,6 +38,37 @@ def _context_exhaustion_line() -> str:
 
 
 class TestClaudeStreamParser:
+    def test_parse_line_system_api_retry_returns_api_retry_kind(self) -> None:
+        parser = ClaudeStreamParser()
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "api_retry",
+                "error": "unknown",
+                "error_status": None,
+                "attempt": 5,
+                "max_retries": 10,
+            }
+        )
+        result = parser.parse_line(line)
+        assert result is not None
+        assert result.kind == BackendEventKind.API_RETRY
+        assert result.is_terminal is False
+        assert result.backend_data is not None
+        assert result.backend_data.record_type == "system"
+        assert result.backend_data.subtype == "api_retry"
+        assert result.backend_data.raw["error"] == "unknown"
+        assert result.backend_data.raw["attempt"] == 5
+
+    def test_parse_line_system_non_retry_still_session_meta(self) -> None:
+        parser = ClaudeStreamParser()
+        line = '{"type": "system", "session_id": "s1"}'
+        result = parser.parse_line(line)
+        assert result is not None
+        assert result.kind == BackendEventKind.SESSION_META
+        assert result.session_id == "s1"
+        assert result.is_terminal is False
+
     def test_parse_line_system_record_session_meta(self) -> None:
         parser = ClaudeStreamParser()
         line = '{"type": "system", "session_id": "test-session-123"}'

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -19,6 +19,11 @@ pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 _snap = partial(_snap_full, captured_at=None)
 
 
+def test_anomaly_kind_api_retry_exhaustion_value():
+    """API_RETRY_EXHAUSTION enum member exists with correct value."""
+    assert AnomalyKind.API_RETRY_EXHAUSTION == "api_retry_exhaustion"
+
+
 def test_detect_oom_spike():
     """OOM score delta > 200 between consecutive snapshots."""
     snaps = [_snap(oom_score=100), _snap(oom_score=350)]

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -117,6 +117,31 @@ class TestClassifyInfraExit:
         result = _sr(returncode=0, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.COMPLETED
 
+    def test_api_retry_exhausted_returns_api_error(self):
+        """api_retry_exhausted=True → API_ERROR."""
+        session = ClaudeSessionResult(
+            subtype="empty_output",
+            is_error=True,
+            result="",
+            session_id="",
+            api_retry_exhausted=True,
+        )
+        result = _sr(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
+    def test_api_retry_not_exhausted_does_not_promote(self):
+        """api_retry_exhausted=False with retries present → no promotion."""
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=False,
+            result="Done.",
+            session_id="s1",
+            api_retry_count=3,
+            api_retry_exhausted=False,
+        )
+        result = _sr(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.COMPLETED
+
     def test_completed_logical_failure(self):
         """Agent failure (success=false, explicit error) → COMPLETED (not infra)."""
         session = ClaudeSessionResult(

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -1027,6 +1027,10 @@ class TestBuildSkillResultCrossValidation:
         "git_writes_detected",
         "has_progress_evidence",
         "infra_exit_category",
+        "api_retry_count",
+        "api_retry_last_error",
+        "api_retry_last_status",
+        "api_retry_exhausted",
     }
 
     def test_expected_skill_keys_includes_provider(self):

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -781,7 +781,7 @@ class TestCodexPipelineTerminationBranches:
 
 
 class TestStaleApiRetryExhaustion:
-    """T5: stale/idle_stall sessions with api_retry exhaustion get infra_exit_category=api_error."""
+    """T5: stale/idle_stall + api_retry exhaustion → infra_exit_category=api_error."""
 
     def test_stale_with_api_retry_exhaustion_sets_infra_exit_category(self):
         """Stale + exhausted api_retry → infra_exit_category='api_error', exhausted=True."""
@@ -813,7 +813,7 @@ class TestStaleApiRetryExhaustion:
         assert sr.success is False
         assert sr.infra.exit_category == "api_error"
         assert sr.api_retry.exhausted is True
-        assert sr.api_retry.count > 0
+        assert sr.api_retry.count == 1
 
     def test_stale_without_api_retry_has_empty_infra(self):
         """Stale with no api_retry → infra_exit_category='', count=0."""
@@ -927,6 +927,6 @@ class TestNormalApiRetry:
         result = _sr(0, ndjson, "", TerminationReason.NATURAL_EXIT)
         sr = _build_skill_result(result)
         assert sr.success is True
-        assert sr.api_retry.count > 0
+        assert sr.api_retry.count == 1
         assert sr.api_retry.exhausted is False
         assert sr.api_retry.last_error == "unknown"

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -778,3 +778,155 @@ class TestCodexPipelineTerminationBranches:
         )
         sr = _build_skill_result(result, supports_claude_format_stdout=False)
         assert sr.success is False
+
+
+class TestStaleApiRetryExhaustion:
+    """T5: stale/idle_stall sessions with api_retry exhaustion get infra_exit_category=api_error."""
+
+    def test_stale_with_api_retry_exhaustion_sets_infra_exit_category(self):
+        """Stale + exhausted api_retry → infra_exit_category='api_error', exhausted=True."""
+        ndjson = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "error": "overloaded",
+                        "error_status": 529,
+                        "attempt": 10,
+                        "max_retries": 10,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "empty_output",
+                        "is_error": True,
+                        "result": "",
+                        "session_id": "s1",
+                    }
+                ),
+            ]
+        )
+        result = _sr(0, ndjson, "", TerminationReason.STALE)
+        sr = _build_skill_result(result)
+        assert sr.success is False
+        assert sr.infra.exit_category == "api_error"
+        assert sr.api_retry.exhausted is True
+        assert sr.api_retry.count > 0
+
+    def test_stale_without_api_retry_has_empty_infra(self):
+        """Stale with no api_retry → infra_exit_category='', count=0."""
+        ndjson = json.dumps(
+            {
+                "type": "result",
+                "subtype": "empty_output",
+                "is_error": True,
+                "result": "",
+                "session_id": "s1",
+            }
+        )
+        result = _sr(0, ndjson, "", TerminationReason.STALE)
+        sr = _build_skill_result(result)
+        assert sr.success is False
+        assert sr.infra.exit_category == ""
+        assert sr.api_retry.count == 0
+
+    def test_stale_recovery_with_api_retry_does_not_set_infra_error(self):
+        """Stale + exhausted api_retry BUT valid result → recovered, infra='' (not api_error)."""
+        ndjson = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "error": "overloaded",
+                        "error_status": 529,
+                        "attempt": 10,
+                        "max_retries": 10,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "is_error": False,
+                        "result": "Done.",
+                        "session_id": "s1",
+                    }
+                ),
+            ]
+        )
+        result = _sr(0, ndjson, "", TerminationReason.STALE)
+        sr = _build_skill_result(result)
+        assert sr.success is True
+        assert sr.subtype == "recovered_from_stale"
+        assert sr.infra.exit_category == ""
+        assert sr.api_retry.exhausted is True
+
+    def test_idle_stall_with_api_retry_exhaustion_sets_infra(self):
+        """Idle_stall + exhausted api_retry → infra_exit_category='api_error'."""
+        ndjson = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "error": "overloaded",
+                        "error_status": 529,
+                        "attempt": 10,
+                        "max_retries": 10,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "empty_output",
+                        "is_error": True,
+                        "result": "",
+                        "session_id": "s1",
+                    }
+                ),
+            ]
+        )
+        result = _sr(0, ndjson, "", TerminationReason.IDLE_STALL)
+        sr = _build_skill_result(result)
+        assert sr.success is False
+        assert sr.infra.exit_category == "api_error"
+        assert sr.api_retry.exhausted is True
+
+
+class TestNormalApiRetry:
+    """T10: normal-path SkillResult carries api_retry data."""
+
+    def test_normal_completion_with_api_retry_carries_data(self):
+        """Normal exit with non-exhausted api_retry → api_retry data preserved."""
+        ndjson = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "error": "unknown",
+                        "error_status": None,
+                        "attempt": 3,
+                        "max_retries": 10,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "is_error": False,
+                        "result": "Done.",
+                        "session_id": "s1",
+                    }
+                ),
+            ]
+        )
+        result = _sr(0, ndjson, "", TerminationReason.NATURAL_EXIT)
+        sr = _build_skill_result(result)
+        assert sr.success is True
+        assert sr.api_retry.count > 0
+        assert sr.api_retry.exhausted is False
+        assert sr.api_retry.last_error == "unknown"

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -867,3 +867,68 @@ def test_token_usage_json_model_identifier_empty_when_no_breakdown(tmp_path):
     tu_path = tmp_path / "sessions" / "model-id-002" / "token_usage.json"
     data = json.loads(tu_path.read_text())
     assert data.get("model_identifier", "") == ""
+
+
+class TestApiRetryFields:
+    """T8: api_retry fields written to summary.json, sessions.jsonl, and anomalies.jsonl."""
+
+    def test_api_retry_fields_in_summary(self, tmp_path):
+        """summary.json includes api_retry_count, api_retry_last_error, api_retry_last_status, api_retry_exhausted."""
+        _flush(
+            tmp_path,
+            session_id="retry-summary",
+            api_retry_count=5,
+            api_retry_last_error="overloaded",
+            api_retry_last_status=529,
+            api_retry_exhausted=True,
+            proc_snapshots=None,
+        )
+        summary = json.loads(
+            (tmp_path / "sessions" / "retry-summary" / "summary.json").read_text()
+        )
+        assert summary["api_retry_count"] == 5
+        assert summary["api_retry_last_error"] == "overloaded"
+        assert summary["api_retry_last_status"] == 529
+        assert summary["api_retry_exhausted"] is True
+
+    def test_api_retry_fields_in_index(self, tmp_path):
+        """sessions.jsonl includes api_retry_count and api_retry_exhausted."""
+        _flush(
+            tmp_path,
+            session_id="retry-index",
+            api_retry_count=3,
+            api_retry_last_error="unknown",
+            api_retry_last_status=None,
+            api_retry_exhausted=True,
+            proc_snapshots=None,
+        )
+        entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])
+        assert entry["api_retry_count"] == 3
+        assert entry["api_retry_exhausted"] is True
+
+    def test_api_retry_fields_default_zero_in_summary(self, tmp_path):
+        """flush_session_log without api_retry params produces zero/false defaults."""
+        _flush(tmp_path, session_id="retry-defaults", proc_snapshots=None)
+        summary = json.loads(
+            (tmp_path / "sessions" / "retry-defaults" / "summary.json").read_text()
+        )
+        assert summary["api_retry_count"] == 0
+        assert summary["api_retry_exhausted"] is False
+
+    def test_api_retry_exhaustion_anomaly_fires_without_token_usage(self, tmp_path):
+        """API_RETRY_EXHAUSTION anomaly fires even when token_usage=None."""
+        _flush(
+            tmp_path,
+            session_id="retry-anomaly",
+            api_retry_count=10,
+            api_retry_last_error="overloaded",
+            api_retry_last_status=529,
+            api_retry_exhausted=True,
+            token_usage=None,
+            proc_snapshots=None,
+        )
+        anomaly_path = tmp_path / "sessions" / "retry-anomaly" / "anomalies.jsonl"
+        anomalies = [json.loads(line) for line in anomaly_path.read_text().strip().split("\n")]
+        api_retry_anomalies = [a for a in anomalies if a["kind"] == "api_retry_exhaustion"]
+        assert len(api_retry_anomalies) == 1
+        assert api_retry_anomalies[0]["detail"]["api_retry_count"] == 10

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -532,6 +532,10 @@ class TestSkillResult:
             "git_writes_detected",
             "has_progress_evidence",
             "infra_exit_category",
+            "api_retry_count",
+            "api_retry_last_error",
+            "api_retry_last_status",
+            "api_retry_exhausted",
         }
         assert set(parsed.keys()) == expected
 
@@ -555,6 +559,31 @@ class TestSkillResult:
         sr = self._make(token_usage=None)
         parsed = json.loads(sr.to_json())
         assert parsed["token_usage"] is None
+
+    def test_api_retry_outcome_in_to_json(self):
+        from autoskillit.core.types import ApiRetryOutcome
+
+        sr = self._make(
+            api_retry=ApiRetryOutcome(
+                count=5,
+                last_error="overloaded",
+                last_status=529,
+                exhausted=True,
+            )
+        )
+        parsed = json.loads(sr.to_json())
+        assert parsed["api_retry_count"] == 5
+        assert parsed["api_retry_last_error"] == "overloaded"
+        assert parsed["api_retry_last_status"] == 529
+        assert parsed["api_retry_exhausted"] is True
+
+    def test_api_retry_default_in_to_json(self):
+        sr = self._make()
+        parsed = json.loads(sr.to_json())
+        assert parsed["api_retry_count"] == 0
+        assert parsed["api_retry_last_error"] == ""
+        assert parsed["api_retry_last_status"] is None
+        assert parsed["api_retry_exhausted"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_session_result.py
+++ b/tests/execution/test_session_result.py
@@ -726,3 +726,106 @@ def test_parse_session_result_missing_stop_reason_skipped():
     parsed = parse_session_result(ndjson)
     assert parsed.stop_reasons == []
     assert parsed.last_stop_reason == ""
+
+
+# ---------------------------------------------------------------------------
+# api_retry accumulation tests
+# ---------------------------------------------------------------------------
+
+
+class TestApiRetryAccumulation:
+    def test_api_retry_fields_accumulated_from_ndjson(self):
+        ndjson = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "error": "overloaded",
+                        "error_status": 529,
+                        "attempt": 1,
+                        "max_retries": 10,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "error": "unknown",
+                        "error_status": None,
+                        "attempt": 2,
+                        "max_retries": 10,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "error": "unknown",
+                        "error_status": None,
+                        "attempt": 3,
+                        "max_retries": 10,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "is_error": False,
+                        "result": "Done.",
+                        "session_id": "s1",
+                    }
+                ),
+            ]
+        )
+        session = parse_session_result(ndjson)
+        assert session.api_retry_count == 3
+        assert session.api_retry_last_error == "unknown"
+        assert session.api_retry_last_status is None
+        assert session.api_retry_exhausted is False
+
+    def test_api_retry_exhausted_when_attempt_equals_max(self):
+        ndjson = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "api_retry",
+                        "error": "overloaded",
+                        "error_status": 529,
+                        "attempt": 10,
+                        "max_retries": 10,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "is_error": False,
+                        "result": "Done.",
+                        "session_id": "s1",
+                    }
+                ),
+            ]
+        )
+        session = parse_session_result(ndjson)
+        assert session.api_retry_count == 1
+        assert session.api_retry_exhausted is True
+        assert session.api_retry_last_error == "overloaded"
+        assert session.api_retry_last_status == 529
+
+    def test_no_api_retry_fields_when_no_retry_events(self):
+        ndjson = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "Done.",
+                "session_id": "s1",
+            }
+        )
+        session = parse_session_result(ndjson)
+        assert session.api_retry_count == 0
+        assert session.api_retry_exhausted is False
+        assert session.api_retry_last_error == ""
+        assert session.api_retry_last_status is None


### PR DESCRIPTION
## Summary

When a Claude Code headless session experiences API retry exhaustion and goes stale, the orchestrator receives `subtype: "stale"` with an empty `infra_exit_category` — zero indication of the root cause. This PR adds end-to-end observability for `api_retry` events: parsing them from NDJSON stdout, accumulating them on `ClaudeSessionResult`, surfacing them through `SkillResult` via a new `ApiRetryOutcome` bundle, adding an `API_RETRY_EXHAUSTION` anomaly, and writing api_retry diagnostic fields to `summary.json` and `sessions.jsonl`.

Key constraint from adversarial review: the actual NDJSON shape is `{"type": "system", "subtype": "api_retry", ...}` — NOT `{"type": "api_retry"}`. The `ClaudeStreamParser` is frozen and cannot accumulate mutable state; all accumulation happens in `parse_session_result`'s `_ParseAccumulator`.

## Requirements

## Problem

When a Claude Code headless session gets stuck in an API retry loop and eventually goes stale, the cause of the staleness is silently swallowed. The orchestrator receives `subtype: "stale"` with no indication that the session went stale specifically because of API retry exhaustion.

### Information loss chain

| Stage | Component | What happens | What's lost |
|-------|-----------|-------------|-------------|
| 1 | `ClaudeStreamParser.parse_line` (`claude.py:356`) | `type=api_retry` → catch-all → `BackendEventKind.IGNORED` | Error field, attempt count, error code |
| 2 | `parse_session_result` (`_session_model.py:339`) | Skips all non-`assistant`/non-`result` NDJSON records | api_retry records never accumulated |
| 3 | `classify_infra_exit` (`_exit_classification.py:41`) | `error=unknown` matches no `_KNOWN_API_ERROR_PATTERNS` | Returns `COMPLETED` instead of `API_ERROR` |
| 4 | Stale branch (`_headless_result.py:318`) | Early return before `classify_infra_exit` | `infra.exit_category` stays empty |
| 5 | `SkillResult.to_json()` | `subtype: "stale"`, `infra_exit_category: ""` | Orchestrator can't distinguish WHY stale |
| 6 | `anomaly_detection.py` | Process-level metrics only, no stdout analysis | api_retry invisible to anomaly system |

## Implementation

### Capture api_retry events in ClaudeStreamParser

Add a `BackendEventKind.API_RETRY` variant. When `parse_line` encounters `type=api_retry`, extract `error`, `error_status`, `attempt`, `max_retries` fields and emit a structured `SessionEvent`. Downstream consumers can accumulate these.

### Surface api_retry data in diagnostic logs

Add to `summary.json`:
- `api_retry_count: int` — total api_retry events observed
- `api_retry_last_error: str | null` — error field from the last api_retry event
- `api_retry_last_status: int | null` — error_status from the last api_retry event
- `api_retry_exhausted: bool` — whether attempt reached max_retries

### Add anomaly type

Add `AnomalyKind.API_RETRY_EXHAUSTION` that fires when api_retry events show `attempt == max_retries` (budget exhausted).

### Surface in SkillResult for stale sessions

The stale branch in `_headless_result.py` should scan raw_stdout for api_retry events before constructing the SkillResult. If retry exhaustion is detected, include it in the result metadata so the orchestrator can see "stale due to API retry exhaustion with error=unknown" rather than just "stale."

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
src/autoskillit/core/__init__.pyi
src/autoskillit/core/types/_type_enums.py
src/autoskillit/core/types/_type_results.py
src/autoskillit/execution/anomaly_detection.py
src/autoskillit/execution/backends/claude.py
src/autoskillit/execution/headless/__init__.py
src/autoskillit/execution/headless/_headless_result.py
src/autoskillit/execution/session/_exit_classification.py
src/autoskillit/execution/session/_session_model.py
src/autoskillit/execution/session_log.py
tests/arch/test_execution_source_split.py
tests/arch/test_subpackage_isolation.py
tests/core/test_backend_event_kind.py
tests/core/test_session_index_schema.py
tests/execution/backends/test_claude_stream_parser.py
tests/execution/test_anomaly_detection.py
tests/execution/test_exit_classification.py
tests/execution/test_headless_core.py
tests/execution/test_headless_result.py
tests/execution/test_session_log_fields.py
tests/execution/test_session_parsing.py
tests/execution/test_session_result.py

Closes #2763

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-074006-028680/.autoskillit/temp/make-plan/surface_api_retry_events_plan_2026-05-23_075000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 93 | 35.6k | 2.9M | 121.2k | 240 | 117.1k | 18m 49s |
| verify | claude-sonnet-4-6 | 1 | 538 | 20.6k | 922.2k | 88.0k | 185 | 71.5k | 10m 36s |
| implement* | MiniMax-M2.7-highspeed | 1 | 7.2M | 30.2k | 3.8M | 115.6k | 303 | 270.3k | 13m 25s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 121.4k | 5.3k | 235.5k | 29.8k | 21 | 15.0k | 1m 45s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 58.7k | 2.1k | 235.5k | 29.8k | 16 | 14.8k | 55s |
| review_pr | claude-sonnet-4-6 | 1 | 110 | 48.8k | 766.1k | 106.3k | 42 | 93.8k | 11m 27s |
| resolve_review | claude-sonnet-4-6 | 1 | 373 | 22.4k | 3.0M | 86.7k | 110 | 73.7k | 11m 53s |
| **Total** | | | 7.4M | 164.9k | 11.9M | 121.2k | | 656.2k | 1h 8m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 560 | 6837.9 | 482.7 | 54.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 187370.1 | 4606.1 | 1402.2 |
| **Total** | **576** | 20669.6 | 1139.3 | 286.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.1k | 127.3k | 7.6M | 356.1k | 52m 46s |
| MiniMax-M2.7-highspeed | 3 | 7.4M | 37.6k | 4.3M | 300.2k | 16m 6s |