### PR TITLE
Add configure_fleet / configure_order MCP Tools with Shared Config Infrastructure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 53 MCP tools and 135 bundled skills.
+→ tests → PR → merge pipelines using 55 MCP tools and 135 bundled skills.
 
 ## Start here
 

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 53 MCP tools and 135 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 55 MCP tools and 135 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 
@@ -68,7 +68,7 @@ AutoSkillit supports four session modes with different tool and skill visibility
   `$ claude`); `/open-kitchen` reveals kitchen tools.
 
 - **`$ autoskillit order`**: Pipeline orchestrator session. Kitchen is pre-opened at startup —
-  all 53 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
+  all 55 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
   delegates work through `run_skill` (headless sessions) and `run_cmd` (shell commands).
 
 - **`run_skill` (headless)**: Worker sessions launched by the orchestrator. Sees 4 Free Range

--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -1,6 +1,6 @@
 # MCP Tool Access Control
 
-AutoSkillit provides 53 MCP tools organized into three access levels that control which
+AutoSkillit provides 55 MCP tools organized into three access levels that control which
 session types can see each tool.
 
 ## Three Access Levels
@@ -86,7 +86,7 @@ missing kitchen visibility.
 
 ## Complete MCP Tool Access Control Map
 
-All 53 tools with their access level, tags, source file, and functional category.
+All 55 tools with their access level, tags, source file, and functional category.
 
 **Tag abbreviations**: AS = `autoskillit`, K = `kitchen`, HL = `headless`,
 GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`, FL = `fleet`
@@ -101,6 +101,8 @@ GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`, FL = `fleet`
 | `close_kitchen` | AS | `server/tools_kitchen.py` |
 | `disable_quota_guard` | AS | `server/tools_kitchen.py` |
 | `reload_session` | AS | `server/tools_kitchen.py` |
+| `configure_fleet` | AS | `server/tools_config.py` |
+| `configure_order` | AS | `server/tools_config.py` |
 
 ---
 

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -95,7 +95,7 @@ and `/autoskillit:close-kitchen`. Skills in `skills_extended/` are never seen.
 
 Order is similar to cook: AutoSkillit launches Claude Code with access to all tiers.
 The key difference is the orchestrator (`sous-chef` skill) is injected and the kitchen
-is pre-opened so all 53 MCP tools are available from the start.
+is pre-opened so all 55 MCP tools are available from the start.
 
 ### Headless session (launched by `run_skill`)
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -18,7 +18,9 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_DIR = PROJECT_ROOT / "src" / "autoskillit" / "skills"
 SKILLS_EXTENDED_DIR = PROJECT_ROOT / "src" / "autoskillit" / "skills_extended"
 RECIPES_DIR = PROJECT_ROOT / "src" / "autoskillit" / "recipes"
-TYPES_FILE = PROJECT_ROOT / "src" / "autoskillit" / "core" / "types" / "_type_constants.py"
+TYPES_FILE = (
+    PROJECT_ROOT / "src" / "autoskillit" / "core" / "types" / "_type_constants_registries.py"
+)
 
 
 def count_skills() -> int:

--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -150,8 +150,9 @@ There are no exceptions.
 - NEVER call dispatch_food_truck for individual issues in parallel before the execution map \
 has been produced and read.
 
-1. Count total issues across all targets. If the total exceeds max_total_issues ({max_total_issues}),
-   STOP and inform the user the request exceeds the session cap.
+1. Count total issues across all targets. If the total exceeds
+   max_total_issues ({max_total_issues}), STOP and inform the user the
+   request exceeds the session cap.
 
 2. You MUST dispatch bem-wrapper first as the conflict analysis pre-step:
    {mcp_prefix}dispatch_food_truck(
@@ -179,8 +180,9 @@ sous-chef path handles deferred issue lifecycle.
 
 4. For each group in array order:
    - parallel: true → issue ALL dispatch_food_truck calls for this group in a single
-     response (parallel tool calls). The fleet semaphore allows up to max_concurrent_dispatches
-     ({max_concurrent_dispatches}) concurrent dispatches. If a dispatch returns FLEET_PARALLEL_REFUSED,
+     response (parallel tool calls). The fleet semaphore allows up to
+     max_concurrent_dispatches ({max_concurrent_dispatches}) concurrent
+     dispatches. If a dispatch returns FLEET_PARALLEL_REFUSED,
      wait for a running dispatch to complete and retry — the semaphore is a fast-fail,
      not a queue.
    - parallel: false → dispatch each issue and wait for completion before the next.

--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -74,7 +74,11 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
 
 
 def _build_fleet_dispatch_prompt(
-    mcp_prefix: str, recipe_table: str | None = None, max_issues_per_food_truck: int = 3
+    mcp_prefix: str,
+    recipe_table: str | None = None,
+    max_issues_per_food_truck: int = 3,
+    max_total_issues: int = 12,
+    max_concurrent_dispatches: int = 3,
 ) -> str:
     """Build the --append-system-prompt content for an ad-hoc fleet dispatcher session."""
     from autoskillit.fleet import _build_admiral_dispatch_block  # noqa: PLC0415
@@ -146,7 +150,7 @@ There are no exceptions.
 - NEVER call dispatch_food_truck for individual issues in parallel before the execution map \
 has been produced and read.
 
-1. Count total issues across all targets. If the total exceeds max_total_issues (default 12),
+1. Count total issues across all targets. If the total exceeds max_total_issues ({max_total_issues}),
    STOP and inform the user the request exceeds the session cap.
 
 2. You MUST dispatch bem-wrapper first as the conflict analysis pre-step:
@@ -176,7 +180,7 @@ sous-chef path handles deferred issue lifecycle.
 4. For each group in array order:
    - parallel: true → issue ALL dispatch_food_truck calls for this group in a single
      response (parallel tool calls). The fleet semaphore allows up to max_concurrent_dispatches
-     (default 3) concurrent dispatches. If a dispatch returns FLEET_PARALLEL_REFUSED,
+     ({max_concurrent_dispatches}) concurrent dispatches. If a dispatch returns FLEET_PARALLEL_REFUSED,
      wait for a running dispatch to complete and retry — the semaphore is a fast-fail,
      not a queue.
    - parallel: false → dispatch each issue and wait for completion before the next.

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -68,6 +68,8 @@ def _launch_fleet_session(
             mcp_prefix,
             recipe_table=recipe_table,
             max_issues_per_food_truck=cfg.fleet.max_issues_per_food_truck,
+            max_total_issues=cfg.fleet.max_total_issues,
+            max_concurrent_dispatches=cfg.fleet.max_concurrent_dispatches,
         )
         env_spec = FleetSessionEnv(
             session_type="fleet",

--- a/src/autoskillit/config/__init__.py
+++ b/src/autoskillit/config/__init__.py
@@ -5,6 +5,9 @@ either `from autoskillit.config import AutomationConfig` or the explicit
 `from autoskillit.config.settings import AutomationConfig`.
 """
 
+from autoskillit.config._config_dataclasses import (
+    _MAX_CONCURRENT_DISPATCHES as _MAX_CONCURRENT_DISPATCHES,
+)
 from autoskillit.config.ingredient_defaults import (
     iter_display_categories,
     resolve_ingredient_defaults,

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -389,13 +389,13 @@ class WorkspaceConfig:
     temp_dir: str | None = None  # null = canonical default (see resolve_temp_dir)
 
 
-_MAX_CONCURRENT_DISPATCHES = 3
+_MAX_CONCURRENT_DISPATCHES = 8
 
 
 @dataclass
 class FleetConfig:
     default_timeout_sec: int = 3600
-    max_concurrent_dispatches: int = _MAX_CONCURRENT_DISPATCHES
+    max_concurrent_dispatches: int = 3  # default; ceiling is _MAX_CONCURRENT_DISPATCHES
     max_total_issues: int = 12
     enable_deadline_extension: bool = True
     max_extension_seconds: float = 7200

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -75,7 +75,17 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
         ),
     ),
     ("Fleet", FLEET_MENU_TOOLS),
-    ("Kitchen", ("open_kitchen", "close_kitchen", "disable_quota_guard", "reload_session")),
+    (
+        "Kitchen",
+        (
+            "open_kitchen",
+            "close_kitchen",
+            "disable_quota_guard",
+            "reload_session",
+            "configure_fleet",
+            "configure_order",
+        ),
+    ),
 )
 
 

--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -131,7 +131,14 @@ FLEET_MENU_TOOLS: tuple[str, ...] = ("dispatch_food_truck", "record_gate_dispatc
 FLEET_ERROR_CODES: frozenset[str] = frozenset(FleetErrorCode)
 
 FREE_RANGE_TOOLS: frozenset[str] = frozenset(
-    {"open_kitchen", "close_kitchen", "disable_quota_guard", "reload_session"}
+    {
+        "open_kitchen",
+        "close_kitchen",
+        "disable_quota_guard",
+        "reload_session",
+        "configure_fleet",
+        "configure_order",
+    }
 )
 
 UNGATED_TOOLS: frozenset[str] = FREE_RANGE_TOOLS

--- a/src/autoskillit/hooks/formatters/pretty_output_hook.py
+++ b/src/autoskillit/hooks/formatters/pretty_output_hook.py
@@ -218,6 +218,8 @@ _UNFORMATTED_TOOLS: frozenset[str] = frozenset(
         "bootstrap_clone",  # composite clone result dict
         "claim_and_resolve_issue",  # composite claim result dict
         "create_and_publish_branch",  # composite branch result dict
+        "configure_fleet",  # simple config snapshot dict
+        "configure_order",  # simple config snapshot dict
     }
 )
 

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -177,6 +177,28 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
     "get_pr_reviews": frozenset({"pr_number", "cwd", "repo"}),
     "bulk_close_issues": frozenset({"issue_numbers", "comment", "cwd"}),
     "unlock_agent_pack": frozenset({"pack_name"}),
+    "configure_fleet": frozenset(
+        {
+            "max_concurrent_dispatches",
+            "max_total_issues",
+            "default_timeout_sec",
+            "max_extension_seconds",
+            "idle_output_timeout",
+            "acquire_timeout_sec",
+            "max_issues_per_food_truck",
+            "enable_deadline_extension",
+            "default_model",
+        }
+    ),
+    "configure_order": frozenset(
+        {
+            "timeout",
+            "stale_threshold",
+            "idle_output_timeout",
+            "max_suppression_seconds",
+            "default_model",
+        }
+    ),
 }
 
 

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -88,6 +88,9 @@ from autoskillit.server.tools import (  # noqa: E402, F401
     tools_clone as _tools_clone,
 )
 from autoskillit.server.tools import (  # noqa: E402, F401
+    tools_config as _tools_config,
+)
+from autoskillit.server.tools import (  # noqa: E402, F401
     tools_execution as _tools_execution,
 )
 from autoskillit.server.tools import (  # noqa: E402, F401

--- a/src/autoskillit/server/tools/CLAUDE.md
+++ b/src/autoskillit/server/tools/CLAUDE.md
@@ -9,6 +9,7 @@ MCP `@mcp.tool()` handlers registered on import (16 tool modules).
 | `__init__.py` | Docstring-only — tools register via `@mcp.tool()` on import |
 | `_types.py` | TypedDict definitions for server tool JSON responses (RunSkillResult, RunCmdResult, etc.) |
 | `tools_kitchen.py` | `open_kitchen`, `close_kitchen` (gate lifecycle), `recipe://` MCP resource |
+| `tools_config.py` | `configure_fleet`, `configure_order` (session config overlay) |
 | `tools_agents.py` | `unlock_agent_pack` tool + `agent://` resource templates |
 | `tools_ci.py` | `set_commit_status`, `check_repo_merge_state` |
 | `tools_ci_watch.py` | `wait_for_ci`, `get_ci_status`, `_auto_trigger_ci` |

--- a/src/autoskillit/server/tools/tools_config.py
+++ b/src/autoskillit/server/tools/tools_config.py
@@ -1,0 +1,200 @@
+"""Session-scoped configuration MCP tools: configure_fleet, configure_order."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields as dc_fields
+
+from autoskillit.core import atomic_write, get_logger
+from autoskillit.server import mcp
+from autoskillit.server._guards import _require_orchestrator_exact
+from autoskillit.server._misc import _hook_config_overlay_path, _hook_config_path
+from autoskillit.server._notify import track_response_size
+
+logger = get_logger(__name__)
+
+
+def _write_session_config(
+    project_dir, domain: str, params: dict, core_params: dict | None = None
+) -> tuple[bool, dict | str]:
+    """Read-merge-write domain params into the overlay file.
+
+    Returns (success, overlay_dict_or_error_message).
+    """
+    if not _hook_config_path(project_dir).exists():
+        return (False, "Kitchen is not open — hook config file absent.")
+
+    overlay_path = _hook_config_overlay_path(project_dir)
+    overlay_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if overlay_path.exists():
+            existing = json.loads(overlay_path.read_text())
+        else:
+            existing = {}
+    except (json.JSONDecodeError, OSError):
+        existing = {}
+
+    domain_data = dict(existing.get(domain, {}))
+    domain_data.update(params)
+    existing[domain] = domain_data
+
+    if core_params:
+        core_data = dict(existing.get("core", {}))
+        core_data.update(core_params)
+        existing["core"] = core_data
+
+    atomic_write(overlay_path, json.dumps(existing))
+    return (True, existing)
+
+
+def _build_config_snapshot(config, domain: str, overlay: dict) -> dict:
+    """Build complete config snapshot: dataclass defaults + overlay overrides."""
+    if domain == "fleet":
+        defaults = {f.name: getattr(config.fleet, f.name) for f in dc_fields(config.fleet)}
+    elif domain == "order":
+        defaults = {f.name: getattr(config.run_skill, f.name) for f in dc_fields(config.run_skill)}
+    else:
+        defaults = {}
+
+    core_defaults = {f.name: getattr(config.model, f.name) for f in dc_fields(config.model)}
+    core_overrides = overlay.get("core", {})
+
+    domain_overrides = overlay.get(domain, {})
+    snapshot_domain = {**defaults, **domain_overrides}
+
+    return {domain: snapshot_domain, "core": {**core_defaults, **core_overrides}}
+
+
+@mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True})
+@track_response_size("configure_fleet")
+async def configure_fleet(
+    max_concurrent_dispatches: int | None = None,
+    max_total_issues: int | None = None,
+    default_timeout_sec: int | None = None,
+    max_extension_seconds: float | None = None,
+    idle_output_timeout: float | None = None,
+    acquire_timeout_sec: float | None = None,
+    max_issues_per_food_truck: int | None = None,
+    enable_deadline_extension: bool | None = None,
+    default_model: str | None = None,
+) -> str:
+    """Configure fleet dispatch parameters for this kitchen session.
+
+    Sets fleet-specific and core parameters that persist for the remainder
+    of this kitchen session. Call after open_kitchen. Parameters not
+    explicitly set retain their defaults from FleetConfig.
+
+    Returns a complete config snapshot (all fleet + core values, including
+    defaults for anything not explicitly set). Use this snapshot as the
+    single source of truth for session limits.
+
+    Session-scoped only: configuration is cleared when the kitchen is
+    closed and reopened. Does not modify persistent configuration.
+
+    Never raises.
+    """
+    try:
+        if (h := _require_orchestrator_exact("configure_fleet")) is not None:
+            return h
+        from autoskillit.server import _get_ctx
+
+        ctx = _get_ctx()
+
+        if max_concurrent_dispatches is not None:
+            from autoskillit.config._config_dataclasses import _MAX_CONCURRENT_DISPATCHES
+            if max_concurrent_dispatches < 1 or max_concurrent_dispatches > _MAX_CONCURRENT_DISPATCHES:
+                return json.dumps({
+                    "success": False,
+                    "error": f"max_concurrent_dispatches must be between 1 and {_MAX_CONCURRENT_DISPATCHES}, got {max_concurrent_dispatches}",
+                })
+
+        fleet_params = {}
+        for name, val in [
+            ("max_concurrent_dispatches", max_concurrent_dispatches),
+            ("max_total_issues", max_total_issues),
+            ("default_timeout_sec", default_timeout_sec),
+            ("max_extension_seconds", max_extension_seconds),
+            ("idle_output_timeout", idle_output_timeout),
+            ("acquire_timeout_sec", acquire_timeout_sec),
+            ("max_issues_per_food_truck", max_issues_per_food_truck),
+            ("enable_deadline_extension", enable_deadline_extension),
+        ]:
+            if val is not None:
+                fleet_params[name] = val
+
+        core_params = {}
+        if default_model is not None:
+            core_params["default_model"] = default_model
+
+        ok, result = _write_session_config(ctx.project_dir, "fleet", fleet_params, core_params or None)
+        if not ok:
+            return json.dumps({"success": False, "error": result})
+
+        if max_concurrent_dispatches is not None:
+            from autoskillit.fleet._semaphore import FleetSemaphore
+            existing_timeout = ctx.fleet_lock.timeout if ctx.fleet_lock is not None else None
+            timeout = acquire_timeout_sec if acquire_timeout_sec is not None else existing_timeout
+            ctx.fleet_lock = FleetSemaphore(max_concurrent=max_concurrent_dispatches, timeout=timeout)
+
+        snapshot = _build_config_snapshot(ctx.config, "fleet", result)
+        return json.dumps({"success": True, "config": snapshot})
+    except Exception as exc:
+        logger.error("configure_fleet unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+
+
+@mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True})
+@track_response_size("configure_order")
+async def configure_order(
+    timeout: int | None = None,
+    stale_threshold: int | None = None,
+    idle_output_timeout: int | None = None,
+    max_suppression_seconds: int | None = None,
+    default_model: str | None = None,
+) -> str:
+    """Configure order/orchestrator parameters for this kitchen session.
+
+    Sets order-specific (RunSkillConfig) and core parameters that persist
+    for the remainder of this kitchen session. Call after open_kitchen.
+    Parameters not explicitly set retain their defaults from RunSkillConfig.
+
+    Returns a complete config snapshot (all order + core values, including
+    defaults for anything not explicitly set). Use this snapshot as the
+    single source of truth for session limits.
+
+    Session-scoped only: configuration is cleared when the kitchen is
+    closed and reopened. Does not modify persistent configuration.
+
+    Never raises.
+    """
+    try:
+        if (h := _require_orchestrator_exact("configure_order")) is not None:
+            return h
+        from autoskillit.server import _get_ctx
+
+        ctx = _get_ctx()
+
+        order_params = {}
+        for name, val in [
+            ("timeout", timeout),
+            ("stale_threshold", stale_threshold),
+            ("idle_output_timeout", idle_output_timeout),
+            ("max_suppression_seconds", max_suppression_seconds),
+        ]:
+            if val is not None:
+                order_params[name] = val
+
+        core_params = {}
+        if default_model is not None:
+            core_params["default_model"] = default_model
+
+        ok, result = _write_session_config(ctx.project_dir, "order", order_params, core_params or None)
+        if not ok:
+            return json.dumps({"success": False, "error": result})
+
+        snapshot = _build_config_snapshot(ctx.config, "order", result)
+        return json.dumps({"success": True, "config": snapshot})
+    except Exception as exc:
+        logger.error("configure_order unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools/tools_config.py
+++ b/src/autoskillit/server/tools/tools_config.py
@@ -66,7 +66,72 @@ def _build_config_snapshot(config, domain: str, overlay: dict) -> dict:
     return {domain: snapshot_domain, "core": {**core_defaults, **core_overrides}}
 
 
-@mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True})
+def _collect_fleet_params(
+    max_concurrent_dispatches: int | None,
+    max_total_issues: int | None,
+    default_timeout_sec: int | None,
+    max_extension_seconds: float | None,
+    idle_output_timeout: float | None,
+    acquire_timeout_sec: float | None,
+    max_issues_per_food_truck: int | None,
+    enable_deadline_extension: bool | None,
+) -> dict:
+    params: dict = {}
+    for name, val in [
+        ("max_concurrent_dispatches", max_concurrent_dispatches),
+        ("max_total_issues", max_total_issues),
+        ("default_timeout_sec", default_timeout_sec),
+        ("max_extension_seconds", max_extension_seconds),
+        ("idle_output_timeout", idle_output_timeout),
+        ("acquire_timeout_sec", acquire_timeout_sec),
+        ("max_issues_per_food_truck", max_issues_per_food_truck),
+        ("enable_deadline_extension", enable_deadline_extension),
+    ]:
+        if val is not None:
+            params[name] = val
+    return params
+
+
+def _collect_order_params(
+    timeout: int | None,
+    stale_threshold: int | None,
+    idle_output_timeout: int | None,
+    max_suppression_seconds: int | None,
+) -> dict:
+    params: dict = {}
+    for name, val in [
+        ("timeout", timeout),
+        ("stale_threshold", stale_threshold),
+        ("idle_output_timeout", idle_output_timeout),
+        ("max_suppression_seconds", max_suppression_seconds),
+    ]:
+        if val is not None:
+            params[name] = val
+    return params
+
+
+def _validate_max_concurrent(value: int) -> str | None:
+    from autoskillit.config import _MAX_CONCURRENT_DISPATCHES
+
+    if value < 1 or value > _MAX_CONCURRENT_DISPATCHES:
+        return (
+            f"max_concurrent_dispatches must be between 1 and "
+            f"{_MAX_CONCURRENT_DISPATCHES}, got {value}"
+        )
+    return None
+
+
+def _replace_fleet_semaphore(ctx, max_concurrent: int, acquire_timeout_sec: float | None) -> None:
+    from autoskillit.fleet import FleetSemaphore
+
+    existing_timeout = ctx.fleet_lock.timeout if ctx.fleet_lock is not None else None
+    timeout = acquire_timeout_sec if acquire_timeout_sec is not None else existing_timeout
+    ctx.fleet_lock = FleetSemaphore(max_concurrent=max_concurrent, timeout=timeout)
+
+
+@mcp.tool(
+    tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
+)
 @track_response_size("configure_fleet")
 async def configure_fleet(
     max_concurrent_dispatches: int | None = None,
@@ -102,41 +167,30 @@ async def configure_fleet(
         ctx = _get_ctx()
 
         if max_concurrent_dispatches is not None:
-            from autoskillit.config._config_dataclasses import _MAX_CONCURRENT_DISPATCHES
-            if max_concurrent_dispatches < 1 or max_concurrent_dispatches > _MAX_CONCURRENT_DISPATCHES:
-                return json.dumps({
-                    "success": False,
-                    "error": f"max_concurrent_dispatches must be between 1 and {_MAX_CONCURRENT_DISPATCHES}, got {max_concurrent_dispatches}",
-                })
+            if (err := _validate_max_concurrent(max_concurrent_dispatches)) is not None:
+                return json.dumps({"success": False, "error": err})
 
-        fleet_params = {}
-        for name, val in [
-            ("max_concurrent_dispatches", max_concurrent_dispatches),
-            ("max_total_issues", max_total_issues),
-            ("default_timeout_sec", default_timeout_sec),
-            ("max_extension_seconds", max_extension_seconds),
-            ("idle_output_timeout", idle_output_timeout),
-            ("acquire_timeout_sec", acquire_timeout_sec),
-            ("max_issues_per_food_truck", max_issues_per_food_truck),
-            ("enable_deadline_extension", enable_deadline_extension),
-        ]:
-            if val is not None:
-                fleet_params[name] = val
+        fleet_params = _collect_fleet_params(
+            max_concurrent_dispatches,
+            max_total_issues,
+            default_timeout_sec,
+            max_extension_seconds,
+            idle_output_timeout,
+            acquire_timeout_sec,
+            max_issues_per_food_truck,
+            enable_deadline_extension,
+        )
 
-        core_params = {}
-        if default_model is not None:
-            core_params["default_model"] = default_model
+        core_params = {"default_model": default_model} if default_model is not None else None
 
-        ok, result = _write_session_config(ctx.project_dir, "fleet", fleet_params, core_params or None)
+        ok, result = _write_session_config(ctx.project_dir, "fleet", fleet_params, core_params)
         if not ok:
             return json.dumps({"success": False, "error": result})
 
         if max_concurrent_dispatches is not None:
-            from autoskillit.fleet._semaphore import FleetSemaphore
-            existing_timeout = ctx.fleet_lock.timeout if ctx.fleet_lock is not None else None
-            timeout = acquire_timeout_sec if acquire_timeout_sec is not None else existing_timeout
-            ctx.fleet_lock = FleetSemaphore(max_concurrent=max_concurrent_dispatches, timeout=timeout)
+            _replace_fleet_semaphore(ctx, max_concurrent_dispatches, acquire_timeout_sec)
 
+        assert isinstance(result, dict)
         snapshot = _build_config_snapshot(ctx.config, "fleet", result)
         return json.dumps({"success": True, "config": snapshot})
     except Exception as exc:
@@ -144,7 +198,9 @@ async def configure_fleet(
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True})
+@mcp.tool(
+    tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
+)
 @track_response_size("configure_order")
 async def configure_order(
     timeout: int | None = None,
@@ -175,24 +231,17 @@ async def configure_order(
 
         ctx = _get_ctx()
 
-        order_params = {}
-        for name, val in [
-            ("timeout", timeout),
-            ("stale_threshold", stale_threshold),
-            ("idle_output_timeout", idle_output_timeout),
-            ("max_suppression_seconds", max_suppression_seconds),
-        ]:
-            if val is not None:
-                order_params[name] = val
+        order_params = _collect_order_params(
+            timeout, stale_threshold, idle_output_timeout, max_suppression_seconds
+        )
 
-        core_params = {}
-        if default_model is not None:
-            core_params["default_model"] = default_model
+        core_params = {"default_model": default_model} if default_model is not None else None
 
-        ok, result = _write_session_config(ctx.project_dir, "order", order_params, core_params or None)
+        ok, result = _write_session_config(ctx.project_dir, "order", order_params, core_params)
         if not ok:
             return json.dumps({"success": False, "error": result})
 
+        assert isinstance(result, dict)
         snapshot = _build_config_snapshot(ctx.config, "order", result)
         return json.dumps({"success": True, "config": snapshot})
     except Exception as exc:

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -270,6 +270,7 @@ def test_ungated_tools_do_not_call_require_enabled() -> None:
     from autoskillit.pipeline.gate import UNGATED_TOOLS
     from autoskillit.server.tools import (
         tools_clone,
+        tools_config,
         tools_execution,
         tools_git,
         tools_github,
@@ -282,6 +283,7 @@ def test_ungated_tools_do_not_call_require_enabled() -> None:
     )
 
     _all_tool_modules = [
+        tools_config,
         tools_execution,
         tools_git,
         tools_workspace,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -844,7 +844,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "pipeline": 12,
         "fleet": 19,
         "recipe/rules": 46,
-        "server/tools": 21,
+        "server/tools": 22,
         "hooks/guards": 22,
     }
     violations: list[str] = []

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -91,7 +91,11 @@ def test_fleet_dispatch_exits_when_claude_missing(
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
     monkeypatch.setattr("autoskillit.cli.fleet.is_feature_enabled", lambda *a, **kw: True)
-    _fleet = type("Fleet", (), {"max_issues_per_food_truck": 3})()
+    _fleet = type(
+        "Fleet",
+        (),
+        {"max_issues_per_food_truck": 3, "max_total_issues": 12, "max_concurrent_dispatches": 3},
+    )()
     _agent_backend = type("AB", (), {"backend": "claude-code"})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",
@@ -131,7 +135,11 @@ def test_fleet_dispatch_exits_when_disabled(
             checked_features.append(name) or False
         ),
     )
-    _fleet = type("Fleet", (), {"max_issues_per_food_truck": 3})()
+    _fleet = type(
+        "Fleet",
+        (),
+        {"max_issues_per_food_truck": 3, "max_total_issues": 12, "max_concurrent_dispatches": 3},
+    )()
     monkeypatch.setattr(
         "autoskillit.config.load_config",
         lambda path: type(
@@ -159,7 +167,11 @@ def test_fleet_dispatch_proceeds_when_enabled(
         "autoskillit.cli.fleet.is_feature_enabled",
         lambda name, features, *, experimental_enabled=False: True,
     )
-    _fleet = type("Fleet", (), {"max_issues_per_food_truck": 3})()
+    _fleet = type(
+        "Fleet",
+        (),
+        {"max_issues_per_food_truck": 3, "max_total_issues": 12, "max_concurrent_dispatches": 3},
+    )()
     _agent_backend = type("AB", (), {"backend": "claude-code"})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -222,7 +222,7 @@ def test_fleet_reload_relaunches_without_resume(
     monkeypatch.setattr("autoskillit.cli.detect_autoskillit_mcp_prefix", lambda: "autoskillit")
     monkeypatch.setattr(
         "autoskillit.cli._prompts._build_fleet_dispatch_prompt",
-        lambda mcp_prefix, recipe_table=None, max_issues_per_food_truck=3: "test-prompt",
+        lambda mcp_prefix, **kw: "test-prompt",
     )
     monkeypatch.chdir(tmp_path)
 

--- a/tests/config/test_fleet_config.py
+++ b/tests/config/test_fleet_config.py
@@ -120,12 +120,12 @@ class TestFleetConfig:
 
         assert FleetConfig().max_concurrent_dispatches == 3
 
-    def test_fleet_config_max_concurrent_dispatches_rejects_above_3(self) -> None:
-        """FleetConfig.validate() rejects max_concurrent_dispatches > 3."""
+    def test_fleet_config_max_concurrent_dispatches_rejects_above_ceiling(self) -> None:
+        """FleetConfig.validate() rejects max_concurrent_dispatches above the ceiling."""
         from autoskillit.config.settings import FleetConfig
 
-        with pytest.raises(ValueError, match="must be <= 3"):
-            FleetConfig(max_concurrent_dispatches=4).validate(feature_enabled=True)
+        with pytest.raises(ValueError, match="must be <= 8"):
+            FleetConfig(max_concurrent_dispatches=9).validate(feature_enabled=True)
 
     def test_fleet_config_max_concurrent_dispatches_validates_positive(self) -> None:
         """FleetConfig raises ValueError when max_concurrent_dispatches is 0."""

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -313,6 +313,8 @@ def test_free_range_tools_contains_expected_names():
         "close_kitchen",
         "disable_quota_guard",
         "reload_session",
+        "configure_fleet",
+        "configure_order",
     }
 
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -204,9 +204,9 @@ def test_kitchen_tagged_tool_count_is_38() -> None:
     assert count == 38, f"Expected 38 kitchen-tagged tools; found {count}"
 
 
-def test_free_range_tool_count_is_15() -> None:
-    assert _count_free_range_tools() == 15, (
-        f"Expected 15 free-range tools; found {_count_free_range_tools()}"
+def test_free_range_tool_count_is_17() -> None:
+    assert _count_free_range_tools() == 17, (
+        f"Expected 17 free-range tools; found {_count_free_range_tools()}"
     )
 
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -293,8 +293,8 @@ def _assert_doc_states_number(doc: Path, label: str, expected: int) -> None:
         DOCS_DIR / "execution" / "tool-access.md",
     ],
 )
-def test_docs_state_53_mcp_tools(doc_path: Path) -> None:
-    _assert_doc_states_number(doc_path, "MCP tools", 53)
+def test_docs_state_55_mcp_tools(doc_path: Path) -> None:
+    _assert_doc_states_number(doc_path, "MCP tools", 55)
 
 
 @pytest.mark.parametrize(

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -136,6 +136,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/cli/_marketplace.py", 96),
     # _marketplace.py — hooks.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 188),
+    # tools_config.py — hook config overlay dict (session-scoped, not schema-versioned)
+    ("src/autoskillit/server/tools/tools_config.py", 47),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/update/_update_checks.py", 77),
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -73,7 +73,14 @@ def test_check_quota_not_in_ungated_tools():
 def test_ungated_tools_contains_expected_names():
     from autoskillit.pipeline.gate import UNGATED_TOOLS
 
-    expected = {"open_kitchen", "close_kitchen", "disable_quota_guard", "reload_session"}
+    expected = {
+        "open_kitchen",
+        "close_kitchen",
+        "disable_quota_guard",
+        "reload_session",
+        "configure_fleet",
+        "configure_order",
+    }
     assert UNGATED_TOOLS == expected
 
 

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -36,7 +36,6 @@ def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
 
 def test_deep_staleness_baseline_initialized_eagerly(tmp_path, monkeypatch):
     """_get_process_start_mtime eagerly sets the deep mtime baseline."""
-    import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -349,6 +349,7 @@ _SERVER_TOOL_MODULES = [
     "autoskillit.server.tools.tools_pr_ops",
     "autoskillit.server.tools.tools_workspace",
     "autoskillit.server.tools.tools_agents",
+    "autoskillit.server.tools.tools_config",
 ]
 
 _FRAMEWORK_PARAMS = frozenset({"ctx"})

--- a/tests/recipe/test_staleness_cache.py
+++ b/tests/recipe/test_staleness_cache.py
@@ -150,7 +150,9 @@ def test_check_staleness_writes_cache_on_miss(monkeypatch, tmp_path):
         compute_called.append(skill_name)
         return "sha256:" + "b" * 64
 
-    monkeypatch.setattr("autoskillit.recipe._contracts_staleness.compute_skill_hash", tracking_compute)
+    monkeypatch.setattr(
+        "autoskillit.recipe._contracts_staleness.compute_skill_hash", tracking_compute
+    )
 
     contract = {
         "bundled_manifest_version": manifest_version,

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -100,6 +100,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_clone_result_exhaustiveness.py` | Structural test enforcing exhaustive CloneResult gate handling in _require_clone_success |
 | `test_subprocess_validation.py` | Tests for _run_subprocess cwd validation (empty, relative, nonexistent paths) |
 | `test_tools_bootstrap.py` | Tests for bootstrap composite MCP tools (bootstrap_clone, claim_and_resolve_issue, create_and_publish_branch) |
+| `test_tools_config.py` | Tests for `configure_fleet` and `configure_order` MCP tools |
 | `test_tools_run_skill_retry.py` | Tests verifying run_skill_retry was removed and run_skill handles all sessions |
 | `test_tools_session_diagnostics.py` | Tests for session diagnostics helpers in tools_github |
 | `test_tools_status_kitchen.py` | Tests for server status tools: kitchen status, pipeline report, and telemetry recovery |

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -33,7 +33,7 @@ class TestNoSkillsDirectoryProvider:
 
 
 class TestToolRegistration:
-    """All 52 tools are registered on the MCP server."""
+    """All 54 tools are registered on the MCP server."""
 
     @pytest.mark.anyio
     async def test_all_tools_exist(self, kitchen_enabled):
@@ -102,6 +102,8 @@ class TestToolRegistration:
             "claim_and_resolve_issue",
             "create_and_publish_branch",
             "unlock_agent_pack",
+            "configure_fleet",
+            "configure_order",
         }
         assert expected == tool_names
 

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from autoskillit.config import AutomationConfig
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -50,7 +51,6 @@ async def test_configure_fleet_replaces_semaphore(tmp_path, monkeypatch) -> None
     """configure_fleet replaces ctx.fleet_lock with resized FleetSemaphore."""
     from autoskillit.fleet._semaphore import FleetSemaphore
     from autoskillit.server import _state
-    from tests.server._helpers import _HOOK_CONFIG_OVERLAY_RELPATH
 
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
     hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
@@ -145,6 +145,7 @@ async def test_configure_order_writes_overlay(tmp_path, monkeypatch) -> None:
 
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
+    mock_ctx.config = AutomationConfig()
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -234,6 +235,7 @@ async def test_configure_fleet_no_params_returns_defaults(tmp_path, monkeypatch)
 
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
+    mock_ctx.config = AutomationConfig()
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -259,6 +261,7 @@ async def test_configure_order_no_params_returns_defaults(tmp_path, monkeypatch)
 
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
+    mock_ctx.config = AutomationConfig()
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -275,7 +278,6 @@ async def test_configure_order_no_params_returns_defaults(tmp_path, monkeypatch)
 @pytest.mark.anyio
 async def test_configure_fleet_semaphore_null_fleet_lock(tmp_path, monkeypatch) -> None:
     """configure_fleet creates new semaphore when fleet_lock is None."""
-    from autoskillit.fleet._semaphore import FleetSemaphore
     from autoskillit.server import _state
 
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
@@ -285,6 +287,7 @@ async def test_configure_fleet_semaphore_null_fleet_lock(tmp_path, monkeypatch) 
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
     mock_ctx.fleet_lock = None
+    mock_ctx.config = AutomationConfig()
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -1,0 +1,299 @@
+"""Tests for configure_fleet and configure_order MCP tools."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.server.conftest import _make_mock_ctx
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+_HOOK_CONFIG_RELPATH = (".autoskillit", "temp", ".hook_config.json")
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_writes_overlay(tmp_path, monkeypatch) -> None:
+    """configure_fleet writes fleet params to overlay and returns snapshot."""
+    from autoskillit.server import _state
+    from tests.server._helpers import _HOOK_CONFIG_OVERLAY_RELPATH
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=5, max_total_issues=20)
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    overlay_path = tmp_path.joinpath(*_HOOK_CONFIG_OVERLAY_RELPATH)
+    overlay = json.loads(overlay_path.read_text())
+    assert overlay["fleet"]["max_concurrent_dispatches"] == 5
+    assert overlay["fleet"]["max_total_issues"] == 20
+    assert hook_cfg_path.read_text() == "{}"
+    assert "max_concurrent_dispatches" in payload["config"]["fleet"]
+    assert "max_total_issues" in payload["config"]["fleet"]
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_replaces_semaphore(tmp_path, monkeypatch) -> None:
+    """configure_fleet replaces ctx.fleet_lock with resized FleetSemaphore."""
+    from autoskillit.fleet._semaphore import FleetSemaphore
+    from autoskillit.server import _state
+    from tests.server._helpers import _HOOK_CONFIG_OVERLAY_RELPATH
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=6)
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    assert mock_ctx.fleet_lock.max_concurrent == 6
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_preserves_existing_overlay(tmp_path, monkeypatch) -> None:
+    """configure_fleet merges into existing overlay without clobbering."""
+    from autoskillit.server import _state
+    from tests.server._helpers import _HOOK_CONFIG_OVERLAY_RELPATH
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    overlay_path = tmp_path.joinpath(*_HOOK_CONFIG_OVERLAY_RELPATH)
+    overlay_path.parent.mkdir(parents=True, exist_ok=True)
+    overlay_path.write_text(json.dumps({"quota_guard": {"disabled": True}}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_total_issues=8)
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    overlay = json.loads(overlay_path.read_text())
+    assert overlay["quota_guard"]["disabled"] is True
+    assert overlay["fleet"]["max_total_issues"] == 8
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_denies_headless(tmp_path, monkeypatch) -> None:
+    """configure_fleet rejects headless sessions."""
+    monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=5)
+    payload = json.loads(result)
+    assert payload["success"] is False
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_returns_error_when_kitchen_not_open(tmp_path, monkeypatch) -> None:
+    """configure_fleet returns error when kitchen is not open."""
+    from autoskillit.server import _state
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=5)
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert "not open" in payload["error"]
+
+
+@pytest.mark.anyio
+async def test_configure_order_writes_overlay(tmp_path, monkeypatch) -> None:
+    """configure_order writes order + core params to overlay and returns snapshot."""
+    from autoskillit.server import _state
+    from tests.server._helpers import _HOOK_CONFIG_OVERLAY_RELPATH
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_order
+
+    result = await configure_order(timeout=3600, default_model="opus")
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    overlay_path = tmp_path.joinpath(*_HOOK_CONFIG_OVERLAY_RELPATH)
+    overlay = json.loads(overlay_path.read_text())
+    assert overlay["order"]["timeout"] == 3600
+    assert overlay["core"]["default_model"] == "opus"
+    assert "timeout" in payload["config"]["order"]
+
+
+@pytest.mark.anyio
+async def test_configure_order_denies_headless(tmp_path, monkeypatch) -> None:
+    """configure_order rejects headless sessions."""
+    monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+    from autoskillit.server.tools.tools_config import configure_order
+
+    result = await configure_order(timeout=3600)
+    payload = json.loads(result)
+    assert payload["success"] is False
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_accumulates_across_calls(tmp_path, monkeypatch) -> None:
+    """configure_fleet accumulates params across multiple calls."""
+    from autoskillit.server import _state
+    from tests.server._helpers import _HOOK_CONFIG_OVERLAY_RELPATH
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    await configure_fleet(max_concurrent_dispatches=5)
+    await configure_fleet(max_total_issues=20)
+
+    overlay_path = tmp_path.joinpath(*_HOOK_CONFIG_OVERLAY_RELPATH)
+    overlay = json.loads(overlay_path.read_text())
+    assert overlay["fleet"]["max_concurrent_dispatches"] == 5
+    assert overlay["fleet"]["max_total_issues"] == 20
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_validates_ceiling(tmp_path, monkeypatch) -> None:
+    """configure_fleet rejects max_concurrent_dispatches above ceiling."""
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=9)
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert "must be between" in payload["error"]
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_no_params_returns_defaults(tmp_path, monkeypatch) -> None:
+    """configure_fleet with no params returns full snapshot with defaults."""
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet()
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    assert "max_concurrent_dispatches" in payload["config"]["fleet"]
+    assert "max_total_issues" in payload["config"]["fleet"]
+
+
+@pytest.mark.anyio
+async def test_configure_order_no_params_returns_defaults(tmp_path, monkeypatch) -> None:
+    """configure_order with no params returns full snapshot with defaults."""
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_order
+
+    result = await configure_order()
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    assert "timeout" in payload["config"]["order"]
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_semaphore_null_fleet_lock(tmp_path, monkeypatch) -> None:
+    """configure_fleet creates new semaphore when fleet_lock is None."""
+    from autoskillit.fleet._semaphore import FleetSemaphore
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.fleet_lock = None
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=4)
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    assert mock_ctx.fleet_lock.max_concurrent == 4
+    assert mock_ctx.fleet_lock.timeout is None

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -27,6 +27,7 @@ async def test_configure_fleet_writes_overlay(tmp_path, monkeypatch) -> None:
 
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
+    mock_ctx.config = AutomationConfig()
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -59,6 +60,7 @@ async def test_configure_fleet_replaces_semaphore(tmp_path, monkeypatch) -> None
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
     mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
+    mock_ctx.config = AutomationConfig()
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -88,6 +90,7 @@ async def test_configure_fleet_preserves_existing_overlay(tmp_path, monkeypatch)
 
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
+    mock_ctx.config = AutomationConfig()
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -186,6 +189,7 @@ async def test_configure_fleet_accumulates_across_calls(tmp_path, monkeypatch) -
 
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
+    mock_ctx.config = AutomationConfig()
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)


### PR DESCRIPTION
## Summary

Add two session-scoped configuration MCP tools (`configure_fleet`, `configure_order`) that allow the orchestrator to set runtime parameters at session start. Both tools share a common overlay-write/snapshot-read infrastructure following the proven `disable_quota_guard` pattern. `configure_fleet` additionally replaces `ctx.fleet_lock` with a resized `FleetSemaphore`. The `_MAX_CONCURRENT_DISPATCHES` ceiling is raised from 3 to 8 (default remains 3). Hardcoded prompt literals `"(default 12)"` / `"(default 3)"` are replaced with config-derived interpolation.

## Requirements

(Closing issue not fetched — gh access unavailable in read-only session; requirements not extracted.)

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-083840-504095/.autoskillit/temp/make-plan/add_configure_fleet_configure_order_mcp_tools_plan_2026-05-24_091500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 2 | 15.5k | 73.1k | 5.6M | 156.9k | 540 | 309.9k | 45m 2s |
| verify | claude-sonnet-4-6 | 1 | 47 | 14.6k | 1.2M | 77.0k | 148 | 63.1k | 9m 22s |
| implement* | MiniMax-M2.7 | 1 | 517.9k | 25.9k | 5.4M | 30.0k | 214 | 30.0k | 14m 17s |
| prepare_pr* | MiniMax-M2.7 | 1 | 51.9k | 5.2k | 678.2k | 0 | 37 | 0 | 1m 37s |
| compose_pr* | MiniMax-M2.7 | 1 | 72.2k | 3.0k | 442.8k | 30.0k | 35 | 42.7k | 1m 36s |
| review_pr | claude-sonnet-4-6 | 1 | 2.6k | 23.1k | 737.0k | 86.1k | 102 | 75.2k | 9m 43s |
| resolve_review | claude-opus-4-6 | 1 | 59 | 14.3k | 3.0M | 94.9k | 75 | 80.2k | 14m 21s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 47 | 9.0k | 1.4M | 61.3k | 55 | 46.1k | 3m 46s |
| **Total** | | | 660.4k | 168.2k | 18.4M | 156.9k | | 647.2k | 1h 39m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 584 | 9294.6 | 51.4 | 44.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 7157 | 194.3 | 6.4 | 1.3 |
| **Total** | **7741** | 2378.3 | 83.6 | 21.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 18.2k | 110.8k | 7.5M | 448.2k | 1h 4m |
| MiniMax-M2.7 | 3 | 642.1k | 34.1k | 6.5M | 72.7k | 17m 31s |
| claude-opus-4-6 | 2 | 106 | 23.3k | 4.4M | 126.3k | 18m 7s |