### PR TITLE
Split monolithic file execution/headless/__init__.py (1003 lines)

### DIFF
--- a/src/autoskillit/execution/headless/CLAUDE.md
+++ b/src/autoskillit/execution/headless/CLAUDE.md
@@ -6,7 +6,9 @@ Headless Claude session orchestration — command prep, subprocess invocation, r
 
 | File | Purpose |
 |------|---------|
-| `__init__.py` | Main module: `run_headless_core()`, `DefaultHeadlessExecutor`, `_execute_claude_headless()` |
+| `__init__.py` | Facade: `run_headless_core()`, `DefaultHeadlessExecutor`, re-exports |
+| `_headless_helpers.py` | Session helpers: `_session_log_dir`, `_resolve_model`, `PostSessionMetrics` |
+| `_headless_execute.py` | Subprocess core: `_execute_claude_headless()` — shared skill/fleet path |
 | `_headless_git.py` | Git LOC tracking: `_capture_git_head_sha()`, `_compute_loc_changed()` |
 | `_headless_path_tokens.py` | Path-token extraction and output-path validation from assistant messages |
 | `_headless_recovery.py` | Session recovery: `_recover_from_separate_marker`, `_synthesize_from_write_artifacts` |
@@ -16,4 +18,4 @@ Headless Claude session orchestration — command prep, subprocess invocation, r
 
 ## Architecture Notes
 
-The `__init__.py` IS the main module body (not a thin facade). It uses a deferred import for `flush_session_log` to avoid circular imports. `_execute_claude_headless` is the shared path for both `run_skill` (skill session) and `dispatch_food_truck` (fleet) flows.
+The `__init__.py` is a facade with public API (`run_headless_core`, `DefaultHeadlessExecutor`) and re-exports from all submodules. `_execute_claude_headless` in `_headless_execute.py` is the shared subprocess execution path for both `run_skill` (leaf) and `dispatch_food_truck` (fleet) flows. It uses a deferred import for `flush_session_log` to avoid circular imports.

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -10,58 +10,47 @@ Public API:
 
 from __future__ import annotations
 
-import dataclasses
-import os
-import time
-import traceback
 from collections.abc import Callable, Mapping, Sequence
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
-import anyio
 import structlog
 
 from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
-    CAMPAIGN_ID_ENV_VAR,
-    DISPATCH_ID_ENV_VAR,
     FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
-    CmdSpec,
-    CodingAgentBackend,
-    KillReason,
-    ProviderOutcome,
-    RecipeIdentity,
-    RetryReason,
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
     SkillSessionConfig,
     ValidatedAddDir,
     WriteBehaviorSpec,
-    claude_code_project_dir,
-    collect_version_snapshot,
     get_logger,
-    is_feature_enabled,
-    is_git_worktree,
     temp_dir_display_str,
-)
-from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
-from autoskillit.execution.clone_guard import (
-    check_and_revert_clone_contamination,
-    is_worktree_skill,
-    snapshot_clone_state,
 )
 from autoskillit.execution.headless._headless_evidence import (
     _adapt_agent_result,  # noqa: F401
     _apply_budget_guard,  # noqa: F401
-    _build_error_path_telemetry,
-    _build_session_telemetry,
+    _build_error_path_telemetry,  # noqa: F401
+    _build_session_telemetry,  # noqa: F401
     _capture_failure,  # noqa: F401
 )
+from autoskillit.execution.headless._headless_execute import (
+    _execute_claude_headless,
+)
 from autoskillit.execution.headless._headless_git import (
-    _capture_git_head_sha,
-    _compute_loc_changed,
-    _detect_branch_divergence,
+    _capture_git_head_sha,  # noqa: F401
+    _compute_loc_changed,  # noqa: F401
+    _detect_branch_divergence,  # noqa: F401
+)
+from autoskillit.execution.headless._headless_helpers import (
+    PostSessionMetrics,
+    _compute_post_session_metrics,  # noqa: F401
+    _derive_step_name_from_skill_command,
+    _recursive_snapshot,  # noqa: F401
+    _resolve_model,
+    _resolve_pty_mode,  # noqa: F401
+    _resolve_session_log_dir,
+    _session_log_dir,  # noqa: F401
 )
 from autoskillit.execution.headless._headless_path_tokens import (  # noqa: F401
     _INTENTIONALLY_EXCLUDED_PATH_TOKENS,
@@ -78,7 +67,7 @@ from autoskillit.execution.headless._headless_recovery import (
     _CHANNEL_B_RECOVERABLE_SUBTYPES,  # noqa: F401
     _NUDGE_TIMEOUT,  # noqa: F401
     _TOKEN_NAME_RE,  # noqa: F401
-    _attempt_contract_nudge,
+    _attempt_contract_nudge,  # noqa: F401
     _extract_missing_token_hints,  # noqa: F401
     _is_path_capture_pattern,  # noqa: F401
     _merge_token_usage,  # noqa: F401
@@ -87,7 +76,7 @@ from autoskillit.execution.headless._headless_recovery import (
     _synthesize_from_write_artifacts,  # noqa: F401
 )
 from autoskillit.execution.headless._headless_result import (
-    _build_skill_result,
+    _build_skill_result,  # noqa: F401
     _parse_stdout,  # noqa: F401
     _resolve_skill_session_id,  # noqa: F401
 )
@@ -95,13 +84,7 @@ from autoskillit.execution.headless._headless_scan import _scan_jsonl_write_path
 from autoskillit.execution.recording import RecordingSubprocessRunner
 
 if TYPE_CHECKING:
-    from autoskillit.config import (
-        AutomationConfig,
-    )
-    from autoskillit.core import SubprocessResult
-    from autoskillit.pipeline.context import (
-        ToolContext,
-    )
+    from autoskillit.pipeline.context import ToolContext
 
 __all__ = [
     "DefaultHeadlessExecutor",
@@ -110,580 +93,6 @@ __all__ = [
 ]
 
 logger = get_logger(__name__)
-
-
-def _session_log_dir(cwd: str) -> Path:
-    """Derive Claude Code session log directory from project cwd.
-
-    Pre-creates the directory if absent so Channel B always has a directory
-    to poll.  Without this, a fresh clone path whose encoded project dir
-    doesn't exist yet causes ``_session_log_monitor`` to burn its entire
-    phase-1 timeout absorbing ``OSError``, ultimately producing a false
-    ``EMPTY_OUTPUT`` retry.
-    """
-    log_dir = claude_code_project_dir(cwd)
-    logger.info("session_log_dir_computed", path=str(log_dir), cwd=cwd)
-    if not log_dir.exists():
-        logger.info("session_log_dir_precreating", path=str(log_dir), cwd=cwd)
-        try:
-            log_dir.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            logger.warning("session_log_dir_mkdir_failed", path=str(log_dir), cwd=cwd)
-            raise
-    return log_dir
-
-
-def _resolve_pty_mode(ctx: ToolContext) -> bool:
-    backend = cast(CodingAgentBackend, ctx.backend)
-    return backend.capabilities.pty_required
-
-
-def _resolve_session_log_dir(cwd: str, ctx: ToolContext) -> Path | None:
-    backend = cast(CodingAgentBackend, ctx.backend)
-    if not backend.capabilities.channel_b_capable:
-        return None
-    return _session_log_dir(cwd)
-
-
-def _resolve_model(
-    step_model: str,
-    config: AutomationConfig,
-    *,
-    step_name: str = "",
-    recipe_name: str = "",
-) -> str | None:
-    """Resolve model selection with 5-tier precedence.
-
-    override > recipe_overrides[recipe][step] > step_overrides[step] > step_model > default
-    """
-    if config.model.model_override:
-        logger.debug("model_resolved", tier="override", model=config.model.model_override)
-        return config.model.model_override
-    if recipe_name and step_name:
-        recipe_model = config.model.recipe_overrides.get(recipe_name, {}).get(step_name)
-        if recipe_model:
-            logger.debug("model_resolved", tier="recipe_override", model=recipe_model)
-            return recipe_model
-    if step_name:
-        step_override = config.model.step_overrides.get(step_name)
-        if step_override:
-            logger.debug("model_resolved", tier="step_override", model=step_override)
-            return step_override
-    if step_model:
-        logger.debug("model_resolved", tier="step", model=step_model)
-        return step_model
-    if config.model.default_model:
-        logger.debug("model_resolved", tier="default", model=config.model.default_model)
-        return config.model.default_model
-    logger.debug("model_resolved", tier="none", model=None)
-    return None
-
-
-def _derive_step_name_from_skill_command(skill_command: str) -> str:
-    """Extract a recording step name from a skill command string.
-
-    Examples:
-        "/autoskillit:smoke-task arg1" -> "smoke-task"
-        "/investigate foo"             -> "investigate"
-        "/autoskillit:make-plan"       -> "make-plan"
-        ""                             -> ""
-    """
-    stripped = skill_command.strip()
-    if not stripped:
-        return ""
-    token = stripped.split()[0].lstrip("/")
-    if ":" in token:
-        token = token.rsplit(":", 1)[-1]
-    return token
-
-
-def _recursive_snapshot(directory: Path) -> set[str]:
-    """Recursively enumerate all files under directory as relative paths."""
-    return {
-        str(Path(dp).relative_to(directory) / f) for dp, _, fns in os.walk(directory) for f in fns
-    }
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class PostSessionMetrics:
-    loc_insertions: int
-    loc_deletions: int
-    effective_cwd: str
-
-
-def _compute_post_session_metrics(
-    cwd: str,
-    pre_session_sha: str,
-    skill_result: SkillResult,
-) -> PostSessionMetrics:
-    effective_cwd = skill_result.worktree_path or cwd
-    loc_ins, loc_del = _compute_loc_changed(effective_cwd, pre_session_sha)
-    return PostSessionMetrics(
-        loc_insertions=loc_ins,
-        loc_deletions=loc_del,
-        effective_cwd=effective_cwd,
-    )
-
-
-async def _execute_claude_headless(
-    spec: CmdSpec,
-    cwd: str,
-    ctx: ToolContext,
-    *,
-    skill_command: str = "",
-    step_name: str = "",
-    kitchen_id: str = "",
-    caller_session_id: str = "",
-    order_id: str = "",
-    campaign_id: str = "",
-    dispatch_id: str = "",
-    project_dir: str = "",
-    timeout: float,
-    stale_threshold: float,
-    idle_output_timeout: float | None = None,
-    expected_output_patterns: Sequence[str] = (),
-    write_behavior: WriteBehaviorSpec | None = None,
-    completion_marker: str = "",
-    prior_completion_markers: Sequence[str] | None = None,
-    recipe_name: str = "",
-    recipe_content_hash: str = "",
-    recipe_composite_hash: str = "",
-    recipe_version: str = "",
-    on_spawn: Callable[[int, int], None] | None = None,
-    skip_clone_guard: bool = False,
-    readonly_skill: bool = False,
-    write_watch_dirs: Sequence[Path] = (),
-    provider_name: str = "",
-    provider_fallback_env: dict[str, str] | None = None,
-    provider_fallback_name: str = "",
-    provider_extras: Mapping[str, str] | None = None,
-    enable_deadline_extension: bool = False,
-    max_extension_seconds: float = 7200,
-    marker_dir: Path | None = None,
-    session_id: str | None = None,
-) -> SkillResult:
-    """Shared subprocess execution for headless Claude sessions.
-
-    Accepts an already-built CmdSpec and handles runner invocation,
-    exception handling, _build_skill_result, and session log flushing.
-    Used by both run_headless_core (leaf path) and
-    DefaultHeadlessExecutor.dispatch_food_truck (food truck path).
-    """
-    campaign_id = campaign_id or os.environ.get(CAMPAIGN_ID_ENV_VAR, "")
-    dispatch_id = dispatch_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
-
-    cfg = ctx.config.run_skill
-    if idle_output_timeout is not None:
-        _raw_idle = idle_output_timeout
-    else:
-        env_idle = os.environ.get("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT")
-        if env_idle is not None:
-            try:
-                _raw_idle = float(env_idle)
-            except ValueError:
-                logger.warning(
-                    "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT: invalid float — falling back to config",
-                    env_value=env_idle,
-                    fallback=cfg.idle_output_timeout,
-                )
-                _raw_idle = float(cfg.idle_output_timeout)
-        else:
-            _raw_idle = float(cfg.idle_output_timeout)
-    effective_idle: float | None = _raw_idle if _raw_idle > 0.0 else None
-
-    current_provider_name: str = provider_name
-    fallback_activated: bool = False
-    remaining_attempts = ctx.config.providers.provider_retry_limit if provider_fallback_env else 0
-
-    runner = ctx.runner
-    if runner is None:
-        raise RuntimeError("No subprocess runner configured")
-
-    if ctx.backend is not None and spec.cmd:
-        _binary = Path(spec.cmd[0]).stem
-        if _binary in {"claude", "codex"}:
-            _expected = "claude" if ctx.backend.name == "claude-code" else "codex"
-            if _binary != _expected:
-                raise RuntimeError(
-                    f"Backend coherence violation: ctx.backend.name={ctx.backend.name!r} "
-                    f"but subprocess binary is {_binary!r}"
-                )
-
-    linux_tracing_cfg = ctx.config.linux_tracing
-    _start_ts = datetime.now(UTC).isoformat()
-    _start_mono = time.monotonic()
-    _versions = collect_version_snapshot()
-
-    _readonly_skill = readonly_skill
-    _has_write_scope = bool(write_watch_dirs)
-    _clone_snapshot = None
-    if (
-        not skip_clone_guard
-        and not is_git_worktree(Path(cwd))
-        and (is_worktree_skill(skill_command) or _readonly_skill or _has_write_scope)
-    ):
-        _clone_snapshot = await snapshot_clone_state(cwd, runner)
-
-    _watch_dirs: list[Path] = list(write_watch_dirs) if write_watch_dirs else []
-    if not _watch_dirs:
-        _default = _resolve_skill_temp_dir(cwd, skill_command)
-        if _default:
-            _watch_dirs.append(_default)
-
-    _temp_snapshots_pre: dict[Path, set[str]] = {}
-    for _wd in _watch_dirs:
-        if _wd.is_dir():
-            try:
-                _temp_snapshots_pre[_wd] = _recursive_snapshot(_wd)
-            except OSError:
-                logger.warning("watch_dir_pre_scan_failed", watch_dir=str(_wd), exc_info=True)
-                _temp_snapshots_pre[_wd] = set()
-
-    _pre_session_sha = _capture_git_head_sha(cwd)
-    _result: SubprocessResult | None = None
-    result: SubprocessResult
-    skill_result: SkillResult
-    _stream_parser = cast(CodingAgentBackend, ctx.backend).stream_parser(
-        completion_marker=completion_marker
-    )
-    while True:
-        try:
-            _result = await runner(
-                list(spec.cmd),
-                cwd=Path(cwd),
-                timeout=timeout,
-                env=spec.env,
-                pty_mode=_resolve_pty_mode(ctx),
-                session_log_dir=_resolve_session_log_dir(cwd, ctx),
-                completion_marker=completion_marker,
-                stale_threshold=stale_threshold,
-                completion_drain_timeout=cfg.completion_drain_timeout,
-                linux_tracing_config=linux_tracing_cfg,
-                idle_output_timeout=effective_idle,
-                max_suppression_seconds=cfg.max_suppression_seconds,
-                on_pid_resolved=on_spawn,
-                enable_deadline_extension=enable_deadline_extension,
-                max_extension_seconds=max_extension_seconds,
-                marker_dir=marker_dir,
-                session_id=session_id,
-                stream_parser=_stream_parser,
-            )
-        except Exception as exc:
-            logger.error("headless_runner_crashed", exc_info=True)
-            _exc_text = traceback.format_exc()
-            _log_dir = ctx.config.linux_tracing.log_dir
-            try:
-                from autoskillit.execution import flush_session_log
-
-                flush_session_log(
-                    log_dir=_log_dir,
-                    cwd=str(cwd),
-                    kitchen_id=kitchen_id,
-                    caller_session_id=caller_session_id,
-                    order_id=order_id,
-                    campaign_id=campaign_id,
-                    dispatch_id=dispatch_id,
-                    project_dir=project_dir,
-                    build_protected_campaign_ids=ctx.build_protected_campaign_ids,
-                    session_id="",
-                    pid=0,
-                    skill_command=skill_command,
-                    success=False,
-                    subtype="crashed",
-                    exit_code=-1,
-                    start_ts=_start_ts,
-                    proc_snapshots=None,
-                    termination_reason="CRASHED",
-                    exception_text=_exc_text,
-                    versions=_versions,
-                    provider_outcome=ProviderOutcome(
-                        provider_used=current_provider_name,
-                        fallback_activated=fallback_activated,
-                    ),
-                    recipe_identity=RecipeIdentity(
-                        name=recipe_name,
-                        content_hash=recipe_content_hash,
-                        composite_hash=recipe_composite_hash,
-                        version=recipe_version,
-                    ),
-                    max_sessions=ctx.config.linux_tracing.max_sessions,
-                    telemetry=_build_error_path_telemetry(ctx.github_api_log),
-                )
-            except Exception:
-                logger.debug("flush_session_log during crash failed", exc_info=True)
-            _crashed = SkillResult.crashed(
-                exception=exc,
-                skill_command=skill_command,
-                order_id=order_id,
-            )
-            return dataclasses.replace(
-                _crashed,
-                provider=ProviderOutcome(
-                    provider_used=current_provider_name, fallback_activated=fallback_activated
-                ),
-            )
-        except BaseException:
-            logger.warning("headless_runner_cancelled", exc_info=True)
-            _exc_text = traceback.format_exc()
-            _log_dir = ctx.config.linux_tracing.log_dir
-            try:
-                from autoskillit.execution import flush_session_log
-
-                with anyio.CancelScope(shield=True):
-                    flush_session_log(
-                        log_dir=_log_dir,
-                        cwd=str(cwd),
-                        kitchen_id=kitchen_id,
-                        caller_session_id=caller_session_id,
-                        order_id=order_id,
-                        campaign_id=campaign_id,
-                        dispatch_id=dispatch_id,
-                        project_dir=project_dir,
-                        build_protected_campaign_ids=ctx.build_protected_campaign_ids,
-                        session_id="",
-                        pid=0,
-                        skill_command=skill_command,
-                        success=False,
-                        subtype="cancelled",
-                        exit_code=-1,
-                        start_ts=_start_ts,
-                        proc_snapshots=None,
-                        termination_reason="CANCELLED",
-                        exception_text=_exc_text,
-                        versions=_versions,
-                        provider_outcome=ProviderOutcome(
-                            provider_used=current_provider_name,
-                            fallback_activated=fallback_activated,
-                        ),
-                        recipe_identity=RecipeIdentity(
-                            name=recipe_name,
-                            content_hash=recipe_content_hash,
-                            composite_hash=recipe_composite_hash,
-                            version=recipe_version,
-                        ),
-                        max_sessions=ctx.config.linux_tracing.max_sessions,
-                        telemetry=_build_error_path_telemetry(ctx.github_api_log),
-                    )
-            except Exception:
-                logger.debug("flush_session_log during cancel failed", exc_info=True)
-            raise
-        _elapsed = time.monotonic() - _start_mono
-        _end_ts = (datetime.fromisoformat(_start_ts) + timedelta(seconds=_elapsed)).isoformat()
-        result = dataclasses.replace(  # type: ignore[arg-type]
-            _result, start_ts=_start_ts, end_ts=_end_ts, elapsed_seconds=_elapsed
-        )
-
-        _fs_writes_detected = False
-        for _wd in _watch_dirs:
-            if _wd.is_dir():
-                try:
-                    _post = _recursive_snapshot(_wd)
-                except OSError:
-                    logger.warning("watch_dir_post_scan_failed", watch_dir=str(_wd), exc_info=True)
-                    _post = set()
-                _pre = _temp_snapshots_pre.get(_wd, set())
-                if _post - _pre:
-                    _fs_writes_detected = True
-                    break
-
-        _git_writes_detected = False
-        if is_git_worktree(Path(cwd)):
-            _git_writes_detected = _detect_branch_divergence(cwd)
-
-        audit_count_before = len(ctx.audit.get_report())
-        _supports_fmt = cast(
-            "CodingAgentBackend", ctx.backend
-        ).capabilities.supports_claude_format_stdout
-        _backend = cast(CodingAgentBackend, ctx.backend)
-        skill_result = _build_skill_result(
-            result,
-            completion_marker=completion_marker,
-            skill_command=skill_command,
-            audit=ctx.audit,
-            expected_output_patterns=expected_output_patterns,
-            cwd=cwd,
-            write_behavior=write_behavior,
-            fs_writes_detected=_fs_writes_detected,
-            git_writes_detected=_git_writes_detected,
-            prior_completion_markers=prior_completion_markers,
-            provider_used=current_provider_name,
-            supports_claude_format_stdout=_supports_fmt,
-            backend=_backend,
-        )
-
-        if (
-            skill_result.needs_retry
-            and skill_result.session_id
-            and skill_result.retry_reason
-            in (RetryReason.CONTRACT_RECOVERY, RetryReason.EARLY_STOP)
-        ):
-            nudge_success = await _attempt_contract_nudge(
-                skill_result,
-                result,
-                expected_output_patterns,
-                completion_marker,
-                cwd,
-                runner,
-                backend=ctx.backend,
-                result_parser=ctx.backend.result_parser() if ctx.backend else None,
-                provider_extras=provider_extras,
-                retry_reason=skill_result.retry_reason,
-            )
-            if nudge_success is not None:
-                skill_result = nudge_success
-
-        _clone_reverted = False
-        if _clone_snapshot is not None:
-            _effective_readonly = _readonly_skill or _has_write_scope
-            _exclude_prefix = ".autoskillit/"
-            if write_watch_dirs:
-                try:
-                    _rel = write_watch_dirs[0].relative_to(Path(cwd))
-                    _exclude_prefix = str(_rel.parts[0]) + "/"
-                except ValueError:
-                    pass  # output_dir not under cwd — keep default ".autoskillit/" fallback
-            skill_result, _clone_reverted = await check_and_revert_clone_contamination(
-                _clone_snapshot,
-                skill_result,
-                cwd,
-                runner,
-                ctx.audit,
-                skill_command=skill_command,
-                readonly_skill=_effective_readonly,
-                exclude_prefix=_exclude_prefix,
-            )
-
-        if (
-            skill_result.retry_reason in {RetryReason.STALE, RetryReason.BUDGET_EXHAUSTED}
-            and provider_fallback_env is not None
-            and remaining_attempts > 0
-            and provider_name
-            and is_feature_enabled("providers", ctx.config.features)
-        ):
-            if not fallback_activated:
-                spec = dataclasses.replace(spec, env={**spec.env, **provider_fallback_env})
-                if provider_fallback_name:
-                    current_provider_name = provider_fallback_name
-            fallback_activated = True
-            remaining_attempts -= 1
-            continue
-        break
-
-    _metrics = _compute_post_session_metrics(cwd, _pre_session_sha, skill_result)
-
-    timing_seconds: float = result.elapsed_seconds
-
-    # Extract the audit record (if any) added by this session
-    new_audit_records = ctx.audit.get_report_as_dicts()[audit_count_before:]
-    audit_record = new_audit_records[0] if new_audit_records else None
-
-    if (
-        result.proc_snapshots is not None
-        or not skill_result.success
-        or bool(step_name)
-        or skill_result.token_usage is not None
-    ):
-        from autoskillit.execution.session_log import flush_session_log
-
-        try:
-            flush_session_log(
-                log_dir=ctx.config.linux_tracing.log_dir,
-                cwd=cwd,
-                kitchen_id=kitchen_id,
-                caller_session_id=caller_session_id,
-                order_id=order_id,
-                campaign_id=campaign_id,
-                dispatch_id=dispatch_id,
-                project_dir=project_dir,
-                build_protected_campaign_ids=ctx.build_protected_campaign_ids,
-                session_id=skill_result.session_id,
-                pid=result.pid,
-                skill_command=skill_command,
-                success=skill_result.success,
-                subtype=skill_result.subtype,
-                cli_subtype=skill_result.cli_subtype,
-                exit_code=skill_result.exit_code,
-                start_ts=result.start_ts,
-                end_ts=result.end_ts,
-                elapsed_seconds=result.elapsed_seconds,
-                termination_reason=result.termination.value,
-                kill_reason=skill_result.kill_reason.value,
-                snapshot_interval_seconds=ctx.config.linux_tracing.proc_interval,
-                proc_snapshots=result.proc_snapshots,
-                step_name=step_name,
-                telemetry=_build_session_telemetry(
-                    skill_result=skill_result,
-                    timing_seconds=timing_seconds,
-                    audit_record=audit_record,
-                    github_api_log=ctx.github_api_log,
-                    loc_insertions=_metrics.loc_insertions,
-                    loc_deletions=_metrics.loc_deletions,
-                ),
-                api_retry_count=skill_result.api_retry.count,
-                api_retry_last_error=skill_result.api_retry.last_error,
-                api_retry_last_status=skill_result.api_retry.last_status,
-                api_retry_exhausted=skill_result.api_retry.exhausted,
-                write_path_warnings=skill_result.write_path_warnings,
-                write_call_count=skill_result.evidence.write_call_count,
-                fs_writes_detected=skill_result.evidence.fs_writes_detected,
-                git_writes_detected=skill_result.evidence.git_writes_detected,
-                file_changes_count=skill_result.evidence.file_changes_count,
-                clone_contamination_reverted=_clone_reverted,
-                tracked_comm=result.tracked_comm,
-                orphaned_tool_result=result.orphaned_tool_result,
-                raw_stdout=result.stdout
-                if (
-                    not skill_result.success or skill_result.kill_reason != KillReason.NATURAL_EXIT
-                )
-                else "",
-                last_stop_reason=skill_result.last_stop_reason,
-                versions=_versions,
-                provider_outcome=ProviderOutcome(
-                    provider_used=current_provider_name,
-                    fallback_activated=fallback_activated,
-                ),
-                recipe_identity=RecipeIdentity(
-                    name=recipe_name,
-                    content_hash=recipe_content_hash,
-                    composite_hash=recipe_composite_hash,
-                    version=recipe_version,
-                ),
-                max_sessions=ctx.config.linux_tracing.max_sessions,
-            )
-        except Exception:
-            logger.debug("session_log_flush_failed", exc_info=True)
-
-    logger.debug(
-        "headless_session_exit",
-        success=skill_result.success,
-        needs_retry=skill_result.needs_retry,
-        subtype=skill_result.subtype,
-        session_id=skill_result.session_id,
-    )
-
-    from autoskillit.execution.session_log import _resolve_session_label
-
-    _token_label = _resolve_session_label(step_name, dispatch_id)
-    try:
-        ctx.token_log.record(
-            _token_label,
-            skill_result.token_usage,
-            start_ts=result.start_ts,
-            end_ts=result.end_ts,
-            elapsed_seconds=result.elapsed_seconds,
-            order_id=order_id,
-            loc_insertions=_metrics.loc_insertions,
-            loc_deletions=_metrics.loc_deletions,
-        )
-    except Exception:
-        logger.debug("token_log_record_failed", exc_info=True)
-    skill_result = dataclasses.replace(
-        skill_result,
-        provider=ProviderOutcome(
-            provider_used=current_provider_name, fallback_activated=fallback_activated
-        ),
-    )
-    return skill_result
 
 
 async def run_headless_core(

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -1,0 +1,520 @@
+"""Shared subprocess execution core for headless Claude sessions."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import time
+import traceback
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import anyio
+
+from autoskillit.core import (
+    CAMPAIGN_ID_ENV_VAR,
+    DISPATCH_ID_ENV_VAR,
+    CmdSpec,
+    CodingAgentBackend,
+    KillReason,
+    ProviderOutcome,
+    RecipeIdentity,
+    RetryReason,
+    SkillResult,
+    WriteBehaviorSpec,
+    collect_version_snapshot,
+    get_logger,
+    is_feature_enabled,
+    is_git_worktree,
+)
+from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
+from autoskillit.execution.clone_guard import (
+    check_and_revert_clone_contamination,
+    is_worktree_skill,
+    snapshot_clone_state,
+)
+from autoskillit.execution.headless._headless_evidence import (
+    _build_error_path_telemetry,
+    _build_session_telemetry,
+)
+from autoskillit.execution.headless._headless_git import (
+    _capture_git_head_sha,
+    _detect_branch_divergence,
+)
+from autoskillit.execution.headless._headless_helpers import (
+    _compute_post_session_metrics,
+    _recursive_snapshot,
+    _resolve_pty_mode,
+    _resolve_session_log_dir,
+)
+from autoskillit.execution.headless._headless_recovery import _attempt_contract_nudge
+from autoskillit.execution.headless._headless_result import _build_skill_result
+
+if TYPE_CHECKING:
+    from autoskillit.core import SubprocessResult
+    from autoskillit.pipeline.context import ToolContext
+
+logger = get_logger(__name__)
+
+
+async def _execute_claude_headless(
+    spec: CmdSpec,
+    cwd: str,
+    ctx: ToolContext,
+    *,
+    skill_command: str = "",
+    step_name: str = "",
+    kitchen_id: str = "",
+    caller_session_id: str = "",
+    order_id: str = "",
+    campaign_id: str = "",
+    dispatch_id: str = "",
+    project_dir: str = "",
+    timeout: float,
+    stale_threshold: float,
+    idle_output_timeout: float | None = None,
+    expected_output_patterns: Sequence[str] = (),
+    write_behavior: WriteBehaviorSpec | None = None,
+    completion_marker: str = "",
+    prior_completion_markers: Sequence[str] | None = None,
+    recipe_name: str = "",
+    recipe_content_hash: str = "",
+    recipe_composite_hash: str = "",
+    recipe_version: str = "",
+    on_spawn: Callable[[int, int], None] | None = None,
+    skip_clone_guard: bool = False,
+    readonly_skill: bool = False,
+    write_watch_dirs: Sequence[Path] = (),
+    provider_name: str = "",
+    provider_fallback_env: dict[str, str] | None = None,
+    provider_fallback_name: str = "",
+    provider_extras: Mapping[str, str] | None = None,
+    enable_deadline_extension: bool = False,
+    max_extension_seconds: float = 7200,
+    marker_dir: Path | None = None,
+    session_id: str | None = None,
+) -> SkillResult:
+    """Shared subprocess execution for headless Claude sessions.
+
+    Accepts an already-built CmdSpec and handles runner invocation,
+    exception handling, _build_skill_result, and session log flushing.
+    Used by both run_headless_core (leaf path) and
+    DefaultHeadlessExecutor.dispatch_food_truck (food truck path).
+    """
+    campaign_id = campaign_id or os.environ.get(CAMPAIGN_ID_ENV_VAR, "")
+    dispatch_id = dispatch_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
+
+    cfg = ctx.config.run_skill
+    if idle_output_timeout is not None:
+        _raw_idle = idle_output_timeout
+    else:
+        env_idle = os.environ.get("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT")
+        if env_idle is not None:
+            try:
+                _raw_idle = float(env_idle)
+            except ValueError:
+                logger.warning(
+                    "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT: invalid float — falling back to config",
+                    env_value=env_idle,
+                    fallback=cfg.idle_output_timeout,
+                )
+                _raw_idle = float(cfg.idle_output_timeout)
+        else:
+            _raw_idle = float(cfg.idle_output_timeout)
+    effective_idle: float | None = _raw_idle if _raw_idle > 0.0 else None
+
+    current_provider_name: str = provider_name
+    fallback_activated: bool = False
+    remaining_attempts = ctx.config.providers.provider_retry_limit if provider_fallback_env else 0
+
+    runner = ctx.runner
+    if runner is None:
+        raise RuntimeError("No subprocess runner configured")
+
+    if ctx.backend is not None and spec.cmd:
+        _binary = Path(spec.cmd[0]).stem
+        if _binary in {"claude", "codex"}:
+            _expected = "claude" if ctx.backend.name == "claude-code" else "codex"
+            if _binary != _expected:
+                raise RuntimeError(
+                    f"Backend coherence violation: ctx.backend.name={ctx.backend.name!r} "
+                    f"but subprocess binary is {_binary!r}"
+                )
+
+    linux_tracing_cfg = ctx.config.linux_tracing
+    _start_ts = datetime.now(UTC).isoformat()
+    _start_mono = time.monotonic()
+    _versions = collect_version_snapshot()
+
+    _readonly_skill = readonly_skill
+    _has_write_scope = bool(write_watch_dirs)
+    _clone_snapshot = None
+    if (
+        not skip_clone_guard
+        and not is_git_worktree(Path(cwd))
+        and (is_worktree_skill(skill_command) or _readonly_skill or _has_write_scope)
+    ):
+        _clone_snapshot = await snapshot_clone_state(cwd, runner)
+
+    _watch_dirs: list[Path] = list(write_watch_dirs) if write_watch_dirs else []
+    if not _watch_dirs:
+        _default = _resolve_skill_temp_dir(cwd, skill_command)
+        if _default:
+            _watch_dirs.append(_default)
+
+    _temp_snapshots_pre: dict[Path, set[str]] = {}
+    for _wd in _watch_dirs:
+        if _wd.is_dir():
+            try:
+                _temp_snapshots_pre[_wd] = _recursive_snapshot(_wd)
+            except OSError:
+                logger.warning("watch_dir_pre_scan_failed", watch_dir=str(_wd), exc_info=True)
+                _temp_snapshots_pre[_wd] = set()
+
+    _pre_session_sha = _capture_git_head_sha(cwd)
+    _result: SubprocessResult | None = None
+    result: SubprocessResult
+    skill_result: SkillResult
+    _stream_parser = cast(CodingAgentBackend, ctx.backend).stream_parser(
+        completion_marker=completion_marker
+    )
+    while True:
+        try:
+            _result = await runner(
+                list(spec.cmd),
+                cwd=Path(cwd),
+                timeout=timeout,
+                env=spec.env,
+                pty_mode=_resolve_pty_mode(ctx),
+                session_log_dir=_resolve_session_log_dir(cwd, ctx),
+                completion_marker=completion_marker,
+                stale_threshold=stale_threshold,
+                completion_drain_timeout=cfg.completion_drain_timeout,
+                linux_tracing_config=linux_tracing_cfg,
+                idle_output_timeout=effective_idle,
+                max_suppression_seconds=cfg.max_suppression_seconds,
+                on_pid_resolved=on_spawn,
+                enable_deadline_extension=enable_deadline_extension,
+                max_extension_seconds=max_extension_seconds,
+                marker_dir=marker_dir,
+                session_id=session_id,
+                stream_parser=_stream_parser,
+            )
+        except Exception as exc:
+            logger.error("headless_runner_crashed", exc_info=True)
+            _exc_text = traceback.format_exc()
+            _log_dir = ctx.config.linux_tracing.log_dir
+            try:
+                from autoskillit.execution import flush_session_log
+
+                flush_session_log(
+                    log_dir=_log_dir,
+                    cwd=str(cwd),
+                    kitchen_id=kitchen_id,
+                    caller_session_id=caller_session_id,
+                    order_id=order_id,
+                    campaign_id=campaign_id,
+                    dispatch_id=dispatch_id,
+                    project_dir=project_dir,
+                    build_protected_campaign_ids=ctx.build_protected_campaign_ids,
+                    session_id="",
+                    pid=0,
+                    skill_command=skill_command,
+                    success=False,
+                    subtype="crashed",
+                    exit_code=-1,
+                    start_ts=_start_ts,
+                    proc_snapshots=None,
+                    termination_reason="CRASHED",
+                    exception_text=_exc_text,
+                    versions=_versions,
+                    provider_outcome=ProviderOutcome(
+                        provider_used=current_provider_name,
+                        fallback_activated=fallback_activated,
+                    ),
+                    recipe_identity=RecipeIdentity(
+                        name=recipe_name,
+                        content_hash=recipe_content_hash,
+                        composite_hash=recipe_composite_hash,
+                        version=recipe_version,
+                    ),
+                    max_sessions=ctx.config.linux_tracing.max_sessions,
+                    telemetry=_build_error_path_telemetry(ctx.github_api_log),
+                )
+            except Exception:
+                logger.debug("flush_session_log during crash failed", exc_info=True)
+            _crashed = SkillResult.crashed(
+                exception=exc,
+                skill_command=skill_command,
+                order_id=order_id,
+            )
+            return dataclasses.replace(
+                _crashed,
+                provider=ProviderOutcome(
+                    provider_used=current_provider_name, fallback_activated=fallback_activated
+                ),
+            )
+        except BaseException:
+            logger.warning("headless_runner_cancelled", exc_info=True)
+            _exc_text = traceback.format_exc()
+            _log_dir = ctx.config.linux_tracing.log_dir
+            try:
+                from autoskillit.execution import flush_session_log
+
+                with anyio.CancelScope(shield=True):
+                    flush_session_log(
+                        log_dir=_log_dir,
+                        cwd=str(cwd),
+                        kitchen_id=kitchen_id,
+                        caller_session_id=caller_session_id,
+                        order_id=order_id,
+                        campaign_id=campaign_id,
+                        dispatch_id=dispatch_id,
+                        project_dir=project_dir,
+                        build_protected_campaign_ids=ctx.build_protected_campaign_ids,
+                        session_id="",
+                        pid=0,
+                        skill_command=skill_command,
+                        success=False,
+                        subtype="cancelled",
+                        exit_code=-1,
+                        start_ts=_start_ts,
+                        proc_snapshots=None,
+                        termination_reason="CANCELLED",
+                        exception_text=_exc_text,
+                        versions=_versions,
+                        provider_outcome=ProviderOutcome(
+                            provider_used=current_provider_name,
+                            fallback_activated=fallback_activated,
+                        ),
+                        recipe_identity=RecipeIdentity(
+                            name=recipe_name,
+                            content_hash=recipe_content_hash,
+                            composite_hash=recipe_composite_hash,
+                            version=recipe_version,
+                        ),
+                        max_sessions=ctx.config.linux_tracing.max_sessions,
+                        telemetry=_build_error_path_telemetry(ctx.github_api_log),
+                    )
+            except Exception:
+                logger.debug("flush_session_log during cancel failed", exc_info=True)
+            raise
+        _elapsed = time.monotonic() - _start_mono
+        _end_ts = (datetime.fromisoformat(_start_ts) + timedelta(seconds=_elapsed)).isoformat()
+        result = dataclasses.replace(  # type: ignore[arg-type]
+            _result, start_ts=_start_ts, end_ts=_end_ts, elapsed_seconds=_elapsed
+        )
+
+        _fs_writes_detected = False
+        for _wd in _watch_dirs:
+            if _wd.is_dir():
+                try:
+                    _post = _recursive_snapshot(_wd)
+                except OSError:
+                    logger.warning("watch_dir_post_scan_failed", watch_dir=str(_wd), exc_info=True)
+                    _post = set()
+                _pre = _temp_snapshots_pre.get(_wd, set())
+                if _post - _pre:
+                    _fs_writes_detected = True
+                    break
+
+        _git_writes_detected = False
+        if is_git_worktree(Path(cwd)):
+            _git_writes_detected = _detect_branch_divergence(cwd)
+
+        audit_count_before = len(ctx.audit.get_report())
+        _supports_fmt = cast(
+            "CodingAgentBackend", ctx.backend
+        ).capabilities.supports_claude_format_stdout
+        _backend = cast(CodingAgentBackend, ctx.backend)
+        skill_result = _build_skill_result(
+            result,
+            completion_marker=completion_marker,
+            skill_command=skill_command,
+            audit=ctx.audit,
+            expected_output_patterns=expected_output_patterns,
+            cwd=cwd,
+            write_behavior=write_behavior,
+            fs_writes_detected=_fs_writes_detected,
+            git_writes_detected=_git_writes_detected,
+            prior_completion_markers=prior_completion_markers,
+            provider_used=current_provider_name,
+            supports_claude_format_stdout=_supports_fmt,
+            backend=_backend,
+        )
+
+        if (
+            skill_result.needs_retry
+            and skill_result.session_id
+            and skill_result.retry_reason
+            in (RetryReason.CONTRACT_RECOVERY, RetryReason.EARLY_STOP)
+        ):
+            nudge_success = await _attempt_contract_nudge(
+                skill_result,
+                result,
+                expected_output_patterns,
+                completion_marker,
+                cwd,
+                runner,
+                backend=ctx.backend,
+                result_parser=ctx.backend.result_parser() if ctx.backend else None,
+                provider_extras=provider_extras,
+                retry_reason=skill_result.retry_reason,
+            )
+            if nudge_success is not None:
+                skill_result = nudge_success
+
+        _clone_reverted = False
+        if _clone_snapshot is not None:
+            _effective_readonly = _readonly_skill or _has_write_scope
+            _exclude_prefix = ".autoskillit/"
+            if write_watch_dirs:
+                try:
+                    _rel = write_watch_dirs[0].relative_to(Path(cwd))
+                    _exclude_prefix = str(_rel.parts[0]) + "/"
+                except ValueError:
+                    pass  # output_dir not under cwd — keep default ".autoskillit/" fallback
+            skill_result, _clone_reverted = await check_and_revert_clone_contamination(
+                _clone_snapshot,
+                skill_result,
+                cwd,
+                runner,
+                ctx.audit,
+                skill_command=skill_command,
+                readonly_skill=_effective_readonly,
+                exclude_prefix=_exclude_prefix,
+            )
+
+        if (
+            skill_result.retry_reason in {RetryReason.STALE, RetryReason.BUDGET_EXHAUSTED}
+            and provider_fallback_env is not None
+            and remaining_attempts > 0
+            and provider_name
+            and is_feature_enabled("providers", ctx.config.features)
+        ):
+            if not fallback_activated:
+                spec = dataclasses.replace(spec, env={**spec.env, **provider_fallback_env})
+                if provider_fallback_name:
+                    current_provider_name = provider_fallback_name
+            fallback_activated = True
+            remaining_attempts -= 1
+            continue
+        break
+
+    _metrics = _compute_post_session_metrics(cwd, _pre_session_sha, skill_result)
+
+    timing_seconds: float = result.elapsed_seconds
+
+    # Extract the audit record (if any) added by this session
+    new_audit_records = ctx.audit.get_report_as_dicts()[audit_count_before:]
+    audit_record = new_audit_records[0] if new_audit_records else None
+
+    if (
+        result.proc_snapshots is not None
+        or not skill_result.success
+        or bool(step_name)
+        or skill_result.token_usage is not None
+    ):
+        from autoskillit.execution.session_log import flush_session_log
+
+        try:
+            flush_session_log(
+                log_dir=ctx.config.linux_tracing.log_dir,
+                cwd=cwd,
+                kitchen_id=kitchen_id,
+                caller_session_id=caller_session_id,
+                order_id=order_id,
+                campaign_id=campaign_id,
+                dispatch_id=dispatch_id,
+                project_dir=project_dir,
+                build_protected_campaign_ids=ctx.build_protected_campaign_ids,
+                session_id=skill_result.session_id,
+                pid=result.pid,
+                skill_command=skill_command,
+                success=skill_result.success,
+                subtype=skill_result.subtype,
+                cli_subtype=skill_result.cli_subtype,
+                exit_code=skill_result.exit_code,
+                start_ts=result.start_ts,
+                end_ts=result.end_ts,
+                elapsed_seconds=result.elapsed_seconds,
+                termination_reason=result.termination.value,
+                kill_reason=skill_result.kill_reason.value,
+                snapshot_interval_seconds=ctx.config.linux_tracing.proc_interval,
+                proc_snapshots=result.proc_snapshots,
+                step_name=step_name,
+                telemetry=_build_session_telemetry(
+                    skill_result=skill_result,
+                    timing_seconds=timing_seconds,
+                    audit_record=audit_record,
+                    github_api_log=ctx.github_api_log,
+                    loc_insertions=_metrics.loc_insertions,
+                    loc_deletions=_metrics.loc_deletions,
+                ),
+                api_retry_count=skill_result.api_retry.count,
+                api_retry_last_error=skill_result.api_retry.last_error,
+                api_retry_last_status=skill_result.api_retry.last_status,
+                api_retry_exhausted=skill_result.api_retry.exhausted,
+                write_path_warnings=skill_result.write_path_warnings,
+                write_call_count=skill_result.evidence.write_call_count,
+                fs_writes_detected=skill_result.evidence.fs_writes_detected,
+                git_writes_detected=skill_result.evidence.git_writes_detected,
+                file_changes_count=skill_result.evidence.file_changes_count,
+                clone_contamination_reverted=_clone_reverted,
+                tracked_comm=result.tracked_comm,
+                orphaned_tool_result=result.orphaned_tool_result,
+                raw_stdout=result.stdout
+                if (
+                    not skill_result.success or skill_result.kill_reason != KillReason.NATURAL_EXIT
+                )
+                else "",
+                last_stop_reason=skill_result.last_stop_reason,
+                versions=_versions,
+                provider_outcome=ProviderOutcome(
+                    provider_used=current_provider_name,
+                    fallback_activated=fallback_activated,
+                ),
+                recipe_identity=RecipeIdentity(
+                    name=recipe_name,
+                    content_hash=recipe_content_hash,
+                    composite_hash=recipe_composite_hash,
+                    version=recipe_version,
+                ),
+                max_sessions=ctx.config.linux_tracing.max_sessions,
+            )
+        except Exception:
+            logger.debug("session_log_flush_failed", exc_info=True)
+
+    logger.debug(
+        "headless_session_exit",
+        success=skill_result.success,
+        needs_retry=skill_result.needs_retry,
+        subtype=skill_result.subtype,
+        session_id=skill_result.session_id,
+    )
+
+    from autoskillit.execution.session_log import _resolve_session_label
+
+    _token_label = _resolve_session_label(step_name, dispatch_id)
+    try:
+        ctx.token_log.record(
+            _token_label,
+            skill_result.token_usage,
+            start_ts=result.start_ts,
+            end_ts=result.end_ts,
+            elapsed_seconds=result.elapsed_seconds,
+            order_id=order_id,
+            loc_insertions=_metrics.loc_insertions,
+            loc_deletions=_metrics.loc_deletions,
+        )
+    except Exception:
+        logger.debug("token_log_record_failed", exc_info=True)
+    skill_result = dataclasses.replace(
+        skill_result,
+        provider=ProviderOutcome(
+            provider_used=current_provider_name, fallback_activated=fallback_activated
+        ),
+    )
+    return skill_result

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -1,0 +1,114 @@
+"""Headless session helper utilities and resolution functions."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from autoskillit.core import (
+    CodingAgentBackend,
+    SkillResult,
+    claude_code_project_dir,
+    get_logger,
+)
+from autoskillit.execution.headless._headless_git import _compute_loc_changed
+
+if TYPE_CHECKING:
+    from autoskillit.config import AutomationConfig
+    from autoskillit.pipeline.context import ToolContext
+
+logger = get_logger(__name__)
+
+
+def _session_log_dir(cwd: str) -> Path:
+    log_dir = claude_code_project_dir(cwd)
+    logger.info("session_log_dir_computed", path=str(log_dir), cwd=cwd)
+    if not log_dir.exists():
+        logger.info("session_log_dir_precreating", path=str(log_dir), cwd=cwd)
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            logger.warning("session_log_dir_mkdir_failed", path=str(log_dir), cwd=cwd)
+            raise
+    return log_dir
+
+
+def _resolve_pty_mode(ctx: ToolContext) -> bool:
+    backend = cast(CodingAgentBackend, ctx.backend)
+    return backend.capabilities.pty_required
+
+
+def _resolve_session_log_dir(cwd: str, ctx: ToolContext) -> Path | None:
+    backend = cast(CodingAgentBackend, ctx.backend)
+    if not backend.capabilities.channel_b_capable:
+        return None
+    return _session_log_dir(cwd)
+
+
+def _resolve_model(
+    step_model: str,
+    config: AutomationConfig,
+    *,
+    step_name: str = "",
+    recipe_name: str = "",
+) -> str | None:
+    if config.model.model_override:
+        logger.debug("model_resolved", tier="override", model=config.model.model_override)
+        return config.model.model_override
+    if recipe_name and step_name:
+        recipe_model = config.model.recipe_overrides.get(recipe_name, {}).get(step_name)
+        if recipe_model:
+            logger.debug("model_resolved", tier="recipe_override", model=recipe_model)
+            return recipe_model
+    if step_name:
+        step_override = config.model.step_overrides.get(step_name)
+        if step_override:
+            logger.debug("model_resolved", tier="step_override", model=step_override)
+            return step_override
+    if step_model:
+        logger.debug("model_resolved", tier="step", model=step_model)
+        return step_model
+    if config.model.default_model:
+        logger.debug("model_resolved", tier="default", model=config.model.default_model)
+        return config.model.default_model
+    logger.debug("model_resolved", tier="none", model=None)
+    return None
+
+
+def _derive_step_name_from_skill_command(skill_command: str) -> str:
+    stripped = skill_command.strip()
+    if not stripped:
+        return ""
+    token = stripped.split()[0].lstrip("/")
+    if ":" in token:
+        token = token.rsplit(":", 1)[-1]
+    return token
+
+
+def _recursive_snapshot(directory: Path) -> set[str]:
+    return {
+        str(Path(dp).relative_to(directory) / f) for dp, _, fns in os.walk(directory) for f in fns
+    }
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PostSessionMetrics:
+    loc_insertions: int
+    loc_deletions: int
+    effective_cwd: str
+
+
+def _compute_post_session_metrics(
+    cwd: str,
+    pre_session_sha: str,
+    skill_result: SkillResult,
+) -> PostSessionMetrics:
+    effective_cwd = skill_result.worktree_path or cwd
+    loc_ins, loc_del = _compute_loc_changed(effective_cwd, pre_session_sha)
+    return PostSessionMetrics(
+        loc_insertions=loc_ins,
+        loc_deletions=loc_del,
+        effective_cwd=effective_cwd,
+    )

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -12,9 +12,13 @@ NEW_HEADLESS_MODULES = [
     "_headless_recovery.py",
     "_headless_path_tokens.py",
     "_headless_result.py",
+    "_headless_helpers.py",
+    "_headless_execute.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 1030,
+    "headless/__init__.py": 460,
+    "headless/_headless_helpers.py": 175,
+    "headless/_headless_execute.py": 550,
     "headless/_headless_recovery.py": 365,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,
@@ -60,6 +64,28 @@ def test_headless_facade_does_not_define_path_token_functions():
         "_extract_worktree_path",
     ):
         assert f"def {fn}" not in src, f"{fn} must live in _headless_path_tokens.py"
+
+
+def test_headless_facade_does_not_define_helpers():
+    src = (SRC_EXECUTION / "headless" / "__init__.py").read_text()
+    for fn in (
+        "def _session_log_dir",
+        "def _resolve_pty_mode",
+        "def _resolve_session_log_dir",
+        "def _resolve_model",
+        "def _derive_step_name_from_skill_command",
+        "def _recursive_snapshot",
+        "class PostSessionMetrics",
+        "def _compute_post_session_metrics",
+    ):
+        assert fn not in src, f"{fn} must live in _headless_helpers.py"
+
+
+def test_headless_facade_does_not_define_execute():
+    src = (SRC_EXECUTION / "headless" / "__init__.py").read_text()
+    assert "async def _execute_claude_headless" not in src, (
+        "_execute_claude_headless must live in _headless_execute.py"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/arch/test_import_linter_contracts.py
+++ b/tests/arch/test_import_linter_contracts.py
@@ -29,7 +29,9 @@ _FORBIDDEN_BY_CONTRACT: dict[str, frozenset[str]] = {
 
 EXPECTED_CROSS_LAYER_GUARDS: dict[str, frozenset[str]] = {
     "core/types/_type_protocols_recipe.py": frozenset({"recipe"}),
-    "execution/headless/__init__.py": frozenset({"config", "pipeline"}),
+    "execution/headless/__init__.py": frozenset({"pipeline"}),
+    "execution/headless/_headless_execute.py": frozenset({"pipeline"}),
+    "execution/headless/_headless_helpers.py": frozenset({"config", "pipeline"}),
     "execution/linux_tracing.py": frozenset({"config"}),
     "execution/process/__init__.py": frozenset({"config"}),
     "execution/testing.py": frozenset({"config"}),

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -910,20 +910,6 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "REQ-CNST-010-E1: canonical type registry — wide surface required to prevent "
         "circular imports; all enums/protocols/constants consolidated here",
     ),
-    "execution/headless/__init__.py": (
-        1030,
-        "REQ-CNST-010-E2: headless session orchestration — Channel B drain-race "
-        "recovery + IDLE_STALL routing + contract nudge resume tier "
-        "+ DIR_MISSING late-bind recovery arm + RecordingSubprocessRunner "
-        "step-name auto-derivation gate + recipe identity threading "
-        "+ _execute_claude_headless extraction + dispatch_food_truck orchestration-L2 path "
-        "+ campaign_id/dispatch_id propagation kwargs "
-        "+ fs-level write detection (pre/post temp-dir snapshot + _resolve_skill_temp_dir) "
-        "+ clone guard write-scope extension (planner session write isolation) "
-        "+ api_retry field forwarding to flush_session_log "
-        "+ 5-tier _resolve_model (step_overrides + recipe_overrides tiers); "
-        "splitting would fragment the adjudication pipeline across modules",
-    ),
     "session.py": (
         1060,
         "REQ-CNST-010-E3: session adjudication pipeline — exhaustive match arms "

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -95,7 +95,9 @@ class TestExecutionSubpackages:
     def test_headless_has_expected_modules(self):
         expected = {
             "_headless_evidence",
+            "_headless_execute",
             "_headless_git",
+            "_headless_helpers",
             "_headless_path_tokens",
             "_headless_recovery",
             "_headless_result",

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -524,12 +524,12 @@ class TestGroupDApiContractPreservation:
         )
 
     def test_req_api_004_headless_subprocess_result_under_type_checking(self):
-        """execution/headless.py must import SubprocessResult only under TYPE_CHECKING."""
-        source = (self._pkg_root() / "execution" / "headless" / "__init__.py").read_text()
+        """execution/headless/_headless_execute.py must import SubprocessResult only under TYPE_CHECKING."""
+        source = (self._pkg_root() / "execution" / "headless" / "_headless_execute.py").read_text()
         assert "SubprocessResult" in source, (
-            "SubprocessResult reference vanished from headless.py entirely"
+            "SubprocessResult reference vanished from _headless_execute.py entirely"
         )
-        assert "TYPE_CHECKING" in source, "TYPE_CHECKING guard removed from headless.py"
+        assert "TYPE_CHECKING" in source, "TYPE_CHECKING guard removed from _headless_execute.py"
         # A top-level (non-indented) import of SubprocessResult is the violation.
         runtime_import = re.search(
             r"^from\s+\S+\s+import\s+.*SubprocessResult",
@@ -537,7 +537,7 @@ class TestGroupDApiContractPreservation:
             re.MULTILINE,
         )
         assert runtime_import is None, (
-            f"SubprocessResult has a runtime (non-TYPE_CHECKING) import in headless.py: "
+            f"SubprocessResult has a runtime (non-TYPE_CHECKING) import in _headless_execute.py: "
             f"{runtime_import.group()!r}"
         )
 

--- a/tests/execution/headless/test_headless_helpers_execute_split_integrity.py
+++ b/tests/execution/headless/test_headless_helpers_execute_split_integrity.py
@@ -1,0 +1,68 @@
+"""Split integrity tests for _headless_helpers and _headless_execute modules."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+SRC = Path(__file__).resolve().parents[3] / "src" / "autoskillit" / "execution" / "headless"
+
+
+class TestHeadlessHelpersModuleExists:
+    """Symbols moved to _headless_helpers are importable from there."""
+
+    def test_session_log_dir_importable(self):
+        from autoskillit.execution.headless._headless_helpers import _session_log_dir
+
+        assert callable(_session_log_dir)
+
+    def test_resolve_pty_mode_importable(self):
+        from autoskillit.execution.headless._headless_helpers import _resolve_pty_mode
+
+        assert callable(_resolve_pty_mode)
+
+    def test_resolve_session_log_dir_importable(self):
+        from autoskillit.execution.headless._headless_helpers import _resolve_session_log_dir
+
+        assert callable(_resolve_session_log_dir)
+
+    def test_resolve_model_importable(self):
+        from autoskillit.execution.headless._headless_helpers import _resolve_model
+
+        assert callable(_resolve_model)
+
+    def test_derive_step_name_importable(self):
+        from autoskillit.execution.headless._headless_helpers import (
+            _derive_step_name_from_skill_command,
+        )
+
+        assert callable(_derive_step_name_from_skill_command)
+
+    def test_recursive_snapshot_importable(self):
+        from autoskillit.execution.headless._headless_helpers import _recursive_snapshot
+
+        assert callable(_recursive_snapshot)
+
+    def test_post_session_metrics_importable(self):
+        from autoskillit.execution.headless._headless_helpers import PostSessionMetrics
+
+        assert PostSessionMetrics is not None
+
+    def test_compute_post_session_metrics_importable(self):
+        from autoskillit.execution.headless._headless_helpers import (
+            _compute_post_session_metrics,
+        )
+
+        assert callable(_compute_post_session_metrics)
+
+
+class TestHeadlessExecuteModuleExists:
+    """_execute_claude_headless is importable from _headless_execute."""
+
+    def test_execute_claude_headless_importable(self):
+        from autoskillit.execution.headless._headless_execute import (
+            _execute_claude_headless,
+        )
+
+        assert callable(_execute_claude_headless)

--- a/tests/execution/test_backend_dispatch.py
+++ b/tests/execution/test_backend_dispatch.py
@@ -29,7 +29,9 @@ async def test_run_headless_core_uses_ctx_backend_for_command_construction(minim
     mock_runner.return_value = mock_result
     minimal_ctx.runner = mock_runner
 
-    with patch("autoskillit.execution.headless._build_skill_result") as mock_build_result:
+    with patch(
+        "autoskillit.execution.headless._headless_execute._build_skill_result"
+    ) as mock_build_result:
         mock_build_result.return_value = SkillResult(
             success=True,
             result="",

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -34,19 +34,19 @@ def _patch_common(monkeypatch, tmp_path, skill_result, ctx):
         return _sub_result
 
     monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: skill_result,  # noqa: ARG005
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._capture_git_head_sha",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
         lambda *a: "",  # noqa: ARG005
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless.collect_version_snapshot",
+        "autoskillit.execution.headless._headless_execute.collect_version_snapshot",
         lambda: {},
     )
 
@@ -126,22 +126,24 @@ class TestProviderFieldsReachFlush:
             call_count[0] += 1
             return r
 
-        monkeypatch.setattr("autoskillit.execution.headless._build_skill_result", build_result)
         monkeypatch.setattr(
-            "autoskillit.execution.headless._compute_post_session_metrics",
+            "autoskillit.execution.headless._headless_execute._build_skill_result", build_result
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
             lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
         )
         monkeypatch.setattr(
-            "autoskillit.execution.headless._capture_git_head_sha",
+            "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
             lambda *a: "",  # noqa: ARG005
         )
         monkeypatch.setattr(
-            "autoskillit.execution.headless.collect_version_snapshot",
+            "autoskillit.execution.headless._headless_execute.collect_version_snapshot",
             lambda: {},
         )
         monkeypatch.setattr(minimal_ctx.config.providers, "provider_retry_limit", 2)
         monkeypatch.setattr(
-            "autoskillit.execution.headless.is_feature_enabled",
+            "autoskillit.execution.headless._headless_execute.is_feature_enabled",
             lambda name, *a, **kw: name == "providers",  # noqa: ARG005
         )
 
@@ -178,7 +180,7 @@ class TestProviderFieldsReachFlush:
         from autoskillit.execution.headless import _execute_claude_headless
 
         monkeypatch.setattr(
-            "autoskillit.execution.headless.collect_version_snapshot",
+            "autoskillit.execution.headless._headless_execute.collect_version_snapshot",
             lambda: {},
         )
 
@@ -220,7 +222,7 @@ class TestProviderFieldsReachFlush:
         from autoskillit.execution.headless import _execute_claude_headless
 
         monkeypatch.setattr(
-            "autoskillit.execution.headless.collect_version_snapshot",
+            "autoskillit.execution.headless._headless_execute.collect_version_snapshot",
             lambda: {},
         )
 

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -31,7 +31,7 @@ class TestResolveSessionLogDir:
 
         minimal_ctx.backend = _mock_backend(channel_b_capable=True)
         monkeypatch.setattr(
-            "autoskillit.execution.headless._session_log_dir",
+            "autoskillit.execution.headless._headless_helpers._session_log_dir",
             lambda cwd: Path("/fake/log/dir"),
         )
         result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx)

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -817,7 +817,9 @@ class TestRunHeadlessCore:
         runner.set_default(_sr(0, _success_session_json("done"), ""))
         minimal_ctx.runner = runner
 
-        with patch("autoskillit.execution.headless._build_skill_result") as mock_build:
+        with patch(
+            "autoskillit.execution.headless._headless_execute._build_skill_result"
+        ) as mock_build:
             mock_build.return_value = SkillResult(
                 success=True,
                 result="",
@@ -2473,7 +2475,7 @@ class TestCrashSessionLog:
 
         tool_ctx.runner = raising_runner  # type: ignore[assignment]
 
-        with patch("autoskillit.execution.headless.logger") as mock_logger:
+        with patch("autoskillit.execution.headless._headless_execute.logger") as mock_logger:
             result = await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
             mock_logger.error.assert_called_once()
             call_kwargs = mock_logger.error.call_args

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -347,7 +347,7 @@ class TestDispatchFoodTruckGuards:
 
         mock_snapshot = AsyncMock()
         monkeypatch.setattr(
-            "autoskillit.execution.headless.snapshot_clone_state",
+            "autoskillit.execution.headless._headless_execute.snapshot_clone_state",
             mock_snapshot,
         )
 

--- a/tests/execution/test_headless_ordering.py
+++ b/tests/execution/test_headless_ordering.py
@@ -20,7 +20,7 @@ _HEADLESS_PATH = (
     / "autoskillit"
     / "execution"
     / "headless"
-    / "__init__.py"
+    / "_headless_execute.py"
 )
 
 

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -82,7 +82,7 @@ class TestProviderFallbackLoop:
             )
 
         monkeypatch.setattr(
-            "autoskillit.execution.headless._build_skill_result",
+            "autoskillit.execution.headless._headless_execute._build_skill_result",
             build_result_fn,
         )
         monkeypatch.setattr(

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -86,19 +86,19 @@ class TestProviderFallbackLoop:
             build_result_fn,
         )
         monkeypatch.setattr(
-            "autoskillit.execution.headless._compute_post_session_metrics",
+            "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
             lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
         )
         monkeypatch.setattr(
-            "autoskillit.execution.headless._capture_git_head_sha",
+            "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
             lambda *a: "",  # noqa: ARG005
         )
         monkeypatch.setattr(
-            "autoskillit.execution.headless.is_feature_enabled",
+            "autoskillit.execution.headless._headless_execute.is_feature_enabled",
             lambda name, *a, **kw: name == "providers",  # noqa: ARG005
         )
         monkeypatch.setattr(
-            "autoskillit.execution.headless.collect_version_snapshot",
+            "autoskillit.execution.headless._headless_execute.collect_version_snapshot",
             lambda: {},
         )
         monkeypatch.setattr(_sl_mod, "flush_session_log", lambda **kw: None)  # noqa: ARG005

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -243,15 +243,15 @@ async def test_no_fallback_env_returns_empty_provider_used(
     minimal_ctx.backend = _mock_backend()
 
     monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: _STUB_RESULT,  # noqa: ARG005
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._capture_git_head_sha",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
         lambda *a: "",  # noqa: ARG005
     )
 
@@ -285,15 +285,15 @@ async def test_provider_name_stamps_provider_used_on_result(
     minimal_ctx.backend = _mock_backend()
 
     monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: _STUB_RESULT,  # noqa: ARG005
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._capture_git_head_sha",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
         lambda *a: "",  # noqa: ARG005
     )
 
@@ -417,9 +417,11 @@ async def test_dispatch_food_truck_forwards_marker_dir_and_session_id(
         )
 
     monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
-    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha", lambda *a: ""
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: object(),
     )
 
@@ -467,9 +469,11 @@ async def test_dispatch_food_truck_derives_marker_dir_from_cwd(
         "autoskillit.execution.headless._resolve_session_log_dir",
         lambda cwd, ctx: Path("/derived/project"),
     )
-    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha", lambda *a: ""
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: object(),
     )
 
@@ -505,9 +509,11 @@ async def test_dispatch_food_truck_marker_dir_none_when_cwd_falsy(
         )
 
     monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
-    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha", lambda *a: ""
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: object(),
     )
 
@@ -544,7 +550,7 @@ async def test_execute_claude_headless_forwards_marker_dir_to_runner(
     minimal_ctx.runner = fake_runner
     minimal_ctx.backend = _mock_backend()
     monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: SkillResult(
             success=True,
             result="ok",
@@ -558,10 +564,12 @@ async def test_execute_claude_headless_forwards_marker_dir_to_runner(
         ),
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
     )
-    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha", lambda *a: ""
+    )
 
     await _execute_claude_headless(
         spec,
@@ -599,7 +607,7 @@ async def test_execute_claude_headless_pty_mode_from_backend(
     minimal_ctx.runner = fake_runner
     minimal_ctx.backend = _mock_backend(pty_required=False)
     monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: SkillResult(
             success=True,
             result="ok",
@@ -613,10 +621,12 @@ async def test_execute_claude_headless_pty_mode_from_backend(
         ),
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
     )
-    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha", lambda *a: ""
+    )
 
     await _execute_claude_headless(
         spec,
@@ -648,7 +658,7 @@ async def test_execute_claude_headless_session_log_dir_none_when_no_channel_b(
     minimal_ctx.runner = fake_runner
     minimal_ctx.backend = _mock_backend(channel_b_capable=False)
     monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: SkillResult(
             success=True,
             result="ok",
@@ -662,10 +672,12 @@ async def test_execute_claude_headless_session_log_dir_none_when_no_channel_b(
         ),
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
     )
-    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha", lambda *a: ""
+    )
 
     await _execute_claude_headless(
         spec,
@@ -699,9 +711,11 @@ async def test_dispatch_food_truck_marker_dir_none_when_no_channel_b(
         )
 
     monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
-    monkeypatch.setattr("autoskillit.execution.headless._capture_git_head_sha", lambda *a: "")
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha", lambda *a: ""
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: object(),
     )
 
@@ -745,15 +759,15 @@ async def test_execute_claude_headless_passes_stream_parser_to_runner(
     minimal_ctx.backend = backend
 
     monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: _STUB_RESULT,
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._capture_git_head_sha",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
         lambda *a: "",
     )
 
@@ -786,15 +800,15 @@ async def test_execute_claude_headless_stream_parser_receives_completion_marker(
     minimal_ctx.backend = backend
 
     monkeypatch.setattr(
-        "autoskillit.execution.headless._build_skill_result",
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: _STUB_RESULT,
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._compute_post_session_metrics",
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
         lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
     )
     monkeypatch.setattr(
-        "autoskillit.execution.headless._capture_git_head_sha",
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
         lambda *a: "",
     )
 

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -141,7 +141,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
             return None
 
         monkeypatch.setattr(
-            "autoskillit.execution.headless._attempt_contract_nudge",
+            "autoskillit.execution.headless._headless_execute._attempt_contract_nudge",
             _no_nudge,
         )
         minimal_ctx.config.run_skill.idle_output_timeout = 45

--- a/tests/execution/test_loc_capture.py
+++ b/tests/execution/test_loc_capture.py
@@ -270,7 +270,10 @@ def test_post_session_metrics_effective_cwd_resolution(tmp_path: Path):
     mock_result_with_worktree = MagicMock()
     mock_result_with_worktree.worktree_path = worktree
 
-    with patch("autoskillit.execution.headless._compute_loc_changed", return_value=(0, 0)):
+    with patch(
+        "autoskillit.execution.headless._headless_helpers._compute_loc_changed",
+        return_value=(0, 0),
+    ):
         metrics_no_wt = _compute_post_session_metrics(cwd, "abc123", mock_result_no_worktree)
         metrics_with_wt = _compute_post_session_metrics(cwd, "abc123", mock_result_with_worktree)
 

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -54,17 +54,17 @@ class TestMultiDirFsSnapshot:
         self, tmp_path: Path, minimal_ctx, monkeypatch
     ) -> None:
         """When write_watch_dirs is provided, _resolve_skill_temp_dir is NOT called."""
-        import autoskillit.execution.headless as headless_mod
+        import autoskillit.execution.headless._headless_execute as _exec_mod
         from autoskillit.execution.headless import run_headless_core
 
         resolver_calls: list[str] = []
-        original = headless_mod._resolve_skill_temp_dir
+        original = _exec_mod._resolve_skill_temp_dir
 
         def recording_resolver(cwd: str, skill_command: str) -> Path | None:
             resolver_calls.append(skill_command)
             return original(cwd, skill_command)
 
-        monkeypatch.setattr(headless_mod, "_resolve_skill_temp_dir", recording_resolver)
+        monkeypatch.setattr(_exec_mod, "_resolve_skill_temp_dir", recording_resolver)
 
         explicit_dir = tmp_path / "planner" / "run-20260502"
         explicit_dir.mkdir(parents=True)

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -124,7 +124,9 @@ def _suppress_nudge(monkeypatch):
     async def _noop(*_args, **_kwargs):
         return None
 
-    monkeypatch.setattr("autoskillit.execution.headless._attempt_contract_nudge", _noop)
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._attempt_contract_nudge", _noop
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Extract two new submodules from `execution/headless/__init__.py` to reduce it from 1011 lines to ~430 lines:

- **`_headless_helpers.py`** (~150 lines): Small utility functions (`_session_log_dir`, `_resolve_pty_mode`, `_resolve_session_log_dir`, `_resolve_model`, `_derive_step_name_from_skill_command`, `_recursive_snapshot`) and the `PostSessionMetrics` dataclass with its factory `_compute_post_session_metrics`.
- **`_headless_execute.py`** (~520 lines): The 459-line `_execute_claude_headless` async function — the shared subprocess execution core for both skill sessions and fleet dispatch.

After the split, `__init__.py` retains `run_headless_core` and `DefaultHeadlessExecutor` (the public API surface) plus re-exports from all submodules. This converts the file from a "main module body" pattern toward the thin-facade pattern used by `session/__init__.py`.

All existing `from autoskillit.execution.headless import X` statements continue to work because moved symbols are re-exported from `__init__.py` with `# noqa: F401`. However, `monkeypatch.setattr` paths that target symbols inside `_execute_claude_headless`'s call chain must be updated to the new module namespace where `_execute_claude_headless` resolves those names.

## Requirements

(Issue #2844 has no ## Requirements section)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

(None — no conflict report provided)

Closes #2844

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-064704-802067/.autoskillit/temp/make-plan/split_headless_init_plan_2026-05-24_071000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 90 | 49.2k | 3.0M | 154.4k | 220 | 147.4k | 24m 35s |
| verify | claude-opus-4-6 | 1 | 57 | 15.0k | 1.4M | 82.1k | 85 | 67.3k | 6m 45s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.6M | 27.1k | 2.2M | 30.0k | 157 | 42.6k | 9m 1s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 106.0k | 6.2k | 209.7k | 30.0k | 21 | 42.1k | 2m 9s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 48.9k | 1.7k | 206.8k | 30.0k | 15 | 14.8k | 44s |
| review_pr | claude-sonnet-4-6 | 2 | 270 | 62.6k | 1.6M | 108.9k | 228 | 192.2k | 26m 51s |
| resolve_review | claude-opus-4-6 | 2 | 177 | 39.9k | 8.3M | 97.2k | 213 | 155.0k | 39m 38s |
| **Total** | | | 3.7M | 201.6k | 16.9M | 154.4k | | 661.3k | 1h 49m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 1518 | 1480.9 | 28.0 | 17.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **1518** | 11115.6 | 435.6 | 132.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 360 | 111.8k | 4.5M | 339.6k | 51m 27s |
| claude-opus-4-6 | 2 | 234 | 54.9k | 9.7M | 222.2k | 46m 24s |
| MiniMax-M2.7-highspeed | 3 | 3.7M | 35.0k | 2.7M | 99.5k | 11m 55s |