### PR TITLE
Rectify: Staleness Check Context Immunity

### DIFF
--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -183,7 +183,7 @@ def _get_process_start_mtime() -> int:
 def _check_process_staleness() -> bool:
     """Return True if the package directory or rule files were modified after process start.
 
-    Fleet sessions (L3) always return False — dispatched subprocesses have fresh
+    Fleet sessions always return False — dispatched subprocesses have fresh
     baselines and revalidate independently.
     """
     if session_type() is SessionType.FLEET:

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -16,12 +16,14 @@ from autoskillit.core import (
     ProcessStaleError,
     RecipeNotFoundError,
     RecipeSource,
+    SessionType,
     SkillLister,
     YAMLError,
     get_logger,
     load_yaml,
     pkg_root,
     resolve_temp_dir,
+    session_type,
 )
 from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe._recipe_composition import (
@@ -179,7 +181,15 @@ def _get_process_start_mtime() -> int:
 
 
 def _check_process_staleness() -> bool:
-    """Return True if the package directory or rule files were modified after process start."""
+    """Return True if the package directory or rule files were modified after process start.
+
+    Fleet sessions (L3) always return False — dispatched subprocesses have fresh
+    baselines and revalidate independently.
+    """
+    if session_type() is SessionType.FLEET:
+        _get_process_start_mtime()
+        return False
+
     global _STALENESS_LAST_CHECK, _STALENESS_IS_STALE  # noqa: PLW0603
     now = time.monotonic()
     if now - _STALENESS_LAST_CHECK < _STALENESS_TTL:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -402,10 +402,13 @@ class InMemoryRecipeRepository(RecipeRepository):
             }
         )
         if self._stale:
-            raise ProcessStaleError(
-                "Process is running stale code — package directory was modified on disk "
-                "since server startup. Restart the MCP server via reload_session."
-            )
+            from autoskillit.core import SessionType, session_type  # noqa: PLC0415
+
+            if session_type() is not SessionType.FLEET:
+                raise ProcessStaleError(
+                    "Process is running stale code — package directory was modified on disk "
+                    "since server startup. Restart the MCP server via reload_session."
+                )
         if name not in self._validated and name not in self._recipes:
             raise RecipeNotFoundError(f"No recipe named '{name}' found")
         return self._validated.get(name, {"valid": True, "suggestions": []})

--- a/tests/fleet/CLAUDE.md
+++ b/tests/fleet/CLAUDE.md
@@ -50,7 +50,7 @@ Fleet campaign dispatch, state persistence, and sidecar tests.
 | `test_sidecar.py` | Sidecar tests |
 | `test_startup_label_recovery.py` | Tests for sweep_stale_dispatch_labels — dead dispatch label cleanup, alive dispatch skip, missing sidecar, multi-campaign |
 | `test_find_dispatch_for_issue.py` | Tests for find_dispatch_for_issue — running dispatch sidecar lookup, non-running skip, missing sidecar, empty state, corrupt state |
-| `test_staleness_propagation.py` | Tests for ProcessStaleError propagation through fleet dispatch — FLEET_PROCESS_STALE error code |
+| `test_staleness_propagation.py` | Tests that fleet dispatch proceeds despite process staleness — L2 subprocess revalidates independently |
 | `test_state.py` | Tests for fleet state module (Group J) |
 | `test_state_lock_contract.py` | Locking contract tests — AST scan for flock targets, flock acquisition per mutation, cross-caller concurrency |
 | `test_state_protection.py` | Tests for fleet.state.build_protected_campaign_ids (PROT_1–PROT_9) |

--- a/tests/fleet/test_staleness_propagation.py
+++ b/tests/fleet/test_staleness_propagation.py
@@ -34,10 +34,11 @@ def _simple_prompt_builder(**kwargs) -> str:
 
 class TestStalenessErrorPropagation:
     @pytest.mark.anyio
-    async def test_stale_process_returns_fleet_process_stale(self, tool_ctx):
-        """ProcessStaleError from load_and_validate → FLEET_PROCESS_STALE rejection."""
+    async def test_stale_process_does_not_block_dispatch(self, tool_ctx, monkeypatch):
+        """Fleet dispatch must proceed despite process staleness — L2 revalidates."""
         from autoskillit.fleet._api import execute_dispatch
 
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
         tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
         repo = InMemoryRecipeRepository()
         recipe_info = _make_recipe_info("test-recipe")
@@ -45,7 +46,8 @@ class TestStalenessErrorPropagation:
         repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe", ["task"]))
         repo.set_stale(True)
         tool_ctx.recipes = repo
-        tool_ctx.executor = InMemoryHeadlessExecutor()
+        executor = InMemoryHeadlessExecutor()
+        tool_ctx.executor = executor
 
         dispatch_result = await execute_dispatch(
             tool_ctx=tool_ctx,
@@ -59,6 +61,7 @@ class TestStalenessErrorPropagation:
             quota_refresher=_noop_quota_refresher,
         )
         result = json.loads(dispatch_result.outcome.to_envelope())
-        assert result["success"] is False
-        assert result["error"] == FleetErrorCode.FLEET_PROCESS_STALE
-        assert "stale" in result["user_visible_message"].lower()
+        # Must NOT be FLEET_PROCESS_STALE — dispatch should proceed
+        assert result.get("error") != FleetErrorCode.FLEET_PROCESS_STALE
+        # Executor must have been called (dispatch proceeded past validation)
+        assert len(executor.dispatch_calls) == 1

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -28,7 +28,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_callable_contracts.py` | Contract tests for run_python callable inputs and outputs |
 | `test_campaign_loader.py` | Tests for campaign recipe loading |
 | `test_create_worktree_functional.py` | Functional tests for scripts/recipe/create_worktree.sh — actually executes the script against real git repos |
-| `test_deep_staleness.py` | Tests for deep staleness detection — rule file mtime scan in _check_process_staleness |
+| `test_deep_staleness.py` | Tests for deep staleness detection — rule file mtime scan and session-type bypass for fleet sessions |
 | `test_check_ci_already_passed_routing.py` | Tests for check_ci_already_passed routing logic |
 | `test_check_repo_merge_state_routing.py` | Tests for check_repo_merge_state routing logic |
 | `test_cmd_rpc.py` | Tests for recipe/_cmd_rpc.py run_python callables |

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -43,3 +43,32 @@ def test_deep_staleness_baseline_initialized_eagerly(tmp_path, monkeypatch):
 
     api_mod._get_process_start_mtime()
     assert api_mod._DEEP_MTIME_BASELINE == 5000
+
+
+def test_staleness_check_skipped_for_fleet_sessions(monkeypatch):
+    """Fleet sessions skip staleness — subprocess revalidates with fresh baselines."""
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+    import autoskillit.recipe._api as api_mod
+
+    # Force stale baselines
+    monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", 1)
+    monkeypatch.setattr(api_mod, "_DEEP_MTIME_BASELINE", 1)
+    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(api_mod, "_STALENESS_IS_STALE", False)
+
+    assert api_mod._check_process_staleness() is False
+
+
+def test_fleet_guard_still_initializes_baseline(monkeypatch):
+    """FLEET guard must still call _get_process_start_mtime() so baseline is set."""
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+    import autoskillit.recipe._api as api_mod
+
+    monkeypatch.setattr(api_mod, "_PROCESS_START_PKG_MTIME", None)
+    monkeypatch.setattr(api_mod, "_DEEP_MTIME_BASELINE", None)
+    monkeypatch.setattr(api_mod, "_STALENESS_LAST_CHECK", 0.0)
+
+    api_mod._check_process_staleness()
+
+    assert api_mod._PROCESS_START_PKG_MTIME is not None
+    assert api_mod._DEEP_MTIME_BASELINE is not None


### PR DESCRIPTION
## Summary

`_check_process_staleness()` in `recipe/_api.py` is context-blind — it fires identically whether called from `open_kitchen` (where staleness matters because the L2 server process uses the result) or from `_run_dispatch` (where staleness is redundant because the L2 subprocess has fresh baselines). The fix makes the staleness check session-type-aware using the same `session_type()` mechanism already used by `_guards.py`, eliminating the asymmetry at its root. Fleet sessions (L3) now bypass the staleness check since dispatched subprocesses revalidate independently with fresh baselines.

Closes #2850

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260524-000248-785864/.autoskillit/temp/rectify/rectify_staleness_context_immunity_2026-05-24_002500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 69 | 19.9k | 2.3M | 109.6k | 333 | 171.8k | 27m 6s |
| dry_walkthrough | claude-opus-4-6 | 1 | 35 | 9.1k | 951.0k | 77.5k | 89 | 77.8k | 4m 31s |
| implement | claude-sonnet-4-6 | 1 | 1.1k | 14.1k | 845.6k | 61.5k | 142 | 62.5k | 10m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 115.2k | 3.1k | 296.9k | 30.0k | 20 | 15.1k | 1m 27s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.8k | 1.4k | 206.9k | 30.0k | 17 | 14.8k | 42s |
| review_pr | claude-sonnet-4-6 | 1 | 118 | 36.8k | 592.5k | 72.6k | 35 | 66.0k | 8m 19s |
| resolve_review | claude-sonnet-4-6 | 1 | 221 | 27.1k | 1.5M | 84.7k | 95 | 77.7k | 14m 22s |
| **Total** | | | 163.5k | 111.5k | 6.6M | 109.6k | | 485.7k | 1h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 71 | 11909.2 | 879.8 | 198.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **71** | 93516.6 | 6840.7 | 1571.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.5k | 97.9k | 5.2M | 378.0k | 1h 0m |
| claude-opus-4-6 | 1 | 35 | 9.1k | 951.0k | 77.8k | 4m 31s |
| MiniMax-M2.7-highspeed | 2 | 162.0k | 4.6k | 503.8k | 29.9k | 2m 9s |