### PR TITLE
Implementation Plan: P2-A3-WP1 — Branch _register_all() on agent_backend

### DIFF
--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -435,9 +435,8 @@ def _register_all(
         sync_hooks_to_settings,
     )
     from autoskillit.config import load_config
-    from autoskillit.core import ensure_project_temp
-    from autoskillit.core.types import AGENT_BACKEND_CODEX
-    from autoskillit.execution.backends import ensure_codex_mcp_registered
+    from autoskillit.core import AGENT_BACKEND_CODEX, ensure_project_temp
+    from autoskillit.execution import ensure_codex_mcp_registered
 
     # Refuse to register from inside the autoskillit source tree — this would
     # plant source-tree absolute paths in the project scope.
@@ -470,6 +469,7 @@ def _register_all(
         _cfg = load_config(project_dir)
         _backend_name = _cfg.agent_backend.backend
     except Exception:
+        logger.warning("load_config failed, defaulting to claude-code backend", exc_info=True)
         _backend_name = "claude-code"
 
     if _backend_name == AGENT_BACKEND_CODEX:

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -434,7 +434,10 @@ def _register_all(
         sweep_all_scopes_for_orphans,
         sync_hooks_to_settings,
     )
+    from autoskillit.config import load_config
     from autoskillit.core import ensure_project_temp
+    from autoskillit.core.types import AGENT_BACKEND_CODEX
+    from autoskillit.execution.backends import ensure_codex_mcp_registered
 
     # Refuse to register from inside the autoskillit source tree — this would
     # plant source-tree absolute paths in the project scope.
@@ -462,9 +465,27 @@ def _register_all(
     _B, _C, _D, _G, _Y, _R = _colors()
 
     ensure_project_temp(project_dir)
-    settings_path = _claude_settings_path(scope)
-    _evict_stale_autoskillit_hooks(settings_path)
-    sync_hooks_to_settings(settings_path)
+
+    try:
+        _cfg = load_config(project_dir)
+        _backend_name = _cfg.agent_backend.backend
+    except Exception:
+        _backend_name = "claude-code"
+
+    if _backend_name == AGENT_BACKEND_CODEX:
+        ensure_codex_mcp_registered()
+        # P4: insert Codex hook registration here
+        plugin_ok = None
+    else:
+        settings_path = _claude_settings_path(scope)
+        _evict_stale_autoskillit_hooks(settings_path)
+        sync_hooks_to_settings(settings_path)
+
+        plugin_ok = _is_plugin_installed()
+        if not plugin_ok:
+            _register_mcp_server(_user_claude_json_path())
+        else:
+            evict_direct_mcp_entry(_user_claude_json_path())
 
     # Prompt for github.default_repo if running interactively
     github_repo = None
@@ -490,12 +511,6 @@ def _register_all(
 
     _create_secrets_template(project_dir)
 
-    plugin_ok = _is_plugin_installed()
-    if not plugin_ok:
-        _register_mcp_server(_user_claude_json_path())
-    else:
-        evict_direct_mcp_entry(_user_claude_json_path())  # remove stale direct entry
-
     # --- Summary block ---
     print()
     from autoskillit import __version__
@@ -510,10 +525,14 @@ def _register_all(
         print(f"  {_Y}{'gh auth':>12}{_R}  {_G}authenticated{_R}")
     else:
         print(f"  {_Y}{'gh auth':>12}{_R}  {_D}not found — run{_R} {_G}gh auth login{_R}")
-    if plugin_ok:
-        print(f"  {_Y}{'plugin':>12}{_R}  {_G}registered{_R}")
+    if _backend_name == AGENT_BACKEND_CODEX:
+        print(f"  {_Y}{'mcp':>12}{_R}  {_G}~/.codex/config.toml{_R}")
     else:
-        print(f"  {_Y}{'plugin':>12}{_R}  {_G}registered via ~/.claude.json{_R}")
-    print(f"  {_Y}{'hooks':>12}{_R}  {_G}synced{_R} {_D}({scope} scope){_R}")
+        if plugin_ok:
+            print(f"  {_Y}{'plugin':>12}{_R}  {_G}registered{_R}")
+        else:
+            print(f"  {_Y}{'plugin':>12}{_R}  {_G}registered via ~/.claude.json{_R}")
+        print(f"  {_Y}{'hooks':>12}{_R}  {_G}synced{_R} {_D}({scope} scope){_R}")
+
     print()
     _print_next_steps(context="init")

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -20,6 +20,7 @@ from autoskillit.execution.anomaly_detection import (
 from autoskillit.execution.backends import (
     ClaudeCodeBackend,
     CodexBackend,
+    ensure_codex_mcp_registered,
     get_backend,
 )
 from autoskillit.execution.ci import DefaultCIWatcher
@@ -212,6 +213,7 @@ __all__ = [
     # backends
     "ClaudeCodeBackend",
     "CodexBackend",
+    "ensure_codex_mcp_registered",
     # anomaly_detection
     "detect_anomalies",
     "AnomalyKind",


### PR DESCRIPTION
## Summary

Restructure `_register_all()` in `src/autoskillit/cli/_init_helpers.py` to branch on `cfg.agent_backend.backend`. The Codex path calls `ensure_codex_mcp_registered()` and leaves a P4 hook placeholder comment. The Claude Code path retains the existing hook-sync and MCP plugin registration logic. Unconditional operations (sweep, temp dir, secrets template, github prompt) remain outside the branch. The summary print block is updated to show backend-appropriate rows.

## Changed Files

### Modified (●):

● src/autoskillit/cli/_init_helpers.py
● src/autoskillit/execution/__init__.py

Closes #2863

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/p2_a3_wp1_branch_register_all_plan_2026-05-24_095500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 75 | 13.2k | 1.4M | 65.6k | 77 | 57.8k | 6m 18s |
| verify | claude-opus-4-6 | 1 | 39 | 9.5k | 1.1M | 69.3k | 53 | 55.7k | 3m 28s |
| implement* | MiniMax-M2.7-highspeed | 1 | 471.0k | 6.1k | 656.8k | 30.0k | 46 | 15.5k | 2m 22s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 154.2k | 3.2k | 359.8k | 30.0k | 33 | 42.0k | 1m 24s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 62.2k | 1.4k | 267.0k | 30.0k | 18 | 14.8k | 52s |
| review_pr | claude-sonnet-4-6 | 1 | 262 | 23.0k | 1.1M | 57.5k | 68 | 48.9k | 6m 43s |
| resolve_review | claude-sonnet-4-6 | 1 | 337 | 30.9k | 2.4M | 87.5k | 105 | 78.8k | 14m 38s |
| **Total** | | | 688.1k | 87.3k | 7.4M | 87.5k | | 313.6k | 35m 48s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 45 | 14594.6 | 344.8 | 136.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **45** | 165253.6 | 6969.2 | 1939.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 114 | 22.6k | 2.6M | 113.5k | 9m 47s |
| MiniMax-M2.7-highspeed | 3 | 687.4k | 10.8k | 1.3M | 72.4k | 4m 38s |
| claude-sonnet-4-6 | 2 | 599 | 53.9k | 3.6M | 127.7k | 21m 22s |