### PR TITLE
Backend-Aware CWD Validation Wrapper

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -30,6 +30,7 @@ from .branch_guard import is_protected_branch as is_protected_branch
 from .claude_conventions import ClaudeDirectoryConventions as ClaudeDirectoryConventions
 from .claude_conventions import LayoutError as LayoutError
 from .claude_conventions import validate_add_dir as validate_add_dir
+from .claude_conventions import validate_project_local_skill_dir as validate_project_local_skill_dir
 from .claude_conventions import validate_worktree_path as validate_worktree_path
 from .feature_flags import _collect_disabled_feature_tags as _collect_disabled_feature_tags
 from .feature_flags import is_feature_enabled as is_feature_enabled

--- a/src/autoskillit/core/claude_conventions.py
+++ b/src/autoskillit/core/claude_conventions.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .types import ValidatedAddDir, ValidatedWorktreePath
+from .types import AGENT_BACKEND_CODEX, CodingAgentBackend, ValidatedAddDir, ValidatedWorktreePath
 
 
 class LayoutError(ValueError):
@@ -60,6 +60,18 @@ def validate_add_dir(path: Path) -> ValidatedAddDir:
     if not skill_files:
         raise LayoutError(f"{path}/.claude/skills/ contains no SKILL.md files")
     return ValidatedAddDir(path=str(path))
+
+
+def validate_project_local_skill_dir(
+    cwd: Path,
+    backend: CodingAgentBackend | None,
+) -> ValidatedAddDir | None:
+    if backend is not None and backend.name == AGENT_BACKEND_CODEX:
+        return None
+    try:
+        return validate_add_dir(cwd)
+    except LayoutError:
+        return None
 
 
 def validate_worktree_path(path: Path | str) -> ValidatedWorktreePath | None:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -15,12 +15,11 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import (
     DISPATCH_ID_ENV_VAR,
-    LayoutError,
     SkillResult,
     ValidatedAddDir,
     get_logger,
     truncate_text,
-    validate_add_dir,
+    validate_project_local_skill_dir,
 )
 from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
 from autoskillit.server import mcp
@@ -457,10 +456,9 @@ async def run_skill(
 
             if target_name:
                 tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
-        try:
-            skill_add_dirs.append(validate_add_dir(Path(cwd)))
-        except LayoutError:
-            pass  # cwd has no project-local skills — already accessible as working dir
+        _local_dir = validate_project_local_skill_dir(Path(cwd), tool_ctx.backend)
+        if _local_dir is not None:
+            skill_add_dirs.append(_local_dir)
 
         _start = time.monotonic()
         try:


### PR DESCRIPTION
## Summary

Add `validate_project_local_skill_dir(cwd, backend)` to `core/claude_conventions.py` — a backend-aware wrapper around `validate_add_dir()` that returns `ValidatedAddDir | None`. For Claude Code (or `None` backend) it calls `validate_add_dir()` and catches `LayoutError` returning `None`; for Codex it unconditionally returns `None`. Then wire the new function into `tools_execution.py` replacing the existing try/except block, remove the now-unused `LayoutError` and `validate_add_dir` imports, and export the new symbol through `core/__init__.pyi`.

Closes #2871

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-121717-413309/.autoskillit/temp/dry-walkthrough/py3_p3_a8_wp1_plan_2026-05-24_122600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 76 | 8.4k | 1.1M | 78.4k | 148 | 63.3k | 11m 12s |
| verify | claude-sonnet-4-6 | 1 | 50 | 12.4k | 530.1k | 64.7k | 132 | 62.9k | 9m 30s |
| implement* | MiniMax-M2.7-highspeed | 1 | 889.2k | 6.5k | 1.2M | 30.0k | 82 | 15.7k | 3m 9s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 77.5k | 3.7k | 236.8k | 30.0k | 23 | 15.1k | 1m 12s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 153.8k | 2.9k | 476.6k | 30.0k | 34 | 15.0k | 1m 18s |
| review_pr | claude-sonnet-4-6 | 3 | 288 | 28.5k | 1.3M | 49.4k | 121 | 98.2k | 9m 26s |
| **Total** | | | 1.1M | 62.4k | 4.9M | 78.4k | | 270.2k | 35m 49s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 25 | 47828.4 | 627.0 | 260.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **25** | 194231.9 | 10807.4 | 2495.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 414 | 49.3k | 2.9M | 224.4k | 30m 9s |
| MiniMax-M2.7-highspeed | 3 | 1.1M | 13.1k | 1.9M | 45.8k | 5m 40s |