### PR TITLE
Split monolithic files — execution/ package area (4 files)

### DIFF
--- a/src/autoskillit/execution/CLAUDE.md
+++ b/src/autoskillit/execution/CLAUDE.md
@@ -15,7 +15,8 @@ backends/ (see backends/CLAUDE.md).
 | `diff_annotator.py` | Diff annotation + findings filter for review-pr |
 | `linux_tracing.py` | `/proc` + psutil process tracing (Linux) |
 | `anomaly_detection.py` | Post-hoc anomaly detection over snapshots |
-| `session_log.py` | XDG-aware session diagnostics log writer |
+| `session_log.py` | XDG-aware session diagnostics log writer (crash recovery moved to `_session_log_recovery.py`) |
+| `_session_log_recovery.py` | `recover_crashed_sessions` — tmpfs orphan scanner for SIGKILL'd sessions |
 | `recording.py` | Record/replay subprocess runners via api-simulator |
 | `_recording_skills.py` | Skill dir snapshot/restore for record/replay sessions |
 | `quota.py` | `QuotaStatus`, cache, `check_and_sleep_if_needed` |

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -11,6 +11,7 @@ from autoskillit.execution._recording_skills import (
     scan_skill_snapshots,
     snapshot_skill_dir,
 )
+from autoskillit.execution._session_log_recovery import recover_crashed_sessions
 from autoskillit.execution.anomaly_detection import (
     AnomalyKind,
     AnomalySeverity,
@@ -115,7 +116,6 @@ from autoskillit.execution.session import (
 from autoskillit.execution.session_log import (
     flush_session_log,
     read_telemetry_clear_marker,
-    recover_crashed_sessions,
     resolve_log_dir,
     write_telemetry_clear_marker,
 )

--- a/src/autoskillit/execution/_session_log_recovery.py
+++ b/src/autoskillit/execution/_session_log_recovery.py
@@ -1,0 +1,136 @@
+"""Crash recovery scanner for SIGKILL'd headless sessions."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import psutil
+
+from autoskillit.core import get_logger
+from autoskillit.execution.linux_tracing import read_boot_id, read_enrollment, read_starttime_ticks
+from autoskillit.execution.session_log import flush_session_log
+
+logger = get_logger(__name__)
+
+
+def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") -> int:
+    """Scan tmpfs for orphaned trace files from SIGKILL'd sessions and finalize them.
+
+    Returns the number of sessions recovered.
+    """
+    tmpfs = Path(tmpfs_path)
+    if not tmpfs.is_dir():
+        return 0
+
+    count = 0
+    current_boot_id = read_boot_id()
+    for trace_file in sorted(tmpfs.glob("autoskillit_trace_*.jsonl")):
+        # Skip files modified within the last 30 seconds — may be active
+        try:
+            age_seconds = time.time() - trace_file.stat().st_mtime
+        except OSError:
+            continue
+        if age_seconds < 30:
+            continue
+
+        # Extract PID from filename: autoskillit_trace_{pid}.jsonl
+        try:
+            pid = int(trace_file.stem.split("_")[-1])
+        except (ValueError, IndexError):
+            pid = -1
+
+        # Gate 1: Enrollment sidecar must exist — no sidecar means alien/test file
+        enrollment_path = tmpfs / f"autoskillit_enrollment_{pid}.json"
+        enrollment = read_enrollment(enrollment_path)
+        if enrollment is None:
+            logger.debug("Skipping %s: no enrollment sidecar", trace_file.name)
+            continue
+
+        # Gate 2: Boot ID must match current boot — mismatch means pre-reboot stale file
+        if current_boot_id and enrollment.boot_id and enrollment.boot_id != current_boot_id:
+            logger.debug("Skipping %s: boot_id mismatch", trace_file.name)
+            trace_file.unlink(missing_ok=True)
+            enrollment_path.unlink(missing_ok=True)
+            continue
+
+        # Gate 3: PID liveness + starttime_ticks identity
+        if psutil.pid_exists(pid):
+            current_ticks = read_starttime_ticks(pid)
+            if current_ticks is not None and current_ticks == enrollment.starttime_ticks:
+                logger.debug("Skipping %s: PID %d still alive", trace_file.name, pid)
+                continue
+            # PID recycled — original process is gone, treat as crash
+
+        # All gates passed — read snapshots and emit crashed row
+        snapshots: list[dict[str, object]] = []
+        try:
+            for line in trace_file.read_text().splitlines():
+                try:
+                    snapshots.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        except OSError:
+            continue
+
+        # Gate 4: comm-based alien file rejection (issue #806 immunity)
+        # Use enrollment.comm as the expected comm (schema_version=2 records carry the
+        # enrolled binary name). Pre-fix schema_version=1 records have comm="" — skip
+        # the check for those to preserve recovery of legitimate crash data.
+        _is_alien = False
+        expected_comm = enrollment.comm
+        if snapshots and expected_comm:
+            first_comm = snapshots[0].get("comm", "")
+            if first_comm and isinstance(first_comm, str) and first_comm != expected_comm:
+                logger.debug(
+                    "Skipping %s: alien comm '%s' (expected '%s')",
+                    trace_file.name,
+                    first_comm,
+                    expected_comm,
+                )
+                _is_alien = True
+        if _is_alien:
+            # Delete the alien trace — don't leave it to confuse future recovery runs
+            trace_file.unlink(missing_ok=True)
+            enrollment_path.unlink(missing_ok=True)
+            continue
+
+        # Compute start_ts from file mtime
+        try:
+            mtime_ts = datetime.fromtimestamp(trace_file.stat().st_mtime, tz=UTC).isoformat()
+        except OSError:
+            continue
+
+        try:
+            from autoskillit.core import ProviderOutcome, RecipeIdentity, SessionTelemetry
+
+            flush_session_log(
+                log_dir=log_dir,
+                cwd="",
+                session_id=f"crashed_{pid}_{mtime_ts.replace(':', '-')}",
+                pid=pid,
+                skill_command="",
+                success=False,
+                subtype="crashed",
+                exit_code=-1,
+                start_ts=mtime_ts,
+                proc_snapshots=snapshots if snapshots else None,
+                termination_reason="CRASHED",
+                provider_outcome=ProviderOutcome.none_used(),
+                recipe_identity=RecipeIdentity.empty(),
+                telemetry=SessionTelemetry.empty(),
+            )
+        except Exception:
+            logger.debug(
+                "recover_crashed_sessions: failed to finalize %s", trace_file, exc_info=True
+            )
+            continue
+
+        trace_file.unlink(missing_ok=True)
+        enrollment_path.unlink(missing_ok=True)
+
+        count += 1
+
+    return count

--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -7,5 +7,8 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 | File | Purpose |
 |------|---------|
 | `__init__.py` | `BACKEND_REGISTRY`, `get_backend()` factory, re-exports |
-| `claude.py` | `ClaudeCodeBackend`, `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` |
-| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexStreamParser`, `CodexEnvPolicy`, `CodexSessionLocator`, `CodexResultParser`, `_CodexParseAccumulator`, `_scan_codex_ndjson`, `CODEX_ENV_DENYLIST`, `CODEX_ENV_PREFIX_DENYLIST`, `ensure_codex_mcp_registered`, `_read_codex_config`, `_write_codex_config`, `_serialize_toml`, `_format_toml_value`, `_format_inline_table`, `_emit_toml_table`, `_is_autoskillit_registered` |
+| `claude.py` | `ClaudeCodeBackend`, `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` (prompt utilities moved to `_claude_prompt.py`) |
+| `_claude_prompt.py` | Prompt injection utilities, session constants (`_ensure_skill_prefix`, `_inject_completion_directive`, `_compose_resume_prompt`, etc.), shared by claude + codex + commands |
+| `codex.py` | `CodexFlags`, `CodexBackend`, `CodexEnvPolicy`, `CodexSessionLocator` (parse/config moved to `_codex_parse.py` / `_codex_config.py`) |
+| `_codex_config.py` | TOML serialization, MCP registration (`ensure_codex_mcp_registered`, `_serialize_toml`) |
+| `_codex_parse.py` | `CodexStreamParser`, `CodexResultParser`, `_scan_codex_ndjson`, `_CodexParseAccumulator` |

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from autoskillit.core import CodingAgentBackend
 
+from ._codex_config import ensure_codex_mcp_registered
+from ._codex_parse import CodexResultParser, CodexStreamParser
 from .claude import (
     ClaudeCodeBackend,
     ClaudeEnvPolicy,
@@ -13,10 +15,7 @@ from .codex import (
     CodexBackend,
     CodexEnvPolicy,
     CodexFlags,
-    CodexResultParser,
     CodexSessionLocator,
-    CodexStreamParser,
-    ensure_codex_mcp_registered,
 )
 
 BACKEND_REGISTRY: dict[str, type[CodingAgentBackend]] = {

--- a/src/autoskillit/execution/backends/_claude_prompt.py
+++ b/src/autoskillit/execution/backends/_claude_prompt.py
@@ -1,0 +1,221 @@
+"""Prompt injection utilities and session constants shared by claude, codex, and commands."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any
+
+from autoskillit.core import (
+    ClaudeFlags,
+    OutputFormat,
+    SessionCheckpoint,
+    extract_skill_name,
+    temp_dir_display_str,
+)
+
+
+def _marker_is_standalone(text: str, marker: str) -> bool:
+    for text_line in text.splitlines():
+        if text_line.strip() == marker:
+            return True
+    return False
+
+
+def _extract_write_artifacts(tool_uses: list[dict[str, Any]]) -> list[str]:
+    return [
+        t.get("file_path", "")
+        for t in tool_uses
+        if t.get("name") in {"Write", "Edit"} and t.get("file_path")
+    ]
+
+
+# Injected into every AutoSkillit-launched headless and cook session.
+# Raises the Claude Code client-side MCP tool result size gate from the
+# default 25,000 tokens to 50,000, preventing open_kitchen() responses
+# from being persisted to a file instead of returned inline.
+_MAX_MCP_OUTPUT_TOKENS_VALUE: str = "50000"
+
+# Baseline env vars injected into EVERY AutoSkillit-launched Claude session
+# (both interactive and headless). Callers can override via env_extras.
+# Analogous to IDE_ENV_ALWAYS_EXTRAS in _claude_env.py but scoped to
+# session-level concerns rather than IDE scrubbing.
+_SESSION_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
+    {
+        "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
+        "MCP_CONNECTION_NONBLOCKING": "0",
+    }
+)
+
+# Variables that _build_skill_session_cmd_impl controls exclusively. They must not
+# leak from the host process environment — the caller opts in via explicit
+# parameters (exit_after_stop_delay_ms, scenario_step_name, allowed_write_prefix, etc.).
+# Note: CLAUDE_CODE_EXIT_AFTER_STOP_DELAY, SCENARIO_STEP_NAME, and
+# MAX_MCP_OUTPUT_TOKENS also overlap with IDE_ENV_DENYLIST in
+# core/_claude_env.py. AUTOSKILLIT_SESSION_TYPE, AUTOSKILLIT_CAMPAIGN_ID, and
+# AUTOSKILLIT_PROVIDER_PROFILE overlap with AUTOSKILLIT_PRIVATE_ENV_VARS
+# (scrubbed by build_agent_env).
+# All lists must be kept in sync when adding new exclusive variables.
+_HEADLESS_EXCLUSIVE_VARS: frozenset[str] = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "AUTOSKILLIT_ALLOWED_WRITE_PREFIX",
+        "AUTOSKILLIT_CAMPAIGN_ID",
+        "AUTOSKILLIT_COMPLETION_MARKER",
+        "AUTOSKILLIT_KITCHEN_SESSION_ID",
+        "AUTOSKILLIT_LAUNCH_ID",
+        "AUTOSKILLIT_PROVIDER_PROFILE",
+        "AUTOSKILLIT_SESSION_TYPE",
+        "AUTOSKILLIT_SKILL_NAME",
+        "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY",
+        "CLAUDE_STREAM_IDLE_TIMEOUT_MS",
+        "MAX_MCP_OUTPUT_TOKENS",
+        "SCENARIO_STEP_NAME",
+    }
+)
+
+
+def _apply_output_format(cmd: list[str], output_format: OutputFormat) -> None:
+    """Append --output-format and all required CLI flags, deduplicating."""
+    cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format.value]
+    for flag in output_format.required_cli_flags:
+        if flag not in cmd:
+            cmd.append(flag)
+
+
+def _ensure_skill_prefix(skill_command: str, *, provider_profile: str = "") -> str:
+    """Prompt-formatting helper: wrap slash-commands for headless session loading.
+
+    Transforms `/foo args` into `Use the /foo skill args` so non-Claude models
+    recognize the slash command as a Skill tool invocation rather than a task description.
+
+    This is NOT a validator. Non-slash input passes through unchanged by design —
+    runtime validation is enforced by the skill_command_guard PreToolUse hook.
+    """
+    stripped = skill_command.strip()
+    if stripped.startswith("/"):
+        parts = stripped.split(None, 1)
+        slash_cmd = parts[0]
+        rest = parts[1] if len(parts) > 1 else ""
+        formatted = f"Use the {slash_cmd} skill"
+        if rest:
+            formatted += f" {rest}"
+        if provider_profile:
+            skill_name = extract_skill_name(stripped) or slash_cmd.lstrip("/")
+            formatted = (
+                f"FIRST ACTION: Your first action should be to load the skill instructions "
+                f'by calling the Skill tool with skill="{skill_name}". '
+                f"If the Skill tool is unavailable or returns an error, read the skill "
+                f"instructions from the skill's SKILL.md file instead.\n\n"
+                f"{formatted}"
+            )
+        return formatted
+    return skill_command
+
+
+def _inject_completion_directive(skill_command: str, marker: str) -> str:
+    """Append an orchestration directive to make the session write a completion marker."""
+    directive = (
+        f"\n\nORCHESTRATION DIRECTIVE: When your task is complete, "
+        f"your final text output MUST end with: {marker}\n"
+        f"CRITICAL: Append {marker} at the very end of your substantive response, "
+        f"in the SAME message. Do NOT output {marker} as a separate standalone message."
+    )
+    return skill_command + directive
+
+
+def _inject_cwd_anchor(skill_command: str, cwd: str, temp_dir_relpath: str | None = None) -> str:
+    """Append a working directory anchor directive to prevent path contamination."""
+    if not cwd or not os.path.isabs(cwd):
+        return skill_command
+    relpath = temp_dir_relpath if temp_dir_relpath is not None else temp_dir_display_str(None)
+    directive = (
+        f"\n\nWORKING DIRECTORY ANCHOR: Your working directory is {cwd}. "
+        f"All relative paths ({relpath}/, .autoskillit/, etc.) "
+        f"MUST resolve against {cwd}. "
+        f"Do NOT use any other directory as a base for relative paths."
+    )
+    return skill_command + directive
+
+
+def _inject_narration_suppression(skill_command: str, *, has_skill_prefix: bool = False) -> str:
+    """Append an efficiency directive to suppress inter-tool narration.
+
+    Targets prose status text and phase announcements emitted between tool
+    calls — the primary driver of unnecessary context-length overhead in
+    long-running sessions. Does NOT suppress the final response, which is
+    where structured output tokens (worktree_path, plan_path, etc.) live.
+    """
+    opener = "After loading the skill instructions, d" if has_skill_prefix else "D"
+    directive = (
+        f"\n\nEFFICIENCY DIRECTIVE: {opener}o NOT output prose status text, phase "
+        "announcements, or progress summaries between tool calls. Every "
+        "non-final assistant turn MUST invoke at least one tool. The only "
+        "permitted text-only turn is the final response required by the "
+        "ORCHESTRATION DIRECTIVE above."
+    )
+    return skill_command + directive
+
+
+def _inject_completion_reminder(prompt: str, marker: str) -> str:
+    """Append a short completion marker reminder as the final prompt line.
+
+    Provides recency-priority reinforcement for models that attend more strongly
+    to end-of-prompt instructions.
+    """
+    if not marker:
+        return prompt
+    return f"{prompt}\nRemember: end your final response with {marker}"
+
+
+def _compose_resume_prompt(
+    *,
+    base_prompt: str,
+    resume_checkpoint: SessionCheckpoint | None,
+    sentinel_contract: str = "",
+    resume_message: str | None = None,
+) -> str:
+    """Compose resume directives ON TOP of the caller's base prompt.
+
+    Never discards ``base_prompt`` — resume adds context layers, not substitutes.
+    """
+    sections: list[str] = []
+
+    sections.append(
+        "RESUME SESSION: Your previous session was interrupted before completion. "
+        "Continue your work from where you left off. "
+        "Do NOT restart from scratch — pick up exactly where you stopped. "
+        "Do NOT re-emit any prior failure, exhaustion, or error sentinels from "
+        "your conversation history. Conditions may have changed since the prior "
+        "session — re-attempt the next pending operation."
+    )
+
+    if resume_message:
+        sections.append(f"CALLER CONTEXT: {resume_message}")
+
+    if resume_checkpoint and resume_checkpoint.completed_items:
+        sections.append(_build_resume_context(resume_checkpoint))
+
+    if sentinel_contract:
+        sections.append(sentinel_contract)
+
+    sections.append(f"ORIGINAL TASK CONTEXT:\n{base_prompt}")
+
+    return "\n\n".join(sections)
+
+
+def _build_resume_context(checkpoint: SessionCheckpoint) -> str:
+    lines = [
+        "RESUME CONTEXT: The following items were completed in the previous session "
+        "and MUST be skipped. Do NOT redo any of them — continue from where the "
+        "previous session left off.",
+        "",
+    ]
+    for item in checkpoint.completed_items:
+        lines.append(f"  - COMPLETED: {item}")
+    if checkpoint.step_name:
+        lines.append(f"\nLast active step: {checkpoint.step_name}")
+    return "\n".join(lines)

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -1,0 +1,141 @@
+"""TOML serialization and MCP registration for the Codex backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from autoskillit.core import (
+    HEADLESS_AUTO_GATE_ENV_VAR,
+    HEADLESS_ENV_VAR,
+    atomic_write,
+    get_logger,
+)
+
+logger = get_logger()
+
+
+def _format_toml_value(v: Any) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, str):
+        escaped = (
+            v.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
+        return f'"{escaped}"'
+    if isinstance(v, int):
+        return str(v)
+    if isinstance(v, float):
+        return str(v)
+    if isinstance(v, list):
+        items = ", ".join(_format_toml_value(item) for item in v)
+        return f"[{items}]"
+    msg = f"Unsupported TOML value type: {type(v).__name__}"
+    raise TypeError(msg)
+
+
+def _format_inline_table(d: dict[str, Any]) -> str:
+    pairs = [f"{k} = {_format_toml_value(v)}" for k, v in d.items()]
+    return "{" + ", ".join(pairs) + "}"
+
+
+def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> None:
+    header = f"[{'.'.join(path)}]"
+    scalars = [(k, v) for k, v in d.items() if not isinstance(v, dict)]
+    tables = [(k, v) for k, v in d.items() if isinstance(v, dict)]
+    has_scalars = bool(scalars)
+
+    inline_tables: list[tuple[str, dict[str, Any]]] = []
+    recurse_tables: list[tuple[str, dict[str, Any]]] = []
+    for k, v in tables:
+        if not v:
+            inline_tables.append((k, v))
+            continue
+        is_leaf = not any(isinstance(sv, dict) for sv in v.values())
+        if is_leaf and has_scalars:
+            inline_tables.append((k, v))
+        else:
+            recurse_tables.append((k, v))
+
+    if scalars or inline_tables:
+        lines.append(f"\n{header}")
+        for k, v in scalars:
+            lines.append(f"{k} = {_format_toml_value(v)}")
+        for k, v in inline_tables:
+            lines.append(f"{k} = {_format_inline_table(v)}")
+
+    for k, v in recurse_tables:
+        _emit_toml_table(v, [*path, k], lines)
+
+
+def _serialize_toml(data: dict[str, Any]) -> str:
+    lines: list[str] = []
+    for k, v in data.items():
+        if not isinstance(v, dict):
+            lines.append(f"{k} = {_format_toml_value(v)}")
+    for k, v in data.items():
+        if isinstance(v, dict):
+            _emit_toml_table(v, [k], lines)
+    text = "\n".join(lines).lstrip("\n")
+    return text + "\n" if text else ""
+
+
+def _read_codex_config(path: Path) -> dict[str, Any]:
+    import tomllib
+
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError:
+        return {}
+    except tomllib.TOMLDecodeError:
+        logger.warning("corrupt_codex_config", path=str(path))
+        return {}
+    return data
+
+
+def _write_codex_config(path: Path, data: dict[str, Any]) -> None:
+    atomic_write(path, _serialize_toml(data))
+
+
+def _is_autoskillit_registered(config: dict[str, Any], *, headless_auto_gate: bool) -> bool:
+    entry = config.get("mcp_servers", {}).get("autoskillit")
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("command") != "autoskillit":
+        return False
+    env = entry.get("env", {})
+    if env.get(HEADLESS_ENV_VAR) != "1":
+        return False
+    if headless_auto_gate and env.get(HEADLESS_AUTO_GATE_ENV_VAR) != "1":
+        return False
+    return True
+
+
+def ensure_codex_mcp_registered(
+    *,
+    config_path: Path | None = None,
+    headless_auto_gate: bool = True,
+) -> bool:
+    """Return True if the entry was written, False if already registered."""
+    if config_path is None:
+        config_path = Path.home() / ".codex" / "config.toml"
+    config = _read_codex_config(config_path)
+    if _is_autoskillit_registered(config, headless_auto_gate=headless_auto_gate):
+        return False
+    env: dict[str, str] = {HEADLESS_ENV_VAR: "1"}
+    if headless_auto_gate:
+        env[HEADLESS_AUTO_GATE_ENV_VAR] = "1"
+    entry: dict[str, Any] = {
+        "command": "autoskillit",
+        "env": env,
+        "startup_timeout_sec": 30.0,
+        "tool_timeout_sec": 120.0,
+    }
+    config.setdefault("mcp_servers", {})["autoskillit"] = entry
+    _write_codex_config(config_path, config)
+    return True

--- a/src/autoskillit/execution/backends/_codex_parse.py
+++ b/src/autoskillit/execution/backends/_codex_parse.py
@@ -1,0 +1,277 @@
+"""NDJSON stream/result parsing for the Codex backend."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from autoskillit.core import (
+    AGENT_BACKEND_CODEX,
+    AgentSessionResult,
+    BackendEventKind,
+    CanonicalTokenUsage,
+    CliSubtype,
+    CodexEventData,
+    SessionEvent,
+    fast_loads,
+)
+from autoskillit.execution.process import _marker_is_standalone
+
+
+@dataclass
+class _CodexParseAccumulator:
+    session_id: str = ""
+    agent_messages: list[str] = field(default_factory=list)
+    command_executions: list[dict[str, Any]] = field(default_factory=list)
+    mcp_tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    file_changes: list[str] = field(default_factory=list)
+    last_usage: dict[str, Any] | None = None
+    saw_failure: bool = False
+    success: bool = False
+    error_message: str = ""
+
+
+def _scan_codex_ndjson(stdout: str) -> _CodexParseAccumulator:
+    if not stdout.strip():
+        return _CodexParseAccumulator()
+    acc = _CodexParseAccumulator()
+    for line in stdout.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        event_type = obj.get("type", "")
+        if event_type == "thread.started":
+            acc.session_id = obj.get("thread_id", "")
+        elif event_type == "item.completed":
+            item = obj.get("item", {})
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type", "")
+            if item_type == "message":
+                for block in item.get("content", []):
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if text:
+                            acc.agent_messages.append(text)
+            elif item_type == "function_call":
+                acc.command_executions.append(item)
+            elif item_type == "mcp_tool_call":
+                acc.mcp_tool_calls.append(item)
+            elif item_type == "file_change":
+                path = item.get("path")
+                if path:
+                    acc.file_changes.append(path)
+        elif event_type == "turn.completed":
+            usage = obj.get("usage")
+            if isinstance(usage, dict):
+                acc.last_usage = usage
+            if not acc.saw_failure:
+                acc.success = True
+        elif event_type == "turn.failed":
+            error = obj.get("error", {})
+            if isinstance(error, dict):
+                acc.error_message = error.get("message", "")
+            else:
+                acc.error_message = str(error) if error else ""
+            acc.saw_failure = True
+            acc.success = False
+    return acc
+
+
+@dataclass(frozen=True, slots=True)
+class CodexResultParser:
+    def parse_result(self, events: Sequence[SessionEvent]) -> AgentSessionResult:
+        if not events:
+            return AgentSessionResult(
+                success=False,
+                exit_code=1,
+                backend_name=AGENT_BACKEND_CODEX,
+                elapsed_seconds=0.0,
+                error="empty events sequence",
+            )
+        session_id: str | None = None
+        has_completion = False
+        for event in events:
+            if event.kind == BackendEventKind.SESSION_META and event.session_id:
+                session_id = event.session_id
+            if event.kind == BackendEventKind.COMPLETION:
+                has_completion = True
+        return AgentSessionResult(
+            success=has_completion,
+            exit_code=0 if has_completion else 1,
+            backend_name=AGENT_BACKEND_CODEX,
+            elapsed_seconds=0.0,
+            session_id=session_id,
+        )
+
+    def parse_stdout(self, stdout: str, *, exit_code: int = 0) -> AgentSessionResult:
+        acc = _scan_codex_ndjson(stdout)
+        if acc.success:
+            subtype = CliSubtype.SUCCESS.value
+        elif acc.error_message:
+            subtype = CliSubtype.ERROR_DURING_EXECUTION.value
+        elif not stdout.strip():
+            subtype = CliSubtype.EMPTY_OUTPUT.value
+        else:
+            subtype = CliSubtype.UNPARSEABLE.value
+        is_error = subtype != CliSubtype.SUCCESS.value
+        canonical_dict = None
+        if acc.last_usage is not None:
+            canonical = CanonicalTokenUsage.from_codex_dict(acc.last_usage)
+            canonical_dict = canonical.to_dict()
+        return AgentSessionResult(
+            success=not is_error,
+            exit_code=0 if not is_error else (exit_code or 1),
+            backend_name=AGENT_BACKEND_CODEX,
+            elapsed_seconds=0.0,
+            session_id=acc.session_id or None,
+            output="\n".join(acc.agent_messages),
+            error=acc.error_message,
+            raw={
+                "subtype": subtype,
+                "is_error": is_error,
+                "token_usage": acc.last_usage,
+                "canonical_token_usage": canonical_dict,
+                "agent_messages": acc.agent_messages,
+                "command_executions": acc.command_executions,
+                "mcp_tool_calls": acc.mcp_tool_calls,
+                "file_changes": acc.file_changes,
+            },
+        )
+
+
+@dataclass(slots=True)
+class CodexStreamParser:
+    """Stateful NDJSON stream parser for Codex CLI output.
+
+    One instance per session — accumulates marker detection state across
+    parse_line() calls. Not reusable across sessions.
+    """
+
+    completion_marker: str = ""
+    _saw_marker: bool = field(default=False, init=False, repr=False)
+
+    def parse_line(self, line: str) -> SessionEvent | None:
+        line = line.strip()
+        if not line:
+            return None
+        try:
+            obj = fast_loads(line)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(obj, dict):
+            return None
+
+        event_type = obj.get("type", "")
+
+        if event_type == "thread.started":
+            return SessionEvent(
+                kind=BackendEventKind.SESSION_META,
+                is_terminal=False,
+                has_marker=False,
+                session_id=obj.get("thread_id", "") or None,
+            )
+
+        if event_type == "item.completed":
+            item = obj.get("item", {})
+            if not isinstance(item, dict):
+                return SessionEvent(
+                    kind=BackendEventKind.IGNORED,
+                    is_terminal=False,
+                    has_marker=False,
+                )
+            item_type = item.get("type", "")
+
+            if item_type == "message":
+                for block in item.get("content", []):
+                    if (
+                        isinstance(block, dict)
+                        and block.get("type") == "text"
+                        and self.completion_marker
+                        and _marker_is_standalone(block.get("text", ""), self.completion_marker)
+                    ):
+                        self._saw_marker = True
+                return SessionEvent(
+                    kind=BackendEventKind.TOOL_OUTPUT,
+                    is_terminal=False,
+                    has_marker=False,
+                    backend_data=CodexEventData(
+                        record_type="item.completed",
+                        thread_id="",
+                        item_type="message",
+                        raw=obj,
+                    ),
+                )
+
+            if item_type in ("file_change", "function_call"):
+                return SessionEvent(
+                    kind=BackendEventKind.TOOL_OUTPUT,
+                    is_terminal=False,
+                    has_marker=False,
+                    backend_data=CodexEventData(
+                        record_type="item.completed",
+                        thread_id="",
+                        item_type=item_type,
+                        raw=obj,
+                    ),
+                )
+
+            return SessionEvent(
+                kind=BackendEventKind.IGNORED,
+                is_terminal=False,
+                has_marker=False,
+            )
+
+        if event_type == "turn.completed":
+            return SessionEvent(
+                kind=BackendEventKind.COMPLETION,
+                is_terminal=True,
+                has_marker=self._saw_marker,
+                backend_data=CodexEventData(
+                    record_type="turn.completed",
+                    thread_id="",
+                    item_type="",
+                    raw=obj,
+                    usage=obj.get("usage"),
+                ),
+            )
+
+        if event_type == "turn.failed":
+            return SessionEvent(
+                kind=BackendEventKind.COMPLETION,
+                is_terminal=True,
+                has_marker=False,
+                backend_data=CodexEventData(
+                    record_type="turn.failed",
+                    thread_id="",
+                    item_type="",
+                    raw=obj,
+                ),
+            )
+
+        if event_type == "error":
+            return SessionEvent(
+                kind=BackendEventKind.ERROR,
+                is_terminal=True,
+                has_marker=False,
+                backend_data=CodexEventData(
+                    record_type="error",
+                    thread_id="",
+                    item_type="",
+                    raw=obj,
+                ),
+            )
+
+        return SessionEvent(
+            kind=BackendEventKind.IGNORED,
+            is_terminal=False,
+            has_marker=False,
+        )

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -4,8 +4,6 @@ import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from types import MappingProxyType
-from typing import Any
 
 from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
@@ -36,7 +34,20 @@ from autoskillit.core import (
     build_agent_env,
     extract_skill_name,
     fast_loads,
-    temp_dir_display_str,
+)
+from autoskillit.execution.backends._claude_prompt import (
+    _HEADLESS_EXCLUSIVE_VARS,
+    _MAX_MCP_OUTPUT_TOKENS_VALUE,
+    _SESSION_BASELINE_ENV,
+    _apply_output_format,
+    _compose_resume_prompt,
+    _ensure_skill_prefix,
+    _extract_write_artifacts,
+    _inject_completion_directive,
+    _inject_completion_reminder,
+    _inject_cwd_anchor,
+    _inject_narration_suppression,
+    _marker_is_standalone,
 )
 from autoskillit.execution.session import parse_session_result
 
@@ -47,211 +58,6 @@ __all__ = [
     "ClaudeSessionLocator",
     "ClaudeStreamParser",
 ]
-
-
-def _marker_is_standalone(text: str, marker: str) -> bool:
-    for text_line in text.splitlines():
-        if text_line.strip() == marker:
-            return True
-    return False
-
-
-def _extract_write_artifacts(tool_uses: list[dict[str, Any]]) -> list[str]:
-    return [
-        t.get("file_path", "")
-        for t in tool_uses
-        if t.get("name") in {"Write", "Edit"} and t.get("file_path")
-    ]
-
-
-# Injected into every AutoSkillit-launched headless and cook session.
-# Raises the Claude Code client-side MCP tool result size gate from the
-# default 25,000 tokens to 50,000, preventing open_kitchen() responses
-# from being persisted to a file instead of returned inline.
-_MAX_MCP_OUTPUT_TOKENS_VALUE: str = "50000"
-
-# Baseline env vars injected into EVERY AutoSkillit-launched Claude session
-# (both interactive and headless). Callers can override via env_extras.
-# Analogous to IDE_ENV_ALWAYS_EXTRAS in _claude_env.py but scoped to
-# session-level concerns rather than IDE scrubbing.
-_SESSION_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
-    {
-        "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
-        "MCP_CONNECTION_NONBLOCKING": "0",
-    }
-)
-
-# Variables that _build_skill_session_cmd_impl controls exclusively. They must not
-# leak from the host process environment — the caller opts in via explicit
-# parameters (exit_after_stop_delay_ms, scenario_step_name, allowed_write_prefix, etc.).
-# Note: CLAUDE_CODE_EXIT_AFTER_STOP_DELAY, SCENARIO_STEP_NAME, and
-# MAX_MCP_OUTPUT_TOKENS also overlap with IDE_ENV_DENYLIST in
-# core/_claude_env.py. AUTOSKILLIT_SESSION_TYPE, AUTOSKILLIT_CAMPAIGN_ID, and
-# AUTOSKILLIT_PROVIDER_PROFILE overlap with AUTOSKILLIT_PRIVATE_ENV_VARS
-# (scrubbed by build_agent_env).
-# All lists must be kept in sync when adding new exclusive variables.
-_HEADLESS_EXCLUSIVE_VARS: frozenset[str] = frozenset(
-    {
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "AUTOSKILLIT_ALLOWED_WRITE_PREFIX",
-        "AUTOSKILLIT_CAMPAIGN_ID",
-        "AUTOSKILLIT_COMPLETION_MARKER",
-        "AUTOSKILLIT_KITCHEN_SESSION_ID",
-        "AUTOSKILLIT_LAUNCH_ID",
-        "AUTOSKILLIT_PROVIDER_PROFILE",
-        "AUTOSKILLIT_SESSION_TYPE",
-        "AUTOSKILLIT_SKILL_NAME",
-        "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY",
-        "CLAUDE_STREAM_IDLE_TIMEOUT_MS",
-        "MAX_MCP_OUTPUT_TOKENS",
-        "SCENARIO_STEP_NAME",
-    }
-)
-
-
-def _apply_output_format(cmd: list[str], output_format: OutputFormat) -> None:
-    """Append --output-format and all required CLI flags, deduplicating."""
-    cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format.value]
-    for flag in output_format.required_cli_flags:
-        if flag not in cmd:
-            cmd.append(flag)
-
-
-def _ensure_skill_prefix(skill_command: str, *, provider_profile: str = "") -> str:
-    """Prompt-formatting helper: wrap slash-commands for headless session loading.
-
-    Transforms `/foo args` into `Use the /foo skill args` so non-Claude models
-    recognize the slash command as a Skill tool invocation rather than a task description.
-
-    This is NOT a validator. Non-slash input passes through unchanged by design —
-    runtime validation is enforced by the skill_command_guard PreToolUse hook.
-    """
-    stripped = skill_command.strip()
-    if stripped.startswith("/"):
-        parts = stripped.split(None, 1)
-        slash_cmd = parts[0]
-        rest = parts[1] if len(parts) > 1 else ""
-        formatted = f"Use the {slash_cmd} skill"
-        if rest:
-            formatted += f" {rest}"
-        if provider_profile:
-            skill_name = extract_skill_name(stripped) or slash_cmd.lstrip("/")
-            formatted = (
-                f"FIRST ACTION: Your first action should be to load the skill instructions "
-                f'by calling the Skill tool with skill="{skill_name}". '
-                f"If the Skill tool is unavailable or returns an error, read the skill "
-                f"instructions from the skill's SKILL.md file instead.\n\n"
-                f"{formatted}"
-            )
-        return formatted
-    return skill_command
-
-
-def _inject_completion_directive(skill_command: str, marker: str) -> str:
-    """Append an orchestration directive to make the session write a completion marker."""
-    directive = (
-        f"\n\nORCHESTRATION DIRECTIVE: When your task is complete, "
-        f"your final text output MUST end with: {marker}\n"
-        f"CRITICAL: Append {marker} at the very end of your substantive response, "
-        f"in the SAME message. Do NOT output {marker} as a separate standalone message."
-    )
-    return skill_command + directive
-
-
-def _inject_cwd_anchor(skill_command: str, cwd: str, temp_dir_relpath: str | None = None) -> str:
-    """Append a working directory anchor directive to prevent path contamination."""
-    if not cwd or not os.path.isabs(cwd):
-        return skill_command
-    relpath = temp_dir_relpath if temp_dir_relpath is not None else temp_dir_display_str(None)
-    directive = (
-        f"\n\nWORKING DIRECTORY ANCHOR: Your working directory is {cwd}. "
-        f"All relative paths ({relpath}/, .autoskillit/, etc.) "
-        f"MUST resolve against {cwd}. "
-        f"Do NOT use any other directory as a base for relative paths."
-    )
-    return skill_command + directive
-
-
-def _inject_narration_suppression(skill_command: str, *, has_skill_prefix: bool = False) -> str:
-    """Append an efficiency directive to suppress inter-tool narration.
-
-    Targets prose status text and phase announcements emitted between tool
-    calls — the primary driver of unnecessary context-length overhead in
-    long-running sessions. Does NOT suppress the final response, which is
-    where structured output tokens (worktree_path, plan_path, etc.) live.
-    """
-    opener = "After loading the skill instructions, d" if has_skill_prefix else "D"
-    directive = (
-        f"\n\nEFFICIENCY DIRECTIVE: {opener}o NOT output prose status text, phase "
-        "announcements, or progress summaries between tool calls. Every "
-        "non-final assistant turn MUST invoke at least one tool. The only "
-        "permitted text-only turn is the final response required by the "
-        "ORCHESTRATION DIRECTIVE above."
-    )
-    return skill_command + directive
-
-
-def _inject_completion_reminder(prompt: str, marker: str) -> str:
-    """Append a short completion marker reminder as the final prompt line.
-
-    Provides recency-priority reinforcement for models that attend more strongly
-    to end-of-prompt instructions.
-    """
-    if not marker:
-        return prompt
-    return f"{prompt}\nRemember: end your final response with {marker}"
-
-
-def _compose_resume_prompt(
-    *,
-    base_prompt: str,
-    resume_checkpoint: SessionCheckpoint | None,
-    sentinel_contract: str = "",
-    resume_message: str | None = None,
-) -> str:
-    """Compose resume directives ON TOP of the caller's base prompt.
-
-    Never discards ``base_prompt`` — resume adds context layers, not substitutes.
-    """
-    sections: list[str] = []
-
-    sections.append(
-        "RESUME SESSION: Your previous session was interrupted before completion. "
-        "Continue your work from where you left off. "
-        "Do NOT restart from scratch — pick up exactly where you stopped. "
-        "Do NOT re-emit any prior failure, exhaustion, or error sentinels from "
-        "your conversation history. Conditions may have changed since the prior "
-        "session — re-attempt the next pending operation."
-    )
-
-    if resume_message:
-        sections.append(f"CALLER CONTEXT: {resume_message}")
-
-    if resume_checkpoint and resume_checkpoint.completed_items:
-        sections.append(_build_resume_context(resume_checkpoint))
-
-    if sentinel_contract:
-        sections.append(sentinel_contract)
-
-    sections.append(f"ORIGINAL TASK CONTEXT:\n{base_prompt}")
-
-    return "\n\n".join(sections)
-
-
-def _build_resume_context(checkpoint: SessionCheckpoint) -> str:
-    lines = [
-        "RESUME CONTEXT: The following items were completed in the previous session "
-        "and MUST be skipped. Do NOT redo any of them — continue from where the "
-        "previous session left off.",
-        "",
-    ]
-    for item in checkpoint.completed_items:
-        lines.append(f"  - COMPLETED: {item}")
-    if checkpoint.step_name:
-        lines.append(f"\nLast active step: {checkpoint.step_name}")
-    return "\n".join(lines)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -2,44 +2,30 @@
 
 from __future__ import annotations
 
-import json
 import os
-import tomllib
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum, unique
 from pathlib import Path
-from typing import Any
 
 from autoskillit.core import (
     AGENT_BACKEND_CODEX,
     AUTOSKILLIT_PRIVATE_ENV_VARS,
     CAMPAIGN_ID_ENV_VAR,
-    HEADLESS_AUTO_GATE_ENV_VAR,
-    HEADLESS_ENV_VAR,
     KITCHEN_SESSION_ID_ENV_VAR,
     SESSION_TYPE_SKILL,
-    AgentSessionResult,
     BackendCapabilities,
-    BackendEventKind,
-    CanonicalTokenUsage,
-    CliSubtype,
     CmdSpec,
-    CodexEventData,
     NoResume,
     OutputFormat,
     PluginSource,
     ResumeSpec,
     SessionCheckpoint,
-    SessionEvent,
     SkillSessionConfig,
     ValidatedAddDir,
-    atomic_write,
     extract_skill_name,
-    fast_loads,
-    get_logger,
 )
-from autoskillit.execution.backends.claude import (
+from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
     _compose_resume_prompt,
@@ -49,155 +35,16 @@ from autoskillit.execution.backends.claude import (
     _inject_cwd_anchor,
     _inject_narration_suppression,
 )
-from autoskillit.execution.process import _marker_is_standalone
+from autoskillit.execution.backends._codex_config import ensure_codex_mcp_registered
+from autoskillit.execution.backends._codex_parse import CodexResultParser, CodexStreamParser
 
 __all__ = [
     "CodexBackend",
     "CodexEnvPolicy",
     "CodexFlags",
-    "CodexResultParser",
     "CodexSessionLocator",
-    "CodexStreamParser",
     "ensure_codex_mcp_registered",
 ]
-
-
-CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
-    {
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "CLAUDE_STREAM_IDLE_TIMEOUT_MS",
-    }
-)
-
-CODEX_ENV_PREFIX_DENYLIST: tuple[str, ...] = ("CLAUDE_CODE_",)
-
-logger = get_logger()
-
-
-def _format_toml_value(v: Any) -> str:
-    if isinstance(v, bool):
-        return "true" if v else "false"
-    if isinstance(v, str):
-        escaped = (
-            v.replace("\\", "\\\\")
-            .replace('"', '\\"')
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-            .replace("\t", "\\t")
-        )
-        return f'"{escaped}"'
-    if isinstance(v, int):
-        return str(v)
-    if isinstance(v, float):
-        return str(v)
-    if isinstance(v, list):
-        items = ", ".join(_format_toml_value(item) for item in v)
-        return f"[{items}]"
-    msg = f"Unsupported TOML value type: {type(v).__name__}"
-    raise TypeError(msg)
-
-
-def _format_inline_table(d: dict[str, Any]) -> str:
-    pairs = [f"{k} = {_format_toml_value(v)}" for k, v in d.items()]
-    return "{" + ", ".join(pairs) + "}"
-
-
-def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> None:
-    header = f"[{'.'.join(path)}]"
-    scalars = [(k, v) for k, v in d.items() if not isinstance(v, dict)]
-    tables = [(k, v) for k, v in d.items() if isinstance(v, dict)]
-    has_scalars = bool(scalars)
-
-    inline_tables: list[tuple[str, dict[str, Any]]] = []
-    recurse_tables: list[tuple[str, dict[str, Any]]] = []
-    for k, v in tables:
-        if not v:
-            inline_tables.append((k, v))
-            continue
-        is_leaf = not any(isinstance(sv, dict) for sv in v.values())
-        if is_leaf and has_scalars:
-            inline_tables.append((k, v))
-        else:
-            recurse_tables.append((k, v))
-
-    if scalars or inline_tables:
-        lines.append(f"\n{header}")
-        for k, v in scalars:
-            lines.append(f"{k} = {_format_toml_value(v)}")
-        for k, v in inline_tables:
-            lines.append(f"{k} = {_format_inline_table(v)}")
-
-    for k, v in recurse_tables:
-        _emit_toml_table(v, [*path, k], lines)
-
-
-def _serialize_toml(data: dict[str, Any]) -> str:
-    lines: list[str] = []
-    for k, v in data.items():
-        if not isinstance(v, dict):
-            lines.append(f"{k} = {_format_toml_value(v)}")
-    for k, v in data.items():
-        if isinstance(v, dict):
-            _emit_toml_table(v, [k], lines)
-    text = "\n".join(lines).lstrip("\n")
-    return text + "\n" if text else ""
-
-
-def _read_codex_config(path: Path) -> dict[str, Any]:
-    try:
-        with open(path, "rb") as f:
-            data = tomllib.load(f)
-    except FileNotFoundError:
-        return {}
-    except tomllib.TOMLDecodeError:
-        logger.warning("corrupt_codex_config", path=str(path))
-        return {}
-    return data
-
-
-def _write_codex_config(path: Path, data: dict[str, Any]) -> None:
-    atomic_write(path, _serialize_toml(data))
-
-
-def _is_autoskillit_registered(config: dict[str, Any], *, headless_auto_gate: bool) -> bool:
-    entry = config.get("mcp_servers", {}).get("autoskillit")
-    if not isinstance(entry, dict):
-        return False
-    if entry.get("command") != "autoskillit":
-        return False
-    env = entry.get("env", {})
-    if env.get(HEADLESS_ENV_VAR) != "1":
-        return False
-    if headless_auto_gate and env.get(HEADLESS_AUTO_GATE_ENV_VAR) != "1":
-        return False
-    return True
-
-
-def ensure_codex_mcp_registered(
-    *,
-    config_path: Path | None = None,
-    headless_auto_gate: bool = True,
-) -> bool:
-    """Return True if the entry was written, False if already registered."""
-    if config_path is None:
-        config_path = Path.home() / ".codex" / "config.toml"
-    config = _read_codex_config(config_path)
-    if _is_autoskillit_registered(config, headless_auto_gate=headless_auto_gate):
-        return False
-    env: dict[str, str] = {HEADLESS_ENV_VAR: "1"}
-    if headless_auto_gate:
-        env[HEADLESS_AUTO_GATE_ENV_VAR] = "1"
-    entry: dict[str, Any] = {
-        "command": "autoskillit",
-        "env": env,
-        "startup_timeout_sec": 30.0,
-        "tool_timeout_sec": 120.0,
-    }
-    config.setdefault("mcp_servers", {})["autoskillit"] = entry
-    _write_codex_config(config_path, config)
-    return True
 
 
 @unique
@@ -215,261 +62,16 @@ class CodexFlags(StrEnum):
     LAST = "--last"
 
 
-@dataclass
-class _CodexParseAccumulator:
-    session_id: str = ""
-    agent_messages: list[str] = field(default_factory=list)
-    command_executions: list[dict[str, Any]] = field(default_factory=list)
-    mcp_tool_calls: list[dict[str, Any]] = field(default_factory=list)
-    file_changes: list[str] = field(default_factory=list)
-    last_usage: dict[str, Any] | None = None
-    saw_failure: bool = False
-    success: bool = False
-    error_message: str = ""
+CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "CLAUDE_STREAM_IDLE_TIMEOUT_MS",
+    }
+)
 
-
-def _scan_codex_ndjson(stdout: str) -> _CodexParseAccumulator:
-    if not stdout.strip():
-        return _CodexParseAccumulator()
-    acc = _CodexParseAccumulator()
-    for line in stdout.strip().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(obj, dict):
-            continue
-        event_type = obj.get("type", "")
-        if event_type == "thread.started":
-            acc.session_id = obj.get("thread_id", "")
-        elif event_type == "item.completed":
-            item = obj.get("item", {})
-            if not isinstance(item, dict):
-                continue
-            item_type = item.get("type", "")
-            if item_type == "message":
-                for block in item.get("content", []):
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text = block.get("text", "")
-                        if text:
-                            acc.agent_messages.append(text)
-            elif item_type == "function_call":
-                acc.command_executions.append(item)
-            elif item_type == "mcp_tool_call":
-                acc.mcp_tool_calls.append(item)
-            elif item_type == "file_change":
-                path = item.get("path")
-                if path:
-                    acc.file_changes.append(path)
-        elif event_type == "turn.completed":
-            usage = obj.get("usage")
-            if isinstance(usage, dict):
-                acc.last_usage = usage
-            if not acc.saw_failure:
-                acc.success = True
-        elif event_type == "turn.failed":
-            error = obj.get("error", {})
-            if isinstance(error, dict):
-                acc.error_message = error.get("message", "")
-            else:
-                acc.error_message = str(error) if error else ""
-            acc.saw_failure = True
-            acc.success = False
-    return acc
-
-
-@dataclass(frozen=True, slots=True)
-class CodexResultParser:
-    def parse_result(self, events: Sequence[SessionEvent]) -> AgentSessionResult:
-        if not events:
-            return AgentSessionResult(
-                success=False,
-                exit_code=1,
-                backend_name=AGENT_BACKEND_CODEX,
-                elapsed_seconds=0.0,
-                error="empty events sequence",
-            )
-        session_id: str | None = None
-        has_completion = False
-        for event in events:
-            if event.kind == BackendEventKind.SESSION_META and event.session_id:
-                session_id = event.session_id
-            if event.kind == BackendEventKind.COMPLETION:
-                has_completion = True
-        return AgentSessionResult(
-            success=has_completion,
-            exit_code=0 if has_completion else 1,
-            backend_name=AGENT_BACKEND_CODEX,
-            elapsed_seconds=0.0,
-            session_id=session_id,
-        )
-
-    def parse_stdout(self, stdout: str, *, exit_code: int = 0) -> AgentSessionResult:
-        acc = _scan_codex_ndjson(stdout)
-        if acc.success:
-            subtype = CliSubtype.SUCCESS.value
-        elif acc.error_message:
-            subtype = CliSubtype.ERROR_DURING_EXECUTION.value
-        elif not stdout.strip():
-            subtype = CliSubtype.EMPTY_OUTPUT.value
-        else:
-            subtype = CliSubtype.UNPARSEABLE.value
-        is_error = subtype != CliSubtype.SUCCESS.value
-        canonical_dict = None
-        if acc.last_usage is not None:
-            canonical = CanonicalTokenUsage.from_codex_dict(acc.last_usage)
-            canonical_dict = canonical.to_dict()
-        return AgentSessionResult(
-            success=not is_error,
-            exit_code=0 if not is_error else (exit_code or 1),
-            backend_name=AGENT_BACKEND_CODEX,
-            elapsed_seconds=0.0,
-            session_id=acc.session_id or None,
-            output="\n".join(acc.agent_messages),
-            error=acc.error_message,
-            raw={
-                "subtype": subtype,
-                "is_error": is_error,
-                "token_usage": acc.last_usage,
-                "canonical_token_usage": canonical_dict,
-                "agent_messages": acc.agent_messages,
-                "command_executions": acc.command_executions,
-                "mcp_tool_calls": acc.mcp_tool_calls,
-                "file_changes": acc.file_changes,
-            },
-        )
-
-
-@dataclass(slots=True)
-class CodexStreamParser:
-    """Stateful NDJSON stream parser for Codex CLI output.
-
-    One instance per session — accumulates marker detection state across
-    parse_line() calls. Not reusable across sessions.
-    """
-
-    completion_marker: str = ""
-    _saw_marker: bool = field(default=False, init=False, repr=False)
-
-    def parse_line(self, line: str) -> SessionEvent | None:
-        line = line.strip()
-        if not line:
-            return None
-        try:
-            obj = fast_loads(line)
-        except (ValueError, TypeError):
-            return None
-        if not isinstance(obj, dict):
-            return None
-
-        event_type = obj.get("type", "")
-
-        if event_type == "thread.started":
-            return SessionEvent(
-                kind=BackendEventKind.SESSION_META,
-                is_terminal=False,
-                has_marker=False,
-                session_id=obj.get("thread_id", "") or None,
-            )
-
-        if event_type == "item.completed":
-            item = obj.get("item", {})
-            if not isinstance(item, dict):
-                return SessionEvent(
-                    kind=BackendEventKind.IGNORED,
-                    is_terminal=False,
-                    has_marker=False,
-                )
-            item_type = item.get("type", "")
-
-            if item_type == "message":
-                for block in item.get("content", []):
-                    if (
-                        isinstance(block, dict)
-                        and block.get("type") == "text"
-                        and self.completion_marker
-                        and _marker_is_standalone(block.get("text", ""), self.completion_marker)
-                    ):
-                        self._saw_marker = True
-                return SessionEvent(
-                    kind=BackendEventKind.TOOL_OUTPUT,
-                    is_terminal=False,
-                    has_marker=False,
-                    backend_data=CodexEventData(
-                        record_type="item.completed",
-                        thread_id="",
-                        item_type="message",
-                        raw=obj,
-                    ),
-                )
-
-            if item_type in ("file_change", "function_call"):
-                return SessionEvent(
-                    kind=BackendEventKind.TOOL_OUTPUT,
-                    is_terminal=False,
-                    has_marker=False,
-                    backend_data=CodexEventData(
-                        record_type="item.completed",
-                        thread_id="",
-                        item_type=item_type,
-                        raw=obj,
-                    ),
-                )
-
-            return SessionEvent(
-                kind=BackendEventKind.IGNORED,
-                is_terminal=False,
-                has_marker=False,
-            )
-
-        if event_type == "turn.completed":
-            return SessionEvent(
-                kind=BackendEventKind.COMPLETION,
-                is_terminal=True,
-                has_marker=self._saw_marker,
-                backend_data=CodexEventData(
-                    record_type="turn.completed",
-                    thread_id="",
-                    item_type="",
-                    raw=obj,
-                    usage=obj.get("usage"),
-                ),
-            )
-
-        if event_type == "turn.failed":
-            return SessionEvent(
-                kind=BackendEventKind.COMPLETION,
-                is_terminal=True,
-                has_marker=False,
-                backend_data=CodexEventData(
-                    record_type="turn.failed",
-                    thread_id="",
-                    item_type="",
-                    raw=obj,
-                ),
-            )
-
-        if event_type == "error":
-            return SessionEvent(
-                kind=BackendEventKind.ERROR,
-                is_terminal=True,
-                has_marker=False,
-                backend_data=CodexEventData(
-                    record_type="error",
-                    thread_id="",
-                    item_type="",
-                    raw=obj,
-                ),
-            )
-
-        return SessionEvent(
-            kind=BackendEventKind.IGNORED,
-            is_terminal=False,
-            has_marker=False,
-        )
+CODEX_ENV_PREFIX_DENYLIST: tuple[str, ...] = ("CLAUDE_CODE_",)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -14,11 +14,10 @@ from autoskillit.core import (
     ResumeSpec,
     ValidatedAddDir,
 )
-from autoskillit.execution.backends.claude import (
+from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,  # noqa: F401 — re-export for downstream consumers
     _MAX_MCP_OUTPUT_TOKENS_VALUE,  # noqa: F401 — re-export for downstream consumers
     _SESSION_BASELINE_ENV,  # noqa: F401 — re-export for downstream consumers
-    ClaudeCodeBackend,
     _apply_output_format,  # noqa: F401 — re-export for downstream consumers
     _build_resume_context,  # noqa: F401 — re-export for downstream consumers
     _compose_resume_prompt,  # noqa: F401 — re-export for downstream consumers
@@ -28,6 +27,7 @@ from autoskillit.execution.backends.claude import (
     _inject_cwd_anchor,  # noqa: F401 — re-export for downstream consumers
     _inject_narration_suppression,  # noqa: F401 — re-export for downstream consumers
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/headless/CLAUDE.md
+++ b/src/autoskillit/execution/headless/CLAUDE.md
@@ -10,7 +10,8 @@ Headless Claude session orchestration — command prep, subprocess invocation, r
 | `_headless_git.py` | Git LOC tracking: `_capture_git_head_sha()`, `_compute_loc_changed()` |
 | `_headless_path_tokens.py` | Path-token extraction and output-path validation from assistant messages |
 | `_headless_recovery.py` | Session recovery: `_recover_from_separate_marker`, `_synthesize_from_write_artifacts` |
-| `_headless_result.py` | `SkillResult` construction: `_build_skill_result`, `_build_session_telemetry`, `_apply_budget_guard` |
+| `_headless_result.py` | `SkillResult` construction: `_build_skill_result` (evidence/telemetry moved to `_headless_evidence.py`) |
+| `_headless_evidence.py` | Evidence computation (`_compute_write_evidence`, `_adapt_agent_result`), audit recording (`_capture_failure`, `_apply_budget_guard`), telemetry builders (`_build_session_telemetry`, `_build_error_path_telemetry`) |
 | `_headless_scan.py` | `_scan_jsonl_write_paths()` — scans stdout JSONL for Write/Edit/Bash tool calls |
 
 ## Architecture Notes

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -51,6 +51,13 @@ from autoskillit.execution.clone_guard import (
     is_worktree_skill,
     snapshot_clone_state,
 )
+from autoskillit.execution.headless._headless_evidence import (
+    _adapt_agent_result,  # noqa: F401
+    _apply_budget_guard,  # noqa: F401
+    _build_error_path_telemetry,
+    _build_session_telemetry,
+    _capture_failure,  # noqa: F401
+)
 from autoskillit.execution.headless._headless_git import (
     _capture_git_head_sha,
     _compute_loc_changed,
@@ -80,12 +87,7 @@ from autoskillit.execution.headless._headless_recovery import (
     _synthesize_from_write_artifacts,  # noqa: F401
 )
 from autoskillit.execution.headless._headless_result import (
-    _adapt_agent_result,  # noqa: F401
-    _apply_budget_guard,  # noqa: F401
-    _build_error_path_telemetry,
-    _build_session_telemetry,
     _build_skill_result,
-    _capture_failure,  # noqa: F401
     _parse_stdout,  # noqa: F401
     _resolve_skill_session_id,  # noqa: F401
 )

--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -1,0 +1,192 @@
+"""Evidence computation, audit recording, and telemetry builders for headless sessions."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from autoskillit.core import (
+    AGENT_BACKEND_CLAUDE_CODE,
+    AgentSessionResult,
+    CliSubtype,
+    FailureRecord,
+    RetryReason,
+    SessionTelemetry,
+    SkillResult,
+    WriteEvidence,
+    get_logger,
+)
+from autoskillit.execution.session._session_model import ClaudeSessionResult
+
+if TYPE_CHECKING:
+    from autoskillit.core import AuditLog, CodingAgentBackend, GitHubApiLog
+
+logger = get_logger(__name__)
+
+
+def _capture_failure(
+    skill_command: str,
+    exit_code: int,
+    subtype: str,
+    needs_retry: bool,
+    retry_reason: str,
+    stderr: str,
+    audit: AuditLog | None,
+) -> None:
+    """Record a failure in the audit log. No-op if skill_command is empty or audit is None."""
+    if not skill_command or audit is None:
+        return
+    audit.record_failure(
+        FailureRecord(
+            timestamp=datetime.now(UTC).isoformat(),
+            skill_command=skill_command,
+            exit_code=exit_code,
+            subtype=subtype,
+            needs_retry=needs_retry,
+            retry_reason=retry_reason,
+            stderr=stderr,
+        )
+    )
+
+
+def _apply_budget_guard(
+    sr: SkillResult,
+    skill_command: str,
+    audit: AuditLog | None,
+    max_consecutive_retries: int,
+) -> SkillResult:
+    """Override needs_retry to False when the consecutive-failure budget is exhausted."""
+    if not sr.needs_retry or audit is None or not skill_command:
+        return sr
+    consecutive = audit.consecutive_failures(skill_command)
+    # current failure already recorded; consecutive count includes this attempt
+    if consecutive > max_consecutive_retries:
+        logger.warning(
+            "retry_budget_exhausted",
+            skill_command=skill_command,
+            consecutive_failures=consecutive,
+            max_consecutive_retries=max_consecutive_retries,
+        )
+        return dataclasses.replace(
+            sr,
+            needs_retry=False,
+            retry_reason=RetryReason.BUDGET_EXHAUSTED,
+        )
+    return sr
+
+
+def _adapt_agent_result(agent_result: AgentSessionResult) -> ClaudeSessionResult:
+    raw = agent_result.raw
+
+    session_id = agent_result.session_id or ""
+    is_error = raw.get("is_error", not agent_result.success)
+    result_text = agent_result.output
+    subtype = CliSubtype.from_cli(raw.get("subtype", "unknown"))
+    stop_reasons: list[str] = raw.get("stop_reasons", [])
+
+    error_subtypes = {
+        CliSubtype.ERROR_DURING_EXECUTION,
+        CliSubtype.ERROR_MAX_TURNS,
+        CliSubtype.UNKNOWN,
+    }
+    jsonl_context_exhausted = subtype in error_subtypes and "context_length_exceeded" in (
+        agent_result.error or ""
+    )
+
+    token_usage = raw.get("canonical_token_usage") or raw.get("token_usage")
+
+    command_executions: list[dict[str, Any]] = raw.get("command_executions", [])
+    mcp_tool_calls: list[dict[str, Any]] = raw.get("mcp_tool_calls", [])
+    file_change_paths: list[str] = raw.get("file_changes", [])
+    file_change_entries = [
+        {"name": "file_change", "type": "file_change", "path": p} for p in file_change_paths
+    ]
+    tool_uses = command_executions + mcp_tool_calls + file_change_entries
+
+    assistant_messages: list[str] = raw.get("agent_messages", [])
+
+    return ClaudeSessionResult(
+        subtype=subtype,
+        is_error=is_error,
+        result=result_text,
+        session_id=session_id,
+        token_usage=token_usage,
+        assistant_messages=assistant_messages,
+        tool_uses=tool_uses,
+        jsonl_context_exhausted=jsonl_context_exhausted,
+        stop_reasons=stop_reasons,
+        has_thinking_only_turn=False,
+        seen_block_types=frozenset(),
+    )
+
+
+def _compute_write_evidence(
+    session: ClaudeSessionResult,
+    fs_writes_detected: bool,
+    git_writes_detected: bool,
+    backend: CodingAgentBackend,
+    file_changes: Sequence[str] = (),
+) -> WriteEvidence:
+    write_names = backend.write_tool_names()
+    write_call_count = sum(1 for t in session.tool_uses if t.get("name") in write_names)
+    # Codex fallback: only count file_changes when no Write/Edit tool calls provide evidence.
+    file_changes_count = len(file_changes) if write_call_count == 0 else 0
+    return WriteEvidence(
+        write_call_count=write_call_count,
+        fs_writes_detected=fs_writes_detected,
+        git_writes_detected=git_writes_detected,
+        file_changes_count=file_changes_count,
+    )
+
+
+def _extract_file_changes(stdout: str, backend: CodingAgentBackend) -> list[str]:
+    if backend.name == AGENT_BACKEND_CLAUDE_CODE:
+        return []
+    agent_result = backend.result_parser().parse_stdout(stdout)
+    return list(agent_result.raw.get("file_changes", []))
+
+
+def _stdout_mentions_write_tools(stdout: str) -> bool:
+    return '"Edit"' in stdout or '"Write"' in stdout
+
+
+def _build_session_telemetry(
+    *,
+    skill_result: SkillResult,
+    timing_seconds: float | None,
+    audit_record: dict | None,
+    github_api_log: GitHubApiLog | None,
+    loc_insertions: int,
+    loc_deletions: int,
+) -> SessionTelemetry:
+    _api_usage = (
+        github_api_log.drain(skill_result.session_id) if github_api_log is not None else None
+    )
+    return SessionTelemetry(
+        token_usage=skill_result.token_usage,
+        timing_seconds=timing_seconds,
+        audit_record=audit_record,
+        github_api_usage=_api_usage,
+        github_api_requests=_api_usage.get("total_requests", 0) if _api_usage else 0,
+        loc_insertions=loc_insertions,
+        loc_deletions=loc_deletions,
+    )
+
+
+def _build_error_path_telemetry(
+    github_api_log: GitHubApiLog | None,
+    session_id: str = "",
+) -> SessionTelemetry:
+    """Build SessionTelemetry for crash/cancel paths where no SkillResult exists."""
+    _api_usage = github_api_log.drain(session_id) if github_api_log is not None else None
+    return SessionTelemetry(
+        token_usage=None,
+        timing_seconds=None,
+        audit_record=None,
+        github_api_usage=_api_usage,
+        github_api_requests=_api_usage.get("total_requests", 0) if _api_usage else 0,
+        loc_insertions=0,
+        loc_deletions=0,
+    )

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -4,23 +4,19 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Sequence
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, assert_never
+from typing import TYPE_CHECKING, assert_never
 
 from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
-    AgentSessionResult,
     ApiRetryOutcome,
     ChannelConfirmation,
     CliSubtype,
-    FailureRecord,
     InfraExitCategory,
     InfraOutcome,
     KillReason,
     ProviderOutcome,
     RetryReason,
     SessionOutcome,
-    SessionTelemetry,
     SkillResult,
     TerminationReason,
     WriteBehaviorSpec,
@@ -28,6 +24,14 @@ from autoskillit.core import (
     get_logger,
     truncate_text,
     validate_worktree_path,
+)
+from autoskillit.execution.headless._headless_evidence import (
+    _adapt_agent_result,
+    _apply_budget_guard,
+    _capture_failure,
+    _compute_write_evidence,
+    _extract_file_changes,
+    _stdout_mentions_write_tools,
 )
 from autoskillit.execution.headless._headless_path_tokens import (
     _extract_output_paths,
@@ -53,71 +57,18 @@ from autoskillit.execution.session._session_outcome import (
 )
 
 if TYPE_CHECKING:
-    from autoskillit.core import AuditLog, CodingAgentBackend, GitHubApiLog, SubprocessResult
+    from autoskillit.core import AuditLog, CodingAgentBackend, SubprocessResult
 
 logger = get_logger(__name__)
 _truncate = truncate_text
 
 __all__ = [
-    "_adapt_agent_result",
-    "_build_error_path_telemetry",
-    "_build_session_telemetry",
-    "_capture_failure",
-    "_apply_budget_guard",
-    "_resolve_skill_session_id",
     "_build_skill_result",
+    "_make_terminated_result",
+    "_parse_stdout",
+    "_resolve_skill_session_id",
+    "_build_api_retry_outcome",
 ]
-
-
-def _capture_failure(
-    skill_command: str,
-    exit_code: int,
-    subtype: str,
-    needs_retry: bool,
-    retry_reason: str,
-    stderr: str,
-    audit: AuditLog | None,
-) -> None:
-    """Record a failure in the audit log. No-op if skill_command is empty or audit is None."""
-    if not skill_command or audit is None:
-        return
-    audit.record_failure(
-        FailureRecord(
-            timestamp=datetime.now(UTC).isoformat(),
-            skill_command=skill_command,
-            exit_code=exit_code,
-            subtype=subtype,
-            needs_retry=needs_retry,
-            retry_reason=retry_reason,
-            stderr=stderr,
-        )
-    )
-
-
-def _apply_budget_guard(
-    sr: SkillResult,
-    skill_command: str,
-    audit: AuditLog | None,
-    max_consecutive_retries: int,
-) -> SkillResult:
-    """Override needs_retry to False when the consecutive-failure budget is exhausted."""
-    if not sr.needs_retry or audit is None or not skill_command:
-        return sr
-    consecutive = audit.consecutive_failures(skill_command)
-    # current failure already recorded; consecutive count includes this attempt
-    if consecutive > max_consecutive_retries:
-        logger.warning(
-            "retry_budget_exhausted",
-            skill_command=skill_command,
-            consecutive_failures=consecutive,
-            max_consecutive_retries=max_consecutive_retries,
-        )
-        return dataclasses.replace(
-            sr,
-            needs_retry=False,
-            retry_reason=RetryReason.BUDGET_EXHAUSTED,
-        )
-    return sr
 
 
 def _resolve_skill_session_id(
@@ -135,81 +86,6 @@ def _parse_stdout(stdout: str, backend: CodingAgentBackend) -> ClaudeSessionResu
         return parse_session_result(stdout)
     agent_result = backend.result_parser().parse_stdout(stdout)
     return _adapt_agent_result(agent_result)
-
-
-def _adapt_agent_result(agent_result: AgentSessionResult) -> ClaudeSessionResult:
-    raw = agent_result.raw
-
-    session_id = agent_result.session_id or ""
-    is_error = raw.get("is_error", not agent_result.success)
-    result_text = agent_result.output
-    subtype = CliSubtype.from_cli(raw.get("subtype", "unknown"))
-    stop_reasons: list[str] = raw.get("stop_reasons", [])
-
-    error_subtypes = {
-        CliSubtype.ERROR_DURING_EXECUTION,
-        CliSubtype.ERROR_MAX_TURNS,
-        CliSubtype.UNKNOWN,
-    }
-    jsonl_context_exhausted = subtype in error_subtypes and "context_length_exceeded" in (
-        agent_result.error or ""
-    )
-
-    token_usage = raw.get("canonical_token_usage") or raw.get("token_usage")
-
-    command_executions: list[dict[str, Any]] = raw.get("command_executions", [])
-    mcp_tool_calls: list[dict[str, Any]] = raw.get("mcp_tool_calls", [])
-    file_change_paths: list[str] = raw.get("file_changes", [])
-    file_change_entries = [
-        {"name": "file_change", "type": "file_change", "path": p} for p in file_change_paths
-    ]
-    tool_uses = command_executions + mcp_tool_calls + file_change_entries
-
-    assistant_messages: list[str] = raw.get("agent_messages", [])
-
-    return ClaudeSessionResult(
-        subtype=subtype,
-        is_error=is_error,
-        result=result_text,
-        session_id=session_id,
-        token_usage=token_usage,
-        assistant_messages=assistant_messages,
-        tool_uses=tool_uses,
-        jsonl_context_exhausted=jsonl_context_exhausted,
-        stop_reasons=stop_reasons,
-        has_thinking_only_turn=False,
-        seen_block_types=frozenset(),
-    )
-
-
-def _compute_write_evidence(
-    session: ClaudeSessionResult,
-    fs_writes_detected: bool,
-    git_writes_detected: bool,
-    backend: CodingAgentBackend,
-    file_changes: Sequence[str] = (),
-) -> WriteEvidence:
-    write_names = backend.write_tool_names()
-    write_call_count = sum(1 for t in session.tool_uses if t.get("name") in write_names)
-    # Codex fallback: only count file_changes when no Write/Edit tool calls provide evidence.
-    file_changes_count = len(file_changes) if write_call_count == 0 else 0
-    return WriteEvidence(
-        write_call_count=write_call_count,
-        fs_writes_detected=fs_writes_detected,
-        git_writes_detected=git_writes_detected,
-        file_changes_count=file_changes_count,
-    )
-
-
-def _extract_file_changes(stdout: str, backend: CodingAgentBackend) -> list[str]:
-    if backend.name == AGENT_BACKEND_CLAUDE_CODE:
-        return []
-    agent_result = backend.result_parser().parse_stdout(stdout)
-    return list(agent_result.raw.get("file_changes", []))
-
-
-def _stdout_mentions_write_tools(stdout: str) -> bool:
-    return '"Edit"' in stdout or '"Write"' in stdout
 
 
 def _build_api_retry_outcome(session: ClaudeSessionResult) -> ApiRetryOutcome:
@@ -817,43 +693,3 @@ def _build_skill_result(
         write_call_count=sr.evidence.write_call_count,
     )
     return sr
-
-
-def _build_session_telemetry(
-    *,
-    skill_result: SkillResult,
-    timing_seconds: float | None,
-    audit_record: dict | None,
-    github_api_log: GitHubApiLog | None,
-    loc_insertions: int,
-    loc_deletions: int,
-) -> SessionTelemetry:
-    _api_usage = (
-        github_api_log.drain(skill_result.session_id) if github_api_log is not None else None
-    )
-    return SessionTelemetry(
-        token_usage=skill_result.token_usage,
-        timing_seconds=timing_seconds,
-        audit_record=audit_record,
-        github_api_usage=_api_usage,
-        github_api_requests=_api_usage.get("total_requests", 0) if _api_usage else 0,
-        loc_insertions=loc_insertions,
-        loc_deletions=loc_deletions,
-    )
-
-
-def _build_error_path_telemetry(
-    github_api_log: GitHubApiLog | None,
-    session_id: str = "",
-) -> SessionTelemetry:
-    """Build SessionTelemetry for crash/cancel paths where no SkillResult exists."""
-    _api_usage = github_api_log.drain(session_id) if github_api_log is not None else None
-    return SessionTelemetry(
-        token_usage=None,
-        timing_seconds=None,
-        audit_record=None,
-        github_api_usage=_api_usage,
-        github_api_requests=_api_usage.get("total_requests", 0) if _api_usage else 0,
-        loc_insertions=0,
-        loc_deletions=0,
-    )

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -12,7 +12,6 @@ import json
 import os
 import shutil
 import sys
-import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -21,7 +20,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from autoskillit.core import ProviderOutcome, RecipeIdentity, SessionTelemetry
 
-import psutil
 
 from autoskillit.core import (
     atomic_write,
@@ -35,11 +33,6 @@ from autoskillit.execution.anomaly_detection import (
     detect_anomalies,
     detect_identity_drift,
     detect_outcome_anomalies,
-)
-from autoskillit.execution.linux_tracing import (
-    read_boot_id,
-    read_enrollment,
-    read_starttime_ticks,
 )
 
 logger = get_logger(__name__)
@@ -606,123 +599,3 @@ def _enforce_retention(
             except json.JSONDecodeError:
                 continue
         atomic_write(index_path, "\n".join(kept) + "\n" if kept else "")
-
-
-def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") -> int:
-    """Scan tmpfs for orphaned trace files from SIGKILL'd sessions and finalize them.
-
-    Returns the number of sessions recovered.
-    """
-    tmpfs = Path(tmpfs_path)
-    if not tmpfs.is_dir():
-        return 0
-
-    count = 0
-    current_boot_id = read_boot_id()
-    for trace_file in sorted(tmpfs.glob("autoskillit_trace_*.jsonl")):
-        # Skip files modified within the last 30 seconds — may be active
-        try:
-            age_seconds = time.time() - trace_file.stat().st_mtime
-        except OSError:
-            continue
-        if age_seconds < 30:
-            continue
-
-        # Extract PID from filename: autoskillit_trace_{pid}.jsonl
-        try:
-            pid = int(trace_file.stem.split("_")[-1])
-        except (ValueError, IndexError):
-            pid = -1
-
-        # Gate 1: Enrollment sidecar must exist — no sidecar means alien/test file
-        enrollment_path = tmpfs / f"autoskillit_enrollment_{pid}.json"
-        enrollment = read_enrollment(enrollment_path)
-        if enrollment is None:
-            logger.debug("Skipping %s: no enrollment sidecar", trace_file.name)
-            continue
-
-        # Gate 2: Boot ID must match current boot — mismatch means pre-reboot stale file
-        if current_boot_id and enrollment.boot_id and enrollment.boot_id != current_boot_id:
-            logger.debug("Skipping %s: boot_id mismatch", trace_file.name)
-            trace_file.unlink(missing_ok=True)
-            enrollment_path.unlink(missing_ok=True)
-            continue
-
-        # Gate 3: PID liveness + starttime_ticks identity
-        if psutil.pid_exists(pid):
-            current_ticks = read_starttime_ticks(pid)
-            if current_ticks is not None and current_ticks == enrollment.starttime_ticks:
-                logger.debug("Skipping %s: PID %d still alive", trace_file.name, pid)
-                continue
-            # PID recycled — original process is gone, treat as crash
-
-        # All gates passed — read snapshots and emit crashed row
-        snapshots: list[dict[str, object]] = []
-        try:
-            for line in trace_file.read_text().splitlines():
-                try:
-                    snapshots.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-        except OSError:
-            continue
-
-        # Gate 4: comm-based alien file rejection (issue #806 immunity)
-        # Use enrollment.comm as the expected comm (schema_version=2 records carry the
-        # enrolled binary name). Pre-fix schema_version=1 records have comm="" — skip
-        # the check for those to preserve recovery of legitimate crash data.
-        _is_alien = False
-        expected_comm = enrollment.comm
-        if snapshots and expected_comm:
-            first_comm = snapshots[0].get("comm", "")
-            if first_comm and isinstance(first_comm, str) and first_comm != expected_comm:
-                logger.debug(
-                    "Skipping %s: alien comm '%s' (expected '%s')",
-                    trace_file.name,
-                    first_comm,
-                    expected_comm,
-                )
-                _is_alien = True
-        if _is_alien:
-            # Delete the alien trace — don't leave it to confuse future recovery runs
-            trace_file.unlink(missing_ok=True)
-            enrollment_path.unlink(missing_ok=True)
-            continue
-
-        # Compute start_ts from file mtime
-        try:
-            mtime_ts = datetime.fromtimestamp(trace_file.stat().st_mtime, tz=UTC).isoformat()
-        except OSError:
-            continue
-
-        try:
-            from autoskillit.core import ProviderOutcome, RecipeIdentity, SessionTelemetry
-
-            flush_session_log(
-                log_dir=log_dir,
-                cwd="",
-                session_id=f"crashed_{pid}_{mtime_ts.replace(':', '-')}",
-                pid=pid,
-                skill_command="",
-                success=False,
-                subtype="crashed",
-                exit_code=-1,
-                start_ts=mtime_ts,
-                proc_snapshots=snapshots if snapshots else None,
-                termination_reason="CRASHED",
-                provider_outcome=ProviderOutcome.none_used(),
-                recipe_identity=RecipeIdentity.empty(),
-                telemetry=SessionTelemetry.empty(),
-            )
-        except Exception:
-            logger.debug(
-                "recover_crashed_sessions: failed to finalize %s", trace_file, exc_info=True
-            )
-            continue
-
-        trace_file.unlink(missing_ok=True)
-        enrollment_path.unlink(missing_ok=True)
-
-        count += 1
-
-    return count

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -141,7 +141,7 @@ _STRENUM_SRC_COMPARE_EXEMPT_PATHS: frozenset[str] = frozenset(
         "execution/process/_process_monitor.py",  # psutil Connection.status: plain str
         "fleet/_api.py",  # L3ParseResult.outcome: Literal[...], not SessionOutcome
         "fleet/_checkpoint_bridge.py",  # IssueSidecarEntry.status: Literal[...], not StrEnum
-        "fleet/_outcome.py",  # classify_dispatch_outcome: L3ParseResult.outcome Literal comparisons
+        "fleet/_outcome.py",  # classify_dispatch_outcome: Literal comparisons
     }
 )
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -316,7 +316,8 @@ def test_skill_tools_defined_in_types():
     """SKILL_TOOLS must be a top-level assignment in _type_constants_registries.py."""
     tree = _get_module_ast("core/types/_type_constants_registries.py")
     assert "SKILL_TOOLS" in _top_level_assign_targets(tree), (
-        "SKILL_TOOLS not found in core/types/_type_constants_registries.py; it must be defined there"
+        "SKILL_TOOLS not found in core/types/_type_constants_registries.py;"
+        " it must be defined there"
     )
 
 

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -94,6 +94,7 @@ class TestExecutionSubpackages:
 
     def test_headless_has_expected_modules(self):
         expected = {
+            "_headless_evidence",
             "_headless_git",
             "_headless_path_tokens",
             "_headless_recovery",

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -109,6 +109,8 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_write_evidence_invariants.py` | Write-evidence invariants: 'no work done' retry reasons must be overridden by write evidence |
 | `test_zero_write_detection.py` | Contract: sessions expected to write must actually write (behavioral write-count gate) |
 
+| `test_session_log_recovery_split_integrity.py` | Split integrity tests for `_session_log_recovery` module |
+
 ## Architecture Notes
 
 `conftest.py` provides shared fixtures for the execution test suite. The headless tests are split across multiple files by concern (dispatch, synthesis, path validation, env injection, ordering) following the P1-F01 audit fix.

--- a/tests/execution/backends/test_backends_split_integrity.py
+++ b/tests/execution/backends/test_backends_split_integrity.py
@@ -1,0 +1,84 @@
+"""Split integrity tests for execution/backends/ split.
+
+Verifies that new modules are importable and the public API surface is preserved.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestClaudePromptModuleExists:
+    """Symbols moved to _claude_prompt are importable from there."""
+
+    def test__ensure_skill_prefix_importable(self):
+        from autoskillit.execution.backends._claude_prompt import _ensure_skill_prefix
+
+        assert callable(_ensure_skill_prefix)
+
+    def test__inject_completion_directive_importable(self):
+        from autoskillit.execution.backends._claude_prompt import _inject_completion_directive
+
+        assert callable(_inject_completion_directive)
+
+    def test__MAX_MCP_OUTPUT_TOKENS_VALUE_importable(self):
+        from autoskillit.execution.backends._claude_prompt import _MAX_MCP_OUTPUT_TOKENS_VALUE
+
+        assert _MAX_MCP_OUTPUT_TOKENS_VALUE == "50000"
+
+
+class TestCodexConfigModuleExists:
+    """Symbols moved to _codex_config are importable from there."""
+
+    def test__ensure_codex_mcp_registered_importable(self):
+        from autoskillit.execution.backends._codex_config import ensure_codex_mcp_registered
+
+        assert callable(ensure_codex_mcp_registered)
+
+    def test__serialize_toml_importable(self):
+        from autoskillit.execution.backends._codex_config import _serialize_toml
+
+        assert callable(_serialize_toml)
+
+
+class TestCodexParseModuleExists:
+    """Symbols moved to _codex_parse are importable from there."""
+
+    def test__CodexStreamParser_importable(self):
+        from autoskillit.execution.backends._codex_parse import CodexStreamParser
+
+        assert CodexStreamParser is not None
+
+    def test__CodexResultParser_importable(self):
+        from autoskillit.execution.backends._codex_parse import CodexResultParser
+
+        assert CodexResultParser is not None
+
+    def test__scan_codex_ndjson_importable(self):
+        from autoskillit.execution.backends._codex_parse import _scan_codex_ndjson
+
+        assert callable(_scan_codex_ndjson)
+
+
+class TestBackendsPublicAPISurfacePreserved:
+    """All __all__ symbols from backends/__init__ are importable."""
+
+    def test_claude_backend_importable(self):
+        from autoskillit.execution.backends import ClaudeCodeBackend
+
+        assert ClaudeCodeBackend is not None
+
+    def test_codex_backend_importable(self):
+        from autoskillit.execution.backends import CodexBackend
+
+        assert CodexBackend is not None
+
+    def test_ensure_codex_mcp_registered_importable(self):
+        from autoskillit.execution.backends import ensure_codex_mcp_registered
+
+        assert callable(ensure_codex_mcp_registered)
+
+    def test_get_backend_importable(self):
+        from autoskillit.execution.backends import get_backend
+
+        assert callable(get_backend)

--- a/tests/execution/backends/test_claude_result_parser.py
+++ b/tests/execution/backends/test_claude_result_parser.py
@@ -242,7 +242,7 @@ class TestClaudeResultParser:
             assert set(result.raw["seen_block_types"]) == {"text", "thinking"}
 
     def test_extract_write_artifacts_filters_correctly(self) -> None:
-        from autoskillit.execution.backends.claude import _extract_write_artifacts
+        from autoskillit.execution.backends._claude_prompt import _extract_write_artifacts
 
         tool_uses = [
             {"name": "Write", "id": "1", "file_path": "/a.py"},
@@ -258,7 +258,7 @@ class TestClaudeResultParser:
         assert _extract_write_artifacts(tool_uses) == ["/a.py", "/b.py"]
 
     def test_extract_write_artifacts_empty_list(self) -> None:
-        from autoskillit.execution.backends.claude import _extract_write_artifacts
+        from autoskillit.execution.backends._claude_prompt import _extract_write_artifacts
 
         assert _extract_write_artifacts([]) == []
 

--- a/tests/execution/backends/test_codex_config.py
+++ b/tests/execution/backends/test_codex_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.execution.backends import ensure_codex_mcp_registered
-from autoskillit.execution.backends.codex import (
+from autoskillit.execution.backends._codex_config import (
     _is_autoskillit_registered,
     _read_codex_config,
     _serialize_toml,

--- a/tests/execution/backends/test_codex_fixtures.py
+++ b/tests/execution/backends/test_codex_fixtures.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-from autoskillit.execution.backends.codex import _scan_codex_ndjson
+from autoskillit.execution.backends._codex_parse import _scan_codex_ndjson
 from autoskillit.execution.process import _marker_is_standalone
 from tests.fixtures.codex import (
     CODEX_SCHEMA_VERSION,

--- a/tests/execution/backends/test_codex_mcp_registration.py
+++ b/tests/execution/backends/test_codex_mcp_registration.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.execution.backends.codex import ensure_codex_mcp_registered
+from autoskillit.execution.backends._codex_config import ensure_codex_mcp_registered
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 

--- a/tests/execution/backends/test_codex_result_parser.py
+++ b/tests/execution/backends/test_codex_result_parser.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 import pytest
 
 from autoskillit.core import BackendEventKind, CodexEventData, ResultParser, SessionEvent
-from autoskillit.execution.backends.codex import (
+from autoskillit.execution.backends._codex_parse import (
     CodexResultParser,
     CodexStreamParser,
     _scan_codex_ndjson,

--- a/tests/execution/backends/test_codex_stream_parser.py
+++ b/tests/execution/backends/test_codex_stream_parser.py
@@ -10,7 +10,7 @@ from autoskillit.core import (
     CodexEventData,
     StreamParser,
 )
-from autoskillit.execution.backends.codex import CodexStreamParser
+from autoskillit.execution.backends._codex_parse import CodexStreamParser
 from tests.fixtures.codex import (
     HAPPY_PATH_SINGLE_TURN,
     MULTI_TURN_WITH_COMPACTION,

--- a/tests/execution/headless/test_headless_evidence_split_integrity.py
+++ b/tests/execution/headless/test_headless_evidence_split_integrity.py
@@ -1,0 +1,32 @@
+"""Split integrity tests for execution/headless/ _headless_evidence split.
+
+Verifies that symbols moved to _headless_evidence are importable.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestHeadlessEvidenceModuleExists:
+    """Symbols moved to _headless_evidence are importable from there."""
+
+    def test__adapt_agent_result_importable(self):
+        from autoskillit.execution.headless._headless_evidence import _adapt_agent_result
+
+        assert callable(_adapt_agent_result)
+
+    def test__compute_write_evidence_importable(self):
+        from autoskillit.execution.headless._headless_evidence import _compute_write_evidence
+
+        assert callable(_compute_write_evidence)
+
+    def test__build_session_telemetry_importable(self):
+        from autoskillit.execution.headless._headless_evidence import _build_session_telemetry
+
+        assert callable(_build_session_telemetry)
+
+    def test__capture_failure_importable(self):
+        from autoskillit.execution.headless._headless_evidence import _capture_failure
+
+        assert callable(_capture_failure)

--- a/tests/execution/test_adapt_agent_result.py
+++ b/tests/execution/test_adapt_agent_result.py
@@ -13,7 +13,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
-from autoskillit.execution.headless._headless_result import _adapt_agent_result
+from autoskillit.execution.headless._headless_evidence import _adapt_agent_result
 from autoskillit.execution.session._exit_classification import classify_infra_exit
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -2170,7 +2170,7 @@ class TestBuildSkillResultTokenUsage:
 
 
 class TestFailureCaptureInBuildSkillResult:
-    """_build_skill_result(backend=ClaudeCodeBackend()) must capture failures into tool_ctx.audit."""
+    """_build_skill_result(backend=ClaudeCodeBackend()) captures failures into audit."""
 
     def test_captures_non_zero_exit_code(self, tool_ctx):
         result = _make_result(

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -28,7 +28,7 @@ from autoskillit.execution.headless import (
     _parse_stdout,
     _synthesize_from_write_artifacts,
 )
-from autoskillit.execution.headless._headless_result import (
+from autoskillit.execution.headless._headless_evidence import (
     _adapt_agent_result,
     _compute_write_evidence,
 )
@@ -1191,7 +1191,7 @@ class TestNormalApiRetry:
 class TestExtractFileChanges:
     def test_extract_file_changes_returns_empty_for_claude_backend(self) -> None:
         from autoskillit.execution.backends.claude import ClaudeCodeBackend
-        from autoskillit.execution.headless._headless_result import _extract_file_changes
+        from autoskillit.execution.headless._headless_evidence import _extract_file_changes
 
         assert _extract_file_changes("", ClaudeCodeBackend()) == []
 
@@ -1199,7 +1199,7 @@ class TestExtractFileChanges:
         import json as _json
 
         from autoskillit.execution.backends.codex import CodexBackend
-        from autoskillit.execution.headless._headless_result import _extract_file_changes
+        from autoskillit.execution.headless._headless_evidence import _extract_file_changes
 
         lines = [
             _json.dumps(

--- a/tests/execution/test_session_log_recovery_split_integrity.py
+++ b/tests/execution/test_session_log_recovery_split_integrity.py
@@ -1,0 +1,37 @@
+"""Split integrity tests for execution/ _session_log_recovery split.
+
+Verifies that symbols moved to _session_log_recovery are importable and
+execution gateway still exports all session_log symbols.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestSessionLogRecoveryModuleExists:
+    """Symbols moved to _session_log_recovery are importable from there."""
+
+    def test__recover_crashed_sessions_importable(self):
+        from autoskillit.execution._session_log_recovery import recover_crashed_sessions
+
+        assert callable(recover_crashed_sessions)
+
+
+class TestExecutionGatewayPreserved:
+    """execution/ gateway still exports all session_log symbols."""
+
+    def test_flush_session_log_importable(self):
+        from autoskillit.execution import flush_session_log
+
+        assert flush_session_log is not None
+
+    def test_recover_crashed_sessions_importable(self):
+        from autoskillit.execution import recover_crashed_sessions
+
+        assert callable(recover_crashed_sessions)
+
+    def test_resolve_log_dir_importable(self):
+        from autoskillit.execution import resolve_log_dir
+
+        assert callable(resolve_log_dir)

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -16,11 +16,9 @@ from autoskillit.core.types._type_results_execution import (
     RecipeIdentity,
     SessionTelemetry,
 )
+from autoskillit.execution._session_log_recovery import recover_crashed_sessions
 from autoskillit.execution.linux_tracing import read_boot_id, read_starttime_ticks
-from autoskillit.execution.session_log import (
-    flush_session_log,
-    recover_crashed_sessions,
-)
+from autoskillit.execution.session_log import flush_session_log
 from autoskillit.fleet import build_protected_campaign_ids
 from tests.execution.conftest import _flush, _snap
 
@@ -274,7 +272,7 @@ def test_recover_crashed_sessions_skips_file_without_enrollment(tmp_path):
 def test_recover_crashed_sessions_skips_wrong_boot_id(tmp_path, monkeypatch):
     """An enrollment sidecar with a different boot_id must be rejected."""
     monkeypatch.setattr(
-        "autoskillit.execution.session_log.read_boot_id",
+        "autoskillit.execution._session_log_recovery.read_boot_id",
         lambda: "current-boot-id",
     )
     tmpfs = tmp_path / "shm"

--- a/tests/fleet/test_food_truck_prompt.py
+++ b/tests/fleet/test_food_truck_prompt.py
@@ -131,7 +131,7 @@ def test_food_truck_prompt_injects_caller_instructions_section():
 
 
 def test_food_truck_prompt_no_caller_instructions_section_when_none():
-    """L3 food truck prompt must not include caller instructions section when caller_instructions is None."""
+    """Food truck prompt must omit caller instructions section when caller_instructions is None."""
     prompt = _build_food_truck_prompt(
         recipe="test-recipe",
         task="Test task",
@@ -145,7 +145,7 @@ def test_food_truck_prompt_no_caller_instructions_section_when_none():
 
 
 def test_food_truck_prompt_no_caller_instructions_section_when_empty():
-    """L3 food truck prompt must not include caller instructions section when caller_instructions is empty."""
+    """Food truck prompt omits CALLER INSTRUCTIONS when caller_instructions is empty."""
     prompt = _build_food_truck_prompt(
         recipe="test-recipe",
         task="Test task",

--- a/tests/hooks/test_planner_result_naming_guard.py
+++ b/tests/hooks/test_planner_result_naming_guard.py
@@ -278,9 +278,12 @@ def _run_write_guard(
     from autoskillit.hooks.guards.write_guard import main
 
     stdin_text = json.dumps(event) if isinstance(event, dict) else event
-    env_patch: dict[str, str] = {"AUTOSKILLIT_HEADLESS": "1"}
-    if allowed_prefix:
-        env_patch["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = allowed_prefix
+    env_patch: dict[str, str] = {
+        "AUTOSKILLIT_HEADLESS": "1",
+        # Explicitly set (or clear) the write prefix so ambient skill-session
+        # env vars do not interfere with tests that expect an unrestricted env.
+        "AUTOSKILLIT_ALLOWED_WRITE_PREFIX": allowed_prefix,
+    }
     if skill_name:
         env_patch["AUTOSKILLIT_SKILL_NAME"] = skill_name
     buf = io.StringIO()

--- a/tests/server/test_tools_dispatch_params.py
+++ b/tests/server/test_tools_dispatch_params.py
@@ -104,7 +104,7 @@ async def test_dispatch_food_truck_tool_passes_caller_instructions_into_prompt(
 async def test_dispatch_food_truck_no_caller_instructions_section_when_not_specified(
     tool_ctx_kitchen_open, monkeypatch
 ):
-    """When caller_instructions is not specified, no CALLER INSTRUCTIONS section appears in prompt."""
+    """When caller_instructions is absent, no CALLER INSTRUCTIONS section appears in prompt."""
     from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")


### PR DESCRIPTION
## Summary

Split 4 monolithic files in the `execution/` package area into focused sub-modules:

1. **`backends/claude.py`** (824→~590) → extract `_claude_prompt.py` (~260 lines): prompt injection utilities + session constants
2. **`backends/codex.py`** (755→~330) → extract `_codex_config.py` (~150 lines) + `_codex_parse.py` (~280 lines): TOML config + stream/result parsing
3. **`headless/_headless_result.py`** (861→~680) → extract `_headless_evidence.py` (~220 lines): evidence computation, audit, telemetry
4. **`session_log.py`** (728→~610) → extract `_session_log_recovery.py` (~140 lines): crash recovery scanner

Total: 4 files → 4 rumps + 5 new modules. Eliminates the `codex → claude` import coupling by giving prompt utilities a neutral home.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-031925-718743/.autoskillit/temp/make-plan/split_execution_package_4_files_plan_2026-05-24_033000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 94 | 44.2k | 2.3M | 138.2k | 261 | 123.1k | 23m 32s |
| verify | claude-opus-4-6 | 1 | 53 | 14.3k | 839.3k | 65.7k | 107 | 50.4k | 8m 0s |
| implement* | MiniMax-M2.7-highspeed | 1 | 13.4M | 74.5k | 4.1M | 35.0k | 309 | 28.6k | 25m 0s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 82.6k | 5.2k | 179.9k | 30.0k | 18 | 42.0k | 1m 28s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 108.6k | 1.9k | 356.9k | 30.0k | 27 | 14.8k | 1m 5s |
| review_pr | claude-sonnet-4-6 | 1 | 196 | 25.8k | 1.6M | 111.6k | 98 | 102.2k | 14m 52s |
| resolve_review | claude-opus-4-6 | 1 | 73 | 11.7k | 2.7M | 71.9k | 81 | 57.1k | 8m 14s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 99 | 16.3k | 5.4M | 85.1k | 140 | 70.2k | 10m 40s |
| **Total** | | | 13.6M | 193.7k | 17.5M | 138.2k | | 488.4k | 1h 32m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 1046 | 3955.0 | 27.4 | 71.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 1609 | 3376.7 | 43.6 | 10.1 |
| **Total** | **2655** | 6599.4 | 184.0 | 73.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 290 | 69.9k | 3.9M | 225.3k | 38m 25s |
| claude-opus-4-6 | 3 | 225 | 42.2k | 8.9M | 177.6k | 26m 55s |
| MiniMax-M2.7-highspeed | 3 | 13.6M | 81.6k | 4.7M | 85.5k | 27m 34s |