### PR TITLE
Rectify: Multi-Signal Evidence Architecture for Session Classification

### DIFF
--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -478,6 +478,7 @@ def _build_skill_result(
     try:
         _backend_write_names = set(backend.write_tool_names()) if backend else {"Write", "Edit"}
     except Exception:
+        logger.warning("backend_write_tool_names_failed", exc_info=True)
         _backend_write_names = {"Write", "Edit"}
     _parsed_has_write_tools = any(tu.get("name") in {"Write", "Edit"} for tu in session.tool_uses)
     if (
@@ -728,51 +729,35 @@ def _build_skill_result(
                 warnings=write_path_warnings[:5],
             )
 
+    sr = SkillResult(
+        success=success,
+        result=result_text,
+        session_id=session.session_id or result.session_id,
+        subtype=normalized_subtype,
+        is_error=session.is_error,
+        exit_code=returncode,
+        needs_retry=needs_retry,
+        retry_reason=retry_reason,
+        stderr=_truncate(result.stderr),
+        token_usage=session.token_usage,
+        worktree_path=effective_worktree_path,
+        cli_subtype=session.subtype,
+        write_path_warnings=write_path_warnings,
+        evidence=evidence,
+        kill_reason=result.kill_reason,
+        last_stop_reason=session.last_stop_reason,
+        lifespan_started=session.lifespan_started,
+        provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
+        infra=InfraOutcome(exit_category=infra_category.value),
+        api_retry=api_retry,
+    )
     if path_contamination:
-        sr = SkillResult(
+        sr = dataclasses.replace(
+            sr,
             success=False,
-            result=result_text,
-            session_id=session.session_id or result.session_id,
             subtype="path_contamination",
-            is_error=session.is_error,
-            exit_code=returncode,
             needs_retry=True,
             retry_reason=RetryReason.PATH_CONTAMINATION,
-            stderr=_truncate(result.stderr),
-            token_usage=session.token_usage,
-            worktree_path=effective_worktree_path,
-            cli_subtype=session.subtype,
-            write_path_warnings=write_path_warnings,
-            evidence=evidence,
-            kill_reason=result.kill_reason,
-            last_stop_reason=session.last_stop_reason,
-            lifespan_started=session.lifespan_started,
-            provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
-            infra=InfraOutcome(exit_category=infra_category.value),
-            api_retry=api_retry,
-        )
-    else:
-        sr = SkillResult(
-            success=success,
-            result=result_text,
-            session_id=session.session_id or result.session_id,
-            subtype=normalized_subtype,
-            is_error=session.is_error,
-            exit_code=returncode,
-            needs_retry=needs_retry,
-            retry_reason=retry_reason,
-            stderr=_truncate(result.stderr),
-            token_usage=session.token_usage,
-            worktree_path=effective_worktree_path,
-            cli_subtype=session.subtype,
-            write_path_warnings=write_path_warnings,
-            evidence=evidence,
-            kill_reason=result.kill_reason,
-            last_stop_reason=session.last_stop_reason,
-            lifespan_started=session.lifespan_started,
-            provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
-            infra=InfraOutcome(exit_category=infra_category.value),
-            api_retry=api_retry,
         )
     sr = _apply_budget_guard(sr, skill_command, audit, max_consecutive_retries)
 

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -348,9 +348,12 @@ def _build_skill_result(
             stderr=result.stderr if result.stderr else "",
             audit=audit,
         )
+        _stale_is_api_error = stale_session.api_retry_exhausted or (
+            stale_session.api_error_status is not None and stale_session.api_error_status >= 400
+        )
         stale_infra = (
             InfraOutcome(exit_category=InfraExitCategory.API_ERROR.value)
-            if stale_session.api_retry_exhausted
+            if _stale_is_api_error
             else InfraOutcome()
         )
         stale_sr = _make_terminated_result(
@@ -423,9 +426,12 @@ def _build_skill_result(
         logger.warning(
             "Headless session killed: stdout idle for configured threshold (IDLE_STALL)"
         )
+        _idle_is_api_error = idle_session.api_retry_exhausted or (
+            idle_session.api_error_status is not None and idle_session.api_error_status >= 400
+        )
         idle_infra = (
             InfraOutcome(exit_category=InfraExitCategory.API_ERROR.value)
-            if idle_session.api_retry_exhausted
+            if _idle_is_api_error
             else InfraOutcome()
         )
         idle_sr = _make_terminated_result(
@@ -469,12 +475,24 @@ def _build_skill_result(
     )
     _has_write_evidence = evidence.has_evidence
 
-    if evidence.write_call_count == 0 and _stdout_mentions_write_tools(result.stdout):
+    try:
+        _backend_write_names = set(backend.write_tool_names()) if backend else {"Write", "Edit"}
+    except Exception:
+        _backend_write_names = {"Write", "Edit"}
+    _parsed_has_write_tools = any(tu.get("name") in {"Write", "Edit"} for tu in session.tool_uses)
+    if (
+        evidence.write_call_count == 0
+        and _backend_write_names & {"Write", "Edit"}
+        and _stdout_mentions_write_tools(result.stdout)
+        and not _parsed_has_write_tools
+    ):
         logger.warning(
             "write_call_count_cross_check_mismatch",
             stdout_length=len(result.stdout),
             tool_use_count=len(session.tool_uses),
         )
+        evidence = dataclasses.replace(evidence, write_call_count=1)
+        _has_write_evidence = True
 
     # Channel B drain-race: recover from assistant_messages if type=result was not flushed.
     match result.channel_confirmation:

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -23,6 +23,7 @@ _API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"socket hang up", re.IGNORECASE),
     re.compile(r"network error", re.IGNORECASE),
     re.compile(r"connection reset", re.IGNORECASE),
+    re.compile(r"rate.limited", re.IGNORECASE),
 )
 
 _CODEX_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
@@ -61,6 +62,8 @@ def classify_infra_exit(
     # api_retry_last_error can be "unknown" or another value not in _KNOWN_API_ERROR_PATTERNS.
     # In that case _has_api_error() returns False while api_retry_exhausted is still True.
     if session.api_retry_exhausted:
+        return InfraExitCategory.API_ERROR
+    if session.api_error_status is not None and session.api_error_status >= 400:
         return InfraExitCategory.API_ERROR
     if result.returncode is not None and result.returncode < 0:
         return InfraExitCategory.PROCESS_KILLED

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -73,6 +73,7 @@ class ClaudeSessionResult:
     api_retry_last_error: str = ""
     api_retry_last_status: int | None = None
     api_retry_exhausted: bool = False
+    api_error_status: int | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.result, str):
@@ -302,7 +303,7 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
 
 
 _KNOWN_RESULT_KEYS: frozenset[str] = frozenset(
-    {"type", "subtype", "is_error", "result", "session_id", "errors", "usage"}
+    {"type", "subtype", "is_error", "result", "session_id", "errors", "usage", "api_error_status"}
 )
 
 
@@ -321,6 +322,7 @@ class _ParseAccumulator:
     api_retry_last_error: str = ""
     api_retry_last_status: int | None = None
     api_retry_exhausted: bool = False
+    api_error_status: int | None = None
 
 
 def parse_session_result(stdout: str) -> ClaudeSessionResult:
@@ -368,8 +370,17 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
                     acc.api_retry_exhausted = True
                 continue
 
+            if record_type == "rate_limit_event":
+                info = obj.get("rate_limit_info") or obj
+                if isinstance(info, dict) and info.get("status") == "rejected":
+                    acc.api_retry_exhausted = True
+                continue
+
             if record_type == "result":
                 acc.result_obj = obj
+                raw_status = obj.get("api_error_status")
+                if isinstance(raw_status, int):
+                    acc.api_error_status = raw_status
             elif record_type == "assistant":
                 msg = obj.get("message")
                 if isinstance(msg, dict):
@@ -454,6 +465,9 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
             fallback = json.loads(stdout)
             if isinstance(fallback, dict) and fallback.get("type") == "result":
                 acc.result_obj = fallback
+                raw_status = fallback.get("api_error_status")
+                if isinstance(raw_status, int):
+                    acc.api_error_status = raw_status
         except json.JSONDecodeError:
             pass
 
@@ -497,4 +511,5 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
         api_retry_last_error=acc.api_retry_last_error,
         api_retry_last_status=acc.api_retry_last_status,
         api_retry_exhausted=acc.api_retry_exhausted,
+        api_error_status=acc.api_error_status,
     )

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -86,7 +86,6 @@ class ClaudeSessionResult:
                     block_type = ClaudeContentBlockType.from_api(b.get("type", ""))
                     if block_type == ClaudeContentBlockType.TEXT:
                         parts.append(b.get("text", ""))
-                    # Non-text blocks (thinking, tool_use, etc.) contribute no text
                 self.result = "\n".join(parts)
             elif not isinstance(self.result, str):
                 self.result = "" if self.result is None else str(self.result)
@@ -111,25 +110,18 @@ class ClaudeSessionResult:
             return False
         marker = CONTEXT_EXHAUSTION_MARKER
         codex = CODEX_CONTEXT_EXHAUSTION_MARKER
-        if any(marker in e.lower() or codex in e.lower() for e in self.errors):
-            return True
-        if codex in self.result.lower():
-            return True
-        if (
-            self.subtype in (CliSubtype.SUCCESS, CliSubtype.ERROR_MAX_TURNS)
-            and marker in self.result.lower()
-        ):
-            return True
-        if any(codex in m.lower() for m in self.assistant_messages):
-            return True
-        return False
+        return (
+            any(marker in e.lower() or codex in e.lower() for e in self.errors)
+            or codex in self.result.lower()
+            or (
+                self.subtype in (CliSubtype.SUCCESS, CliSubtype.ERROR_MAX_TURNS)
+                and marker in self.result.lower()
+            )
+            or any(codex in m.lower() for m in self.assistant_messages)
+        )
 
     def _has_api_error(self) -> bool:
-        """True when the session encountered an API infrastructure error.
-
-        Scans assistant_messages, errors, and result for API error patterns.
-        This is the channel-agnostic counterpart to _is_context_exhausted().
-        """
+        """True when the session encountered an API infrastructure error."""
         from autoskillit.execution.session._exit_classification import _KNOWN_API_ERROR_PATTERNS
 
         searchable = "\n".join(self.assistant_messages)
@@ -159,11 +151,7 @@ class ClaudeSessionResult:
     @property
     def needs_retry(self) -> bool:
         """Whether the session didn't finish and should be retried."""
-        if self.subtype == CliSubtype.ERROR_MAX_TURNS:
-            return True
-        if self._is_context_exhausted():
-            return True
-        return False
+        return self.subtype == CliSubtype.ERROR_MAX_TURNS or self._is_context_exhausted()
 
     @property
     def retry_reason(self) -> RetryReason:
@@ -447,7 +435,6 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
                     if _stop:
                         acc.stop_reasons.append(str(_stop))
                 elif "message" not in obj:
-                    # Flat assistant record — detect context exhaustion inline.
                     if obj.get("output_tokens", -1) == 0:
                         flat_content = obj.get("content", [])
                         if isinstance(flat_content, list) and any(
@@ -504,9 +491,7 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
         jsonl_context_exhausted=acc.jsonl_context_exhausted,
         stop_reasons=acc.stop_reasons,
         has_thinking_only_turn=acc.has_thinking_only_turn,
-        seen_block_types=frozenset(
-            acc.seen_block_types
-        ),  # accumulator uses set; result is immutable
+        seen_block_types=frozenset(acc.seen_block_types),
         api_retry_count=acc.api_retry_count,
         api_retry_last_error=acc.api_retry_last_error,
         api_retry_last_status=acc.api_retry_last_status,

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -15,6 +15,7 @@ import pytest
 from autoskillit.core.types import (
     ChannelConfirmation,
     InfraExitCategory,
+    RetryReason,
     SubprocessResult,
     TerminationReason,
 )
@@ -38,6 +39,7 @@ API_ERROR_SIGNALS: list[str] = [
     "socket hang up",
     "network error",
     "connection reset",
+    "Rate limited",
     # OpenAI/Codex API error types
     *CODEX_API_ERROR_SIGNAL_STRINGS,
 ]
@@ -140,7 +142,6 @@ class TestApiErrorPtyModeEndToEnd:
     @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
     def test_api_error_pty_mode_routes_to_resume(self, signal: str) -> None:
         """Empty stderr + API error in stdout NDJSON → needs_retry=True, RESUME."""
-        from autoskillit.core.types import RetryReason
 
         ndjson = _make_synthetic_api_error_ndjson(
             error_type=f"{signal}_error" if " " not in signal else signal,
@@ -173,7 +174,6 @@ class TestApiErrorPtyModeEndToEnd:
 
     def test_api_error_pty_mode_realistic_overload(self) -> None:
         """Realistic production scenario: overloaded_error, returncode=0, empty stderr."""
-        from autoskillit.core.types import RetryReason
 
         ndjson = _make_synthetic_api_error_ndjson(
             error_type="overloaded_error",
@@ -203,7 +203,6 @@ class TestApiErrorPtyModeEndToEnd:
 
     def test_context_length_exceeded_pty_mode_routes_to_context_exhausted(self) -> None:
         """PTY mode: context_length_exceeded → CONTEXT_EXHAUSTED, needs_retry=True, RESUME."""
-        from autoskillit.core.types import RetryReason
 
         ndjson = _make_synthetic_api_error_ndjson(
             error_type="context_length_exceeded",
@@ -288,3 +287,31 @@ class TestContextExhaustedCodexInvariant:
         )
         result = _make_result(returncode=1, stderr="Error: context_length_exceeded", stdout="")
         assert classify_infra_exit(session, result) == InfraExitCategory.CONTEXT_EXHAUSTED
+
+
+class TestApiErrorStatusChannelInvariance:
+    """api_error_status structured signal must route to RESUME end-to-end."""
+
+    def test_api_error_status_triggers_api_error_classification(self) -> None:
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "partial work",
+                "session_id": "s1",
+                "is_error": False,
+                "api_error_status": 429,
+            }
+        )
+        result = SubprocessResult(
+            returncode=0,
+            stdout=result_line,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+            channel_confirmation=ChannelConfirmation.UNMONITORED,
+        )
+        sr = _build_skill_result(result, completion_marker="DONE")
+        assert sr.infra.exit_category == "api_error"
+        assert sr.needs_retry is True
+        assert sr.retry_reason == RetryReason.RESUME

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -218,6 +218,41 @@ def test_all_infra_categories_handled(category: InfraExitCategory) -> None:
     assert category.value in {"completed", "context_exhausted", "api_error", "process_killed"}
 
 
+class TestRateLimitClassification:
+    def test_rate_limited_text_classified_as_api_error(self) -> None:
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=False,
+            result="API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+            session_id="s1",
+            assistant_messages=["Rate limited"],
+        )
+        result = _sr(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
+    def test_api_error_status_triggers_api_error_classification(self) -> None:
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=False,
+            result="done",
+            session_id="s1",
+            api_error_status=429,
+        )
+        result = _sr(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
+    def test_api_error_status_below_400_does_not_trigger(self) -> None:
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=False,
+            result="done",
+            session_id="s1",
+            api_error_status=200,
+        )
+        result = _sr(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.COMPLETED
+
+
 def test_codex_api_error_patterns_count() -> None:
     """Structural test: _CODEX_API_ERROR_PATTERNS has exactly 4 entries."""
     assert len(_CODEX_API_ERROR_PATTERNS) == 4

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -223,7 +223,10 @@ class TestRateLimitClassification:
         session = ClaudeSessionResult(
             subtype="success",
             is_error=False,
-            result="API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+            result=(
+                "API Error: Server is temporarily limiting requests"
+                " (not your usage limit) · Rate limited"
+            ),
             session_id="s1",
             assistant_messages=["Rate limited"],
         )

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -14,10 +14,11 @@ from autoskillit.core.types import (
     AgentSessionResult,
     CliSubtype,
     KillReason,
+    RetryReason,
     SkillResult,
     SubprocessResult,
     TerminationReason,
-    WriteEvidence,
+    WriteBehaviorSpec,
 )
 from autoskillit.execution.backends.codex import CodexBackend
 from autoskillit.execution.headless import _build_skill_result, _parse_stdout
@@ -585,21 +586,25 @@ class TestIdleStallRecoveryWriteEvidence:
         )
 
 
+def _truncated_tool_use_line() -> str:
+    """Truncated NDJSON containing '"Edit"' that fails to parse — simulates a parse failure."""
+    return '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","id":"t1"'
+
+
 class TestWriteEvidenceCrossCheck:
     def test_cross_check_logs_mismatch(self) -> None:
-        stdout = _tool_use_ndjson("Edit", file_path="/a/b.py", old_string="a", new_string="b")
-        result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
+        result_line = _success_result_json()
+        result = _sr(
+            0,
+            _truncated_tool_use_line() + "\n" + result_line,
+            "",
+            TerminationReason.NATURAL_EXIT,
+        )
 
         from autoskillit.execution.headless import _headless_result
 
-        def zero_evidence(*args, **kwargs):
-            return WriteEvidence.none_observed()
-
         cap = structlog.testing.CapturingLogger()
-        with (
-            unittest.mock.patch.object(_headless_result, "_compute_write_evidence", zero_evidence),
-            unittest.mock.patch.object(_headless_result, "logger", cap),
-        ):
+        with unittest.mock.patch.object(_headless_result, "logger", cap):
             _build_skill_result(result)
 
         assert any(
@@ -608,6 +613,83 @@ class TestWriteEvidenceCrossCheck:
             and "write_call_count_cross_check_mismatch" in call.args[0]
             for call in cap.calls
         ), "Cross-check must warn when count=0 but stdout contains write tool names"
+
+    def test_cross_check_corrects_evidence_when_stdout_mentions_write_tools(self) -> None:
+        result_line = _success_result_json()
+        result = _sr(
+            0,
+            _truncated_tool_use_line() + "\n" + result_line,
+            "",
+            TerminationReason.NATURAL_EXIT,
+        )
+        sr = _build_skill_result(result)
+        assert sr.subtype != "zero_writes"
+        assert sr.evidence.write_call_count >= 1
+
+    def test_cross_check_sets_has_write_evidence(self) -> None:
+        result_line = _success_result_json()
+        result = _sr(
+            0,
+            _truncated_tool_use_line() + "\n" + result_line,
+            "",
+            TerminationReason.NATURAL_EXIT,
+        )
+        sr = _build_skill_result(
+            result,
+            write_behavior=WriteBehaviorSpec(mode="always"),
+        )
+        assert sr.success is True
+
+    def test_rate_limit_session_not_classified_as_early_stop(self) -> None:
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "Rate limited",
+                "session_id": "s1",
+                "is_error": False,
+                "api_error_status": 429,
+            }
+        )
+        result = _sr(
+            0,
+            result_line,
+            "",
+            TerminationReason.NATURAL_EXIT,
+        )
+        sr = _build_skill_result(result, completion_marker="DONE")
+        assert sr.retry_reason != RetryReason.EARLY_STOP
+        assert sr.retry_reason == RetryReason.RESUME
+
+    def test_stale_session_api_error_status_classified(self) -> None:
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "empty_output",
+                "result": "",
+                "session_id": "s1",
+                "is_error": True,
+                "api_error_status": 429,
+            }
+        )
+        result = _stale_result(stdout=result_line)
+        sr = _build_skill_result(result)
+        assert sr.infra.exit_category == "api_error"
+
+    def test_idle_stall_session_api_error_status_classified(self) -> None:
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "empty_output",
+                "result": "",
+                "session_id": "s1",
+                "is_error": True,
+                "api_error_status": 429,
+            }
+        )
+        result = _idle_stall_result(result_line)
+        sr = _build_skill_result(result)
+        assert sr.infra.exit_category == "api_error"
 
 
 class TestCodexPipelineHappyPath:

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -481,6 +481,89 @@ class TestExtractTokenUsageArchitecture:
         assert parsed.token_usage is None
 
 
+class TestApiErrorStatusParsing:
+    def test_api_error_status_captured_from_result_record(self) -> None:
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "done",
+                "session_id": "s1",
+                "is_error": False,
+                "api_error_status": 429,
+            }
+        )
+        session = parse_session_result(stdout)
+        assert session.api_error_status == 429
+
+    def test_api_error_status_captured_from_fallback_json(self) -> None:
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "done",
+                "session_id": "s1",
+                "is_error": False,
+                "api_error_status": 429,
+            }
+        )
+        session = parse_session_result(stdout)
+        assert session.api_error_status == 429
+
+    def test_api_error_status_none_when_absent(self) -> None:
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "done",
+                "session_id": "s1",
+                "is_error": False,
+            }
+        )
+        session = parse_session_result(stdout)
+        assert session.api_error_status is None
+
+    def test_rate_limit_event_rejected_sets_api_retry_exhausted(self) -> None:
+        rate_limit_line = json.dumps(
+            {
+                "type": "rate_limit_event",
+                "rate_limit_info": {"status": "rejected"},
+            }
+        )
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "done",
+                "session_id": "s1",
+                "is_error": False,
+            }
+        )
+        stdout = rate_limit_line + "\n" + result_line
+        session = parse_session_result(stdout)
+        assert session.api_retry_exhausted is True
+
+    def test_rate_limit_event_active_does_not_set_exhausted(self) -> None:
+        rate_limit_line = json.dumps(
+            {
+                "type": "rate_limit_event",
+                "rate_limit_info": {"status": "active"},
+            }
+        )
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "done",
+                "session_id": "s1",
+                "is_error": False,
+            }
+        )
+        stdout = rate_limit_line + "\n" + result_line
+        session = parse_session_result(stdout)
+        assert session.api_retry_exhausted is False
+
+
 class TestExtractTokenUsageMalformedInput:
     def test_skips_malformed_lines(self):
         malformed = "not json\n" + _assistant_ndjson(input_tokens=10, output_tokens=5)

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -497,6 +497,9 @@ class TestApiErrorStatusParsing:
         assert session.api_error_status == 429
 
     def test_api_error_status_captured_from_fallback_json(self) -> None:
+        # Pretty-printed JSON: individual lines aren't valid JSON, so the
+        # line-by-line NDJSON scan misses it and the whole-string fallback
+        # parse at _session_model.py:450 triggers instead.
         stdout = json.dumps(
             {
                 "type": "result",
@@ -505,7 +508,8 @@ class TestApiErrorStatusParsing:
                 "session_id": "s1",
                 "is_error": False,
                 "api_error_status": 429,
-            }
+            },
+            indent=2,
         )
         session = parse_session_result(stdout)
         assert session.api_error_status == 429


### PR DESCRIPTION
## Summary

Session classification relies on single-source evidence at two critical gates: the **zero_writes gate** depends exclusively on `tool_uses` parsed from stdout NDJSON (Channel A), and the **API error override** depends exclusively on text pattern matching against a static list. Both gates have cross-checks that detect mismatches but only log warnings — the "warn-but-discard" anti-pattern. The architectural fix replaces single-source evidence with a **multi-signal evidence protocol** that fuses Channel A (stdout), Channel B (session JSONL), and structured metadata fields before any gate decision, and eliminates the warn-but-discard pattern by requiring all cross-checks to produce corrective actions.

Part A addresses the zero_writes false positive (the primary pipeline-killing bug) and the rate-limit misclassification through: (1) promoting the existing cross-check from warning to correction; (2) adding `api_error_status` as a structured signal in `_ParseAccumulator` and `ClaudeSessionResult`; (3) adding `rate_limit_event` record handling in `parse_session_result`; (4) adding a rate-limit pattern to `_API_ERROR_PATTERNS`; (5) extending STALE and IDLE_STALL paths for consistent `api_error_status` coverage. Part B will cover Channel B tool data integration as a secondary write evidence source (the structural fix for complete immunity).

## Requirements

The issue describes a classification pipeline bug where HTTP 429 rate-limit responses are misclassified as `early_stop`/`missing_completion_marker` instead of `API_ERROR`, causing the orchestrator to route to `escalate_stop` instead of a retry-eligible path. The fix adds structured multi-signal detection: `api_error_status` field capture, `rate_limit_event` record handling, and a rate-limit text pattern, applied consistently across NORMAL, STALE, and IDLE_STALL termination paths. The cross-check from stdout-parse mismatch is promoted from warning to corrective action to eliminate zero_writes false positives.

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_multi_signal_evidence_architecture_2026-05-23_170000.md`

## Test Plan

- `test_api_error_signal_invariants`: new test asserting that `api_error_status` is always populated after parsing across all termination paths (NORMAL, STALE, IDLE_STALL)
- `test_exit_classification`: updated to cover rate-limit → `API_ERROR` routing
- `test_headless_result`: updated to cover `api_error_status` field in `ClaudeSessionResult`
- `test_session_parsing`: updated to cover `rate_limit_event` record parsing and pattern matching

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 75 | 26.9k | 1.2M | 114.6k | 285 | 132.7k | 46m 45s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 65 | 22.0k | 1.8M | 82.0k | 202 | 66.5k | 10m 42s |
| implement | claude-opus-4-6 | 1 | 124 | 34.7k | 5.4M | 130.9k | 138 | 115.6k | 13m 11s |
| prepare_pr* | MiniMax-M2.7 | 1 | 81.8k | 4.5k | 546.4k | 0 | 35 | 0 | 1m 56s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.1k | 2.5k | 311.7k | 0 | 20 | 0 | 1m 18s |
| review_pr | claude-opus-4-6 | 1 | 50 | 22.8k | 737.2k | 81.5k | 33 | 81.9k | 6m 13s |
| resolve_review | claude-opus-4-6 | 1 | 34 | 5.2k | 775.7k | 58.8k | 35 | 45.2k | 6m 57s |
| **Total** | | | 121.2k | 118.5k | 10.8M | 130.9k | | 441.9k | 1h 27m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 297 | 18173.9 | 389.3 | 116.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 129288.7 | 7536.5 | 864.8 |
| **Total** | **303** | 35798.1 | 1458.5 | 391.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 140 | 48.9k | 3.1M | 199.2k | 57m 27s |
| claude-opus-4-6 | 3 | 208 | 62.7k | 6.9M | 242.7k | 26m 22s |
| MiniMax-M2.7 | 2 | 120.9k | 7.0k | 858.2k | 0 | 3m 15s |