### PR TITLE
Add build_interactive_cmd as a Typed Protocol Method on CodingAgentBackend

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -16,6 +16,8 @@ from ._type_backend import (
 from ._type_checkpoint import SessionCheckpoint
 from ._type_enums import OutputFormat
 from ._type_plugin_source import PluginSource
+from ._type_results import ValidatedAddDir
+from ._type_resume import NoResume, ResumeSpec
 
 __all__ = [
     "StreamParser",
@@ -122,4 +124,17 @@ class CodingAgentBackend(Protocol):
         allowed_write_prefix: str = "",
         sentinel_contract: str = "",
         resume_message: str | None = None,
+    ) -> CmdSpec: ...
+
+    def build_interactive_cmd(
+        self,
+        *,
+        initial_prompt: str | None = None,
+        model: str | None = None,
+        plugin_source: PluginSource | None = None,
+        add_dirs: Sequence[Path | str | ValidatedAddDir] = (),
+        resume_spec: ResumeSpec = NoResume(),
+        system_prompt: str | None = None,
+        env_extras: Mapping[str, str] | None = None,
+        required_env: frozenset[str] | None = None,
     ) -> CmdSpec: ...

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -484,6 +484,7 @@ class ClaudeCodeBackend:
         plugin_source: PluginSource | None = None,
         add_dirs: Sequence[Path | str | ValidatedAddDir] = (),
         resume_spec: ResumeSpec = NoResume(),
+        system_prompt: str | None = None,
         env_extras: Mapping[str, str] | None = None,
         required_env: frozenset[str] | None = None,
     ) -> CmdSpec:
@@ -507,6 +508,9 @@ class ClaudeCodeBackend:
             Resume intent discriminated union. ``NoResume`` (default) starts a fresh
             session. ``BareResume`` passes ``--resume`` without an ID (Claude Code's
             interactive picker). ``NamedResume`` passes ``--resume <id>``.
+        system_prompt
+            Optional system prompt text. Unused in A1 — reserved for A2 wiring,
+            which will translate it to ``--append-system-prompt <value>``.
         env_extras
             Optional caller overrides merged into the resolved env after IDE scrubbing.
         required_env

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -26,8 +26,10 @@ from autoskillit.core import (
     CliSubtype,
     CmdSpec,
     CodexEventData,
+    NoResume,
     OutputFormat,
     PluginSource,
+    ResumeSpec,
     SessionCheckpoint,
     SessionEvent,
     SkillSessionConfig,
@@ -714,8 +716,19 @@ class CodexBackend:
             "Codex CLI does not support L2 orchestrator (food truck) sessions"
         )
 
-    def build_interactive_cmd(self, **kwargs: object) -> CmdSpec:
-        raise NotImplementedError("Codex CLI does not support interactive mode")
+    def build_interactive_cmd(
+        self,
+        *,
+        initial_prompt: str | None = None,
+        model: str | None = None,
+        plugin_source: PluginSource | None = None,
+        add_dirs: Sequence[Path | str | ValidatedAddDir] = (),
+        resume_spec: ResumeSpec = NoResume(),
+        system_prompt: str | None = None,
+        env_extras: Mapping[str, str] | None = None,
+        required_env: frozenset[str] | None = None,
+    ) -> CmdSpec:
+        raise NotImplementedError("Codex interactive mode is implemented in P6-A3")
 
     def build_resume_cmd(
         self,

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -55,6 +55,7 @@ def build_interactive_cmd(
     plugin_source: PluginSource | None = None,
     add_dirs: Sequence[Path | str | ValidatedAddDir] = (),
     resume_spec: ResumeSpec = NoResume(),
+    system_prompt: str | None = None,
     env_extras: Mapping[str, str] | None = None,
     required_env: frozenset[str] | None = None,
 ) -> ClaudeInteractiveCmd:
@@ -65,6 +66,7 @@ def build_interactive_cmd(
         plugin_source=plugin_source,
         add_dirs=add_dirs,
         resume_spec=resume_spec,
+        system_prompt=system_prompt,
         env_extras=env_extras,
         required_env=required_env,
     )

--- a/tests/arch/test_backend_protocol_completeness.py
+++ b/tests/arch/test_backend_protocol_completeness.py
@@ -29,6 +29,29 @@ def test_coding_agent_backend_protocol_includes_food_truck_cmd():
     )
 
 
+def test_coding_agent_backend_protocol_includes_build_interactive_cmd():
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+
+    assert hasattr(CodingAgentBackend, "build_interactive_cmd"), (
+        "CodingAgentBackend protocol must define build_interactive_cmd"
+    )
+    assert callable(getattr(CodingAgentBackend, "build_interactive_cmd")), (
+        "build_interactive_cmd must be callable"
+    )
+
+
+def test_all_backends_implement_build_interactive_cmd():
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    for name, cls in BACKEND_REGISTRY.items():
+        assert hasattr(cls, "build_interactive_cmd"), (
+            f"{name} backend must implement build_interactive_cmd"
+        )
+        assert callable(getattr(cls, "build_interactive_cmd")), (
+            f"{name} backend build_interactive_cmd must be callable"
+        )
+
+
 def test_all_backends_implement_skill_session_cmd():
     from autoskillit.execution.backends import BACKEND_REGISTRY
 

--- a/tests/contracts/test_backend_protocol.py
+++ b/tests/contracts/test_backend_protocol.py
@@ -204,3 +204,33 @@ def test_build_skill_session_cmd_impl_exists():
 
     assert hasattr(ClaudeCodeBackend, "_build_skill_session_cmd_impl")
     assert callable(getattr(ClaudeCodeBackend, "_build_skill_session_cmd_impl"))
+
+
+def test_build_interactive_cmd_satisfies_protocol_claude():
+    from autoskillit.core import CodingAgentBackend
+    from autoskillit.execution.backends import ClaudeCodeBackend
+
+    assert isinstance(ClaudeCodeBackend(), CodingAgentBackend)
+
+
+def test_build_interactive_cmd_codex_raises_not_implemented():
+    from autoskillit.execution.backends import CodexBackend
+
+    with pytest.raises(NotImplementedError, match="P6-A3"):
+        CodexBackend().build_interactive_cmd()
+
+
+def test_build_interactive_cmd_signature_shape():
+    import inspect
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+
+    sig = inspect.signature(CodingAgentBackend.build_interactive_cmd)
+    params = sig.parameters
+
+    assert "order_mode" not in params, "order_mode must not be in signature"
+    assert params["system_prompt"].default is None
+    for name, param in params.items():
+        if name == "self":
+            continue
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY, f"{name} must be KEYWORD_ONLY"

--- a/tests/core/test_backend_protocols.py
+++ b/tests/core/test_backend_protocols.py
@@ -58,17 +58,23 @@ def test_stub_class_satisfies_stream_parser():
 
 
 def test_stub_class_satisfies_coding_agent_backend():
+    from collections.abc import Sequence
+    from pathlib import Path
+
     from autoskillit.core import (
         BackendCapabilities,
         CmdSpec,
         CodingAgentBackend,
         EnvPolicy,
+        NoResume,
         OutputFormat,
         PluginSource,
         ResultParser,
+        ResumeSpec,
         SessionLocator,
         SkillSessionConfig,
         StreamParser,
+        ValidatedAddDir,
     )
 
     class _Backend:
@@ -115,6 +121,19 @@ def test_stub_class_satisfies_coding_agent_backend():
             plugin_source: PluginSource,
             cwd: str,
             completion_marker: str,
+        ) -> CmdSpec: ...
+
+        def build_interactive_cmd(
+            self,
+            *,
+            initial_prompt: str | None = None,
+            model: str | None = None,
+            plugin_source: PluginSource | None = None,
+            add_dirs: Sequence[Path | str | ValidatedAddDir] = (),
+            resume_spec: ResumeSpec = NoResume(),
+            system_prompt: str | None = None,
+            env_extras: Mapping[str, str] | None = None,
+            required_env: frozenset[str] | None = None,
         ) -> CmdSpec: ...
 
     assert isinstance(_Backend(), CodingAgentBackend)


### PR DESCRIPTION
## Summary

Add `build_interactive_cmd` to the `CodingAgentBackend` Protocol in `_type_protocols_backend.py` with a fully typed, all-keyword-only signature including `system_prompt`. Update `CodexBackend` from the `**kwargs` catch-all stub to the full typed signature (raising `NotImplementedError`). Extend `ClaudeCodeBackend.build_interactive_cmd` with the `system_prompt` parameter as a no-op stub. Update the `commands.py` forwarding shim to mirror the new parameter. Fix the `_Backend` stub in `tests/core/test_backend_protocols.py` to include the new method. Add 5 tests across arch and contract layers.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-004756-574392/.autoskillit/temp/make-plan/add_build_interactive_cmd_protocol_plan_2026-05-24_005300.md`

Closes #2852

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 74 | 17.6k | 1.0M | 83.4k | 96 | 75.2k | 10m 43s |
| verify | claude-opus-4-6 | 1 | 422 | 21.2k | 1.0M | 88.0k | 79 | 74.1k | 9m 24s |
| implement* | MiniMax-M2.7-highspeed | 1 | 905.6k | 9.4k | 1.1M | 30.0k | 78 | 15.5k | 7m 36s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 136.8k | 2.6k | 356.9k | 30.0k | 24 | 14.9k | 1m 17s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 69.5k | 1.7k | 266.9k | 30.0k | 20 | 14.8k | 49s |
| review_pr | claude-sonnet-4-6 | 1 | 128 | 44.8k | 627.7k | 81.5k | 61 | 75.1k | 12m 9s |
| resolve_review | claude-sonnet-4-6 | 1 | 285 | 17.8k | 1.9M | 69.8k | 98 | 63.0k | 11m 42s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 131.4k | 2.7k | 386.8k | 30.0k | 28 | 14.7k | 3m 34s |
| resolve_ci | claude-sonnet-4-6 | 1 | 93 | 4.8k | 293.0k | 35.3k | 26 | 27.8k | 4m 1s |
| **Total** | | | 1.2M | 122.5k | 6.9M | 88.0k | | 375.3k | 1h 1m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 110 | 9783.6 | 140.8 | 85.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 0 | — | — | — |
| **Total** | **110** | 62988.1 | 3411.4 | 1113.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 496 | 38.8k | 2.0M | 149.3k | 20m 8s |
| MiniMax-M2.7-highspeed | 4 | 1.2M | 16.4k | 2.1M | 60.0k | 13m 17s |
| claude-sonnet-4-6 | 3 | 506 | 67.3k | 2.8M | 165.9k | 27m 53s |