### PR TITLE
[FEATURE] Make backend Parameter Required (Non-None) in _headless_result.py

### DIFF
--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -492,6 +492,7 @@ async def _execute_claude_headless(
         _supports_fmt = cast(
             "CodingAgentBackend", ctx.backend
         ).capabilities.supports_claude_format_stdout
+        _backend = cast(CodingAgentBackend, ctx.backend)
         skill_result = _build_skill_result(
             result,
             completion_marker=completion_marker,
@@ -505,7 +506,7 @@ async def _execute_claude_headless(
             prior_completion_markers=prior_completion_markers,
             provider_used=current_provider_name,
             supports_claude_format_stdout=_supports_fmt,
-            backend=ctx.backend,
+            backend=_backend,
         )
 
         if (

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -130,8 +130,8 @@ def _resolve_skill_session_id(
     return result.session_id or result.channel_b_session_id
 
 
-def _parse_stdout(stdout: str, backend: CodingAgentBackend | None = None) -> ClaudeSessionResult:
-    if backend is None or backend.name == AGENT_BACKEND_CLAUDE_CODE:
+def _parse_stdout(stdout: str, backend: CodingAgentBackend) -> ClaudeSessionResult:
+    if backend.name == AGENT_BACKEND_CLAUDE_CODE:
         return parse_session_result(stdout)
     agent_result = backend.result_parser().parse_stdout(stdout)
     return _adapt_agent_result(agent_result)
@@ -186,12 +186,10 @@ def _compute_write_evidence(
     session: ClaudeSessionResult,
     fs_writes_detected: bool,
     git_writes_detected: bool,
-    backend: CodingAgentBackend | None = None,
+    backend: CodingAgentBackend,
     file_changes: Sequence[str] = (),
 ) -> WriteEvidence:
-    write_names = (
-        backend.write_tool_names() if backend is not None else frozenset({"Write", "Edit"})
-    )
+    write_names = backend.write_tool_names()
     write_call_count = sum(1 for t in session.tool_uses if t.get("name") in write_names)
     # Codex fallback: only count file_changes when no Write/Edit tool calls provide evidence.
     file_changes_count = len(file_changes) if write_call_count == 0 else 0
@@ -203,8 +201,8 @@ def _compute_write_evidence(
     )
 
 
-def _extract_file_changes(stdout: str, backend: CodingAgentBackend | None) -> list[str]:
-    if backend is None or backend.name == AGENT_BACKEND_CLAUDE_CODE:
+def _extract_file_changes(stdout: str, backend: CodingAgentBackend) -> list[str]:
+    if backend.name == AGENT_BACKEND_CLAUDE_CODE:
         return []
     agent_result = backend.result_parser().parse_stdout(stdout)
     return list(agent_result.raw.get("file_changes", []))
@@ -274,7 +272,7 @@ def _build_skill_result(
     *,
     provider_used: str = "",
     supports_claude_format_stdout: bool = True,
-    backend: CodingAgentBackend | None = None,
+    backend: CodingAgentBackend,
 ) -> SkillResult:
     """Route SubprocessResult fields into the standard run_skill response."""
     file_changes = _extract_file_changes(result.stdout, backend)
@@ -476,11 +474,13 @@ def _build_skill_result(
     _has_write_evidence = evidence.has_evidence
 
     try:
-        _backend_write_names = set(backend.write_tool_names()) if backend else {"Write", "Edit"}
+        _backend_write_names = set(backend.write_tool_names())
     except Exception:
         logger.warning("backend_write_tool_names_failed", exc_info=True)
         _backend_write_names = {"Write", "Edit"}
-    _parsed_has_write_tools = any(tu.get("name") in {"Write", "Edit"} for tu in session.tool_uses)
+    _parsed_has_write_tools = any(
+        tu.get("name") in _backend_write_names for tu in session.tool_uses
+    )
     if (
         evidence.write_call_count == 0
         and _backend_write_names & {"Write", "Edit"}
@@ -579,9 +579,7 @@ def _build_skill_result(
         # _recover_block_from_assistant_messages is unavailable. For CHANNEL_A/B
         # sessions, if the pattern was absent from assistant_messages the agent never
         # emitted it — synthesis would fabricate a token the agent did not produce.
-        write_names = (
-            backend.write_tool_names() if backend is not None else frozenset({"Write", "Edit"})
-        )
+        write_names = backend.write_tool_names()
         if (
             expected_output_patterns
             and _has_write_evidence

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -19,6 +19,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.headless._headless_result import _build_skill_result
 from autoskillit.execution.session._exit_classification import classify_infra_exit
 from autoskillit.execution.session._session_model import ClaudeSessionResult, parse_session_result
@@ -164,7 +165,7 @@ class TestApiErrorPtyModeEndToEnd:
             pid=12345,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "api_error", (
             f"Expected infra.exit_category='api_error' for signal='{signal}', "
             f"got '{sr.infra.exit_category}'"
@@ -196,7 +197,7 @@ class TestApiErrorPtyModeEndToEnd:
             pid=12345,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "api_error"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME
@@ -225,7 +226,7 @@ class TestApiErrorPtyModeEndToEnd:
             pid=12345,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "context_exhausted"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME
@@ -311,7 +312,7 @@ class TestApiErrorStatusChannelInvariance:
             pid=12345,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr = _build_skill_result(result, completion_marker="DONE")
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend(), completion_marker="DONE")
         assert sr.infra.exit_category == "api_error"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -12,6 +12,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.clone_guard import (
     CloneSnapshot,
     check_and_revert_clone_contamination,
@@ -370,7 +371,7 @@ def test_worktree_path_always_extracted(tmp_path):
         termination=TerminationReason.NATURAL_EXIT,
         pid=12345,
     )
-    skill = _build_skill_result(sr)
+    skill = _build_skill_result(sr, backend=ClaudeCodeBackend())
     assert skill.worktree_path == str(wt)
 
 

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -14,6 +14,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.commands import _ensure_skill_prefix
 from autoskillit.execution.headless import (
     _build_skill_result,
@@ -303,7 +304,7 @@ class TestBuildSkillResult:
                 "session_id": "sess-abc",
             }
         )
-        skill = _build_skill_result(_sr(stdout=payload))
+        skill = _build_skill_result(_sr(stdout=payload), backend=ClaudeCodeBackend())
         assert skill.success is True
         assert skill.needs_retry is False
 
@@ -311,7 +312,10 @@ class TestBuildSkillResult:
         """TIMED_OUT termination → success=False, needs_retry=False (timeout is non-retriable)."""
         from autoskillit.execution.headless import _build_skill_result
 
-        skill = _build_skill_result(_sr(returncode=-1, termination=TerminationReason.TIMED_OUT))
+        skill = _build_skill_result(
+            _sr(returncode=-1, termination=TerminationReason.TIMED_OUT),
+            backend=ClaudeCodeBackend(),
+        )
         assert skill.success is False
         assert skill.needs_retry is False
 
@@ -329,7 +333,8 @@ class TestBuildSkillResult:
             }
         )
         skill = _build_skill_result(
-            _sr(returncode=-15, stdout=payload, termination=TerminationReason.STALE)
+            _sr(returncode=-15, stdout=payload, termination=TerminationReason.STALE),
+            backend=ClaudeCodeBackend(),
         )
         assert skill.success is True
         assert skill.subtype == "recovered_from_stale"
@@ -339,7 +344,8 @@ class TestBuildSkillResult:
         from autoskillit.execution.headless import _build_skill_result
 
         skill = _build_skill_result(
-            _sr(returncode=-15, stdout="", termination=TerminationReason.STALE)
+            _sr(returncode=-15, stdout="", termination=TerminationReason.STALE),
+            backend=ClaudeCodeBackend(),
         )
         assert skill.success is False
         assert skill.needs_retry is True
@@ -363,6 +369,7 @@ class TestBuildSkillResult:
             audit=None,
             expected_output_patterns=[],
             cwd="/tmp",
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.session_id == "b077addc-926d-4869-b27a-7465a4c0fda4"
 
@@ -371,7 +378,8 @@ class TestBuildSkillResult:
         from autoskillit.execution.headless import _build_skill_result
 
         skill = _build_skill_result(
-            _sr(returncode=-15, stdout="", termination=TerminationReason.IDLE_STALL)
+            _sr(returncode=-15, stdout="", termination=TerminationReason.IDLE_STALL),
+            backend=ClaudeCodeBackend(),
         )
         assert skill.success is False
         assert skill.needs_retry is True
@@ -396,6 +404,7 @@ class TestBuildSkillResult:
             audit=None,
             expected_output_patterns=[],
             cwd="/tmp",
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.session_id == "c1ee2a00-1234-5678-abcd-deadbeefcafe"
         assert skill_result.success is False
@@ -433,6 +442,7 @@ class TestBuildSkillResult:
             audit=None,
             expected_output_patterns=[],
             cwd="/tmp",
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.session_id == stdout_session  # NOT channel_b_uuid
 
@@ -465,7 +475,7 @@ class TestRecoverFromSeparateMarker:
             pid=0,
             channel_confirmation=channel,
         )
-        return _build_skill_result(result, completion_marker=marker)
+        return _build_skill_result(result, completion_marker=marker, backend=ClaudeCodeBackend())
 
     def test_recovery_yields_success_when_marker_in_separate_message(self):
         """CHANNEL_B + standalone marker in separate assistant msg → result text populated.
@@ -631,7 +641,9 @@ class TestBuildSkillResultUsesComputeOutcome:
                 "session_id": "s1",
             }
         )
-        skill = _build_skill_result(_sr(stdout=payload), completion_marker=marker)
+        skill = _build_skill_result(
+            _sr(stdout=payload), completion_marker=marker, backend=ClaudeCodeBackend()
+        )
         assert skill.success is True
         assert skill.needs_retry is False
 
@@ -648,7 +660,7 @@ class TestBuildSkillResultUsesComputeOutcome:
                 "session_id": "s1",
             }
         )
-        skill = _build_skill_result(_sr(returncode=1, stdout=payload))
+        skill = _build_skill_result(_sr(returncode=1, stdout=payload), backend=ClaudeCodeBackend())
         assert skill.success is False
         assert skill.needs_retry is True
 
@@ -656,7 +668,10 @@ class TestBuildSkillResultUsesComputeOutcome:
         """Timeout session → success=False, needs_retry=False."""
         from autoskillit.execution.headless import _build_skill_result
 
-        skill = _build_skill_result(_sr(returncode=-1, termination=TerminationReason.TIMED_OUT))
+        skill = _build_skill_result(
+            _sr(returncode=-1, termination=TerminationReason.TIMED_OUT),
+            backend=ClaudeCodeBackend(),
+        )
         assert skill.success is False
         assert skill.needs_retry is False
 
@@ -681,7 +696,8 @@ class TestBuildSkillResultUsesComputeOutcome:
                 termination=TerminationReason.NATURAL_EXIT,
                 pid=0,
                 channel_confirmation=ChannelConfirmation.CHANNEL_B,
-            )
+            ),
+            backend=ClaudeCodeBackend(),
         )
         # Contradiction guard: CHANNEL_B bypass makes success=True, error_max_turns
         # makes needs_retry=True. Retry signal is authoritative → success=False.
@@ -709,7 +725,8 @@ class TestBuildSkillResultUsesComputeOutcome:
                 termination=TerminationReason.NATURAL_EXIT,
                 pid=0,
                 channel_confirmation=ChannelConfirmation.CHANNEL_A,
-            )
+            ),
+            backend=ClaudeCodeBackend(),
         )
         # Dead-end guard: success=False (empty result), needs_retry=False (CHANNEL_A
         # returns False from _compute_retry), but CHANNEL_A confirms completion →
@@ -946,7 +963,9 @@ class TestStalenessReturnsNeedsRetry:
             termination=TerminationReason.STALE,
             pid=12345,
         )
-        response = json.loads(_build_skill_result(stale_result).to_json())
+        response = json.loads(
+            _build_skill_result(stale_result, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["needs_retry"] is True
         assert response["retry_reason"] == "stale"
         assert response["subtype"] == "stale"
@@ -1000,7 +1019,9 @@ class TestBuildSkillResultCrossValidation:
         result_obj = SubprocessResult(
             returncode=0, stdout="", stderr="", termination=TerminationReason.NATURAL_EXIT, pid=1
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["success"] is False
         assert response["is_error"] is True
 
@@ -1009,7 +1030,9 @@ class TestBuildSkillResultCrossValidation:
         result_obj = SubprocessResult(
             returncode=-1, stdout="", stderr="", termination=TerminationReason.TIMED_OUT, pid=1
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["success"] is False
         assert response["is_error"] is True
         assert response["subtype"] == "timeout"
@@ -1019,7 +1042,9 @@ class TestBuildSkillResultCrossValidation:
         result_obj = SubprocessResult(
             returncode=-1, stdout="", stderr="", termination=TerminationReason.STALE, pid=1
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["success"] is False
         assert response["needs_retry"] is True
 
@@ -1041,7 +1066,9 @@ class TestBuildSkillResultCrossValidation:
             termination=TerminationReason.NATURAL_EXIT,
             pid=1,
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["success"] is True
         assert response["is_error"] is False
         assert response["result"] == "Task completed."
@@ -1064,7 +1091,9 @@ class TestBuildSkillResultCrossValidation:
             termination=TerminationReason.NATURAL_EXIT,
             pid=1,
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["success"] is False
 
     @pytest.mark.parametrize(
@@ -1103,7 +1132,9 @@ class TestBuildSkillResultCrossValidation:
     )
     def test_schema_keys(self, result_obj: SubprocessResult):
         """Response always exposes the full standard key set."""
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert set(response.keys()) == self.EXPECTED_SKILL_KEYS
 
 
@@ -1144,13 +1175,13 @@ class TestBuildSkillResultLifespanStarted:
     def test_build_skill_result_sets_lifespan_started_true(self):
         """Non-empty tool_uses in stdout → _build_skill_result produces lifespan_started=True."""
         result = _make_subprocess_result_with_tool_uses(tool_use_names=["Write", "Edit"])
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.lifespan_started is True
 
     def test_build_skill_result_sets_lifespan_started_false_no_tool_uses(self):
         """Empty tool_uses in stdout → _build_skill_result produces lifespan_started=False."""
         result = _make_subprocess_result_with_tool_uses(tool_use_names=None)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.lifespan_started is False
 
 
@@ -1175,7 +1206,9 @@ class TestBuildSkillResultStderr:
             termination=TerminationReason.NATURAL_EXIT,
             pid=1,
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["stderr"] == "queue contention"
 
     def test_stderr_truncated(self):
@@ -1197,7 +1230,9 @@ class TestBuildSkillResultStderr:
             termination=TerminationReason.NATURAL_EXIT,
             pid=1,
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert len(response["stderr"]) < len(long_stderr)
         assert "truncated" in response["stderr"]
 
@@ -1219,7 +1254,9 @@ class TestBuildSkillResultStderr:
             termination=TerminationReason.NATURAL_EXIT,
             pid=1,
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["stderr"] == ""
 
     def test_stale_branch_has_empty_stderr(self):
@@ -1227,7 +1264,9 @@ class TestBuildSkillResultStderr:
         result_obj = SubprocessResult(
             returncode=-1, stdout="", stderr="", termination=TerminationReason.STALE, pid=1
         )
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["stderr"] == ""
 
 
@@ -1431,7 +1470,7 @@ class TestBuildSkillResultWorktreePath:
             pid=1234,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr = _build_skill_result(sub_result, "", "/test", None)
+        sr = _build_skill_result(sub_result, "", "/test", None, backend=ClaudeCodeBackend())
         assert sr.success is False
         assert sr.needs_retry is True
         assert sr.worktree_path == path
@@ -1446,7 +1485,7 @@ class TestBuildSkillResultWorktreePath:
             pid=1234,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr = _build_skill_result(sub_result, "", "/test", None)
+        sr = _build_skill_result(sub_result, "", "/test", None, backend=ClaudeCodeBackend())
         assert sr.success is False
         assert sr.needs_retry is True
         assert sr.worktree_path is None
@@ -1457,7 +1496,7 @@ class TestBuildSkillResultWorktreePath:
             returncode=0,
             stdout=_success_session_json("worktree_path=/path\nbranch_name=impl-fix"),
         )
-        sr = _build_skill_result(sub_result, "", "/test", None)
+        sr = _build_skill_result(sub_result, "", "/test", None, backend=ClaudeCodeBackend())
         assert sr.success is True
         assert sr.worktree_path is None
 
@@ -1504,7 +1543,7 @@ class TestBuildSkillResultWorktreePath:
             pid=1234,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr = _build_skill_result(sub_result, "", "/test", None)
+        sr = _build_skill_result(sub_result, "", "/test", None, backend=ClaudeCodeBackend())
         assert sr.worktree_path == str(second)
 
 
@@ -1544,7 +1583,7 @@ class TestWorktreePathOnContextExhaustion:
             pid=1234,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr = _build_skill_result(sub, "", "/test", None)
+        sr = _build_skill_result(sub, "", "/test", None, backend=ClaudeCodeBackend())
         data = json.loads(sr.to_json())
 
         assert sr.success is False
@@ -1578,6 +1617,7 @@ def test_relative_worktree_path_causes_adjudicated_failure() -> None:
         expected_output_patterns=["worktree_path\\s*=\\s*/.+"],
         cwd="/some/project",
         skill_command="implement-worktree-no-merge",
+        backend=ClaudeCodeBackend(),
     )
     assert skill_result.subtype == "adjudicated_failure"
     assert skill_result.success is False
@@ -1603,7 +1643,7 @@ class TestBuildSkillResultCompleted:
             stdout=stdout,
             termination_reason=TerminationReason.COMPLETED,
         )
-        parsed = json.loads(_build_skill_result(result).to_json())
+        parsed = json.loads(_build_skill_result(result, backend=ClaudeCodeBackend()).to_json())
         assert parsed["success"] is True
 
     def test_build_skill_result_completed_empty_result_is_failure(self):
@@ -1614,7 +1654,7 @@ class TestBuildSkillResultCompleted:
             termination_reason=TerminationReason.COMPLETED,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        parsed = json.loads(_build_skill_result(result).to_json())
+        parsed = json.loads(_build_skill_result(result, backend=ClaudeCodeBackend()).to_json())
         assert parsed["success"] is False
         assert parsed["needs_retry"] is True
 
@@ -1655,7 +1695,9 @@ class TestBuildSkillResultCompleted:
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
         parsed = json.loads(
-            _build_skill_result(result, completion_marker="", skill_command="/test").to_json()
+            _build_skill_result(
+                result, completion_marker="", skill_command="/test", backend=ClaudeCodeBackend()
+            ).to_json()
         )
         assert parsed["success"] is False
         assert parsed["needs_retry"] is True
@@ -1681,7 +1723,11 @@ class TestBuildSkillResultCompleted:
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
         sr = _build_skill_result(
-            result, completion_marker="", skill_command="/test", audit=tool_ctx.audit
+            result,
+            completion_marker="",
+            skill_command="/test",
+            audit=tool_ctx.audit,
+            backend=ClaudeCodeBackend(),
         )
         report = tool_ctx.audit.get_report()
         assert len(report) == 1
@@ -1707,7 +1753,9 @@ class TestBuildSkillResultCompleted:
             termination_reason=TerminationReason.COMPLETED,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr1 = _build_skill_result(result1, completion_marker="", skill_command="/test")
+        sr1 = _build_skill_result(
+            result1, completion_marker="", skill_command="/test", backend=ClaudeCodeBackend()
+        )
         assert sr1.success is False
         assert sr1.subtype != "success", (
             f"subtype must not be 'success' when success=False, got {sr1.subtype!r}"
@@ -1730,7 +1778,12 @@ class TestBuildSkillResultCompleted:
             termination_reason=TerminationReason.NATURAL_EXIT,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        sr2 = _build_skill_result(result2, completion_marker="%%ORDER_UP%%", skill_command="/test")
+        sr2 = _build_skill_result(
+            result2,
+            completion_marker="%%ORDER_UP%%",
+            skill_command="/test",
+            backend=ClaudeCodeBackend(),
+        )
         assert sr2.success is False
         assert sr2.subtype != "success", (
             f"subtype must not be 'success' when success=False, got {sr2.subtype!r}"
@@ -1745,7 +1798,9 @@ class TestBuildSkillResultCompleted:
             termination_reason=TerminationReason.COMPLETED,
             channel_confirmation=ChannelConfirmation.CHANNEL_B,
         )
-        sr = _build_skill_result(result, completion_marker="", skill_command="/test")
+        sr = _build_skill_result(
+            result, completion_marker="", skill_command="/test", backend=ClaudeCodeBackend()
+        )
         assert sr.success is True
         assert sr.subtype == "success"
         assert sr.cli_subtype == "empty_output"
@@ -1795,7 +1850,9 @@ class TestMarkerCrossValidation:
             pid=1,
         )
         response = json.loads(
-            _build_skill_result(result_obj, completion_marker=self.MARKER).to_json()
+            _build_skill_result(
+                result_obj, completion_marker=self.MARKER, backend=ClaudeCodeBackend()
+            ).to_json()
         )
         assert self.MARKER not in response["result"]
         assert "Task completed." in response["result"]
@@ -1952,6 +2009,7 @@ class TestMarkerCrossValidation:
             completion_marker=self.MARKER,
             skill_command="test-skill",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert result.success is True, (
             f"Expected success=True for COMPLETED+CHANNEL_A+rc=-9, got success={result.success}, "
@@ -1983,6 +2041,7 @@ class TestMarkerCrossValidation:
             completion_marker=marker,
             skill_command="audit-impl",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert result.success is True
         assert "Detailed audit report." in result.result
@@ -2011,6 +2070,7 @@ class TestMarkerCrossValidation:
             completion_marker=marker,
             skill_command="",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert result.success is False
 
@@ -2055,7 +2115,9 @@ class TestBuildSkillResultTokenUsage:
         """JSON response includes token_usage when session has usage data."""
         stdout = self._make_ndjson()
         result_obj = _make_result(0, stdout, "")
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert "token_usage" in response
         usage = response["token_usage"]
         assert usage is not None
@@ -2079,7 +2141,9 @@ class TestBuildSkillResultTokenUsage:
             }
         )
         result_obj = _make_result(0, stdout, "")
-        response = json.loads(_build_skill_result(result_obj).to_json())
+        response = json.loads(
+            _build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["token_usage"] is None
 
     def test_stale_result_has_null_token_usage(self):
@@ -2091,18 +2155,22 @@ class TestBuildSkillResultTokenUsage:
             termination=TerminationReason.STALE,
             pid=1,
         )
-        response = json.loads(_build_skill_result(stale_result).to_json())
+        response = json.loads(
+            _build_skill_result(stale_result, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["token_usage"] is None
 
     def test_timeout_result_has_null_token_usage(self):
         """Timeout termination produces null token_usage."""
         timeout_result = _make_timeout_result(stdout="", stderr="")
-        response = json.loads(_build_skill_result(timeout_result).to_json())
+        response = json.loads(
+            _build_skill_result(timeout_result, backend=ClaudeCodeBackend()).to_json()
+        )
         assert response["token_usage"] is None
 
 
 class TestFailureCaptureInBuildSkillResult:
-    """_build_skill_result() must capture failures into tool_ctx.audit."""
+    """_build_skill_result(backend=ClaudeCodeBackend()) must capture failures into tool_ctx.audit."""
 
     def test_captures_non_zero_exit_code(self, tool_ctx):
         result = _make_result(
@@ -2110,12 +2178,16 @@ class TestFailureCaptureInBuildSkillResult:
             stdout=_failed_session_json(),
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        _build_skill_result(result, skill_command="/test:cmd", audit=tool_ctx.audit)
+        _build_skill_result(
+            result, skill_command="/test:cmd", audit=tool_ctx.audit, backend=ClaudeCodeBackend()
+        )
         assert len(tool_ctx.audit.get_report()) == 1
 
     def test_does_not_capture_clean_success(self, tool_ctx):
         result = _make_result(returncode=0, stdout=_success_session_json("done"))
-        _build_skill_result(result, skill_command="/test:cmd", audit=tool_ctx.audit)
+        _build_skill_result(
+            result, skill_command="/test:cmd", audit=tool_ctx.audit, backend=ClaudeCodeBackend()
+        )
         assert tool_ctx.audit.get_report() == []
 
     def test_captured_record_has_correct_skill_command(self, tool_ctx):
@@ -2125,7 +2197,10 @@ class TestFailureCaptureInBuildSkillResult:
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
         _build_skill_result(
-            result, skill_command="/autoskillit:implement-worktree", audit=tool_ctx.audit
+            result,
+            skill_command="/autoskillit:implement-worktree",
+            audit=tool_ctx.audit,
+            backend=ClaudeCodeBackend(),
         )
         assert tool_ctx.audit.get_report()[0].skill_command == "/autoskillit:implement-worktree"
 
@@ -2137,20 +2212,26 @@ class TestFailureCaptureInBuildSkillResult:
             stdout=_failed_session_json(),
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        _build_skill_result(result, skill_command="/test", audit=tool_ctx.audit)
+        _build_skill_result(
+            result, skill_command="/test", audit=tool_ctx.audit, backend=ClaudeCodeBackend()
+        )
         record = tool_ctx.audit.get_report()[0]
         assert datetime.fromisoformat(record.timestamp)  # valid ISO 8601 format
 
     def test_stale_termination_is_captured(self, tool_ctx):
         result = _make_result(returncode=0, termination_reason=TerminationReason.STALE)
-        _build_skill_result(result, skill_command="/test", audit=tool_ctx.audit)
+        _build_skill_result(
+            result, skill_command="/test", audit=tool_ctx.audit, backend=ClaudeCodeBackend()
+        )
         report = tool_ctx.audit.get_report()
         assert len(report) == 1
         assert report[0].subtype == "stale"
 
     def test_needs_retry_is_captured(self, tool_ctx):
         result = _make_result(returncode=1, stdout=_context_exhausted_session_json())
-        _build_skill_result(result, skill_command="/test", audit=tool_ctx.audit)
+        _build_skill_result(
+            result, skill_command="/test", audit=tool_ctx.audit, backend=ClaudeCodeBackend()
+        )
         report = tool_ctx.audit.get_report()
         assert len(report) == 1
         assert report[0].needs_retry is True
@@ -2163,7 +2244,9 @@ class TestFailureCaptureInBuildSkillResult:
             stdout=_failed_session_json(),
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        _build_skill_result(result, skill_command="/test", audit=tool_ctx.audit)
+        _build_skill_result(
+            result, skill_command="/test", audit=tool_ctx.audit, backend=ClaudeCodeBackend()
+        )
         assert len(tool_ctx.audit.get_report()[0].stderr) <= 500
 
 
@@ -2191,14 +2274,14 @@ class TestStalePathStdoutCheck:
             }
         )
         result_obj = self._make_stale_result(stdout=valid_completed_jsonl)
-        parsed = json.loads(_build_skill_result(result_obj).to_json())
+        parsed = json.loads(_build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json())
         assert parsed["success"] is True
         assert parsed["subtype"] == "recovered_from_stale"
 
     def test_stale_with_empty_stdout_returns_failure(self):
         """Stale session with no stdout — original failure response preserved."""
         result_obj = self._make_stale_result(stdout="")
-        parsed = json.loads(_build_skill_result(result_obj).to_json())
+        parsed = json.loads(_build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json())
         assert parsed["success"] is False
         assert parsed["subtype"] == "stale"
 
@@ -2214,7 +2297,7 @@ class TestStalePathStdoutCheck:
             }
         )
         result_obj = self._make_stale_result(stdout=error_jsonl)
-        parsed = json.loads(_build_skill_result(result_obj).to_json())
+        parsed = json.loads(_build_skill_result(result_obj, backend=ClaudeCodeBackend()).to_json())
         assert parsed["success"] is False
         assert parsed["subtype"] == "stale"
 
@@ -2243,6 +2326,7 @@ class TestBuildSkillResultDataConfirmedPropagation:
             completion_marker="%%ORDER_UP%%",
             skill_command="cmd",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is True
         assert skill_result.subtype == "recovered_from_stale"
@@ -2259,6 +2343,7 @@ class TestBuildSkillResultDataConfirmedPropagation:
             completion_marker="%%ORDER_UP%%",
             skill_command="cmd",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is False
         assert skill_result.subtype == "stale"
@@ -2277,6 +2362,7 @@ class TestBuildSkillResultDataConfirmedPropagation:
             completion_marker="%%ORDER_UP%%",
             skill_command="cmd",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is True  # FAILS before fix: False
         assert skill_result.needs_retry is False  # FAILS before fix: True
@@ -2295,6 +2381,7 @@ class TestBuildSkillResultDataConfirmedPropagation:
             completion_marker="%%ORDER_UP%%",
             skill_command="cmd",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is False
         assert skill_result.needs_retry is True
@@ -2506,6 +2593,7 @@ class TestRetryBudgetEnforcement:
             skill_command="/autoskillit:open-pr",
             audit=audit,  # type: ignore[arg-type]
             max_consecutive_retries=3,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.STALE
@@ -2519,6 +2607,7 @@ class TestRetryBudgetEnforcement:
             skill_command="/autoskillit:open-pr",
             audit=audit,  # type: ignore[arg-type]
             max_consecutive_retries=3,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.needs_retry is False
         assert sr.retry_reason == RetryReason.BUDGET_EXHAUSTED
@@ -2531,6 +2620,7 @@ class TestRetryBudgetEnforcement:
             skill_command="/autoskillit:open-pr",
             audit=None,
             max_consecutive_retries=3,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.STALE
@@ -2544,6 +2634,7 @@ class TestRetryBudgetEnforcement:
             skill_command="/autoskillit:open-pr",
             audit=audit,  # type: ignore[arg-type]
             max_consecutive_retries=3,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.STALE
@@ -2561,6 +2652,7 @@ class TestRetryBudgetEnforcement:
             skill_command="/autoskillit:open-pr",
             audit=audit,  # type: ignore[arg-type]
             max_consecutive_retries=3,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.needs_retry is False
         assert sr.retry_reason == RetryReason.BUDGET_EXHAUSTED

--- a/tests/execution/test_headless_debug_logging.py
+++ b/tests/execution/test_headless_debug_logging.py
@@ -8,6 +8,7 @@ import pytest
 import structlog.testing
 
 from autoskillit.core.types import SubprocessResult, TerminationReason
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -33,7 +34,7 @@ class TestBuildSkillResultLogging:
             }
         )
         with structlog.testing.capture_logs() as logs:
-            _build_skill_result(_sr(stdout=payload))
+            _build_skill_result(_sr(stdout=payload), backend=ClaudeCodeBackend())
         entry_logs = [r for r in logs if r.get("event") == "build_skill_result_entry"]
         assert entry_logs, (
             f"Expected build_skill_result_entry, got: {[r.get('event') for r in logs]}"
@@ -54,7 +55,7 @@ class TestBuildSkillResultLogging:
             }
         )
         with structlog.testing.capture_logs() as logs:
-            _build_skill_result(_sr(stdout=payload))
+            _build_skill_result(_sr(stdout=payload), backend=ClaudeCodeBackend())
         exit_logs = [r for r in logs if r.get("event") == "build_skill_result_exit"]
         assert exit_logs, (
             f"Expected build_skill_result_exit, got: {[r.get('event') for r in logs]}"
@@ -66,7 +67,9 @@ class TestBuildSkillResultLogging:
         from autoskillit.execution.headless import _build_skill_result
 
         with structlog.testing.capture_logs() as logs:
-            _build_skill_result(_sr(stdout="", termination=TerminationReason.STALE))
+            _build_skill_result(
+                _sr(stdout="", termination=TerminationReason.STALE), backend=ClaudeCodeBackend()
+            )
         entry_logs = [r for r in logs if r.get("event") == "build_skill_result_entry"]
         assert entry_logs
         assert entry_logs[0]["branch"] == "stale"
@@ -76,7 +79,8 @@ class TestBuildSkillResultLogging:
 
         with structlog.testing.capture_logs() as logs:
             _build_skill_result(
-                _sr(stdout="", returncode=-1, termination=TerminationReason.TIMED_OUT)
+                _sr(stdout="", returncode=-1, termination=TerminationReason.TIMED_OUT),
+                backend=ClaudeCodeBackend(),
             )
         entry_logs = [r for r in logs if r.get("event") == "build_skill_result_entry"]
         assert entry_logs

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -915,6 +915,7 @@ def make_build_skill_result_kwargs():
             "expected_output_patterns": expected_output_patterns or [],
             "skill_command": skill_command,
             "audit": audit,
+            "backend": ClaudeCodeBackend(),
         }
 
     return _factory

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -11,7 +11,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
-from autoskillit.execution.backends.claude import ClaudeResultParser
+from autoskillit.execution.backends.claude import ClaudeCodeBackend, ClaudeResultParser
 from autoskillit.execution.headless import (
     _build_skill_result,
     _extract_missing_token_hints,
@@ -65,6 +65,7 @@ class TestBuildSkillResultChannelAPatternRecovery:
             sub_result,
             completion_marker="%%ORDER_UP%%",
             expected_output_patterns=["verdict\\s*=\\s*(GO|NO GO)"],
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "CHANNEL_A should recover patterns from assistant_messages, same as CHANNEL_B."
@@ -105,6 +106,7 @@ class TestBuildSkillResultChannelAPatternRecovery:
             sub_result,
             completion_marker="%%ORDER_UP%%",
             expected_output_patterns=["verdict\\s*=\\s*(GO|NO GO)"],
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False
         assert sr.needs_retry is False
@@ -132,6 +134,7 @@ class TestBuildSkillResultChannelAPatternRecovery:
             sub_result,
             completion_marker="%%ORDER_UP%%",
             expected_output_patterns=["plan_path\\s*=\\s*/.+"],
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
         assert sr.subtype != "adjudicated_failure"
@@ -175,6 +178,7 @@ class TestBuildSkillResultChannelAPatternRecovery:
             sub_result,
             completion_marker="%%ORDER_UP%%",
             expected_output_patterns=["plan_path\\s*=\\s*/.+"],
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
         assert sr.subtype != "adjudicated_failure"
@@ -229,7 +233,9 @@ class TestBuildSkillResultDirMissingRecovery:
             channel_confirmation=ChannelConfirmation.DIR_MISSING,
         )
         with structlog.testing.capture_logs() as logs:
-            skill = _build_skill_result(sub_result, completion_marker=marker)
+            skill = _build_skill_result(
+                sub_result, completion_marker=marker, backend=ClaudeCodeBackend()
+            )
         # Recovery should succeed — marker found as standalone line in assistant_messages
         assert skill.success is True
         # Verify the recovery code path was taken, not just the outcome
@@ -245,7 +251,7 @@ class TestBuildSkillResultDirMissingRecovery:
             pid=12345,
             channel_confirmation=ChannelConfirmation.DIR_MISSING,
         )
-        skill = _build_skill_result(sub_result)
+        skill = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert skill.success is False
 
 
@@ -276,7 +282,7 @@ class TestTimedOutAlwaysProducesTimeoutSubtype:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.subtype == "timeout", (
             f"UNPARSEABLE leak: TIMED_OUT session produced subtype={sr.subtype!r}, "
             f"expected 'timeout'. parse_session_result returned CliSubtype.UNPARSEABLE "
@@ -310,7 +316,7 @@ class TestTimedOutAlwaysProducesTimeoutSubtype:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.subtype == "timeout"
         assert sr.cli_subtype == CliSubtype.TIMEOUT
         assert sr.success is False
@@ -335,7 +341,7 @@ class TestTimedOutAlwaysProducesTimeoutSubtype:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.subtype == "timeout"
         assert sr.cli_subtype == CliSubtype.TIMEOUT
         assert sr.success is False
@@ -360,7 +366,7 @@ class TestTimedOutAlwaysProducesTimeoutSubtype:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.subtype == "timeout"
         assert sr.cli_subtype == CliSubtype.TIMEOUT
         assert sr.success is False
@@ -385,7 +391,7 @@ class TestTimedOutAlwaysProducesTimeoutSubtype:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.subtype == "timeout"
         assert sr.cli_subtype == CliSubtype.TIMEOUT
         assert sr.success is False
@@ -410,7 +416,7 @@ class TestTimedOutAlwaysProducesTimeoutSubtype:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.subtype == "timeout"
         assert sr.cli_subtype == CliSubtype.TIMEOUT
         assert sr.success is False
@@ -435,7 +441,7 @@ class TestTimedOutAlwaysProducesTimeoutSubtype:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.subtype == "timeout"
         assert sr.cli_subtype == CliSubtype.TIMEOUT
         assert sr.success is False
@@ -464,7 +470,7 @@ class TestTimedOutSessionPreservesState:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.evidence.write_call_count == 2
         assert sr.success is False
         assert sr.needs_retry is False
@@ -482,7 +488,7 @@ class TestTimedOutSessionPreservesState:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.success is False
         assert sr.evidence.write_call_count == 0
         assert sr.subtype == "timeout"
@@ -513,7 +519,7 @@ class TestTimedOutSessionPreservesState:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.cli_subtype == CliSubtype.TIMEOUT
         assert sr.subtype == "timeout"
         assert sr.evidence.write_call_count == 1
@@ -1006,7 +1012,7 @@ class TestBuildSkillResultSessionIdFromSubprocess:
             pid=1,
             session_id="real-uuid-from-channel-b",
         )
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.session_id == "real-uuid-from-channel-b"
 
     def test_timeout_empty_stdout_session_id_from_subprocess_result(self) -> None:
@@ -1019,7 +1025,7 @@ class TestBuildSkillResultSessionIdFromSubprocess:
             pid=1,
             session_id="real-uuid-from-channel-b",
         )
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.session_id == "real-uuid-from-channel-b"
 
     def test_channel_a_session_id_takes_precedence(self) -> None:
@@ -1041,7 +1047,7 @@ class TestBuildSkillResultSessionIdFromSubprocess:
             pid=1,
             session_id="ch-b-uuid",
         )
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.session_id == "stdout-uuid"
 
     def test_context_exhaustion_session_id_from_subprocess_result(self) -> None:
@@ -1060,7 +1066,7 @@ class TestBuildSkillResultSessionIdFromSubprocess:
             pid=1,
             session_id="ch-b-uuid-5678",
         )
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.session_id == "ch-b-uuid-5678"
 
 
@@ -1647,7 +1653,7 @@ def test_build_skill_result_surfaces_last_stop_reason():
         ]
     )
     result = _make_result(returncode=0, stdout=ndjson)
-    sr = _build_skill_result(result)
+    sr = _build_skill_result(result, backend=ClaudeCodeBackend())
     assert sr.last_stop_reason == "end_turn"
 
 
@@ -1944,8 +1950,7 @@ class TestEarlyStopDetection:
             pid=12345,
         )
         sr = _build_skill_result(
-            sub_result,
-            completion_marker="%%ORDER_UP::abc%%",
+            sub_result, completion_marker="%%ORDER_UP::abc%%", backend=ClaudeCodeBackend()
         )
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.EARLY_STOP
@@ -1971,7 +1976,7 @@ class TestTerminationSubtypeConsistencyInvariant:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.subtype == "timeout"
 
     def test_timed_out_with_parsed_unparseable_is_promoted(self):
@@ -1986,7 +1991,7 @@ class TestTerminationSubtypeConsistencyInvariant:
             termination=TerminationReason.TIMED_OUT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         # The invariant guard is inside _build_skill_result; if subtype != 'timeout',
         # it would raise RuntimeError. So a successful return means it passed.
         assert sr.subtype == "timeout"
@@ -2016,7 +2021,7 @@ class TestTerminationSubtypeConsistencyInvariant:
             termination=TerminationReason.NATURAL_EXIT,  # Not TIMED_OUT → no guard
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         # NATURAL_EXIT with UNPARSEABLE → normalize_subtype returns "unparseable"
         # The guard does not apply (only TIMED_OUT is guarded), so no RuntimeError
         assert sr.subtype == "unparseable"
@@ -2036,7 +2041,7 @@ class TestTerminationSubtypeConsistencyInvariant:
             termination=TerminationReason.IDLE_STALL,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         # IDLE_STALL early-returns with hardcoded subtype='idle_stall'
         # No invariant guard applies to this path
         assert sr.subtype == "idle_stall"
@@ -2075,7 +2080,7 @@ class TestWorktreePathPropagationWithEmptyMessages:
             termination=TerminationReason.NATURAL_EXIT,
             pid=12345,
         )
-        sr = _build_skill_result(sub_result)
+        sr = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
         assert sr.worktree_path is None
 
     def test_extract_worktree_path_extracts_nonexistent_path(self):

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core.types import RetryReason, SkillResult
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from tests.execution.conftest import _mock_backend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -335,9 +336,9 @@ def test_build_skill_result_stamps_provider_used_on_result() -> None:
     from tests.execution.conftest import _sr
 
     sub_result = _sr(stdout="result: done\n", returncode=0)
-    sr = _build_skill_result(sub_result, provider_used="vertex")
+    sr = _build_skill_result(sub_result, provider_used="vertex", backend=ClaudeCodeBackend())
     assert sr.provider.provider_used == "vertex"
-    sr_default = _build_skill_result(sub_result)
+    sr_default = _build_skill_result(sub_result, backend=ClaudeCodeBackend())
     assert sr_default.provider.provider_used == ""
 
 
@@ -354,6 +355,7 @@ def test_build_skill_result_provider_used_survives_budget_guard() -> None:
         audit=audit,
         max_consecutive_retries=3,
         provider_used="bedrock",
+        backend=ClaudeCodeBackend(),
     )
     assert sr.provider.provider_used == "bedrock"
 

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -214,36 +214,40 @@ class TestIdleStallLifespanStarted:
     def test_idle_stall_failure_preserves_lifespan_started_true(self):
         stdout = _tool_use_ndjson("Write", file_path="/worktree/src/foo.py")
         result = _idle_stall_result(stdout)
-        skill_result = _build_skill_result(result)
+        skill_result = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert skill_result.lifespan_started is True
 
     def test_idle_stall_failure_preserves_lifespan_started_false(self):
         result = _idle_stall_result("")
-        skill_result = _build_skill_result(result)
+        skill_result = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert skill_result.lifespan_started is False
 
 
 class TestKillReasonPropagation:
     def test_stale_failure_propagates_infra_kill(self):
         result = _stale_result(kill_reason=KillReason.INFRA_KILL)
-        skill_result = _build_skill_result(result)
+        skill_result = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert skill_result.kill_reason == KillReason.INFRA_KILL
 
     def test_idle_stall_failure_propagates_infra_kill(self):
         result = _idle_stall_result_with_kill(kill_reason=KillReason.INFRA_KILL)
-        skill_result = _build_skill_result(result)
+        skill_result = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert skill_result.kill_reason == KillReason.INFRA_KILL
 
     def test_recovered_stale_propagates_infra_kill(self):
         stdout = _success_result_json()
         result = _stale_result(kill_reason=KillReason.INFRA_KILL, stdout=stdout)
-        skill_result = _build_skill_result(result, completion_marker="done")
+        skill_result = _build_skill_result(
+            result, completion_marker="done", backend=ClaudeCodeBackend()
+        )
         assert skill_result.kill_reason == KillReason.INFRA_KILL
 
     def test_recovered_idle_stall_propagates_infra_kill(self):
         stdout = _success_result_json()
         result = _idle_stall_result_with_kill(kill_reason=KillReason.INFRA_KILL, stdout=stdout)
-        skill_result = _build_skill_result(result, completion_marker="done")
+        skill_result = _build_skill_result(
+            result, completion_marker="done", backend=ClaudeCodeBackend()
+        )
         assert skill_result.kill_reason == KillReason.INFRA_KILL
 
     def test_path_contamination_propagates_kill_reason(self):
@@ -266,7 +270,7 @@ class TestKillReasonPropagation:
             session_id="sess-contam",
             channel_b_session_id="",
         )
-        skill_result = _build_skill_result(result, cwd="/wrong/path")
+        skill_result = _build_skill_result(result, cwd="/wrong/path", backend=ClaudeCodeBackend())
         assert skill_result.kill_reason == KillReason.INFRA_KILL
 
 
@@ -281,7 +285,7 @@ class TestStaleTokenUsagePropagation:
             "cache_read_tokens": 75,
         }
         result = _stale_result_with_token_usage(usage, kill_reason=KillReason.INFRA_KILL)
-        skill_result = _build_skill_result(result)
+        skill_result = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert skill_result.token_usage is not None
         tu = skill_result.token_usage
         assert tu["input_tokens"] == 100
@@ -706,7 +710,7 @@ class TestStaleRecoveryWriteEvidence:
             + _success_result_json("done")
         )
         result = _stale_result(kill_reason=KillReason.NATURAL_EXIT, stdout=stdout)
-        sr = _build_skill_result(result, completion_marker="done")
+        sr = _build_skill_result(result, completion_marker="done", backend=ClaudeCodeBackend())
         assert sr.evidence.write_call_count > 0, (
             "STALE recovery must propagate write evidence from parsed stdout"
         )
@@ -714,7 +718,7 @@ class TestStaleRecoveryWriteEvidence:
     def test_stale_failure_carries_write_evidence(self):
         stdout = _tool_use_ndjson("Edit", file_path="/a/b.py", old_string="a", new_string="b")
         result = _stale_result(kill_reason=KillReason.NATURAL_EXIT, stdout=stdout)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.evidence.write_call_count > 0, (
             "STALE failure must propagate write evidence from parsed stdout"
         )
@@ -728,7 +732,7 @@ class TestIdleStallRecoveryWriteEvidence:
             + _success_result_json("done")
         )
         result = _idle_stall_result_with_kill(kill_reason=KillReason.NATURAL_EXIT, stdout=stdout)
-        sr = _build_skill_result(result, completion_marker="done")
+        sr = _build_skill_result(result, completion_marker="done", backend=ClaudeCodeBackend())
         assert sr.evidence.write_call_count > 0, (
             "IDLE_STALL recovery must propagate write evidence from parsed stdout"
         )
@@ -736,7 +740,7 @@ class TestIdleStallRecoveryWriteEvidence:
     def test_idle_stall_failure_carries_write_evidence(self):
         stdout = _tool_use_ndjson("Edit", file_path="/a/b.py", old_string="a", new_string="b")
         result = _idle_stall_result_with_kill(kill_reason=KillReason.NATURAL_EXIT, stdout=stdout)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.evidence.write_call_count > 0, (
             "IDLE_STALL failure must propagate write evidence from parsed stdout"
         )
@@ -761,7 +765,7 @@ class TestWriteEvidenceCrossCheck:
 
         cap = structlog.testing.CapturingLogger()
         with unittest.mock.patch.object(_headless_result, "logger", cap):
-            _build_skill_result(result)
+            _build_skill_result(result, backend=ClaudeCodeBackend())
 
         assert any(
             call.method_name == "warning"
@@ -778,7 +782,7 @@ class TestWriteEvidenceCrossCheck:
             "",
             TerminationReason.NATURAL_EXIT,
         )
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.subtype != "zero_writes"
         assert sr.evidence.write_call_count >= 1
 
@@ -793,6 +797,7 @@ class TestWriteEvidenceCrossCheck:
         sr = _build_skill_result(
             result,
             write_behavior=WriteBehaviorSpec(mode="always"),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
 
@@ -813,7 +818,7 @@ class TestWriteEvidenceCrossCheck:
             "",
             TerminationReason.NATURAL_EXIT,
         )
-        sr = _build_skill_result(result, completion_marker="DONE")
+        sr = _build_skill_result(result, completion_marker="DONE", backend=ClaudeCodeBackend())
         assert sr.retry_reason != RetryReason.EARLY_STOP
         assert sr.retry_reason == RetryReason.RESUME
 
@@ -829,7 +834,7 @@ class TestWriteEvidenceCrossCheck:
             }
         )
         result = _stale_result(stdout=result_line)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "api_error"
 
     def test_idle_stall_session_api_error_status_classified(self) -> None:
@@ -844,7 +849,7 @@ class TestWriteEvidenceCrossCheck:
             }
         )
         result = _idle_stall_result(result_line)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "api_error"
 
 
@@ -908,7 +913,9 @@ class TestCodexPipelineTurnFailed:
         )
 
     def _build(self) -> SkillResult:
-        return _build_skill_result(self._result, supports_claude_format_stdout=False)
+        return _build_skill_result(
+            self._result, supports_claude_format_stdout=False, backend=CodexBackend()
+        )
 
     def test_failure_success_is_false(self):
         sr = self._build()
@@ -961,6 +968,7 @@ class TestCodexPipelineTerminationBranches:
             result,
             completion_marker="%%ORDER_UP%%",
             supports_claude_format_stdout=False,
+            backend=CodexBackend(),
         )
         assert sr.success is True
 
@@ -971,7 +979,9 @@ class TestCodexPipelineTerminationBranches:
             termination=TerminationReason.STALE,
             kill_reason=KillReason.INFRA_KILL,
         )
-        sr = _build_skill_result(result, supports_claude_format_stdout=False)
+        sr = _build_skill_result(
+            result, supports_claude_format_stdout=False, backend=CodexBackend()
+        )
         assert sr.success is False
 
     def test_stale_codex_error_fixture_fails(self):
@@ -981,7 +991,9 @@ class TestCodexPipelineTerminationBranches:
             termination=TerminationReason.STALE,
             kill_reason=KillReason.INFRA_KILL,
         )
-        sr = _build_skill_result(result, supports_claude_format_stdout=False)
+        sr = _build_skill_result(
+            result, supports_claude_format_stdout=False, backend=CodexBackend()
+        )
         assert sr.success is False
 
     def test_idle_stall_codex_happy_path_with_backend_succeeds(self):
@@ -995,6 +1007,7 @@ class TestCodexPipelineTerminationBranches:
             result,
             completion_marker="%%ORDER_UP%%",
             supports_claude_format_stdout=False,
+            backend=CodexBackend(),
         )
         assert sr.success is True
 
@@ -1005,7 +1018,9 @@ class TestCodexPipelineTerminationBranches:
             termination=TerminationReason.IDLE_STALL,
             kill_reason=KillReason.INFRA_KILL,
         )
-        sr = _build_skill_result(result, supports_claude_format_stdout=False)
+        sr = _build_skill_result(
+            result, supports_claude_format_stdout=False, backend=CodexBackend()
+        )
         assert sr.success is False
 
     def test_idle_stall_codex_error_fixture_fails(self):
@@ -1015,7 +1030,9 @@ class TestCodexPipelineTerminationBranches:
             termination=TerminationReason.IDLE_STALL,
             kill_reason=KillReason.INFRA_KILL,
         )
-        sr = _build_skill_result(result, supports_claude_format_stdout=False)
+        sr = _build_skill_result(
+            result, supports_claude_format_stdout=False, backend=CodexBackend()
+        )
         assert sr.success is False
 
 
@@ -1048,7 +1065,7 @@ class TestStaleApiRetryExhaustion:
             ]
         )
         result = _sr(0, ndjson, "", TerminationReason.STALE)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.success is False
         assert sr.infra.exit_category == "api_error"
         assert sr.api_retry.exhausted is True
@@ -1066,7 +1083,7 @@ class TestStaleApiRetryExhaustion:
             }
         )
         result = _sr(0, ndjson, "", TerminationReason.STALE)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.success is False
         assert sr.infra.exit_category == ""
         assert sr.api_retry.count == 0
@@ -1097,7 +1114,7 @@ class TestStaleApiRetryExhaustion:
             ]
         )
         result = _sr(0, ndjson, "", TerminationReason.STALE)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.success is True
         assert sr.subtype == "recovered_from_stale"
         assert sr.infra.exit_category == ""
@@ -1129,7 +1146,7 @@ class TestStaleApiRetryExhaustion:
             ]
         )
         result = _sr(0, ndjson, "", TerminationReason.IDLE_STALL)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.success is False
         assert sr.infra.exit_category == "api_error"
         assert sr.api_retry.exhausted is True
@@ -1164,7 +1181,7 @@ class TestNormalApiRetry:
             ]
         )
         result = _sr(0, ndjson, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.success is True
         assert sr.api_retry.count == 1
         assert sr.api_retry.exhausted is False

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -20,7 +20,7 @@ from autoskillit.core.types import (
     TerminationReason,
     WriteBehaviorSpec,
 )
-from autoskillit.execution.backends.claude import ClaudeResultParser
+from autoskillit.execution.backends.claude import ClaudeCodeBackend, ClaudeResultParser
 from autoskillit.execution.backends.codex import CodexBackend
 from autoskillit.execution.headless import (
     _build_skill_result,
@@ -161,7 +161,7 @@ def _make_codex_parse_stdout() -> object:
     unconditionally routes through CodexResultParser.
     """
 
-    def _patched(stdout: str, backend: object = None) -> ClaudeSessionResult:  # noqa: ARG001
+    def _patched(stdout: str, backend: object) -> ClaudeSessionResult:  # noqa: ARG001
         agent_result = CodexBackend().result_parser().parse_stdout(stdout)
         session = _adapt_codex_result(agent_result)
         for line in stdout.strip().splitlines():
@@ -291,8 +291,8 @@ class TestStaleTokenUsagePropagation:
 
 
 class TestBackendDelegatedWriteToolNames:
-    def test_backend_none_uses_fallback_write_edit(self):
-        """backend=None falls back to frozenset({'Write', 'Edit'})."""
+    def test_claude_backend_uses_write_edit_tool_names(self):
+        """ClaudeCodeBackend uses frozenset({'Write', 'Edit'})."""
         stdout = (
             _make_tool_use_line("Write", {"file_path": "/a/b.py", "content": "x"})
             + "\n"
@@ -303,7 +303,7 @@ class TestBackendDelegatedWriteToolNames:
             + _success_session_json("Done")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, backend=None)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.evidence.write_call_count == 2
 
     def test_backend_provides_custom_tool_names(self):
@@ -323,7 +323,7 @@ class TestBackendDelegatedWriteToolNames:
         sr = _build_skill_result(result, backend=mock_backend)
         assert sr.evidence.write_call_count == 1
 
-    def test_backend_none_default_preserves_behavior(self):
+    def test_default_backend_behavior_preserved(self):
         """backend=None with no Write/Edit tools yields write_call_count=0."""
         stdout = (
             _make_tool_use_line("Read", {"file_path": "/a/b.py"})
@@ -331,7 +331,7 @@ class TestBackendDelegatedWriteToolNames:
             + _success_session_json("Done")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, backend=None)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.evidence.write_call_count == 0
 
     def test_codex_backend_produces_zero_write_count(self):
@@ -375,7 +375,7 @@ class TestBackendDelegatedWriteToolNames:
         captured: dict = {}
         original_parse = _headless_result._parse_stdout
 
-        def spy(stdout, backend=None):
+        def spy(stdout, backend):
             captured["backend"] = backend
             return original_parse(stdout, backend=backend)
 
@@ -397,7 +397,7 @@ class TestBackendDelegatedWriteToolNames:
         captured: dict = {}
         original_parse = _headless_result._parse_stdout
 
-        def spy(stdout, backend=None):
+        def spy(stdout, backend):
             captured["backend"] = backend
             return original_parse(stdout, backend=backend)
 
@@ -419,7 +419,7 @@ class TestBackendDelegatedWriteToolNames:
         captured: dict = {}
         original_parse = _headless_result._parse_stdout
 
-        def spy(stdout, backend=None):
+        def spy(stdout, backend):
             captured["backend"] = backend
             return original_parse(stdout, backend=backend)
 
@@ -441,7 +441,7 @@ class TestBackendDelegatedWriteToolNames:
         captured: dict = {}
         original_parse = _headless_result._parse_stdout
 
-        def spy(stdout, backend=None):
+        def spy(stdout, backend):
             captured["backend"] = backend
             return original_parse(stdout, backend=backend)
 
@@ -605,12 +605,12 @@ class TestComputeWriteEvidenceCodex:
 
 
 class TestParseStdout:
-    def test_backend_none_calls_parse_session_result(self):
-        """_parse_stdout with backend=None returns the same result as parse_session_result."""
+    def test_claude_backend_calls_parse_session_result(self):
+        """_parse_stdout with ClaudeCodeBackend returns the same result as parse_session_result."""
         from autoskillit.execution.session import parse_session_result
 
         stdout = _success_session_json("test result")
-        result = _parse_stdout(stdout)
+        result = _parse_stdout(stdout, backend=ClaudeCodeBackend())
         expected = parse_session_result(stdout)
         assert result.result == expected.result
         assert result.session_id == expected.session_id
@@ -620,7 +620,7 @@ class TestParseStdout:
         """_parse_stdout with no backend arg returns a ClaudeSessionResult."""
 
         stdout = _success_session_json("test result")
-        result = _parse_stdout(stdout)
+        result = _parse_stdout(stdout, ClaudeCodeBackend())
         assert isinstance(result, ClaudeSessionResult)
         assert result.result == "test result"
 
@@ -641,7 +641,7 @@ class TestParseStdout:
         mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
         stdout = _success_session_json("test result")
         with_backend = _parse_stdout(stdout, backend=mock_backend)
-        without_backend = _parse_stdout(stdout)
+        without_backend = _parse_stdout(stdout, ClaudeCodeBackend())
         assert with_backend.result == without_backend.result
         assert with_backend.session_id == without_backend.session_id
         assert with_backend.session_complete == without_backend.session_complete
@@ -680,17 +680,6 @@ class TestParseStdout:
         mock_backend.result_parser.return_value.parse_stdout.assert_called_once_with(stdout)
         assert isinstance(result, ClaudeSessionResult)
         assert result.result == "adapter output"
-
-    def test_parse_stdout_backend_none_unchanged(self):
-        """_parse_stdout with backend=None matches parse_session_result (regression guard)."""
-        from autoskillit.execution.session import parse_session_result
-
-        stdout = _success_session_json("test result")
-        result = _parse_stdout(stdout, backend=None)
-        expected = parse_session_result(stdout)
-        assert result.result == expected.result
-        assert result.session_id == expected.session_id
-        assert result.session_complete == expected.session_complete
 
     def test_parse_stdout_codex_backend_dispatches_through_adapter(self, monkeypatch):
         """CodexBackend dispatches through _adapt_agent_result (non-Claude path)."""
@@ -1183,11 +1172,6 @@ class TestNormalApiRetry:
 
 
 class TestExtractFileChanges:
-    def test_extract_file_changes_returns_empty_for_no_backend(self) -> None:
-        from autoskillit.execution.headless._headless_result import _extract_file_changes
-
-        assert _extract_file_changes("", None) == []
-
     def test_extract_file_changes_returns_empty_for_claude_backend(self) -> None:
         from autoskillit.execution.backends.claude import ClaudeCodeBackend
         from autoskillit.execution.headless._headless_result import _extract_file_changes
@@ -1227,7 +1211,9 @@ class TestComputeWriteEvidenceWithFileChanges:
             session_id="s1",
             tool_uses=[],
         )
-        evidence = _compute_write_evidence(session, False, False, file_changes=["a.py", "b.py"])
+        evidence = _compute_write_evidence(
+            session, False, False, backend=ClaudeCodeBackend(), file_changes=["a.py", "b.py"]
+        )
         assert evidence.file_changes_count == 2
         assert evidence.has_evidence is True
 
@@ -1240,6 +1226,8 @@ class TestComputeWriteEvidenceWithFileChanges:
             session_id="s1",
             tool_uses=[{"name": "Write", "id": "t1"}],
         )
-        evidence = _compute_write_evidence(session, False, False, file_changes=["a.py"])
+        evidence = _compute_write_evidence(
+            session, False, False, backend=ClaudeCodeBackend(), file_changes=["a.py"]
+        )
         assert evidence.file_changes_count == 0
         assert evidence.write_call_count == 1

--- a/tests/execution/test_headless_result_write_reconciliation.py
+++ b/tests/execution/test_headless_result_write_reconciliation.py
@@ -14,6 +14,7 @@ import pytest
 from autoskillit.core.types import (
     RetryReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.headless import _build_skill_result
 from autoskillit.pipeline.audit import DefaultAuditLog, FailureRecord
 from tests.execution.conftest import EMPTY_OUTPUT_RESULT_LINE, WRITE_TOOL_LINE, _sr
@@ -34,7 +35,7 @@ _SUCCESS_EMPTY_RESULT_LINE = json.dumps(
 class TestEmptyOutputWriteReconciliation:
     def test_empty_output_with_write_tool_use_becomes_completed_no_flush(self) -> None:
         stdout = "\n".join([WRITE_TOOL_LINE, EMPTY_OUTPUT_RESULT_LINE])
-        sr = _build_skill_result(_sr(stdout=stdout))
+        sr = _build_skill_result(_sr(stdout=stdout), backend=ClaudeCodeBackend())
 
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.COMPLETED_NO_FLUSH
@@ -44,7 +45,9 @@ class TestEmptyOutputWriteReconciliation:
     def test_empty_output_with_fs_writes_only_becomes_completed_no_flush(self) -> None:
         """fs_writes_detected alone (no tool_uses) triggers reclassification."""
         stdout = EMPTY_OUTPUT_RESULT_LINE
-        sr = _build_skill_result(_sr(stdout=stdout), fs_writes_detected=True)
+        sr = _build_skill_result(
+            _sr(stdout=stdout), backend=ClaudeCodeBackend(), fs_writes_detected=True
+        )
 
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.COMPLETED_NO_FLUSH
@@ -53,7 +56,7 @@ class TestEmptyOutputWriteReconciliation:
     def test_success_empty_result_with_write_evidence_becomes_completed_no_flush(self) -> None:
         """success subtype with empty result + write evidence → COMPLETED_NO_FLUSH."""
         stdout = "\n".join([WRITE_TOOL_LINE, _SUCCESS_EMPTY_RESULT_LINE])
-        sr = _build_skill_result(_sr(stdout=stdout))
+        sr = _build_skill_result(_sr(stdout=stdout), backend=ClaudeCodeBackend())
 
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.COMPLETED_NO_FLUSH
@@ -62,7 +65,9 @@ class TestEmptyOutputWriteReconciliation:
     def test_empty_output_without_write_evidence_stays_empty_output(self) -> None:
         """EMPTY_OUTPUT with no writes preserves original reason — correct behavior unchanged."""
         stdout = EMPTY_OUTPUT_RESULT_LINE
-        sr = _build_skill_result(_sr(stdout=stdout), fs_writes_detected=False)
+        sr = _build_skill_result(
+            _sr(stdout=stdout), backend=ClaudeCodeBackend(), fs_writes_detected=False
+        )
 
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.EMPTY_OUTPUT
@@ -87,6 +92,7 @@ class TestEmptyOutputWriteReconciliation:
 
         sr = _build_skill_result(
             _sr(stdout=stdout),
+            backend=ClaudeCodeBackend(),
             skill_command=skill_command,
             audit=audit,
         )

--- a/tests/execution/test_headless_synthesis.py
+++ b/tests/execution/test_headless_synthesis.py
@@ -10,6 +10,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.headless import _build_skill_result, _scan_jsonl_write_paths
 from tests.execution.conftest import _make_tool_use_line, _sr, _success_session_json
 
@@ -144,7 +145,7 @@ class TestBuildSkillResultPathContamination:
             + _success_session_json("Plan created.")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/correct/clone")
+        sr = _build_skill_result(result, cwd="/correct/clone", backend=ClaudeCodeBackend())
         assert sr.success is False
         assert sr.subtype == "path_contamination"
         assert sr.needs_retry is True
@@ -163,7 +164,7 @@ class TestBuildSkillResultPathContamination:
             + _success_session_json("Plan created.")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/correct/clone")
+        sr = _build_skill_result(result, cwd="/correct/clone", backend=ClaudeCodeBackend())
         assert sr.retry_reason == RetryReason.PATH_CONTAMINATION
         assert sr.needs_retry is True
 
@@ -176,7 +177,7 @@ class TestBuildSkillResultPathContamination:
             + _success_session_json("Plan created.")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/correct/clone")
+        sr = _build_skill_result(result, cwd="/correct/clone", backend=ClaudeCodeBackend())
         assert sr.success is True
         assert sr.subtype != "path_contamination"
 
@@ -187,14 +188,14 @@ class TestBuildSkillResultPathContamination:
             self._assistant_ndjson(f"plan_path = {path}") + "\n" + _success_session_json("Done.")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="")
+        sr = _build_skill_result(result, cwd="", backend=ClaudeCodeBackend())
         assert sr.success is True
 
     def test_no_contamination_when_no_path_tokens(self):
         """No output path tokens means validation passes."""
         stdout = _success_session_json("Done with no file output.")
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/clone/path")
+        sr = _build_skill_result(result, cwd="/clone/path", backend=ClaudeCodeBackend())
         assert sr.success is True
 
 
@@ -311,7 +312,7 @@ class TestBuildSkillResultWritePathWarnings:
             + _success_session_json("Done %%DONE%%")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/clone/worktree")
+        sr = _build_skill_result(result, cwd="/clone/worktree", backend=ClaudeCodeBackend())
         assert sr.write_path_warnings == []
 
     def test_write_path_warnings_populated_for_contaminated_session(self):
@@ -323,7 +324,7 @@ class TestBuildSkillResultWritePathWarnings:
             + _success_session_json("Done %%DONE%%")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/clone/worktree")
+        sr = _build_skill_result(result, cwd="/clone/worktree", backend=ClaudeCodeBackend())
         assert len(sr.write_path_warnings) == 1
         assert "/source/repo/.autoskillit/temp/stolen.md" in sr.write_path_warnings[0]
 
@@ -334,7 +335,7 @@ class TestBuildSkillResultWritePathWarnings:
             + _success_session_json("Done %%DONE%%")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/clone/worktree")
+        sr = _build_skill_result(result, cwd="/clone/worktree", backend=ClaudeCodeBackend())
         data = json.loads(sr.to_json())
         assert "write_path_warnings" in data
         assert len(data["write_path_warnings"]) == 1
@@ -365,7 +366,7 @@ class TestBuildSkillResultWritePathWarnings:
             + _success_session_json("Done %%DONE%%")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/clone/worktree")
+        sr = _build_skill_result(result, cwd="/clone/worktree", backend=ClaudeCodeBackend())
         # subtype is path_contamination (from _validate_output_paths)
         assert sr.subtype == "path_contamination"
         # write_path_warnings also populated from JSONL scan
@@ -419,6 +420,7 @@ class TestBuildSkillResultChannelBPatternRecovery:
             sub_result,
             completion_marker="%%ORDER_UP%%",
             expected_output_patterns=["---prepare-issue-result---"],
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
         assert "---prepare-issue-result---" in sr.result
@@ -454,6 +456,7 @@ class TestBuildSkillResultChannelBPatternRecovery:
         sr = _build_skill_result(
             sub_result,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False
         assert sr.subtype not in {"success"}
@@ -496,6 +499,7 @@ class TestBuildSkillResultChannelBPatternRecovery:
         sr = _build_skill_result(
             sub_result,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False
         assert "arch_lens_selection" not in sr.result
@@ -537,6 +541,7 @@ class TestBuildSkillResultChannelBPatternRecovery:
         sr = _build_skill_result(
             sub_result,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False
         assert "plan_path" not in sr.result
@@ -553,7 +558,12 @@ class TestCapabilityGatedWritePathScan:
             + _success_session_json("Done %%DONE%%")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/some/path", supports_claude_format_stdout=False)
+        sr = _build_skill_result(
+            result,
+            cwd="/some/path",
+            supports_claude_format_stdout=False,
+            backend=ClaudeCodeBackend(),
+        )
         assert sr.write_path_warnings == []
 
     def test_true_default_preserves_existing_behavior(self):
@@ -566,5 +576,10 @@ class TestCapabilityGatedWritePathScan:
             + _success_session_json("Done %%DONE%%")
         )
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
-        sr = _build_skill_result(result, cwd="/some/path", supports_claude_format_stdout=True)
+        sr = _build_skill_result(
+            result,
+            cwd="/some/path",
+            supports_claude_format_stdout=True,
+            backend=ClaudeCodeBackend(),
+        )
         assert len(sr.write_path_warnings) == 1

--- a/tests/execution/test_output_format_contract.py
+++ b/tests/execution/test_output_format_contract.py
@@ -23,6 +23,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.commands import (
     build_food_truck_cmd,
     build_headless_resume_cmd,
@@ -134,7 +135,9 @@ class TestRecoveryIntegrationWithFormat:
             pid=1234,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        skill_result = _build_skill_result(sub_result, "%%ORDER_UP%%", "/test", None)
+        skill_result = _build_skill_result(
+            sub_result, "%%ORDER_UP%%", "/test", None, backend=ClaudeCodeBackend()
+        )
         assert skill_result.success is True
         assert "MERGE APPROVED" in skill_result.result
 
@@ -163,7 +166,9 @@ class TestRecoveryIntegrationWithFormat:
             pid=1234,
             channel_confirmation=ChannelConfirmation.UNMONITORED,
         )
-        skill_result = _build_skill_result(sub_result, "%%ORDER_UP%%", "/test", None)
+        skill_result = _build_skill_result(
+            sub_result, "%%ORDER_UP%%", "/test", None, backend=ClaudeCodeBackend()
+        )
         # With JSON format, result is only the marker — stripped to empty — fails content check.
         # With UNMONITORED channel, dead-end guard does not promote to retriable.
         assert skill_result.success is False

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -8,6 +8,7 @@ import textwrap
 import pytest
 
 from autoskillit.core.types import ChannelConfirmation, SubprocessResult, TerminationReason
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.process import run_managed_async
 from tests.execution.conftest import WRITE_RESULT_THEN_HANG_SCRIPT
 
@@ -373,6 +374,7 @@ class TestChannelBFullPipelineAdjudication:
             completion_marker="%%ORDER_UP%%",
             skill_command="test-command",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is True  # FAILS before fix: False
         assert skill_result.needs_retry is False  # FAILS before fix: True
@@ -421,6 +423,7 @@ class TestChannelBDrainRacePipelineAdjudication:
             completion_marker="%%ORDER_UP%%",
             skill_command="resolve-failures",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
 
         assert skill_result.success is True
@@ -452,7 +455,11 @@ class TestNaturalExitWithChannelConfirmation:
             channel_confirmation=ChannelConfirmation.CHANNEL_B,
         )
         skill_result = _build_skill_result(
-            result, completion_marker="", skill_command="test", audit=None
+            result,
+            completion_marker="",
+            skill_command="test",
+            audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is True
         assert skill_result.needs_retry is False

--- a/tests/execution/test_process_pty.py
+++ b/tests/execution/test_process_pty.py
@@ -21,6 +21,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.headless import _build_skill_result, _recover_from_separate_marker
 from autoskillit.execution.process import (
     RaceSignals,
@@ -276,6 +277,7 @@ class TestSTOPDelayPipelineAdjudication:
             completion_marker="%%ORDER_UP%%",
             skill_command="resolve-failures",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
 
         assert skill_result.success is False
@@ -310,6 +312,7 @@ class TestSTOPDelayPipelineAdjudication:
             completion_marker="%%ORDER_UP%%",
             skill_command="resolve-failures",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
 
         assert skill_result.success is False
@@ -343,6 +346,7 @@ class TestSTOPDelayPipelineAdjudication:
             completion_marker="%%ORDER_UP%%",
             skill_command="resolve-failures",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
 
         assert skill_result.success is False
@@ -396,6 +400,7 @@ class TestStaleRecoveryPipelineAdjudication:
             completion_marker="",
             skill_command="investigate",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
 
         assert skill_result.success is True
@@ -439,6 +444,7 @@ class TestTimedOutPipelineAdjudication:
             completion_marker="%%ORDER_UP%%",
             skill_command="investigate",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
 
         assert skill_result.success is False
@@ -668,6 +674,7 @@ class TestChannelBDrainRaceRecovery:
             skill_command="/make-plan",
             audit=None,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is True
         assert skill_result.needs_retry is False
@@ -696,6 +703,7 @@ class TestChannelBDrainRaceRecovery:
             skill_command="/test",
             audit=None,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is False
         assert skill_result.needs_retry is False
@@ -732,6 +740,7 @@ class TestChannelBDrainRaceRecovery:
             completion_marker="%%ORDER_UP%%",
             skill_command="/test",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is True
 
@@ -757,6 +766,7 @@ class TestChannelBDrainRaceRecovery:
             completion_marker="%%ORDER_UP%%",
             skill_command="/test",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is False
 
@@ -778,6 +788,7 @@ class TestChannelBDrainRaceRecovery:
             completion_marker="%%ORDER_UP%%",
             skill_command="/test",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is False
 
@@ -797,6 +808,7 @@ class TestChannelBDrainRaceRecovery:
             skill_command="/test",
             audit=None,
             expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            backend=ClaudeCodeBackend(),
         )
         assert skill_result.success is False
 
@@ -828,6 +840,7 @@ class TestAdjudicationGuards:
             completion_marker="",
             skill_command="/test",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         # Must not be a dead end — guard must escalate to retriable
         assert skill_result.success or skill_result.needs_retry, (
@@ -851,6 +864,7 @@ class TestAdjudicationGuards:
             completion_marker="",
             skill_command="/test",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         # Must not be contradictory — contradiction guard must set success=False
         assert not (skill_result.success and skill_result.needs_retry), (
@@ -875,6 +889,7 @@ class TestAdjudicationGuards:
             completion_marker="",
             skill_command="/test",
             audit=None,
+            backend=ClaudeCodeBackend(),
         )
         assert not (skill_result.success and skill_result.needs_retry), (
             f"Contradiction: success={skill_result.success}, "

--- a/tests/execution/test_session_adjudication_retry.py
+++ b/tests/execution/test_session_adjudication_retry.py
@@ -11,6 +11,7 @@ from autoskillit.core.types import (
     RetryReason,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.session import (
     ClaudeSessionResult,
     ContentState,
@@ -582,7 +583,7 @@ class TestApiErrorRetryRouting:
             }
         )
         result = self._make_result(stderr="", returncode=0, stdout=ndjson + "\n" + result_line)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "api_error"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME
@@ -609,7 +610,7 @@ class TestApiErrorRetryRouting:
             }
         )
         result = self._make_result(stderr="", returncode=0, stdout=ndjson + "\n" + result_line)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "api_error"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME
@@ -636,7 +637,7 @@ class TestApiErrorRetryRouting:
             }
         )
         result = self._make_result(stderr="", returncode=0, stdout=ndjson + "\n" + result_line)
-        sr = _build_skill_result(result)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "api_error"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RESUME

--- a/tests/execution/test_write_evidence_invariants.py
+++ b/tests/execution/test_write_evidence_invariants.py
@@ -14,6 +14,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.headless import _build_skill_result
 from tests.execution.conftest import EMPTY_OUTPUT_RESULT_LINE, WRITE_TOOL_LINE
 
@@ -37,7 +38,7 @@ def test_no_work_reasons_are_overridden_by_write_evidence(reason: RetryReason) -
         termination=TerminationReason.NATURAL_EXIT,
         pid=12345,
     )
-    sr = _build_skill_result(result, fs_writes_detected=True)
+    sr = _build_skill_result(result, fs_writes_detected=True, backend=ClaudeCodeBackend())
 
     assert sr.retry_reason != reason, (
         f"RetryReason.{reason.name} was not overridden despite write evidence. "

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.core import RetryReason, WriteBehaviorSpec, extract_skill_name
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.headless import _build_skill_result
 from tests.conftest import _make_result
 
@@ -53,6 +54,7 @@ class TestZeroWriteDetection:
             _make_result(returncode=0, stdout=stdout),
             skill_command="/make-plan task",
             write_behavior=WriteBehaviorSpec(mode="always"),
+            backend=ClaudeCodeBackend(),
         )
         assert not sr.success
         assert sr.subtype == "zero_writes"
@@ -65,6 +67,7 @@ class TestZeroWriteDetection:
             _make_result(returncode=0, stdout=stdout),
             skill_command="/make-plan task",
             write_behavior=WriteBehaviorSpec(mode="always"),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
         assert sr.subtype != "zero_writes"
@@ -90,6 +93,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(r"conflict_report_path\s*=\s*/.+",),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
 
@@ -110,6 +114,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(r"conflict_report_path\s*=\s*/.+",),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert not sr.success
         assert sr.subtype == "zero_writes"
@@ -121,6 +126,7 @@ class TestZeroWriteDetection:
             _make_result(returncode=0, stdout=stdout),
             skill_command="/investigate err",
             write_behavior=WriteBehaviorSpec(),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
 
@@ -131,6 +137,7 @@ class TestZeroWriteDetection:
             _make_result(returncode=0, stdout=stdout),
             skill_command="/investigate err",
             write_behavior=None,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
 
@@ -140,6 +147,7 @@ class TestZeroWriteDetection:
             _make_result(returncode=0, stdout=stdout),
             skill_command="/make-plan task description",
             write_behavior=WriteBehaviorSpec(mode="always"),
+            backend=ClaudeCodeBackend(),
         )
         assert not sr.success
         assert sr.subtype == "zero_writes"
@@ -173,6 +181,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(r"verdict\s*=\s*real_fix",),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "Already-green worktree (verdict = already_green) must NOT be demoted. "
@@ -203,6 +212,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(r"verdict\s*=\s*real_fix",),
             ),
+            backend=ClaudeCodeBackend(),
         )
         # Write not expected (no verdict = real_fix) → success, NOT demoted
         assert sr.success is True, (
@@ -232,6 +242,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(r"verdict\s*=\s*real_fix",),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False, (
             "verdict = real_fix with 0 writes must be demoted to zero_writes"
@@ -261,6 +272,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(r"fixes_applied\s*=\s*[1-9][0-9]*",),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False
         assert sr.subtype == "zero_writes"
@@ -290,6 +302,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(r"phases_implemented\s*=\s*[1-9][0-9]*",),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "All-phases-done worktree (phases_implemented = 0) must NOT be demoted to zero_writes."
@@ -317,6 +330,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(r"fixes_applied\s*=\s*[1-9][0-9]*",),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "No-PR graceful degradation (no fixes_applied token) must NOT be demoted."
@@ -340,6 +354,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "No 'verdict = real_fix' token must NOT trigger zero_writes gate."
@@ -367,6 +382,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "All-escalations path (verdict = already_green) must NOT be demoted."
@@ -394,6 +410,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "Graceful degradation (no 'verdict = real_fix' token) must NOT be demoted."
@@ -421,6 +438,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False, (
             "'verdict = real_fix' with 0 writes must be demoted — silent degradation detected."
@@ -441,6 +459,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, "Real fix with actual writes must NOT be demoted."
         assert sr.subtype != "zero_writes"
@@ -462,6 +481,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "No 'verdict = real_fix' token must NOT trigger zero_writes gate."
@@ -485,6 +505,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "All-escalations path (verdict = already_green) must NOT be demoted."
@@ -508,6 +529,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "Graceful degradation (no 'verdict = real_fix' token) must NOT be demoted."
@@ -531,6 +553,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False, (
             "'verdict = real_fix' with 0 writes must be demoted — silent degradation detected."
@@ -548,6 +571,7 @@ class TestZeroWriteDetection:
                 mode="conditional",
                 expected_when=(FIXTURE_CONDITIONAL_PATTERN,),
             ),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, "Real fix with actual writes must NOT be demoted."
         assert sr.subtype != "zero_writes"
@@ -561,6 +585,7 @@ class TestWriteCallCountPropagation:
         sr = _build_skill_result(
             _make_result(returncode=0, stdout=stdout),
             skill_command="/investigate something",
+            backend=ClaudeCodeBackend(),
         )
         assert sr.evidence.write_call_count == 4
 
@@ -569,6 +594,7 @@ class TestWriteCallCountPropagation:
         sr = _build_skill_result(
             _make_result(returncode=0, stdout=stdout),
             skill_command="/investigate something",
+            backend=ClaudeCodeBackend(),
         )
         assert sr.evidence.write_call_count == 0
 
@@ -577,6 +603,7 @@ class TestWriteCallCountPropagation:
         sr = _build_skill_result(
             _make_result(returncode=0, stdout=stdout),
             skill_command="/investigate something",
+            backend=ClaudeCodeBackend(),
         )
         parsed = json.loads(sr.to_json())
         assert parsed["write_call_count"] == 2
@@ -608,6 +635,7 @@ class TestFilesystemWriteDetection:
             _make_result(returncode=0, stdout=stdout),
             skill_command="/autoskillit:prepare-pr args",
             write_behavior=WriteBehaviorSpec(mode="always"),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.evidence.write_call_count == 0
 
@@ -620,6 +648,7 @@ class TestFilesystemWriteDetection:
             skill_command="/autoskillit:prepare-pr args",
             write_behavior=WriteBehaviorSpec(mode="always"),
             fs_writes_detected=True,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
         assert sr.subtype != "zero_writes"
@@ -642,6 +671,7 @@ class TestFilesystemWriteDetection:
             write_behavior=WriteBehaviorSpec(mode="always"),
             expected_output_patterns=["prep_path\\s*=\\s*/.+"],
             fs_writes_detected=False,
+            backend=ClaudeCodeBackend(),
         )
         assert sr_without_fs.subtype == "adjudicated_failure"
         assert sr_without_fs.needs_retry is False
@@ -652,6 +682,7 @@ class TestFilesystemWriteDetection:
             write_behavior=WriteBehaviorSpec(mode="always"),
             expected_output_patterns=["prep_path\\s*=\\s*/.+"],
             fs_writes_detected=True,
+            backend=ClaudeCodeBackend(),
         )
         assert sr_with_fs.needs_retry is True
         assert sr_with_fs.retry_reason == RetryReason.CONTRACT_RECOVERY
@@ -665,6 +696,7 @@ class TestFilesystemWriteDetection:
             skill_command="/autoskillit:make-plan task",
             write_behavior=WriteBehaviorSpec(mode="always"),
             fs_writes_detected=False,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False
         assert sr.subtype == "zero_writes"
@@ -677,6 +709,7 @@ class TestFilesystemWriteDetection:
             skill_command="/autoskillit:make-plan task",
             write_behavior=WriteBehaviorSpec(mode="always"),
             fs_writes_detected=True,
+            backend=ClaudeCodeBackend(),
         )
         json_data = json.loads(sr.to_json())
         assert json_data["fs_writes_detected"] is True
@@ -720,6 +753,7 @@ class TestGitWritesDetection:
             skill_command="/make-plan task",
             write_behavior=WriteBehaviorSpec(mode="always"),
             git_writes_detected=True,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True
         assert sr.subtype != "zero_writes"
@@ -734,6 +768,7 @@ class TestGitWritesDetection:
             skill_command="/make-plan task",
             write_behavior=WriteBehaviorSpec(mode="always"),
             git_writes_detected=False,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is False
         assert sr.subtype == "zero_writes"
@@ -749,6 +784,7 @@ class TestGitWritesDetection:
                 expected_when=(r"verdict\s*=\s*real_fix",),
             ),
             git_writes_detected=True,
+            backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
             "git_writes_detected=True must suppress zero_writes gate even when "
@@ -820,6 +856,7 @@ class TestContractDrivenAlwaysWriteSkills:
             _make_result(returncode=0, stdout=stdout),
             skill_command=f"/autoskillit:{skill_name} arg",
             write_behavior=WriteBehaviorSpec(mode="always"),
+            backend=ClaudeCodeBackend(),
         )
         assert sr.evidence.has_evidence is True, (
             f"Skill {skill_name!r} (write_behavior=always) must detect write evidence"

--- a/tests/fleet/test_api_split_integrity.py
+++ b/tests/fleet/test_api_split_integrity.py
@@ -1,4 +1,5 @@
 """Structural guard: fleet._api.py split into cohesive modules."""
+
 from __future__ import annotations
 
 import pytest
@@ -9,34 +10,41 @@ pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature
 class TestExpressionModuleExists:
     def test_evaluate_skip_when_importable(self):
         from autoskillit.fleet._expressions import evaluate_skip_when
+
         assert callable(evaluate_skip_when)
 
     def test_interpolate_campaign_refs_importable(self):
         from autoskillit.fleet._expressions import _interpolate_campaign_refs
+
         assert callable(_interpolate_campaign_refs)
 
     def test_campaign_ref_re_importable(self):
         from autoskillit.fleet._expressions import _CAMPAIGN_REF_RE
+
         assert _CAMPAIGN_REF_RE is not None
 
 
 class TestCaptureModuleExists:
     def test_extract_captures_importable(self):
         from autoskillit.fleet._capture import _extract_captures
+
         assert callable(_extract_captures)
 
     def test_capture_completeness_error_importable(self):
         from autoskillit.fleet._capture import CaptureCompletenessError
+
         assert issubclass(CaptureCompletenessError, RuntimeError)
 
     def test_normalize_capture_spec_importable(self):
         from autoskillit.fleet._capture import _normalize_capture_spec
+
         assert callable(_normalize_capture_spec)
 
 
 class TestOutcomeModuleExists:
     def test_classify_dispatch_outcome_importable(self):
         from autoskillit.fleet._outcome import classify_dispatch_outcome
+
         assert callable(classify_dispatch_outcome)
 
 
@@ -44,11 +52,12 @@ class TestPublicAPISurfacePreserved:
     def test_all_public_symbols_accessible_via_gateway(self):
         from autoskillit.fleet import (
             CaptureCompletenessError,
+            _write_pid,
             classify_dispatch_outcome,
             evaluate_skip_when,
             execute_dispatch,
-            _write_pid,
         )
+
         assert callable(execute_dispatch)
         assert callable(evaluate_skip_when)
         assert callable(classify_dispatch_outcome)

--- a/tests/infra/test_pretty_output_hook_infra.py
+++ b/tests/infra/test_pretty_output_hook_infra.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from autoskillit.core.types import ChannelConfirmation, TerminationReason
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.headless import _build_skill_result
 from autoskillit.hooks.formatters.pretty_output_hook import _format_response
 from tests.conftest import _make_result
@@ -191,7 +192,9 @@ def test_fmt_run_skill_contradictory_subtype_never_renders_fail_success():
         termination_reason=TerminationReason.COMPLETED,
         channel_confirmation=ChannelConfirmation.UNMONITORED,
     )
-    sr = _build_skill_result(result, completion_marker="", skill_command="/test")
+    sr = _build_skill_result(
+        result, completion_marker="", skill_command="/test", backend=ClaudeCodeBackend()
+    )
     assert sr.success is False, "Precondition: this path must produce a failure"
 
     payload = json.loads(sr.to_json())

--- a/tests/recipe/test_recipe_dry_walkthrough_scope.py
+++ b/tests/recipe/test_recipe_dry_walkthrough_scope.py
@@ -7,7 +7,6 @@ import pytest
 from autoskillit.core import pkg_root
 from autoskillit.recipe.io import load_recipe
 
-
 _RECIPES_WITH_DRY_WALKTHROUGH = (
     "implementation",
     "implementation-groups",
@@ -34,9 +33,7 @@ def test_dry_walkthrough_output_dir_does_not_scope_to_subdirectory(
         if "dry-walkthrough" not in cmd:
             continue
         output_dir = (step.with_args or {}).get("output_dir", "")
-        assert not output_dir.endswith(
-            "/dry-walkthrough"
-        ), (
+        assert not output_dir.endswith("/dry-walkthrough"), (
             f"{recipe_name}.{step_name}: output_dir must not scope to "
             f"/dry-walkthrough subdirectory — dry-walkthrough edits plan files "
             f"at make-plan/ or rectify/ locations (issue #2919)"


### PR DESCRIPTION
## Summary

Remove all `CodingAgentBackend | None` type annotations and `= None` defaults from `_parse_stdout`, `_extract_file_changes`, `_compute_write_evidence`, and `_build_skill_result` in `_headless_result.py`. Delete every `if backend is None` fallback branch and hardcoded `{'Write', 'Edit'}` backend fallbacks, relying on the post-P1-A4 guarantee that all callers pass a concrete `CodingAgentBackend`. Update all test files (16 files total) to pass `ClaudeCodeBackend()` (or `CodexBackend()` for Codex-specific test classes) where `backend` was previously omitted or `None`.

Closes #2856

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-025535-925104/.autoskillit/temp/dry-walkthrough/p1_a5_wp1_backend_required_plan_2026-05-24_030300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 82 | 22.1k | 979.4k | 93.4k | 138 | 84.3k | 12m 43s |
| verify | claude-opus-4-6 | 1 | 1.3k | 26.4k | 1.4M | 86.7k | 162 | 71.3k | 12m 29s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.2M | 18.7k | 1.7M | 41.8k | 500 | 131.1k | 45m 9s |
| fix | claude-sonnet-4-6 | 1 | 330 | 35.0k | 3.2M | 113.4k | 87 | 106.4k | 16m 24s |
| dispatch:4ae7f33b-2862-4705-80f0-76c6341bfa6b | claude-sonnet-4-6 | 1 | 348 | 96 | 2.6M | 71.9k | 43 | 115.2k | 1h 38m |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 125.6k | 3.8k | 305.0k | 35.1k | 28 | 52.1k | 1m 23s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 161.0k | 2.8k | 356.9k | 30.0k | 27 | 14.8k | 1m 9s |
| review_pr | claude-sonnet-4-6 | 1 | 1.6k | 26.3k | 564.8k | 84.0k | 85 | 78.5k | 9m 1s |
| resolve_review | claude-sonnet-4-6 | 1 | 461 | 27.7k | 3.5M | 86.6k | 133 | 77.7k | 15m 35s |
| **Total** | | | 2.4M | 162.8k | 14.7M | 113.4k | | 731.5k | 3h 32m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 518 | 3223.4 | 253.2 | 36.1 |
| fix | 72 | 44009.6 | 1477.5 | 485.7 |
| dispatch:4ae7f33b-2862-4705-80f0-76c6341bfa6b | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **590** | 24831.8 | 1239.9 | 276.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 1.4k | 48.5k | 2.4M | 155.6k | 25m 12s |
| MiniMax-M2.7-highspeed | 3 | 2.4M | 25.3k | 2.3M | 198.1k | 47m 42s |
| claude-sonnet-4-6 | 4 | 2.8k | 89.0k | 9.9M | 377.9k | 2h 19m |