### PR TITLE
Extend write_guard.py to intercept Codex apply_patch tool calls

### DIFF
--- a/src/autoskillit/hooks/guards/CLAUDE.md
+++ b/src/autoskillit/hooks/guards/CLAUDE.md
@@ -27,7 +27,7 @@ PreToolUse guard scripts — standalone Python processes enforcing tool-call pol
 | `skill_command_guard.py` | Blocks `run_skill` with non-slash `skill_command` |
 | `unsafe_install_guard.py` | Blocks `pip install -e` targeting system Python |
 | `skill_load_guard.py` | Denies native tools until Skill tool is called in non-Anthropic headless skill sessions; exempts subagents via `agent_id` |
-| `write_guard.py` | Blocks Write/Edit/Bash outside allowed prefix in write-scoped sessions |
+| `write_guard.py` | Blocks Write/Edit/Bash/apply_patch outside allowed prefix in write-scoped sessions |
 
 ## Architecture Notes
 

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -1,4 +1,5 @@
-"""PreToolUse hook: blocks Write/Edit/Bash outside the allowed prefix in write-scoped sessions."""
+"""PreToolUse hook: blocks Write/Edit/Bash/apply_patch outside
+the allowed prefix in write-scoped sessions."""
 
 from __future__ import annotations
 
@@ -60,6 +61,17 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
     return targets
 
 
+def _extract_paths_from_patch(command: str) -> list[str]:
+    """Extract target file paths from a unified diff patch ('+++ b/' lines)."""
+    if not command:
+        return []
+    paths: list[str] = []
+    for line in command.split("\n"):
+        if line.startswith("+++ b/"):
+            paths.append(line[6:])
+    return paths
+
+
 def _deny(reason: str) -> None:
     json.dump(
         {
@@ -85,11 +97,13 @@ def main() -> None:
     try:
         data = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError, OSError):
-        _deny(f"Write/Edit blocked: {WRITE_GUARD_DENY_TRIGGER} (malformed hook input).")
+        _deny(
+            f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER} (malformed hook input)."
+        )
         return
 
     tool_name = data.get("tool_name", "")
-    if tool_name not in ("Write", "Edit", "Bash") and "run_cmd" not in tool_name:
+    if tool_name not in ("Write", "Edit", "Bash", "apply_patch") and "run_cmd" not in tool_name:
         sys.exit(0)
 
     tool_input = data.get("tool_input", {})
@@ -112,7 +126,25 @@ def main() -> None:
         for target in targets:
             if not _within_prefix(target):
                 _deny(
-                    f"Write/Edit blocked: {WRITE_GUARD_DENY_TRIGGER}. "
+                    f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
+                    f"Only writes to {allowed_prefix} are permitted."
+                )
+                return
+        sys.exit(0)
+
+    if tool_name == "apply_patch":
+        command = tool_input.get("command", "")
+        paths = _extract_paths_from_patch(command)
+        if not paths:
+            _deny(
+                f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER} "
+                f"(no target paths found in patch)."
+            )
+            return
+        for p in paths:
+            if not _within_prefix(p):
+                _deny(
+                    f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
                     f"Only writes to {allowed_prefix} are permitted."
                 )
                 return
@@ -121,14 +153,14 @@ def main() -> None:
     # Write or Edit
     file_path = tool_input.get("file_path", "")
     if not file_path:
-        _deny(f"Write/Edit blocked: {WRITE_GUARD_DENY_TRIGGER} (no file_path).")
+        _deny(f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER} (no file_path).")
         return
 
     if _within_prefix(file_path):
         sys.exit(0)
 
     _deny(
-        f"Write/Edit blocked: {WRITE_GUARD_DENY_TRIGGER}. "
+        f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
         f"Only writes to {allowed_prefix} are permitted."
     )
 

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -134,6 +134,73 @@ def _build_bash_event(command: str) -> dict:
     return {"tool_name": "Bash", "tool_input": {"command": command}}
 
 
+def _build_apply_patch_event(patch_text: str) -> dict:
+    return {"tool_name": "apply_patch", "tool_input": {"command": patch_text}}
+
+
+class TestWriteGuardApplyPatch:
+    """write_guard intercepts apply_patch tool calls with unified diff path extraction."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_headless(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+
+    def test_apply_patch_within_prefix_allowed(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        allowed = tmp_path / "workspace"
+        allowed.mkdir()
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", str(allowed) + "/")
+        patch_text = f"--- a/old.py\n+++ b/{allowed}/foo.py\n@@ -1 +1 @@\n-old\n+new"
+        result = _run_hook(_build_apply_patch_event(patch_text))
+        assert result == ""
+
+    def test_apply_patch_outside_prefix_denied(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        allowed = tmp_path / "workspace"
+        allowed.mkdir()
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", str(allowed) + "/")
+        patch_text = "--- a/old.py\n+++ b/outside/bar.py\n@@ -1 +1 @@\n-old\n+new"
+        result = _run_hook(_build_apply_patch_event(patch_text))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert (
+            "read-only skill session" in parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        )
+
+    def test_apply_patch_multiple_files_one_outside_denied(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        allowed = tmp_path / "workspace"
+        allowed.mkdir()
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", str(allowed) + "/")
+        patch_text = (
+            f"--- a/a.py\n+++ b/{allowed}/a.py\n@@ -1 +1 @@\n-x\n+y\n"
+            f"--- a/b.py\n+++ b/outside/b.py\n@@ -1 +1 @@\n-x\n+y"
+        )
+        result = _run_hook(_build_apply_patch_event(patch_text))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_apply_patch_no_target_paths_denies(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        allowed = tmp_path / "workspace"
+        allowed.mkdir()
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", str(allowed) + "/")
+        patch_text = "some random text\nwithout any diff headers\n"
+        result = _run_hook(_build_apply_patch_event(patch_text))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert (
+            "no target paths found in patch"
+            in parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        )
+
+    def test_apply_patch_empty_command_denies(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        allowed = tmp_path / "workspace"
+        allowed.mkdir()
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", str(allowed) + "/")
+        result = _run_hook(_build_apply_patch_event(""))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
 class TestWriteGuardBashBypass:
     """write_guard intercepts Bash tool calls containing file-modifying commands."""
 

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -36,7 +36,6 @@ def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
 
 def test_deep_staleness_baseline_initialized_eagerly(tmp_path, monkeypatch):
     """_get_process_start_mtime eagerly sets the deep mtime baseline."""
-    import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)

--- a/tests/recipe/test_staleness_cache.py
+++ b/tests/recipe/test_staleness_cache.py
@@ -150,7 +150,9 @@ def test_check_staleness_writes_cache_on_miss(monkeypatch, tmp_path):
         compute_called.append(skill_name)
         return "sha256:" + "b" * 64
 
-    monkeypatch.setattr("autoskillit.recipe._contracts_staleness.compute_skill_hash", tracking_compute)
+    monkeypatch.setattr(
+        "autoskillit.recipe._contracts_staleness.compute_skill_hash", tracking_compute
+    )
 
     contract = {
         "bundled_manifest_version": manifest_version,


### PR DESCRIPTION
## Summary

Add `apply_patch` tool interception to `write_guard.py` so that Codex's unified-diff-based file modification tool is subject to the same write-prefix enforcement as Write/Edit/Bash. This includes a new path extractor for unified diff `+++ b/` lines, a dispatch branch, updated deny message prefixes, and 5 new tests.

**Dependency note:** The HOOK_REGISTRY matcher for `write_guard.py` does NOT include `apply_patch` — it will be updated in P4-A6-WP1 (which depends on this WP). Until then, the guard logic is present but the hook dispatch won't route `apply_patch` calls to this script.

## Requirements

## Goal

Extend write_guard.py to intercept Codex's apply_patch tool calls by adding apply_patch to the tool_name guard, implementing a patch-path extractor, adding a dispatch branch that validates each extracted path against the allowed prefix, and updating deny message prefixes at all three deny call sites.

## Acceptance Criteria

- tool_name check includes 'apply_patch' alongside 'Write' and 'Edit'.
- _extract_paths_from_patch('') returns [].
- _extract_paths_from_patch with '+++ b/src/foo.py' returns ['src/foo.py'].
- Lines like '+++ /dev/null' are excluded from extracted paths.
- When tool_name is 'apply_patch' and command yields empty path list, _deny is called with 'no target paths found in patch'.
- When an extracted path resolves outside the allowed prefix, _deny is called with 'Write/Edit/apply_patch blocked:' and 'read-only skill session'.
- When all extracted paths resolve within allowed prefix, sys.exit(0) is called.
- All three pre-existing _deny call sites use prefix 'Write/Edit/apply_patch blocked:'.
- WRITE_GUARD_DENY_TRIGGER remains 'read-only skill session'.
- HOOK_REGISTRY matcher for write_guard.py (r'Write|Edit') is not modified.
- _build_apply_patch_event(patch_text) returns {'tool_name': 'apply_patch', 'tool_input': {'command': patch_text}}.
- TestWriteGuardApplyPatch has an autouse fixture setting AUTOSKILLIT_HEADLESS=1.
- test_apply_patch_within_prefix_allowed passes with empty output.
- test_apply_patch_outside_prefix_denied passes with deny decision and 'read-only skill session'.
- test_apply_patch_multiple_files_one_outside_denied passes with deny decision.
- test_apply_patch_no_target_paths_denies passes with 'no target paths found in patch'.
- test_apply_patch_empty_command_denies passes with deny decision.
- No malformed-JSON test inside TestWriteGuardApplyPatch.
- All new tests use monkeypatch.setenv for AUTOSKILLIT_ALLOWED_WRITE_PREFIX with real tmp_path directory.
- task test-check passes with no regressions.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

(none)

Closes #2876

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-121737-670443/.autoskillit/temp/dry-walkthrough/py4_p4_a3_wp1_extend_write_guard_apply_patch_plan_2026-05-24_121900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 74 | 9.0k | 879.0k | 62.3k | 66 | 51.6k | 6m 50s |
| verify | claude-sonnet-4-6 | 1 | 40 | 14.7k | 631.2k | 65.7k | 81 | 50.4k | 8m 0s |
| implement* | MiniMax-M2.7-highspeed | 1 | 4.6M | 29.9k | 3.1M | 30.0k | 234 | 15.7k | 10m 23s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 38.2k | 3.4k | 155.0k | 35.1k | 21 | 50.3k | 1m 8s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 63.3k | 2.8k | 206.9k | 30.0k | 16 | 14.9k | 58s |
| review_pr | claude-sonnet-4-6 | 2 | 226 | 78.3k | 1.6M | 96.3k | 103 | 152.1k | 20m 54s |
| resolve_review | claude-sonnet-4-6 | 2 | 424 | 34.7k | 2.7M | 72.5k | 124 | 106.2k | 14m 28s |
| **Total** | | | 4.7M | 172.8k | 9.2M | 96.3k | | 441.2k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 118 | 26134.0 | 132.9 | 253.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **118** | 77735.3 | 3738.6 | 1464.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 74 | 9.0k | 879.0k | 51.6k | 6m 50s |
| claude-sonnet-4-6 | 3 | 690 | 127.7k | 4.8M | 308.7k | 43m 24s |
| MiniMax-M2.7-highspeed | 3 | 4.7M | 36.1k | 3.4M | 80.9k | 12m 29s |