### PR TITLE
Add Missing TestSkillAutoGateBoot Tests

### DIFF
--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -1165,10 +1165,13 @@ class TestSkillAutoGateBoot:
                     await _skill_auto_gate_boot(tool_ctx)
 
         mock_write_hook_config.assert_called_once_with()
+        assert tool_ctx.gate.enabled is True
 
     @pytest.mark.anyio
     async def test_skill_auto_gate_boot_skips_when_both_absent(self, tool_ctx, monkeypatch):
         """Neither HEADLESS nor AUTO_GATE set: gate remains closed."""
+        from unittest.mock import patch
+
         from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
         from autoskillit.pipeline.gate import DefaultGateState
         from autoskillit.server._lifespan import _skill_auto_gate_boot
@@ -1177,9 +1180,15 @@ class TestSkillAutoGateBoot:
         monkeypatch.delenv(HEADLESS_ENV_VAR, raising=False)
         monkeypatch.delenv(HEADLESS_AUTO_GATE_ENV_VAR, raising=False)
 
-        await _skill_auto_gate_boot(tool_ctx)
+        with patch(
+            "autoskillit.server.tools.tools_kitchen._write_hook_config"
+        ) as mock_write_hook_config:
+            with patch("autoskillit.core.register_active_kitchen") as mock_register_kitchen:
+                await _skill_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is False
+        mock_write_hook_config.assert_not_called()
+        mock_register_kitchen.assert_not_called()
 
 
 @pytest.mark.feature("skill")

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -1144,6 +1144,43 @@ class TestSkillAutoGateBoot:
             for entry in logs
         )
 
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_writes_hook_config(self, tool_ctx, monkeypatch):
+        """SKILL+HEADLESS+AUTO_GATE: _write_hook_config is called once."""
+        from unittest.mock import AsyncMock, patch
+
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.setenv(HEADLESS_ENV_VAR, "1")
+        monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
+
+        with patch(
+            "autoskillit.server.tools.tools_kitchen._write_hook_config"
+        ) as mock_write_hook_config:
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.core.register_active_kitchen"):
+                    await _skill_auto_gate_boot(tool_ctx)
+
+        mock_write_hook_config.assert_called_once_with()
+
+    @pytest.mark.anyio
+    async def test_skill_auto_gate_boot_skips_when_both_absent(self, tool_ctx, monkeypatch):
+        """Neither HEADLESS nor AUTO_GATE set: gate remains closed."""
+        from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _skill_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        monkeypatch.delenv(HEADLESS_ENV_VAR, raising=False)
+        monkeypatch.delenv(HEADLESS_AUTO_GATE_ENV_VAR, raising=False)
+
+        await _skill_auto_gate_boot(tool_ctx)
+
+        assert tool_ctx.gate.enabled is False
+
 
 @pytest.mark.feature("skill")
 class TestSkillAutoGateBootRegistry:
@@ -1168,6 +1205,12 @@ class TestSkillAutoGateBootRegistry:
             assert _LIFESPAN_BOOT_REGISTRY.get(session_type) is not None, (
                 f"{session_type} has no boot handler in _LIFESPAN_BOOT_REGISTRY"
             )
+
+    def test_headless_auto_gate_env_var_constant_value(self) -> None:
+        from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS, HEADLESS_AUTO_GATE_ENV_VAR
+
+        assert HEADLESS_AUTO_GATE_ENV_VAR == "AUTOSKILLIT_HEADLESS_AUTO_GATE"
+        assert HEADLESS_AUTO_GATE_ENV_VAR in AUTOSKILLIT_PRIVATE_ENV_VARS
 
 
 @pytest.mark.feature("fleet")


### PR DESCRIPTION
## Summary

Add three missing test methods to `tests/server/test_server_init_session_visibility.py` to complete the `TestSkillAutoGateBoot` and `TestSkillAutoGateBootRegistry` test classes per issue #2702 deliverables. No production code changes required.

## Requirements

- `test_skill_auto_gate_boot_writes_hook_config` — async test asserting `_write_hook_config` is called exactly once when both `HEADLESS` and `AUTO_GATE` env vars are set
- `test_skill_auto_gate_boot_skips_when_both_absent` — async test asserting gate stays closed when both env vars are absent
- `test_headless_auto_gate_env_var_constant_value` — sync test asserting `HEADLESS_AUTO_GATE_ENV_VAR == 'AUTOSKILLIT_HEADLESS_AUTO_GATE'` and membership in `AUTOSKILLIT_PRIVATE_ENV_VARS`

Closes #2702

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-101152-198968/.autoskillit/temp/make-plan/add_test_skill_auto_gate_boot_plan_2026-05-23_101600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.4k | 8.8k | 580.7k | 75.1k | 49 | 64.9k | 4m 30s |
| verify | claude-opus-4-6 | 1 | 669 | 9.6k | 1.7M | 65.5k | 90 | 51.6k | 4m 37s |
| implement* | MiniMax-M2.7-highspeed | 1 | 225.2k | 3.4k | 533.5k | 29.8k | 37 | 15.5k | 1m 40s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 78.7k | 4.1k | 235.5k | 29.8k | 20 | 15.0k | 1m 31s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 59.6k | 1.5k | 205.7k | 29.8k | 17 | 14.8k | 44s |
| review_pr | claude-sonnet-4-6 | 2 | 192 | 22.9k | 863.0k | 51.9k | 63 | 67.9k | 6m 24s |
| resolve_review | claude-sonnet-4-6 | 1 | 197 | 12.1k | 1.2M | 67.4k | 55 | 52.3k | 4m 45s |
| **Total** | | | 368.0k | 62.4k | 5.3M | 75.1k | | 282.1k | 24m 13s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 43 | 12405.9 | 360.0 | 80.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 11 | 111014.6 | 4754.3 | 1100.3 |
| **Total** | **54** | 98498.6 | 5223.3 | 1156.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 4.1k | 18.4k | 2.3M | 116.6k | 9m 8s |
| MiniMax-M2.7-highspeed | 3 | 363.6k | 9.0k | 974.6k | 45.3k | 3m 55s |
| claude-sonnet-4-6 | 2 | 389 | 35.0k | 2.1M | 120.2k | 11m 9s |