### PR TITLE
Replace the Claude Code-specific opener in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ generic_automation_mcp/
 
 **Session diagnostics logs** — per-backend log paths and session identification:
 
-- **Claude Code**: Logs live at `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Override with `linux_tracing.log_dir`. Session directories are named by the agent session ID when available (resolved from stdout or, for Claude Code backends, from the session JSONL filename via the side-channel stream). Fallback: `no_session_{timestamp}`. Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`.
+- **Claude Code**: Logs live at `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Override with `linux_tracing.log_dir`. Session directories are named by the agent session ID when available (resolved from stdout or, for Claude Code backends, from the session JSONL filename via Channel B (the JSONL side-channel stream)). Fallback: `no_session_{timestamp}`. Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`.
 - **Codex**: Session log discovery is not yet wired (`CodexSessionLocator` returns `None`; `session_record_types` is empty). The `thread_id` (from the `thread.started` NDJSON event) is the canonical session identifier for Codex backends.
 
 **Import layer vs. orchestration level — disambiguation table:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Mandatory instructions for AI-assisted development in this repository.
 
 ## **1. Core Project Goal**
 
-A Claude Code plugin that orchestrates automated skill-driven workflows using headless sessions. It provides MCP tools (gated behind `open_kitchen`/`close_kitchen` via FastMCP v3 tag-based visibility) and bundled skills registered as `/autoskillit:*` slash commands.
+A coding-agent plugin that orchestrates automated skill-driven workflows using headless sessions. It provides MCP tools (gated behind `open_kitchen`/`close_kitchen` via FastMCP v3 tag-based visibility) and bundled skills registered as `/autoskillit:*` slash commands.
 
 ## **2. General Principles**
 
@@ -91,13 +91,16 @@ generic_automation_mcp/
 | `fleet/` | IL-2 | Campaign dispatch, semaphore, sidecar, liveness, state persistence |
 | `server/` | IL-3 | FastMCP server — tools/, kitchen gating, session-type dispatch |
 | `cli/` | IL-3 | CLI — doctor/, update/, fleet/ subcommands, ui/, session/ management |
-| `hooks/` | — | Claude Code hook scripts — guards/, formatters/ |
+| `hooks/` | — | coding-agent hook scripts — guards/, formatters/ |
 | `agents/` | — | Bundled agent definition markdown files served as MCP resources |
 | `recipes/` | — | Bundled recipe YAML + contracts, diagrams, sub-recipes |
 | `skills/` | — | Tier 1 skills: open-kitchen, close-kitchen, sous-chef |
 | `skills_extended/` | — | Tier 2 (interactive) + Tier 3 (pipeline) skills, incl. arch-lens-* (13), exp-lens-* (18), vis-lens-* (12) |
 
-**Session diagnostics logs** live at `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Override with `linux_tracing.log_dir`. Session directories are named by Claude Code session UUID when available (parsed from stdout, or discovered from JSONL filename via Channel B (the JSONL stream written by the Claude Code subprocess)). Fallback: `no_session_{timestamp}`. Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`.
+**Session diagnostics logs** — per-backend log paths and session identification:
+
+- **Claude Code**: Logs live at `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Override with `linux_tracing.log_dir`. Session directories are named by the agent session ID when available (resolved from stdout or, for Claude Code backends, from the session JSONL filename via the side-channel stream). Fallback: `no_session_{timestamp}`. Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`.
+- **Codex**: Session log discovery is not yet wired (`CodexSessionLocator` returns `None`; `session_record_types` is empty). The `thread_id` (from the `thread.started` NDJSON event) is the canonical session identifier for Codex backends.
 
 **Import layer vs. orchestration level — disambiguation table:**
 


### PR DESCRIPTION
## Summary

Replace three Claude Code-specific phrases in AGENTS.md with backend-agnostic equivalents and restructure the session diagnostics paragraph into a two-entry format covering both Claude Code and Codex backends. Only AGENTS.md is modified; no code or test changes are required.

Closes #2861

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-094803-777308/.autoskillit/temp/dry-walkthrough/py2_p2_a1_wp1_replace_claude_code_opener_plan_2026-05-24_095700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 59 | 5.4k | 507.9k | 44.5k | 23 | 33.8k | 2m 50s |
| verify | claude-opus-4-6 | 1 | 42 | 15.4k | 746.6k | 71.2k | 60 | 57.6k | 7m 28s |
| implement* | MiniMax-M2.7-highspeed | 1 | 692.3k | 7.9k | 1.1M | 30.0k | 75 | 15.5k | 7m 11s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 84.2k | 2.7k | 267.0k | 30.0k | 20 | 15.2k | 1m 6s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 55.5k | 2.0k | 237.0k | 30.0k | 18 | 14.9k | 48s |
| review_pr | claude-sonnet-4-6 | 3 | 488 | 31.4k | 2.0M | 48.0k | 141 | 99.5k | 9m 35s |
| **Total** | | | 832.6k | 64.8k | 4.8M | 71.2k | | 236.6k | 28m 59s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 9 | 119628.2 | 1725.2 | 879.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **9** | 538879.2 | 26287.9 | 7203.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 101 | 20.8k | 1.3M | 91.4k | 10m 18s |
| MiniMax-M2.7-highspeed | 3 | 832.0k | 12.6k | 1.6M | 45.7k | 9m 5s |
| claude-sonnet-4-6 | 1 | 488 | 31.4k | 2.0M | 99.5k | 9m 35s |