### PR TITLE
Create Test Module Skeleton for ensure_codex_mcp_registered()

### DIFF
--- a/.autoskillit/test-source-map.json
+++ b/.autoskillit/test-source-map.json
@@ -2407,6 +2407,7 @@
     "tests/arch/test_backend_coherence.py",
     "tests/execution/backends/test_codex_backend.py",
     "tests/execution/backends/test_codex_env_policy.py",
+    "tests/execution/backends/test_codex_mcp_registration.py",
     "tests/execution/backends/test_codex_fixtures.py",
     "tests/execution/backends/test_codex_result_parser.py",
     "tests/execution/backends/test_codex_stream_parser.py",

--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -8,4 +8,4 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 |------|---------|
 | `__init__.py` | `BACKEND_REGISTRY`, `get_backend()` factory, re-exports |
 | `claude.py` | `ClaudeCodeBackend`, `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` |
-| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson`, `CODEX_ENV_DENYLIST`, `CODEX_ENV_PREFIX_DENYLIST` |
+| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson`, `CODEX_ENV_DENYLIST`, `CODEX_ENV_PREFIX_DENYLIST`, `ensure_codex_mcp_registered` |

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -16,6 +16,7 @@ from .codex import (
     CodexResultParser,
     CodexSessionLocator,
     CodexStreamParser,
+    ensure_codex_mcp_registered,
 )
 
 BACKEND_REGISTRY: dict[str, type[CodingAgentBackend]] = {
@@ -47,5 +48,6 @@ __all__ = [
     "CodexResultParser",
     "CodexSessionLocator",
     "CodexStreamParser",
+    "ensure_codex_mcp_registered",
     "get_backend",
 ]

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -51,7 +51,13 @@ __all__ = [
     "CodexResultParser",
     "CodexSessionLocator",
     "CodexStreamParser",
+    "ensure_codex_mcp_registered",
 ]
+
+
+def ensure_codex_mcp_registered() -> bool:
+    raise NotImplementedError("ensure_codex_mcp_registered: awaiting P5-A7-WP1 implementation")
+
 
 CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
     {

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -127,5 +127,6 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_backend_registry.py` | Tests for backend registry |
 | `test_codex_backend.py` | Tests for CodexFlags, CodexBackend protocol conformance, headless/resume command builders, CodexSessionLocator |
 | `test_codex_env_policy.py` | Tests for CodexEnvPolicy three-layer scrub |
+| `test_codex_mcp_registration.py` | Tests for ensure_codex_mcp_registered: file creation, TOML fields, idempotency, foreign section preservation, dir creation |
 | `test_codex_stream_parser.py` | Full test suite for CodexStreamParser: happy-path, item parsing, degradation, fixture-driven integration, protocol conformance |
 | `test_codex_result_parser.py` | Tests for CodexResultParser |

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -51,6 +51,7 @@ class TestBackendRegistry:
             "CodexResultParser",
             "CodexSessionLocator",
             "CodexStreamParser",
+            "ensure_codex_mcp_registered",
             "get_backend",
         }
         assert set(all_exports) == expected

--- a/tests/execution/backends/test_codex_mcp_registration.py
+++ b/tests/execution/backends/test_codex_mcp_registration.py
@@ -9,6 +9,12 @@ from autoskillit.execution.backends.codex import ensure_codex_mcp_registered
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
+_xfail_stub = pytest.mark.xfail(
+    raises=NotImplementedError,
+    reason="stub awaiting P5-A7-WP1 implementation",
+    strict=True,
+)
+
 
 @pytest.fixture()
 def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -27,39 +33,46 @@ class TestEnsureCodexMcpRegisteredCreate:
     def test_config_toml_does_not_exist_before_call(self, fake_home: Path) -> None:
         assert not (fake_home / ".codex" / "config.toml").exists()
 
+    @_xfail_stub
     def test_config_toml_exists_after_call(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         assert (fake_home / ".codex" / "config.toml").exists()
 
+    @_xfail_stub
     def test_mcp_servers_autoskillit_section_present(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         assert "autoskillit" in data.get("mcp_servers", {})
 
+    @_xfail_stub
     def test_command_is_autoskillit(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         section = data["mcp_servers"]["autoskillit"]
         assert section["command"] == "autoskillit"
 
+    @_xfail_stub
     def test_env_contains_headless_flag(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         env = data["mcp_servers"]["autoskillit"]["env"]
         assert env["AUTOSKILLIT_HEADLESS"] == "1"
 
+    @_xfail_stub
     def test_startup_timeout(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         section = data["mcp_servers"]["autoskillit"]
         assert section["startup_timeout_sec"] == 30.0
 
+    @_xfail_stub
     def test_tool_timeout(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         section = data["mcp_servers"]["autoskillit"]
         assert section["tool_timeout_sec"] == 120.0
 
+    @_xfail_stub
     def test_no_type_key(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
@@ -72,6 +85,7 @@ class TestEnsureCodexMcpRegisteredCreate:
 # ---------------------------------------------------------------------------
 
 
+@_xfail_stub
 class TestEnsureCodexMcpRegisteredIdempotent:
     def test_second_call_returns_false(self, fake_home: Path) -> None:
         first = ensure_codex_mcp_registered()
@@ -97,6 +111,7 @@ class TestEnsureCodexMcpRegisteredIdempotent:
 # ---------------------------------------------------------------------------
 
 
+@_xfail_stub
 class TestEnsureCodexMcpRegisteredPreservation:
     _FOREIGN_TOML = '[mcp_servers.other_tool]\ncommand = "other"\n'
 
@@ -124,6 +139,7 @@ class TestEnsureCodexMcpRegisteredPreservation:
 # ---------------------------------------------------------------------------
 
 
+@_xfail_stub
 def test_other_tool_env_block_is_unchanged(fake_home: Path) -> None:
     foreign = (
         '[mcp_servers.other_tool]\ncommand = "other"\n\n'
@@ -146,14 +162,17 @@ class TestEnsureCodexMcpRegisteredDirCreation:
     def test_codex_dir_does_not_exist_before_call(self, fake_home: Path) -> None:
         assert not (fake_home / ".codex").exists()
 
+    @_xfail_stub
     def test_codex_dir_created(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         assert (fake_home / ".codex").is_dir()
 
+    @_xfail_stub
     def test_config_toml_created(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         assert (fake_home / ".codex" / "config.toml").is_file()
 
+    @_xfail_stub
     def test_toml_valid(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         raw = (fake_home / ".codex" / "config.toml").read_text()

--- a/tests/execution/backends/test_codex_mcp_registration.py
+++ b/tests/execution/backends/test_codex_mcp_registration.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from autoskillit.execution.backends.codex import ensure_codex_mcp_registered
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCodexMcpRegisteredCreate:
+    def test_config_toml_does_not_exist_before_call(self, fake_home: Path) -> None:
+        assert not (fake_home / ".codex" / "config.toml").exists()
+
+    def test_config_toml_exists_after_call(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        assert (fake_home / ".codex" / "config.toml").exists()
+
+    def test_mcp_servers_autoskillit_section_present(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+        assert "autoskillit" in data.get("mcp_servers", {})
+
+    def test_command_is_autoskillit(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+        section = data["mcp_servers"]["autoskillit"]
+        assert section["command"] == "autoskillit"
+
+    def test_env_contains_headless_flag(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+        env = data["mcp_servers"]["autoskillit"]["env"]
+        assert env["AUTOSKILLIT_HEADLESS"] == "1"
+
+    def test_startup_timeout(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+        section = data["mcp_servers"]["autoskillit"]
+        assert section["startup_timeout_sec"] == 30.0
+
+    def test_tool_timeout(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+        section = data["mcp_servers"]["autoskillit"]
+        assert section["tool_timeout_sec"] == 120.0
+
+    def test_no_type_key(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+        section = data["mcp_servers"]["autoskillit"]
+        assert "type" not in section
+
+
+# ---------------------------------------------------------------------------
+# Idempotent
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCodexMcpRegisteredIdempotent:
+    def test_second_call_returns_false(self, fake_home: Path) -> None:
+        first = ensure_codex_mcp_registered()
+        second = ensure_codex_mcp_registered()
+        assert first is True
+        assert second is False
+
+    def test_exactly_one_section(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        ensure_codex_mcp_registered()
+        raw = (fake_home / ".codex" / "config.toml").read_text()
+        assert raw.count("[mcp_servers.autoskillit]") == 1
+
+    def test_toml_parseable_after_double_call(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        ensure_codex_mcp_registered()
+        raw = (fake_home / ".codex" / "config.toml").read_text()
+        tomllib.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# Preservation
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCodexMcpRegisteredPreservation:
+    _FOREIGN_TOML = '[mcp_servers.other_tool]\ncommand = "other"\n'
+
+    def _pre_write(self, fake_home: Path) -> None:
+        codex_dir = fake_home / ".codex"
+        codex_dir.mkdir(parents=True, exist_ok=True)
+        (codex_dir / "config.toml").write_text(self._FOREIGN_TOML)
+
+    def test_foreign_section_survives(self, fake_home: Path) -> None:
+        self._pre_write(fake_home)
+        ensure_codex_mcp_registered()
+        data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+        assert "other_tool" in data["mcp_servers"]
+        assert data["mcp_servers"]["other_tool"]["command"] == "other"
+
+    def test_autoskillit_section_added(self, fake_home: Path) -> None:
+        self._pre_write(fake_home)
+        ensure_codex_mcp_registered()
+        data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+        assert "autoskillit" in data["mcp_servers"]
+
+
+# ---------------------------------------------------------------------------
+# Nested env sub-table preservation (standalone)
+# ---------------------------------------------------------------------------
+
+
+def test_other_tool_env_block_is_unchanged(fake_home: Path) -> None:
+    foreign = (
+        '[mcp_servers.other_tool]\ncommand = "other"\n\n'
+        '[mcp_servers.other_tool.env]\nFOO = "bar"\n'
+    )
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "config.toml").write_text(foreign)
+    ensure_codex_mcp_registered()
+    data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+    assert data["mcp_servers"]["other_tool"]["env"]["FOO"] == "bar"
+
+
+# ---------------------------------------------------------------------------
+# Dir creation
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCodexMcpRegisteredDirCreation:
+    def test_codex_dir_does_not_exist_before_call(self, fake_home: Path) -> None:
+        assert not (fake_home / ".codex").exists()
+
+    def test_codex_dir_created(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        assert (fake_home / ".codex").is_dir()
+
+    def test_config_toml_created(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        assert (fake_home / ".codex" / "config.toml").is_file()
+
+    def test_toml_valid(self, fake_home: Path) -> None:
+        ensure_codex_mcp_registered()
+        raw = (fake_home / ".codex" / "config.toml").read_text()
+        tomllib.loads(raw)

--- a/tests/execution/backends/test_codex_mcp_registration.py
+++ b/tests/execution/backends/test_codex_mcp_registration.py
@@ -85,20 +85,22 @@ class TestEnsureCodexMcpRegisteredCreate:
 # ---------------------------------------------------------------------------
 
 
-@_xfail_stub
 class TestEnsureCodexMcpRegisteredIdempotent:
+    @_xfail_stub
     def test_second_call_returns_false(self, fake_home: Path) -> None:
         first = ensure_codex_mcp_registered()
         second = ensure_codex_mcp_registered()
         assert first is True
         assert second is False
 
+    @_xfail_stub
     def test_exactly_one_section(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         ensure_codex_mcp_registered()
         raw = (fake_home / ".codex" / "config.toml").read_text()
         assert raw.count("[mcp_servers.autoskillit]") == 1
 
+    @_xfail_stub
     def test_toml_parseable_after_double_call(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         ensure_codex_mcp_registered()
@@ -111,7 +113,6 @@ class TestEnsureCodexMcpRegisteredIdempotent:
 # ---------------------------------------------------------------------------
 
 
-@_xfail_stub
 class TestEnsureCodexMcpRegisteredPreservation:
     _FOREIGN_TOML = '[mcp_servers.other_tool]\ncommand = "other"\n'
 
@@ -120,6 +121,7 @@ class TestEnsureCodexMcpRegisteredPreservation:
         codex_dir.mkdir(parents=True, exist_ok=True)
         (codex_dir / "config.toml").write_text(self._FOREIGN_TOML)
 
+    @_xfail_stub
     def test_foreign_section_survives(self, fake_home: Path) -> None:
         self._pre_write(fake_home)
         ensure_codex_mcp_registered()
@@ -127,6 +129,7 @@ class TestEnsureCodexMcpRegisteredPreservation:
         assert "other_tool" in data["mcp_servers"]
         assert data["mcp_servers"]["other_tool"]["command"] == "other"
 
+    @_xfail_stub
     def test_autoskillit_section_added(self, fake_home: Path) -> None:
         self._pre_write(fake_home)
         ensure_codex_mcp_registered()


### PR DESCRIPTION
## Summary

Create `tests/execution/backends/test_codex_mcp_registration.py` containing:
- Module-level `pytestmark` with `layer("execution")` and `small` markers
- Module-level import of `ensure_codex_mcp_registered` from `autoskillit.execution.backends.codex`
- A `fake_home` fixture that monkeypatches `Path.home()` to a controlled tmp directory
- Four test classes: `TestEnsureCodexMcpRegisteredCreate`, `TestEnsureCodexMcpRegisteredIdempotent`, `TestEnsureCodexMcpRegisteredPreservation`, and `TestEnsureCodexMcpRegisteredDirCreation`
- A standalone `test_other_tool_env_block_is_unchanged` function

**Dependency:** This test module imports `ensure_codex_mcp_registered` which must be implemented in `src/autoskillit/execution/backends/codex.py` (P5-A7-WP1). If that function does not yet exist, a minimal stub must be added to `codex.py` so pytest collection succeeds (acceptance criterion). The stub should raise `NotImplementedError` so tests fail clearly rather than erroring at import.

**Test isolation:** The project-wide `_isolated_home` autouse fixture in `tests/conftest.py` already monkeypatches `Path.home()` for every test. The `fake_home` fixture in this module overrides that with a specific, named subdirectory (`tmp_path / "home"`) so tests can make assertions about directory creation (e.g., `.codex/` not existing before the call). This is the standard override pattern documented in the `_isolated_home` fixture's docstring.

Closes #2703

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-101152-827045/.autoskillit/temp/make-plan/p5_a12_wp1_test_codex_mcp_registration_plan_2026-05-23_101600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.2k | 16.4k | 929.7k | 98.4k | 116 | 62.4k | 9m 49s |
| verify | claude-opus-4-6 | 1 | 726 | 10.6k | 577.3k | 57.6k | 74 | 43.7k | 5m 28s |
| implement* | MiniMax-M2.7-highspeed | 1 | 523.4k | 7.0k | 749.2k | 54.2k | 63 | 29.4k | 6m 21s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 76.1k | 3.9k | 205.8k | 29.8k | 20 | 15.1k | 1m 27s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.2k | 1.5k | 205.7k | 29.8k | 15 | 14.8k | 41s |
| review_pr | claude-sonnet-4-6 | 2 | 154 | 44.0k | 695.8k | 62.5k | 59 | 101.2k | 9m 14s |
| resolve_review | claude-sonnet-4-6 | 1 | 141 | 10.2k | 811.8k | 61.7k | 40 | 47.1k | 5m 17s |
| **Total** | | | 647.9k | 93.4k | 4.2M | 98.4k | | 313.6k | 38m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 172 | 4356.0 | 170.9 | 40.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 7 | 115964.4 | 6727.6 | 1458.7 |
| **Total** | **179** | 23325.1 | 1752.1 | 522.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 1.4k | 70.6k | 2.4M | 210.7k | 24m 21s |
| claude-opus-4-6 | 1 | 726 | 10.6k | 577.3k | 43.7k | 5m 28s |
| MiniMax-M2.7-highspeed | 3 | 645.7k | 12.3k | 1.2M | 59.2k | 8m 29s |