### PR TITLE
Implementation Plan: P5-A1-WP1 — Confirm _watch_stdout_idle Has Zero Channel B Dependency and Add Observability Log

### DIFF
--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -194,6 +194,11 @@ async def _watch_stdout_idle(
                 now = _time.monotonic()
                 if suppression_start_marker is None:
                     suppression_start_marker = now
+                    logger.debug(
+                        "stdout_idle_stall_suppression_evaluated",
+                        marker_dir_present=True,
+                        session_id=session_id,
+                    )
                 elapsed = now - suppression_start_marker
                 if elapsed < max_suppression_seconds:
                     logger.warning(
@@ -204,6 +209,14 @@ async def _watch_stdout_idle(
                         max_suppression_seconds=max_suppression_seconds,
                     )
                     continue
+            logger.debug(
+                "stdout_idle_stall_suppression_evaluated",
+                marker_dir_present=marker_dir is not None,
+                session_id=session_id,
+                **(
+                    {"suppression_skipped_reason": "marker_dir_none"} if marker_dir is None else {}
+                ),
+            )
             logger.warning(
                 "stdout idle for %ss — firing IDLE_STALL",
                 idle_output_timeout,

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -7,6 +7,7 @@ import os
 import sys
 import textwrap
 import time
+from unittest.mock import MagicMock, patch
 
 import anyio
 import pytest
@@ -16,6 +17,145 @@ from autoskillit.execution.process._process_race import (
     RaceAccumulator,
     _watch_stdout_idle,
 )
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_emits_suppression_evaluated_debug_log(
+    tmp_path: anyio.Path,
+) -> None:
+    """Debug log fires when marker_dir is None and IDLE_STALL fires."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with patch(
+        "autoskillit.execution.process._process_race.logger", new=MagicMock()
+    ) as mock_debug:
+        with anyio.fail_after(2.0):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(
+                    functools.partial(
+                        _watch_stdout_idle,
+                        stdout_file,
+                        0.1,
+                        acc,
+                        trigger,
+                        0.05,
+                    )
+                )
+                await trigger.wait()
+
+    debug_calls = mock_debug.debug.call_args_list
+    evaluated_calls = [
+        c for c in debug_calls if c.args and c.args[0] == "stdout_idle_stall_suppression_evaluated"
+    ]
+    assert len(evaluated_calls) == 1
+    call_kwargs = evaluated_calls[0].kwargs
+    assert call_kwargs.get("marker_dir_present") is False
+    assert call_kwargs.get("session_id") is None
+    assert call_kwargs.get("suppression_skipped_reason") == "marker_dir_none"
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_emits_suppression_evaluated_with_marker_dir(
+    tmp_path: anyio.Path,
+) -> None:
+    """Debug log fires when marker_dir is present but marker inactive."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with patch(
+        "autoskillit.execution.process._process_race.logger", new=MagicMock()
+    ) as mock_debug:
+        with anyio.fail_after(2.0):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(
+                    functools.partial(
+                        _watch_stdout_idle,
+                        stdout_file,
+                        0.1,
+                        acc,
+                        trigger,
+                        0.05,
+                        marker_dir=tmp_path,
+                    )
+                )
+                await trigger.wait()
+
+    debug_calls = mock_debug.debug.call_args_list
+    evaluated_calls = [
+        c for c in debug_calls if c.args and c.args[0] == "stdout_idle_stall_suppression_evaluated"
+    ]
+    assert len(evaluated_calls) == 1
+    call_kwargs = evaluated_calls[0].kwargs
+    assert call_kwargs.get("marker_dir_present") is True
+    assert "suppression_skipped_reason" not in call_kwargs
+
+
+@pytest.mark.anyio
+async def test_watch_stdout_idle_suppression_evaluated_fires_once_during_suppression(
+    tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Debug log fires exactly once on first suppression entry, not each tick."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    monkeypatch.setattr(
+        "autoskillit.execution.process._process_race._has_active_dispatch_marker",
+        lambda marker_dir, session_id=None: True,
+    )
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with patch(
+        "autoskillit.execution.process._process_race.logger", new=MagicMock()
+    ) as mock_debug:
+
+        async def cancel_when_suppressed() -> None:
+            # Wait for at least 2 suppressed warnings before cancelling
+            suppressed_count = 0
+            start = anyio.current_time()
+            while suppressed_count < 2:
+                await anyio.sleep(0.02)
+                suppressed_count = sum(
+                    1
+                    for c in mock_debug.call_args_list
+                    if (c.kwargs.get("event") == "stdout_idle_stall_suppressed")
+                )
+                if anyio.current_time() - start > 1.5:
+                    break
+            trigger.set()
+
+        with anyio.fail_after(2.0):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(cancel_when_suppressed)
+                tg.start_soon(
+                    functools.partial(
+                        _watch_stdout_idle,
+                        stdout_file,
+                        0.05,
+                        acc,
+                        trigger,
+                        0.02,
+                        marker_dir=tmp_path,
+                        session_id="test-sess",
+                        max_suppression_seconds=10.0,
+                    )
+                )
+                await trigger.wait()
+
+    debug_calls = mock_debug.debug.call_args_list
+    evaluated_calls = [
+        c for c in debug_calls if c.args and c.args[0] == "stdout_idle_stall_suppression_evaluated"
+    ]
+    assert len(evaluated_calls) == 1
+
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
@@ -496,3 +636,6 @@ async def test_watch_stdout_idle_marker_suppression_bounded(
     assert acc.idle_stall is True
     assert elapsed >= 1.5
     assert elapsed < 5.0
+
+
+# test write


### PR DESCRIPTION
## Summary

Add a single `logger.debug` call at the idle-threshold evaluation branch in `_watch_stdout_idle` so Codex session kills are observable without Channel B diagnostics. All code confirmations in the issue have been verified: `_watch_stdout_idle` has zero Channel B / `session_log_dir` dependency for Codex sessions.

## Changed Files

- `src/autoskillit/execution/process/_process_race.py` — Added `stdout_idle_stall_suppression_evaluated` debug log at the idle-threshold evaluation branch in `_watch_stdout_idle`
- `tests/execution/test_process_idle_watchdog.py` — Added test covering the new debug log behavior

Closes #2881

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-144958-083583/.autoskillit/temp/make-plan/p5_a1_wp1_stdout_idle_suppression_debug_log_plan_2026-05-24_150200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 113 | 8.3k | 1.1M | 57.0k | 87 | 57.1k | 10m 37s |
| verify | claude-sonnet-4-6 | 2 | 97 | 19.5k | 1.6M | 80.7k | 132 | 109.2k | 9m 57s |
| implement* | MiniMax-M2.7-highspeed | 2 | 2.6M | 32.7k | 2.5M | 30.7k | 198 | 59.1k | 22m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 97.6k | 3.9k | 245.4k | 30.7k | 28 | 43.1k | 1m 16s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 53.6k | 1.3k | 242.5k | 30.7k | 17 | 15.0k | 37s |
| review_pr | claude-sonnet-4-6 | 1 | 68 | 20.5k | 297.9k | 57.3k | 25 | 46.1k | 5m 1s |
| resolve_review | claude-sonnet-4-6 | 1 | 317 | 15.7k | 2.3M | 76.7k | 92 | 60.6k | 7m 42s |
| **Total** | | | 2.8M | 101.8k | 8.3M | 80.7k | | 390.1k | 57m 57s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 260 | 9427.3 | 227.3 | 125.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **260** | 31759.5 | 1500.4 | 391.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 113 | 8.3k | 1.1M | 57.1k | 10m 37s |
| claude-sonnet-4-6 | 3 | 482 | 55.7k | 4.2M | 215.9k | 22m 41s |
| MiniMax-M2.7-highspeed | 3 | 2.8M | 37.9k | 2.9M | 117.2k | 24m 39s |