### PR TITLE
Batch multiple parallel-safe issues per food truck in fleet dispatch

### DIFF
--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -23,7 +23,7 @@ def _has_dynamic_dispatch(campaign_recipe: Recipe) -> bool:
     return any("dispatch_plan" in d.capture for d in campaign_recipe.dispatches)
 
 
-def _build_dynamic_dispatch_section(mcp_prefix: str) -> str:
+def _build_dynamic_dispatch_section(mcp_prefix: str, max_issues_per_food_truck: int = 3) -> str:
     return f"""\
 ## DYNAMIC DISPATCH — IMPLEMENT-FINDINGS
 
@@ -46,7 +46,8 @@ If the array is empty (`[]`) there are no issues to implement — skip to INTERR
 **Step 2 — For each group (in array order):**
 
 1. Parse the group's `issues` string into individual issue URLs.
-2. If the group has more issues than `max_issues_per_food_truck` (default: 5), split into
+2. If the group has more issues than `max_issues_per_food_truck`
+   (default: {max_issues_per_food_truck}), split into
    batches of that size. Name batches: `implement-findings-g{{N}}-a`, `-b`, `-c` …
    If the group fits in one batch, use the name `implement-findings-g{{N}}-a`.
 3. If `parallel` is `true`: issue ALL `{mcp_prefix}dispatch_food_truck` calls for this
@@ -111,6 +112,7 @@ def _build_fleet_campaign_prompt(
     ingredients_table: str | None = None,
     prior_dispatch_id: str = "",
     resume_checkpoint: dict[str, Any] | None = None,
+    max_issues_per_food_truck: int = 3,
 ) -> str:
     """Build the system prompt for an L3 campaign dispatcher headless session.
 
@@ -172,7 +174,9 @@ dispatch name NOT listed above.
 """
 
     dynamic_dispatch_section = (
-        _build_dynamic_dispatch_section(mcp_prefix)
+        _build_dynamic_dispatch_section(
+            mcp_prefix, max_issues_per_food_truck=max_issues_per_food_truck
+        )
         if _has_dynamic_dispatch(campaign_recipe)
         else ""
     )

--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -71,7 +71,9 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
     return text
 
 
-def _build_fleet_dispatch_prompt(mcp_prefix: str, recipe_table: str | None = None) -> str:
+def _build_fleet_dispatch_prompt(
+    mcp_prefix: str, recipe_table: str | None = None, max_issues_per_food_truck: int = 3
+) -> str:
     """Build the --append-system-prompt content for an ad-hoc fleet dispatcher session."""
     from autoskillit.fleet import _build_admiral_dispatch_block  # noqa: PLC0415
 
@@ -168,6 +170,38 @@ has been produced and read.
    - Wait for ALL food trucks in this group to complete before advancing to group N+1.
 
 BEM already caps parallel group sizes via max_parallel (default 6 issues per group).
+
+## BATCH DISPATCH MODE — OPTIONAL
+
+When dispatching the `implementation` recipe for multiple issues and the user has set the
+`batch_dispatch` ingredient to `"true"`, use batched dispatch instead of per-issue dispatch:
+
+1. After BEM produces the dispatch_plan, for each parallel group (parallel: true):
+   a. Chunk the group's issues into sub-groups of up to {max_issues_per_food_truck} issues.
+   b. Dispatch each chunk as a SINGLE `implement-findings` food truck:
+      {mcp_prefix}dispatch_food_truck(
+          recipe="implement-findings",
+          task="Implement issues #X, #Y, #Z — parallel-safe per BEM group {{N}}",
+          ingredients={{{{
+              "issue_urls": "<comma-separated issue URLs for this chunk>",
+              "execution_map": "<captured execution_map from bem-wrapper>",
+              "base_branch": "<target branch>",
+          }}}},
+          dispatch_name="implement-g{{N}}-{{letter}}",
+      )
+   c. Name chunks sequentially: `implement-g{{N}}-a`, `-b`, `-c` …
+   d. Issue ALL chunks for a parallel group in a single response (parallel tool calls).
+      The fleet semaphore gates actual concurrency — if FLEET_PARALLEL_REFUSED is returned,
+      wait for a running dispatch to complete and retry.
+
+2. Groups with only 1 issue or sequential groups (parallel: false): dispatch via the
+   `implementation` recipe as normal — one food truck per issue, not batched.
+
+3. When `batch_dispatch` is `"false"` (the default): use the standard per-issue dispatch
+   from Step 4 above — one `implementation` food truck per issue. Do NOT use implement-findings.
+
+4. The execution_map captured from bem-wrapper MUST be passed as an ingredient to each
+   implement-findings food truck so BEM is not re-run inside the food truck.
 
 ## DISPATCHER DISCIPLINE
 

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -56,11 +56,19 @@ def _launch_fleet_session(
 
     project_dir = Path.cwd()
 
+    from autoskillit.config import load_config  # noqa: PLC0415
+
+    cfg = load_config(project_dir)
+
     if campaign_recipe is None:
         # Ad-hoc mode: no campaign, no state, bare kitchen open
         from autoskillit.cli._prompts import _build_fleet_dispatch_prompt
 
-        prompt = _build_fleet_dispatch_prompt(mcp_prefix, recipe_table=recipe_table)
+        prompt = _build_fleet_dispatch_prompt(
+            mcp_prefix,
+            recipe_table=recipe_table,
+            max_issues_per_food_truck=cfg.fleet.max_issues_per_food_truck,
+        )
         env_spec = FleetSessionEnv(
             session_type="fleet",
             fleet_mode=fleet_mode,
@@ -154,6 +162,7 @@ def _launch_fleet_session(
             ingredients_table=ingredients_table,
             prior_dispatch_id=resume_dispatch_id,
             resume_checkpoint=resume_checkpoint,
+            max_issues_per_food_truck=cfg.fleet.max_issues_per_food_truck,
         )
         env_spec = FleetSessionEnv(
             session_type="fleet",
@@ -237,4 +246,5 @@ def _launch_fleet_session(
                 ingredients_table=ingredients_table,
                 prior_dispatch_id=resume_dispatch_id,
                 resume_checkpoint=resume_checkpoint,
+                max_issues_per_food_truck=cfg.fleet.max_issues_per_food_truck,
             )

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -382,6 +382,7 @@ class FleetConfig:
     max_extension_seconds: float = 7200
     idle_output_timeout: float = 1800
     acquire_timeout_sec: float = 300.0
+    max_issues_per_food_truck: int = 3
 
     def validate(self, feature_enabled: bool) -> None:
         """Validate only when the feature is active."""
@@ -413,6 +414,15 @@ class FleetConfig:
         if self.acquire_timeout_sec <= 0:
             raise ValueError(
                 f"acquire_timeout_sec must be positive, got {self.acquire_timeout_sec}"
+            )
+        if self.max_issues_per_food_truck < 1:
+            raise ValueError(
+                f"max_issues_per_food_truck must be >= 1, got {self.max_issues_per_food_truck}"
+            )
+        if self.max_issues_per_food_truck > self.max_total_issues:
+            raise ValueError(
+                f"max_issues_per_food_truck must be <= max_total_issues"
+                f" ({self.max_total_issues}), got {self.max_issues_per_food_truck}"
             )
 
 

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -295,6 +295,7 @@ fleet:
   enable_deadline_extension: true
   max_extension_seconds: 7200
   idle_output_timeout: 1800
+  max_issues_per_food_truck: 3
 
 providers:
   default_provider: null

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -536,6 +536,9 @@ class AutomationConfig:
                 acquire_timeout_sec=float(
                     val(fr, "acquire_timeout_sec", _fr["acquire_timeout_sec"])
                 ),
+                max_issues_per_food_truck=int(
+                    val(fr, "max_issues_per_food_truck", _fr["max_issues_per_food_truck"])
+                ),
             ),
             providers=ProvidersConfig(
                 default_provider=val(pvd, "default_provider", _pvd["default_provider"]),

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -47,6 +47,10 @@
       "description": "Automatically merge the PR after required checks pass — via merge queue when available, direct merge otherwise",
       "default": "true"
     },
+    "batch_dispatch": {
+      "description": "Pack multiple parallel-safe issues per food truck. When \"true\", the fleet dispatcher batches parallel-safe issues (up to max_issues_per_food_truck) into implement-findings food trucks with comma-separated issue_urls.",
+      "default": "false"
+    },
     "review_max_retries": {
       "description": "Maximum number of review-resolve retry cycles before proceeding to CI",
       "default": "3"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -35,6 +35,12 @@ ingredients:
       Automatically merge the PR after required checks pass —
       via merge queue when available, direct merge otherwise
     default: "true"
+  batch_dispatch:
+    description: >-
+      Pack multiple parallel-safe issues per food truck. When "true", the fleet
+      dispatcher batches parallel-safe issues (up to max_issues_per_food_truck)
+      into implement-findings food trucks with comma-separated issue_urls.
+    default: "false"
   review_max_retries:
     description: Maximum number of review-resolve retry cycles before proceeding to CI
     default: "3"

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -90,9 +90,12 @@ def test_fleet_dispatch_exits_when_claude_missing(
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
     monkeypatch.setattr("autoskillit.cli.fleet.is_feature_enabled", lambda *a, **kw: True)
+    _fleet = type("Fleet", (), {"max_issues_per_food_truck": 3})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",
-        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
+        lambda path: type(
+            "C", (), {"features": {}, "experimental_enabled": False, "fleet": _fleet}
+        )(),
     )
     _stub_list_recipes(monkeypatch, [])
     monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
@@ -119,9 +122,12 @@ def test_fleet_dispatch_exits_when_disabled(
             checked_features.append(name) or False
         ),
     )
+    _fleet = type("Fleet", (), {"max_issues_per_food_truck": 3})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",
-        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
+        lambda path: type(
+            "C", (), {"features": {}, "experimental_enabled": False, "fleet": _fleet}
+        )(),
     )
     with pytest.raises(SystemExit) as exc_info:
         _fleet_dispatch()
@@ -144,9 +150,12 @@ def test_fleet_dispatch_proceeds_when_enabled(
         "autoskillit.cli.fleet.is_feature_enabled",
         lambda name, features, *, experimental_enabled=False: True,
     )
+    _fleet = type("Fleet", (), {"max_issues_per_food_truck": 3})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",
-        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
+        lambda path: type(
+            "C", (), {"features": {}, "experimental_enabled": False, "fleet": _fleet}
+        )(),
     )
     _stub_list_recipes(monkeypatch, [])
     monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")

--- a/tests/cli/test_fleet_session.py
+++ b/tests/cli/test_fleet_session.py
@@ -806,3 +806,76 @@ class TestFleetSessionPromptPriorDispatchId:
 
         sig = inspect.signature(_build_fleet_campaign_prompt)
         assert "prior_dispatch_id" in sig.parameters
+
+
+class TestLaunchFleetSessionMaxIssuesPerFoodTruck:
+    """Contract: _launch_fleet_session threads max_issues_per_food_truck to prompt builders."""
+
+    def test_adhoc_dispatch_forwards_max_issues_per_food_truck(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Ad-hoc threads cfg.fleet.max_issues_per_food_truck to _build_fleet_dispatch_prompt."""
+        captured: dict = {}
+
+        def _fake_build(*args: object, **kwargs: object) -> str:
+            captured.update(kwargs)
+            return "fake-prompt"
+
+        monkeypatch.setattr("autoskillit.cli._prompts._build_fleet_dispatch_prompt", _fake_build)
+        monkeypatch.setattr(
+            "autoskillit.cli.session._session_launch._run_interactive_session",
+            lambda *a, **kw: None,
+        )
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir(exist_ok=True)
+        (config_dir / "config.yaml").write_text("fleet:\n  max_issues_per_food_truck: 7\n")
+        monkeypatch.chdir(tmp_path)
+
+        from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+        _launch_fleet_session(None, None, None, None, fleet_mode="dispatch")
+        assert captured.get("max_issues_per_food_truck") == 7
+
+    def test_campaign_dispatch_forwards_max_issues_per_food_truck(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Campaign threads max_issues cfg to campaign prompt builder."""
+        captured: dict = {}
+
+        def _fake_build(
+            campaign_recipe: object,
+            manifest_yaml: str,
+            completed_dispatches: str,
+            mcp_prefix: str,
+            campaign_id: str,
+            **kwargs: object,
+        ) -> str:
+            captured.update(kwargs)
+            return "fake-prompt"
+
+        monkeypatch.setattr("autoskillit.cli._prompts._build_fleet_campaign_prompt", _fake_build)
+        monkeypatch.setattr(
+            "autoskillit.cli.session._session_launch._run_interactive_session",
+            lambda *a, **kw: None,
+        )
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir(exist_ok=True)
+        (config_dir / "config.yaml").write_text("fleet:\n  max_issues_per_food_truck: 7\n")
+        monkeypatch.chdir(tmp_path)
+
+        state_path = tmp_path / ".autoskillit" / "temp" / "fleet" / "test-id"
+        state_path.mkdir(parents=True)
+        (state_path / "state.json").write_text("{}")
+
+        from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+        _launch_fleet_session(
+            _make_campaign_recipe(),
+            "test-id",
+            state_path / "state.json",
+            None,
+            fleet_mode="campaign",
+        )
+        assert captured.get("max_issues_per_food_truck") == 7

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -223,7 +223,7 @@ def test_fleet_reload_relaunches_without_resume(
     monkeypatch.setattr("autoskillit.cli.detect_autoskillit_mcp_prefix", lambda: "autoskillit")
     monkeypatch.setattr(
         "autoskillit.cli._prompts._build_fleet_dispatch_prompt",
-        lambda mcp_prefix, recipe_table=None: "test-prompt",
+        lambda mcp_prefix, recipe_table=None, max_issues_per_food_truck=3: "test-prompt",
     )
     monkeypatch.chdir(tmp_path)
 

--- a/tests/config/test_fleet_config.py
+++ b/tests/config/test_fleet_config.py
@@ -216,6 +216,49 @@ class TestFleetConfig:
         with pytest.raises(ValueError, match="idle_output_timeout must be non-negative"):
             FleetConfig(idle_output_timeout=-1).validate(feature_enabled=True)
 
+    def test_fleet_config_max_issues_per_food_truck_defaults_to_3(self) -> None:
+        """FleetConfig.max_issues_per_food_truck defaults to 3."""
+        from autoskillit.config.settings import FleetConfig
+
+        assert FleetConfig().max_issues_per_food_truck == 3
+
+    def test_fleet_config_max_issues_per_food_truck_rejects_zero(self) -> None:
+        """FleetConfig raises ValueError when max_issues_per_food_truck is 0."""
+        from autoskillit.config.settings import FleetConfig
+
+        with pytest.raises(ValueError, match="max_issues_per_food_truck must be >= 1"):
+            FleetConfig(max_issues_per_food_truck=0).validate(feature_enabled=True)
+
+    def test_fleet_config_max_issues_per_food_truck_rejects_above_max_total(self) -> None:
+        """FleetConfig raises ValueError when max_issues > max_total_issues."""
+        from autoskillit.config.settings import FleetConfig
+
+        with pytest.raises(ValueError, match="max_issues_per_food_truck must be <="):
+            FleetConfig(max_issues_per_food_truck=13, max_total_issues=12).validate(
+                feature_enabled=True
+            )
+
+    def test_fleet_config_max_issues_per_food_truck_matches_defaults_yaml(self) -> None:
+        """FleetConfig.max_issues_per_food_truck matches defaults.yaml."""
+        from autoskillit.config.settings import FleetConfig
+        from autoskillit.core.io import load_yaml
+        from autoskillit.core.paths import pkg_root
+
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+        assert (
+            FleetConfig().max_issues_per_food_truck
+            == defaults["fleet"]["max_issues_per_food_truck"]
+        )
+
+    def test_load_config_fleet_max_issues_per_food_truck_override(self, tmp_path: Path) -> None:
+        """User config can override max_issues_per_food_truck."""
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {"fleet": {"max_issues_per_food_truck": 5}}
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.fleet.max_issues_per_food_truck == 5
+
 
 def test_config_resolution_fleet_enabled_via_experimental(tmp_path) -> None:
     """Full config resolution enables fleet when experimental_enabled=True in project config."""

--- a/tests/contracts/test_campaign_prompt_accuracy.py
+++ b/tests/contracts/test_campaign_prompt_accuracy.py
@@ -25,7 +25,7 @@ def test_campaign_prompt_does_not_claim_queuing(dynamic_dispatch_text: str) -> N
 def test_dynamic_dispatch_section_uses_configured_max_issues() -> None:
     """Dynamic dispatch section must use the passed max_issues_per_food_truck value."""
     text = _build_dynamic_dispatch_section(mcp_prefix=MCP_PREFIX, max_issues_per_food_truck=7)
-    assert "7" in text
+    assert "(default: 7)" in text
     assert "(default: 5)" not in text
 
 

--- a/tests/contracts/test_campaign_prompt_accuracy.py
+++ b/tests/contracts/test_campaign_prompt_accuracy.py
@@ -20,3 +20,16 @@ def test_campaign_prompt_does_not_claim_queuing(dynamic_dispatch_text: str) -> N
         "Campaign prompt must not claim 'calls queue when the semaphore is saturated' — "
         "FLEET_PARALLEL_REFUSED is a fast-fail, not a queue. Dispatcher must wait and retry."
     )
+
+
+def test_dynamic_dispatch_section_uses_configured_max_issues() -> None:
+    """Dynamic dispatch section must use the passed max_issues_per_food_truck value."""
+    text = _build_dynamic_dispatch_section(mcp_prefix=MCP_PREFIX, max_issues_per_food_truck=7)
+    assert "7" in text
+    assert "(default: 5)" not in text
+
+
+def test_dynamic_dispatch_section_default_max_issues_is_3() -> None:
+    """Default max_issues_per_food_truck when unspecified should be 3."""
+    text = _build_dynamic_dispatch_section(mcp_prefix=MCP_PREFIX)
+    assert "(default: 3)" in text

--- a/tests/contracts/test_fleet_dispatch_bem_gate.py
+++ b/tests/contracts/test_fleet_dispatch_bem_gate.py
@@ -116,7 +116,7 @@ def test_fleet_prompt_batch_section_references_execution_map(fleet_prompt: str) 
 def test_fleet_prompt_batch_section_contains_max_issues_cap(fleet_prompt: str) -> None:
     """Batch dispatch section must contain the max_issues_per_food_truck cap value."""
     batch_section = fleet_prompt.split("BATCH DISPATCH")[1].split("## DISPATCHER")[0]
-    assert "3" in batch_section or "max_issues_per_food_truck" in batch_section
+    assert "3" in batch_section
 
 
 def test_fleet_prompt_batch_section_preserves_single_issue_fallback(fleet_prompt: str) -> None:

--- a/tests/contracts/test_fleet_dispatch_bem_gate.py
+++ b/tests/contracts/test_fleet_dispatch_bem_gate.py
@@ -94,3 +94,48 @@ def test_fleet_prompt_bem_gate_has_never_block(fleet_prompt: str) -> None:
         "BEM gate section must contain NEVER directives prohibiting "
         "multi-issue dispatch without prior BEM execution"
     )
+
+
+def test_fleet_prompt_contains_batch_dispatch_section(fleet_prompt: str) -> None:
+    """Fleet dispatcher prompt must contain batch dispatch mode section."""
+    assert "BATCH DISPATCH" in fleet_prompt
+
+
+def test_fleet_prompt_batch_section_references_implement_findings(fleet_prompt: str) -> None:
+    """Batch dispatch section must reference implement-findings recipe."""
+    batch_section = fleet_prompt.split("BATCH DISPATCH")[1].split("## DISPATCHER")[0]
+    assert "implement-findings" in batch_section
+
+
+def test_fleet_prompt_batch_section_references_execution_map(fleet_prompt: str) -> None:
+    """Batch dispatch section must instruct passing execution_map to implement-findings."""
+    batch_section = fleet_prompt.split("BATCH DISPATCH")[1].split("## DISPATCHER")[0]
+    assert "execution_map" in batch_section
+
+
+def test_fleet_prompt_batch_section_contains_max_issues_cap(fleet_prompt: str) -> None:
+    """Batch dispatch section must contain the max_issues_per_food_truck cap value."""
+    batch_section = fleet_prompt.split("BATCH DISPATCH")[1].split("## DISPATCHER")[0]
+    assert "3" in batch_section or "max_issues_per_food_truck" in batch_section
+
+
+def test_fleet_prompt_batch_section_preserves_single_issue_fallback(fleet_prompt: str) -> None:
+    """Batch section must instruct fallback to implementation recipe for single-issue groups."""
+    batch_section = fleet_prompt.split("BATCH DISPATCH")[1].split("## DISPATCHER")[0]
+    lower = batch_section.lower()
+    assert "single" in lower or "1 issue" in lower or "only 1" in lower
+
+
+def test_implementation_recipe_has_batch_dispatch_ingredient() -> None:
+    """implementation.yaml must expose a visible batch_dispatch ingredient."""
+    from autoskillit.core.io import load_yaml
+    from autoskillit.core.paths import pkg_root
+
+    recipe_yaml = load_yaml(pkg_root() / "recipes" / "implementation.yaml")
+    ingredients = recipe_yaml["ingredients"]
+    assert "batch_dispatch" in ingredients, (
+        "implementation.yaml must have batch_dispatch ingredient"
+    )
+    bd = ingredients["batch_dispatch"]
+    assert bd.get("default") == "false", "batch_dispatch must default to 'false'"
+    assert bd.get("hidden") is not True, "batch_dispatch must be visible (not hidden)"


### PR DESCRIPTION
## Summary

Add multi-issue batching to the ad-hoc fleet dispatch flow. When `batch_dispatch="true"` is set on the `implementation` recipe, the fleet dispatcher groups parallel-safe issues (as determined by BEM) into chunks of up to `max_issues_per_food_truck` and dispatches each chunk as an `implement-findings` food truck with comma-separated `issue_urls`, instead of spawning one `implementation` food truck per issue. This reduces session bootstrap overhead proportionally to the batch size.

Four changes:
1. Add `max_issues_per_food_truck: int = 3` field to `FleetConfig` with validation
2. Add `batch_dispatch` visible ingredient to `implementation.yaml`
3. Add batch dispatch instructions to the fleet dispatch prompt (`_prompts_kitchen.py`)
4. Replace the hardcoded `max_issues_per_food_truck (default: 5)` in the campaign prompt with the configurable value

## Acceptance Criteria

- [ ] `batch_dispatch` ingredient added to `implementation.yaml` (visible in table, default `"false"`)
- [ ] `FleetConfig.max_issues_per_food_truck` is configurable (default 3) with validation
- [ ] When `batch_dispatch=false` (default): fleet dispatcher uses current one-issue-per-food-truck behavior (no regression)
- [ ] When `batch_dispatch=true`: fleet dispatcher batches parallel-safe issues into `implement-findings` food trucks of up to `max_issues_per_food_truck` issues
- [ ] Campaign prompt reads `FleetConfig.max_issues_per_food_truck` instead of hardcoding 5
- [ ] Sequential groups and single-issue groups still dispatch via `implementation` recipe regardless of `batch_dispatch`
- [ ] Execution map path is passed to `implement-findings` via the `execution_map` ingredient so BEM is not re-run inside the food truck
- [ ] Existing tests pass; new tests cover config validation and prompt batching content for both modes

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-185718-795185/.autoskillit/temp/make-plan/fleet_batch_dispatch_plan_2026-05-23_190500.md`

## Changed Files

- `src/autoskillit/cli/_prompts_campaign.py` — Thread `max_issues_per_food_truck` through campaign prompt builder
- `src/autoskillit/cli/_prompts_kitchen.py` — Add batch dispatch mode section to fleet dispatch prompt
- `src/autoskillit/cli/fleet/_fleet_session.py` — Wire config value to prompt builders (ad-hoc and campaign paths)
- `src/autoskillit/config/_config_dataclasses.py` — Add `max_issues_per_food_truck` field with validation
- `src/autoskillit/config/defaults.yaml` — Default `max_issues_per_food_truck: 3`
- `src/autoskillit/config/settings.py` — Wire field through `from_dynaconf`
- `src/autoskillit/recipes/implementation.yaml` — Expose `batch_dispatch` ingredient
- `src/autoskillit/recipes/implementation.json` — Regenerated contract card
- `tests/cli/test_fleet_dispatch.py` — New tests
- `tests/cli/test_fleet_session.py` — New wiring tests for both ad-hoc and campaign paths
- `tests/cli/test_reload_loop.py` — Updated mocks
- `tests/config/test_fleet_config.py` — New tests for config field and validation
- `tests/contracts/test_campaign_prompt_accuracy.py` — New tests for configurable max value
- `tests/contracts/test_fleet_dispatch_bem_gate.py` — New tests for batch prompt section

Closes #2817

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 105 | 34.8k | 1.5M | 117.8k | 198 | 197.1k | 26m 46s |
| verify | claude-opus-4-6 | 1 | 1.5k | 15.8k | 617.6k | 67.3k | 96 | 52.9k | 7m 16s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.3M | 19.8k | 2.0M | 98.7k | 135 | 111.5k | 8m 30s |
| prepare_pr* | MiniMax-M2.7 | 1 | 64.6k | 4.4k | 251.6k | 0 | 22 | 0 | 1m 39s |
| compose_pr* | MiniMax-M2.7 | 1 | 48.8k | 2.8k | 384.1k | 0 | 26 | 0 | 1m 4s |
| review_pr | claude-sonnet-4-6 | 1 | 92 | 30.1k | 520.2k | 76.2k | 38 | 62.1k | 7m 23s |
| resolve_review | claude-opus-4-6 | 1 | 52 | 11.5k | 892.6k | 69.3k | 76 | 54.1k | 9m 10s |
| **Total** | | | 3.4M | 119.2k | 6.1M | 117.8k | | 477.8k | 1h 1m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 256 | 7687.2 | 435.7 | 77.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 223140.0 | 13524.2 | 2874.8 |
| **Total** | **260** | 23600.5 | 1837.5 | 458.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 197 | 64.9k | 2.0M | 259.2k | 34m 10s |
| claude-opus-4-6 | 2 | 1.6k | 27.3k | 1.5M | 107.0k | 16m 27s |
| MiniMax-M2.7-highspeed | 1 | 3.3M | 19.8k | 2.0M | 111.5k | 8m 30s |
| MiniMax-M2.7 | 2 | 113.5k | 7.2k | 635.6k | 0 | 2m 43s |