### PR TITLE
Add extras and required kwargs to EnvPolicy.build_env

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -51,7 +51,13 @@ class ResultParser(Protocol):
 class EnvPolicy(Protocol):
     """Protocol for building the subprocess environment for a backend launch."""
 
-    def build_env(self, base_env: Mapping[str, str]) -> dict[str, str]: ...
+    def build_env(
+        self,
+        base_env: Mapping[str, str],
+        *,
+        extras: Mapping[str, str] | None = None,
+        required: frozenset[str] | None = None,
+    ) -> dict[str, str]: ...
 
 
 @runtime_checkable

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -62,7 +62,13 @@ __all__ = [
 
 @dataclass(frozen=True, slots=True)
 class ClaudeEnvPolicy:
-    def build_env(self, base_env: Mapping[str, str]) -> dict[str, str]:
+    def build_env(
+        self,
+        base_env: Mapping[str, str],
+        *,
+        extras: Mapping[str, str] | None = None,
+        required: frozenset[str] | None = None,
+    ) -> dict[str, str]:
         return dict(build_agent_env(base=base_env))
 
 

--- a/tests/contracts/test_backend_protocol.py
+++ b/tests/contracts/test_backend_protocol.py
@@ -89,6 +89,54 @@ def test_claude_code_backend_stream_parser_forwards_completion_marker():
     assert parser.completion_marker == "%%ORDER_UP%%"
 
 
+# -- isinstance conformance: CodexBackend ------------------------------------
+
+
+def test_codex_backend_satisfies_coding_agent_backend():
+    from autoskillit.core import CodingAgentBackend
+    from autoskillit.execution.backends import CodexBackend
+
+    assert isinstance(CodexBackend(), CodingAgentBackend)
+
+
+def test_codex_backend_stream_parser_satisfies_protocol():
+    from autoskillit.core import StreamParser
+    from autoskillit.execution.backends import CodexBackend
+
+    assert isinstance(CodexBackend().stream_parser(), StreamParser)
+
+
+def test_codex_backend_result_parser_satisfies_protocol():
+    from autoskillit.core import ResultParser
+    from autoskillit.execution.backends import CodexBackend
+
+    assert isinstance(CodexBackend().result_parser(), ResultParser)
+
+
+def test_codex_backend_env_policy_satisfies_protocol():
+    from autoskillit.core import EnvPolicy
+    from autoskillit.execution.backends import CodexBackend
+
+    assert isinstance(CodexBackend().env_policy(), EnvPolicy)
+
+
+# -- Signature conformance: EnvPolicy.build_env -------------------------------
+
+
+def test_env_policy_build_env_signature_includes_extras_and_required():
+    import inspect
+
+    from autoskillit.core import EnvPolicy
+
+    sig = inspect.signature(EnvPolicy.build_env)
+    params = sig.parameters
+
+    assert "extras" in params, "EnvPolicy.build_env must have 'extras' parameter"
+    assert params["extras"].default is None
+    assert "required" in params, "EnvPolicy.build_env must have 'required' parameter"
+    assert params["required"].default is None
+
+
 # -- Signature conformance: build_skill_session_cmd ---------------------------
 
 


### PR DESCRIPTION
## Summary

Widen the `EnvPolicy` protocol's `build_env` method signature to include keyword-only parameters `extras: Mapping[str, str] | None = None` and `required: frozenset[str] | None = None`. Update `ClaudeEnvPolicy.build_env` to accept the same two kwargs (silently ignoring them — body unchanged per issue directive). Add 4 CodexBackend isinstance conformance tests and 1 EnvPolicy.build_env signature conformance test to `tests/contracts/test_backend_protocol.py`.

## Requirements

(Would be fetched from issue 2864 - requirements section)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

(None)

Closes #2864

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-094933-427583/.autoskillit/temp/make-plan/py2_p2_a4_wp1_plan_2026-05-24_095600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 74 | 11.5k | 1.0M | 76.9k | 108 | 63.0k | 9m 13s |
| verify | claude-sonnet-4-6 | 1 | 45 | 9.6k | 708.0k | 67.0k | 133 | 40.8k | 11m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 407.8k | 5.0k | 596.8k | 30.0k | 47 | 15.5k | 2m 1s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 47.9k | 2.6k | 177.0k | 30.0k | 20 | 15.1k | 1m 32s |
| compose_pr* | MiniMax-M2.7-highspeed | 2 | 207.3k | 5.1k | 626.9k | 30.0k | 48 | 56.7k | 2m 11s |
| review_pr | claude-sonnet-4-6 | 1 | 102 | 11.6k | 372.9k | 42.2k | 29 | 33.5k | 3m 28s |
| resolve_review | claude-sonnet-4-6 | 1 | 237 | 14.7k | 1.4M | 66.9k | 67 | 58.1k | 7m 2s |
| **Total** | | | 663.5k | 60.1k | 4.9M | 76.9k | | 282.7k | 36m 39s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 64 | 9325.1 | 242.3 | 77.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **64** | 77186.4 | 4416.5 | 939.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 458 | 47.5k | 3.5M | 195.4k | 30m 54s |
| MiniMax-M2.7-highspeed | 3 | 663.0k | 12.7k | 1.4M | 87.3k | 5m 45s |