### PR TITLE
Fleet dispatch — allow L3 to pass free-text instructions to L2 food truck

### DIFF
--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -308,6 +308,9 @@ dispatch_food_truck(
 If a dispatch has no `capture:` field, pass `capture={{}}` or omit the parameter.
 The `${{{{ campaign.* }}}}` references in ingredients are resolved before the L2 session
 is started — the L2 food truck agent always receives concrete values.
+
+If the user provided extra guidance at campaign launch, pass it to each dispatch via
+`caller_instructions=<guidance>`. The L2 food truck treats it as authoritative.
 {gate_section}{dynamic_dispatch_section}
 ## RESUME DISCIPLINE
 

--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -38,6 +38,8 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
         "2. Display the ingredients table and collect required values from the user.\n"
         f"3. Call {mcp_prefix}dispatch_food_truck(recipe='<recipe>', task='<task>', "
         "ingredients={...}) with the collected values.\n"
+        'If the user provides extra guidance for the food truck (e.g., "use opus model", '
+        "\"skip review\"), pass it via caller_instructions='<guidance>'.\n"
         "Do NOT call open_kitchen without ingredients_only=True when dispatching "
         "— the full recipe content is unnecessary for dispatch and wastes context.\n"
         "If the user wants to run a recipe interactively (pipeline execution), "
@@ -124,6 +126,10 @@ issue context when the task involves a GitHub issue.
 - `task` parameter: provide a clear, actionable one-line description of the work for each dispatch.
 - `ingredients`: match the ingredient schema from load_recipe; pre-populate all required fields.
 - Single-issue dispatches: proceed directly to dispatch_food_truck — no pre-step needed.
+- `caller_instructions`: when the user provides extra guidance for the food truck session
+  (e.g., 'use model opus for implement', 'skip review if diff is under 20 lines'),
+  pass it as caller_instructions. This free-text is injected into the L2 system prompt
+  as authoritative guidance from the dispatcher.
 
 ## MULTI-ISSUE DISPATCH — BEM PRE-STEP GATE — MANDATORY
 

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -382,6 +382,7 @@ async def execute_dispatch(
     caller_session_id: str = "",
     prior_dispatch_id: str | None = None,
     resume_message: str | None = None,
+    caller_instructions: str | None = None,
 ) -> DispatchResult:
     """Execute a single food truck dispatch.
 
@@ -447,6 +448,7 @@ async def execute_dispatch(
             caller_session_id=caller_session_id,
             prior_dispatch_id=prior_dispatch_id,
             resume_message=resume_message,
+            caller_instructions=caller_instructions,
         )
     except asyncio.CancelledError:
         raise
@@ -560,6 +562,7 @@ async def _run_dispatch(
     caller_session_id: str = "",
     prior_dispatch_id: str | None = None,
     resume_message: str | None = None,
+    caller_instructions: str | None = None,
 ) -> DispatchResult:
     """Inner dispatch body — called after lock acquisition."""
     from autoskillit.fleet.state import (
@@ -782,6 +785,7 @@ async def _run_dispatch(
         campaign_id=campaign_id,
         l3_timeout_sec=int(resolved_timeout),
         capture=capture,
+        caller_instructions=caller_instructions,
     )
 
     if tool_ctx.executor is None:

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -65,6 +65,7 @@ def _build_food_truck_prompt(
     campaign_id: str,
     l3_timeout_sec: int,
     capture: dict[str, CaptureEntrySpec] | None = None,
+    caller_instructions: str | None = None,
 ) -> str:
     """Build the system prompt for an L2 food truck headless session.
 
@@ -103,6 +104,17 @@ def _build_food_truck_prompt(
         if capture_field_pairs
         else ""
     )
+
+    caller_instructions_section = ""
+    if caller_instructions:
+        caller_instructions_section = f"""\
+--- SECTION 6b: CALLER INSTRUCTIONS ---
+
+The dispatching session has provided the following instructions. Treat these as
+authoritative guidance from the caller — they override default behavior where applicable.
+
+{caller_instructions}
+"""
 
     return f"""\
 You are an L2 food truck orchestrator. Execute the recipe '{recipe}' autonomously.
@@ -281,7 +293,7 @@ Timeout: {l3_timeout_sec} seconds
 
 Execute the recipe pipeline for the task above. Follow all routing
 rules and failure predicates. Emit the sentinel block upon completion.
-
+{caller_instructions_section}
 --- SECTION 7: INGREDIENT VALUES ---
 
 The following ingredient values have been applied via open_kitchen overrides.

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -293,8 +293,8 @@ Timeout: {l3_timeout_sec} seconds
 
 Execute the recipe pipeline for the task above. Follow all routing
 rules and failure predicates. Emit the sentinel block upon completion.
-{caller_instructions_section}
---- SECTION 7: INGREDIENT VALUES ---
+
+{caller_instructions_section}--- SECTION 7: INGREDIENT VALUES ---
 
 The following ingredient values have been applied via open_kitchen overrides.
 They are provided here for reference only — do NOT re-apply or re-prompt.

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -151,9 +151,9 @@ async def dispatch_food_truck(
             Injected as a CALLER CONTEXT section in the resume prompt, allowing the
             caller to communicate changed conditions (e.g. "quota guard is now
             disabled") that the LLM should act on.
-        caller_instructions: Optional free-text instructions from the caller (L3) to
-            the food truck (L2) session. Injected as a CALLER INSTRUCTIONS section in
-            the L2 system prompt. Use to forward user guidance such as "use model opus
+        caller_instructions: Optional free-text instructions from the dispatching caller to
+            the food truck session. Injected as a CALLER INSTRUCTIONS section in
+            the food truck system prompt. Use to forward user guidance such as "use model opus
             for the implement step" or "skip review if diff is under 20 lines."
             Only meaningful on fresh dispatches (not resumes). When None or empty,
             the L2 prompt is unchanged.

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -22,6 +22,8 @@ from autoskillit.server._notify import track_response_size
 
 logger = get_logger(__name__)
 
+_MAX_CALLER_INSTRUCTIONS_LEN = 2000
+
 
 def _write_dispatch_to_campaign_state(
     campaign_state_path_str: str,
@@ -172,7 +174,6 @@ async def dispatch_food_truck(
         return fleet_gate
 
     try:
-        _MAX_CALLER_INSTRUCTIONS_LEN = 2000
         if caller_instructions and len(caller_instructions) > _MAX_CALLER_INSTRUCTIONS_LEN:
             caller_instructions = caller_instructions[:_MAX_CALLER_INSTRUCTIONS_LEN]
 

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -166,16 +166,16 @@ async def dispatch_food_truck(
 
     Never raises.
     """
-    _MAX_CALLER_INSTRUCTIONS_LEN = 2000
-    if caller_instructions and len(caller_instructions) > _MAX_CALLER_INSTRUCTIONS_LEN:
-        caller_instructions = caller_instructions[:_MAX_CALLER_INSTRUCTIONS_LEN]
-
     if (gate := _require_enabled()) is not None:
         return gate
     if (fleet_gate := _require_fleet("dispatch_food_truck")) is not None:
         return fleet_gate
 
     try:
+        _MAX_CALLER_INSTRUCTIONS_LEN = 2000
+        if caller_instructions and len(caller_instructions) > _MAX_CALLER_INSTRUCTIONS_LEN:
+            caller_instructions = caller_instructions[:_MAX_CALLER_INSTRUCTIONS_LEN]
+
         # Feature guard: config authority check independent of MCP visibility state.
         # Fleet sessions open the gate unconditionally at boot; this catch-all ensures
         # dispatch_food_truck never executes when features.fleet is disabled in config.

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -123,6 +123,7 @@ async def dispatch_food_truck(
     prior_dispatch_id: str | None = None,
     skip_when: str | None = None,
     resume_message: str | None = None,
+    caller_instructions: str | None = None,
     ctx: Context = CurrentContext(),
 ) -> str:
     """Dispatch a single food truck L2 session for one recipe.
@@ -150,6 +151,12 @@ async def dispatch_food_truck(
             Injected as a CALLER CONTEXT section in the resume prompt, allowing the
             caller to communicate changed conditions (e.g. "quota guard is now
             disabled") that the LLM should act on.
+        caller_instructions: Optional free-text instructions from the caller (L3) to
+            the food truck (L2) session. Injected as a CALLER INSTRUCTIONS section in
+            the L2 system prompt. Use to forward user guidance such as "use model opus
+            for the implement step" or "skip review if diff is under 20 lines."
+            Only meaningful on fresh dispatches (not resumes). When None or empty,
+            the L2 prompt is unchanged.
 
     Resume vs. Fresh Dispatch:
         - ``resume_session_id``: Session ID to resume (``--resume <id>``).
@@ -292,6 +299,7 @@ async def dispatch_food_truck(
             caller_session_id=caller_session_id,
             prior_dispatch_id=prior_dispatch_id,
             resume_message=resume_message,
+            caller_instructions=caller_instructions,
         )
 
         if campaign_state_path_str and isinstance(result, DispatchResult):

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -166,6 +166,10 @@ async def dispatch_food_truck(
 
     Never raises.
     """
+    _MAX_CALLER_INSTRUCTIONS_LEN = 2000
+    if caller_instructions and len(caller_instructions) > _MAX_CALLER_INSTRUCTIONS_LEN:
+        caller_instructions = caller_instructions[:_MAX_CALLER_INSTRUCTIONS_LEN]
+
     if (gate := _require_enabled()) is not None:
         return gate
     if (fleet_gate := _require_fleet("dispatch_food_truck")) is not None:

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -175,47 +175,6 @@ class TestExecuteDispatchCancelledErrorLockRelease:
         assert captured_kwargs[0].get("caller_instructions") == "skip review"
 
     @pytest.mark.anyio
-    async def test_execute_dispatch_passes_caller_instructions_to_prompt_builder(
-        self, tool_ctx, monkeypatch
-    ) -> None:
-        """Verify caller_instructions is forwarded to prompt_builder.
-
-        Patches _run_dispatch to capture prompt_builder kwargs, then raises
-        CancelledError to short-circuit. The capture must occur inside _run_dispatch
-        since that is where prompt_builder is called.
-        """
-        from tests.fleet._helpers import _setup_dispatch
-
-        _setup_dispatch(tool_ctx, monkeypatch)
-
-        prompt_builder_calls: list[dict] = []
-
-        async def _run_dispatch_with_capture(**kwargs):
-            prompt_builder_calls.append(kwargs)
-            raise asyncio.CancelledError
-
-        monkeypatch.setattr("autoskillit.fleet._api._run_dispatch", _run_dispatch_with_capture)
-
-        with pytest.raises(asyncio.CancelledError):
-            from autoskillit.fleet import execute_dispatch
-
-            await execute_dispatch(
-                tool_ctx=tool_ctx,
-                recipe="test-recipe",
-                task="do something",
-                ingredients=None,
-                dispatch_name="test-dispatch",
-                timeout_sec=None,
-                prompt_builder=lambda *a, **kw: "prompt",
-                quota_checker=lambda *a, **kw: None,
-                quota_refresher=lambda *a, **kw: None,
-                caller_instructions="test instructions",
-            )
-
-        assert prompt_builder_calls, "prompt_builder was never called"
-        assert prompt_builder_calls[0].get("caller_instructions") == "test instructions"
-
-    @pytest.mark.anyio
     async def test_cancelled_dispatch_triggers_label_cleanup(self, tool_ctx, monkeypatch) -> None:
         """swap_labels is called for the claimed issue when dispatch is cancelled.
 

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -134,6 +134,81 @@ class TestExecuteDispatchCancelledErrorLockRelease:
         assert captured_kwargs[0].get("resume_session_id") == "abc-123"
 
     @pytest.mark.anyio
+    async def test_execute_dispatch_passes_caller_instructions_to_run_dispatch(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        """Verify caller_instructions is forwarded to _run_dispatch.
+
+        Raises CancelledError from the _run_dispatch mock intentionally: this
+        short-circuits execute_dispatch after kwarg capture, avoiding the need
+        to wire a full dispatch chain while still asserting kwarg forwarding.
+        """
+        from tests.fleet._helpers import _setup_dispatch
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+
+        captured_kwargs: list[dict] = []
+
+        async def _capture(**kwargs):
+            captured_kwargs.append(kwargs)
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr("autoskillit.fleet._api._run_dispatch", _capture)
+
+        with pytest.raises(asyncio.CancelledError):
+            from autoskillit.fleet import execute_dispatch
+
+            await execute_dispatch(
+                tool_ctx=tool_ctx,
+                recipe="test-recipe",
+                task="do something",
+                ingredients=None,
+                dispatch_name="test-dispatch",
+                timeout_sec=None,
+                prompt_builder=lambda *a, **kw: "prompt",
+                quota_checker=lambda *a, **kw: None,
+                quota_refresher=lambda *a, **kw: None,
+                caller_instructions="skip review",
+            )
+
+        assert captured_kwargs, "_run_dispatch was never called"
+        assert captured_kwargs[0].get("caller_instructions") == "skip review"
+
+    @pytest.mark.anyio
+    async def test_execute_dispatch_passes_caller_instructions_to_prompt_builder(
+        self, tool_ctx, monkeypatch
+    ) -> None:
+        """Verify caller_instructions is forwarded to prompt_builder."""
+        from tests.fleet._helpers import _setup_dispatch
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+
+        prompt_builder_calls: list[dict] = []
+
+        async def _capturing_prompt_builder(**kwargs):
+            prompt_builder_calls.append(kwargs)
+            return "prompt"
+
+        with pytest.raises(asyncio.CancelledError):
+            from autoskillit.fleet import execute_dispatch
+
+            await execute_dispatch(
+                tool_ctx=tool_ctx,
+                recipe="test-recipe",
+                task="do something",
+                ingredients=None,
+                dispatch_name="test-dispatch",
+                timeout_sec=None,
+                prompt_builder=_capturing_prompt_builder,
+                quota_checker=lambda *a, **kw: None,
+                quota_refresher=lambda *a, **kw: None,
+                caller_instructions="test instructions",
+            )
+
+        assert prompt_builder_calls, "prompt_builder was never called"
+        assert prompt_builder_calls[0].get("caller_instructions") == "test instructions"
+
+    @pytest.mark.anyio
     async def test_cancelled_dispatch_triggers_label_cleanup(self, tool_ctx, monkeypatch) -> None:
         """swap_labels is called for the claimed issue when dispatch is cancelled.
 

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -178,16 +178,23 @@ class TestExecuteDispatchCancelledErrorLockRelease:
     async def test_execute_dispatch_passes_caller_instructions_to_prompt_builder(
         self, tool_ctx, monkeypatch
     ) -> None:
-        """Verify caller_instructions is forwarded to prompt_builder."""
+        """Verify caller_instructions is forwarded to prompt_builder.
+
+        Patches _run_dispatch to capture prompt_builder kwargs, then raises
+        CancelledError to short-circuit. The capture must occur inside _run_dispatch
+        since that is where prompt_builder is called.
+        """
         from tests.fleet._helpers import _setup_dispatch
 
         _setup_dispatch(tool_ctx, monkeypatch)
 
         prompt_builder_calls: list[dict] = []
 
-        async def _capturing_prompt_builder(**kwargs):
+        async def _run_dispatch_with_capture(**kwargs):
             prompt_builder_calls.append(kwargs)
-            return "prompt"
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr("autoskillit.fleet._api._run_dispatch", _run_dispatch_with_capture)
 
         with pytest.raises(asyncio.CancelledError):
             from autoskillit.fleet import execute_dispatch
@@ -199,7 +206,7 @@ class TestExecuteDispatchCancelledErrorLockRelease:
                 ingredients=None,
                 dispatch_name="test-dispatch",
                 timeout_sec=None,
-                prompt_builder=_capturing_prompt_builder,
+                prompt_builder=lambda *a, **kw: "prompt",
                 quota_checker=lambda *a, **kw: None,
                 quota_refresher=lambda *a, **kw: None,
                 caller_instructions="test instructions",

--- a/tests/fleet/test_food_truck_prompt.py
+++ b/tests/fleet/test_food_truck_prompt.py
@@ -111,3 +111,49 @@ def test_food_truck_prompt_has_anti_fabrication_guard():
         "Food truck prompt must include anti-fabrication language"
     )
     assert "ROUTING AUTHORITY" in prompt
+
+
+def test_food_truck_prompt_injects_caller_instructions_section():
+    """L3 food truck prompt must inject caller instructions when provided."""
+    prompt = _build_food_truck_prompt(
+        recipe="test-recipe",
+        task="Test task",
+        ingredients={},
+        mcp_prefix=DIRECT_PREFIX,
+        dispatch_id="test-dispatch",
+        campaign_id="test-campaign",
+        l3_timeout_sec=300,
+        caller_instructions="use opus for implement",
+    )
+    assert "CALLER INSTRUCTIONS" in prompt
+    assert "use opus for implement" in prompt
+    assert "SECTION 6b" in prompt
+
+
+def test_food_truck_prompt_no_caller_instructions_section_when_none():
+    """L3 food truck prompt must not include caller instructions section when caller_instructions is None."""
+    prompt = _build_food_truck_prompt(
+        recipe="test-recipe",
+        task="Test task",
+        ingredients={},
+        mcp_prefix=DIRECT_PREFIX,
+        dispatch_id="test-dispatch",
+        campaign_id="test-campaign",
+        l3_timeout_sec=300,
+    )
+    assert "CALLER INSTRUCTIONS" not in prompt
+
+
+def test_food_truck_prompt_no_caller_instructions_section_when_empty():
+    """L3 food truck prompt must not include caller instructions section when caller_instructions is empty."""
+    prompt = _build_food_truck_prompt(
+        recipe="test-recipe",
+        task="Test task",
+        ingredients={},
+        mcp_prefix=DIRECT_PREFIX,
+        dispatch_id="test-dispatch",
+        campaign_id="test-campaign",
+        l3_timeout_sec=300,
+        caller_instructions="",
+    )
+    assert "CALLER INSTRUCTIONS" not in prompt

--- a/tests/server/test_tools_dispatch_params.py
+++ b/tests/server/test_tools_dispatch_params.py
@@ -72,6 +72,60 @@ async def test_dispatch_food_truck_tool_passes_resume_message_to_executor(
     assert executor.dispatch_calls[0].resume_message == "retry with new quota"
 
 
+@pytest.mark.anyio
+async def test_dispatch_food_truck_tool_passes_caller_instructions_into_prompt(
+    tool_ctx_kitchen_open, monkeypatch
+):
+    """dispatch_food_truck MCP tool embeds caller_instructions in the orchestrator prompt."""
+    from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
+
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+    tool_ctx_kitchen_open.fleet_lock = FleetSemaphore(max_concurrent=1)
+    repo = InMemoryRecipeRepository()
+    recipe_info = _make_recipe_info("test-recipe")
+    repo.add_recipe("test-recipe", recipe_info)
+    repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe"))
+    tool_ctx_kitchen_open.recipes = repo
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+
+    await dispatch_food_truck(
+        recipe="test-recipe",
+        task="do-work",
+        caller_instructions="use opus for implement",
+    )
+
+    assert executor.dispatch_calls, "dispatch_food_truck executor was never called"
+    assert "CALLER INSTRUCTIONS" in executor.dispatch_calls[0].orchestrator_prompt
+    assert "use opus for implement" in executor.dispatch_calls[0].orchestrator_prompt
+
+
+@pytest.mark.anyio
+async def test_dispatch_food_truck_no_caller_instructions_section_when_not_specified(
+    tool_ctx_kitchen_open, monkeypatch
+):
+    """When caller_instructions is not specified, no CALLER INSTRUCTIONS section appears in prompt."""
+    from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
+
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+    tool_ctx_kitchen_open.fleet_lock = FleetSemaphore(max_concurrent=1)
+    repo = InMemoryRecipeRepository()
+    recipe_info = _make_recipe_info("test-recipe")
+    repo.add_recipe("test-recipe", recipe_info)
+    repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe"))
+    tool_ctx_kitchen_open.recipes = repo
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+
+    await dispatch_food_truck(
+        recipe="test-recipe",
+        task="do-work",
+    )
+
+    assert executor.dispatch_calls, "dispatch_food_truck executor was never called"
+    assert "CALLER INSTRUCTIONS" not in executor.dispatch_calls[0].orchestrator_prompt
+
+
 class TestDispatchFoodTruckIdleTimeout:
     """Tests for idle_output_timeout passthrough through the dispatch chain."""
 


### PR DESCRIPTION
## Summary

Add a `caller_instructions` parameter to `dispatch_food_truck` that allows L3 dispatchers to forward free-text guidance (e.g., "use model opus for the implement step") to L2 food truck sessions. The parameter threads through `execute_dispatch` → `_run_dispatch` → `_build_food_truck_prompt`, where it is injected as a clearly delineated section in the L2 system prompt. When `None` or empty, the prompt is unchanged. L3 prompt templates are updated to document the parameter so the L3 knows to use it when the user provides extra guidance.

**Key design point:** `caller_instructions` is consumed by the prompt builder and embedded into the `orchestrator_prompt` string. It does NOT flow to the `HeadlessExecutor.dispatch_food_truck` method — the executor receives the already-built prompt. This means the `HeadlessExecutor` Protocol, `DefaultHeadlessExecutor`, and `InMemoryHeadlessExecutor` are unchanged.

**Naming rationale:** `caller_instructions` follows the existing naming pattern where `resume_message` is "caller-supplied context for the resumed session." `caller_instructions` is "caller-supplied instructions for the fresh session." It is self-documenting for both the L3 caller ("I am the caller providing instructions") and the codebase ("these are instructions from the caller").

## Requirements

1. Add a parameter to `dispatch_food_truck` (MCP tool) that accepts free-text caller instructions.
2. Thread it through `execute_dispatch` → `_run_dispatch` → `_build_food_truck_prompt`.
3. Inject it into the food truck prompt as a clearly delineated section so the L2 treats it as authoritative guidance from the caller.
4. Update the L3 fleet dispatch prompt (`_prompts_kitchen.py`) and campaign prompt (`_prompts_campaign.py`) so the L3 knows this parameter exists and uses it when the user provides extra guidance.
5. When the parameter is `None` or empty, the prompt should be unchanged (no empty section).

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

*(none)*

## Changed Files

### New (★):
None

### Modified (●):
- src/autoskillit/cli/_prompts_campaign.py
- src/autoskillit/cli/_prompts_kitchen.py
- src/autoskillit/fleet/_api.py
- src/autoskillit/fleet/_prompts.py
- src/autoskillit/server/tools/tools_fleet_dispatch.py
- tests/fleet/test_api.py
- tests/fleet/test_food_truck_prompt.py
- tests/server/test_tools_dispatch_params.py

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/fleet_dispatch_caller_instructions_plan_2026-05-23_214500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 78 | 20.3k | 1.6M | 119.4k | 160 | 109.3k | 12m 48s |
| verify | claude-opus-4-6 | 1 | 28 | 4.5k | 655.5k | 101.0k | 71 | 85.7k | 4m 26s |
| implement* | MiniMax-M2.7 | 1 | 84.8k | 10.8k | 2.5M | 29.9k | 108 | 43.3k | 7m 36s |
| prepare_pr* | MiniMax-M2.7 | 1 | 43.9k | 3.2k | 247.7k | 0 | 19 | 0 | 1m 47s |
| compose_pr* | MiniMax-M2.7 | 1 | 44.3k | 2.3k | 367.0k | 0 | 26 | 0 | 3m 6s |
| review_pr | claude-opus-4-6 | 3 | 119 | 84.1k | 2.0M | 83.3k | 98 | 181.3k | 22m 56s |
| resolve_review | claude-opus-4-6 | 2 | 109 | 26.6k | 3.5M | 90.4k | 122 | 125.8k | 15m 57s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 33 | 3.4k | 587.4k | 50.0k | 30 | 34.5k | 1m 52s |
| **Total** | | | 173.3k | 155.1k | 11.5M | 119.4k | | 579.9k | 1h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 217 | 11426.8 | 199.3 | 49.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 52 | 67974.5 | 2419.8 | 511.3 |
| ci_conflict_fix | 4290 | 136.9 | 8.0 | 0.8 |
| **Total** | **4559** | 2515.7 | 127.2 | 34.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 5 | 367 | 138.8k | 8.4M | 536.6k | 58m 2s |
| MiniMax-M2.7 | 3 | 173.0k | 16.3k | 3.1M | 43.3k | 12m 30s |