### PR TITLE
Change capability guard in _attempt_contract_nudge from skill_injection_capable to session_resume_capable

### DIFF
--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -224,7 +224,7 @@ async def _attempt_contract_nudge(
     Returns a patched SkillResult(success=True) on success, or None to indicate the
     nudge failed and the caller should fall through to the original path.
     """
-    if backend is None or not backend.capabilities.skill_injection_capable:
+    if backend is None or not backend.capabilities.session_resume_capable:
         return None
     if result_parser is None:
         return None

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -1744,7 +1744,7 @@ class TestNudgeBackendGuard:
         assert len(tool_ctx.runner.call_args_list) == 1
 
     @pytest.mark.anyio
-    async def test_nudge_skips_when_not_skill_injection_capable(self, tool_ctx):
+    async def test_nudge_skips_when_not_session_resume_capable(self, tool_ctx):
         from dataclasses import replace
         from unittest.mock import Mock
 
@@ -1753,7 +1753,7 @@ class TestNudgeBackendGuard:
         from autoskillit.execution.headless import run_headless_core
 
         marker = tool_ctx.config.run_skill.completion_marker
-        caps = replace(CLAUDE_CODE_CAPABILITIES, skill_injection_capable=False)
+        caps = replace(CLAUDE_CODE_CAPABILITIES, session_resume_capable=False)
         mock_backend = Mock()
         mock_backend.name = "claude-code"
         mock_backend.capabilities = caps
@@ -1771,7 +1771,7 @@ class TestNudgeBackendGuard:
             ctx=tool_ctx,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
         )
-        # Without skill_injection_capable, nudge is skipped
+        # Without session_resume_capable, nudge is skipped
         assert result.retry_reason == RetryReason.CONTRACT_RECOVERY
         assert len(tool_ctx.runner.call_args_list) == 1
 
@@ -1785,7 +1785,7 @@ class TestNudgeBackendGuard:
         from autoskillit.execution.headless import run_headless_core
 
         marker = tool_ctx.config.run_skill.completion_marker
-        caps = replace(CLAUDE_CODE_CAPABILITIES, skill_injection_capable=True)
+        caps = replace(CLAUDE_CODE_CAPABILITIES, session_resume_capable=True)
         mock_backend = Mock()
         mock_backend.name = "claude-code"
         mock_backend.capabilities = caps
@@ -1804,7 +1804,7 @@ class TestNudgeBackendGuard:
             ctx=tool_ctx,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
         )
-        # result_parser=None prevents nudge even when skill_injection_capable=True
+        # result_parser=None prevents nudge even when session_resume_capable=True
         assert result.retry_reason == RetryReason.CONTRACT_RECOVERY
         assert len(tool_ctx.runner.call_args_list) == 1
 
@@ -1846,7 +1846,7 @@ class TestNudgeBackendGuard:
         assert call_kwargs.kwargs["resume_session_id"] == "sess-main"
 
     @pytest.mark.anyio
-    async def test_nudge_calls_build_resume_cmd_when_skill_injection_capable(self, tool_ctx):
+    async def test_nudge_calls_build_resume_cmd_when_session_resume_capable(self, tool_ctx):
         from dataclasses import replace
         from unittest.mock import Mock
 
@@ -1854,7 +1854,7 @@ class TestNudgeBackendGuard:
         from autoskillit.execution.headless import run_headless_core
 
         marker = tool_ctx.config.run_skill.completion_marker
-        caps = replace(CLAUDE_CODE_CAPABILITIES, skill_injection_capable=True)
+        caps = replace(CLAUDE_CODE_CAPABILITIES, session_resume_capable=True)
         expected_cmd = CmdSpec(
             cmd=("claude", "--resume", "sess-main", "--print", "emit marker"),
             env={"TEST": "val"},


### PR DESCRIPTION
## Summary

Change the capability guard at line 227 of `src/autoskillit/execution/headless/_headless_recovery.py` from checking `skill_injection_capable` to `session_resume_capable`. This unblocks the contract nudge recovery path for Codex sessions, which have `session_resume_capable=True` but `skill_injection_capable=False`. The nudge calls `build_resume_cmd()` — a session resume operation — so the guard should gate on session resume capability, not skill injection.

Two existing tests reference `skill_injection_capable` in the nudge guard context and must be updated to reference `session_resume_capable` instead.

Closes #2699

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-101149-248633/.autoskillit/temp/make-plan/change_capability_guard_contract_nudge_plan_2026-05-23_101500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 61 | 8.0k | 738.3k | 63.8k | 42 | 52.4k | 4m 14s |
| verify | claude-opus-4-6 | 1 | 37 | 6.7k | 401.6k | 53.6k | 62 | 40.2k | 4m 20s |
| implement* | MiniMax-M2.7-highspeed | 1 | 229.9k | 4.0k | 533.5k | 29.8k | 36 | 15.5k | 1m 38s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 89.1k | 2.9k | 295.1k | 29.8k | 20 | 15.1k | 1m 15s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 35.6k | 1.4k | 175.9k | 29.8k | 13 | 14.8k | 39s |
| review_pr | claude-sonnet-4-6 | 3 | 268 | 27.8k | 1.1M | 46.3k | 86 | 97.0k | 8m 4s |
| **Total** | | | 354.9k | 50.9k | 3.3M | 63.8k | | 235.0k | 20m 12s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 16 | 33341.9 | 969.7 | 246.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **16** | 204523.7 | 14689.7 | 3179.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 98 | 14.7k | 1.1M | 92.7k | 8m 35s |
| MiniMax-M2.7-highspeed | 3 | 354.6k | 8.3k | 1.0M | 45.4k | 3m 32s |
| claude-sonnet-4-6 | 1 | 268 | 27.8k | 1.1M | 97.0k | 8m 4s |