### PR TITLE
Encapsulate --append-system-prompt Flag Injection

### DIFF
--- a/apply_changes.py
+++ b/apply_changes.py
@@ -1,8 +1,8 @@
-import re
 import base64
 
 filepath = "tests/workspace/test_session_skills_provider.py"
 import sys
+
 if base64.b64een(sys.argV1).truncate() != "2":
     print("Fail: python3 v3 only")
     sys.exit(1)

--- a/tests/execution/backends/test_claude_backend.py
+++ b/tests/execution/backends/test_claude_backend.py
@@ -146,6 +146,11 @@ class TestBuildInteractiveCmdSystemPrompt:
         )
         assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in spec.cmd
 
+    def test_no_system_prompt_omits_flag_with_no_resume(self) -> None:
+        backend = ClaudeCodeBackend()
+        spec = backend.build_interactive_cmd(system_prompt=None, resume_spec=NoResume())
+        assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in spec.cmd
+
 
 class TestBuildHeadlessResumeCmdEquivalence:
     def test_minimal(self) -> None:

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -15,6 +15,7 @@ from autoskillit.core import (
     NamedResume,
     NoResume,
 )
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.commands import (
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
     ClaudeHeadlessCmd,
@@ -283,3 +284,16 @@ def test_cmdspec_in_execution_all() -> None:
     import autoskillit.execution as m
 
     assert "CmdSpec" in m.__all__
+
+
+def test_system_prompt_forwarded_to_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    original = ClaudeCodeBackend.build_interactive_cmd
+
+    def spy(self_inner: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return original(self_inner, **kwargs)
+
+    monkeypatch.setattr(ClaudeCodeBackend, "build_interactive_cmd", spy)
+    build_interactive_cmd(system_prompt="forwarded-prompt")
+    assert captured["system_prompt"] == "forwarded-prompt"


### PR DESCRIPTION
## Summary

Encapsulate `--append-system-prompt` flag injection inside `ClaudeCodeBackend.build_interactive_cmd` so callers no longer handle this Claude-specific flag directly, and keep the `commands.py` shim in sync.

The core implementation is already complete — `system_prompt: str | None = None` exists on `build_interactive_cmd` in the backend, protocol, and shim, and the flag injection logic is gated correctly on `NoResume`. Two acceptance-criteria tests are missing and must be added.

## Requirements

## Goal

Encapsulate --append-system-prompt flag injection inside ClaudeCodeBackend.build_interactive_cmd so callers no longer handle this Claude-specific flag directly, and keep the commands.py shim in sync.

## Context

- Phase: Codex Interactive Mode and CLI Backend Awareness (Milestone: 6-codex-interactive-mode-and-cli-backend-awareness)
- Assignment: P6-A2 (Update ClaudeCodeBackend.build_interactive_cmd to accept system_prompt and append --append-system-prompt internally when not resuming)
- Depends on: P1-A1-WP1
- Depended on by: P6-A4-WP1

## Deliverables

- `src/autoskillit/execution/backends/claude.py — extended build_interactive_cmd`
- `src/autoskillit/execution/commands.py — shim updated to forward system_prompt`
- `tests/execution/backends/test_claude_code_backend.py — TestBuildInteractiveCmdSystemPrompt class`
- `tests/execution/test_commands.py — test_system_prompt_forwarded_to_backend`

## Acceptance Criteria

- system_prompt='<prompt>' with NoResume() produces CmdSpec containing ['--append-system-prompt', '<prompt>'].
- system_prompt='<prompt>' with BareResume() does NOT contain '--append-system-prompt'.
- system_prompt='<prompt>' with NamedResume() does NOT contain '--append-system-prompt'.
- system_prompt=None produces CmdSpec identical to pre-WP baseline.
- commands.build_interactive_cmd(system_prompt='<prompt>') forwards correctly.
- No changes to _session_launch.py or _type_protocols_backend.py.
- test_system_prompt_with_no_resume_injects_flag passes.
- test_system_prompt_with_named_resume_omits_flag passes.
- test_system_prompt_with_bare_resume_omits_flag passes.
- test_no_system_prompt_omits_flag_with_no_resume passes.
- test_system_prompt_forwarded_to_backend passes.
- All tests carry pytest.mark.layer('execution') and pytest.mark.small.

## Changed Files

### Modified (●):

- `apply_changes.py`
- `tests/execution/backends/test_claude_backend.py`
- `tests/execution/test_commands.py`

Closes #2886

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-145009-231613/.autoskillit/temp/make-plan/p6_a2_wp1_plan_2026-05-24_150500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 3.2k | 9.4k | 1.1M | 58.4k | 112 | 42.1k | 9m 0s |
| verify | claude-opus-4-6 | 1 | 41 | 6.3k | 851.4k | 50.0k | 50 | 33.9k | 3m 5s |
| implement* | MiniMax-M2.7-highspeed | 2 | 685.5k | 9.1k | 1.3M | 30.7k | 85 | 31.3k | 3m 49s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 152.1k | 5.2k | 426.5k | 30.7k | 36 | 15.2k | 2m 46s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 38.6k | 1.6k | 181.1k | 30.7k | 13 | 15.0k | 37s |
| review_pr | claude-sonnet-4-6 | 3 | 428 | 48.8k | 2.2M | 58.2k | 135 | 121.7k | 12m 39s |
| resolve_review | claude-sonnet-4-6 | 3 | 727 | 44.6k | 4.5M | 76.6k | 209 | 149.9k | 26m 15s |
| **Total** | | | 880.5k | 125.0k | 10.4M | 76.6k | | 409.1k | 58m 14s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 48 | 26080.6 | 652.3 | 188.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **48** | 216466.7 | 8523.5 | 2603.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 3.2k | 15.7k | 1.9M | 75.9k | 12m 6s |
| MiniMax-M2.7-highspeed | 3 | 876.1k | 15.9k | 1.9M | 61.5k | 7m 13s |
| claude-sonnet-4-6 | 2 | 1.2k | 93.4k | 6.6M | 271.6k | 38m 54s |