### PR TITLE
P1-A2-WP1: Replace the no-op system_prompt stub added by P1-A1-WP3 with real emission logic

### DIFF
--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -50,10 +50,8 @@ def _run_interactive_session(
     from autoskillit.cli.ui._terminal import terminal_guard
     from autoskillit.core import (
         MARKETPLACE_PREFIX,
-        BareResume,
         ClaudeFlags,
         InfraExitCategory,
-        NamedResume,
         NoResume,
         detect_autoskillit_mcp_prefix,
         pkg_root,
@@ -63,6 +61,7 @@ def _run_interactive_session(
     spec = backend.build_interactive_cmd(
         initial_prompt=initial_message,
         resume_spec=resume_spec if resume_spec is not None else NoResume(),
+        system_prompt=system_prompt,
         env_extras=extra_env,
         required_env=required_env,
     )
@@ -72,13 +71,11 @@ def _run_interactive_session(
             if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX
             else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
         )
-        _is_resume = isinstance(resume_spec, (BareResume, NamedResume))
         cmd = [
             *spec.cmd,
             *plugin_flags,
             ClaudeFlags.TOOLS,
             "AskUserQuestion",
-            *([] if _is_resume else [ClaudeFlags.APPEND_SYSTEM_PROMPT, system_prompt]),
         ]
     else:
         cmd = [*spec.cmd]

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -509,8 +509,10 @@ class ClaudeCodeBackend:
             session. ``BareResume`` passes ``--resume`` without an ID (Claude Code's
             interactive picker). ``NamedResume`` passes ``--resume <id>``.
         system_prompt
-            Optional system prompt text. Unused in A1 — reserved for A2 wiring,
-            which will translate it to ``--append-system-prompt <value>``.
+            Optional system prompt text. When provided and resume_spec is NoResume,
+            appended as ``--append-system-prompt <value>``. Suppressed on resume
+            sessions (BareResume or NamedResume) because ``--append-system-prompt``
+            is incompatible with ``--resume``.
         env_extras
             Optional caller overrides merged into the resolved env after IDE scrubbing.
         required_env
@@ -534,6 +536,8 @@ class ClaudeCodeBackend:
                 cmd.append(ClaudeFlags.RESUME)
             case NoResume():
                 pass
+        if system_prompt is not None and isinstance(resume_spec, NoResume):
+            cmd += [ClaudeFlags.APPEND_SYSTEM_PROMPT, system_prompt]
         if model:
             cmd += [ClaudeFlags.MODEL, model]
         match plugin_source:

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -73,7 +73,7 @@ def test_run_interactive_session_restricts_tools(monkeypatch: pytest.MonkeyPatch
 
 
 def test_run_interactive_session_appends_system_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_run_interactive_session appends --append-system-prompt <prompt>."""
+    """--append-system-prompt <prompt> present in subprocess cmd (via build_interactive_cmd)."""
     _stub_plugin_installed(monkeypatch)
     captured = _capture_subprocess(monkeypatch)
     _run_interactive_session(system_prompt="my-unique-prompt")
@@ -132,7 +132,7 @@ def test_run_interactive_session_no_plugin_dir_when_installed(
 def test_run_interactive_session_suppresses_system_prompt_on_named_resume(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_run_interactive_session omits --append-system-prompt when resume_spec is NamedResume."""
+    """--append-system-prompt absent on NamedResume (suppressed by build_interactive_cmd)."""
     from autoskillit.core import NamedResume
 
     _stub_plugin_installed(monkeypatch)
@@ -147,7 +147,7 @@ def test_run_interactive_session_suppresses_system_prompt_on_named_resume(
 def test_run_interactive_session_suppresses_system_prompt_on_bare_resume(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_run_interactive_session omits --append-system-prompt when resume_spec is BareResume."""
+    """--append-system-prompt absent on BareResume (suppressed by build_interactive_cmd)."""
     from autoskillit.core import BareResume
 
     _stub_plugin_installed(monkeypatch)
@@ -169,7 +169,7 @@ def test_session_type_cook_order_in_cli_session() -> None:
 def test_run_interactive_session_appends_system_prompt_on_fresh_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_run_interactive_session appends --append-system-prompt for fresh (NoResume) sessions."""
+    """--append-system-prompt present for fresh NoResume sessions (via build_interactive_cmd)."""
     from autoskillit.core import NoResume
 
     _stub_plugin_installed(monkeypatch)
@@ -189,7 +189,7 @@ def test_run_interactive_session_appends_system_prompt_on_fresh_session(
 
 
 def test_skill_injection_disabled_omits_flags(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When skill_injection_capable=False, no plugin/tools/system-prompt flags are injected."""
+    """When skill_injection_capable=False, no plugin/tools flags injected by _run_interactive_session."""
     from autoskillit.core import BackendCapabilities, CmdSpec
 
     no_inject_caps = BackendCapabilities(

--- a/tests/execution/backends/test_claude_backend.py
+++ b/tests/execution/backends/test_claude_backend.py
@@ -7,9 +7,11 @@ import pytest
 
 from autoskillit.core import (
     BareResume,
+    ClaudeFlags,
     CmdSpec,
     DirectInstall,
     NamedResume,
+    NoResume,
     OutputFormat,
     SessionCheckpoint,
     SkillSessionConfig,
@@ -113,6 +115,36 @@ class TestBuildInteractiveCmdEquivalence:
         shim = commands.build_interactive_cmd(model="sonnet")
         assert spec.cmd == tuple(shim.cmd)
         assert spec.env == shim.env
+
+
+class TestBuildInteractiveCmdSystemPrompt:
+    """system_prompt is emitted as --append-system-prompt by build_interactive_cmd."""
+
+    def test_system_prompt_with_no_resume_appends_flag(self) -> None:
+        backend = ClaudeCodeBackend()
+        spec = backend.build_interactive_cmd(system_prompt="my-prompt", resume_spec=NoResume())
+        assert ClaudeFlags.APPEND_SYSTEM_PROMPT in spec.cmd
+        idx = spec.cmd.index(ClaudeFlags.APPEND_SYSTEM_PROMPT)
+        assert spec.cmd[idx + 1] == "my-prompt"
+
+    def test_system_prompt_none_does_not_append_flag(self) -> None:
+        backend = ClaudeCodeBackend()
+        spec = backend.build_interactive_cmd(system_prompt=None)
+        assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in spec.cmd
+
+    def test_system_prompt_with_named_resume_suppresses_flag(self) -> None:
+        backend = ClaudeCodeBackend()
+        spec = backend.build_interactive_cmd(
+            system_prompt="should-suppress", resume_spec=NamedResume(session_id="s1")
+        )
+        assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in spec.cmd
+
+    def test_system_prompt_with_bare_resume_suppresses_flag(self) -> None:
+        backend = ClaudeCodeBackend()
+        spec = backend.build_interactive_cmd(
+            system_prompt="should-suppress", resume_spec=BareResume()
+        )
+        assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in spec.cmd
 
 
 class TestBuildHeadlessResumeCmdEquivalence:


### PR DESCRIPTION
## Summary

Move system_prompt → `--append-system-prompt` flag emission from the post-call block in `_session_launch.py` into `ClaudeCodeBackend.build_interactive_cmd`. The backend conditionally appends the flag when `system_prompt is not None` and `resume_spec` is `NoResume`, suppressing it for `BareResume` and `NamedResume`. The `_session_launch.py` call site passes `system_prompt=system_prompt` to the backend and removes its own `_is_resume` / `APPEND_SYSTEM_PROMPT` logic.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-050316-429975/.autoskillit/temp/make-plan/p1_a2_wp1_system_prompt_emission_plan_2026-05-24_051200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 81 | 18.5k | 1.0M | 105.0k | 121 | 72.2k | 15m 10s |
| verify | claude-opus-4-6 | 1 | 57 | 11.6k | 867.4k | 59.4k | 98 | 43.8k | 8m 30s |
| implement* | MiniMax-M2.7-highspeed | 1 | 677.9k | 8.7k | 929.3k | 30.0k | 75 | 42.6k | 7m 22s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 144.9k | 4.7k | 329.7k | 30.0k | 34 | 42.0k | 1m 47s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 168.7k | 3.0k | 446.7k | 30.0k | 36 | 14.8k | 1m 23s |
| review_pr | claude-sonnet-4-6 | 3 | 492 | 43.2k | 2.2M | 51.7k | 142 | 119.5k | 12m 54s |
| **Total** | | | 992.1k | 89.5k | 5.8M | 105.0k | | 334.9k | 47m 8s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 55 | 16895.6 | 774.5 | 157.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **55** | 105155.4 | 6089.3 | 1628.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 573 | 61.6k | 3.2M | 191.7k | 28m 4s |
| claude-opus-4-6 | 1 | 57 | 11.6k | 867.4k | 43.8k | 8m 30s |
| MiniMax-M2.7-highspeed | 3 | 991.5k | 16.3k | 1.7M | 99.4k | 10m 32s |