### PR TITLE
Fix write guard blocking dry-walkthrough from editing plan in-place

### DIFF
--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -211,7 +211,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "verify",
         "review_path": "${{ context.review_path }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough"
+        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}"
       },
       "on_success": "implement",
       "on_failure": "release_issue_failure",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -218,7 +218,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "verify"
       review_path: "${{ context.review_path }}"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough
+      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}
     on_success: implement
     on_failure: release_issue_failure
     note: "SEQUENTIAL EXECUTION: For each plan_part, run the FULL cycle — verify → implement → test → merge — for that part before advancing to the next part. Never run verify for all parts first. If review produced a report, context.review_path is available — pass it as an additional arg to dry-walkthrough."

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -208,7 +208,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "verify",
         "review_path": "${{ context.review_path }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough"
+        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}"
       },
       "on_success": "implement",
       "on_failure": "release_issue_failure",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -215,7 +215,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "verify"
       review_path: "${{ context.review_path }}"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough
+      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}
     on_success: implement
     on_failure: release_issue_failure
     on_context_limit: implement

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -872,7 +872,7 @@
         "skill_command": "/autoskillit:dry-walkthrough ${{ context.pr_plan_path }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "verify",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough"
+        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}"
       },
       "on_success": "implement",
       "on_failure": "register_clone_failure",

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -806,7 +806,7 @@ steps:
       skill_command: "/autoskillit:dry-walkthrough ${{ context.pr_plan_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "verify"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough
+      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}
     on_success: implement
     on_failure: register_clone_failure
     retries: 5

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -220,7 +220,7 @@
       "with": {
         "skill_command": "/autoskillit:dry-walkthrough ${{ context.plan_path }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough",
+        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}",
         "review_path": "${{ context.review_path }}",
         "step_name": "dry_walkthrough"
       },

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -214,7 +214,7 @@ steps:
     with:
       skill_command: "/autoskillit:dry-walkthrough ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough"
+      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}"
       review_path: "${{ context.review_path }}"
       step_name: "dry_walkthrough"
     on_success: implement

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -76,6 +76,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_recipe_ci_applicable_routing.py` | Structural tests for ci_applicable routing guards across all wait_for_ci chains |
 | `test_recipe_ci_contracts.py` | Cross-recipe ci_event/branch coherence and remote_url structural tests |
 | `test_recipe_ci_watch_event.py` | Tests for CI watch event in recipe steps |
+| `test_recipe_dry_walkthrough_scope.py` | Regression test: dry-walkthrough output_dir must not scope to /dry-walkthrough subdirectory (#2919) |
 | `test_recipe_order.py` | Tests for BUNDLED_RECIPE_ORDER stable display order registry |
 | `test_report_frontmatter_schema.py` | Tests for report.md YAML frontmatter audit-trail schema |
 | `test_recipe_scripts.py` | Tests for recipe script callables |

--- a/tests/recipe/test_recipe_dry_walkthrough_scope.py
+++ b/tests/recipe/test_recipe_dry_walkthrough_scope.py
@@ -1,0 +1,43 @@
+"""Regression test for #2919: dry-walkthrough output_dir must not exclude plan locations."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import pkg_root
+from autoskillit.recipe.io import load_recipe
+
+
+_RECIPES_WITH_DRY_WALKTHROUGH = (
+    "implementation",
+    "implementation-groups",
+    "remediation",
+    "merge-prs",
+)
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
+
+
+@pytest.mark.parametrize("recipe_name", _RECIPES_WITH_DRY_WALKTHROUGH)
+def test_dry_walkthrough_output_dir_does_not_scope_to_subdirectory(
+    recipe_name: str,
+) -> None:
+    """output_dir on dry-walkthrough steps must cover make-plan/ and rectify/ locations.
+
+    If output_dir scopes to .../dry-walkthrough/, the write guard blocks in-place
+    edits to plan files that live under .../make-plan/ or .../rectify/.
+    """
+    recipe_path = pkg_root() / "recipes" / f"{recipe_name}.yaml"
+    recipe = load_recipe(recipe_path)
+    for step_name, step in recipe.steps.items():
+        cmd = (step.with_args or {}).get("skill_command", "")
+        if "dry-walkthrough" not in cmd:
+            continue
+        output_dir = (step.with_args or {}).get("output_dir", "")
+        assert not output_dir.endswith(
+            "/dry-walkthrough"
+        ), (
+            f"{recipe_name}.{step_name}: output_dir must not scope to "
+            f"/dry-walkthrough subdirectory — dry-walkthrough edits plan files "
+            f"at make-plan/ or rectify/ locations (issue #2919)"
+        )


### PR DESCRIPTION
## Summary

The verify/dry-walkthrough step in four recipe YAML files sets `output_dir` to `${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dry-walkthrough`, which scopes the write guard prefix to `.autoskillit/temp/dry-walkthrough/`. dry-walkthrough needs to edit the plan file at `.autoskillit/temp/make-plan/` (or `.autoskillit/temp/rectify/` in remediation), which is outside that prefix. The fix widens `output_dir` to the common parent `${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}` so the write guard allows edits to any plan file under `.autoskillit/temp/`.

Closes #2919

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-003520-268770/.autoskillit/temp/make-plan/write_guard_dry_walkthrough_output_dir_plan_2026-05-24_004300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 1.7k | 10.4k | 1.0M | 62.3k | 101 | 53.0k | 5m 51s |
| verify | claude-opus-4-6 | 1 | 50 | 12.7k | 545.5k | 54.3k | 64 | 41.0k | 7m 25s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 9.7k | 1.2M | 30.0k | 93 | 42.6k | 8m 30s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 151.9k | 5.5k | 416.8k | 30.0k | 32 | 14.9k | 2m 13s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 121.4k | 1.8k | 386.8k | 30.0k | 27 | 14.8k | 1m 3s |
| review_pr | claude-sonnet-4-6 | 1 | 182 | 26.5k | 777.5k | 60.4k | 52 | 53.2k | 6m 26s |
| resolve_review | claude-sonnet-4-6 | 1 | 133 | 6.0k | 563.6k | 47.2k | 37 | 40.2k | 3m 20s |
| **Total** | | | 1.3M | 72.8k | 4.9M | 62.3k | | 259.7k | 34m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 60 | 19981.3 | 709.8 | 162.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **60** | 81942.6 | 4328.3 | 1212.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 1.8k | 23.2k | 1.6M | 93.9k | 13m 17s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 17.1k | 2.0M | 72.4k | 11m 47s |
| claude-sonnet-4-6 | 2 | 315 | 32.5k | 1.3M | 93.4k | 9m 47s |