### PR TITLE
Add membership assertion tests for private env vars

### DIFF
--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -407,3 +407,24 @@ def test_headless_auto_gate_env_var_in_private_env_vars() -> None:
     from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS
 
     assert "AUTOSKILLIT_HEADLESS_AUTO_GATE" in AUTOSKILLIT_PRIVATE_ENV_VARS
+
+
+def test_scenario_step_name_in_private_env_vars() -> None:
+    """SCENARIO_STEP_NAME must be in AUTOSKILLIT_PRIVATE_ENV_VARS."""
+    from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS
+
+    assert "SCENARIO_STEP_NAME" in AUTOSKILLIT_PRIVATE_ENV_VARS
+
+
+def test_autoskillit_allowed_write_prefix_in_private_env_vars() -> None:
+    """AUTOSKILLIT_ALLOWED_WRITE_PREFIX must be in AUTOSKILLIT_PRIVATE_ENV_VARS."""
+    from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS
+
+    assert "AUTOSKILLIT_ALLOWED_WRITE_PREFIX" in AUTOSKILLIT_PRIVATE_ENV_VARS
+
+
+def test_max_mcp_output_tokens_in_private_env_vars() -> None:
+    """MAX_MCP_OUTPUT_TOKENS must be in AUTOSKILLIT_PRIVATE_ENV_VARS."""
+    from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS
+
+    assert "MAX_MCP_OUTPUT_TOKENS" in AUTOSKILLIT_PRIVATE_ENV_VARS


### PR DESCRIPTION
## Summary

Add three focused membership-assertion tests to `tests/core/test_type_constants.py` confirming that `SCENARIO_STEP_NAME`, `AUTOSKILLIT_ALLOWED_WRITE_PREFIX`, and `MAX_MCP_OUTPUT_TOKENS` are present in `AUTOSKILLIT_PRIVATE_ENV_VARS`. Each test follows the established single-assertion pattern with a local import.

All three variables are already present in the `AUTOSKILLIT_PRIVATE_ENV_VARS` frozenset (added by P6-A2-WP1 at `src/autoskillit/core/types/_type_constants.py:134-136`), so the tests will pass immediately.

## Requirements

Confirm that SCENARIO_STEP_NAME, AUTOSKILLIT_ALLOWED_WRITE_PREFIX, and MAX_MCP_OUTPUT_TOKENS are present in AUTOSKILLIT_PRIVATE_ENV_VARS via three focused membership assertion tests.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-163151-753412/.autoskillit/temp/make-plan/px6_p6_a6_wp2_private_env_var_membership_tests_plan_2026-05-23_163600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 57 | 3.8k | 420.7k | 44.1k | 28 | 30.6k | 2m 24s |
| verify | claude-opus-4-6 | 1 | 26 | 7.6k | 332.4k | 61.5k | 17 | 46.6k | 3m 1s |
| implement* | MiniMax-M2.7 | 1 | 68.3k | 2.3k | 474.2k | 0 | 29 | 0 | 1m 9s |
| prepare_pr* | MiniMax-M2.7 | 1 | 63.3k | 3.0k | 420.0k | 21.1k | 27 | 0 | 1m 28s |
| compose_pr* | MiniMax-M2.7 | 1 | 38.0k | 1.5k | 272.9k | 0 | 20 | 0 | 1m 9s |
| review_pr | claude-opus-4-6 | 3 | 160 | 21.8k | 1.0M | 45.9k | 79 | 88.0k | 7m 36s |
| **Total** | | | 169.9k | 40.0k | 2.9M | 61.5k | | 165.2k | 16m 49s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 21 | 22581.1 | 0.0 | 109.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **21** | 140259.8 | 7866.4 | 1904.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 3 | 243 | 33.2k | 1.8M | 165.2k | 13m 2s |
| MiniMax-M2.7 | 3 | 169.7k | 6.8k | 1.2M | 0 | 3m 46s |