### PR TITLE
PX6 P6-A6-WP1: Add TestRecoveryWriteNameWiring and TestComputeWriteEvidenceCodex

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -45,7 +45,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_headless_provider_forwarding.py` | Tests verifying provider_extras and profile_name forwarding through the headless call chain |
 | `test_headless_result_write_reconciliation.py` | Integration tests for EMPTY_OUTPUT + write-evidence reconciliation gate in _build_skill_result |
 | `test_headless_synthesis.py` | Tests for headless.py synthesis helpers: output path extraction, validation, contamination |
-| `test_headless_result.py` | Tests for _build_skill_result: idle_stall lifespan_started, kill_reason propagation, backend delegation, write evidence, and Codex NDJSON pipeline (happy path, turn failed, termination branches) |
+| `test_headless_result.py` | Tests for _build_skill_result: idle_stall lifespan_started, kill_reason propagation, backend delegation, write evidence, recovery write-name wiring, Codex write-evidence computation, and Codex NDJSON pipeline (happy path, turn failed, termination branches) |
 | `test_idle_output_env.py` | Group G (execution part): AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env variable injection tests |
 | `test_linux_tracing.py` | Tests for Linux-only process tracing via psutil and /proc filesystem |
 | `test_linux_tracing_pty_integration.py` | Integration test: PTY-wrapped command is traced at the workload level, not the wrapper |

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -27,7 +27,10 @@ from autoskillit.execution.headless import (
     _parse_stdout,
     _synthesize_from_write_artifacts,
 )
-from autoskillit.execution.headless._headless_result import _adapt_agent_result
+from autoskillit.execution.headless._headless_result import (
+    _adapt_agent_result,
+    _compute_write_evidence,
+)
 from autoskillit.execution.session import ClaudeSessionResult
 from autoskillit.execution.session._session_outcome import _compute_outcome
 from tests.execution.conftest import _make_tool_use_line, _sr, _success_session_json
@@ -537,7 +540,6 @@ class TestComputeWriteEvidenceCodex:
     """Codex file_changes path: _compute_write_evidence with file_changes parameter."""
 
     def test_single_file_change_has_evidence(self):
-        from autoskillit.execution.headless._headless_result import _compute_write_evidence
 
         session = ClaudeSessionResult(
             subtype=CliSubtype.SUCCESS,
@@ -559,7 +561,6 @@ class TestComputeWriteEvidenceCodex:
         assert evidence.file_changes_count == 1
 
     def test_multiple_file_changes_has_evidence(self):
-        from autoskillit.execution.headless._headless_result import _compute_write_evidence
 
         session = ClaudeSessionResult(
             subtype=CliSubtype.SUCCESS,
@@ -581,7 +582,6 @@ class TestComputeWriteEvidenceCodex:
         assert evidence.file_changes_count == 3
 
     def test_empty_file_changes_no_write_tools_no_evidence(self):
-        from autoskillit.execution.headless._headless_result import _compute_write_evidence
 
         session = ClaudeSessionResult(
             subtype=CliSubtype.SUCCESS,
@@ -1137,7 +1137,6 @@ class TestExtractFileChanges:
 
 class TestComputeWriteEvidenceWithFileChanges:
     def test_compute_write_evidence_sets_file_changes_count_when_no_write_calls(self) -> None:
-        from autoskillit.execution.headless._headless_result import _compute_write_evidence
 
         session = ClaudeSessionResult(
             subtype=CliSubtype.SUCCESS,
@@ -1151,7 +1150,6 @@ class TestComputeWriteEvidenceWithFileChanges:
         assert evidence.has_evidence is True
 
     def test_compute_write_evidence_ignores_file_changes_when_write_calls_exist(self) -> None:
-        from autoskillit.execution.headless._headless_result import _compute_write_evidence
 
         session = ClaudeSessionResult(
             subtype=CliSubtype.SUCCESS,

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -19,8 +19,14 @@ from autoskillit.core.types import (
     TerminationReason,
     WriteEvidence,
 )
+from autoskillit.execution.backends.claude import ClaudeResultParser
 from autoskillit.execution.backends.codex import CodexBackend
-from autoskillit.execution.headless import _build_skill_result, _parse_stdout
+from autoskillit.execution.headless import (
+    _build_skill_result,
+    _extract_missing_token_hints,
+    _parse_stdout,
+    _synthesize_from_write_artifacts,
+)
 from autoskillit.execution.headless._headless_result import _adapt_agent_result
 from autoskillit.execution.session import ClaudeSessionResult
 from autoskillit.execution.session._session_outcome import _compute_outcome
@@ -187,6 +193,16 @@ def _codex_subprocess_result(
         pid=12345,
         session_id="",
         channel_b_session_id="",
+    )
+
+
+def _make_session(tool_name: str, file_path: str) -> ClaudeSessionResult:
+    return ClaudeSessionResult(
+        subtype=CliSubtype.SUCCESS,
+        is_error=False,
+        result="",
+        session_id="s-wiring",
+        tool_uses=[{"name": tool_name, "id": "t1", "file_path": file_path}],
     )
 
 
@@ -434,6 +450,157 @@ class TestBackendDelegatedWriteToolNames:
         _build_skill_result(result, backend=mock_backend)
         assert "backend" in captured, "_parse_stdout was not called"
         assert captured["backend"] is mock_backend
+
+
+class TestRecoveryWriteNameWiring:
+    """Write-tool-name wiring: _synthesize and _extract respect write_tool_names."""
+
+    def test_synthesize_recognizes_non_default_write_tool_name(self):
+        session = _make_session("CustomWrite", "/tmp/plan.md")
+        result = _synthesize_from_write_artifacts(
+            session,
+            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            write_call_count=1,
+            write_tool_names=frozenset({"CustomWrite"}),
+        )
+        assert result is not None
+
+    def test_synthesize_ignores_claude_names_when_write_tool_names_empty(self):
+        session = _make_session("Write", "/tmp/plan.md")
+        result = _synthesize_from_write_artifacts(
+            session,
+            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            write_call_count=1,
+            write_tool_names=frozenset(),
+        )
+        assert result is None
+
+    def test_synthesize_explicit_frozenset_overrides_default(self):
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.SUCCESS,
+            is_error=False,
+            result="",
+            session_id="s-wiring",
+            tool_uses=[
+                {"name": "Write", "id": "t1", "file_path": "/tmp/wrong.md"},
+                {"name": "CustomEdit", "id": "t2", "file_path": "/tmp/right.md"},
+            ],
+        )
+        result = _synthesize_from_write_artifacts(
+            session,
+            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            write_call_count=2,
+            write_tool_names=frozenset({"CustomEdit"}),
+        )
+        assert result is not None
+        assert "/tmp/right.md" in result.result
+        assert "/tmp/wrong.md" not in result.result
+
+    def test_extract_hints_recognizes_non_default_write_tool_name(self):
+        mock_parser = Mock()
+        mock_parser.parse_stdout.return_value = AgentSessionResult(
+            success=True,
+            exit_code=0,
+            backend_name="test",
+            elapsed_seconds=0.0,
+            session_id="s1",
+            output="done",
+            error="",
+            raw={
+                "tool_uses": [{"name": "CustomWrite", "id": "t1", "file_path": "/tmp/plan.md"}],
+            },
+        )
+        hints = _extract_missing_token_hints(
+            "",
+            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            result_parser=mock_parser,
+            write_tool_names=frozenset({"CustomWrite"}),
+        )
+        assert len(hints) > 0
+
+    def test_extract_hints_ignores_claude_names_when_write_tool_names_empty(self):
+        stdout = (
+            _tool_use_ndjson("Write", file_path="/tmp/plan.md")
+            + "\n"
+            + _success_result_json("done")
+        )
+        hints = _extract_missing_token_hints(
+            stdout,
+            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            result_parser=ClaudeResultParser(),
+            write_tool_names=frozenset(),
+        )
+        assert len(hints) == 0
+
+
+class TestComputeWriteEvidenceCodex:
+    """Codex file_changes path: _compute_write_evidence with file_changes parameter."""
+
+    def test_single_file_change_has_evidence(self):
+        from autoskillit.execution.headless._headless_result import _compute_write_evidence
+
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.SUCCESS,
+            is_error=False,
+            result="done",
+            session_id="s1",
+            tool_uses=[],
+        )
+        backend = Mock()
+        backend.write_tool_names.return_value = frozenset()
+        evidence = _compute_write_evidence(
+            session,
+            False,
+            False,
+            backend=backend,
+            file_changes=["src/foo.py"],
+        )
+        assert evidence.has_evidence is True
+        assert evidence.file_changes_count == 1
+
+    def test_multiple_file_changes_has_evidence(self):
+        from autoskillit.execution.headless._headless_result import _compute_write_evidence
+
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.SUCCESS,
+            is_error=False,
+            result="done",
+            session_id="s1",
+            tool_uses=[],
+        )
+        backend = Mock()
+        backend.write_tool_names.return_value = frozenset()
+        evidence = _compute_write_evidence(
+            session,
+            False,
+            False,
+            backend=backend,
+            file_changes=["a.py", "b.py", "c.py"],
+        )
+        assert evidence.has_evidence is True
+        assert evidence.file_changes_count == 3
+
+    def test_empty_file_changes_no_write_tools_no_evidence(self):
+        from autoskillit.execution.headless._headless_result import _compute_write_evidence
+
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.SUCCESS,
+            is_error=False,
+            result="done",
+            session_id="s1",
+            tool_uses=[],
+        )
+        backend = Mock()
+        backend.write_tool_names.return_value = frozenset()
+        evidence = _compute_write_evidence(
+            session,
+            False,
+            False,
+            backend=backend,
+            file_changes=[],
+        )
+        assert evidence.has_evidence is False
+        assert evidence.file_changes_count == 0
 
 
 class TestParseStdout:


### PR DESCRIPTION
## Summary

Add two test classes to `tests/execution/test_headless_result.py`:
1. **TestRecoveryWriteNameWiring** (5 tests) — validates that `_synthesize_from_write_artifacts` and `_extract_missing_token_hints` correctly respect the `write_tool_names` parameter, including custom tool names and empty frozensets.
2. **TestComputeWriteEvidenceCodex** (3 tests) — validates that `_compute_write_evidence` correctly handles the `file_changes` Codex fallback path, setting `file_changes_count` and `has_evidence` appropriately.

Both classes are xdist-safe (inline `ClaudeSessionResult` construction, no shared state) and carry the module-level `pytestmark` markers.

## Requirements

## Goal

Add TestRecoveryWriteNameWiring and TestComputeWriteEvidenceCodex to test_headless_result.py covering write_tool_names parameterization and file_changes-based evidence detection.

## Context

- Phase: Recovery Paths, Edge Cases & Hardening (Milestone: 6-recovery-paths-edge-cases-hardening)
- Assignment: P6-A6 (Add tests for all five changes: recovery write-name wiring, env var set membership, Codex write evidence, context exhaustion classification, and doctor version check)
- Depends on: P6-A1-WP1, P6-A3-WP1
- Depended on by: None

## Deliverables

- `TestRecoveryWriteNameWiring class in test_headless_result.py with 5 unit tests`
- `TestComputeWriteEvidenceCodex class with three test methods: single file_change, multiple file_changes, empty file_changes`

## Acceptance Criteria

- pytest tests/execution/test_headless_result.py::TestRecoveryWriteNameWiring collects 5 tests and all pass.
- test_synthesize_recognizes_non_default_write_tool_name returns non-None for CustomWrite with matching frozenset.
- test_synthesize_ignores_claude_names_when_write_tool_names_empty returns None for 'Write' with empty frozenset.
- test_synthesize_explicit_frozenset_overrides_default synthesizes from CustomEdit, not Write.
- test_extract_hints_recognizes_non_default_write_tool_name returns non-empty hints.
- test_extract_hints_ignores_claude_names_when_write_tool_names_empty returns empty hints.
- All tests are xdist-safe.
- test_single_file_change_has_evidence: has_evidence=True and file_changes_count==1.
- test_multiple_file_changes_has_evidence: has_evidence=True and file_changes_count==3.
- test_empty_file_changes_no_write_tools_no_evidence: has_evidence=False and file_changes_count==0.
- All tests xdist-safe.
- Module-level pytestmark applies.
- Mock backend isolates file_changes path.

## Changed Files

- tests/execution/CLAUDE.md
- tests/execution/test_headless_result.py

Closes #2709

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-163150-762671/.autoskillit/temp/make-plan/add_test_recovery_write_name_wiring_and_test_compute_write_evidence_codex_plan_2026-05-23_163600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.1k | 9.7k | 1.0M | 81.1k | 116 | 57.9k | 8m 49s |
| verify | claude-opus-4-6 | 1 | 57 | 24.5k | 1.3M | 90.0k | 80 | 79.8k | 10m 14s |
| implement* | MiniMax-M2.7 | 1 | 73.5k | 5.1k | 1.3M | 0 | 52 | 0 | 5m 22s |
| prepare_pr* | MiniMax-M2.7 | 1 | 46.0k | 3.4k | 321.3k | 0 | 22 | 0 | 1m 2s |
| compose_pr* | MiniMax-M2.7 | 1 | 40.9k | 2.2k | 272.0k | 0 | 18 | 0 | 29s |
| review_pr | claude-opus-4-6 | 3 | 115 | 36.2k | 1.4M | 55.0k | 86 | 117.2k | 10m 30s |
| resolve_review | claude-opus-4-6 | 1 | 55 | 5.1k | 901.9k | 55.4k | 36 | 40.4k | 3m 21s |
| **Total** | | | 162.7k | 86.2k | 6.6M | 90.0k | | 295.3k | 39m 49s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 171 | 7851.0 | 0.0 | 29.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 90188.2 | 4041.3 | 513.5 |
| **Total** | **181** | 36422.3 | 1631.5 | 476.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 2.1k | 9.7k | 1.0M | 57.9k | 8m 49s |
| claude-opus-4-6 | 3 | 227 | 65.8k | 3.6M | 237.5k | 24m 6s |
| MiniMax-M2.7 | 3 | 160.4k | 10.7k | 1.9M | 0 | 6m 53s |