### PR TITLE
Crash-Safe TOML Read/Write Primitives for Codex Config

### DIFF
--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -8,4 +8,4 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 |------|---------|
 | `__init__.py` | `BACKEND_REGISTRY`, `get_backend()` factory, re-exports |
 | `claude.py` | `ClaudeCodeBackend`, `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` |
-| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson`, `CODEX_ENV_DENYLIST`, `CODEX_ENV_PREFIX_DENYLIST`, `ensure_codex_mcp_registered` |
+| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson`, `CODEX_ENV_DENYLIST`, `CODEX_ENV_PREFIX_DENYLIST`, `ensure_codex_mcp_registered`, `_read_codex_config`, `_write_codex_config`, `_serialize_toml`, `_format_toml_value`, `_format_inline_table`, `_emit_toml_table`, `_is_autoskillit_registered` |

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -115,6 +115,9 @@ def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> No
     inline_tables: list[tuple[str, dict[str, Any]]] = []
     recurse_tables: list[tuple[str, dict[str, Any]]] = []
     for k, v in tables:
+        if not v:
+            inline_tables.append((k, v))
+            continue
         is_leaf = not any(isinstance(sv, dict) for sv in v.values())
         if is_leaf and has_scalars:
             inline_tables.append((k, v))

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -60,10 +60,6 @@ __all__ = [
 ]
 
 
-def ensure_codex_mcp_registered() -> bool:
-    raise NotImplementedError("ensure_codex_mcp_registered: awaiting P5-A7-WP1 implementation")
-
-
 CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
     {
         "ANTHROPIC_API_KEY",

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import tomllib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum, unique
@@ -14,6 +15,8 @@ from autoskillit.core import (
     AGENT_BACKEND_CODEX,
     AUTOSKILLIT_PRIVATE_ENV_VARS,
     CAMPAIGN_ID_ENV_VAR,
+    HEADLESS_AUTO_GATE_ENV_VAR,
+    HEADLESS_ENV_VAR,
     KITCHEN_SESSION_ID_ENV_VAR,
     SESSION_TYPE_SKILL,
     AgentSessionResult,
@@ -29,6 +32,7 @@ from autoskillit.core import (
     SessionEvent,
     SkillSessionConfig,
     ValidatedAddDir,
+    atomic_write,
     extract_skill_name,
     fast_loads,
 )
@@ -69,6 +73,116 @@ CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
 )
 
 CODEX_ENV_PREFIX_DENYLIST: tuple[str, ...] = ("CLAUDE_CODE_",)
+
+
+def _format_toml_value(v: Any) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, str):
+        escaped = v.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    if isinstance(v, int):
+        return str(v)
+    if isinstance(v, float):
+        return str(v)
+    if isinstance(v, list):
+        items = ", ".join(_format_toml_value(item) for item in v)
+        return f"[{items}]"
+    msg = f"Unsupported TOML value type: {type(v).__name__}"
+    raise TypeError(msg)
+
+
+def _format_inline_table(d: dict[str, Any]) -> str:
+    pairs = [f"{k} = {_format_toml_value(v)}" for k, v in d.items()]
+    return "{" + ", ".join(pairs) + "}"
+
+
+def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> None:
+    has_nested_tables = any(
+        isinstance(v, dict) and any(isinstance(sv, dict) for sv in v.values()) for v in d.values()
+    )
+    header = f"[{'.'.join(path)}]"
+    if has_nested_tables:
+        header_emitted = False
+        for k, v in d.items():
+            if not isinstance(v, dict):
+                if not header_emitted:
+                    lines.append(f"\n{header}")
+                    header_emitted = True
+                lines.append(f"{k} = {_format_toml_value(v)}")
+        for k, v in d.items():
+            if isinstance(v, dict):
+                _emit_toml_table(v, [*path, k], lines)
+    else:
+        lines.append(f"\n{header}")
+        for k, v in d.items():
+            if isinstance(v, dict):
+                lines.append(f"{k} = {_format_inline_table(v)}")
+            else:
+                lines.append(f"{k} = {_format_toml_value(v)}")
+
+
+def _serialize_toml(data: dict[str, Any]) -> str:
+    lines: list[str] = []
+    for k, v in data.items():
+        if not isinstance(v, dict):
+            lines.append(f"{k} = {_format_toml_value(v)}")
+    for k, v in data.items():
+        if isinstance(v, dict):
+            _emit_toml_table(v, [k], lines)
+    text = "\n".join(lines).lstrip("\n")
+    return text + "\n" if text else ""
+
+
+def _read_codex_config(path: Path) -> dict[str, Any]:
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (FileNotFoundError, tomllib.TOMLDecodeError):
+        return {}
+    return data
+
+
+def _write_codex_config(path: Path, data: dict[str, Any]) -> None:
+    atomic_write(path, _serialize_toml(data))
+
+
+def _is_autoskillit_registered(config: dict[str, Any], *, headless_auto_gate: bool) -> bool:
+    entry = config.get("mcp_servers", {}).get("autoskillit")
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("command") != "autoskillit":
+        return False
+    env = entry.get("env", {})
+    if env.get(HEADLESS_ENV_VAR) != "1":
+        return False
+    if headless_auto_gate and env.get(HEADLESS_AUTO_GATE_ENV_VAR) != "1":
+        return False
+    return True
+
+
+def ensure_codex_mcp_registered(
+    *,
+    config_path: Path | None = None,
+    headless_auto_gate: bool = True,
+) -> bool:
+    if config_path is None:
+        config_path = Path.home() / ".codex" / "config.toml"
+    config = _read_codex_config(config_path)
+    if _is_autoskillit_registered(config, headless_auto_gate=headless_auto_gate):
+        return False
+    env: dict[str, str] = {HEADLESS_ENV_VAR: "1"}
+    if headless_auto_gate:
+        env[HEADLESS_AUTO_GATE_ENV_VAR] = "1"
+    entry: dict[str, Any] = {
+        "command": "autoskillit",
+        "env": env,
+        "startup_timeout_sec": 30.0,
+        "tool_timeout_sec": 120.0,
+    }
+    config.setdefault("mcp_servers", {})["autoskillit"] = entry
+    _write_codex_config(config_path, config)
+    return True
 
 
 @unique

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -182,6 +182,7 @@ def ensure_codex_mcp_registered(
     config_path: Path | None = None,
     headless_auto_gate: bool = True,
 ) -> bool:
+    """Return True if the entry was written, False if already registered."""
     if config_path is None:
         config_path = Path.home() / ".codex" / "config.toml"
     config = _read_codex_config(config_path)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -98,28 +98,29 @@ def _format_inline_table(d: dict[str, Any]) -> str:
 
 
 def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> None:
-    has_nested_tables = any(
-        isinstance(v, dict) and any(isinstance(sv, dict) for sv in v.values()) for v in d.values()
-    )
     header = f"[{'.'.join(path)}]"
-    if has_nested_tables:
-        header_emitted = False
-        for k, v in d.items():
-            if not isinstance(v, dict):
-                if not header_emitted:
-                    lines.append(f"\n{header}")
-                    header_emitted = True
-                lines.append(f"{k} = {_format_toml_value(v)}")
-        for k, v in d.items():
-            if isinstance(v, dict):
-                _emit_toml_table(v, [*path, k], lines)
-    else:
+    scalars = [(k, v) for k, v in d.items() if not isinstance(v, dict)]
+    tables = [(k, v) for k, v in d.items() if isinstance(v, dict)]
+    has_scalars = bool(scalars)
+
+    inline_tables: list[tuple[str, dict[str, Any]]] = []
+    recurse_tables: list[tuple[str, dict[str, Any]]] = []
+    for k, v in tables:
+        is_leaf = not any(isinstance(sv, dict) for sv in v.values())
+        if is_leaf and has_scalars:
+            inline_tables.append((k, v))
+        else:
+            recurse_tables.append((k, v))
+
+    if scalars or inline_tables:
         lines.append(f"\n{header}")
-        for k, v in d.items():
-            if isinstance(v, dict):
-                lines.append(f"{k} = {_format_inline_table(v)}")
-            else:
-                lines.append(f"{k} = {_format_toml_value(v)}")
+        for k, v in scalars:
+            lines.append(f"{k} = {_format_toml_value(v)}")
+        for k, v in inline_tables:
+            lines.append(f"{k} = {_format_inline_table(v)}")
+
+    for k, v in recurse_tables:
+        _emit_toml_table(v, [*path, k], lines)
 
 
 def _serialize_toml(data: dict[str, Any]) -> str:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -75,7 +75,7 @@ CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
 
 CODEX_ENV_PREFIX_DENYLIST: tuple[str, ...] = ("CLAUDE_CODE_",)
 
-_log = get_logger()
+logger = get_logger()
 
 
 def _format_toml_value(v: Any) -> str:
@@ -151,7 +151,7 @@ def _read_codex_config(path: Path) -> dict[str, Any]:
     except FileNotFoundError:
         return {}
     except tomllib.TOMLDecodeError:
-        _log.warning("corrupt_codex_config", path=str(path))
+        logger.warning("corrupt_codex_config", path=str(path))
         return {}
     return data
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -35,6 +35,7 @@ from autoskillit.core import (
     atomic_write,
     extract_skill_name,
     fast_loads,
+    get_logger,
 )
 from autoskillit.execution.backends.claude import (
     _HEADLESS_EXCLUSIVE_VARS,
@@ -74,12 +75,20 @@ CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
 
 CODEX_ENV_PREFIX_DENYLIST: tuple[str, ...] = ("CLAUDE_CODE_",)
 
+_log = get_logger()
+
 
 def _format_toml_value(v: Any) -> str:
     if isinstance(v, bool):
         return "true" if v else "false"
     if isinstance(v, str):
-        escaped = v.replace("\\", "\\\\").replace('"', '\\"')
+        escaped = (
+            v.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
         return f'"{escaped}"'
     if isinstance(v, int):
         return str(v)
@@ -139,7 +148,10 @@ def _read_codex_config(path: Path) -> dict[str, Any]:
     try:
         with open(path, "rb") as f:
             data = tomllib.load(f)
-    except (FileNotFoundError, tomllib.TOMLDecodeError):
+    except FileNotFoundError:
+        return {}
+    except tomllib.TOMLDecodeError:
+        _log.warning("corrupt_codex_config", path=str(path))
         return {}
     return data
 

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -130,3 +130,4 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_codex_mcp_registration.py` | Tests for ensure_codex_mcp_registered: file creation, TOML fields, idempotency, foreign section preservation, dir creation |
 | `test_codex_stream_parser.py` | Full test suite for CodexStreamParser: happy-path, item parsing, degradation, fixture-driven integration, protocol conformance |
 | `test_codex_result_parser.py` | Tests for CodexResultParser |
+| `test_codex_config.py` | Tests for TOML read/write primitives, _is_autoskillit_registered, and ensure_codex_mcp_registered |

--- a/tests/execution/backends/test_codex_config.py
+++ b/tests/execution/backends/test_codex_config.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.execution.backends import ensure_codex_mcp_registered
+from autoskillit.execution.backends.codex import (
+    _is_autoskillit_registered,
+    _read_codex_config,
+    _serialize_toml,
+    _write_codex_config,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestReadCodexConfig:
+    def test_returns_empty_dict_when_path_missing(self, tmp_path):
+        result = _read_codex_config(tmp_path / "nonexistent.toml")
+        assert result == {}
+
+    def test_returns_empty_dict_when_file_is_empty(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.write_bytes(b"")
+        result = _read_codex_config(p)
+        assert result == {}
+
+    def test_parses_mcp_servers_section(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.write_bytes(b'[mcp_servers.autoskillit]\ncommand = "autoskillit"\n')
+        result = _read_codex_config(p)
+        assert result["mcp_servers"]["autoskillit"]["command"] == "autoskillit"
+
+
+class TestSerializeToml:
+    def test_top_level_string(self):
+        result = _serialize_toml({"key": "value"})
+        assert 'key = "value"' in result
+
+    def test_top_level_float(self):
+        result = _serialize_toml({"timeout": 30.0})
+        assert "timeout = 30.0" in result
+
+    def test_section_header(self):
+        data = {"section": {"key": "val"}}
+        result = _serialize_toml(data)
+        assert "[section]" in result
+
+    def test_nested_table_header(self):
+        data = {"parent": {"child": {"key": "val"}}}
+        result = _serialize_toml(data)
+        assert "[parent.child]" in result
+
+    def test_inline_dict(self):
+        data = {"sec": {"sub": {"key": "val", "env": {"A": "1"}}}}
+        result = _serialize_toml(data)
+        assert "env = {" in result
+
+    def test_list_values_serialize_as_arrays(self):
+        data = {"sec": {"sub": {"args": ["--stdio", "--verbose"]}}}
+        result = _serialize_toml(data)
+        assert 'args = ["--stdio", "--verbose"]' in result
+
+    def test_round_trip_fidelity(self):
+        import tomllib
+
+        original = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "startup_timeout_sec": 30.0,
+                    "tool_timeout_sec": 120.0,
+                    "env": {"AUTOSKILLIT_HEADLESS": "1"},
+                }
+            }
+        }
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_with_list_values(self):
+        import tomllib
+
+        original = {
+            "mcp_servers": {
+                "other": {
+                    "command": "other",
+                    "args": ["--stdio"],
+                },
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "env": {"AUTOSKILLIT_HEADLESS": "1"},
+                },
+            }
+        }
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_no_duplicate_section_headers(self):
+        import tomllib
+
+        data = {
+            "mcp_servers": {
+                "server1": {
+                    "command": "s1",
+                    "timeout": 10.0,
+                    "env": {"A": "1"},
+                },
+            }
+        }
+        serialized = _serialize_toml(data)
+        count = serialized.count("[mcp_servers.server1]")
+        assert count == 1
+        tomllib.loads(serialized)
+
+
+class TestWriteCodexConfig:
+    def test_writes_readable_toml(self, tmp_path):
+        p = tmp_path / "config.toml"
+        data = {"mcp_servers": {"test": {"command": "test"}}}
+        _write_codex_config(p, data)
+        assert _read_codex_config(p) == data
+
+    def test_atomic_write_creates_parent_dirs(self, tmp_path):
+        p = tmp_path / "nested" / "dir" / "config.toml"
+        _write_codex_config(p, {"key": "val"})
+        assert p.exists()
+
+
+class TestIsAutoskillitRegistered:
+    def test_empty_config_returns_false(self):
+        assert _is_autoskillit_registered({}, headless_auto_gate=True) is False
+
+    def test_mcp_servers_without_autoskillit_returns_false(self):
+        assert (
+            _is_autoskillit_registered({"mcp_servers": {"other": {}}}, headless_auto_gate=True)
+            is False
+        )
+
+    def test_wrong_command_returns_false(self):
+        config = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "wrong",
+                    "env": {"AUTOSKILLIT_HEADLESS": "1"},
+                }
+            }
+        }
+        assert _is_autoskillit_registered(config, headless_auto_gate=False) is False
+
+    def test_missing_headless_env_returns_false(self):
+        config = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "env": {},
+                }
+            }
+        }
+        assert _is_autoskillit_registered(config, headless_auto_gate=False) is False
+
+    def test_headless_auto_gate_true_missing_auto_gate_env_returns_false(self):
+        config = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "env": {"AUTOSKILLIT_HEADLESS": "1"},
+                }
+            }
+        }
+        assert _is_autoskillit_registered(config, headless_auto_gate=True) is False
+
+    def test_headless_auto_gate_false_ignores_auto_gate_env(self):
+        config = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "env": {"AUTOSKILLIT_HEADLESS": "1"},
+                }
+            }
+        }
+        assert _is_autoskillit_registered(config, headless_auto_gate=False) is True
+
+    def test_all_checks_pass_with_auto_gate(self):
+        config = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "env": {
+                        "AUTOSKILLIT_HEADLESS": "1",
+                        "AUTOSKILLIT_HEADLESS_AUTO_GATE": "1",
+                    },
+                }
+            }
+        }
+        assert _is_autoskillit_registered(config, headless_auto_gate=True) is True
+
+    def test_extra_keys_tolerated(self):
+        config = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "env": {"AUTOSKILLIT_HEADLESS": "1", "EXTRA": "yes"},
+                    "extra_field": 42,
+                }
+            }
+        }
+        assert _is_autoskillit_registered(config, headless_auto_gate=False) is True
+
+
+class TestEnsureCodexMcpRegistered:
+    def test_first_call_returns_true_and_writes(self, tmp_path):
+        p = tmp_path / ".codex" / "config.toml"
+        result = ensure_codex_mcp_registered(config_path=p)
+        assert result is True
+        config = _read_codex_config(p)
+        entry = config["mcp_servers"]["autoskillit"]
+        assert entry["command"] == "autoskillit"
+        assert entry["env"]["AUTOSKILLIT_HEADLESS"] == "1"
+        assert entry["startup_timeout_sec"] == 30.0
+        assert entry["tool_timeout_sec"] == 120.0
+
+    def test_headless_auto_gate_true_includes_auto_gate_env(self, tmp_path):
+        p = tmp_path / "config.toml"
+        ensure_codex_mcp_registered(config_path=p, headless_auto_gate=True)
+        config = _read_codex_config(p)
+        assert config["mcp_servers"]["autoskillit"]["env"]["AUTOSKILLIT_HEADLESS_AUTO_GATE"] == "1"
+
+    def test_headless_auto_gate_false_omits_auto_gate_env(self, tmp_path):
+        p = tmp_path / "config.toml"
+        ensure_codex_mcp_registered(config_path=p, headless_auto_gate=False)
+        config = _read_codex_config(p)
+        assert "AUTOSKILLIT_HEADLESS_AUTO_GATE" not in config["mcp_servers"]["autoskillit"]["env"]
+
+    def test_second_call_returns_false(self, tmp_path):
+        p = tmp_path / "config.toml"
+        ensure_codex_mcp_registered(config_path=p)
+        mtime_before = p.stat().st_mtime_ns
+        result = ensure_codex_mcp_registered(config_path=p)
+        assert result is False
+        assert p.stat().st_mtime_ns == mtime_before
+
+    def test_default_config_path(self, monkeypatch, tmp_path):
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        ensure_codex_mcp_registered()
+        assert (fake_home / ".codex" / "config.toml").exists()
+
+    def test_creates_parent_directory(self, tmp_path):
+        p = tmp_path / "nonexistent" / ".codex" / "config.toml"
+        ensure_codex_mcp_registered(config_path=p)
+        assert p.exists()
+
+    def test_no_type_field_in_written_toml(self, tmp_path):
+        p = tmp_path / "config.toml"
+        ensure_codex_mcp_registered(config_path=p)
+        raw = p.read_text()
+        assert "type" not in raw
+
+    def test_preserves_existing_config(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('[mcp_servers.other]\ncommand = "other"\n')
+        ensure_codex_mcp_registered(config_path=p)
+        config = _read_codex_config(p)
+        assert "other" in config["mcp_servers"]
+        assert "autoskillit" in config["mcp_servers"]
+
+    def test_preserves_existing_config_with_list_values(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('[mcp_servers.other]\ncommand = "other"\nargs = ["--stdio"]\n')
+        ensure_codex_mcp_registered(config_path=p)
+        config = _read_codex_config(p)
+        assert config["mcp_servers"]["other"]["args"] == ["--stdio"]
+        assert "autoskillit" in config["mcp_servers"]
+
+
+class TestExports:
+    def test_ensure_codex_mcp_registered_in_codex_all(self):
+        from autoskillit.execution.backends import codex
+
+        assert "ensure_codex_mcp_registered" in codex.__all__
+
+    def test_private_functions_not_in_all(self):
+        from autoskillit.execution.backends import codex
+
+        assert "_read_codex_config" not in codex.__all__
+        assert "_write_codex_config" not in codex.__all__
+        assert "_serialize_toml" not in codex.__all__
+        assert "_is_autoskillit_registered" not in codex.__all__
+
+    def test_importable_from_backends(self):
+        from autoskillit.execution.backends import ensure_codex_mcp_registered
+
+        assert callable(ensure_codex_mcp_registered)
+
+    def test_no_third_party_toml_in_codex(self):
+        import ast
+
+        source = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "autoskillit"
+            / "execution"
+            / "backends"
+            / "codex.py"
+        )
+        tree = ast.parse(source.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                names = []
+                if isinstance(node, ast.Import):
+                    names = [a.name for a in node.names]
+                else:
+                    names = [node.module or ""]
+                for name in names:
+                    assert name not in ("toml", "tomli", "tomlkit"), (
+                        f"Third-party TOML import found: {name}"
+                    )

--- a/tests/execution/backends/test_codex_config.py
+++ b/tests/execution/backends/test_codex_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -63,7 +64,6 @@ class TestSerializeToml:
         assert 'args = ["--stdio", "--verbose"]' in result
 
     def test_round_trip_fidelity(self):
-        import tomllib
 
         original = {
             "mcp_servers": {
@@ -80,7 +80,6 @@ class TestSerializeToml:
         assert parsed == original
 
     def test_round_trip_with_list_values(self):
-        import tomllib
 
         original = {
             "mcp_servers": {
@@ -99,7 +98,6 @@ class TestSerializeToml:
         assert parsed == original
 
     def test_no_duplicate_section_headers(self):
-        import tomllib
 
         data = {
             "mcp_servers": {

--- a/tests/execution/backends/test_codex_mcp_registration.py
+++ b/tests/execution/backends/test_codex_mcp_registration.py
@@ -9,12 +9,6 @@ from autoskillit.execution.backends.codex import ensure_codex_mcp_registered
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
-_xfail_stub = pytest.mark.xfail(
-    raises=NotImplementedError,
-    reason="stub awaiting P5-A7-WP1 implementation",
-    strict=True,
-)
-
 
 @pytest.fixture()
 def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -33,46 +27,39 @@ class TestEnsureCodexMcpRegisteredCreate:
     def test_config_toml_does_not_exist_before_call(self, fake_home: Path) -> None:
         assert not (fake_home / ".codex" / "config.toml").exists()
 
-    @_xfail_stub
     def test_config_toml_exists_after_call(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         assert (fake_home / ".codex" / "config.toml").exists()
 
-    @_xfail_stub
     def test_mcp_servers_autoskillit_section_present(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         assert "autoskillit" in data.get("mcp_servers", {})
 
-    @_xfail_stub
     def test_command_is_autoskillit(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         section = data["mcp_servers"]["autoskillit"]
         assert section["command"] == "autoskillit"
 
-    @_xfail_stub
     def test_env_contains_headless_flag(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         env = data["mcp_servers"]["autoskillit"]["env"]
         assert env["AUTOSKILLIT_HEADLESS"] == "1"
 
-    @_xfail_stub
     def test_startup_timeout(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         section = data["mcp_servers"]["autoskillit"]
         assert section["startup_timeout_sec"] == 30.0
 
-    @_xfail_stub
     def test_tool_timeout(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
         section = data["mcp_servers"]["autoskillit"]
         assert section["tool_timeout_sec"] == 120.0
 
-    @_xfail_stub
     def test_no_type_key(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         data = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
@@ -86,21 +73,18 @@ class TestEnsureCodexMcpRegisteredCreate:
 
 
 class TestEnsureCodexMcpRegisteredIdempotent:
-    @_xfail_stub
     def test_second_call_returns_false(self, fake_home: Path) -> None:
         first = ensure_codex_mcp_registered()
         second = ensure_codex_mcp_registered()
         assert first is True
         assert second is False
 
-    @_xfail_stub
     def test_exactly_one_section(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         ensure_codex_mcp_registered()
         raw = (fake_home / ".codex" / "config.toml").read_text()
         assert raw.count("[mcp_servers.autoskillit]") == 1
 
-    @_xfail_stub
     def test_toml_parseable_after_double_call(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         ensure_codex_mcp_registered()
@@ -121,7 +105,6 @@ class TestEnsureCodexMcpRegisteredPreservation:
         codex_dir.mkdir(parents=True, exist_ok=True)
         (codex_dir / "config.toml").write_text(self._FOREIGN_TOML)
 
-    @_xfail_stub
     def test_foreign_section_survives(self, fake_home: Path) -> None:
         self._pre_write(fake_home)
         ensure_codex_mcp_registered()
@@ -129,7 +112,6 @@ class TestEnsureCodexMcpRegisteredPreservation:
         assert "other_tool" in data["mcp_servers"]
         assert data["mcp_servers"]["other_tool"]["command"] == "other"
 
-    @_xfail_stub
     def test_autoskillit_section_added(self, fake_home: Path) -> None:
         self._pre_write(fake_home)
         ensure_codex_mcp_registered()
@@ -142,7 +124,6 @@ class TestEnsureCodexMcpRegisteredPreservation:
 # ---------------------------------------------------------------------------
 
 
-@_xfail_stub
 def test_other_tool_env_block_is_unchanged(fake_home: Path) -> None:
     foreign = (
         '[mcp_servers.other_tool]\ncommand = "other"\n\n'
@@ -165,17 +146,14 @@ class TestEnsureCodexMcpRegisteredDirCreation:
     def test_codex_dir_does_not_exist_before_call(self, fake_home: Path) -> None:
         assert not (fake_home / ".codex").exists()
 
-    @_xfail_stub
     def test_codex_dir_created(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         assert (fake_home / ".codex").is_dir()
 
-    @_xfail_stub
     def test_config_toml_created(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         assert (fake_home / ".codex" / "config.toml").is_file()
 
-    @_xfail_stub
     def test_toml_valid(self, fake_home: Path) -> None:
         ensure_codex_mcp_registered()
         raw = (fake_home / ".codex" / "config.toml").read_text()


### PR DESCRIPTION
## Summary

Add crash-safe TOML read/write primitives and an idempotent MCP server registration function to `codex.py`. The read path uses stdlib `tomllib` (Python 3.11+). The write path uses a minimal hand-rolled serializer targeting the `mcp_servers` table shape (with list/array support for round-trip safety), with atomic writes delegated to the existing `atomic_write` from `core/io.py`. The registration function `ensure_codex_mcp_registered()` is exported from `backends/__init__.py` for downstream consumers.

## Requirements

(Gh not available — requirements not fetched)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-101148-357411/.autoskillit/temp/make-plan/crash_safe_toml_primitives_plan_2026-05-23_101500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 63 | 28.6k | 1.1M | 106.9k | 162 | 101.2k | 13m 35s |
| verify | claude-opus-4-6 | 1 | 38 | 15.2k | 464.3k | 59.3k | 67 | 46.3k | 7m 2s |
| implement* | MiniMax-M2.7-highspeed | 1 | 631.6k | 10.3k | 783.6k | 61.8k | 68 | 109.5k | 3m 9s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 115.5k | 3.3k | 273.3k | 34.9k | 25 | 52.8k | 1m 36s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 84.5k | 2.0k | 295.2k | 29.8k | 23 | 14.8k | 58s |
| review_pr | claude-sonnet-4-6 | 2 | 192 | 66.1k | 1.2M | 87.9k | 81 | 157.6k | 16m 8s |
| resolve_review | claude-opus-4-6 | 2 | 127 | 34.9k | 4.8M | 96.1k | 158 | 177.3k | 23m 38s |
| resolve_queue_merge_conflicts | claude-opus-4-6 | 1 | 41 | 5.2k | 954.3k | 50.2k | 41 | 35.0k | 2m 16s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 88.6k | 1.4k | 178.9k | 29.8k | 14 | 41.6k | 47s |
| resolve_ci | claude-opus-4-6 | 1 | 48 | 6.4k | 1.0M | 60.9k | 36 | 45.8k | 4m 52s |
| **Total** | | | 920.6k | 173.4k | 11.1M | 106.9k | | 782.0k | 1h 14m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 444 | 1764.9 | 246.5 | 23.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 24 | 202010.0 | 7387.2 | 1453.9 |
| resolve_queue_merge_conflicts | 264 | 3614.7 | 132.6 | 19.8 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 22 | 46823.8 | 2083.6 | 291.5 |
| **Total** | **754** | 14680.4 | 1037.2 | 230.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 255 | 94.7k | 2.2M | 258.8k | 29m 43s |
| claude-opus-4-6 | 4 | 254 | 61.7k | 7.3M | 304.4k | 37m 49s |
| MiniMax-M2.7-highspeed | 4 | 920.1k | 16.9k | 1.5M | 218.7k | 6m 31s |