### PR TITLE
[FEATURE] PY4 P4-A4-WP1 — Array-of-Tables Serialization + Codex Hook Config

### DIFF
--- a/src/autoskillit/cli/CLAUDE.md
+++ b/src/autoskillit/cli/CLAUDE.md
@@ -12,6 +12,7 @@ session/ (see session/CLAUDE.md), ui/ (see ui/CLAUDE.md), update/ (see update/CL
 | `app.py` | CLI entry: `serve`, `init`, `config`, `skills`, `recipes`, `doctor`, `update`, etc. |
 | `_restart.py` | `perform_restart()` → `NoReturn`: sets `SKIP_UPDATE_CHECK`, calls `os.execv` |
 | `_hooks.py` | `PreToolUse` hook registration helpers |
+| `_hooks_codex.py` | Codex config.toml hook generation and sync (`generate_codex_hooks_config`, `sync_hooks_to_codex_config`) |
 | `_init_helpers.py` | `autoskillit init` implementation helpers |
 | `_installed_plugins.py` | `InstalledPluginsFile` — canonical accessor for `installed_plugins.json` |
 | `_install_info.py` | `InstallInfo`, `InstallType`, `detect_install()`, `comparison_branch()`, `dismissal_window()`, `upgrade_command()` |

--- a/src/autoskillit/cli/_hooks_codex.py
+++ b/src/autoskillit/cli/_hooks_codex.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from autoskillit.execution.backends._codex_config import (
+from autoskillit.execution import (
     _read_codex_config,
     _write_codex_config,
 )
@@ -45,7 +45,7 @@ def _is_autoskillit_hook_entry(entry: dict) -> bool:
     hooks_dir_str = str(HOOKS_DIR)
     for hook in entry.get("hooks", []):
         cmd = hook.get("command", "")
-        if "/autoskillit/" in cmd or hooks_dir_str in cmd:
+        if "/autoskillit/" in cmd or hooks_dir_str in cmd or "_dispatch.py" in cmd:
             return True
     return False
 

--- a/src/autoskillit/cli/_hooks_codex.py
+++ b/src/autoskillit/cli/_hooks_codex.py
@@ -1,0 +1,69 @@
+"""Codex config.toml hook generation and synchronization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autoskillit.execution.backends._codex_config import (
+    _read_codex_config,
+    _write_codex_config,
+)
+from autoskillit.hook_registry import (
+    HOOKS_DIR,
+    _build_hook_command,
+    _build_hook_entry,
+)
+from autoskillit.hooks import HOOK_REGISTRY
+
+
+def generate_codex_hooks_config() -> list[dict]:
+    """Generate Codex config.toml hooks entries from HOOK_REGISTRY.
+
+    Skips interactive_only hooks. Consolidates entries sharing the same
+    (event_type, matcher) key.
+    """
+    groups: dict[tuple[str, str], dict] = {}
+    for hook_def in HOOK_REGISTRY:
+        if hook_def.session_scope == "interactive_only":
+            continue
+        key = (hook_def.event_type, hook_def.matcher)
+        hook_commands = [
+            _build_hook_command(HOOKS_DIR, script, hook_def.timeout_seconds)
+            for script in hook_def.scripts
+        ]
+        if key not in groups:
+            entry = _build_hook_entry(hook_def, hook_commands)
+            entry["event"] = hook_def.event_type
+            groups[key] = entry
+        else:
+            groups[key]["hooks"].extend(hook_commands)
+    return list(groups.values())
+
+
+def _is_autoskillit_hook_entry(entry: dict) -> bool:
+    """Check if a Codex hooks config entry belongs to autoskillit."""
+    hooks_dir_str = str(HOOKS_DIR)
+    for hook in entry.get("hooks", []):
+        cmd = hook.get("command", "")
+        if "/autoskillit/" in cmd or hooks_dir_str in cmd:
+            return True
+    return False
+
+
+def sync_hooks_to_codex_config(config_path: Path | None = None) -> bool:
+    """Sync autoskillit hooks to Codex config.toml.
+
+    Returns True if the config was changed, False if already up to date.
+    """
+    if config_path is None:
+        config_path = Path.home() / ".codex" / "config.toml"
+    config = _read_codex_config(config_path)
+    existing_hooks = config.get("hooks", [])
+    foreign_hooks = [e for e in existing_hooks if not _is_autoskillit_hook_entry(e)]
+    fresh = generate_codex_hooks_config()
+    new_hooks = foreign_hooks + fresh
+    if new_hooks == existing_hooks:
+        return False
+    config["hooks"] = new_hooks
+    _write_codex_config(config_path, config)
+    return True

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -20,6 +20,8 @@ from autoskillit.execution.anomaly_detection import (
 from autoskillit.execution.backends import (
     ClaudeCodeBackend,
     CodexBackend,
+    _read_codex_config,
+    _write_codex_config,
     ensure_codex_mcp_registered,
     get_backend,
 )
@@ -213,6 +215,8 @@ __all__ = [
     # backends
     "ClaudeCodeBackend",
     "CodexBackend",
+    "_read_codex_config",
+    "_write_codex_config",
     "ensure_codex_mcp_registered",
     # anomaly_detection
     "detect_anomalies",

--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -10,5 +10,5 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 | `claude.py` | `ClaudeCodeBackend`, `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` (prompt utilities moved to `_claude_prompt.py`) |
 | `_claude_prompt.py` | Prompt injection utilities, session constants (`_ensure_skill_prefix`, `_inject_completion_directive`, `_compose_resume_prompt`, etc.), shared by claude + codex + commands |
 | `codex.py` | `CodexFlags`, `CodexBackend`, `CodexEnvPolicy`, `CodexSessionLocator` (parse/config moved to `_codex_parse.py` / `_codex_config.py`) |
-| `_codex_config.py` | TOML serialization, MCP registration (`ensure_codex_mcp_registered`, `_serialize_toml`) |
+| `_codex_config.py` | TOML serialization with `[[key]]` array-of-tables support, MCP registration (`ensure_codex_mcp_registered`, `_serialize_toml`) |
 | `_codex_parse.py` | `CodexStreamParser`, `CodexResultParser`, `_scan_codex_ndjson`, `_CodexParseAccumulator` |

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from autoskillit.core import CodingAgentBackend
 
-from ._codex_config import ensure_codex_mcp_registered
+from ._codex_config import (
+    _read_codex_config,
+    _write_codex_config,
+    ensure_codex_mcp_registered,
+)
 from ._codex_parse import CodexResultParser, CodexStreamParser
 from .claude import (
     ClaudeCodeBackend,

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -43,10 +43,51 @@ def _format_inline_table(d: dict[str, Any]) -> str:
     return "{" + ", ".join(pairs) + "}"
 
 
+def _classify_list(key: str, lst: list) -> bool:
+    """Return True if list is all-dicts (array-of-tables), False if all-scalars.
+
+    Raises TypeError for mixed lists containing both dict and non-dict items.
+    """
+    if not lst:
+        return False
+    has_dicts = any(isinstance(item, dict) for item in lst)
+    has_non_dicts = any(not isinstance(item, dict) for item in lst)
+    if has_dicts and has_non_dicts:
+        msg = f"TOML array {key!r} contains both dict and non-dict items"
+        raise TypeError(msg)
+    return has_dicts
+
+
+def _emit_aot_entry(d: dict[str, Any], path: list[str], lines: list[str]) -> None:
+    """Emit a single [[path]] array-of-tables entry."""
+    lines.append(f"\n[[{'.'.join(path)}]]")
+    nested_aot: list[tuple[str, list[dict]]] = []
+    for k, v in d.items():
+        if isinstance(v, dict):
+            lines.append(f"{k} = {_format_inline_table(v)}")
+        elif isinstance(v, list) and _classify_list(k, v):
+            nested_aot.append((k, v))
+        else:
+            lines.append(f"{k} = {_format_toml_value(v)}")
+    for k, entries in nested_aot:
+        for entry in entries:
+            _emit_aot_entry(entry, [*path, k], lines)
+
+
 def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> None:
     header = f"[{'.'.join(path)}]"
-    scalars = [(k, v) for k, v in d.items() if not isinstance(v, dict)]
-    tables = [(k, v) for k, v in d.items() if isinstance(v, dict)]
+
+    scalars: list[tuple[str, Any]] = []
+    tables: list[tuple[str, dict]] = []
+    aot_keys: list[tuple[str, list[dict]]] = []
+    for k, v in d.items():
+        if isinstance(v, dict):
+            tables.append((k, v))
+        elif isinstance(v, list) and _classify_list(k, v):
+            aot_keys.append((k, v))
+        else:
+            scalars.append((k, v))
+
     has_scalars = bool(scalars)
 
     inline_tables: list[tuple[str, dict[str, Any]]] = []
@@ -71,15 +112,26 @@ def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> No
     for k, v in recurse_tables:
         _emit_toml_table(v, [*path, k], lines)
 
+    for k, entries in aot_keys:
+        for entry in entries:
+            _emit_aot_entry(entry, [*path, k], lines)
+
 
 def _serialize_toml(data: dict[str, Any]) -> str:
     lines: list[str] = []
     for k, v in data.items():
-        if not isinstance(v, dict):
-            lines.append(f"{k} = {_format_toml_value(v)}")
+        if isinstance(v, dict):
+            continue
+        if isinstance(v, list) and _classify_list(k, v):
+            continue
+        lines.append(f"{k} = {_format_toml_value(v)}")
     for k, v in data.items():
         if isinstance(v, dict):
             _emit_toml_table(v, [k], lines)
+    for k, v in data.items():
+        if isinstance(v, list) and _classify_list(k, v):
+            for entry in v:
+                _emit_aot_entry(entry, [k], lines)
     text = "\n".join(lines).lstrip("\n")
     return text + "\n" if text else ""
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -23,6 +23,7 @@ def _flush_structlog_proxy_caches() -> None:
             continue
         for lg in vars(mod).values():
             if isinstance(lg, _sc.BoundLoggerLazyProxy):
+                lg.__dict__.pop("_bound_logger", None)
                 lg.__dict__.pop("bind", None)
             elif hasattr(lg, "_processors"):
                 lg._processors = current_procs

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -685,153 +685,156 @@ def test_test_suite_oversized_files_split():
 def test_no_subpackage_exceeds_10_files() -> None:
     """REQ-CNST-003: No sub-package directory may contain more than 10 Python files.
 
-    Exemptions (rule ID | rationale):
-      server/ — REQ-CNST-003-E1: server/ splits tool handlers into per-domain files
-        (tools_clone, tools_github, tools_issue_headless, tools_issue_labels, tools_pr_ops,
-        tools_ci, tools_git, tools_recipe, tools_status, tools_workspace, tools_execution,
-        tools_kitchen, helpers, git, _factory, _state, __init__); each file is a thin
-        routing layer. Exempt at 16 files.
-      recipe/ — REQ-CNST-003-E2: recipe/ hosts one file per semantic-rule domain
-        (rules_bypass, rules_ci, rules_clone, rules_packs, etc.) for independent testability.
-        Adding rules_cmd.py for run_cmd echo-capture alignment validation and
-        rules_isolation.py for workspace isolation checks brings the count to 30.
-        rules_blocks.py adds the block-level budget rule family, bringing the count to 32.
-        rules_reachability.py adds symbolic BFS reachability rules, bringing the count to 33.
-        rules_fixing.py adds conditional-write-skill ungated-push detection,
-        bringing the count to 34.
-        rules_campaign_dispatch.py, rules_campaign_deps.py, rules_campaign_ingredients.py,
-        rules_campaign_capture.py, and rules_campaign_flow.py split rules_campaign.py,
-        bringing the count to 37.
-        rules_temp_path.py adds the non-unique-output-path lint rule for output path
-        isolation enforcement, bringing the count to 39.
-        identity.py adds recipe identity hashing (content and composite fingerprints),
-        bringing the count to 40.
-        order.py adds the stable display order registry (BUNDLED_RECIPE_ORDER) for
-        Group 0 bundled recipes, bringing the count to 41.
-        Monolithic file splits (_api.py → _recipe_ingredients + _recipe_composition;
-        _analysis.py → _analysis_graph + _analysis_bfs + _analysis_blocks +
-        _analysis_detectors) add 6 files, bringing the count to 47.
-        _skill_helpers.py extracts the shared _get_skill_category_map helper from
-        rules_skills.py and rules_features.py to eliminate duplication,
-        bringing the count to 48.
-        rules/rules_callable_scope.py adds the callable-requires-scoped-discovery
-        rule enforcing scoped directory arguments for file-discovering callables,
-        bringing the rules/ count to 29. rules/rules_remediation.py adds the
-        audit-impl-remediation-route rule ensuring remediation_path captures have
-        non-terminal non-GO routes, bringing the rules/ count to 30.
-        rules/rules_loop_progress.py adds the loop-body-uncaptured-output rule
-        ensuring run_skill steps inside routing cycles capture declared outputs,
-        bringing the rules/ count to 31. Exempt at 48 files.
-      execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
-        focused single-concern modules (_process_io, _process_kill, _process_race,
-        etc.) that cannot be merged without re-introducing the coupling they isolate.
-        recording.py adds the RecordingSubprocessRunner decorator as a separate module
-        to keep scenario recording concerns isolated from the core process lifecycle.
-        _headless_scan.py extracts write-path JSONL scanning from headless.py to keep
-        that module within its REQ-CNST-010-E2 line budget.
-        _headless_recovery.py, _headless_path_tokens.py, and _headless_result.py
-        split the remaining headless.py concern groups into private sub-modules
-        following the _process_*.py precedent (P8-F1), bringing the count to 29.
-        _session_model.py and _session_content.py split session.py (P8-F3),
-        _merge_queue_classifier.py and _merge_queue_repo_state.py split merge_queue.py
-        (P8-F4), bringing the count to 33.
-        _retry_fsm.py and _session_outcome.py split session retry and outcome logic,
-        bringing the count to 35.
-        _merge_queue_group_ci.py extracts merge-group CI helpers and GraphQL mutation/query
-        strings from merge_queue.py to satisfy the 500-line size budget (P8-F4 follow-up),
-        bringing the count to 36.
-        _headless_git.py extracts git LOC-capture helpers (_capture_git_head_sha,
-        _parse_numstat, _compute_loc_changed) from headless.py to keep it under the
-        750-line architectural budget, bringing the count to 37.
-        _recording_skills.py adds snapshot/restore helpers for ephemeral skill dirs in
-        the record/replay system, isolated from recording.py to keep snapshot logic
-        independently testable, bringing the count to 38.
-        Exempt at 38 files.
-      core/ — REQ-CNST-003-E4: core/ types split into per-concern type modules
-        (_type_enums, _type_protocols_logging, _type_protocols_execution,
-        _type_protocols_github, _type_protocols_workspace, _type_protocols_recipe,
-        _type_protocols_infra, _type_results, _type_subprocess, etc.) to
-        prevent circular imports while keeping IL-0 types co-located. Also houses
-        _terminal_table.py as the IL-0 shared terminal rendering primitive so that
-        both cli/ (IL-3) and pipeline/ (IL-1) can import it without layer violations.
-        _claude_env.py adds the canonical IDE-scrubbing env builder for all
-        claude subprocess launches. kitchen_state.py adds the stdlib-only
-        kitchen-open session marker reader for hook subprocesses.
-        _version_snapshot.py adds the process-scoped version snapshot for session
-        telemetry (collect_version_snapshot, lru_cache'd).
-        _plugin_cache.py adds the plugin cache lifecycle: retiring cache sweep,
-        install locking, and kitchen registry (accessible from server/ without
-        cli/ import).
-        feature_flags.py adds the IL-0 is_feature_enabled() primitive — must live
-        in core/ to be importable by all layers without cross-layer violations.
-        session_registry.py adds the stdlib-only session registry mapping
-        autoskillit launch IDs to Claude Code session UUIDs for the scoped
-        resume picker.
-        tool_sequence_analysis.py adds the stdlib-only cross-session tool call
-        sequence DFG analysis (IL-0; must live in core/ to be importable by server/).
-        Monolithic protocol module split into 6 domain-grouped shard files (net +5 files).
-        _install_detect.py adds the is_dev_install() predicate for config resolution
-        to auto-detect whether the install is editable when experimental_enabled is absent,
-        bringing the count to 33.
-        _type_session_env.py adds FleetSessionEnv frozen dataclass for typed env spec
-        at the session launch boundary, bringing the count to 20.
-        _type_backend.py adds BackendCapabilities frozen dataclass and CLAUDE_CODE_CAPABILITIES
-        constant for backend capability declarations (IL-0), bringing the count to 21.
-        _type_token.py adds CanonicalTokenUsage frozen dataclass for provider-agnostic
-        token usage normalization (IL-0), bringing the count to 22.
-        _type_exceptions.py adds RecipeLoadError hierarchy (ProcessStaleError,
-        RecipeNotFoundError) for exception-based error propagation from
-        load_and_validate, bringing the count to 23.
-        Exempt at 35 files (core/types: 23).
-      cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
-        for backward-compatible cli/ imports; canonical implementation lives in
-        core/_terminal_table.py. Also contains _terminal.py — the terminal state
-        management context manager (terminal_guard) for interactive subprocess
-        sessions. _install_info.py adds pure install classification + policy.
-        _update_checks.py adds the unified update check orchestration.
-        _update.py adds the first-class update subcommand implementation.
-        _fleet.py adds fleet error envelope rendering for CLI consumers.
-        _features.py adds feature gate inspection subcommand (list/status).
-        _session_picker.py adds the scoped session resume picker that filters
-        sessions by type (cook/order) using the session registry.
-        _sessions.py adds the sessions analyze CLI subcommand for cross-session
-        tool call sequence diagnostics.
-        _restart.py adds the perform_restart() NoReturn contract for post-upgrade
-        process re-exec, keeping the restart logic isolated from update orchestration.
-        _doctor.py was split (1245 lines → facade + 9 sub-modules) following the
-        _process_*.py pattern: _doctor_types.py (shared DoctorResult type),
-        _doctor_mcp.py, _doctor_hooks.py, _doctor_install.py, _doctor_config.py,
-        _doctor_runtime.py, _doctor_env.py, _doctor_features.py, _doctor_fleet.py.
-        _prompts.py (819 lines) was decomposed into three domain-focused submodules:
-        _prompts_campaign.py (IL-3 campaign dispatcher), _prompts_orchestrator.py
-        (IL-1/IL-2 cook session), and _prompts_kitchen.py (open-kitchen + fleet-dispatch),
-        with _prompts.py reduced to a shared-helpers + re-export hub (~50 lines).
-        Exempt at 20 files.
-      hooks/ — REQ-CNST-003-E6: hooks/ hosts one standalone script per hook event
-        (PreToolUse, PostToolUse, SessionStart). Each script must remain a separate
-        file so Claude Code can invoke it directly as a subprocess. pretty_output_hook.py
-        additionally owns a set of underscore-prefixed private formatter modules
-        (_fmt_primitives.py, _fmt_execution.py, _fmt_status.py, _fmt_recipe.py)
-        that are imported helpers — not standalone hook scripts — split out to
-        keep pretty_output_hook.py under its line budget. ask_user_question_guard.py
-        gates AskUserQuestion on kitchen-open state. grep_pattern_lint_guard.py adds
-        input-validation guard for Grep tool BRE pattern syntax. review_gate_post_hook.py
-        and review_loop_gate.py add the review gate enforcement hooks. recipe_write_advisor.py
-        adds a non-blocking advisory hook for recipe YAML writes. write_guard.py
-        blocks Write/Edit outside the allowed prefix in read-only skill sessions.
-        _hook_utils.py provides shared stdlib-only utilities (e.g., find_project_root)
-        for hook scripts that need common path resolution logic.
-        Exempt at 28 files.
-      pipeline/ — REQ-CNST-003-E7: pipeline/ added github_api_log.py for session-scoped
-        GitHub API request tracking (DefaultGitHubApiLog accumulator + GitHubApiEntry).
-        Exempt at 12 files.
-      fleet/ — REQ-CNST-003-E8: fleet/ added _semaphore.py for FleetSemaphore, the
-        configurable asyncio.BoundedSemaphore implementation of the FleetLock protocol.
-        Placed in fleet/ rather than server/ to preserve conservative test-filter cascade
-        narrowing: changes to fleet/_semaphore.py only cascade to fleet/ tests, not to
-        server/ tests. state.py was decomposed into state_types.py, state_gates.py, and
-        state_recovery.py to reduce the 757-line monolith and centralize deserialization
-        logic on DispatchRecord.from_dict. Exempt at 15 files.
+        Exemptions (rule ID | rationale):
+          server/ — REQ-CNST-003-E1: server/ splits tool handlers into per-domain files
+            (tools_clone, tools_github, tools_issue_headless, tools_issue_labels, tools_pr_ops,
+            tools_ci, tools_git, tools_recipe, tools_status, tools_workspace, tools_execution,
+            tools_kitchen, helpers, git, _factory, _state, __init__); each file is a thin
+            routing layer. Exempt at 16 files.
+          recipe/ — REQ-CNST-003-E2: recipe/ hosts one file per semantic-rule domain
+            (rules_bypass, rules_ci, rules_clone, rules_packs, etc.) for independent testability.
+            Adding rules_cmd.py for run_cmd echo-capture alignment validation and
+            rules_isolation.py for workspace isolation checks brings the count to 30.
+            rules_blocks.py adds the block-level budget rule family, bringing the count to 32.
+            rules_reachability.py adds symbolic BFS reachability rules, bringing the count to 33.
+            rules_fixing.py adds conditional-write-skill ungated-push detection,
+            bringing the count to 34.
+            rules_campaign_dispatch.py, rules_campaign_deps.py, rules_campaign_ingredients.py,
+            rules_campaign_capture.py, and rules_campaign_flow.py split rules_campaign.py,
+            bringing the count to 37.
+            rules_temp_path.py adds the non-unique-output-path lint rule for output path
+            isolation enforcement, bringing the count to 39.
+            identity.py adds recipe identity hashing (content and composite fingerprints),
+            bringing the count to 40.
+            order.py adds the stable display order registry (BUNDLED_RECIPE_ORDER) for
+            Group 0 bundled recipes, bringing the count to 41.
+            Monolithic file splits (_api.py → _recipe_ingredients + _recipe_composition;
+            _analysis.py → _analysis_graph + _analysis_bfs + _analysis_blocks +
+            _analysis_detectors) add 6 files, bringing the count to 47.
+            _skill_helpers.py extracts the shared _get_skill_category_map helper from
+            rules_skills.py and rules_features.py to eliminate duplication,
+            bringing the count to 48.
+            rules/rules_callable_scope.py adds the callable-requires-scoped-discovery
+            rule enforcing scoped directory arguments for file-discovering callables,
+            bringing the rules/ count to 29. rules/rules_remediation.py adds the
+            audit-impl-remediation-route rule ensuring remediation_path captures have
+            non-terminal non-GO routes, bringing the rules/ count to 30.
+            rules/rules_loop_progress.py adds the loop-body-uncaptured-output rule
+            ensuring run_skill steps inside routing cycles capture declared outputs,
+            bringing the rules/ count to 31. Exempt at 48 files.
+          execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
+            focused single-concern modules (_process_io, _process_kill, _process_race,
+            etc.) that cannot be merged without re-introducing the coupling they isolate.
+            recording.py adds the RecordingSubprocessRunner decorator as a separate module
+            to keep scenario recording concerns isolated from the core process lifecycle.
+            _headless_scan.py extracts write-path JSONL scanning from headless.py to keep
+            that module within its REQ-CNST-010-E2 line budget.
+            _headless_recovery.py, _headless_path_tokens.py, and _headless_result.py
+            split the remaining headless.py concern groups into private sub-modules
+            following the _process_*.py precedent (P8-F1), bringing the count to 29.
+            _session_model.py and _session_content.py split session.py (P8-F3),
+            _merge_queue_classifier.py and _merge_queue_repo_state.py split merge_queue.py
+            (P8-F4), bringing the count to 33.
+            _retry_fsm.py and _session_outcome.py split session retry and outcome logic,
+            bringing the count to 35.
+            _merge_queue_group_ci.py extracts merge-group CI helpers and GraphQL mutation/query
+            strings from merge_queue.py to satisfy the 500-line size budget (P8-F4 follow-up),
+            bringing the count to 36.
+            _headless_git.py extracts git LOC-capture helpers (_capture_git_head_sha,
+            _parse_numstat, _compute_loc_changed) from headless.py to keep it under the
+            750-line architectural budget, bringing the count to 37.
+            _recording_skills.py adds snapshot/restore helpers for ephemeral skill dirs in
+            the record/replay system, isolated from recording.py to keep snapshot logic
+            independently testable, bringing the count to 38.
+            Exempt at 38 files.
+          core/ — REQ-CNST-003-E4: core/ types split into per-concern type modules
+            (_type_enums, _type_protocols_logging, _type_protocols_execution,
+            _type_protocols_github, _type_protocols_workspace, _type_protocols_recipe,
+            _type_protocols_infra, _type_results, _type_subprocess, etc.) to
+            prevent circular imports while keeping IL-0 types co-located. Also houses
+            _terminal_table.py as the IL-0 shared terminal rendering primitive so that
+            both cli/ (IL-3) and pipeline/ (IL-1) can import it without layer violations.
+            _claude_env.py adds the canonical IDE-scrubbing env builder for all
+            claude subprocess launches. kitchen_state.py adds the stdlib-only
+            kitchen-open session marker reader for hook subprocesses.
+            _version_snapshot.py adds the process-scoped version snapshot for session
+            telemetry (collect_version_snapshot, lru_cache'd).
+            _plugin_cache.py adds the plugin cache lifecycle: retiring cache sweep,
+            install locking, and kitchen registry (accessible from server/ without
+            cli/ import).
+            feature_flags.py adds the IL-0 is_feature_enabled() primitive — must live
+            in core/ to be importable by all layers without cross-layer violations.
+            session_registry.py adds the stdlib-only session registry mapping
+            autoskillit launch IDs to Claude Code session UUIDs for the scoped
+            resume picker.
+            tool_sequence_analysis.py adds the stdlib-only cross-session tool call
+            sequence DFG analysis (IL-0; must live in core/ to be importable by server/).
+            Monolithic protocol module split into 6 domain-grouped shard files (net +5 files).
+            _install_detect.py adds the is_dev_install() predicate for config resolution
+            to auto-detect whether the install is editable when experimental_enabled is absent,
+            bringing the count to 33.
+            _type_session_env.py adds FleetSessionEnv frozen dataclass for typed env spec
+            at the session launch boundary, bringing the count to 20.
+            _type_backend.py adds BackendCapabilities frozen dataclass and CLAUDE_CODE_CAPABILITIES
+            constant for backend capability declarations (IL-0), bringing the count to 21.
+            _type_token.py adds CanonicalTokenUsage frozen dataclass for provider-agnostic
+            token usage normalization (IL-0), bringing the count to 22.
+            _type_exceptions.py adds RecipeLoadError hierarchy (ProcessStaleError,
+            RecipeNotFoundError) for exception-based error propagation from
+            load_and_validate, bringing the count to 23.
+            Exempt at 35 files (core/types: 23).
+          cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
+            for backward-compatible cli/ imports; canonical implementation lives in
+            core/_terminal_table.py. Also contains _terminal.py — the terminal state
+            management context manager (terminal_guard) for interactive subprocess
+            sessions. _install_info.py adds pure install classification + policy.
+            _update_checks.py adds the unified update check orchestration.
+            _update.py adds the first-class update subcommand implementation.
+            _fleet.py adds fleet error envelope rendering for CLI consumers.
+            _features.py adds feature gate inspection subcommand (list/status).
+            _session_picker.py adds the scoped session resume picker that filters
+            sessions by type (cook/order) using the session registry.
+            _sessions.py adds the sessions analyze CLI subcommand for cross-session
+            tool call sequence diagnostics.
+            _restart.py adds the perform_restart() NoReturn contract for post-upgrade
+            process re-exec, keeping the restart logic isolated from update orchestration.
+            _doctor.py was split (1245 lines → facade + 9 sub-modules) following the
+            _process_*.py pattern: _doctor_types.py (shared DoctorResult type),
+            _doctor_mcp.py, _doctor_hooks.py, _doctor_install.py, _doctor_config.py,
+            _doctor_runtime.py, _doctor_env.py, _doctor_features.py, _doctor_fleet.py.
+            _prompts.py (819 lines) was decomposed into three domain-focused submodules:
+            _prompts_campaign.py (IL-3 campaign dispatcher), _prompts_orchestrator.py
+            (IL-1/IL-2 cook session), and _prompts_kitchen.py (open-kitchen + fleet-dispatch),
+            with _prompts.py reduced to a shared-helpers + re-export hub (~50 lines).
+            _hooks_codex.py adds Codex config.toml hook generation and sync
+    (generate_codex_hooks_config, sync_hooks_to_codex_config) paralleling
+    _hooks.py for Claude Code settings.json hooks.
+    Exempt at 21 files.
+          hooks/ — REQ-CNST-003-E6: hooks/ hosts one standalone script per hook event
+            (PreToolUse, PostToolUse, SessionStart). Each script must remain a separate
+            file so Claude Code can invoke it directly as a subprocess. pretty_output_hook.py
+            additionally owns a set of underscore-prefixed private formatter modules
+            (_fmt_primitives.py, _fmt_execution.py, _fmt_status.py, _fmt_recipe.py)
+            that are imported helpers — not standalone hook scripts — split out to
+            keep pretty_output_hook.py under its line budget. ask_user_question_guard.py
+            gates AskUserQuestion on kitchen-open state. grep_pattern_lint_guard.py adds
+            input-validation guard for Grep tool BRE pattern syntax. review_gate_post_hook.py
+            and review_loop_gate.py add the review gate enforcement hooks. recipe_write_advisor.py
+            adds a non-blocking advisory hook for recipe YAML writes. write_guard.py
+            blocks Write/Edit outside the allowed prefix in read-only skill sessions.
+            _hook_utils.py provides shared stdlib-only utilities (e.g., find_project_root)
+            for hook scripts that need common path resolution logic.
+            Exempt at 28 files.
+          pipeline/ — REQ-CNST-003-E7: pipeline/ added github_api_log.py for session-scoped
+            GitHub API request tracking (DefaultGitHubApiLog accumulator + GitHubApiEntry).
+            Exempt at 12 files.
+          fleet/ — REQ-CNST-003-E8: fleet/ added _semaphore.py for FleetSemaphore, the
+            configurable asyncio.BoundedSemaphore implementation of the FleetLock protocol.
+            Placed in fleet/ rather than server/ to preserve conservative test-filter cascade
+            narrowing: changes to fleet/_semaphore.py only cascade to fleet/ tests, not to
+            server/ tests. state.py was decomposed into state_types.py, state_gates.py, and
+            state_recovery.py to reduce the 757-line monolith and centralize deserialization
+            logic on DispatchRecord.from_dict. Exempt at 15 files.
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 14,
@@ -839,7 +842,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "execution": 18,
         "core": 20,
         "core/types": 27,
-        "cli": 20,
+        "cli": 21,
         "hooks": 10,
         "pipeline": 12,
         "fleet": 19,

--- a/tests/execution/backends/test_codex_config.py
+++ b/tests/execution/backends/test_codex_config.py
@@ -113,6 +113,46 @@ class TestSerializeToml:
         assert count == 1
         tomllib.loads(serialized)
 
+    def test_array_of_tables_round_trip(self):
+        original = {
+            "hooks": [{"event": "PreToolUse", "matcher": "Bash", "command": "python3 guard.py"}]
+        }
+        serialized = _serialize_toml(original)
+        assert "[[hooks]]" in serialized
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_nested_array_of_tables_round_trip(self):
+        original = {
+            "hooks": [
+                {
+                    "event": "PreToolUse",
+                    "hooks": [{"type": "command", "command": "python3 guard.py"}],
+                }
+            ]
+        }
+        serialized = _serialize_toml(original)
+        assert "[[hooks]]" in serialized
+        assert "[[hooks.hooks]]" in serialized
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_mixed_list_raises_type_error(self):
+        data = {"items": [{"a": 1}, "b"]}
+        with pytest.raises(TypeError, match="dict and non-dict"):
+            _serialize_toml(data)
+
+    def test_array_of_tables_with_scalar_siblings(self):
+        original = {
+            "config": {
+                "name": "test",
+                "entries": [{"key": "val"}],
+            }
+        }
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
 
 class TestWriteCodexConfig:
     def test_writes_readable_toml(self, tmp_path):

--- a/tests/hooks/CLAUDE.md
+++ b/tests/hooks/CLAUDE.md
@@ -28,6 +28,7 @@ Hook script behavior, registration, and bridge tests.
 | `test_token_summary_appender.py` | Token summary hook script existence and source quality (2 tests); behavioral and unit tests live in tests/infra/ |
 | `test_write_guard.py` | Tests for write_guard.py PreToolUse hook |
 | `test_planner_result_naming_guard.py` | Tests for planner_result_naming_guard.py PreToolUse hook |
+| `test_codex_hooks.py` | Tests for cli/_hooks_codex.py — AST scan, hook generation, sync idempotency |
 | `test_recipe_contract_freshness.py` | Tests for the recipe-contract-freshness pre-commit hook |
 
 ## Architecture Notes

--- a/tests/hooks/test_codex_hooks.py
+++ b/tests/hooks/test_codex_hooks.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from autoskillit.cli._hooks_codex import (
+    _is_autoskillit_hook_entry,
+    generate_codex_hooks_config,
+    sync_hooks_to_codex_config,
+)
+from autoskillit.execution.backends._codex_config import _read_codex_config
+
+pytestmark = []
+
+
+class TestNoThirdPartyToml:
+    def test_no_third_party_toml_in_hooks_codex(self):
+        source = (
+            Path(__file__).resolve().parents[2]
+            / "src"
+            / "autoskillit"
+            / "cli"
+            / "_hooks_codex.py"
+        )
+        tree = ast.parse(source.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                names = []
+                if isinstance(node, ast.Import):
+                    names = [a.name for a in node.names]
+                else:
+                    names = [node.module or ""]
+                for name in names:
+                    assert name not in ("toml", "tomli", "tomlkit"), (
+                        f"Third-party TOML import found: {name}"
+                    )
+
+
+class TestGenerateCodexHooksConfig:
+    def test_generate_excludes_interactive_only(self):
+        result = generate_codex_hooks_config()
+        for entry in result:
+            for hook in entry.get("hooks", []):
+                assert hook.get("session_scope") != "interactive_only"
+
+    def test_generate_consolidates_by_event_matcher(self):
+        result = generate_codex_hooks_config()
+        event_matcher_counts: dict[tuple, int] = {}
+        for entry in result:
+            key = (entry.get("event"), entry.get("matcher"))
+            event_matcher_counts[key] = event_matcher_counts.get(key, 0) + 1
+        for count in event_matcher_counts.values():
+            assert count == 1, "Duplicate (event, matcher) consolidation failed"
+
+    def test_generate_session_start_omits_matcher(self):
+        result = generate_codex_hooks_config()
+        for entry in result:
+            if entry.get("event") == "SessionStart":
+                assert "matcher" not in entry
+
+    def test_generate_includes_timeout(self):
+        result = generate_codex_hooks_config()
+        has_timeout = False
+        for entry in result:
+            for hook in entry.get("hooks", []):
+                if "timeout" in hook:
+                    has_timeout = True
+                    break
+        assert has_timeout
+
+    def test_generate_every_entry_has_event_key(self):
+        result = generate_codex_hooks_config()
+        for entry in result:
+            assert "event" in entry
+
+
+class TestIsAutoskillitHookEntry:
+    def test_is_autoskillit_hook_entry_true_autoskillit_path(self):
+        entry = {"hooks": [{"command": "/autoskillit/hooks/guard.py"}]}
+        assert _is_autoskillit_hook_entry(entry) is True
+
+    def test_is_autoskillit_hook_entry_true_hooks_dir(self):
+        entry = {"hooks": [{"command": "python3 /some/path/hooks/_dispatch.py guard"}]}
+        assert _is_autoskillit_hook_entry(entry) is True
+
+    def test_is_autoskillit_hook_entry_false_foreign(self):
+        entry = {"hooks": [{"command": "python3 /usr/local/bin/foreign.py"}]}
+        assert _is_autoskillit_hook_entry(entry) is False
+
+
+class TestSyncHooksToCodexConfig:
+    def test_sync_creates_from_missing(self, tmp_path):
+        p = tmp_path / "config.toml"
+        result = sync_hooks_to_codex_config(config_path=p)
+        assert result is True
+        config = _read_codex_config(p)
+        assert "hooks" in config
+
+    def test_sync_idempotent(self, tmp_path):
+        p = tmp_path / "config.toml"
+        result1 = sync_hooks_to_codex_config(config_path=p)
+        mtime_before = p.stat().st_mtime_ns
+        result2 = sync_hooks_to_codex_config(config_path=p)
+        assert result1 is True
+        assert result2 is False
+        assert p.stat().st_mtime_ns == mtime_before
+
+    def test_sync_preserves_foreign_hooks(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.write_text('[[hooks]]\nevent = "PreToolUse"\n[[hooks.hooks]]\ncommand = "python3 /usr/local/guard.py"\n')
+        result = sync_hooks_to_codex_config(config_path=p)
+        assert result is True
+        config = _read_codex_config(p)
+        hooks = config.get("hooks", [])
+        foreign = [h for h in hooks if "/usr/local/" in str(h)]
+        assert len(foreign) > 0
+
+    def test_sync_replaces_stale(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.write_text('[[hooks]]\nevent = "PreToolUse"\n[[hooks.hooks]]\ncommand = "/autoskillit/hooks/_dispatch.py old"\n')
+        result = sync_hooks_to_codex_config(config_path=p)
+        assert result is True
+        config = _read_codex_config(p)
+        hooks = config.get("hooks", [])
+        autoskillit_hooks = [h for h in hooks if "/autoskillit/" in str(h)]
+        assert len(autoskillit_hooks) > 0
+
+    def test_sync_empty_config(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.write_text("")
+        result = sync_hooks_to_codex_config(config_path=p)
+        assert result is True
+
+    def test_sync_config_path_override(self, tmp_path):
+        p = tmp_path / "codex.toml"
+        result = sync_hooks_to_codex_config(config_path=p)
+        assert result is True
+        assert p.exists()

--- a/tests/hooks/test_codex_hooks.py
+++ b/tests/hooks/test_codex_hooks.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
-
 from autoskillit.cli._hooks_codex import (
     _is_autoskillit_hook_entry,
     generate_codex_hooks_config,
@@ -18,11 +16,7 @@ pytestmark = []
 class TestNoThirdPartyToml:
     def test_no_third_party_toml_in_hooks_codex(self):
         source = (
-            Path(__file__).resolve().parents[2]
-            / "src"
-            / "autoskillit"
-            / "cli"
-            / "_hooks_codex.py"
+            Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "cli" / "_hooks_codex.py"
         )
         tree = ast.parse(source.read_text())
         for node in ast.walk(tree):
@@ -109,7 +103,9 @@ class TestSyncHooksToCodexConfig:
 
     def test_sync_preserves_foreign_hooks(self, tmp_path):
         p = tmp_path / "config.toml"
-        p.write_text('[[hooks]]\nevent = "PreToolUse"\n[[hooks.hooks]]\ncommand = "python3 /usr/local/guard.py"\n')
+        p.write_text(
+            '[[hooks]]\nevent = "PreToolUse"\n[[hooks.hooks]]\ncommand = "python3 /usr/local/guard.py"\n'
+        )
         result = sync_hooks_to_codex_config(config_path=p)
         assert result is True
         config = _read_codex_config(p)
@@ -119,7 +115,9 @@ class TestSyncHooksToCodexConfig:
 
     def test_sync_replaces_stale(self, tmp_path):
         p = tmp_path / "config.toml"
-        p.write_text('[[hooks]]\nevent = "PreToolUse"\n[[hooks.hooks]]\ncommand = "/autoskillit/hooks/_dispatch.py old"\n')
+        p.write_text(
+            '[[hooks]]\nevent = "PreToolUse"\n[[hooks.hooks]]\ncommand = "/autoskillit/hooks/_dispatch.py old"\n'
+        )
         result = sync_hooks_to_codex_config(config_path=p)
         assert result is True
         config = _read_codex_config(p)

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -36,7 +36,6 @@ def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
 
 def test_deep_staleness_baseline_initialized_eagerly(tmp_path, monkeypatch):
     """_get_process_start_mtime eagerly sets the deep mtime baseline."""
-    import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)

--- a/tests/recipe/test_staleness_cache.py
+++ b/tests/recipe/test_staleness_cache.py
@@ -150,7 +150,9 @@ def test_check_staleness_writes_cache_on_miss(monkeypatch, tmp_path):
         compute_called.append(skill_name)
         return "sha256:" + "b" * 64
 
-    monkeypatch.setattr("autoskillit.recipe._contracts_staleness.compute_skill_hash", tracking_compute)
+    monkeypatch.setattr(
+        "autoskillit.recipe._contracts_staleness.compute_skill_hash", tracking_compute
+    )
 
     contract = {
         "bundled_manifest_version": manifest_version,


### PR DESCRIPTION
## Summary

Add TOML array-of-tables (`[[section]]`) serialization to `_codex_config.py` so list-of-dict values are emitted as proper TOML array-of-tables blocks. Create `cli/_hooks_codex.py` with `generate_codex_hooks_config()`, `_is_autoskillit_hook_entry()`, and `sync_hooks_to_codex_config()` for managing Codex-format hook configuration. Add comprehensive tests and update CLAUDE.md files.

## Changed Files

### New (★):
★ `src/autoskillit/cli/_hooks_codex.py`
★ `tests/hooks/test_codex_hooks.py`

### Modified (●):
● `src/autoskillit/cli/CLAUDE.md`
● `src/autoskillit/execution/__init__.py`
● `src/autoskillit/execution/backends/CLAUDE.md`
● `src/autoskillit/execution/backends/__init__.py`
● `src/autoskillit/execution/backends/_codex_config.py`
● `tests/_helpers.py`
● `tests/arch/test_subpackage_isolation.py`
● `tests/execution/backends/test_codex_config.py`
● `tests/hooks/CLAUDE.md`
● `tests/recipe/test_deep_staleness.py`
● `tests/recipe/test_staleness_cache.py`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-121738-139933/.autoskillit/temp/make-plan/py4_p4_a4_wp1_plan_2026-05-24_122800.md`

Closes #2877

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 2.9k | 35.8k | 1.6M | 128.7k | 146 | 199.7k | 17m 40s |
| verify | claude-sonnet-4-6 | 1 | 44 | 10.0k | 812.4k | 61.1k | 95 | 45.6k | 7m 58s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 11.2k | 1.1M | 30.0k | 78 | 15.7k | 3m 55s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 81.4k | 3.6k | 206.9k | 30.0k | 21 | 15.2k | 1m 12s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.6k | 1.9k | 176.9k | 30.0k | 14 | 15.0k | 43s |
| review_pr | claude-sonnet-4-6 | 1 | 102 | 23.9k | 623.9k | 76.1k | 33 | 61.2k | 5m 34s |
| resolve_review | claude-sonnet-4-6 | 1 | 389 | 22.3k | 2.6M | 81.0k | 114 | 66.8k | 15m 35s |
| **Total** | | | 1.3M | 108.7k | 7.2M | 128.7k | | 419.3k | 52m 41s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 617 | 1840.9 | 25.4 | 18.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **617** | 11692.7 | 679.5 | 176.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 2.9k | 35.8k | 1.6M | 199.7k | 17m 40s |
| claude-sonnet-4-6 | 3 | 535 | 56.2k | 4.1M | 173.7k | 29m 8s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 16.6k | 1.5M | 45.9k | 5m 51s |