### PR TITLE
Implementation Plan: Establish ctx.backend as an Always-Non-None Invariant

### DIFF
--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -17,7 +17,7 @@ import traceback
 from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import anyio
 import structlog
@@ -28,6 +28,7 @@ from autoskillit.core import (
     DISPATCH_ID_ENV_VAR,
     FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
     CmdSpec,
+    CodingAgentBackend,
     KillReason,
     ProviderOutcome,
     RecipeIdentity,
@@ -45,13 +46,11 @@ from autoskillit.core import (
     temp_dir_display_str,
 )
 from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
-from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.clone_guard import (
     check_and_revert_clone_contamination,
     is_worktree_skill,
     snapshot_clone_state,
 )
-from autoskillit.execution.commands import build_skill_session_cmd
 from autoskillit.execution.headless._headless_git import (
     _capture_git_head_sha,
     _compute_loc_changed,
@@ -133,11 +132,13 @@ def _session_log_dir(cwd: str) -> Path:
 
 
 def _resolve_pty_mode(ctx: ToolContext) -> bool:
-    return True if ctx.backend is None else ctx.backend.capabilities.pty_required
+    backend = cast(CodingAgentBackend, ctx.backend)
+    return backend.capabilities.pty_required
 
 
 def _resolve_session_log_dir(cwd: str, ctx: ToolContext) -> Path | None:
-    if ctx.backend is not None and not ctx.backend.capabilities.channel_b_capable:
+    backend = cast(CodingAgentBackend, ctx.backend)
+    if not backend.capabilities.channel_b_capable:
         return None
     return _session_log_dir(cwd)
 
@@ -340,10 +341,8 @@ async def _execute_claude_headless(
     _result: SubprocessResult | None = None
     result: SubprocessResult
     skill_result: SkillResult
-    _stream_parser = (
-        ctx.backend.stream_parser(completion_marker=completion_marker)
-        if ctx.backend is not None
-        else None
+    _stream_parser = cast(CodingAgentBackend, ctx.backend).stream_parser(
+        completion_marker=completion_marker
     )
     while True:
         try:
@@ -490,11 +489,9 @@ async def _execute_claude_headless(
             _git_writes_detected = _detect_branch_divergence(cwd)
 
         audit_count_before = len(ctx.audit.get_report())
-        _supports_fmt = (
-            ctx.backend.capabilities.supports_claude_format_stdout
-            if ctx.backend is not None
-            else True
-        )
+        _supports_fmt = cast(
+            "CodingAgentBackend", ctx.backend
+        ).capabilities.supports_claude_format_stdout
         skill_result = _build_skill_result(
             result,
             completion_marker=completion_marker,
@@ -741,46 +738,28 @@ async def run_headless_core(
             model, ctx.config, step_name=step_name, recipe_name=recipe_name
         )
         add_dirs_tuple = tuple(add_dirs)
-        if ctx.backend is not None:
-            config = SkillSessionConfig(
-                completion_marker=effective_marker,
-                model=resolved_model,
-                plugin_source=ctx.plugin_source,
-                output_format=cfg.output_format,
-                add_dirs=add_dirs_tuple,
-                exit_after_stop_delay_ms=cfg.exit_after_stop_delay_ms,
-                stream_idle_timeout_ms=cfg.stream_idle_timeout_ms,
-                scenario_step_name=step_name,
-                temp_dir_relpath=temp_dir_display_str(ctx.config.workspace.temp_dir),
-                allowed_write_prefix=allowed_write_prefix,
-                provider_extras=provider_extras,
-                profile_name=profile_name,
-                resume_session_id=resume_session_id,
-                resume_checkpoint=resume_checkpoint,
-                resume_message=resume_message,
-            )
-            spec = ctx.backend.build_skill_session_cmd(skill_command, cwd, config)
-            logger.debug("run_headless_core_backend_dispatch", backend=ctx.backend.name)
-        else:
-            spec = build_skill_session_cmd(
-                skill_command,
-                cwd=cwd,
-                completion_marker=effective_marker,
-                model=resolved_model,
-                plugin_source=ctx.plugin_source,
-                output_format=cfg.output_format,
-                add_dirs=add_dirs_tuple,
-                exit_after_stop_delay_ms=cfg.exit_after_stop_delay_ms,
-                stream_idle_timeout_ms=cfg.stream_idle_timeout_ms,
-                scenario_step_name=step_name,
-                temp_dir_relpath=temp_dir_display_str(ctx.config.workspace.temp_dir),
-                allowed_write_prefix=allowed_write_prefix,
-                provider_extras=provider_extras,
-                profile_name=profile_name,
-                resume_session_id=resume_session_id,
-                resume_checkpoint=resume_checkpoint,
-                resume_message=resume_message,
-            )
+        assert ctx.backend is not None, (
+            "ctx.backend must be set before run_headless_core is called"
+        )
+        config = SkillSessionConfig(
+            completion_marker=effective_marker,
+            model=resolved_model,
+            plugin_source=ctx.plugin_source,
+            output_format=cfg.output_format,
+            add_dirs=add_dirs_tuple,
+            exit_after_stop_delay_ms=cfg.exit_after_stop_delay_ms,
+            stream_idle_timeout_ms=cfg.stream_idle_timeout_ms,
+            scenario_step_name=step_name,
+            temp_dir_relpath=temp_dir_display_str(ctx.config.workspace.temp_dir),
+            allowed_write_prefix=allowed_write_prefix,
+            provider_extras=provider_extras,
+            profile_name=profile_name,
+            resume_session_id=resume_session_id,
+            resume_checkpoint=resume_checkpoint,
+            resume_message=resume_message,
+        )
+        spec = ctx.backend.build_skill_session_cmd(skill_command, cwd, config)
+        logger.debug("run_headless_core_backend_dispatch", backend=ctx.backend.name)
 
         effective_timeout = timeout if timeout is not None else cfg.timeout
         effective_stale = stale_threshold if stale_threshold is not None else cfg.stale_threshold
@@ -958,7 +937,8 @@ class DefaultHeadlessExecutor:
             if idle_cfg_val > 0:
                 merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(idle_cfg_val))
 
-        backend = self._ctx.backend or ClaudeCodeBackend()
+        assert self._ctx.backend is not None, "ctx.backend must be set before dispatch_food_truck"
+        backend = self._ctx.backend
         cmd_spec = backend.build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,
             plugin_source=self._ctx.plugin_source,

--- a/tests/arch/test_backend_command_path.py
+++ b/tests/arch/test_backend_command_path.py
@@ -38,7 +38,7 @@ _HEADLESS_IMPORTS = _collect_imports(ast.parse(_HEADLESS_INIT.read_text()))
 
 @pytest.mark.parametrize(
     "symbol",
-    ["build_food_truck_cmd"],
+    ["build_food_truck_cmd", "build_skill_session_cmd"],
 )
 def test_headless_does_not_import_commands_module(symbol: str):
     assert symbol not in _HEADLESS_IMPORTS, (

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -56,6 +56,7 @@ def _mock_backend(
         env={},
     )
     backend.write_tool_names.return_value = frozenset({"Write", "Edit"})
+    backend.result_parser.return_value = None
     return backend
 
 

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core.types import RetryReason, SkillResult
+from tests.execution.conftest import _mock_backend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -72,6 +73,7 @@ class TestProviderFieldsReachFlush:
             monkeypatch, tmp_path, _SUCCESS_RESULT, minimal_ctx
         )
         minimal_ctx.runner = fake_runner  # type: ignore[assignment]
+        minimal_ctx.backend = _mock_backend()
 
         await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -147,6 +149,7 @@ class TestProviderFieldsReachFlush:
         monkeypatch.setattr(_sl_mod, "flush_session_log", lambda **kw: flush_calls.append(kw))
 
         minimal_ctx.runner = fake_runner  # type: ignore[assignment]
+        minimal_ctx.backend = _mock_backend()
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -190,6 +193,7 @@ class TestProviderFieldsReachFlush:
             raise RuntimeError("disk crash")
 
         minimal_ctx.runner = raising_runner  # type: ignore[assignment]
+        minimal_ctx.backend = _mock_backend()
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -231,6 +235,7 @@ class TestProviderFieldsReachFlush:
             raise anyio.get_cancelled_exc_class()()
 
         minimal_ctx.runner = cancelling_runner  # type: ignore[assignment]
+        minimal_ctx.backend = _mock_backend()
 
         with pytest.raises(anyio.get_cancelled_exc_class()):
             await _execute_claude_headless(

--- a/tests/execution/test_headless_add_dirs.py
+++ b/tests/execution/test_headless_add_dirs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core import ValidatedAddDir
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -22,6 +23,7 @@ async def test_run_headless_core_no_add_dir_when_empty(minimal_ctx, tmp_path):
         return _make_result()
 
     minimal_ctx.runner = mock_runner
+    minimal_ctx.backend = ClaudeCodeBackend()
     proj = tmp_path / "proj"
     proj.mkdir()
     await run_headless_core("/autoskillit:investigate foo", str(proj), minimal_ctx, add_dirs=())
@@ -50,6 +52,7 @@ async def test_run_headless_core_two_add_dirs(minimal_ctx, tmp_path):
         return _make_result()
 
     minimal_ctx.runner = mock_runner
+    minimal_ctx.backend = ClaudeCodeBackend()
     proj = tmp_path / "proj"
     proj.mkdir()
     await run_headless_core(

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -12,12 +12,6 @@ pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 class TestResolvePtyMode:
-    def test_none_backend_returns_true(self, minimal_ctx) -> None:
-        import autoskillit.execution.headless as _headless_mod
-
-        minimal_ctx.backend = None
-        assert _headless_mod._resolve_pty_mode(minimal_ctx) is True
-
     def test_pty_required_true_returns_true(self, minimal_ctx) -> None:
         import autoskillit.execution.headless as _headless_mod
 
@@ -32,17 +26,6 @@ class TestResolvePtyMode:
 
 
 class TestResolveSessionLogDir:
-    def test_none_backend_returns_path(self, minimal_ctx, monkeypatch) -> None:
-        import autoskillit.execution.headless as _headless_mod
-
-        minimal_ctx.backend = None
-        monkeypatch.setattr(
-            "autoskillit.execution.headless._session_log_dir",
-            lambda cwd: Path("/fake/log/dir"),
-        )
-        result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx)
-        assert isinstance(result, Path)
-
     def test_channel_b_capable_true_returns_path(self, minimal_ctx, monkeypatch) -> None:
         import autoskillit.execution.headless as _headless_mod
 

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -798,11 +798,6 @@ class TestRunHeadlessCore:
         runner.set_default(_sr(0, _success_session_json("done"), ""))
         minimal_ctx.runner = runner
 
-        monkeypatch.setattr(
-            "autoskillit.execution.headless.build_skill_session_cmd",
-            Mock(side_effect=AssertionError("module-level shim should not be called")),
-        )
-
         with patch("autoskillit.execution.headless._build_skill_result") as mock_build:
             mock_build.return_value = SkillResult(
                 success=True,
@@ -823,50 +818,6 @@ class TestRunHeadlessCore:
             )
 
         assert backend.build_skill_session_cmd.call_count == 1
-
-    @pytest.mark.anyio
-    async def test_run_headless_core_falls_back_to_module_shim_when_backend_is_none(
-        self, minimal_ctx, monkeypatch, tmp_path
-    ):
-        from unittest.mock import Mock
-
-        from autoskillit.core import CmdSpec
-        from autoskillit.execution.headless import run_headless_core
-        from tests.fakes import MockSubprocessRunner
-
-        assert minimal_ctx.backend is None
-
-        shim_mock = Mock(return_value=CmdSpec(cmd=("claude", "--print", "fallback"), env={}))
-        monkeypatch.setattr(
-            "autoskillit.execution.headless.build_skill_session_cmd",
-            shim_mock,
-        )
-
-        runner = MockSubprocessRunner()
-        runner.set_default(_sr(0, _success_session_json("done"), ""))
-        minimal_ctx.runner = runner
-
-        with patch("autoskillit.execution.headless._build_skill_result") as mock_build:
-            mock_build.return_value = SkillResult(
-                success=True,
-                result="",
-                session_id="test-session",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason=RetryReason.NONE,
-                stderr="",
-            )
-            await run_headless_core(
-                "/autoskillit:test-skill",
-                str(tmp_path),
-                minimal_ctx,
-                completion_marker="%%DONE%%",
-            )
-
-        shim_mock.assert_called_once()
-        assert shim_mock.call_args.args[0] == "/autoskillit:test-skill"
 
 
 class TestHeadlessTelemetryContainment:

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -20,7 +20,7 @@ from autoskillit.execution.headless import (
     _extract_worktree_path,
 )
 from tests.conftest import _make_result, _make_timeout_result
-from tests.execution.conftest import _sr, _success_session_json
+from tests.execution.conftest import _mock_backend, _sr, _success_session_json
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -209,6 +209,7 @@ class TestRunHeadlessCoreFilesystemWrites:
         base_runner = MockSubprocessRunner()
         base_runner.set_default(_sr(0, _success_session_json("done"), ""))
         minimal_ctx.runner = _FileSideEffectRunner(base_runner, skill_temp / "output.txt")
+        minimal_ctx.backend = _mock_backend()
 
         result = await run_headless_core(
             "/autoskillit:probe",
@@ -231,6 +232,7 @@ class TestRunHeadlessCoreFilesystemWrites:
         runner = MockSubprocessRunner()
         runner.set_default(_sr(0, _success_session_json("done"), ""))
         minimal_ctx.runner = runner
+        minimal_ctx.backend = _mock_backend()
 
         result = await run_headless_core(
             "/autoskillit:probe",

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.core.types._type_plugin_source import DirectInstall, MarketplaceInstall
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -43,6 +44,7 @@ class TestDispatchFoodTruck:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        minimal_ctx.backend = ClaudeCodeBackend()
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(
@@ -78,6 +80,7 @@ class TestDispatchFoodTruck:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        minimal_ctx.backend = ClaudeCodeBackend()
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         result = await executor.dispatch_food_truck(
@@ -107,6 +110,7 @@ class TestDispatchFoodTruck:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        minimal_ctx.backend = ClaudeCodeBackend()
 
         spawned_pids: list[int] = []
 
@@ -138,6 +142,7 @@ class TestDispatchFoodTruck:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        minimal_ctx.backend = ClaudeCodeBackend()
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         result = await executor.dispatch_food_truck(
@@ -173,6 +178,7 @@ class TestDispatchFoodTruck:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = MarketplaceInstall(cache_path=cache)
+        minimal_ctx.backend = ClaudeCodeBackend()
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(
@@ -254,6 +260,7 @@ class TestDispatchFoodTruckPackInjection:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        minimal_ctx.backend = ClaudeCodeBackend()
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(
@@ -288,6 +295,7 @@ class TestDispatchFoodTruckPackInjection:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        minimal_ctx.backend = ClaudeCodeBackend()
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(
@@ -355,6 +363,7 @@ class TestDispatchFoodTruckGuards:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        minimal_ctx.backend = ClaudeCodeBackend()
         executor = DefaultHeadlessExecutor(minimal_ctx)
 
         await executor.dispatch_food_truck(
@@ -390,35 +399,22 @@ class TestDispatchFoodTruckGuards:
             )
 
     @pytest.mark.anyio
-    async def test_dispatch_food_truck_allows_none_backend(
+    async def test_dispatch_food_truck_raises_for_none_backend(
         self, minimal_ctx, tmp_path: Path
     ) -> None:
-        from autoskillit.core.types import SubprocessResult, TerminationReason
         from autoskillit.core.types._type_plugin_source import DirectInstall
         from autoskillit.execution.headless import DefaultHeadlessExecutor
-        from tests.fakes import MockSubprocessRunner
 
-        runner = MockSubprocessRunner()
-        runner.set_default(
-            SubprocessResult(
-                returncode=0,
-                stdout=_make_success_stdout(),
-                stderr="",
-                termination=TerminationReason.NATURAL_EXIT,
-                pid=55555,
-            )
-        )
-        minimal_ctx.runner = runner
+        minimal_ctx.backend = None
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
-
         executor = DefaultHeadlessExecutor(minimal_ctx)
-        result = await executor.dispatch_food_truck(
-            "some prompt",
-            str(tmp_path),
-            completion_marker="%%FT_DONE%%",
-        )
-        assert result is not None
-        assert len(runner.call_args_list) >= 1
+
+        with pytest.raises(AssertionError):
+            await executor.dispatch_food_truck(
+                "some prompt",
+                str(tmp_path),
+                completion_marker="%%FT_DONE%%",
+            )
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_allows_claude_code_backend(

--- a/tests/execution/test_headless_env_injection.py
+++ b/tests/execution/test_headless_env_injection.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.core.types import SubprocessResult, TerminationReason
+from tests.execution.conftest import _mock_backend
 from tests.fakes import MockSubprocessRunner
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -38,6 +39,7 @@ async def test_headless_command_includes_headless_env_var(minimal_ctx, tmp_path:
         )
     )
 
+    minimal_ctx.backend = _mock_backend()
     await run_headless_core("/investigate foo", str(tmp_path), minimal_ctx)
 
     assert minimal_ctx.runner.call_args_list, "runner was never called"

--- a/tests/execution/test_headless_env_injection.py
+++ b/tests/execution/test_headless_env_injection.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.core import CmdSpec
 from autoskillit.core.types import SubprocessResult, TerminationReason
 from tests.execution.conftest import _mock_backend
 from tests.fakes import MockSubprocessRunner
@@ -39,7 +40,12 @@ async def test_headless_command_includes_headless_env_var(minimal_ctx, tmp_path:
         )
     )
 
-    minimal_ctx.backend = _mock_backend()
+    backend = _mock_backend()
+    backend.build_skill_session_cmd.return_value = CmdSpec(
+        cmd=("claude", "--print", "test"),
+        env={"AUTOSKILLIT_HEADLESS": "1"},
+    )
+    minimal_ctx.backend = backend
     await run_headless_core("/investigate foo", str(tmp_path), minimal_ctx)
 
     assert minimal_ctx.runner.call_args_list, "runner was never called"

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -1789,25 +1789,6 @@ class TestNudgeBackendGuard:
         )
 
     @pytest.mark.anyio
-    async def test_nudge_skips_when_backend_none(self, tool_ctx):
-        from autoskillit.core.types import RetryReason
-        from autoskillit.execution.headless import run_headless_core
-
-        marker = tool_ctx.config.run_skill.completion_marker
-        tool_ctx.backend = None
-        tool_ctx.runner.push(self._main_subprocess_result(marker))
-        tool_ctx.runner.push(self._nudge_response(marker))
-        result = await run_headless_core(
-            "/autoskillit:make-plan foo",
-            cwd="/tmp",
-            ctx=tool_ctx,
-            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
-        )
-        # Without backend, nudge is skipped - CONTRACT_RECOVERY persists
-        assert result.retry_reason == RetryReason.CONTRACT_RECOVERY
-        assert len(tool_ctx.runner.call_args_list) == 1
-
-    @pytest.mark.anyio
     async def test_nudge_skips_when_not_session_resume_capable(self, tool_ctx):
         from dataclasses import replace
         from unittest.mock import Mock

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -117,6 +117,7 @@ class TestProviderFallbackLoop:
             ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
+        minimal_ctx.backend = _mock_backend()
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -145,6 +146,7 @@ class TestProviderFallbackLoop:
             ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
+        minimal_ctx.backend = _mock_backend()
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -11,6 +11,7 @@ from collections import deque
 import pytest
 
 from autoskillit.core.types import RetryReason, SkillResult
+from tests.execution.conftest import _mock_backend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -171,6 +172,7 @@ class TestProviderFallbackLoop:
             _make_queued_build_result(_STALE_RESULT),
         )
         minimal_ctx.runner = fake_runner
+        minimal_ctx.backend = _mock_backend()
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -196,6 +198,7 @@ class TestProviderFallbackLoop:
             ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
+        minimal_ctx.backend = _mock_backend()
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -239,6 +239,7 @@ async def test_no_fallback_env_returns_empty_provider_used(
         return _sub_result
 
     minimal_ctx.runner = fake_runner
+    minimal_ctx.backend = _mock_backend()
 
     monkeypatch.setattr(
         "autoskillit.execution.headless._build_skill_result",
@@ -280,6 +281,7 @@ async def test_provider_name_stamps_provider_used_on_result(
         return _sub_result
 
     minimal_ctx.runner = fake_runner
+    minimal_ctx.backend = _mock_backend()
 
     monkeypatch.setattr(
         "autoskillit.execution.headless._build_skill_result",
@@ -419,6 +421,7 @@ async def test_dispatch_food_truck_forwards_marker_dir_and_session_id(
         lambda *a, **kw: object(),
     )
 
+    minimal_ctx.backend = _mock_backend()
     executor = DefaultHeadlessExecutor(minimal_ctx)
     marker = tmp_path / "markers"
     await executor.dispatch_food_truck(
@@ -468,6 +471,7 @@ async def test_dispatch_food_truck_derives_marker_dir_from_cwd(
         lambda *a, **kw: object(),
     )
 
+    minimal_ctx.backend = _mock_backend()
     executor = DefaultHeadlessExecutor(minimal_ctx)
     await executor.dispatch_food_truck(
         "prompt",
@@ -507,6 +511,7 @@ async def test_dispatch_food_truck_marker_dir_none_when_cwd_falsy(
 
     from autoskillit.execution.headless import DefaultHeadlessExecutor
 
+    minimal_ctx.backend = _mock_backend()
     executor = DefaultHeadlessExecutor(minimal_ctx)
     await executor.dispatch_food_truck(
         "prompt",
@@ -535,6 +540,7 @@ async def test_execute_claude_headless_forwards_marker_dir_to_runner(
         return _sr()
 
     minimal_ctx.runner = fake_runner
+    minimal_ctx.backend = _mock_backend()
     monkeypatch.setattr(
         "autoskillit.execution.headless._build_skill_result",
         lambda *a, **kw: SkillResult(

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -758,43 +758,6 @@ async def test_execute_claude_headless_passes_stream_parser_to_runner(
 
 
 @pytest.mark.anyio
-async def test_execute_claude_headless_stream_parser_none_when_no_backend(
-    minimal_ctx, tmp_path, monkeypatch
-) -> None:
-    from autoskillit.execution.commands import ClaudeHeadlessCmd
-    from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
-    from tests.execution.conftest import _sr
-
-    spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
-    runner_kwargs: dict = {}
-
-    async def fake_runner(cmd, **kwargs):
-        runner_kwargs.update(kwargs)
-        return _sr()
-
-    minimal_ctx.runner = fake_runner
-
-    monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
-        lambda *a, **kw: _STUB_RESULT,
-    )
-    monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
-        lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
-    )
-    monkeypatch.setattr(
-        "autoskillit.execution.headless._capture_git_head_sha",
-        lambda *a: "",
-    )
-
-    await _execute_claude_headless(
-        spec, str(tmp_path), minimal_ctx, timeout=60, stale_threshold=30
-    )
-
-    assert runner_kwargs.get("stream_parser") is None
-
-
-@pytest.mark.anyio
 async def test_execute_claude_headless_stream_parser_receives_completion_marker(
     minimal_ctx, tmp_path, monkeypatch
 ) -> None:

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from autoskillit.core.types import SubprocessResult, TerminationReason
+from tests.execution.conftest import _mock_backend
 from tests.fakes import MockSubprocessRunner
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -45,6 +46,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
         monkeypatch.setenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", "30")
         minimal_ctx.runner = MockSubprocessRunner()
         minimal_ctx.runner.set_default(_success_result())
+        minimal_ctx.backend = _mock_backend()
 
         await run_headless_core("/investigate foo", str(tmp_path), minimal_ctx)
 
@@ -71,6 +73,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
         minimal_ctx.config.run_skill.idle_output_timeout = 60
         minimal_ctx.runner = MockSubprocessRunner()
         minimal_ctx.runner.set_default(_success_result())
+        minimal_ctx.backend = _mock_backend()
 
         await run_headless_core(
             "/investigate foo", str(tmp_path), minimal_ctx, idle_output_timeout=15.0
@@ -117,6 +120,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
         minimal_ctx.config.run_skill.idle_output_timeout = 0  # cfg also 0
         minimal_ctx.runner = MockSubprocessRunner()
         minimal_ctx.runner.set_default(_success_result())
+        minimal_ctx.backend = _mock_backend()
 
         await run_headless_core("/investigate foo", str(tmp_path), minimal_ctx)
 
@@ -145,6 +149,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
         runner = MockSubprocessRunner()
         runner.set_default(_success_result())
         minimal_ctx.runner = runner
+        minimal_ctx.backend = _mock_backend()
 
         await run_headless_core(
             "/autoskillit:some-skill",

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -18,6 +18,7 @@ import pytest
 
 from autoskillit.core import HeadlessExecutor, WriteBehaviorSpec
 from tests.conftest import _make_result
+from tests.execution.conftest import _mock_backend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -72,6 +73,7 @@ class TestMultiDirFsSnapshot:
             return _make_result()
 
         minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -240,6 +242,7 @@ class TestRecursiveSnapshot:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -267,6 +270,7 @@ class TestRecursiveSnapshot:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -301,6 +305,7 @@ class TestPlannerSkillEndToEnd:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
         proj = tmp_path / "proj"
         proj.mkdir()
 

--- a/tests/hooks/test_hook_config_bridge.py
+++ b/tests/hooks/test_hook_config_bridge.py
@@ -106,6 +106,7 @@ def test_deny_message_contains_sleep_from_payload_buffer_seconds(tmp_path, monke
     )
     monkeypatch.chdir(tmp_path)
     _clear_env(monkeypatch)
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
 
     out, _ = _run_hook(event={"tool_name": "run_skill"})
 

--- a/tests/hooks/test_quota_check.py
+++ b/tests/hooks/test_quota_check.py
@@ -91,7 +91,8 @@ def test_deny_when_utilization_above_threshold(tmp_path):
     assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
-def test_deny_message_contains_sleep_seconds(tmp_path):
+def test_deny_message_contains_sleep_seconds(tmp_path, monkeypatch):
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
     cache = tmp_path / "quota_cache.json"
     _write_cache(cache, utilization=95.0)
     out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
@@ -101,8 +102,9 @@ def test_deny_message_contains_sleep_seconds(tmp_path):
     assert "time.sleep" in reason
 
 
-def test_deny_message_contains_echo_repeat(tmp_path):
+def test_deny_message_contains_echo_repeat(tmp_path, monkeypatch):
     """Updated PreToolUse deny message includes echo/repeat instruction."""
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
     cache = tmp_path / "quota_cache.json"
     _write_cache(cache, utilization=90.0)
     out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
@@ -266,6 +268,7 @@ def test_quota_check_buffer_seconds_from_hook_config(tmp_path, monkeypatch):
     (``n = settings.buffer_seconds``), making the assertion deterministic.
     """
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", raising=False)
     cache = tmp_path / "quota_cache.json"
     _write_cache(cache, utilization=95.0, resets_at=None)
@@ -286,6 +289,7 @@ def test_quota_check_buffer_seconds_from_hook_config(tmp_path, monkeypatch):
 def test_quota_check_buffer_seconds_env_var_override(tmp_path, monkeypatch):
     """``AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS`` overrides the deny-message sleep duration."""
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
     monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", "180")
     cache = tmp_path / "quota_cache.json"
     _write_cache(cache, utilization=95.0, resets_at=None)
@@ -349,6 +353,7 @@ def test_quota_event_approved_written_to_log(tmp_path, monkeypatch):
 
 # T2
 def test_quota_event_blocked_written_to_log(tmp_path, monkeypatch):
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
     cache = tmp_path / "quota_cache.json"
     _write_cache(cache, utilization=95.0)
     log_dir = tmp_path / "logs"
@@ -467,7 +472,8 @@ def test_hook_approves_seven_day_at_86_percent_should_block_false(tmp_path):
 
 
 # T-HOOK-PWT-2: seven_day above 98% must still deny.
-def test_hook_blocks_seven_day_above_long_threshold(tmp_path):
+def test_hook_blocks_seven_day_above_long_threshold(tmp_path, monkeypatch):
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
     cache = tmp_path / "quota_cache.json"
     _write_cache(
         cache,
@@ -485,7 +491,8 @@ def test_hook_blocks_seven_day_above_long_threshold(tmp_path):
 
 
 # T-HOOK-PWT-3: short window above 85% must deny with short threshold in message.
-def test_hook_blocks_short_window_above_threshold_message(tmp_path):
+def test_hook_blocks_short_window_above_threshold_message(tmp_path, monkeypatch):
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
     cache = tmp_path / "quota_cache.json"
     _write_cache(
         cache,


### PR DESCRIPTION
## Summary

Remove the silent `ClaudeCodeBackend` fallback and None-backend guard branches from `run_headless_core` and `dispatch_food_truck` in `headless/__init__.py`. Simplify four helper functions (`_resolve_pty_mode`, `_resolve_session_log_dir`, `_stream_parser` assignment, `_supports_fmt` assignment) that previously handled None backends with ternaries. Delete or update tests across test files that validate the now-removed None-backend code paths, wire explicit `ClaudeCodeBackend()` instances into dispatch tests that relied on the silent fallback, and add an arch guard to lock in the new invariant.

Closes #2855

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-004751-919783/.autoskillit/temp/dry-walkthrough/establish_ctx_backend_invariant_plan_2026-05-24_010200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 899 | 11.4k | 641.0k | 64.0k | 102 | 55.7k | 9m 48s |
| verify | claude-sonnet-4-6 | 1 | 53 | 24.4k | 1.0M | 87.1k | 144 | 73.8k | 13m 27s |
| implement* | MiniMax-M2.7-highspeed | 1 | 956.9k | 8.3k | 1.0M | 30.0k | 151 | 50.7k | 10m 29s |
| fix | claude-sonnet-4-6 | 2 | 847 | 89.8k | 9.6M | 157.3k | 248 | 239.2k | 47m 18s |
| dispatch:998e83fc-e150-4006-a797-07f7b97f773b | claude-sonnet-4-6 | 1 | 308 | 56 | 2.2M | 82.5k | 38 | 340.8k | 1h 38m |
| prepare_pr | claude-sonnet-4-6 | 1 | 83 | 8.6k | 223.7k | 32.9k | 29 | 25.9k | 3m 15s |
| compose_pr | claude-sonnet-4-6 | 1 | 67 | 2.5k | 156.0k | 23.5k | 16 | 15.7k | 56s |
| review_pr | claude-sonnet-4-6 | 1 | 160 | 32.2k | 819.7k | 82.8k | 62 | 120.4k | 9m 19s |
| resolve_review | claude-sonnet-4-6 | 1 | 189 | 11.3k | 997.3k | 57.2k | 54 | 58.2k | 7m 19s |
| **Total** | | | 959.5k | 188.6k | 16.7M | 157.3k | | 980.4k | 3h 20m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 254 | 4107.6 | 199.5 | 32.7 |
| fix | 58 | 165043.9 | 4123.9 | 1548.8 |
| dispatch:998e83fc-e150-4006-a797-07f7b97f773b | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **312** | 53421.2 | 3142.2 | 604.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 8 | 2.6k | 180.3k | 15.6M | 929.7k | 3h 9m |
| MiniMax-M2.7-highspeed | 1 | 956.9k | 8.3k | 1.0M | 50.7k | 10m 29s |