### PR TITLE
Extract wp-elaborator agent definition to reduce L1 context pressure in planner-elaborate-wps

### DIFF
--- a/src/autoskillit/agents/CLAUDE.md
+++ b/src/autoskillit/agents/CLAUDE.md
@@ -11,6 +11,7 @@ Bundled agent definition markdown files that serve as both **plugin agents**
 | `plan-foundation-auditor.md` | Adversarial agent: control-flow auditor — traces branch scope, return placement, guard coverage |
 | `plan-interface-mapper.md` | Adversarial agent: variable/data-flow tracer — builds SET/READ tables for wrong-variable detection |
 | `plan-registry-tracer.md` | Adversarial agent: registry/artifact auditor — LSP + tree-sitter + grep symbol tracing |
+| `wp-elaborator.md` | Pipeline agent: work-package elaboration — codebase analysis and structured JSON output |
 
 ## Layout
 
@@ -46,6 +47,7 @@ agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{nam
 | Pack | Tag | Agents | Used By |
 |------|-----|--------|---------|
 | `plan-review` | `plan-review` | 3 adversarial reviewers | make-plan Steps 6-9, rectify Steps 5-7 |
+| _(none)_ | _(none)_ | `wp-elaborator` | planner-elaborate-wps (subagent_type-only) |
 
 ## Adding Agents
 
@@ -54,3 +56,9 @@ agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{nam
 3. Add the pack tag to `ALL_VISIBILITY_TAGS` in `core/types/_type_constants.py`
 4. Register resource template + index resource in `server/tools/tools_agents.py`
 5. Add `mcp.disable(tags={pack_tag})` in `server/__init__.py`
+
+**Packless agents (subagent_type-only):** If the agent is invoked exclusively via
+`subagent_type: "autoskillit:{name}"` and does NOT need MCP resource access via
+`unlock_agent_pack`, only step 1 is required. Steps 2–5 exist for the
+`agent://{pack}/{name}` resource path and can be skipped for packless agents.
+Current packless agents: `wp-elaborator`.

--- a/src/autoskillit/agents/wp-elaborator.md
+++ b/src/autoskillit/agents/wp-elaborator.md
@@ -1,0 +1,50 @@
+---
+name: wp-elaborator
+description: "Work-package elaboration agent for the planner pipeline. Analyzes a single work package against the codebase and returns a structured JSON elaboration."
+tools: [Read, Grep, Glob, Bash]
+model: sonnet
+maxTurns: 30
+color: cyan
+---
+
+# wp-elaborator
+
+You are a codebase analyzer that produces a structured JSON elaboration for a single work package. You receive variable context (WP identity, assignment context, phase context, sibling WPs, and a task file path) in your prompt.
+
+## Tool Constraints
+
+Use only Read, Grep, Glob, and Bash for codebase analysis. Do not spawn sub-agents. Do not write or modify any files.
+
+## Scope-Creep Guard
+
+Read the task description from the task file path provided in your prompt. Every deliverable, acceptance criterion, and file touched must serve the stated task. If the WP's scope drifts beyond the task, constrain it.
+
+## Deliverable Bounds
+
+Produce exactly 1-5 deliverables (hard constraint). If the WP naturally spans more than 5 files, group related files into logical deliverables (e.g., "test suite for module X" rather than individual test files).
+
+## Output Format
+
+Return your result as a single JSON object between ```json and ``` fences. The JSON must contain all of the following fields:
+
+```json
+{
+  "id": "P{N}-A{N}-WP{N}",
+  "name": "...",
+  "goal": "...",
+  "summary": "<=120 chars",
+  "technical_steps": ["..."],
+  "files_touched": ["..."],
+  "apis_defined": ["..."],
+  "apis_consumed": ["..."],
+  "depends_on": ["..."],
+  "deliverables": ["(exactly 1-5 items, hard limit) file_or_logical_group", "..."],
+  "acceptance_criteria": ["..."]
+}
+```
+
+Use the actual WP ID and name provided in your prompt — the placeholders above are for schema illustration only.
+
+## WP ID Format Contract
+
+WP IDs must match the pattern `P{N}-A{N}-WP{N}` where `{N}` is a positive integer (numeric only — no letters or hyphens in the number). Examples: `P1-A2-WP1`, `P3-A1-WP12`. Invalid: `WP2a`, `WP3b`, `WP6-C`, `P1-A1-WP-1`, `wp1`.

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -74,58 +74,38 @@ and `estimated_files` — must serve the stated task. Do not read the full task 
 L1 context or embed it in the L0 prompt — pass the path reference only and instruct L0s
 to read the file from disk for scope creep verification.
 
-### Step 3: Build per-L0 context packets
+### Step 3: Build per-WP variable-data packets
 
-For each WP in the phase, build a self-contained context packet:
+For each WP in the phase, build a variable-data packet containing ONLY the per-WP context.
+The agent definition (`autoskillit:wp-elaborator`) supplies all behavioral instructions,
+output format, and constraints — do NOT re-add any static instructions to these packets.
+
+Each packet contains:
 - WP ID, name, scope, estimated_files (from manifest metadata)
 - Assignment context: the parent assignment's goal, technical_approach
 - All sibling WPs for this phase in short-form (id, name, scope only — for dependency detection)
 - Phase goal and scope
-- Instruct L0 to use Grep/Glob/Read for codebase analysis (no sub-subagents)
-- Instruct L0 to return JSON between triple-backtick json fences
+- Task file path (absolute) — the agent reads this for scope-creep verification
 
 ### Step 4: Spawn L0 subagents in PARALLEL
 
-Use the native Agent/Task tool to spawn one L0 per WP simultaneously.
-If WP count > 6, spawn in sequential batches of 6 — await each batch before starting the next.
+Use the native Agent tool with `subagent_type: "autoskillit:wp-elaborator"` to spawn one
+agent per WP simultaneously. If WP count > 6, spawn in sequential batches of 6 — await
+each batch before starting the next.
 
-Each L0 receives a self-contained prompt that:
-1. Identifies the WP (ID, name, scope, estimated_files)
-2. Provides assignment context (goal, technical_approach)
-3. Lists all sibling WPs in short-form for dependency detection
-4. Provides phase goal and scope
-5. Instructs the L0 to use Grep/Glob/Read for codebase analysis (no sub-subagents)
-6. Instructs the L0 to produce exactly 1–5 deliverables (hard constraint — validate_wp_result rejects out-of-range counts)
-7. Instructs the L0 to return results as JSON between triple-backtick json fences
+Each agent receives its variable-data packet (from Step 3) as the `prompt` parameter.
+The agent definition automatically provides:
+- Role and tool constraints
+- Output JSON schema with all required fields
+- Deliverable bounds (1–5)
+- WP ID format contract
+- Task file scope-creep verification instructions
 
-Each L0 MUST:
-- Use Grep/Glob/Read for codebase analysis (no sub-subagent spawning — they are actual leaf nodes)
-- Elaborate the WP with all mandatory fields
-- Produce exactly 1–5 deliverables — if the WP naturally spans more than 5 files, group related files into logical deliverables (e.g., "test suite for module X" rather than individual test files)
-- Return structured JSON between ` ```json ` and ` ``` ` delimiters
+Do NOT embed any of the above in the prompt — the agent definition handles it.
+Duplicating instructions wastes L1 context budget.
 
-Expected L0 return schema:
-```json
-{
-  "id": "P1-A2-WP1",
-  "name": "...",
-  "goal": "...",
-  "summary": "<=120 chars",
-  "technical_steps": ["..."],
-  "files_touched": ["..."],
-  "apis_defined": ["..."],
-  "apis_consumed": ["..."],
-  "depends_on": ["..."],
-  "deliverables": ["(exactly 1–5 items, hard limit) file_or_logical_group", "..."],
-  "acceptance_criteria": ["..."]
-}
-```
-
-**CRITICAL — WP ID Format Contract:**
-- WP IDs MUST match the pattern `P{N}-A{N}-WP{N}` where `{N}` is a positive integer (numeric only — no letters or hyphens in the number)
-- Examples: `P1-A2-WP1`, `P3-A1-WP12`
-- INVALID: `WP2a`, `WP3b`, `WP6-C`, `P1-A1-WP-1`, `wp1`
-- The result filename is `{wp_id}_result.json` — non-matching filenames are rejected
+**WP ID Format Reference:** WP IDs produced by the agents must match `P{N}-A{N}-WP{N}`
+where `{N}` is a positive integer (numeric only). Non-matching IDs are rejected at validation.
 
 ### Step 5: Collect and validate L0 responses
 

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -281,3 +281,80 @@ def test_retired_agent_names_lowercase():
 
     for name in RETIRED_AGENT_NAMES:
         assert name == name.lower(), f"RETIRED_AGENT_NAMES entry '{name}' is not lowercase"
+
+
+# All 11 WPResult fields (used by T-NEW-2)
+_WP_RESULT_ALL_FIELDS = frozenset(
+    {
+        "id",
+        "name",
+        "summary",
+        "goal",
+        "technical_steps",
+        "files_touched",
+        "apis_defined",
+        "apis_consumed",
+        "depends_on",
+        "deliverables",
+        "acceptance_criteria",
+    }
+)
+
+
+# T-NEW-1: planner-elaborate-wps SKILL.md subagent_type refs resolve to agent files
+def test_elaborate_wps_subagent_type_refs_resolve():
+    """planner-elaborate-wps SKILL.md subagent_type refs resolve to agent files."""
+    import re
+
+    from autoskillit.core import pkg_root
+
+    content = (pkg_root() / "skills_extended" / "planner-elaborate-wps" / "SKILL.md").read_text()
+    refs = re.findall(r'subagent_type.*?["\']autoskillit:([a-z][a-z0-9-]+)["\']', content)
+    unique_refs = set(refs)
+    assert len(unique_refs) >= 1, (
+        f"Expected >=1 subagent_type ref in planner-elaborate-wps SKILL.md, "
+        f"found {len(unique_refs)}"
+    )
+    agents_dir = pkg_root() / "agents"
+    for agent_name in unique_refs:
+        agent_file = agents_dir / f"{agent_name}.md"
+        assert agent_file.exists(), (
+            f"SKILL.md references autoskillit:{agent_name} but {agent_file} does not exist"
+        )
+
+
+# T-NEW-2: wp-elaborator.md JSON schema must contain all WPResult fields
+def test_wp_elaborator_schema_covers_all_wp_fields():
+    """wp-elaborator.md JSON schema must contain all WPResult fields, not just WP_REQUIRED_KEYS."""
+    from autoskillit.core import pkg_root
+    from autoskillit.planner.schema import WP_REQUIRED_KEYS
+
+    agent_path = pkg_root() / "agents" / "wp-elaborator.md"
+    content = agent_path.read_text()
+    parts = content.split("---", 2)
+    assert len(parts) >= 3, "wp-elaborator.md must have YAML frontmatter"
+    body = parts[2]
+    # WP_REQUIRED_KEYS is a subset — verify it hasn't drifted from our full set
+    assert WP_REQUIRED_KEYS <= _WP_RESULT_ALL_FIELDS
+    for key in _WP_RESULT_ALL_FIELDS:
+        assert f'"{key}"' in body, f"wp-elaborator.md schema must contain WPResult field: {key}"
+
+
+# T-NEW-3: wp-elaborator is subagent_type-only — must not be registered in any agent pack
+def test_wp_elaborator_is_packless():
+    """wp-elaborator is subagent_type-only — must not be registered in any agent pack."""
+    from autoskillit.core import pkg_root
+    from autoskillit.core.types._type_constants import AGENT_PACK_REGISTRY
+
+    agent_path = pkg_root() / "agents" / "wp-elaborator.md"
+    assert agent_path.exists(), "wp-elaborator.md must exist"
+    # AGENT_PACK_REGISTRY keys are pack names — guard against a new pack created for wp-elaborator
+    for pack_name in AGENT_PACK_REGISTRY:
+        assert "wp-elaborator" not in pack_name, (
+            f"wp-elaborator must NOT appear in any AGENT_PACK_REGISTRY pack name — "
+            f"found in '{pack_name}'. It is subagent_type-only."
+        )
+    # Guard against accidental inclusion in the plan-review pack glob (plan-*.md)
+    assert not agent_path.stem.startswith("plan-"), (
+        "wp-elaborator.md must NOT start with 'plan-' (would collide with plan-review pack glob)"
+    )


### PR DESCRIPTION
## Summary

Extract the `wp-elaborator` agent definition from `planner-elaborate-wps` to reduce L1 context pressure. The L1 skill currently embeds ~5,049 chars of static behavioral instructions in each Agent tool call's prompt across 35 WPs (Phase P5), causing context exhaustion at peak ~165K tokens. This change moves ~1,400 chars of static instructions per prompt into a dedicated agent definition (`src/autoskillit/agents/wp-elaborator.md`), saving ~49,000 chars (~16,300 tokens) from L1's context window.

**Key design decision — no pack registration:** `wp-elaborator` is invoked via `subagent_type: "autoskillit:wp-elaborator"` (same pattern as `plan-foundation-auditor`). MCP resource exposure via `unlock_agent_pack` is not needed since no consumer reads it via `ReadMcpResourceTool`. The `.md` file in `agents/` is sufficient.

## Requirements

## Problem

The `planner-elaborate-wps` skill (Pass 3 loop body) hit `context_exhausted` when elaborating Phase P5 (35 WPs) in a planner pipeline run against `token-reserve`. P3 (26 WPs) and P4 (20 WPs) completed fine in the same run.

**Root cause:** The L1 skill session runs on `claude-sonnet-4-6` (200K context). Each of the 35 Agent tool calls embeds ~5,049 chars of prompt text in L1's conversation context, and each result adds ~4,340 chars. None of this is evicted. The measured peak context at the last successful API call was **165,293 tokens** (cache_read=144,641 + cache_creation=20,642 + input=10). After batch 6 results accumulated, the Claude Code harness detected the assembled prompt would exceed the context window and emitted a synthetic `blocking_limit` / "Prompt is too long" termination.

**Key measurement:** Of the ~5,049 chars per Agent prompt, approximately **708 chars are byte-identical** across all 35 prompts (role description header, task file path, phase context lines). An additional ~700 chars are _effectively static_ (JSON schema template, tool constraints, output format rules) but currently vary per-WP because L1 embeds the WP-specific ID and name in the schema example. With placeholder values in the schema, approximately **~1,400 chars per prompt are movable** to an agent definition. The remaining ~3,649 chars are genuinely variable per-WP data (ID, name, scope, estimated files, assignment context, sibling list).

**Impact of 0 writes:** 30 of 35 L0 agents completed successfully, but 0 WP result files were written — the skill writes all results in Step 6 after ALL batches complete, so the overflow at batch 6 lost everything.

## Proposed Solution

Create a `wp-elaborator` agent definition (`src/autoskillit/agents/wp-elaborator.md`) that contains the static elaboration instructions as the agent's system prompt. The L1 skill would then invoke via `subagent_type: "autoskillit:wp-elaborator"` with only the variable per-WP data in the `prompt` parameter.

**How this helps:** Agent definition bodies are injected into the subagent's own isolated context window as its system prompt — they are NOT counted against the parent session's context. This moves ~1,400 chars per prompt out of L1 context. Across 35 WPs: **~49,000 chars saved** from L1's context. At ~3 chars/token for structured content, this yields **~16,300 tokens of savings** — meaningful headroom but NOT a complete solution for phases with 40+ WPs.

**Limitations this fix does NOT address:**
- L0 results (~4,340 chars each × 35 WPs = ~152K chars) still accumulate in L1 context
- The sibling WP list (~2,356 chars avg) is duplicated in every prompt but is per-phase data, not per-WP — a separate optimization could deduplicate this
- Rate-limited agents in batch 6 read large files (~75K chars) before failing, wasting context budget
- `planner-elaborate-assignments` (Pass 2) has the identical inline-prompt accumulation pattern and would benefit from the same treatment

## Implementation Steps

### 1. Create the agent definition

Create `src/autoskillit/agents/wp-elaborator.md` with:

**Frontmatter:**
- `name: wp-elaborator`
- `description:` — work-package elaboration agent for planner pipeline
- `tools: [Read, Grep, Glob, Bash]`
- `model: sonnet`
- `maxTurns: 30`
- `color: cyan`

**Body (system prompt):** The static instructions currently embedded in every Agent prompt:
- Role: codebase analyzer that produces structured JSON elaboration for a single work package
- Tool constraints: use only Read/Grep/Glob/Bash, no sub-agent spawning, no file modifications
- Deliverable constraint: exactly 1–5 items
- Output format: JSON between ```json fences, matching the required schema
- JSON schema definition with all required fields (`id`, `name`, `goal`, `summary`, `technical_steps`, `files_touched`, `apis_defined`, `apis_consumed`, `depends_on`, `deliverables`, `acceptance_criteria`) — use PLACEHOLDER values for `id` and `name` (e.g., `"id": "P{N}-A{N}-WP{N}"`) so the schema is fully static
- WP ID format contract (`P{N}-A{N}-WP{N}`)
- Instruction to read the task file from disk for scope-creep verification (currently in SKILL.md Step 2: "instruct L0s to read the file from disk for scope creep verification")

**Important:** The agent body must NOT reference internal orchestration jargon (e.g., "L0", "L1", "Pass 3") — the agent has no awareness of the pipeline hierarchy. It should describe itself simply as a work-package elaboration agent.

### 2. Update the SKILL.md prompt

Update `src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md` Steps 3–4 to:
- Reference `subagent_type: "autoskillit:wp-elaborator"` instead of inline Agent prompts
- Pass only variable per-WP data in the `prompt` parameter: WP ID, name, scope, estimated files, assignment context (goal + technical_approach), phase context (goal + scope), sibling WP list (short-form), and task file path
- Remove all static instructions from the prompt construction — these now live in the agent definition
- Revise Step 3's "self-contained context packet" framing to clarify that the packet contains only the variable data; the agent definition supplies the behavioral instructions. Otherwise L1 may re-add static instructions from memory to make packets "self-contained."

### 3. Register the agent

Follow the mandatory 5-step agent registration checklist from `src/autoskillit/agents/CLAUDE.md`:

1. Create `wp-elaborator.md` (Step 1 above)
2. Add a `planner` pack to `AGENT_PACK_REGISTRY` in `core/types/_type_constants.py`
3. Add the `planner` pack tag to `ALL_VISIBILITY_TAGS` in `core/types/_type_constants.py`
4. Register resource template + index resource for the `planner` pack in `server/tools/tools_agents.py`
5. Add `mcp.disable(tags={"planner"})` in `server/__init__.py`

**Design decision:** The existing `plan-review` agents are gated behind `unlock_agent_pack` because they're read via MCP resources. `wp-elaborator` is invoked directly via `subagent_type` (same as `plan-foundation-auditor` in make-plan). Determine whether MCP resource exposure is needed or if native plugin agent discovery suffices — but registration steps 2-5 are still required per the checklist.

**No `RETIRED_AGENT_NAMES` update needed** — this is a new agent, not a rename. (`RETIRED_AGENT_NAMES` exists at `_type_constants.py:622` and is enforced by `test_no_retired_agent_name_has_a_live_file`.)

### 4. Update CLAUDE.md

Add the new agent to the file table in `src/autoskillit/agents/CLAUDE.md`.

### 5. Add tests

- **Agent discovery test:** Add a test analogous to `test_make_plan_subagent_type_refs_resolve` (in `tests/server/test_tools_agents.py:165`) for the `planner-elaborate-wps/SKILL.md`. Note: the existing test regex `autoskillit:(plan-[a-z-]+)` at line 175 will NOT match `wp-elaborator` — a new test with a broader pattern is needed.
- **Schema drift guard:** Add a test that parses the `wp-elaborator.md` body and asserts its documented JSON fields are a superset of `WP_REQUIRED_KEYS` from `planner/schema.py:6`. This prevents the agent definition from drifting out of sync with the Python validator.
- **Existing test check:** Verify `tests/planner/test_elaborate_wps_contract.py` `TestSkillMdPresence` assertions still pass after SKILL.md changes — if schema text moves to agent.md, `test_has_l0_response_fields` (line 135) may need updating.

### 6. Functional test

- Run a planner pipeline on a project with a phase that has 25+ WPs to confirm context savings
- Verify L0 output JSON schema is unchanged

## Context

- Investigation report: `.autoskillit/temp/investigate/investigation_p5_context_exhaustion_2026-05-23_183500.md`
- Failed session: `16cfa020-de78-4541-bdb3-afbddf749e88`
- Successful P3 session (26 WPs, peak 148K): `dd35c1df-0ec8-4b6b-bad0-aebdbbf572cc`
- `planner-elaborate-assignments` has the same inline-prompt pattern — consider a parallel `assignment-elaborator` agent as follow-up

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/reduce_l1_context_pressure_wp_elaborator_plan_2026-05-23_191500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.8k | 25.7k | 1.1M | 100.8k | 123 | 146.2k | 15m 43s |
| verify | claude-opus-4-6 | 1 | 44 | 8.4k | 913.5k | 69.7k | 71 | 54.4k | 5m 3s |
| implement* | MiniMax-M2.7 | 1 | 64.7k | 8.7k | 1.3M | 20.8k | 68 | 0 | 5m 11s |
| prepare_pr* | MiniMax-M2.7 | 1 | 64.0k | 5.1k | 283.3k | 0 | 20 | 0 | 1m 46s |
| compose_pr* | MiniMax-M2.7 | 1 | 62.6k | 4.2k | 354.3k | 0 | 26 | 0 | 1m 34s |
| review_pr | claude-opus-4-6 | 1 | 50 | 18.1k | 637.6k | 62.3k | 31 | 46.8k | 6m 5s |
| resolve_review | claude-opus-4-6 | 1 | 39 | 4.9k | 564.1k | 57.3k | 28 | 42.4k | 3m 26s |
| **Total** | | | 195.2k | 75.1k | 5.1M | 100.8k | | 289.9k | 38m 52s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 203 | 6180.0 | 0.0 | 42.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **203** | 25299.1 | 1427.9 | 369.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 3.8k | 25.7k | 1.1M | 146.2k | 15m 43s |
| claude-opus-4-6 | 3 | 133 | 31.5k | 2.1M | 143.6k | 14m 36s |
| MiniMax-M2.7 | 3 | 191.3k | 17.9k | 1.9M | 0 | 8m 31s |