### PR TITLE
Implementation Plan: P1-A3-WP1 — Replace hardcoded ClaudeCodeBackend() with config-driven get_backend()

### DIFF
--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -7,10 +7,13 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from autoskillit.config import write_config_layer
 from autoskillit.core import YAMLError, atomic_write, dump_yaml_str, get_logger, load_yaml
+
+if TYPE_CHECKING:
+    from autoskillit.core import CodingAgentBackend
 
 logger = get_logger(__name__)
 
@@ -420,7 +423,9 @@ def _print_next_steps(*, context: str = "install") -> None:
         print(f"  {_D}{i}.{_R} {_G}{cmd}{_R}  {_D}{desc}{_R}")
 
 
-def _register_all(scope: str, project_dir: Path) -> None:
+def _register_all(
+    scope: str, project_dir: Path, *, backend: CodingAgentBackend | None = None
+) -> None:
     """Ensure project temp dir, register hooks and MCP server, print summary."""
     import autoskillit.core.paths as _core_paths
     from autoskillit.cli._hooks import (

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -181,8 +181,7 @@ def init(
         onboarded_marker.unlink(missing_ok=True)
 
     try:
-        from autoskillit.config import load_config
-        from autoskillit.config._config_dataclasses import ConfigSchemaError
+        from autoskillit.config import ConfigSchemaError, load_config
         from autoskillit.execution import get_backend
 
         try:

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -181,7 +181,11 @@ def init(
         onboarded_marker.unlink(missing_ok=True)
 
     try:
-        _register_all(scope, project_dir)
+        from autoskillit.config import load_config
+        from autoskillit.execution.backends import get_backend
+
+        _backend = get_backend(load_config(project_dir).agent_backend.backend)
+        _register_all(scope, project_dir, backend=_backend)
     except CliError as exc:
         print(f"\n  ERROR: {exc}")
         raise SystemExit(1) from None

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -182,9 +182,14 @@ def init(
 
     try:
         from autoskillit.config import load_config
-        from autoskillit.execution.backends import get_backend
+        from autoskillit.config._config_dataclasses import ConfigSchemaError
+        from autoskillit.execution import get_backend
 
-        _backend = get_backend(load_config(project_dir).agent_backend.backend)
+        try:
+            _backend_name = load_config(project_dir).agent_backend.backend
+        except ConfigSchemaError:
+            _backend_name = "claude-code"
+        _backend = get_backend(_backend_name)
         _register_all(scope, project_dir, backend=_backend)
     except CliError as exc:
         print(f"\n  ERROR: {exc}")

--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -8,9 +8,13 @@ import sys
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from autoskillit.cli.ui._terminal import terminal_guard
 from autoskillit.core import is_feature_enabled
+
+if TYPE_CHECKING:
+    from autoskillit.core import CodingAgentBackend
 
 
 def _print_recipes_list() -> None:
@@ -62,17 +66,24 @@ def _run_cook_session(
 
 
 def cook(
-    *, resume: bool = False, session_id: str | None = None, profile: str | None = None
+    *,
+    resume: bool = False,
+    session_id: str | None = None,
+    profile: str | None = None,
+    backend: CodingAgentBackend | None = None,
 ) -> None:
     """Launch Claude with all bundled AutoSkillit skills as slash commands."""
-    from autoskillit.execution import ClaudeCodeBackend
+    from autoskillit.config import iter_display_categories, load_config
+    from autoskillit.execution.backends import get_backend
     from autoskillit.workspace import (
         DefaultSessionSkillManager,
         SkillsDirectoryProvider,
         resolve_ephemeral_root,
     )
 
-    backend = ClaudeCodeBackend()
+    config = load_config()
+    if backend is None:
+        backend = get_backend(config.agent_backend.backend)
 
     if shutil.which(backend.binary_name()) is None:
         print(
@@ -91,10 +102,6 @@ def cook(
     _G = "\x1b[32m" if color else ""
     _Y = "\x1b[33m" if color else ""
     _R = "\x1b[0m" if color else ""
-
-    from autoskillit.config import iter_display_categories, load_config  # noqa: PLC0415
-
-    config = load_config()
 
     if profile is not None:
         if not is_feature_enabled(

--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -74,7 +74,7 @@ def cook(
 ) -> None:
     """Launch Claude with all bundled AutoSkillit skills as slash commands."""
     from autoskillit.config import iter_display_categories, load_config
-    from autoskillit.execution.backends import get_backend
+    from autoskillit.execution import get_backend
     from autoskillit.workspace import (
         DefaultSessionSkillManager,
         SkillsDirectoryProvider,

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from autoskillit.core import NamedResume, NoResume
 
 if TYPE_CHECKING:
-    from autoskillit.core import ResumeSpec
+    from autoskillit.core import CodingAgentBackend, ResumeSpec
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,6 +29,7 @@ def _run_interactive_session(
     resume_spec: ResumeSpec | None = None,
     project_dir: Path | None = None,
     required_env: frozenset[str] | None = None,
+    backend: CodingAgentBackend | None = None,
 ) -> str | _InfraExitSignal | None:
     """Launch an interactive Claude Code session.
 
@@ -37,9 +38,13 @@ def _run_interactive_session(
         _InfraExitSignal — when an infrastructure exit is detected
         None — clean exit
     """
-    from autoskillit.execution import ClaudeCodeBackend, read_session_state
+    from autoskillit.execution import read_session_state
 
-    backend = ClaudeCodeBackend()
+    if backend is None:
+        from autoskillit.config import load_config
+        from autoskillit.execution.backends import get_backend
+
+        backend = get_backend(load_config().agent_backend.backend)
     if shutil.which(backend.binary_name()) is None:
         print(
             f"ERROR: '{backend.binary_name()}' not found. "

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -42,7 +42,7 @@ def _run_interactive_session(
 
     if backend is None:
         from autoskillit.config import load_config
-        from autoskillit.execution.backends import get_backend
+        from autoskillit.execution import get_backend
 
         backend = get_backend(load_config().agent_backend.backend)
     if shutil.which(backend.binary_name()) is None:

--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -88,6 +88,8 @@ class CodingAgentBackend(Protocol):
 
     def write_tool_names(self) -> frozenset[str]: ...
 
+    def binary_name(self) -> str: ...
+
     def build_resume_cmd(
         self,
         *,

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -196,7 +196,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_resume": frozenset({"core", "cli", "execution", "fleet"}),
     "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
     "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "workspace"}),
-    "_type_protocols_backend": frozenset({"core", "execution", "pipeline"}),
+    "_type_protocols_backend": frozenset({"cli", "core", "execution", "pipeline"}),
     "_install_detect": frozenset({"core", "cli", "config"}),
     "_linux_proc": frozenset({"core", "execution", "fleet", "cli"}),
     "_type_plugin_source": frozenset({"core", "execution", "pipeline", "server", "cli"}),

--- a/tests/cli/test_cook_features.py
+++ b/tests/cli/test_cook_features.py
@@ -35,6 +35,7 @@ class TestOrderSubsetGate:
     def _make_config_mock(self, disabled: list[str]) -> MagicMock:
         mock_cfg = MagicMock()
         mock_cfg.subsets.disabled = disabled
+        mock_cfg.agent_backend.backend = "claude-code"
         return mock_cfg
 
     def test_order_hard_error_non_interactive_on_disabled_subset(

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -743,7 +743,7 @@ class TestCookInteractive:
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
             patch("autoskillit.core.write_registry_entry"),
             patch(
-                "autoskillit.execution.backends.get_backend",
+                "autoskillit.execution.get_backend",
                 side_effect=lambda name: get_backend_called.append(name),
             ),
         ):
@@ -789,7 +789,7 @@ class TestCookInteractive:
             patch("autoskillit.core.write_registry_entry"),
             patch("autoskillit.config.load_config", return_value=mock_config),
             patch(
-                "autoskillit.execution.backends.get_backend",
+                "autoskillit.execution.get_backend",
                 side_effect=lambda name: (get_backend_called.append(name), _FakeBackend())[1],
             ),
         ):

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -701,12 +701,11 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.ClaudeCodeBackend", _CapturingBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
 
-            module.cook()
+            module.cook(backend=_CapturingBackend())
 
         assert len(captured_kwargs) == 1, "build_interactive_cmd must have been called"
         call_kwargs = captured_kwargs[0]
@@ -715,3 +714,91 @@ class TestCookInteractive:
         assert "initial_prompt" in call_kwargs
         assert "resume_spec" in call_kwargs
         assert "env_extras" in call_kwargs
+
+    def test_cook_uses_injected_backend(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When backend= is passed, cook() uses it directly without calling get_backend()."""
+        from unittest.mock import MagicMock, patch
+
+        from autoskillit.core import CmdSpec
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_skills_dir.mkdir()
+        mock_mgr = MagicMock()
+        mock_mgr.init_session.return_value = fake_skills_dir
+        build_called: list[dict] = []
+
+        class _InjectedBackend:
+            def binary_name(self) -> str:
+                return "claude"
+
+            def build_interactive_cmd(self, **kwargs):
+                build_called.append(kwargs)
+                return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+        get_backend_called: list = []
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("builtins.input", return_value=""),
+            patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("autoskillit.core.write_registry_entry"),
+            patch(
+                "autoskillit.execution.backends.get_backend",
+                side_effect=lambda name: get_backend_called.append(name),
+            ),
+        ):
+            import autoskillit.cli.session._cook as module
+
+            module.cook(backend=_InjectedBackend())
+
+        assert build_called, "Injected backend's build_interactive_cmd must be called"
+        assert not get_backend_called, "get_backend must NOT be called when backend is injected"
+
+    def test_cook_default_backend_calls_get_backend(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When backend= is not passed, cook() calls get_backend() with the config backend name."""
+        from unittest.mock import MagicMock, patch
+
+        from autoskillit.core import CmdSpec
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_skills_dir.mkdir()
+        mock_mgr = MagicMock()
+        mock_mgr.init_session.return_value = fake_skills_dir
+        get_backend_called: list = []
+
+        class _FakeBackend:
+            def binary_name(self) -> str:
+                return "claude"
+
+            def build_interactive_cmd(self, **kwargs):
+                return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = "claude-code"
+        mock_config.features = {}
+        mock_config.experimental_enabled = False
+        mock_config.providers.profiles = {}
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("builtins.input", return_value=""),
+            patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("autoskillit.core.write_registry_entry"),
+            patch("autoskillit.config.load_config", return_value=mock_config),
+            patch(
+                "autoskillit.execution.backends.get_backend",
+                side_effect=lambda name: (get_backend_called.append(name), _FakeBackend())[1],
+            ),
+        ):
+            import autoskillit.cli.session._cook as module
+
+            module.cook()
+
+        assert get_backend_called, "get_backend must be called when backend is not injected"
+        assert get_backend_called[0] == "claude-code"

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -587,12 +587,11 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.ClaudeCodeBackend", _MockBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
 
-            module.cook()
+            module.cook(backend=_MockBackend())
 
         assert captured_env_extras, "build_interactive_cmd must have been called"
         env_extras = captured_env_extras[0]
@@ -625,12 +624,11 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.ClaudeCodeBackend", _MockBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
 
-            module.cook()
+            module.cook(backend=_MockBackend())
 
         assert captured_env_extras, "build_interactive_cmd must have been called"
         assert "AUTOSKILLIT_LAUNCH_ID" in captured_env_extras[0]
@@ -665,12 +663,11 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
-            patch("autoskillit.execution.ClaudeCodeBackend", _CustomBackend),
             patch("autoskillit.core.write_registry_entry"),
         ):
             import autoskillit.cli.session._cook as module
 
-            module.cook()
+            module.cook(backend=_CustomBackend())
 
         assert "my-test-claude" in captured_which
 

--- a/tests/cli/test_cook_profile.py
+++ b/tests/cli/test_cook_profile.py
@@ -38,7 +38,6 @@ def _run_cook(profile, cfg, mock_mgr):
         patch("builtins.input", return_value=""),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
         patch("subprocess.run", return_value=MagicMock(returncode=0)),
-        patch("autoskillit.execution.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.core.write_registry_entry"),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch(
@@ -47,7 +46,7 @@ def _run_cook(profile, cfg, mock_mgr):
         ),
         patch("autoskillit.cli.ui._timed_input.timed_prompt", return_value=""),
     ):
-        cook_module.cook(profile=profile)
+        cook_module.cook(profile=profile, backend=mock_backend_cls())
     return captured
 
 
@@ -96,12 +95,11 @@ def test_profile_feature_disabled_exits(capsys, _mock_mgr):
     with (
         patch("shutil.which", return_value="/usr/bin/claude"),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=_mock_mgr),
-        patch("autoskillit.execution.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch("autoskillit.cli.session._cook.is_feature_enabled", return_value=False),
     ):
         with pytest.raises(SystemExit) as exc_info:
-            cook_module.cook(profile="minimax")
+            cook_module.cook(profile="minimax", backend=mock_backend_cls())
     assert exc_info.value.code == 1
     assert "providers" in capsys.readouterr().err
 
@@ -115,12 +113,11 @@ def test_profile_unknown_exits(capsys, _mock_mgr):
     with (
         patch("shutil.which", return_value="/usr/bin/claude"),
         patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=_mock_mgr),
-        patch("autoskillit.execution.ClaudeCodeBackend", mock_backend_cls),
         patch("autoskillit.config.load_config", return_value=cfg),
         patch("autoskillit.cli.session._cook.is_feature_enabled", return_value=True),
     ):
         with pytest.raises(SystemExit) as exc_info:
-            cook_module.cook(profile="minimax")
+            cook_module.cook(profile="minimax", backend=mock_backend_cls())
     assert exc_info.value.code == 1
     err = capsys.readouterr().err
     assert "minimax" in err

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -91,10 +91,18 @@ def test_fleet_dispatch_exits_when_claude_missing(
     monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
     monkeypatch.setattr("autoskillit.cli.fleet.is_feature_enabled", lambda *a, **kw: True)
     _fleet = type("Fleet", (), {"max_issues_per_food_truck": 3})()
+    _agent_backend = type("AB", (), {"backend": "claude-code"})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",
-        lambda path: type(
-            "C", (), {"features": {}, "experimental_enabled": False, "fleet": _fleet}
+        lambda path=None: type(
+            "C",
+            (),
+            {
+                "features": {},
+                "experimental_enabled": False,
+                "fleet": _fleet,
+                "agent_backend": _agent_backend,
+            },
         )(),
     )
     _stub_list_recipes(monkeypatch, [])
@@ -151,10 +159,18 @@ def test_fleet_dispatch_proceeds_when_enabled(
         lambda name, features, *, experimental_enabled=False: True,
     )
     _fleet = type("Fleet", (), {"max_issues_per_food_truck": 3})()
+    _agent_backend = type("AB", (), {"backend": "claude-code"})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",
-        lambda path: type(
-            "C", (), {"features": {}, "experimental_enabled": False, "fleet": _fleet}
+        lambda path=None: type(
+            "C",
+            (),
+            {
+                "features": {},
+                "experimental_enabled": False,
+                "fleet": _fleet,
+                "agent_backend": _agent_backend,
+            },
         )(),
     )
     _stub_list_recipes(monkeypatch, [])

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -93,41 +93,27 @@ class TestInitBackendResolution:
         mock_config = MagicMock()
         mock_config.agent_backend.backend = "claude-code"
 
-        # Create minimal project structure
+        # Create minimal project structure with an existing config so init skips prompting
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         config_dir = project_dir / ".autoskillit"
         config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("test_check:\n  command: [pytest]\n")
 
-        # Patch gate to accept bypass
-        import autoskillit.cli._init_helpers as init_helpers_mod
-
-        monkeypatch.setattr(
-            init_helpers_mod,
-            "_check_secret_scanning",
-            lambda p: MagicMock(passed=True, bypass_accepted=False),
-        )
-
-        # Patch _register_all to avoid actual file operations
-        register_called_with: dict = {}
-
-        def fake_register_all(scope, proj_dir, *, backend=None):
-            register_called_with["scope"] = scope
-            register_called_with["backend"] = backend
+        monkeypatch.chdir(project_dir)
 
         with (
+            patch(
+                "autoskillit.cli.app._check_secret_scanning",
+                lambda p: MagicMock(passed=True, bypass_accepted=False),
+            ),
             patch("autoskillit.config.load_config", return_value=mock_config),
-            patch("autoskillit.execution.backends.get_backend", side_effect=fake_get_backend),
-            patch("autoskillit.cli._init_helpers._register_all", side_effect=fake_register_all),
+            patch("autoskillit.execution.get_backend", side_effect=fake_get_backend),
+            patch("autoskillit.cli.app._register_all", side_effect=lambda *a, **kw: None),
         ):
-            # init() uses click — invoke it directly
-            from click.testing import CliRunner
-
             from autoskillit.cli.app import init
 
-            runner = CliRunner()
-            runner.invoke(init, ["--scope", "user"], input="n\n", catch_exceptions=False, obj={})
-            # Command may exit early; get_backend call is what matters
+            init(scope="user", force=False)
 
         assert get_backend_calls, "get_backend must have been called"
         assert get_backend_calls[0] == "claude-code"

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -29,3 +30,104 @@ class TestIsPluginInstalledBackendGuard:
         result = _is_plugin_installed(agent_backend="claude-code")
         assert result is True
         assert len(called) == 1
+
+
+class TestRegisterAllBackendKwarg:
+    """_register_all accepts backend keyword argument."""
+
+    def test_register_all_accepts_backend_kwarg(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """_register_all() accepts backend keyword argument without raising TypeError."""
+        from unittest.mock import MagicMock
+
+        import autoskillit.cli._hooks as _hooks_mod
+        import autoskillit.core.paths as _core_paths
+        from autoskillit.cli._init_helpers import _register_all
+
+        # Patch at source modules — _register_all uses lazy `from ... import` so
+        # patching on _init_helpers would not intercept the local bindings.
+        monkeypatch.setattr(_hooks_mod, "sweep_all_scopes_for_orphans", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "sync_hooks_to_settings", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "_evict_stale_autoskillit_hooks", lambda p: None)
+        monkeypatch.setattr(
+            _hooks_mod, "_claude_settings_path", lambda s: tmp_path / "settings.json"
+        )
+        monkeypatch.setattr(_core_paths, "pkg_root", lambda: tmp_path / "pkg")
+        # _is_plugin_installed and is_git_worktree are already auto-patched by conftest.py
+        monkeypatch.setattr("autoskillit.cli._init_helpers._register_mcp_server", lambda p: None)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._user_claude_json_path",
+            lambda: tmp_path / ".claude.json",
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._create_secrets_template", lambda p: None
+        )
+        monkeypatch.setattr("autoskillit.cli._init_helpers._prompt_github_repo", lambda: None)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers.evict_direct_mcp_entry", lambda p: False
+        )
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        monkeypatch.setattr("autoskillit.core.ensure_project_temp", lambda p: tmp_path / "temp")
+        (tmp_path / "pkg").mkdir()
+
+        # Should not raise TypeError
+        _register_all("user", tmp_path, backend=MagicMock())
+
+
+class TestInitBackendResolution:
+    """Init command resolves backend via get_backend()."""
+
+    def test_init_resolves_backend_via_get_backend(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """init command calls get_backend with config.agent_backend.backend value."""
+        from unittest.mock import MagicMock, patch
+
+        get_backend_calls: list = []
+
+        def fake_get_backend(name: str):
+            get_backend_calls.append(name)
+            return MagicMock()
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = "claude-code"
+
+        # Create minimal project structure
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        config_dir = project_dir / ".autoskillit"
+        config_dir.mkdir()
+
+        # Patch gate to accept bypass
+        import autoskillit.cli._init_helpers as init_helpers_mod
+
+        monkeypatch.setattr(
+            init_helpers_mod,
+            "_check_secret_scanning",
+            lambda p: MagicMock(passed=True, bypass_accepted=False),
+        )
+
+        # Patch _register_all to avoid actual file operations
+        register_called_with: dict = {}
+
+        def fake_register_all(scope, proj_dir, *, backend=None):
+            register_called_with["scope"] = scope
+            register_called_with["backend"] = backend
+
+        with (
+            patch("autoskillit.config.load_config", return_value=mock_config),
+            patch("autoskillit.execution.backends.get_backend", side_effect=fake_get_backend),
+            patch("autoskillit.cli._init_helpers._register_all", side_effect=fake_register_all),
+        ):
+            # init() uses click — invoke it directly
+            from click.testing import CliRunner
+
+            from autoskillit.cli.app import init
+
+            runner = CliRunner()
+            runner.invoke(init, ["--scope", "user"], input="n\n", catch_exceptions=False, obj={})
+            # Command may exit early; get_backend call is what matters
+
+        assert get_backend_calls, "get_backend must have been called"
+        assert get_backend_calls[0] == "claude-code"

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -144,7 +144,6 @@ def test_cook_reload_loop_uses_named_resume(
     monkeypatch.setattr("builtins.input", lambda _prompt="": "")
     monkeypatch.setattr("autoskillit.cli._onboarding.is_first_run", lambda _: False)
     monkeypatch.setattr("autoskillit.cli.session._cook._run_cook_session", fake_run_cook_session)
-    monkeypatch.setattr("autoskillit.execution.ClaudeCodeBackend", _MockBackend)
 
     from autoskillit.workspace.session_skills import DefaultSessionSkillManager
 
@@ -159,7 +158,7 @@ def test_cook_reload_loop_uses_named_resume(
     from autoskillit import cli
     from autoskillit.core import NamedResume
 
-    cli.cook()
+    cli.cook(backend=_MockBackend())
 
     assert run_count[0] == 2
     assert len(captured_resume_specs) == 2

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -353,7 +353,7 @@ def test_run_interactive_session_default_backend_calls_get_backend(
 
     _stub_plugin_installed(monkeypatch, installed=True)
     _capture_subprocess(monkeypatch)
-    monkeypatch.setattr("autoskillit.execution.backends.get_backend", fake_get_backend)
+    monkeypatch.setattr("autoskillit.execution.get_backend", fake_get_backend)
     _run_interactive_session(system_prompt="test")
     assert get_backend_called, "get_backend must be called when backend is not injected"
     assert get_backend_called[0] == "claude-code"

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -189,7 +189,7 @@ def test_run_interactive_session_appends_system_prompt_on_fresh_session(
 
 
 def test_skill_injection_disabled_omits_flags(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When skill_injection_capable=False, no plugin/tools flags injected by _run_interactive_session."""
+    """When skill_injection_capable=False, no plugin/tools flags are injected."""
     from autoskillit.core import BackendCapabilities, CmdSpec
 
     no_inject_caps = BackendCapabilities(
@@ -227,8 +227,7 @@ def test_skill_injection_disabled_omits_flags(monkeypatch: pytest.MonkeyPatch) -
         return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     monkeypatch.setattr(subprocess, "run", mock_run)
-    monkeypatch.setattr("autoskillit.execution.ClaudeCodeBackend", _NoInjectBackend)
-    _run_interactive_session(system_prompt="test")
+    _run_interactive_session(system_prompt="test", backend=_NoInjectBackend())
     assert ClaudeFlags.PLUGIN_DIR not in captured["cmd"]
     assert ClaudeFlags.TOOLS not in captured["cmd"]
     assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in captured["cmd"]
@@ -280,9 +279,81 @@ def test_binary_name_from_backend_used_in_which(monkeypatch: pytest.MonkeyPatch)
         return None
 
     monkeypatch.setattr(shutil, "which", tracking_which)
-    monkeypatch.setattr("autoskillit.execution.ClaudeCodeBackend", _CustomBinaryBackend)
     monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
     from autoskillit.cli.session._session_launch import _run_interactive_session
 
-    _run_interactive_session(system_prompt="test")
+    _run_interactive_session(system_prompt="test", backend=_CustomBinaryBackend())
     assert "test-agent-binary" in captured_which_arg
+
+
+def test_run_interactive_session_uses_injected_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When backend= is passed, _run_interactive_session uses it directly."""
+    from autoskillit.core import BackendCapabilities, CmdSpec
+
+    build_called: list[dict] = []
+
+    class _InjectedBackend:
+        def binary_name(self) -> str:
+            return "claude"
+
+        @property
+        def capabilities(self):
+            return BackendCapabilities(
+                channel_b_capable=True,
+                pty_required=True,
+                session_resume_capable=True,
+                skill_injection_capable=True,
+                supports_thinking_blocks=True,
+                supports_claude_format_stdout=True,
+                exit_code_is_terminal=False,
+                mcp_config_capable=False,
+                completion_record_types=frozenset({"result"}),
+                session_record_types=frozenset({"assistant"}),
+            )
+
+        def build_interactive_cmd(self, **kwargs):
+            build_called.append(kwargs)
+            return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+    _stub_plugin_installed(monkeypatch, installed=True)
+    _capture_subprocess(monkeypatch)
+    _run_interactive_session(system_prompt="test", backend=_InjectedBackend())
+    assert build_called, "Injected backend must be used"
+
+
+def test_run_interactive_session_default_backend_calls_get_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When backend= is not passed, _run_interactive_session calls get_backend()."""
+    from unittest.mock import MagicMock
+
+    get_backend_called: list = []
+
+    class _FakeBackend:
+        def binary_name(self) -> str:
+            return "claude"
+
+        @property
+        def capabilities(self):
+            return MagicMock(
+                skill_injection_capable=True,
+            )
+
+        def build_interactive_cmd(self, **kwargs):
+            from autoskillit.core import CmdSpec
+
+            return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+    mock_config = MagicMock()
+    mock_config.agent_backend.backend = "claude-code"
+
+    def fake_get_backend(name: str):
+        get_backend_called.append(name)
+        return _FakeBackend()
+
+    _stub_plugin_installed(monkeypatch, installed=True)
+    _capture_subprocess(monkeypatch)
+    monkeypatch.setattr("autoskillit.execution.backends.get_backend", fake_get_backend)
+    _run_interactive_session(system_prompt="test")
+    assert get_backend_called, "get_backend must be called when backend is not injected"
+    assert get_backend_called[0] == "claude-code"

--- a/tests/core/test_backend_protocols.py
+++ b/tests/core/test_backend_protocols.py
@@ -97,6 +97,8 @@ def test_stub_class_satisfies_coding_agent_backend():
 
         def write_tool_names(self) -> frozenset[str]: ...
 
+        def binary_name(self) -> str: ...
+
         def build_resume_cmd(
             self,
             *,

--- a/tests/hooks/test_quota_post_check.py
+++ b/tests/hooks/test_quota_post_check.py
@@ -99,6 +99,20 @@ def _run_hook(
     return buf.getvalue(), exit_code
 
 
+@pytest.fixture(autouse=True)
+def _clear_session_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate quota tests from orchestrator env vars that alter hook control flow.
+
+    AUTOSKILLIT_SESSION_DEADLINE: when expired, triggers budget_exceeded path
+    (QUOTA BUDGET EXCEEDED) instead of the normal QUOTA WARNING path.
+    AUTOSKILLIT_PROVIDER_PROFILE: when non-anthropic, triggers provider bypass
+    exit before quota check, producing empty output instead of warning JSON.
+    Tests that need a specific profile set it explicitly via monkeypatch.setenv.
+    """
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_DEADLINE", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_PROVIDER_PROFILE", raising=False)
+
+
 # T1: PostToolUse quota warning emitted when over threshold
 def test_qpc1_emits_warning_when_over_threshold(tmp_path):
     """PostToolUse hook emits updatedMCPToolOutput with quota warning."""

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,9 +127,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 379),
+    ("src/autoskillit/cli/_init_helpers.py", 382),
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 398),
+    ("src/autoskillit/cli/_init_helpers.py", 401),
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_installed_plugins.py", 71),
     # _marketplace.py — marketplace.json (co-owned)

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -167,7 +167,7 @@ class TestModuleCascadeCore:
 
     def test_type_protocols_backend_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_protocols_backend"] == frozenset(
-            {"core", "execution", "pipeline"}
+            {"core", "execution", "pipeline", "cli"}
         )
 
     def test_json_cascade(self) -> None:
@@ -518,7 +518,7 @@ class TestBuildTestScopeCoreCascade:
             assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
     def test_type_protocols_backend_narrow_cascade(self, tmp_path: Path) -> None:
-        """_type_protocols_backend -> cascade of {"core", "execution", "pipeline"} only."""
+        """_type_protocols_backend -> cascade of {"core", "execution", "pipeline", "cli"} only."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         result = build_test_scope(
             changed_files={"src/autoskillit/core/types/_type_protocols_backend.py"},
@@ -527,9 +527,9 @@ class TestBuildTestScopeCoreCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for pkg in ["core", "execution", "pipeline"]:
+        for pkg in ["core", "execution", "pipeline", "cli"]:
             assert pkg in dir_names, f"narrow cascade should include {pkg}"
-        for excluded in ["config", "fleet", "migration", "workspace", "recipe", "cli", "planner"]:
+        for excluded in ["config", "fleet", "migration", "workspace", "recipe", "planner"]:
             assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
     def test_json_narrow_cascade(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Replace the hardcoded `ClaudeCodeBackend()` instantiation in `cook()` and `_run_interactive_session()` with config-driven backend resolution via `get_backend(config.agent_backend.backend)`. Add an optional `backend` parameter for clean test injection. Thread the same DI pattern through `_register_all()` and the `init` command in `app.py`.

Closes #2854

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-060121-427991/.autoskillit/temp/dry-walkthrough/p1_a3_wp1_replace_hardcoded_backend_plan_2026-05-24_061500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 80 | 18.6k | 2.0M | 128.1k | 141 | 113.4k | 10m 7s |
| verify | claude-opus-4-6 | 1 | 2.0k | 16.7k | 2.1M | 93.4k | 170 | 78.3k | 10m 21s |
| implement* | MiniMax-M2.7-highspeed | 1 | 5.4M | 31.8k | 3.3M | 30.0k | 243 | 42.7k | 12m 19s |
| prepare_pr | claude-sonnet-4-6 | 1 | 100 | 6.6k | 319.3k | 36.5k | 27 | 28.1k | 2m 6s |
| compose_pr | claude-sonnet-4-6 | 1 | 59 | 2.0k | 137.1k | 23.1k | 15 | 13.7k | 43s |
| review_pr | claude-sonnet-4-6 | 2 | 236 | 68.0k | 1.4M | 83.6k | 79 | 142.7k | 18m 17s |
| resolve_review | claude-sonnet-4-6 | 2 | 516 | 39.7k | 3.1M | 72.3k | 232 | 114.0k | 34m 22s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 228 | 11.1k | 975.9k | 48.0k | 64 | 38.6k | 4m 21s |
| diagnose_ci | claude-sonnet-4-6 | 2 | 152 | 7.0k | 463.1k | 36.3k | 40 | 49.7k | 3m 7s |
| resolve_ci | claude-sonnet-4-6 | 2 | 409 | 32.2k | 2.5M | 83.4k | 186 | 110.3k | 30m 26s |
| **Total** | | | 5.4M | 233.8k | 16.4M | 128.1k | | 731.7k | 2h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 335 | 9936.0 | 127.5 | 94.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 2182 | 447.2 | 17.7 | 5.1 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 0 | — | — | — |
| **Total** | **2517** | 6505.5 | 290.7 | 92.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 2.1k | 35.3k | 4.1M | 191.7k | 20m 29s |
| MiniMax-M2.7-highspeed | 1 | 5.4M | 31.8k | 3.3M | 42.7k | 12m 19s |
| claude-sonnet-4-6 | 7 | 1.7k | 166.6k | 9.0M | 497.2k | 1h 33m |