### PR TITLE
Add parametrized backend DI tests

### DIFF
--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -799,3 +799,103 @@ class TestCookInteractive:
 
         assert get_backend_called, "get_backend must be called when backend is not injected"
         assert get_backend_called[0] == "claude-code"
+
+    @pytest.mark.parametrize("backend_name", ["claude-code", "codex"])
+    def test_cook_routes_through_get_backend(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, backend_name: str
+    ) -> None:
+        """cook() calls get_backend with config.agent_backend.backend value."""
+        from unittest.mock import MagicMock, patch
+
+        from autoskillit.core import CmdSpec
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_skills_dir.mkdir()
+        mock_mgr = MagicMock()
+        mock_mgr.init_session.return_value = fake_skills_dir
+        get_backend_calls: list = []
+
+        class _StubBackend:
+            def binary_name(self) -> str:
+                return "claude"
+
+            def build_interactive_cmd(self, **kwargs):
+                return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = backend_name
+        mock_config.features = {}
+        mock_config.experimental_enabled = False
+        mock_config.providers.profiles = {}
+
+        def fake_get_backend(name: str):
+            get_backend_calls.append(name)
+            return _StubBackend()
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("builtins.input", return_value=""),
+            patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("autoskillit.core.write_registry_entry"),
+            patch("autoskillit.config.load_config", return_value=mock_config),
+            patch("autoskillit.execution.get_backend", side_effect=fake_get_backend),
+        ):
+            import autoskillit.cli.session._cook as module
+
+            module.cook()
+
+        assert len(get_backend_calls) == 1, "get_backend must be called exactly once"
+        assert get_backend_calls[0] == backend_name
+
+    def test_cook_get_backend_called_not_hardcoded(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """ClaudeCodeBackend is never instantiated when get_backend is the DI path."""
+        from unittest.mock import MagicMock, patch
+
+        from autoskillit.core import CmdSpec
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_skills_dir.mkdir()
+        mock_mgr = MagicMock()
+        mock_mgr.init_session.return_value = fake_skills_dir
+        hardcoded_calls: list = []
+
+        class _StubBackend:
+            def binary_name(self) -> str:
+                return "claude"
+
+            def build_interactive_cmd(self, **kwargs):
+                return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = "claude-code"
+        mock_config.features = {}
+        mock_config.experimental_enabled = False
+        mock_config.providers.profiles = {}
+
+        def tracking_claude_code_backend(*args, **kwargs):
+            hardcoded_calls.append(True)
+            return MagicMock()
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("builtins.input", return_value=""),
+            patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("autoskillit.core.write_registry_entry"),
+            patch("autoskillit.config.load_config", return_value=mock_config),
+            patch("autoskillit.execution.get_backend", return_value=_StubBackend()),
+            patch(
+                "autoskillit.execution.backends.claude.ClaudeCodeBackend",
+                side_effect=tracking_claude_code_backend,
+            ),
+        ):
+            import autoskillit.cli.session._cook as module
+
+            module.cook()
+
+        assert not hardcoded_calls, (
+            "ClaudeCodeBackend must never be instantiated when get_backend is patched"
+        )

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -357,3 +357,96 @@ def test_run_interactive_session_default_backend_calls_get_backend(
     _run_interactive_session(system_prompt="test")
     assert get_backend_called, "get_backend must be called when backend is not injected"
     assert get_backend_called[0] == "claude-code"
+
+
+def test_get_backend_di_used_in_session_launch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_backend DI path in _run_interactive_session invokes stub's build_interactive_cmd."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import BackendCapabilities, CmdSpec
+
+    build_calls: list[dict] = []
+
+    caps = BackendCapabilities(
+        channel_b_capable=True,
+        pty_required=True,
+        session_resume_capable=True,
+        skill_injection_capable=True,
+        supports_thinking_blocks=True,
+        supports_claude_format_stdout=True,
+        exit_code_is_terminal=False,
+        mcp_config_capable=False,
+        completion_record_types=frozenset({"result"}),
+        session_record_types=frozenset({"assistant"}),
+    )
+
+    class _DIBackend:
+        def binary_name(self) -> str:
+            return "claude"
+
+        @property
+        def capabilities(self):
+            return caps
+
+        def build_interactive_cmd(self, **kwargs):
+            build_calls.append(kwargs)
+            return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+    mock_config = MagicMock()
+    mock_config.agent_backend.backend = "claude-code"
+
+    monkeypatch.setattr("autoskillit.config.load_config", lambda: mock_config)
+    monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: _DIBackend())
+    _stub_plugin_installed(monkeypatch)
+    _capture_subprocess(monkeypatch)
+    _run_interactive_session(system_prompt="test")
+    assert build_calls, "Stub backend's build_interactive_cmd must be invoked via get_backend DI"
+
+
+def test_skill_injection_false_via_get_backend_omits_append_system_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """skill_injection_capable=False stub via get_backend DI omits --append-system-prompt."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import BackendCapabilities, ClaudeFlags, CmdSpec
+
+    no_inject_caps = BackendCapabilities(
+        channel_b_capable=True,
+        pty_required=True,
+        session_resume_capable=True,
+        skill_injection_capable=False,
+        supports_thinking_blocks=True,
+        supports_claude_format_stdout=True,
+        exit_code_is_terminal=False,
+        mcp_config_capable=False,
+        completion_record_types=frozenset({"result"}),
+        session_record_types=frozenset({"assistant"}),
+    )
+
+    class _NoInjectDIBackend:
+        def binary_name(self) -> str:
+            return "claude"
+
+        @property
+        def capabilities(self):
+            return no_inject_caps
+
+        def build_interactive_cmd(self, **kwargs):
+            return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+    mock_config = MagicMock()
+    mock_config.agent_backend.backend = "claude-code"
+
+    captured: dict = {}
+    monkeypatch.setattr("autoskillit.config.load_config", lambda: mock_config)
+    monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: _NoInjectDIBackend())
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/claude")
+
+    def mock_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    _run_interactive_session(system_prompt="sentinel")
+    assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in captured["cmd"]

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -661,3 +661,13 @@ def test_make_context_unknown_backend_raises_value_error() -> None:
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="nonexistent"))
     with pytest.raises(ValueError, match="nonexistent"):
         make_context(cfg, runner=_runner())
+
+
+def test_make_context_codex_backend_not_none_plain_config() -> None:
+    """AgentBackendConfig(backend='codex') with no feature flags produces CodexBackend."""
+    from autoskillit.execution.backends.codex import CodexBackend
+
+    cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="codex"))
+    ctx = make_context(cfg, runner=_runner())
+    assert ctx.backend is not None
+    assert isinstance(ctx.backend, CodexBackend)


### PR DESCRIPTION
## Summary

Add parametrized tests proving that `cook()` and `_run_interactive_session()` route through `get_backend()` as a DI path (not hardcoded `ClaudeCodeBackend()`), and that `make_context()` supports codex backend without feature flags. Five new test methods across three files verify config-driven backend selection.

Closes #2859

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-094803-528811/.autoskillit/temp/make-plan/py1_p1_a8_wp1_backend_di_tests_plan_2026-05-24_095300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 79 | 15.7k | 1.5M | 107.4k | 148 | 87.2k | 12m 23s |
| verify | claude-opus-4-6 | 1 | 61 | 15.4k | 1.1M | 106.6k | 72 | 92.9k | 7m 23s |
| implement* | MiniMax-M2.7-highspeed | 1 | 885.0k | 11.9k | 956.7k | 30.0k | 97 | 15.5k | 5m 12s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 55.2k | 2.3k | 177.0k | 30.0k | 16 | 15.1k | 58s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 206.0k | 2.8k | 477.0k | 30.0k | 34 | 14.8k | 1m 15s |
| review_pr | claude-sonnet-4-6 | 2 | 484 | 86.6k | 2.8M | 95.6k | 134 | 185.9k | 22m 40s |
| resolve_review | claude-sonnet-4-6 | 2 | 1.2k | 47.1k | 4.1M | 84.8k | 227 | 139.5k | 26m 30s |
| **Total** | | | 1.1M | 181.7k | 11.1M | 107.4k | | 551.0k | 1h 16m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 203 | 4712.8 | 76.5 | 58.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **203** | 54763.7 | 2714.0 | 895.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 1.8k | 149.3k | 8.4M | 412.6k | 1h 1m |
| claude-opus-4-6 | 1 | 61 | 15.4k | 1.1M | 92.9k | 7m 23s |
| MiniMax-M2.7-highspeed | 3 | 1.1M | 17.0k | 1.6M | 45.5k | 7m 26s |