### PR TITLE
[FEATURE] Prevent SCENARIO_STEP_NAME, AUTOSKILLIT_ALLOWED_WRITE_PREFIX, and MAX_MCP_OUTPUT_TOKENS from leaking into Codex subprocess environments

### DIFF
--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -104,7 +104,9 @@ AGENT_BACKEND_CODEX: str = "codex"
 
 # Env vars that control MCP server-level behavior and must not leak into
 # user-code subprocesses (pytest runs, shell commands, etc.).
-# Add new internal vars here as they are introduced.
+# Three-list sync: vars here may also appear in _HEADLESS_EXCLUSIVE_VARS
+# (execution/backends/claude.py) and IDE_ENV_DENYLIST (core/_claude_env.py).
+# Keep all three lists in sync when adding new exclusive variables.
 AUTOSKILLIT_PRIVATE_ENV_VARS: frozenset[str] = frozenset(
     {
         "AUTOSKILLIT_HEADLESS",
@@ -127,6 +129,10 @@ AUTOSKILLIT_PRIVATE_ENV_VARS: frozenset[str] = frozenset(
         "AUTOSKILLIT_SKILL_NAME",
         # Provider-routing vars — must not leak into user-code subprocesses
         "AUTOSKILLIT_PROVIDER_PROFILE",
+        # Execution-control vars — must not leak into Codex subprocess environments
+        "SCENARIO_STEP_NAME",
+        "AUTOSKILLIT_ALLOWED_WRITE_PREFIX",
+        "MAX_MCP_OUTPUT_TOKENS",
     }
 )
 

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -95,6 +95,18 @@ def test_private_env_vars_includes_franchise_tier_vars() -> None:
     assert "AUTOSKILLIT_L3_TOOL_TAGS" not in AUTOSKILLIT_PRIVATE_ENV_VARS
 
 
+def test_private_env_vars_includes_execution_control_vars() -> None:
+    """Execution-control vars must not leak into Codex subprocess environments."""
+    from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS
+
+    expected = {
+        "SCENARIO_STEP_NAME",
+        "AUTOSKILLIT_ALLOWED_WRITE_PREFIX",
+        "MAX_MCP_OUTPUT_TOKENS",
+    }
+    assert expected <= AUTOSKILLIT_PRIVATE_ENV_VARS
+
+
 def test_campaign_id_env_var_and_kitchen_session_id_env_var_exported_from_core() -> None:
     """CAMPAIGN_ID_ENV_VAR and KITCHEN_SESSION_ID_ENV_VAR are re-exported from autoskillit.core."""
     from autoskillit.core import CAMPAIGN_ID_ENV_VAR, KITCHEN_SESSION_ID_ENV_VAR


### PR DESCRIPTION
## Summary

Add three execution-control environment variables (`SCENARIO_STEP_NAME`, `AUTOSKILLIT_ALLOWED_WRITE_PREFIX`, `MAX_MCP_OUTPUT_TOKENS`) to the `AUTOSKILLIT_PRIVATE_ENV_VARS` frozenset in `_type_constants.py`. These variables already exist in the sister lists `_HEADLESS_EXCLUSIVE_VARS` (claude.py) and `IDE_ENV_DENYLIST` (_claude_env.py), but are missing from the private-env-vars set that `build_agent_env()` uses to scrub the environment before launching Codex subprocesses. Update the comment block above the frozenset to document the three-list sync requirement.

Closes #2705

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-133321-374369/.autoskillit/temp/make-plan/prevent_env_var_leakage_plan_2026-05-23_133600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 58 | 4.7k | 508.6k | 53.1k | 31 | 40.5k | 2m 57s |
| verify | claude-opus-4-6 | 1 | 45 | 6.5k | 356.1k | 55.2k | 44 | 40.0k | 3m 39s |
| implement* | MiniMax-M2.7-highspeed | 1 | 413.1k | 4.1k | 593.2k | 29.8k | 43 | 15.6k | 1m 57s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 69.0k | 2.7k | 235.7k | 29.8k | 21 | 15.1k | 1m 9s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 56.6k | 1.9k | 235.7k | 29.8k | 19 | 14.8k | 45s |
| review_pr | claude-sonnet-4-6 | 3 | 268 | 30.4k | 1.1M | 47.6k | 90 | 97.1k | 8m 42s |
| resolve_review | claude-opus-4-6 | 1 | 41 | 6.9k | 629.6k | 55.0k | 40 | 40.4k | 6m 31s |
| **Total** | | | 539.2k | 57.1k | 3.7M | 55.2k | | 263.6k | 25m 41s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 20 | 29660.0 | 781.0 | 204.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **20** | 185323.0 | 13177.7 | 2856.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 144 | 18.1k | 1.5M | 120.9k | 13m 8s |
| MiniMax-M2.7-highspeed | 3 | 538.7k | 8.7k | 1.1M | 45.5k | 3m 50s |
| claude-sonnet-4-6 | 1 | 268 | 30.4k | 1.1M | 97.1k | 8m 42s |