### PR TITLE
PX6 P6-A1-WP1 — Replace Hardcoded {'Write', 'Edit'} Literal in _headless_recovery.py

### DIFF
--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -118,19 +118,19 @@ def _synthesize_from_write_artifacts(
     expected_output_patterns: list[str],
     write_call_count: int,
     fs_writes_detected: bool = False,
+    write_tool_names: frozenset[str] = frozenset({"Write", "Edit"}),
 ) -> ClaudeSessionResult | None:
-    """Synthesize missing structured output tokens from Write/Edit tool_use file_path data.
+    """Synthesize missing structured output tokens from write tool_use file_path data.
 
     When the session has write evidence (write_call_count >= 1) and expected_output_patterns
     contain path-capture patterns (e.g., ``plan_path\\s*=\\s*/.+``), scan tool_uses for
-    Write/Edit entries with absolute file_path values. For each pattern whose token name can
-    be extracted, inject ``{token_name} = {file_path}`` into session.result so that
-    _compute_outcome sees the token as if the model had emitted it.
+    entries matching write_tool_names with absolute file_path values. For each pattern whose
+    token name can be extracted, inject ``{token_name} = {file_path}`` into session.result so
+    that _compute_outcome sees the token as if the model had emitted it.
 
     Returns a new ClaudeSessionResult with the injected line prepended to result, or None if
     synthesis is not possible (no matching file_path, no path-capture patterns, or pattern
-    already satisfied).
-    """
+    already satisfied)."""
     if write_call_count == 0:
         return None
 
@@ -148,7 +148,7 @@ def _synthesize_from_write_artifacts(
         candidate_paths = [
             t.get("file_path", "")
             for t in session.tool_uses
-            if t.get("name") in {"Write", "Edit"} and t.get("file_path", "").startswith("/")
+            if t.get("name") in write_tool_names and t.get("file_path", "").startswith("/")
         ]
         if candidate_paths:
             synthesized_lines.append(f"{token_name} = {candidate_paths[-1]}")
@@ -164,10 +164,11 @@ def _extract_missing_token_hints(
     stdout: str,
     expected_output_patterns: Sequence[str],
     result_parser: ResultParser,
+    write_tool_names: frozenset[str],
 ) -> list[tuple[str, str]]:
     """Extract (token_name, write_path) pairs for patterns missing from the result.
 
-    Parses raw NDJSON stdout to find Write/Edit tool_use file_path entries,
+    Parses raw NDJSON stdout to find write tool_use file_path entries,
     then matches them against path-capture patterns that are NOT satisfied in
     the result text. Returns the hints needed to build the nudge prompt.
     """
@@ -191,7 +192,7 @@ def _extract_missing_token_hints(
         candidate_paths = [
             t.get("file_path", "")
             for t in session.raw.get("tool_uses", [])
-            if t.get("name") in {"Write", "Edit"} and t.get("file_path", "").startswith("/")
+            if t.get("name") in write_tool_names and t.get("file_path", "").startswith("/")
         ]
         if candidate_paths:
             hints.append((token_name, candidate_paths[-1]))
@@ -237,8 +238,9 @@ async def _attempt_contract_nudge(
         )
         patterns_to_check: Sequence[str] = list(expected_output_patterns)
     else:
+        _write_tool_names = backend.write_tool_names()
         hints = _extract_missing_token_hints(
-            subprocess_result.stdout, expected_output_patterns, result_parser
+            subprocess_result.stdout, expected_output_patterns, result_parser, _write_tool_names
         )
         if not hints:
             logger.debug("nudge_skip_no_hints")

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -538,6 +538,9 @@ def _build_skill_result(
         # _recover_block_from_assistant_messages is unavailable. For CHANNEL_A/B
         # sessions, if the pattern was absent from assistant_messages the agent never
         # emitted it — synthesis would fabricate a token the agent did not produce.
+        write_names = (
+            backend.write_tool_names() if backend is not None else frozenset({"Write", "Edit"})
+        )
         if (
             expected_output_patterns
             and _has_write_evidence
@@ -549,6 +552,7 @@ def _build_skill_result(
                 list(expected_output_patterns),
                 evidence.write_call_count,
                 evidence.fs_writes_detected,
+                write_tool_names=write_names,
             )
             if artifact_recovered is not None:
                 session = artifact_recovered

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -15,9 +15,9 @@ NEW_HEADLESS_MODULES = [
 ]
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 1005,
-    "headless/_headless_recovery.py": 360,
+    "headless/_headless_recovery.py": 365,
     "headless/_headless_path_tokens.py": 175,
-    "headless/_headless_result.py": 835,
+    "headless/_headless_result.py": 840,
 }
 
 

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -1122,7 +1122,7 @@ class TestExtractMissingTokenHints:
 
         stdout = _ndjson_with_write("plan summary\n%%ORDER_UP%%", ["/tmp/out.md"])
         hints = _extract_missing_token_hints(
-            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser()
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser(), frozenset({"Write", "Edit"})
         )
         assert hints == [("plan_path", "/tmp/out.md")]
 
@@ -1130,21 +1130,23 @@ class TestExtractMissingTokenHints:
 
         stdout = _ndjson_with_write("plan_path = /tmp/out.md\n%%ORDER_UP%%", ["/tmp/out.md"])
         hints = _extract_missing_token_hints(
-            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser()
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser(), frozenset({"Write", "Edit"})
         )
         assert hints == []
 
     def test_returns_empty_for_non_path_patterns(self):
 
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/out.md"])
-        hints = _extract_missing_token_hints(stdout, [r"verdict\s*=\s*\w+"], ClaudeResultParser())
+        hints = _extract_missing_token_hints(
+            stdout, [r"verdict\s*=\s*\w+"], ClaudeResultParser(), frozenset({"Write", "Edit"})
+        )
         assert hints == []
 
     def test_uses_last_write_path(self):
 
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/first.md", "/tmp/final.md"])
         hints = _extract_missing_token_hints(
-            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser()
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser(), frozenset({"Write", "Edit"})
         )
         assert hints == [("plan_path", "/tmp/final.md")]
 
@@ -1153,7 +1155,10 @@ class TestExtractMissingTokenHints:
 
         stdout = _ndjson_with_write("%%ORDER_UP%%", ["/tmp/out.md"])
         hints = _extract_missing_token_hints(
-            stdout, [r"elab_result_path\s*=\s*\S+"], ClaudeResultParser()
+            stdout,
+            [r"elab_result_path\s*=\s*\S+"],
+            ClaudeResultParser(),
+            frozenset({"Write", "Edit"}),
         )
         assert hints == [("elab_result_path", "/tmp/out.md")]
 


### PR DESCRIPTION
## Summary

Replace two hardcoded `{"Write", "Edit"}` set literals in `_headless_recovery.py` with a `write_tool_names: frozenset[str]` parameter on `_synthesize_from_write_artifacts` and `_extract_missing_token_hints`. Update their callers (`_build_skill_result` in `_headless_result.py` and `_attempt_contract_nudge` in `_headless_recovery.py`) to derive the value from `backend.write_tool_names()` using the identical pattern already established in `_compute_write_evidence` at `_headless_result.py:191-192`. Update direct test calls to pass the parameter explicitly. Bump the size budgets in `test_execution_source_split.py` to accommodate the new parameter lines.

**Out of scope:** `_stdout_mentions_write_tools` at `_headless_result.py:202-203` hardcodes `'"Edit"'` and `'"Write"'` as fast string probes on raw NDJSON stdout. This is a heuristic pre-check (substring search on serialized JSON) used for a cross-check warning at line 450, not a tool_use name filter.

## Changed Files

### Modified (●):

- `src/autoskillit/execution/headless/_headless_recovery.py`
- `src/autoskillit/execution/headless/_headless_result.py`
- `tests/arch/test_execution_source_split.py`
- `tests/execution/test_headless_path_validation.py`

Closes #2704

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-133320-415270/.autoskillit/temp/make-plan/px6_p6_a1_wp1_replace_write_edit_literal_plan_2026-05-23_134500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 74 | 17.8k | 1.0M | 79.2k | 94 | 68.6k | 9m 50s |
| verify | claude-opus-4-6 | 1 | 35 | 5.0k | 267.5k | 44.8k | 51 | 29.6k | 3m 14s |
| implement* | MiniMax-M2.7-highspeed | 1 | 836.1k | 9.1k | 1.0M | 29.8k | 85 | 92.0k | 3m 25s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 50.1k | 3.3k | 149.0k | 29.8k | 19 | 42.0k | 1m 10s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 55.3k | 1.5k | 235.5k | 29.8k | 16 | 14.8k | 42s |
| review_pr | claude-sonnet-4-6 | 3 | 254 | 45.1k | 1.2M | 54.4k | 89 | 119.1k | 11m 11s |
| **Total** | | | 941.9k | 81.9k | 3.9M | 79.2k | | 366.1k | 29m 33s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 45 | 23180.1 | 2043.4 | 202.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **45** | 86155.2 | 8136.6 | 1819.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 109 | 22.8k | 1.3M | 98.2k | 13m 4s |
| MiniMax-M2.7-highspeed | 3 | 941.5k | 13.9k | 1.4M | 148.8k | 5m 17s |
| claude-sonnet-4-6 | 1 | 254 | 45.1k | 1.2M | 119.1k | 11m 11s |