### PR TITLE
PX6 P6-A5-WP1 — Codex Backend-Gated Version Check Doctor Function

### DIFF
--- a/src/autoskillit/cli/doctor/CLAUDE.md
+++ b/src/autoskillit/cli/doctor/CLAUDE.md
@@ -15,7 +15,7 @@ Diagnostic health checks for the autoskillit installation (28 checks).
 | `_doctor_hooks.py` | Hook registration, executability, and registry drift checks |
 | `_doctor_install.py` | Install path, entry points, version drift, update dismissal checks |
 | `_doctor_mcp.py` | MCP server registration, dual registration, plugin cache checks |
-| `_doctor_runtime.py` | Quota cache schema version and claude process state checks |
+| `_doctor_runtime.py` | Quota cache schema version, claude process state, and codex version checks |
 
 ## Architecture Notes
 

--- a/src/autoskillit/cli/doctor/__init__.py
+++ b/src/autoskillit/cli/doctor/__init__.py
@@ -59,6 +59,7 @@ from ._doctor_mcp import (
 )
 from ._doctor_runtime import (
     _check_claude_process_state_breakdown,
+    _check_codex_version,
     _check_quota_cache_schema,
 )
 from ._doctor_types import _NON_PROBLEM, DoctorResult
@@ -190,6 +191,9 @@ def run_doctor(*, output_json: bool = False) -> None:
 
         # Check 29: Fleet state schema version drift
         results.append(_check_fleet_state_schema())
+
+    # Check 30: Codex CLI version gate
+    results.append(_check_codex_version(backend=cfg.agent_backend.backend))
 
     # Output
     if output_json:

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -1,4 +1,4 @@
-"""Quota cache schema and claude process state doctor checks."""
+"""Quota cache schema, claude process state, and codex version doctor checks."""
 
 from __future__ import annotations
 
@@ -6,12 +6,56 @@ import json
 import subprocess
 from pathlib import Path
 
+import regex as re
+
 from autoskillit.core import Severity, get_logger
 from autoskillit.execution import QUOTA_CACHE_SCHEMA_VERSION
 
 from ._doctor_types import DoctorResult
 
 logger = get_logger(__name__)
+
+CODEX_MIN_VERSION: tuple[int, ...] = (0, 130, 0)
+
+
+def _check_codex_version(*, backend: str | None = None) -> DoctorResult:
+    check_name = "codex_version"
+    if backend is not None and backend != "codex":
+        return DoctorResult(Severity.OK, check_name, f"Skipped (backend={backend})")
+    try:
+        result = subprocess.run(
+            ["codex", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return DoctorResult(
+            Severity.OK,
+            check_name,
+            f"codex unavailable ({type(exc).__name__}); skipping version check",
+        )
+
+    for line in result.stdout.splitlines():
+        m = re.search(r"(\d+)\.(\d+)\.(\d+)", line)
+        if m:
+            parsed = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            if parsed < CODEX_MIN_VERSION:
+                min_str = ".".join(str(v) for v in CODEX_MIN_VERSION)
+                cur_str = ".".join(str(v) for v in parsed)
+                return DoctorResult(
+                    Severity.WARNING,
+                    check_name,
+                    f"Codex CLI {cur_str} is below minimum {min_str}",
+                )
+            cur_str = ".".join(str(v) for v in parsed)
+            return DoctorResult(Severity.OK, check_name, f"Codex CLI {cur_str}")
+
+    return DoctorResult(
+        Severity.OK,
+        check_name,
+        "codex --version output unparseable; skipping version check",
+    )
 
 
 def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -36,7 +36,14 @@ def _check_codex_version(*, backend: str | None = None) -> DoctorResult:
             f"codex unavailable ({type(exc).__name__}); skipping version check",
         )
 
-    for line in result.stdout.splitlines():
+    if result.returncode != 0:
+        return DoctorResult(
+            Severity.OK,
+            check_name,
+            f"codex exited {result.returncode}; skipping version check",
+        )
+
+    for line in (result.stdout + result.stderr).splitlines():
         m = re.search(r"(\d+)\.(\d+)\.(\d+)", line)
         if m:
             parsed = (int(m.group(1)), int(m.group(2)), int(m.group(3)))

--- a/tests/cli/test_doctor_backend_guards.py
+++ b/tests/cli/test_doctor_backend_guards.py
@@ -246,11 +246,11 @@ class TestRunDoctorBackendWiring:
 class TestCheckCodexVersion:
     """Tests for _check_codex_version doctor check (Check 30)."""
 
-    def _codex_result(self, stdout: str, returncode: int = 0):
+    def _codex_result(self, stdout: str, returncode: int = 0, stderr: str = ""):
         return type(
             "CompletedProcess",
             (),
-            {"returncode": returncode, "stdout": stdout},
+            {"returncode": returncode, "stdout": stdout, "stderr": stderr},
         )()
 
     def test_skip_for_non_codex_backend(self) -> None:
@@ -302,6 +302,8 @@ class TestCheckCodexVersion:
         )
         result = _check_codex_version()
         assert result.severity == Severity.WARNING
+        assert "0.129.0" in result.message
+        assert "below minimum" in result.message
 
     def test_version_at_minimum_returns_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import subprocess
@@ -316,6 +318,7 @@ class TestCheckCodexVersion:
         )
         result = _check_codex_version()
         assert result.severity == Severity.OK
+        assert "0.130.0" in result.message
 
     def test_version_above_minimum_returns_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import subprocess
@@ -330,3 +333,4 @@ class TestCheckCodexVersion:
         )
         result = _check_codex_version()
         assert result.severity == Severity.OK
+        assert "0.131.0" in result.message

--- a/tests/cli/test_doctor_backend_guards.py
+++ b/tests/cli/test_doctor_backend_guards.py
@@ -241,3 +241,92 @@ class TestRunDoctorBackendWiring:
             run_doctor()
 
         assert captured_backends == ["aider"]
+
+
+class TestCheckCodexVersion:
+    """Tests for _check_codex_version doctor check (Check 30)."""
+
+    def _codex_result(self, stdout: str, returncode: int = 0):
+        return type(
+            "CompletedProcess",
+            (),
+            {"returncode": returncode, "stdout": stdout},
+        )()
+
+    def test_skip_for_non_codex_backend(self) -> None:
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_version
+        from autoskillit.core import Severity
+
+        result = _check_codex_version(backend="claude-code")
+        assert result.severity == Severity.OK
+        assert "skipped" in result.message.lower()
+
+    def test_file_not_found_returns_ok_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_version
+        from autoskillit.core import Severity
+
+        def _raise(*a, **kw):
+            raise FileNotFoundError("codex")
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = _check_codex_version()
+        assert result.severity == Severity.OK
+        assert "unavailable" in result.message.lower()
+
+    def test_timeout_returns_ok_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_version
+        from autoskillit.core import Severity
+
+        def _raise(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd="codex", timeout=5)
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = _check_codex_version()
+        assert result.severity == Severity.OK
+        assert "unavailable" in result.message.lower()
+
+    def test_version_below_minimum_returns_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_version
+        from autoskillit.core import Severity
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._codex_result("Codex 0.129.0\n"),
+        )
+        result = _check_codex_version()
+        assert result.severity == Severity.WARNING
+
+    def test_version_at_minimum_returns_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_version
+        from autoskillit.core import Severity
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._codex_result("Codex 0.130.0\n"),
+        )
+        result = _check_codex_version()
+        assert result.severity == Severity.OK
+
+    def test_version_above_minimum_returns_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_version
+        from autoskillit.core import Severity
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._codex_result("Codex 0.131.0\n"),
+        )
+        result = _check_codex_version()
+        assert result.severity == Severity.OK

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -235,21 +235,14 @@ def test_quota_thresholds_defaults() -> None:
 
 
 def test_doctor_check_count_is_31() -> None:
-    # _count_doctor_checks() counts every "# Check N:" and "# Check Nb:" marker
-    # in run_doctor() — 17 numbered base markers + 7 lettered sub-check markers
-    # (2b, 2c, 2d, 2e, 4b, 7b, 7c) + 4 ambient env checks (18–21)
-    # + 2 new unconditional feature checks (22–23)
-    # + 6 gated franchise checks (24–29) = 36.
-    # + 1 unconditional Codex CLI version check (30) = 37 total.
-    # test_installation_states_17_doctor_checks checks the *user-visible* count
-    # from docs/installation.md ("15 numbered + 2 lettered sub-checks 4b and 7b
-    # = 17").  The gap of 5 is intentional: Check 2, Check 4, and Check 7 each
-    # appear as separate implementation markers but the docs present them as single
-    # numbered entries that subsume their sub-variants.
+    # 37 total = 17 numbered base + 7 lettered sub-checks (2b–2e, 4b, 7b, 7c)
+    # + 4 ambient env (18–21) + 2 feature (22–23) + 6 gated franchise (24–29)
+    # + 1 codex version (30).
+    # The docs claim 17 user-visible checks; the gap is intentional (Check 2/4/7
+    # split into sub-markers here but appear as single entries in docs).
     # Update both tests whenever a new doctor check is added.
-    assert _count_doctor_checks() == 37, (
-        f"Expected 37 doctor checks; found {_count_doctor_checks()}"
-    )
+    count = _count_doctor_checks()
+    assert count == 37, f"Expected 37 doctor checks; found {count}"
 
 
 def test_bundled_recipe_count_is_14() -> None:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -236,18 +236,19 @@ def test_quota_thresholds_defaults() -> None:
 
 def test_doctor_check_count_is_31() -> None:
     # _count_doctor_checks() counts every "# Check N:" and "# Check Nb:" marker
-    # in run_doctor() — 17 numbered base markers + 6 lettered sub-check markers
-    # (2b, 2c, 2d, 2e, 4b, 7b) + 4 ambient env checks (18–21)
+    # in run_doctor() — 17 numbered base markers + 7 lettered sub-check markers
+    # (2b, 2c, 2d, 2e, 4b, 7b, 7c) + 4 ambient env checks (18–21)
     # + 2 new unconditional feature checks (22–23)
-    # + 6 gated franchise checks (24–29) = 35 total.
+    # + 6 gated franchise checks (24–29) = 36.
+    # + 1 unconditional Codex CLI version check (30) = 37 total.
     # test_installation_states_17_doctor_checks checks the *user-visible* count
     # from docs/installation.md ("15 numbered + 2 lettered sub-checks 4b and 7b
     # = 17").  The gap of 5 is intentional: Check 2, Check 4, and Check 7 each
     # appear as separate implementation markers but the docs present them as single
     # numbered entries that subsume their sub-variants.
     # Update both tests whenever a new doctor check is added.
-    assert _count_doctor_checks() == 36, (
-        f"Expected 36 doctor checks; found {_count_doctor_checks()}"
+    assert _count_doctor_checks() == 37, (
+        f"Expected 37 doctor checks; found {_count_doctor_checks()}"
     )
 
 


### PR DESCRIPTION
## Summary

Add `_check_codex_version` to `_doctor_runtime.py` — a doctor check that guards against running autoskillit against an unsupported Codex CLI version. The function short-circuits with OK for non-codex backends, catches subprocess errors gracefully, parses semver from `codex --version` stdout, and compares against `CODEX_MIN_VERSION = (0, 130, 0)`. Wire as Check 30 in `run_doctor` after the fleet-gated block. Add 6 test methods covering all behavioral paths. Update the doctor check count test and CLAUDE.md description to reflect the new check.

## Changed Files

### Modified (●):
● src/autoskillit/cli/doctor/CLAUDE.md
● src/autoskillit/cli/doctor/__init__.py
● src/autoskillit/cli/doctor/_doctor_runtime.py
● tests/cli/test_doctor_backend_guards.py
● tests/docs/test_doc_counts.py

Closes #2708

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-133322-910064/.autoskillit/temp/make-plan/px6_p6_a5_wp1_codex_version_check_plan_2026-05-23_134600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 67 | 15.0k | 1.2M | 93.6k | 87 | 72.5k | 10m 35s |
| verify | claude-opus-4-6 | 1 | 266 | 15.2k | 887.2k | 67.6k | 52 | 52.1k | 6m 33s |
| implement* | MiniMax-M2.7-highspeed | 1 | 606.4k | 7.0k | 803.4k | 56.2k | 70 | 40.4k | 2m 37s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 118.3k | 3.8k | 295.1k | 29.8k | 21 | 15.1k | 1m 30s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.7k | 1.3k | 205.7k | 29.8k | 17 | 14.7k | 38s |
| review_pr | claude-sonnet-4-6 | 1 | 108 | 27.3k | 595.5k | 69.5k | 40 | 54.4k | 6m 17s |
| resolve_review | claude-opus-4-6 | 1 | 51 | 13.6k | 1.4M | 71.9k | 47 | 57.1k | 7m 38s |
| **Total** | | | 771.9k | 83.2k | 5.4M | 93.6k | | 306.3k | 35m 50s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 152 | 5285.3 | 265.5 | 45.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 38 | 38045.9 | 1502.1 | 358.1 |
| **Total** | **190** | 28365.3 | 1612.3 | 438.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 175 | 42.3k | 1.8M | 126.9k | 16m 52s |
| claude-opus-4-6 | 2 | 317 | 28.8k | 2.3M | 109.2k | 14m 11s |
| MiniMax-M2.7-highspeed | 3 | 771.4k | 12.1k | 1.3M | 70.2k | 4m 46s |