### PR TITLE
Add CONFIG_OVERRIDE = '-c' to CodexFlags StrEnum

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -60,6 +60,7 @@ class CodexFlags(StrEnum):
     EPHEMERAL = "--ephemeral"
     RESUME_SUBCOMMAND = "resume"
     LAST = "--last"
+    CONFIG_OVERRIDE = "-c"
 
 
 CODEX_ENV_DENYLIST: frozenset[str] = frozenset(

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -53,6 +53,7 @@ class TestCodexFlags:
             "EPHEMERAL",
             "RESUME_SUBCOMMAND",
             "LAST",
+            "CONFIG_OVERRIDE",
         }
         actual = {m.name for m in CodexFlags}
         assert actual == expected


### PR DESCRIPTION
## Summary

Add `CONFIG_OVERRIDE = '-c'` as a new member of the `CodexFlags` `StrEnum` in `src/autoskillit/execution/backends/codex.py` and update the `test_all_members_present` assertion in `tests/execution/backends/test_codex_backend.py` to include it. This registers the `-c` (config override) CLI flag as a typed constant for use by Codex command builders.

## Changed Files

### Modified (●):
- `src/autoskillit/execution/backends/codex.py`
- `tests/execution/backends/test_codex_backend.py`

Closes #2862

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-094932-184944/.autoskillit/temp/make-plan/py2_p2_a2_wp1_config_override_plan_2026-05-24_095400.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 60 | 5.9k | 655.3k | 57.3k | 32 | 45.5k | 2m 26s |
| verify | claude-opus-4-6 | 1 | 42 | 10.2k | 1.1M | 57.6k | 65 | 43.9k | 6m 40s |
| implement* | MiniMax-M2.7-highspeed | 1 | 189.6k | 2.4k | 476.9k | 30.0k | 32 | 15.5k | 1m 33s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 51.9k | 3.5k | 177.0k | 30.0k | 18 | 15.1k | 1m 21s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 71.1k | 1.2k | 270.0k | 30.0k | 21 | 41.9k | 44s |
| review_pr | claude-sonnet-4-6 | 3 | 462 | 24.8k | 1.8M | 39.9k | 151 | 88.3k | 10m 48s |
| **Total** | | | 313.1k | 48.1k | 4.5M | 57.6k | | 250.2k | 23m 33s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 2 | 238469.5 | 7763.5 | 1189.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **2** | 2226776.0 | 125113.0 | 24044.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 102 | 16.2k | 1.8M | 89.4k | 9m 6s |
| MiniMax-M2.7-highspeed | 3 | 312.5k | 7.1k | 924.0k | 72.5k | 3m 38s |
| claude-sonnet-4-6 | 1 | 462 | 24.8k | 1.8M | 88.3k | 10m 48s |