### PR TITLE
Extend _compute_retry with exit_code_is_terminal parameter

### DIFF
--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -473,6 +473,7 @@ def _build_skill_result(
             if artifact_recovered is not None:
                 session = artifact_recovered
 
+    exit_code_is_terminal = backend.capabilities.exit_code_is_terminal
     outcome, retry_reason = _compute_outcome(
         session,
         returncode,
@@ -481,6 +482,7 @@ def _build_skill_result(
         channel_confirmation=result.channel_confirmation,
         expected_output_patterns=expected_output_patterns,
         prior_completion_markers=prior_completion_markers,
+        exit_code_is_terminal=exit_code_is_terminal,
     )
     success = outcome == SessionOutcome.SUCCEEDED
     needs_retry = outcome == SessionOutcome.RETRIABLE

--- a/src/autoskillit/execution/session/_retry_fsm.py
+++ b/src/autoskillit/execution/session/_retry_fsm.py
@@ -59,6 +59,7 @@ def _compute_retry(
     completion_marker: str = "",
     prior_completion_markers: Sequence[str] | None = None,
     expected_output_patterns: Sequence[str] = (),
+    exit_code_is_terminal: bool = False,
 ) -> tuple[bool, RetryReason]:
     """Compute whether the session result warrants a retry.
 
@@ -70,6 +71,10 @@ def _compute_retry(
     the provenance bypass applies: Channel B's session-JSONL signal is
     authoritative, so kill-anomaly appearance is a drain-race artifact.
     No retry is needed.
+
+    When ``exit_code_is_terminal=True`` and ``returncode > 0`` in the
+    NATURAL_EXIT arm, the positive returncode is treated as authoritative
+    terminal failure — kill-anomaly and early-stop checks are bypassed.
     """
     # Phase 1: API-level retry signals (context exhaustion, max_turns)
     if session.needs_retry:
@@ -87,6 +92,15 @@ def _compute_retry(
                     "compute_retry_result",
                     termination="NATURAL_EXIT",
                     channel=str(channel_confirmation),
+                    needs_retry=False,
+                )
+                return False, RetryReason.NONE
+            if exit_code_is_terminal and returncode > 0:
+                logger.debug(
+                    "compute_retry_result",
+                    termination="NATURAL_EXIT",
+                    exit_code_is_terminal=True,
+                    returncode=returncode,
                     needs_retry=False,
                 )
                 return False, RetryReason.NONE

--- a/src/autoskillit/execution/session/_session_outcome.py
+++ b/src/autoskillit/execution/session/_session_outcome.py
@@ -150,6 +150,7 @@ def _compute_outcome(
     channel_confirmation: ChannelConfirmation = ChannelConfirmation.UNMONITORED,
     expected_output_patterns: Sequence[str] = (),
     prior_completion_markers: Sequence[str] | None = None,
+    exit_code_is_terminal: bool = False,
 ) -> tuple[SessionOutcome, RetryReason]:
     """Compose _compute_success and _compute_retry into a (SessionOutcome, RetryReason) pair.
 
@@ -173,6 +174,7 @@ def _compute_outcome(
         completion_marker,
         prior_completion_markers,
         expected_output_patterns,
+        exit_code_is_terminal=exit_code_is_terminal,
     )
 
     logger.debug(

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -102,7 +102,7 @@ SESSION_SIZE_BUDGETS = {
 }
 NEW_SESSION_FSM_MODULES = ["_retry_fsm.py", "_session_outcome.py"]
 SESSION_FSM_SIZE_BUDGETS = {
-    "session/_retry_fsm.py": 205,
+    "session/_retry_fsm.py": 215,
     "session/_session_outcome.py": 260,
 }
 MQ_SIZE_BUDGETS = {

--- a/tests/execution/test_session_adjudication_retry.py
+++ b/tests/execution/test_session_adjudication_retry.py
@@ -397,6 +397,47 @@ class TestComputeRetrySuccessEmptyResult:
         assert reason == RetryReason.RESUME  # infrastructure kill — progress existed
 
 
+class TestComputeRetryExitCodeIsTerminal:
+    def test_terminal_nonzero_exit_no_retry(self):
+        session = ClaudeSessionResult(
+            subtype="success", is_error=False, result="", session_id="s1"
+        )
+        needs_retry, reason = _compute_retry(
+            session,
+            1,
+            TerminationReason.NATURAL_EXIT,
+            exit_code_is_terminal=True,
+        )
+        assert needs_retry is False
+        assert reason == RetryReason.NONE
+
+    def test_terminal_zero_exit_passes_through(self):
+        session = ClaudeSessionResult(
+            subtype="success", is_error=False, result="Done.", session_id="s1"
+        )
+        needs_retry, reason = _compute_retry(
+            session,
+            0,
+            TerminationReason.NATURAL_EXIT,
+            exit_code_is_terminal=True,
+        )
+        assert needs_retry is False
+        assert reason == RetryReason.NONE
+
+    def test_api_resume_not_suppressed_by_terminal_flag(self):
+        session = ClaudeSessionResult(
+            subtype="error_max_turns", is_error=False, result="", session_id="s1"
+        )
+        needs_retry, reason = _compute_retry(
+            session,
+            1,
+            TerminationReason.NATURAL_EXIT,
+            exit_code_is_terminal=True,
+        )
+        assert needs_retry is True
+        assert reason == RetryReason.RESUME
+
+
 @pytest.mark.parametrize("termination", list(TerminationReason))
 def test_compute_retry_handles_all_termination_reasons_without_raising(
     termination: TerminationReason,


### PR DESCRIPTION
## Summary

Add an `exit_code_is_terminal: bool = False` keyword parameter to `_compute_retry` in `_retry_fsm.py` and insert a terminal guard in the `NATURAL_EXIT` match arm so that any `returncode > 0` produces `(False, RetryReason.NONE)` when the flag is set. Thread the parameter through `_compute_outcome` and `_build_skill_result`, reading it from `backend.capabilities.exit_code_is_terminal`. This enables Codex backends (which set `exit_code_is_terminal=True`) to treat nonzero exit codes as authoritative terminal failures without triggering kill-anomaly or early-stop retry logic.

## Requirements

## Goal

Extend _compute_retry in _retry_fsm.py with an exit_code_is_terminal: bool = False parameter and insert a terminal guard in the NATURAL_EXIT match arm so that any returncode > 0 produces (False, RetryReason.NONE) when the flag is set.

## Context

- Phase: Session Diagnostics and Stale-Kill Suppression (Milestone: 5-session-diagnostics-and-stale-kill-suppression)
- Assignment: P5-A4 (Wire exit_code_is_terminal through _compute_retry for Codex nonzero exit terminal classification)
- Depends on: P1-A5-WP1
- Depended on by: None

## Deliverables

- `src/autoskillit/execution/session/_retry_fsm.py — updated _compute_retry signature and NATURAL_EXIT terminal guard`
- `src/autoskillit/execution/session/_session_outcome.py — _compute_outcome signature extended with exit_code_is_terminal parameter, forwarded to _compute_retry call`
- `src/autoskillit/execution/headless/_headless_result.py — _build_skill_result reads backend.capabilities.exit_code_is_terminal and passes it to _compute_outcome`
- `tests/execution/test_session_adjudication_retry.py — new class TestComputeRetryExitCodeIsTerminal with three test methods`

## Acceptance Criteria

- _compute_retry signature includes `exit_code_is_terminal: bool = False` as a keyword parameter.
- When exit_code_is_terminal=True and returncode > 0 and termination=NATURAL_EXIT, _compute_retry returns (False, RetryReason.NONE) without evaluating kill-anomaly or early-stop branches.
- When exit_code_is_terminal=False (default), all existing NATURAL_EXIT branches behave identically to the pre-change implementation — no regression.
- The new guard is inserted AFTER the channel_confirmation bypass check so Channel A/B confirmed sessions still bypass terminal classification.
- _compute_retry docstring documents the new parameter's semantics.
- The existing `__all__` export list in _retry_fsm.py remains correct.
- _compute_outcome signature includes `exit_code_is_terminal: bool = False` and passes it through to _compute_retry unchanged.
- _build_skill_result extracts exit_code_is_terminal from backend.capabilities when backend is not None, defaults to False when backend is None, and passes it to _compute_outcome.
- All existing callers of _compute_outcome that omit exit_code_is_terminal continue to work (default False preserves prior behavior).
- No changes are made to BackendCapabilities, CodexBackend, or ClaudeCodeBackend.
- mypy and pre-commit pass with no new type errors on the modified files.
- TestComputeRetryExitCodeIsTerminal contains exactly three test methods covering: (1) terminal nonzero, (2) terminal zero passthrough, (3) API RESUME not suppressed.
- All three tests use in-memory construction only (pytest.mark.small valid).
- Module-level pytestmark inherited without class-level override.
- Tests pass under task test-check without errors.
- If _compute_retry gains exit_code_is_terminal parameter before implementation, tests call it directly.

Closes #2884

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-145008-296381/.autoskillit/temp/make-plan/p5_a4_wp1_extend_compute_retry_exit_code_is_terminal_plan_2026-05-24_150200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 73 | 11.2k | 1.1M | 78.7k | 123 | 49.6k | 17m 0s |
| verify | claude-opus-4-6 | 1 | 175 | 8.0k | 792.3k | 69.5k | 59 | 54.5k | 3m 26s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 8.7k | 981.8k | 30.7k | 70 | 43.5k | 3m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 122.1k | 3.6k | 334.5k | 30.7k | 23 | 15.3k | 1m 18s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 41.6k | 2.1k | 181.2k | 30.7k | 14 | 15.0k | 46s |
| review_pr | claude-sonnet-4-6 | 3 | 360 | 77.3k | 1.9M | 66.4k | 124 | 167.3k | 14m 48s |
| resolve_review | claude-sonnet-4-6 | 1 | 373 | 14.3k | 2.4M | 69.3k | 102 | 53.6k | 7m 30s |
| **Total** | | | 1.3M | 125.2k | 7.7M | 78.7k | | 398.8k | 48m 8s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 61 | 16095.0 | 712.6 | 143.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **61** | 125733.8 | 6537.6 | 2053.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 806 | 102.8k | 5.4M | 270.5k | 39m 20s |
| claude-opus-4-6 | 1 | 175 | 8.0k | 792.3k | 54.5k | 3m 26s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 14.4k | 1.5M | 73.8k | 5m 21s |