### PR TITLE
feat(validate-audit): add effort-based splitting to Ticket Grouper

### DIFF
--- a/.claude/skills/validate-audit/SKILL.md
+++ b/.claude/skills/validate-audit/SKILL.md
@@ -349,6 +349,12 @@ Instructions:
 > - **Grouped ticket**: finding is small, low-risk, non-conflicting. Group same-category small findings together.
 > - **Conflict awareness**: findings touching the same file(s) must be in the same ticket or explicitly sequenced
 > - No rigid severity-to-grouping rule: a HIGH can be grouped if small; a LOW can be standalone if complex
+> - **Minimum group floor**: when the number of VALID findings exceeds 4, you must produce at least 2 ticket groups. When findings exceed 8, produce at least 3 groups. Never collapse all findings into a single group when grouping by scope, file overlap, or category would produce a natural partition.
+> - **Effort-based splitting for multi-file findings**: When a single finding enumerates multiple files for modification (splitting, refactoring, restructuring), do not treat the finding as one atomic unit. Estimate implementation effort per file using line count as a proxy:
+>   - **High effort** (above ~900 lines): Assign to a standalone ticket, or pair with at most one other file.
+>   - **Medium effort** (~750–900 lines): Group in small batches, preferring files in the same directory or package area.
+>   - **Cross-package separation**: Files in different top-level packages should generally land in separate tickets.
+>   - These thresholds are guidelines for judgment — assess the specific files rather than applying rigid per-file caps.
 >
 > Return a grouping manifest listing each proposed ticket with:
 > - Ticket title (descriptive, scoped)

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -401,6 +401,11 @@ Instructions:
 > - **Conflict awareness**: findings touching the same file(s) must be in the same ticket or explicitly sequenced
 > - No rigid severity-to-grouping rule: a HIGH can be grouped if small; a LOW can be standalone if complex
 > - **Minimum group floor**: when the number of VALID findings exceeds 4, you must produce at least 2 ticket groups. When findings exceed 8, produce at least 3 groups. Never collapse all findings into a single group when grouping by scope, file overlap, or category would produce a natural partition.
+> - **Effort-based splitting for multi-file findings**: When a single finding enumerates multiple files for modification (splitting, refactoring, restructuring), do not treat the finding as one atomic unit. Estimate implementation effort per file using line count as a proxy:
+>   - **High effort** (above ~900 lines): Assign to a standalone ticket, or pair with at most one other file.
+>   - **Medium effort** (~750–900 lines): Group in small batches, preferring files in the same directory or package area.
+>   - **Cross-package separation**: Files in different top-level packages should generally land in separate tickets.
+>   - These thresholds are guidelines for judgment — assess the specific files rather than applying rigid per-file caps.
 >
 > Return a grouping manifest listing each proposed ticket with:
 > - Ticket title (descriptive, scoped)

--- a/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
@@ -381,6 +381,11 @@ Instructions:
 > - **Conflict awareness**: findings touching the same file(s) must be in the same ticket or explicitly sequenced
 > - No rigid severity-to-grouping rule: a HIGH can be grouped if small; a LOW can be standalone if complex
 > - **Minimum group floor**: when the number of VALID findings exceeds 4, you must produce at least 2 ticket groups. When findings exceed 8, produce at least 3 groups. Never collapse all findings into a single group when grouping by scope, file overlap, or category would produce a natural partition.
+> - **Effort-based splitting for multi-file findings**: When a single finding enumerates multiple files for modification (splitting, refactoring, restructuring), do not treat the finding as one atomic unit. Estimate implementation effort per file using line count as a proxy:
+>   - **High effort** (above ~900 lines): Assign to a standalone ticket, or pair with at most one other file.
+>   - **Medium effort** (~750–900 lines): Group in small batches, preferring files in the same directory or package area.
+>   - **Cross-package separation**: Files in different top-level packages should generally land in separate tickets.
+>   - These thresholds are guidelines for judgment — assess the specific files rather than applying rigid per-file caps.
 >
 > Return a grouping manifest listing each proposed ticket with:
 > - Ticket title (descriptive, scoped)

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -403,6 +403,11 @@ Instructions:
 > - **Conflict awareness**: findings touching the same file(s) must be in the same ticket or explicitly sequenced
 > - No rigid severity-to-grouping rule: a HIGH can be grouped if small; a LOW can be standalone if complex
 > - **Minimum group floor**: when the number of VALID findings exceeds 4, you must produce at least 2 ticket groups. When findings exceed 8, produce at least 3 groups. Never collapse all findings into a single group when grouping by scope, file overlap, or category would produce a natural partition.
+> - **Effort-based splitting for multi-file findings**: When a single finding enumerates multiple files for modification (splitting, refactoring, restructuring), do not treat the finding as one atomic unit. Estimate implementation effort per file using line count as a proxy:
+>   - **High effort** (above ~900 lines): Assign to a standalone ticket, or pair with at most one other file.
+>   - **Medium effort** (~750–900 lines): Group in small batches, preferring files in the same directory or package area.
+>   - **Cross-package separation**: Files in different top-level packages should generally land in separate tickets.
+>   - These thresholds are guidelines for judgment — assess the specific files rather than applying rigid per-file caps.
 >
 > Return a grouping manifest listing each proposed ticket with:
 > - Ticket title (descriptive, scoped)

--- a/tests/skills/conftest.py
+++ b/tests/skills/conftest.py
@@ -25,6 +25,26 @@ def assert_ticket_grouper_has_minimum_group_floor(text: str) -> None:
     )
 
 
+def assert_ticket_grouper_has_effort_based_splitting(text: str) -> None:
+    start = text.find("Ticket Grouper")
+    if start == -1:
+        grouper_section = ""
+    else:
+        end = text.find("### Step 7")
+        grouper_section = text[start : end if end != -1 else None]
+    has_effort = bool(
+        re.search(
+            r"(?:effort-based|line count|high effort|medium effort)",
+            grouper_section,
+            re.IGNORECASE,
+        )
+    )
+    assert has_effort, (
+        "Ticket Grouper instructions must include effort-based splitting rules "
+        "for findings that enumerate multiple files"
+    )
+
+
 @pytest.fixture(scope="module")
 def skill_text() -> str:
     skill_path = pkg_root() / "skills_extended" / "investigate" / "SKILL.md"

--- a/tests/skills/test_project_local_audit_skill_content.py
+++ b/tests/skills/test_project_local_audit_skill_content.py
@@ -449,3 +449,19 @@ def test_validate_audit_project_local_has_validation_summary() -> None:
     assert "validation_summary_" in content, (
         "validate-audit/.claude/SKILL.md missing validation_summary_ output file"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 23: validate-audit project-local has effort-based splitting
+# ---------------------------------------------------------------------------
+
+
+def test_validate_audit_project_local_has_effort_based_splitting() -> None:
+    path = SKILLS_DIR / "validate-audit" / "SKILL.md"
+    content = path.read_text(encoding="utf-8").lower()
+    assert "effort-based" in content, (
+        "validate-audit/.claude/SKILL.md missing effort-based splitting instructions"
+    )
+    assert "high effort" in content, (
+        "validate-audit/.claude/SKILL.md missing high-effort classification"
+    )

--- a/tests/skills/test_validate_audit_contracts.py
+++ b/tests/skills/test_validate_audit_contracts.py
@@ -6,7 +6,10 @@ import functools
 
 from autoskillit.core.types import SkillSource
 from autoskillit.workspace.skills import DefaultSkillResolver
-from tests.skills.conftest import assert_ticket_grouper_has_minimum_group_floor
+from tests.skills.conftest import (
+    assert_ticket_grouper_has_effort_based_splitting,
+    assert_ticket_grouper_has_minimum_group_floor,
+)
 
 
 @functools.cache
@@ -182,3 +185,7 @@ class TestValidateAuditTicketGrouper:
         """Ticket Grouper instructions must enforce a minimum group count."""
 
         assert_ticket_grouper_has_minimum_group_floor(_skill_text())
+
+    def test_ticket_grouper_has_effort_based_splitting(self) -> None:
+        """Ticket Grouper instructions must include effort-based splitting."""
+        assert_ticket_grouper_has_effort_based_splitting(_skill_text())

--- a/tests/skills/test_validate_review_decisions_contracts.py
+++ b/tests/skills/test_validate_review_decisions_contracts.py
@@ -7,7 +7,10 @@ import re
 
 from autoskillit.core.types import SkillSource
 from autoskillit.workspace.skills import DefaultSkillResolver
-from tests.skills.conftest import assert_ticket_grouper_has_minimum_group_floor
+from tests.skills.conftest import (
+    assert_ticket_grouper_has_effort_based_splitting,
+    assert_ticket_grouper_has_minimum_group_floor,
+)
 
 
 @functools.cache
@@ -209,3 +212,7 @@ class TestValidateReviewDecisionsTicketGrouper:
         """Ticket Grouper instructions must enforce a minimum group count."""
 
         assert_ticket_grouper_has_minimum_group_floor(_skill_text())
+
+    def test_ticket_grouper_has_effort_based_splitting(self) -> None:
+        """Ticket Grouper instructions must include effort-based splitting."""
+        assert_ticket_grouper_has_effort_based_splitting(_skill_text())

--- a/tests/skills/test_validate_test_audit_contracts.py
+++ b/tests/skills/test_validate_test_audit_contracts.py
@@ -7,7 +7,10 @@ import re
 
 from autoskillit.core.types import SkillSource
 from autoskillit.workspace.skills import DefaultSkillResolver
-from tests.skills.conftest import assert_ticket_grouper_has_minimum_group_floor
+from tests.skills.conftest import (
+    assert_ticket_grouper_has_effort_based_splitting,
+    assert_ticket_grouper_has_minimum_group_floor,
+)
 
 
 @functools.cache
@@ -187,3 +190,7 @@ class TestValidateTestAuditTicketGrouper:
         """Ticket Grouper instructions must enforce a minimum group count."""
 
         assert_ticket_grouper_has_minimum_group_floor(_skill_text())
+
+    def test_ticket_grouper_has_effort_based_splitting(self) -> None:
+        """Ticket Grouper instructions must include effort-based splitting."""
+        assert_ticket_grouper_has_effort_based_splitting(_skill_text())


### PR DESCRIPTION
## Summary

The Ticket Grouper subagent in `validate-audit`, `validate-test-audit`, and `validate-review-decisions` skills treats each finding ID as an atomic unit. When a finding lists many files (e.g., 16 files for splitting), the grouper assigns all of them to one ticket because it sees one finding ID, not 16 files. This PR adds effort-based grouping instructions that teach the grouper to estimate per-file implementation effort using line count as a proxy, splitting multi-file findings across multiple ticket groups based on effort classification and package proximity.

## Requirements

**REQ-GRP-001:** The Ticket Grouper subagent instructions in `validate-audit/SKILL.md` must include effort-based grouping rules for findings that enumerate multiple files for modification.

**REQ-GRP-002:** The effort estimation must classify files by line count: 750–900 lines as medium effort, above 900 lines as high effort.

**REQ-GRP-003:** High-effort files must be assigned standalone tickets or paired with at most one other file per ticket.

**REQ-GRP-004:** Medium-effort files must be groupable in small batches, with preference for files in the same directory or touching similar areas.

**REQ-GRP-005:** Files in different top-level packages must be separated into different tickets unless effort budget allows combining.

**REQ-GRP-006:** The effort-based grouping language must leave room for agent judgment — no rigid per-file caps that prevent reasonable grouping decisions.

**REQ-SIB-001:** If `validate-test-audit/SKILL.md` and `validate-review-decisions/SKILL.md` contain Ticket Grouper subagents, the same effort-based grouping instructions must be added to them.

**REQ-TST-001:** A contract test must validate that when a finding lists more than 5 files for splitting, the Ticket Grouper produces more than one ticket group for that finding's files.

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/ticket_grouper_effort_splitting_plan_2026-05-23_231500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.5k | 16.5k | 1.0M | 73.8k | 110 | 121.8k | 11m 22s |
| verify | claude-opus-4-6 | 1 | 59 | 7.3k | 1.1M | 61.2k | 97 | 45.9k | 4m 34s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 12.7k | 1.1M | 30.0k | 133 | 42.6k | 9m 44s |
| prepare_pr* | MiniMax-M2.7 | 1 | 75.8k | 4.6k | 540.7k | 30.0k | 40 | 42.8k | 2m 6s |
| compose_pr* | MiniMax-M2.7 | 1 | 38.1k | 2.6k | 459.7k | 21.9k | 32 | 0 | 1m 17s |
| review_pr | claude-opus-4-6 | 2 | 87 | 44.2k | 1.1M | 68.6k | 83 | 99.0k | 10m 49s |
| resolve_review | claude-opus-4-6 | 1 | 30 | 4.1k | 525.2k | 50.9k | 24 | 35.9k | 2m 5s |
| **Total** | | | 1.3M | 92.0k | 5.8M | 73.8k | | 387.9k | 42m 1s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 4 | 3.7k | 72.1k | 3.7M | 302.5k | 28m 51s |
| MiniMax-M2.7-highspeed | 1 | 1.2M | 12.7k | 1.1M | 42.6k | 9m 44s |
| MiniMax-M2.7 | 2 | 113.9k | 7.2k | 1.0M | 42.8k | 3m 24s |