### PR TITLE
Add model.step_overrides and model.recipe_overrides to CoreRunConfig

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -130,10 +130,29 @@ class CoreRunConfig:
     default_model: str = "sonnet"
     model_override: str | None = None
     provider: str = "anthropic"
+    step_overrides: dict[str, str] = field(default_factory=dict)
+    recipe_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.default_model:
             raise ValueError("CoreRunConfig.default_model must not be empty")
+        for step, model_val in self.step_overrides.items():
+            if not isinstance(model_val, str):
+                raise ValueError(
+                    f"step_overrides[{step!r}] must be a string, got {type(model_val).__name__!r}"
+                )
+        for recipe, overrides in self.recipe_overrides.items():
+            if not isinstance(overrides, dict):
+                raise ValueError(
+                    f"recipe_overrides[{recipe!r}] must be a dict, "
+                    f"got {type(overrides).__name__!r}"
+                )
+            for step, model_val in overrides.items():
+                if not isinstance(model_val, str):
+                    raise ValueError(
+                        f"recipe_overrides[{recipe!r}][{step!r}] must be a string, "
+                        f"got {type(model_val).__name__!r}"
+                    )
 
 
 @dataclass

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -53,6 +53,8 @@ model:
   default: sonnet
   override: null
   provider: anthropic
+  step_overrides: {}
+  recipe_overrides: {}
 
 worktree_setup:
   command: null

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -412,6 +412,8 @@ class AutomationConfig:
                 else _mc["default_model"],
                 model_override=val(mc, "override", _mc["model_override"]) or None,
                 provider=str(val(mc, "provider", _mc["provider"])),
+                step_overrides=val(mc, "step_overrides", _mc["step_overrides"]),
+                recipe_overrides=val(mc, "recipe_overrides", _mc["recipe_overrides"]),
             ),
             worktree_setup=WorktreeSetupConfig(
                 command=_to_optional_list(val(ws, "command", _ws["command"])),
@@ -582,7 +584,9 @@ def _build_config_schema() -> dict[str, frozenset[str]]:
         # YAML uses short keys ('default', 'override') to keep user config concise;
         # the Python fields use explicit names to avoid shadowing builtins.
         if f.name == "model":
-            schema["model"] = frozenset({"default", "override", "provider"})
+            schema["model"] = frozenset(
+                {"default", "override", "provider", "step_overrides", "recipe_overrides"}
+            )
             continue
         # Skip the scalar experimental_enabled field — it is handled under the features section
         if f.name == "experimental_enabled":

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -142,11 +142,30 @@ def _resolve_session_log_dir(cwd: str, ctx: ToolContext) -> Path | None:
     return _session_log_dir(cwd)
 
 
-def _resolve_model(step_model: str, config: AutomationConfig) -> str | None:
-    """Resolve model selection: config override > step > config default."""
+def _resolve_model(
+    step_model: str,
+    config: AutomationConfig,
+    *,
+    step_name: str = "",
+    recipe_name: str = "",
+) -> str | None:
+    """Resolve model selection with 5-tier precedence.
+
+    override > recipe_overrides[recipe][step] > step_overrides[step] > step_model > default
+    """
     if config.model.model_override:
         logger.debug("model_resolved", tier="override", model=config.model.model_override)
         return config.model.model_override
+    if recipe_name and step_name:
+        recipe_model = config.model.recipe_overrides.get(recipe_name, {}).get(step_name)
+        if recipe_model:
+            logger.debug("model_resolved", tier="recipe_override", model=recipe_model)
+            return recipe_model
+    if step_name:
+        step_override = config.model.step_overrides.get(step_name)
+        if step_override:
+            logger.debug("model_resolved", tier="step_override", model=step_override)
+            return step_override
     if step_model:
         logger.debug("model_resolved", tier="step", model=step_model)
         return step_model
@@ -718,7 +737,9 @@ async def run_headless_core(
         skill_command=original_skill_command[:100],
         step_name=step_name or None,
     ):
-        resolved_model = _resolve_model(model, ctx.config)
+        resolved_model = _resolve_model(
+            model, ctx.config, step_name=step_name, recipe_name=recipe_name
+        )
         add_dirs_tuple = tuple(add_dirs)
         if ctx.backend is not None:
             config = SkillSessionConfig(
@@ -915,7 +936,7 @@ class DefaultHeadlessExecutor:
                 f"got {self._ctx.backend.name!r}"
             )
         cfg = self._ctx.config
-        resolved_model = _resolve_model(model, cfg)
+        resolved_model = _resolve_model(model, cfg, step_name=step_name)
         fleet_cfg = cfg.fleet
 
         merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -14,7 +14,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_result.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 1015,
+    "headless/__init__.py": 1030,
     "headless/_headless_recovery.py": 365,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -901,16 +901,17 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "circular imports; all enums/protocols/constants consolidated here",
     ),
     "execution/headless/__init__.py": (
-        1015,
+        1030,
         "REQ-CNST-010-E2: headless session orchestration — Channel B drain-race "
         "recovery + IDLE_STALL routing + contract nudge resume tier "
         "+ DIR_MISSING late-bind recovery arm + RecordingSubprocessRunner "
         "step-name auto-derivation gate + recipe identity threading "
         "+ _execute_claude_headless extraction + dispatch_food_truck orchestration-L2 path "
         "+ campaign_id/dispatch_id propagation kwargs "
-        "+ fs-level write detection (pre/post temp-dir snapshot) "
+        "+ fs-level write detection (pre/post temp-dir snapshot + _resolve_skill_temp_dir) "
         "+ clone guard write-scope extension (planner session write isolation) "
-        "+ api_retry field forwarding to flush_session_log; "
+        "+ api_retry field forwarding to flush_session_log "
+        "+ 5-tier _resolve_model (step_overrides + recipe_overrides tiers); "
         "splitting would fragment the adjudication pipeline across modules",
     ),
     "session.py": (

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -56,6 +56,68 @@ class TestDefaultConfig:
         assert cfg.model_override is None
 
 
+class TestModelStepOverrides:
+    def test_default_model_step_overrides(self):
+        cfg = AutomationConfig()
+        assert cfg.model.step_overrides == {}
+        assert cfg.model.recipe_overrides == {}
+
+    def test_step_overrides_rejects_non_string_value(self):
+        from autoskillit.config import CoreRunConfig
+
+        with pytest.raises(ValueError, match="step_overrides"):
+            CoreRunConfig(step_overrides={"plan": 42})
+
+    def test_recipe_overrides_rejects_non_dict_inner(self):
+        from autoskillit.config import CoreRunConfig
+
+        with pytest.raises(ValueError, match="recipe_overrides"):
+            CoreRunConfig(recipe_overrides={"impl": "opus"})
+
+    def test_recipe_overrides_rejects_non_string_inner_value(self):
+        from autoskillit.config import CoreRunConfig
+
+        with pytest.raises(ValueError, match="recipe_overrides"):
+            CoreRunConfig(recipe_overrides={"impl": {"plan": 42}})
+
+    def test_valid_step_overrides_accepted(self):
+        from autoskillit.config import CoreRunConfig
+
+        cfg = CoreRunConfig(step_overrides={"plan": "opus"})
+        assert cfg.step_overrides == {"plan": "opus"}
+
+    def test_valid_recipe_overrides_accepted(self):
+        from autoskillit.config import CoreRunConfig
+
+        cfg = CoreRunConfig(recipe_overrides={"impl": {"plan": "opus"}})
+        assert cfg.recipe_overrides == {"impl": {"plan": "opus"}}
+
+    def test_yaml_loads_step_overrides(self, tmp_path):
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {"model": {"step_overrides": {"make_plan": "opus"}}}
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.model.step_overrides == {"make_plan": "opus"}
+
+    def test_yaml_loads_recipe_overrides(self, tmp_path):
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {"model": {"recipe_overrides": {"implementation": {"make_plan": "opus"}}}}
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.model.recipe_overrides == {"implementation": {"make_plan": "opus"}}
+
+    def test_validate_layer_keys_accepts_model_step_overrides(self):
+        from autoskillit.config.settings import validate_layer_keys
+
+        validate_layer_keys(
+            {"model": {"step_overrides": {"plan": "opus"}, "recipe_overrides": {}}},
+            Path("/fake/config.yaml"),
+            is_secrets_layer=False,
+        )
+
+
 class TestLoadConfig:
     def test_load_config_no_files_returns_defaults(self, tmp_path):
         """C2: No YAML files on disk -> defaults returned."""

--- a/tests/execution/test_headless_debug_logging.py
+++ b/tests/execution/test_headless_debug_logging.py
@@ -133,3 +133,60 @@ class TestResolveModelLogging:
         model_logs = [r for r in logs if r.get("event") == "model_resolved"]
         assert model_logs
         assert model_logs[0]["tier"] == "none"
+
+    def test_logs_recipe_override_tier(self):
+        from autoskillit.execution.headless import _resolve_model
+
+        cfg = self._make_config()
+        cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
+        with structlog.testing.capture_logs() as logs:
+            result = _resolve_model("", cfg, step_name="plan", recipe_name="impl")
+        assert result == "opus"
+        model_logs = [r for r in logs if r.get("event") == "model_resolved"]
+        assert model_logs
+        assert model_logs[0]["tier"] == "recipe_override"
+
+    def test_logs_step_override_tier(self):
+        from autoskillit.execution.headless import _resolve_model
+
+        cfg = self._make_config()
+        cfg.model.step_overrides = {"plan": "opus"}
+        with structlog.testing.capture_logs() as logs:
+            result = _resolve_model("", cfg, step_name="plan")
+        assert result == "opus"
+        model_logs = [r for r in logs if r.get("event") == "model_resolved"]
+        assert model_logs
+        assert model_logs[0]["tier"] == "step_override"
+
+    def test_recipe_override_beats_step_override(self):
+        from autoskillit.execution.headless import _resolve_model
+
+        cfg = self._make_config()
+        cfg.model.step_overrides = {"plan": "haiku"}
+        cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
+        result = _resolve_model("", cfg, step_name="plan", recipe_name="impl")
+        assert result == "opus"
+
+    def test_step_override_beats_step_model(self):
+        from autoskillit.execution.headless import _resolve_model
+
+        cfg = self._make_config()
+        cfg.model.step_overrides = {"plan": "opus"}
+        result = _resolve_model("sonnet", cfg, step_name="plan")
+        assert result == "opus"
+
+    def test_override_beats_recipe_override(self):
+        from autoskillit.execution.headless import _resolve_model
+
+        cfg = self._make_config(override="haiku")
+        cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
+        result = _resolve_model("", cfg, step_name="plan", recipe_name="impl")
+        assert result == "haiku"
+
+    def test_recipe_override_no_leak(self):
+        from autoskillit.execution.headless import _resolve_model
+
+        cfg = self._make_config(default="sonnet")
+        cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
+        result = _resolve_model("", cfg, step_name="plan", recipe_name="other")
+        assert result == "sonnet"


### PR DESCRIPTION
## Summary

Add two new fields to `CoreRunConfig` (`step_overrides: dict[str, str]` and `recipe_overrides: dict[str, dict[str, str]]`) that allow per-step and per-recipe-per-step model selection from user config YAML, without routing through the providers pipeline. Update `_resolve_model()` to check these two new tiers between the existing `override` and `step_model` tier.

## Requirements

## Acceptance Criteria

- [ ] `model.step_overrides` in config maps step names to model strings (global scope)
- [ ] `model.recipe_overrides` in config maps recipe names to step-name→model dicts (recipe scope)
- [ ] Resolution precedence: `override > recipe_overrides[recipe][step] > step_overrides[step] > recipe step model > default`
- [ ] Recipe-scoped overrides do not leak to other recipes
- [ ] Setting is configurable from `.autoskillit/config.yaml` (user-local, not git-tracked)
- [ ] Does not interact with or trigger the `providers` pipeline
- [ ] Existing tests pass; new tests cover both override tiers

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.


## Changed Files

### New (★):
None

### Modified (●):
src/autoskillit/config/_config_dataclasses.py
src/autoskillit/config/defaults.yaml
src/autoskillit/config/settings.py
src/autoskillit/execution/headless/__init__.py
tests/arch/test_execution_source_split.py
tests/arch/test_subpackage_isolation.py
tests/config/test_config.py
tests/execution/test_headless_debug_logging.py

Closes #2010

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260523-211109-811026/.autoskillit/temp/make-plan/add_model_step_overrides_plan_2026-05-23_211500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.4k | 12.3k | 1.0M | 79.1k | 158 | 63.9k | 9m 17s |
| verify | claude-opus-4-6 | 1 | 2.4k | 18.7k | 2.3M | 86.2k | 150 | 70.6k | 10m 51s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.6M | 11.9k | 1.5M | 62.5k | 116 | 111.3k | 5m 4s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 158.1k | 4.9k | 328.4k | 29.9k | 33 | 41.9k | 1m 43s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 63.1k | 1.5k | 265.8k | 29.9k | 18 | 14.8k | 47s |
| review_pr | claude-sonnet-4-6 | 1 | 94 | 50.2k | 505.4k | 88.9k | 35 | 92.4k | 10m 32s |
| resolve_review | claude-sonnet-4-6 | 1 | 133 | 11.8k | 670.2k | 56.5k | 40 | 42.0k | 6m 54s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 187 | 11.7k | 1.4M | 80.2k | 56 | 65.2k | 4m 23s |
| **Total** | | | 1.8M | 123.2k | 8.0M | 88.9k | | 502.2k | 49m 33s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 4102 | 329.6 | 15.9 | 2.9 |
| **Total** | **4102** | 1948.1 | 122.4 | 30.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.9k | 86.1k | 3.5M | 263.6k | 31m 7s |
| claude-opus-4-6 | 1 | 2.4k | 18.7k | 2.3M | 70.6k | 10m 51s |
| MiniMax-M2.7-highspeed | 3 | 1.8M | 18.3k | 2.1M | 168.0k | 7m 34s |