### PR TITLE
PostToolUse quota hook lacks budget check — L2 sleeps past timeout

### DIFF
--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -351,7 +351,8 @@ Trigger: a dispatch returns reason=quota_exhausted OR
 
 Action:
 1. Sleep min(wait_seconds, {max_quota_wait_sec}) seconds.
-2. Retry that exact dispatch ONCE.
+2. Retry that exact dispatch ONCE, passing the dispatched_session_id from the
+   failed envelope as resume_session_id to dispatch_food_truck.
 3. If the retry still fails: halt campaign (proceed to INTERRUPT/CLEANUP).
 
 This is the ONLY condition where re-dispatching the same dispatch_name is permitted.

--- a/src/autoskillit/core/types/_type_dispatch_identity.py
+++ b/src/autoskillit/core/types/_type_dispatch_identity.py
@@ -31,7 +31,7 @@ as your final output. No other text after the sentinel.
 
 Fields:
 - success: true if all mandatory steps completed without unresolved failures
-- reason: "completed", "failed", "quota_exhausted", "timeout",
+- reason: "completed", "failed", "fleet_quota_exhausted", "timeout",
   "open_kitchen_failed", "missing_on_failure"
 - summary: One-line description of what happened
 

--- a/src/autoskillit/fleet/_outcome.py
+++ b/src/autoskillit/fleet/_outcome.py
@@ -75,6 +75,10 @@ def classify_dispatch_outcome(
 
     if parsed.outcome == "completed_clean" and parsed.payload and parsed.payload.get("success"):
         return DispatchStatus.SUCCESS, ""
+    if parsed.outcome == "completed_clean" and parsed.payload:
+        reason = parsed.payload.get("reason", "")
+        if reason == FleetErrorCode.FLEET_QUOTA_EXHAUSTED:
+            return DispatchStatus.RESUMABLE, FleetErrorCode.FLEET_QUOTA_EXHAUSTED
     if parsed.outcome == "completed_clean":
         reason = parsed.payload.get("reason", "") if parsed.payload else ""
         return DispatchStatus.FAILURE, reason

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -22,6 +22,7 @@ from autoskillit.core import (
 from autoskillit.hooks import (
     QUOTA_BUDGET_EXCEEDED_TRIGGER,
     QUOTA_GUARD_DENY_TRIGGER,
+    QUOTA_POST_BUDGET_EXCEEDED_TRIGGER,
     QUOTA_POST_WARNING_TRIGGER,
 )
 
@@ -249,6 +250,12 @@ QUOTA DENIAL ROUTING — run_skill only (check BEFORE on_failure):
   - A post-execution quota check detected high utilization.
   - The warning contains a run_cmd sleep command. Execute it BEFORE the next run_skill call.
   - After sleeping, proceed normally with the next pipeline step.
+- When run_skill output contains "{QUOTA_POST_BUDGET_EXCEEDED_TRIGGER}":
+  - The required quota sleep EXCEEDS the session's remaining wall-clock budget.
+  - Do NOT sleep. Instead, emit the sentinel block with the fields
+    specified in the output (success=false, reason=fleet_quota_exhausted,
+    wait_seconds, resets_at, summary).
+  - Then STOP — do not call any more tools after emitting the sentinel.
 
 SKILL_COMMAND FORMATTING — MANDATORY:
 - The `skill_command` value in each step's `with:` block is a LITERAL template.
@@ -275,13 +282,13 @@ or quota post-warning), and you cannot make further progress:
 
 Emit the sentinel block with:
   "success": false,
-  "reason": "quota_exhausted",
+  "reason": "fleet_quota_exhausted",
   "wait_seconds": <seconds_until_reset>
 
 The fleet dispatcher will schedule a retry after the wait period.
 Do NOT loop indefinitely on quota denials — if 3 consecutive quota
 denials occur with no successful run_skill between them, emit the
-quota_exhausted sentinel and exit.
+fleet_quota_exhausted sentinel and exit.
 
 --- SECTION 6: CAMPAIGN TASK ---
 

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -48,13 +48,18 @@ _ALWAYS_BLOCKING_STATUSES = frozenset(
 _RETRIABLE_NON_SUCCESS = _ALWAYS_BLOCKING_STATUSES | frozenset({DispatchStatus.FAILURE})
 
 
+_RESUMABLE_RETRY_REASONS: frozenset[str] = frozenset(
+    {FleetErrorCode.FLEET_L3_TIMEOUT, FleetErrorCode.FLEET_QUOTA_EXHAUSTED}
+)
+
+
 def _count_consecutive_resumable_timeouts(history: list[dict[str, Any]]) -> int:
-    """Count consecutive RESUMABLE + FLEET_L3_TIMEOUT entries from the tail."""
+    """Count consecutive RESUMABLE entries with retriable reasons from the tail."""
     count = 0
     for entry in reversed(history):
         if (
             entry.get("status") == str(DispatchStatus.RESUMABLE)
-            and entry.get("reason") == FleetErrorCode.FLEET_L3_TIMEOUT
+            and entry.get("reason") in _RESUMABLE_RETRY_REASONS
         ):
             count += 1
         else:
@@ -241,7 +246,11 @@ def resume_campaign_from_state(
                 timeout_count = _count_consecutive_resumable_timeouts(d.attempt_history)
                 if timeout_count >= MAX_CONSECUTIVE_RESUME_ATTEMPTS:
                     d.status = DispatchStatus.FAILURE
-                    d.reason = FleetErrorCode.FLEET_L3_TIMEOUT
+                    d.reason = (
+                        d.attempt_history[-1].get("reason", FleetErrorCode.FLEET_L3_TIMEOUT)
+                        if d.attempt_history
+                        else FleetErrorCode.FLEET_L3_TIMEOUT
+                    )
                     m.mark_dirty()
                     return ResumeDecision(
                         next_dispatch_name="",

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -119,6 +119,8 @@ class DispatchRecord:
     labels_cleaned: bool = False
     attempt_history: list[dict[str, Any]] = field(default_factory=list)
     resume_checkpoint: dict[str, Any] = field(default_factory=dict)
+    wait_seconds: float | None = None
+    resets_at: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -145,6 +147,8 @@ class DispatchRecord:
             "labels_cleaned": self.labels_cleaned,
             "attempt_history": list(self.attempt_history),
             "resume_checkpoint": dict(self.resume_checkpoint),
+            "wait_seconds": self.wait_seconds,
+            "resets_at": self.resets_at,
         }
 
     @classmethod
@@ -197,6 +201,8 @@ class DispatchRecord:
             labels_cleaned=d.get("labels_cleaned", False),
             attempt_history=d.get("attempt_history", []),
             resume_checkpoint=d.get("resume_checkpoint", {}),
+            wait_seconds=d.get("wait_seconds"),
+            resets_at=d.get("resets_at", ""),
         )
 
     @classmethod

--- a/src/autoskillit/hooks/__init__.py
+++ b/src/autoskillit/hooks/__init__.py
@@ -13,7 +13,10 @@ from autoskillit.hooks.guards.quota_guard import (
 )
 from autoskillit.hooks.guards.review_loop_gate import REVIEW_LOOP_DENY_TRIGGER
 from autoskillit.hooks.guards.skill_orchestration_guard import SKILL_ORCHESTRATION_DENY_TRIGGER
-from autoskillit.hooks.quota_post_hook import QUOTA_POST_WARNING_TRIGGER
+from autoskillit.hooks.quota_post_hook import (
+    QUOTA_POST_BUDGET_EXCEEDED_TRIGGER,
+    QUOTA_POST_WARNING_TRIGGER,
+)
 
 __all__ = [
     "HOOK_REGISTRY",
@@ -23,6 +26,7 @@ __all__ = [
     "QUOTA_GUARD_DENY_TRIGGER",
     "QUOTA_BUDGET_EXCEEDED_TRIGGER",
     "QUOTA_POST_WARNING_TRIGGER",
+    "QUOTA_POST_BUDGET_EXCEEDED_TRIGGER",
     "REVIEW_LOOP_DENY_TRIGGER",
     "_HOOK_CONFIG_PATH_COMPONENTS",
     "generate_hooks_json",

--- a/src/autoskillit/hooks/quota_post_hook.py
+++ b/src/autoskillit/hooks/quota_post_hook.py
@@ -12,6 +12,7 @@ requiring the autoskillit package to be importable.
 import json
 import os
 import sys
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -30,6 +31,7 @@ _AUTOSKILLIT_LOG_DIR_ENV = "AUTOSKILLIT_LOG_DIR"
 
 # Emitted in post-tool output; referenced by orchestrator prompt and sous-chef SKILL.md.
 QUOTA_POST_WARNING_TRIGGER: str = "--- QUOTA WARNING ---"
+QUOTA_POST_BUDGET_EXCEEDED_TRIGGER: str = "QUOTA BUDGET EXCEEDED"
 
 
 def _read_quota_cache(cache_path_str: str, max_age: int) -> dict | None:
@@ -181,31 +183,62 @@ def main(*, cache_path_override: str | None = None) -> None:
 
     result_summary = _extract_run_skill_result(tool_response)
 
-    warning_text = (
-        f"{result_summary}\n\n"
-        f"{QUOTA_POST_WARNING_TRIGGER}\n"
-        f"Post-execution utilization: {utilization:.0f}% on window '{window_name}' "
-        f"(threshold: {effective_threshold:.0f}%)\n"
-        f"MANDATORY ACTION before next run_skill: Call run_cmd with: "
-        f'python3 -c "import time; time.sleep({n})" timeout={n + 30}\n'
-        f"Before executing, state aloud: "
-        f"'Quota at {utilization:.0f}%. Sleeping {n}s before next step.'"
-    )
+    session_deadline_str = os.environ.get("AUTOSKILLIT_SESSION_DEADLINE")
+    budget_exceeded = False
+    remaining_budget = float("inf")
+    if session_deadline_str:
+        try:
+            session_deadline = float(session_deadline_str)
+            remaining_budget = max(0, session_deadline - time.time())
+            if n > remaining_budget:
+                budget_exceeded = True
+        except (ValueError, TypeError):
+            pass
+
+    if budget_exceeded:
+        resets_at_display = resets_at_str or "unknown"
+        warning_text = (
+            f"{result_summary}\n\n"
+            f"{QUOTA_POST_BUDGET_EXCEEDED_TRIGGER}\n"
+            f"Post-execution utilization: {utilization:.0f}% on window '{window_name}' "
+            f"(threshold: {effective_threshold:.0f}%)\n"
+            f"Quota sleep ({n}s) exceeds session budget ({remaining_budget:.0f}s remaining).\n"
+            f"MANDATORY ACTION: Emit your result block with "
+            f'"success": false, '
+            f'"reason": "fleet_quota_exhausted", '
+            f'"wait_seconds": {n}, '
+            f'"resets_at": "{resets_at_display}", '
+            f'"summary": "Quota exceeded; session budget insufficient for sleep. '
+            f'"Resume after window resets." '
+            f"Then STOP — do not call any more tools."
+        )
+    else:
+        warning_text = (
+            f"{result_summary}\n\n"
+            f"{QUOTA_POST_WARNING_TRIGGER}\n"
+            f"Post-execution utilization: {utilization:.0f}% on window '{window_name}' "
+            f"(threshold: {effective_threshold:.0f}%)\n"
+            f"MANDATORY ACTION before next run_skill: Call run_cmd with: "
+            f'python3 -c "import time; time.sleep({n})" timeout={n + 30}\n'
+            f"Before executing, state aloud: "
+            f"'Quota at {utilization:.0f}%. Sleeping {n}s before next step.'"
+        )
 
     _write_quota_log_event(
         {
             "ts": ts,
-            "event": "post_check_warning",
+            "event": "post_check_budget_exceeded" if budget_exceeded else "post_check_warning",
             "effective_threshold": effective_threshold,
             "window_name": window_name,
             "utilization": utilization,
             "sleep_seconds": n,
             "resets_at": resets_at_str,
             "tool_name": tool_name,
+            "budget_exceeded": budget_exceeded,
+            "remaining_budget": remaining_budget if remaining_budget != float("inf") else None,
         },
         log_dir,
     )
-
     print(
         json.dumps(
             {

--- a/tests/contracts/test_exogenous_string_coupling.py
+++ b/tests/contracts/test_exogenous_string_coupling.py
@@ -53,6 +53,27 @@ def test_quota_post_warning_trigger_coupled_to_sous_chef_skill():
     )
 
 
+def test_quota_post_budget_exceeded_trigger_coupled_to_food_truck_prompt():
+    """QUOTA_POST_BUDGET_EXCEEDED_TRIGGER must appear verbatim in the food truck prompt."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.fleet._prompts import _build_food_truck_prompt
+    from autoskillit.hooks.quota_post_hook import QUOTA_POST_BUDGET_EXCEEDED_TRIGGER
+
+    prompt = _build_food_truck_prompt(
+        recipe="test",
+        task="test",
+        ingredients={},
+        mcp_prefix=DIRECT_PREFIX,
+        dispatch_id="did",
+        campaign_id="cid",
+        l3_timeout_sec=3600,
+    )
+    assert QUOTA_POST_BUDGET_EXCEEDED_TRIGGER in prompt, (
+        f"Food truck prompt must reference quota_post_hook.QUOTA_POST_BUDGET_EXCEEDED_TRIGGER "
+        f"({QUOTA_POST_BUDGET_EXCEEDED_TRIGGER!r}) verbatim"
+    )
+
+
 class TestPromptToolReachability:
     """Tools referenced in FIRST ACTION must be registered in the FastMCP app."""
 

--- a/tests/fleet/test_dispatch_outcome_classifier.py
+++ b/tests/fleet/test_dispatch_outcome_classifier.py
@@ -88,8 +88,8 @@ class TestClassifyDispatchOutcomeCompletedClean:
 
 
 class TestQuotaExhaustedOutcome:
-    def test_quota_exhausted_is_failure(self):
-        """completed_clean + success=false + reason=fleet_quota_exhausted → FAILURE."""
+    def test_quota_exhausted_is_resumable(self):
+        """completed_clean + success=false + reason=fleet_quota_exhausted → RESUMABLE."""
         parsed = L3ParseResult(
             outcome="completed_clean",
             payload={"success": False, "reason": FleetErrorCode.FLEET_QUOTA_EXHAUSTED},
@@ -99,7 +99,7 @@ class TestQuotaExhaustedOutcome:
         )
         skill_result = dataclasses.replace(_DEFAULT_SKILL_RESULT)
         status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=False)
-        assert status == DispatchStatus.FAILURE
+        assert status == DispatchStatus.RESUMABLE
         assert reason == FleetErrorCode.FLEET_QUOTA_EXHAUSTED
 
 

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -382,6 +382,8 @@ class TestDispatchRecordToDict:
             "sidecar_path",
             "attempt_history",
             "resume_checkpoint",
+            "wait_seconds",
+            "resets_at",
             "labels_cleaned",
         }
 


### PR DESCRIPTION
## Summary

The PostToolUse `quota_post_hook.py` unconditionally emits a `sleep(N)` instruction after a successful `run_skill` when quota utilization is high — even when `N` exceeds the L2 session's remaining wall-clock budget. This causes L2 to sleep past its timeout, wasting the session and stranding labels.

The fix adds the same `AUTOSKILLIT_SESSION_DEADLINE` budget check that already exists in the PreToolUse `quota_guard.py`. When the computed sleep duration exceeds the remaining budget, the hook emits a budget-exceeded message instead of a sleep instruction, telling L2 to emit a `fleet_quota_exhausted` sentinel and stop. Supporting changes classify this outcome as RESUMABLE in the dispatch classifier, fix prompt reason string inconsistencies across sentinel contracts, extend the retry cap to cover quota-exhausted RESUMABLE dispatches, and wire `resume_session_id` through the L3 QUOTA RETRY path.

## Requirements

### QUOTA — PostToolUse Budget Check

**REQ-QUOTA-001:** The PostToolUse `quota_post_hook.py` must read `AUTOSKILLIT_SESSION_DEADLINE` from the environment and compute `remaining_budget = max(0, deadline - time.time())` before emitting any sleep instruction.

**REQ-QUOTA-002:** When the computed sleep duration `n` exceeds `remaining_budget`, the hook must NOT emit the standard sleep instruction.

**REQ-QUOTA-003:** When `n > remaining_budget` and `AUTOSKILLIT_DISPATCH_ID` is set, the hook must emit an `updatedMCPToolOutput` instructing the session to produce a `fleet_quota_exhausted` result block.

**REQ-QUOTA-004:** The budget-exceeded log event must include `budget_exceeded: true` and `remaining_budget` fields.

### ORCH — L3 Quota Exhaustion Handling

**REQ-ORCH-001:** L3 campaign orchestrator must extract `wait_seconds` and `resets_at` from `fleet_quota_exhausted` dispatch results.

**REQ-ORCH-002:** L3 must sleep at the campaign level before resuming the L2 session.

**REQ-ORCH-003:** After quota wait, L3 must resume the timed-out L2 via `--resume` using the original `dispatched_session_id`.

### CLASSIFY — Dispatch Outcome Classification

**REQ-CLASSIFY-001:** `classify_dispatch_outcome` must return `RESUMABLE` (not `FAILURE`) for `fleet_quota_exhausted`.

**REQ-CLASSIFY-002:** Label cleanup must skip `fleet_quota_exhausted` RESUMABLE dispatches.

### STATE — Quota State Persistence

**REQ-STATE-001:** `DispatchRecord` must include `wait_seconds` and `resets_at` fields.

**REQ-STATE-002:** `resume_campaign_from_state` must recognize `FLEET_QUOTA_EXHAUSTED` RESUMABLE dispatches.

### PROMPT — Reason String Consistency

**REQ-PROMPT-001:** `_prompts.py` Section 5 must use `fleet_quota_exhausted` (not `quota_exhausted`).

**REQ-PROMPT-002:** L3 campaign prompt QUOTA RETRY section must wire `resume_session_id`.

### GUARD — Retry Storm Protection

**REQ-GUARD-001:** Consecutive `FLEET_QUOTA_EXHAUSTED` RESUMABLE dispatches must count toward the retry cap.

## Changed Files

- `src/autoskillit/cli/_prompts_campaign.py`
- `src/autoskillit/core/types/_type_dispatch_identity.py`
- `src/autoskillit/fleet/_api.py`
- `src/autoskillit/fleet/_prompts.py`
- `src/autoskillit/fleet/state_recovery.py`
- `src/autoskillit/fleet/state_types.py`
- `src/autoskillit/hooks/__init__.py`
- `src/autoskillit/hooks/quota_post_hook.py`
- `tests/contracts/test_exogenous_string_coupling.py`
- `tests/fleet/test_dispatch_outcome_classifier.py`
- `tests/fleet/test_state_schema.py`

Closes #2851

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/posttooluse_quota_budget_check_plan_2026-05-24_005000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 104 | 43.7k | 2.4M | 143.2k | 218 | 144.5k | 22m 0s |
| verify | claude-opus-4-6 | 1 | 56 | 25.8k | 2.3M | 103.6k | 174 | 89.8k | 13m 35s |
| implement* | MiniMax-M2.7-highspeed | 1 | 7.5M | 55.2k | 3.2M | 30.0k | 234 | 15.5k | 16m 37s |
| prepare_pr* | MiniMax-M2.7 | 1 | 53.8k | 4.1k | 331.6k | 30.0k | 22 | 42.9k | 2m 5s |
| compose_pr* | MiniMax-M2.7 | 1 | 53.8k | 2.8k | 258.7k | 27.1k | 21 | 8.3k | 1m 34s |
| review_pr | claude-sonnet-4-6 | 1 | 84 | 8.0k | 305.7k | 76.2k | 64 | 33.6k | 6m 49s |
| resolve_review | claude-sonnet-4-6 | 1 | 405 | 42.2k | 3.3M | 103.1k | 115 | 95.4k | 14m 54s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 47 | 7.6k | 1.4M | 59.6k | 55 | 46.1k | 4m 7s |
| **Total** | | | 7.7M | 189.4k | 13.5M | 143.2k | | 476.1k | 1h 21m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 138 | 23436.9 | 112.3 | 400.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 1086 | 1273.7 | 42.4 | 7.0 |
| **Total** | **1224** | 11029.5 | 389.0 | 154.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 593 | 93.9k | 6.0M | 273.5k | 43m 44s |
| claude-opus-4-6 | 2 | 103 | 33.4k | 3.7M | 135.9k | 17m 42s |
| MiniMax-M2.7-highspeed | 1 | 7.5M | 55.2k | 3.2M | 15.5k | 16m 37s |
| MiniMax-M2.7 | 2 | 107.6k | 7.0k | 590.3k | 51.2k | 3m 39s |