### PR TITLE
Replace hardcoded 'claude' string in _triage_batch()

### DIFF
--- a/src/autoskillit/_llm_triage.py
+++ b/src/autoskillit/_llm_triage.py
@@ -19,7 +19,7 @@ from autoskillit.core import (
     build_agent_env,
     get_logger,
 )
-from autoskillit.execution import parse_session_result, run_managed_async
+from autoskillit.execution import get_backend, parse_session_result, run_managed_async
 from autoskillit.recipe import StaleItem, load_bundled_manifest
 from autoskillit.workspace import bundled_skills_dir
 
@@ -120,7 +120,7 @@ async def _triage_batch(
         # Build the command manually — triage is a read-only Haiku query with no
         # tool use, so it must NOT receive --dangerously-skip-permissions.
         triage_cmd: list[str] = [
-            "claude",
+            get_backend(agent_backend).binary_name(),
             ClaudeFlags.PRINT,
             prompt,
             ClaudeFlags.MODEL,

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -415,7 +415,6 @@ def test_no_raw_claude_list_construction() -> None:
     ALLOWED = {
         ("_marketplace.py", "install"),
         ("_cook.py", "cook"),
-        ("_llm_triage.py", "_triage_batch"),
         ("claude.py", "build_interactive_cmd"),
         ("claude.py", "build_headless_cmd"),
         ("claude.py", "build_resume_cmd"),

--- a/tests/test_llm_triage.py
+++ b/tests/test_llm_triage.py
@@ -545,3 +545,62 @@ async def test_triage_env_excludes_ide_vars(tmp_path: Path, monkeypatch: pytest.
     assert "CLAUDE_CODE_SSE_PORT" not in env
     assert "ENABLE_IDE_INTEGRATION" not in env
     assert env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# T-P1-A6-WP1: Binary name must come from backend abstraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_triage_command_uses_backend_binary_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The triage command first element must equal get_backend('claude-code').binary_name()."""
+    from unittest.mock import AsyncMock
+
+    from autoskillit._llm_triage import triage_staleness
+    from autoskillit.execution import get_backend
+    from autoskillit.execution.process import SubprocessResult, TerminationReason
+
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# test skill")
+    monkeypatch.setattr("autoskillit._llm_triage.bundled_skills_dir", lambda: tmp_path)
+
+    ndjson = (
+        __import__("json").dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": __import__("json").dumps(
+                    [
+                        {
+                            "index": 1,
+                            "skill": "test-skill",
+                            "meaningful_change": False,
+                            "summary": "ok",
+                        }
+                    ]
+                ),
+                "session_id": "s1",
+            }
+        )
+        + "\n"
+    )
+    mock_run = AsyncMock(
+        return_value=SubprocessResult(0, ndjson, "", TerminationReason.NATURAL_EXIT, pid=1)
+    )
+    monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
+
+    item = StaleItem(
+        skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
+    )
+    await triage_staleness([item], agent_backend="claude-code")
+
+    cmd = mock_run.call_args.kwargs["cmd"]
+    expected_binary = get_backend("claude-code").binary_name()
+    assert cmd[0] == expected_binary, (
+        f"triage_cmd[0] must equal get_backend().binary_name(), got {cmd[0]!r}"
+    )


### PR DESCRIPTION
## Summary

Replace the hardcoded `"claude"` string literal at line 123 of `_triage_batch()` in `src/autoskillit/_llm_triage.py` with `get_backend(agent_backend).binary_name()`. This routes the binary name through the `get_backend()` factory, consistent with how every other callsite in the codebase resolves backends (e.g., `_session_launch.py`, `_cook.py`, `_factory.py`, `app.py`). The `agent_backend` parameter is already threaded through `_triage_batch()`, so this leverages it rather than ignoring it. The AST enforcement rule in `test_no_raw_claude_list_construction()` already flags this location as an exemption — after the fix, the exemption entry is removed.

Closes #2857

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-094802-395948/.autoskillit/temp/dry-walkthrough/py1_p1_a6_wp1_replace_hardcoded_claude_plan_2026-05-24_095500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 59 | 7.8k | 775.1k | 76.2k | 36 | 65.2k | 3m 4s |
| verify | claude-opus-4-6 | 1 | 49 | 15.7k | 1.3M | 75.6k | 77 | 61.9k | 7m 51s |
| implement* | MiniMax-M2.7-highspeed | 1 | 439.1k | 4.8k | 506.9k | 30.0k | 43 | 15.5k | 2m 6s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 89.4k | 2.8k | 269.9k | 30.0k | 21 | 42.2k | 1m 8s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 52.3k | 1.3k | 237.1k | 30.0k | 16 | 14.9k | 39s |
| review_pr | claude-sonnet-4-6 | 3 | 410 | 43.4k | 1.8M | 53.2k | 146 | 120.9k | 14m 31s |
| resolve_review | claude-sonnet-4-6 | 2 | 442 | 21.1k | 2.1M | 54.3k | 125 | 88.1k | 9m 19s |
| **Total** | | | 581.8k | 96.9k | 7.0M | 76.2k | | 408.7k | 38m 40s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 64 | 7920.0 | 242.8 | 75.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **64** | 108745.5 | 6385.9 | 1514.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 108 | 23.5k | 2.1M | 127.1k | 10m 55s |
| MiniMax-M2.7-highspeed | 3 | 580.9k | 8.9k | 1.0M | 72.6k | 3m 53s |
| claude-sonnet-4-6 | 2 | 852 | 64.6k | 3.9M | 209.0k | 23m 50s |