### PR TITLE
Rectify: write_guard Regex False-Positives on Shell fd-Redirects

### DIFF
--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -21,6 +21,15 @@ _IS_WRITE_CMD_RE = re.compile(
     r"|\bgit\s+reset\s+--hard"
     r"|\b(?:rm|unlink)\s+"
 )
+_PSEUDO_DEVICE_PATHS: frozenset[str] = frozenset(
+    {
+        "/dev/null",
+        "/dev/zero",
+        "/dev/stdout",
+        "/dev/stderr",
+        "/dev/stdin",
+    }
+)
 
 # Each pattern extracts the target file path (group 1) from a file-modifying command.
 _BASH_TARGET_PATTERNS: list[re.Pattern[str]] = [
@@ -56,7 +65,9 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
     for pattern in _BASH_TARGET_PATTERNS:
         m = pattern.search(command)
         if m:
-            targets.append(m.group(1))
+            path = m.group(1)
+            if path not in _PSEUDO_DEVICE_PATHS:
+                targets.append(path)
     return targets
 
 

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -109,3 +109,32 @@ def test_cmd_keyword_regexes_use_path_safe_guards():
                 )
 
     assert violations == [], "Regex patterns missing path-safe guards:\n" + "\n".join(violations)
+
+
+HOOK_GUARD_RULE_FILES = [
+    SRC_ROOT / "hooks" / "guards" / "write_guard.py",
+]
+
+
+def test_redirect_patterns_exclude_fd_redirects():
+    """Redirect-matching regexes in hook guards must not match fd-number redirects
+    without a downstream pseudo-device filter."""
+    for filepath in HOOK_GUARD_RULE_FILES:
+        source = filepath.read_text()
+        for var_name, pattern, lineno in _extract_re_compile_patterns(filepath):
+            if ">+" in pattern:
+                assert "_PSEUDO_DEVICE_PATHS" in source, (
+                    f"{filepath.relative_to(SRC_ROOT.parent.parent)}:{lineno} "
+                    f"{var_name} matches >-redirects but the file has no "
+                    "_PSEUDO_DEVICE_PATHS filter for defense-in-depth"
+                )
+                break
+
+
+def test_write_guard_has_safe_path_filtering():
+    """write_guard must filter pseudo-device paths from extracted targets."""
+    source = (SRC_ROOT / "hooks" / "guards" / "write_guard.py").read_text()
+    assert "/dev/null" in source, "write_guard.py must contain a safe-path set including /dev/null"
+    assert "_PSEUDO_DEVICE_PATHS" in source, (
+        "write_guard.py must define _PSEUDO_DEVICE_PATHS constant"
+    )

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -186,3 +186,126 @@ class TestWriteGuardBashBypass:
         event = _build_bash_event("sed -i 's/x/y/' /clone/src/main.rs")
         result = _run_hook(event)
         assert result == ""
+
+
+class TestExtractBashWriteTargets:
+    """Unit tests for _extract_bash_write_targets -- the two-phase detect+extract logic."""
+
+    def test_stderr_redirect_to_dev_null_not_blocked(self):
+        """2>/dev/null should not produce a blocking target."""
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("gh auth status 2>/dev/null")
+        assert result is None or result == []
+
+    def test_stderr_redirect_with_space_not_blocked(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("gh auth status 2> /dev/null")
+        assert result is None or result == []
+
+    def test_stdout_to_dev_null_not_blocked(self):
+        """>/dev/null is stdout redirect to a pseudo-device -- not a real file write."""
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("echo foo > /dev/null")
+        assert result is None or result == []
+
+    def test_combined_redirect_not_blocked(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("cmd > /dev/null 2>&1")
+        assert result is None or result == []
+
+    def test_fd3_redirect_to_dev_null_not_blocked(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("cmd 3>/dev/null")
+        assert result is None or result == []
+
+    def test_tee_dev_null_not_blocked(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("cmd | tee /dev/null")
+        assert result is None or result == []
+
+    def test_fd_redirect_to_real_path_detected(self):
+        """2>/tmp/steal.log is a real file write -- must be detected and blocked."""
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("exec 2>/tmp/steal.log")
+        assert result == ["/tmp/steal.log"]
+
+    def test_fd_redirect_to_real_path_with_space_detected(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("cmd 2> /tmp/output.log")
+        assert result == ["/tmp/output.log"]
+
+    def test_real_file_write_detected(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("echo secret > /tmp/leak.txt")
+        assert result == ["/tmp/leak.txt"]
+
+    def test_sed_inplace_detected(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("sed -i 's/x/y/' /clone/src/main.py")
+        assert result == ["/clone/src/main.py"]
+
+    def test_non_write_command_returns_none(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("grep foo /clone/src/main.py")
+        assert result is None
+
+    def test_three_way_return_contract(self):
+        """Verify the None / [] / [paths] contract."""
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        assert _extract_bash_write_targets("ls -la") is None
+        result_filtered = _extract_bash_write_targets("echo x > /dev/null")
+        assert result_filtered == []
+        result_real = _extract_bash_write_targets("echo x > /tmp/out.txt")
+        assert result_real == ["/tmp/out.txt"]
+
+
+class TestWriteGuardRealisticCommands:
+    """Integration tests: common agent-generated commands must not be blocked."""
+
+    PREFIX = "/clone/.autoskillit/temp/compose-pr/"
+
+    @pytest.fixture(autouse=True)
+    def _enable_headless(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+
+    def test_gh_auth_status_2_dev_null_allowed(self):
+        """The exact command that caused pipeline 3 (#2864) failure."""
+        result = _run_hook(_build_bash_event("gh auth status 2>/dev/null"))
+        assert result == ""
+
+    def test_curl_stderr_suppression_allowed(self):
+        result = _run_hook(_build_bash_event("curl -s https://api.example.com 2>/dev/null"))
+        assert result == ""
+
+    def test_git_remote_2_dev_null_allowed(self):
+        result = _run_hook(
+            _build_bash_event(
+                "git remote get-url upstream 2>/dev/null && echo upstream || echo origin"
+            )
+        )
+        assert result == ""
+
+    def test_which_2_dev_null_allowed(self):
+        result = _run_hook(_build_bash_event("which gh 2>/dev/null || echo 'not found'"))
+        assert result == ""
+
+    def test_dev_null_combined_allowed(self):
+        result = _run_hook(_build_bash_event("cmd > /dev/null 2>&1"))
+        assert result == ""
+
+    def test_tee_dev_null_allowed(self):
+        result = _run_hook(_build_bash_event("cmd | tee /dev/null"))
+        assert result == ""

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -36,7 +36,6 @@ def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
 
 def test_deep_staleness_baseline_initialized_eagerly(tmp_path, monkeypatch):
     """_get_process_start_mtime eagerly sets the deep mtime baseline."""
-    import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)

--- a/tests/recipe/test_staleness_cache.py
+++ b/tests/recipe/test_staleness_cache.py
@@ -150,7 +150,9 @@ def test_check_staleness_writes_cache_on_miss(monkeypatch, tmp_path):
         compute_called.append(skill_name)
         return "sha256:" + "b" * 64
 
-    monkeypatch.setattr("autoskillit.recipe._contracts_staleness.compute_skill_hash", tracking_compute)
+    monkeypatch.setattr(
+        "autoskillit.recipe._contracts_staleness.compute_skill_hash", tracking_compute
+    )
 
     contract = {
         "bundled_manifest_version": manifest_version,


### PR DESCRIPTION
## Summary

The `write_guard.py` PreToolUse hook uses regex-based shell command parsing to detect file-writing operations. The regex pattern `>+\s*/` in `_IS_WRITE_CMD_RE` matches fd-number redirects (e.g., `2>/dev/null`) as file writes, causing false-positive denials. The companion extraction pattern `>+\s*(/[^\s;|&>]+)` then extracts `/dev/null` as a write target, which fails the prefix check. This blocked `gh auth status 2>/dev/null` in compose_pr, causing pipeline 3 (#2864) to fail.

The architectural weakness is broader than `/dev/null`: the guard has no concept of "pseudo-device paths" — filesystem paths that are never real writes (`/dev/null`, `/dev/zero`, `/dev/stdout`, `/dev/stderr`, `/dev/stdin`). The existing test suite covers only clean, unambiguous write commands and has zero tests for common shell idioms containing redirect-like syntax. The `test_regex_guards.py` architectural guard only covers recipe rule files — all 22 hook guard scripts are unguarded against regex regressions.

The fix adds a `_PSEUDO_DEVICE_PATHS` frozenset to `_extract_bash_write_targets` that filters out pseudo-device paths after extraction. This approach was validated by the Foundation Auditor as the correct and sufficient defense. An alternative approach (adding `(?<!\d)` negative lookbehind to the detection regex) was rejected because it introduces a security regression: `2>/tmp/steal.log` (fd-redirect to a real path) would become undetected.

## Requirements

### Bug: write_guard regex false-positives on `2>/dev/null`, blocking `gh` commands in compose_pr

### Summary

The `_IS_WRITE_CMD_RE` regex in `write_guard.py` matches `2>/dev/null` — the standard shell idiom for suppressing stderr — as a file write to an absolute path. The guard then extracts `/dev/null` as a "write target" and blocks the command because `/dev/null` is outside the session's `AUTOSKILLIT_ALLOWED_WRITE_PREFIX`. This caused pipeline 3 (#2864) to fail at compose_pr when the model's retry attempts all used `2>/dev/null` and never discovered a workaround.

### Observed Failure

Pipeline 3 (issue #2864 — `EnvPolicy.build_env extras/required kwargs`) completed implementation, testing, and branch push successfully. At compose_pr, the session tried to run `gh auth status 2>/dev/null` three times — all blocked by write_guard. The model concluded Bash was entirely blocked and emitted `pr_url = ` (empty), triggering graceful degradation. The orchestrator treated the empty `pr_url` as a pipeline failure.

Pipelines 1 (#2862) and 2 (#2863) hit the **exact same bug** but succeeded because their model instances happened to retry with different syntax:
- Pipeline 1: Dropped the redirect entirely → `gh auth status` → worked
- Pipeline 2: Used `2>&1` instead → worked (not a file redirect)

All 3 pipelines used identical configuration: model `MiniMax-M2.7-highspeed`, recipe hash `sha256:a6f24bf5c0e92f8b6a6e2a744d7432f369ba94d183a01d300e5ae825145ff1f8`, AutoSkillit 0.10.270, Claude Code 2.1.142.

### Root Cause Chain

1. **All headless skill sessions get `AUTOSKILLIT_ALLOWED_WRITE_PREFIX`** set via `_resolve_skill_temp_dir` fallback in `tools_execution.py:396-412`. For compose_pr in pipeline 3, this was `/home/talon/projects/autoskillit-runs/impl-20260524-094933-427583/.autoskillit/temp/compose-pr/`.

2. **`write_guard.py:14-23`** — `_IS_WRITE_CMD_RE` includes pattern `>+\s*/` which matches any `>` followed by `/`. The command `gh auth status 2>/dev/null` contains `2>/dev/null` which matches (the `>` before `/dev/null`).

3. **`write_guard.py:33`** — `_BASH_TARGET_PATTERNS` extracts the redirect target via `re.compile(r">+\s*(/[^\s;|&>]+)")`, capturing `/dev/null` as the write target.

4. **`write_guard.py:112-118`** — `/dev/null` does not start with the allowed prefix, so the command is denied with: `"Write/Edit blocked: read-only skill session. Only writes to .../compose-pr/ are permitted."`

5. **The model in session `800bccf0`** tried 3 variants, all containing `2>/dev/null`:
   ```
   gh auth status 2>/dev/null
   gh auth status 2>/dev/null && echo "AUTH_OK" || echo "AUTH_FAIL"
   which gh 2>/dev/null || echo "gh_not_found"
   ```
   All 3 matched the regex. The model concluded "Bash commands are blocked" and emitted empty `pr_url`.

6. **`dangerouslyDisableSandbox` did not help** — the agent set this flag on retries 2 and 3, but it's a Claude Code internal flag that does not affect PreToolUse hook execution. The write_guard hook still ran and denied.

### Affected Code

**Primary:** `src/autoskillit/hooks/guards/write_guard.py`

The offending regex (lines 14-23):
```python
_IS_WRITE_CMD_RE = re.compile(
    r"\bsed\s+(?:\S+\s+)*(?:-i|--in-place)"
    r"|>+\s*/"          # <-- this line matches 2>/dev/null
    r"|\btee\s+/"
    r"|\b(?:mv|cp)\s+"
    r"|\bpatch\s+"
    r"|\bgit\s+checkout\s+--"
    r"|\bgit\s+reset\s+--hard"
    r"|\b(?:rm|unlink)\s+"
)
```

The target extraction pattern (line 33):
```python
re.compile(r">+\s*(/[^\s;|&>]+)")  # captures /dev/null as a write target
```

### Same-Pattern Variants Also Affected

The regex would also block any command using these standard shell idioms:
- `command 2>/dev/null` (suppress stderr)
- `command >/dev/null 2>&1` (suppress all output)
- `command > /dev/null` (with space before path)

### Pipeline Comparison Table

| Pipeline | Order | Session ID | First `gh` attempt | Recovery | PR created? |
|----------|-------|------------|---------------------|----------|--------------|
| 1 | #2862 | `d2b48f47` | `2>/dev/null` — blocked | Dropped redirect | Yes (#2947) |
| 2 | #2863 | `b03426fc` | `2>/dev/null` — blocked | Used `2>&1` | Yes (#2949) |
| 3 | #2864 | `800bccf0` | `2>/dev/null` — blocked | Kept `2>/dev/null` × 3 | No |
| 3 (retry) | #2864 | `8d3f8221` | `2>/dev/null` — blocked | Used `2>&1` | Yes (#2951) |

### Recommended Fix

Exempt `/dev/null` from write target extraction. Options (in order of preference):

1. **Add `/dev/null` to a safe-path set** in `_extract_bash_write_targets` — filter it out before returning targets:
   ```python
   _SAFE_WRITE_TARGETS = frozenset({"/dev/null", "/dev/zero", "/dev/stdout", "/dev/stderr"})
   # in _extract_bash_write_targets, after collecting targets:
   targets = [t for t in targets if t not in _SAFE_WRITE_TARGETS]
   ```

2. **Negative lookahead in the regex** — change `>+\s*/` to `>+\s*(?!/dev/(?:null|zero|std(?:out|err))(?:\s|$|;))/` to exclude known device files.

3. **Filter in `_within_prefix`** — always return `True` for `/dev/null`. Less clean since it mixes policy with path checking.

Option 1 is the most maintainable and transparent.

### Tests to Add

- Verify `_extract_bash_write_targets("gh auth status 2>/dev/null")` returns `None` or empty (not `["/dev/null"]`)
- Verify `_extract_bash_write_targets("echo foo > /dev/null 2>&1")` returns `None` or empty
- Verify `_extract_bash_write_targets("echo secret > /tmp/leak.txt")` still returns `["/tmp/leak.txt"]` (security intent preserved)
- Integration test: compose_pr with `gh auth status 2>/dev/null` should not be blocked by write_guard

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260524-115552-472811/.autoskillit/temp/rectify/rectify_write_guard_regex_false_positives_2026-05-24_115552.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 11.3k | 18.6k | 1.3M | 101.6k | 287 | 86.1k | 18m 51s |
| dry_walkthrough | claude-opus-4-6 | 1 | 38 | 14.5k | 488.0k | 67.6k | 48 | 51.3k | 7m 27s |
| implement | claude-sonnet-4-6 | 1 | 124 | 9.9k | 510.3k | 54.7k | 71 | 85.3k | 13m 12s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 184.8k | 6.9k | 386.9k | 30.0k | 30 | 15.2k | 2m 17s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 107.6k | 5.0k | 296.9k | 30.0k | 23 | 15.0k | 1m 41s |
| review_pr | claude-sonnet-4-6 | 1 | 126 | 45.5k | 690.6k | 86.6k | 38 | 87.9k | 10m 1s |
| resolve_review | claude-sonnet-4-6 | 1 | 263 | 37.7k | 2.3M | 100.4k | 86 | 86.7k | 13m 22s |
| **Total** | | | 304.3k | 138.0k | 5.9M | 101.6k | | 427.5k | 1h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 170 | 3001.5 | 501.7 | 58.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **170** | 34864.9 | 2514.8 | 812.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 11.8k | 111.6k | 4.8M | 345.9k | 55m 27s |
| claude-opus-4-6 | 1 | 38 | 14.5k | 488.0k | 51.3k | 7m 27s |
| MiniMax-M2.7-highspeed | 2 | 292.4k | 11.9k | 683.8k | 30.3k | 3m 59s |