### PR TITLE
fix: decouple step_name from provider profile in Tier 3 resolution

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -514,6 +514,25 @@ class ProvidersConfig:
                         f"model_overrides[{recipe!r}][{step!r}] must be a string, "
                         f"got {type(model_val).__name__!r}"
                     )
+        known = set(self.profiles.keys()) | {"anthropic"}
+        for step, profile_name in self.step_overrides.items():
+            if profile_name not in known:
+                logger.warning(
+                    "step_override_references_unknown_profile",
+                    step=step,
+                    profile=profile_name,
+                    known_profiles=sorted(known),
+                )
+        for recipe, step_map in self.recipe_overrides.items():
+            for step, profile_name in step_map.items():
+                if profile_name not in known:
+                    logger.warning(
+                        "recipe_override_references_unknown_profile",
+                        recipe=recipe,
+                        step=step,
+                        profile=profile_name,
+                        known_profiles=sorted(known),
+                    )
 
     @property
     def resolved_profiles(self) -> dict[str, ProviderProfileDef]:

--- a/src/autoskillit/hooks/guards/skill_load_guard.py
+++ b/src/autoskillit/hooks/guards/skill_load_guard.py
@@ -121,8 +121,8 @@ def main() -> None:
                 f"skill_load_guard: auto-exempted session {session_id} after "
                 f"{DENY_THRESHOLD} denials (possible deadlock)\n"
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            sys.stderr.write(f"skill_load_guard: flag write failed: {exc}\n")
         sys.exit(0)
 
     _record_denial(temp_dir, session_id)

--- a/src/autoskillit/hooks/guards/skill_load_guard.py
+++ b/src/autoskillit/hooks/guards/skill_load_guard.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
+import time
 from pathlib import Path
 
 _HOOKS_DIR = str(Path(__file__).resolve().parent.parent)
@@ -31,6 +33,47 @@ if _HOOKS_DIR not in sys.path:
 from _hook_utils import find_project_root  # type: ignore[import-not-found]  # noqa: E402
 
 SKILL_LOAD_DENY_TRIGGER: str = "SKILL LOADING REQUIRED"
+
+DENY_THRESHOLD: int = 5
+
+
+def _check_deny_count(temp_dir: Path, session_id: str) -> bool:
+    deny_dir = temp_dir / f"skill_guard_{session_id}_denials"
+    if not deny_dir.exists():
+        return False
+    try:
+        return len(list(deny_dir.iterdir())) >= DENY_THRESHOLD
+    except OSError:
+        return False
+
+
+def _record_denial(temp_dir: Path, session_id: str) -> None:
+    deny_dir = temp_dir / f"skill_guard_{session_id}_denials"
+    deny_dir.mkdir(parents=True, exist_ok=True)
+    deny_file = deny_dir / f"{os.getpid()}_{time.monotonic_ns()}"
+    try:
+        fd = os.open(str(deny_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        os.close(fd)
+    except (FileExistsError, OSError):
+        pass
+
+
+def _atomic_write_flag(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
 
 _DENY_MESSAGE: str = (
     "SKILL LOADING REQUIRED. You MUST call the Skill tool to load the skill "
@@ -65,9 +108,24 @@ def main() -> None:
     if not session_id:
         sys.exit(0)
 
-    flag_path = find_project_root() / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
+    project_root = find_project_root()
+    temp_dir = project_root / ".autoskillit" / "temp"
+    flag_path = temp_dir / f"skill_guard_{session_id}.flag"
     if flag_path.exists():
         sys.exit(0)
+
+    if _check_deny_count(temp_dir, session_id):
+        try:
+            _atomic_write_flag(flag_path, "__auto_exempt__")
+            sys.stderr.write(
+                f"skill_load_guard: auto-exempted session {session_id} after "
+                f"{DENY_THRESHOLD} denials (possible deadlock)\n"
+            )
+        except Exception:
+            pass
+        sys.exit(0)
+
+    _record_denial(temp_dir, session_id)
 
     payload = json.dumps(
         {

--- a/src/autoskillit/hooks/guards/skill_load_guard.py
+++ b/src/autoskillit/hooks/guards/skill_load_guard.py
@@ -42,7 +42,7 @@ def _check_deny_count(temp_dir: Path, session_id: str) -> bool:
     if not deny_dir.exists():
         return False
     try:
-        return len(list(deny_dir.iterdir())) >= DENY_THRESHOLD
+        return sum(1 for p in deny_dir.iterdir() if p.is_file()) >= DENY_THRESHOLD
     except OSError:
         return False
 

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -18,6 +18,7 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
             "cwd",
             "model",
             "step_name",
+            "step_provider",
             "order_id",
             "stale_threshold",
             "idle_output_timeout",

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -160,7 +160,10 @@ def _provider_result(
 ) -> tuple[str, dict[str, str]]:
     if provider == "anthropic":
         return ("anthropic", {})
-    raw = profiles.get(provider, {})
+    raw = profiles.get(provider)
+    if raw is None:
+        logger.warning("provider_profile_not_found", provider=provider, tier="recipe_override")
+        return (provider, {})
     return (provider, {k: v for k, v in raw.items() if v is not None})
 
 
@@ -184,6 +187,8 @@ def _resolve_provider_profile(
     step_name: str,
     recipe_name: str,
     config_providers: ProvidersConfig,
+    *,
+    step_provider: str = "",
 ) -> tuple[str, dict[str, str]]:
 
     # Tiers 0/0W: recipe-scoped overrides — single lookup shared by both tiers
@@ -224,7 +229,9 @@ def _resolve_provider_profile(
                 return ("anthropic", {})
             profile = config_providers.resolved_profiles.get(step_override)
             if profile is None:
-                logger.debug("provider_profile_not_found", provider=step_override)
+                logger.warning(
+                    "provider_profile_not_found", provider=step_override, tier="step_override"
+                )
                 return (step_override, {})
             return (step_override, _profile_to_env(profile))
 
@@ -241,20 +248,26 @@ def _resolve_provider_profile(
                 return ("anthropic", {})
             profile = config_providers.resolved_profiles.get(wildcard)
             if profile is None:
-                logger.debug("provider_profile_not_found", provider=wildcard)
+                logger.warning(
+                    "provider_profile_not_found", provider=wildcard, tier="wildcard_override"
+                )
                 return (wildcard, {})
             return (wildcard, _profile_to_env(profile))
 
-    # Tier 3: step YAML provider field
-    if step_name:
-        logger.debug("provider_profile_resolved", tier="step_provider_field", profile=step_name)
-        if step_name == "anthropic":
+    # Tier 3: explicit step-level provider declaration (YAML provider: field)
+    if step_provider:
+        logger.debug(
+            "provider_profile_resolved", tier="step_provider_field", profile=step_provider
+        )
+        if step_provider == "anthropic":
             return ("anthropic", {})
-        profile = config_providers.resolved_profiles.get(step_name)
+        profile = config_providers.resolved_profiles.get(step_provider)
         if profile is None:
-            logger.debug("provider_profile_not_found", provider=step_name)
-            return (step_name, {})
-        return (step_name, _profile_to_env(profile))
+            logger.warning(
+                "provider_profile_not_found", provider=step_provider, tier="step_provider_field"
+            )
+            return ("anthropic", {})
+        return (step_provider, _profile_to_env(profile))
 
     # Tier 4: default
     name = config_providers.default_provider or "anthropic"
@@ -263,7 +276,7 @@ def _resolve_provider_profile(
         return ("anthropic", {})
     profile = config_providers.resolved_profiles.get(name)
     if profile is None:
-        logger.debug("provider_profile_not_found", provider=name)
+        logger.warning("provider_profile_not_found", provider=name, tier="default")
         return (name, {})
     return (name, _profile_to_env(profile))
 

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -202,6 +202,7 @@ async def run_skill(
     cwd: str,
     model: str = "",
     step_name: str = "",
+    step_provider: str = "",
     order_id: str = "",
     stale_threshold: int | None = None,
     idle_output_timeout: int | None = None,
@@ -329,7 +330,10 @@ async def run_skill(
             )
 
             _profile, _env_dict = _resolve_provider_profile(
-                step_name or "", tool_ctx.recipe_name or "", _cfg.providers
+                step_name or "",
+                tool_ctx.recipe_name or "",
+                _cfg.providers,
+                step_provider=step_provider or "",
             )
             if _profile != "anthropic":
                 provider_extras = _env_dict

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -45,6 +45,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_no_error_dict_return.py` | AST guard: load_and_validate must not return dicts with 'error' key — errors flow via exceptions |
 | `test_no_inline_jsonl_request_id_dedup.py` | AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py |
 | `test_protocol_names.py` | T5-T6: Protocol naming and DefaultSkillResolver export smoke tests |
+| `test_provider_profile_contract.py` | Tier 3 contract: _resolve_provider_profile must never return step_name as profile |
 | `test_python_no_hardcoded_temp.py` | Architectural invariant: no literal `.autoskillit/temp` outside the whitelist |
 | `test_recipe_rule_registration.py` | REQ-RECIPE-001: every recipe/rules_*.py file must be imported by recipe/__init__.py |
 | `test_regex_guards.py` | Arch guard: keyword regexes in cmd-scanning rules must use path-safe lookbehind guards |

--- a/tests/arch/test_provider_profile_contract.py
+++ b/tests/arch/test_provider_profile_contract.py
@@ -1,0 +1,61 @@
+"""Arch test: _resolve_provider_profile Tier 3 must never return step_name as profile."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_STEP_NAMES = ["plan", "implement", "investigate", "verify", "review", "remediate"]
+
+
+@pytest.mark.parametrize("step_name", _STEP_NAMES)
+def test_tier3_never_returns_step_name_as_profile_without_step_provider(step_name):
+    """Tier 3 must not leak step_name as a profile when step_provider is empty."""
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = ProvidersConfig()
+    profile_name, env_dict = _resolve_provider_profile(step_name, "", cfg)
+    assert profile_name != step_name, (
+        f"step_name={step_name!r} leaked as profile name — "
+        f"Tier 3 should only fire for explicit step_provider"
+    )
+    assert profile_name == "anthropic"
+    assert env_dict == {}
+
+
+@pytest.mark.parametrize("step_name", _STEP_NAMES)
+def test_tier3_never_returns_step_name_as_profile_with_recipe_context(step_name):
+    """With recipe context but no overrides, step_name must not become a profile."""
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = ProvidersConfig()
+    profile_name, _ = _resolve_provider_profile(step_name, "implementation", cfg)
+    assert profile_name != step_name
+    assert profile_name == "anthropic"
+
+
+def test_tier3_returns_step_provider_when_profile_exists():
+    """Tier 3 should use step_provider (not step_name) for profile lookup."""
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = ProvidersConfig(profiles={"bedrock": {"AWS_REGION": "us-east-1"}})
+    profile_name, env_dict = _resolve_provider_profile("plan", "", cfg, step_provider="bedrock")
+    assert profile_name == "bedrock"
+    assert env_dict.get("AWS_REGION") == "us-east-1"
+
+
+def test_tier3_unresolvable_step_provider_returns_anthropic():
+    """Unknown step_provider must return anthropic, not propagate the name."""
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = ProvidersConfig()
+    profile_name, env_dict = _resolve_provider_profile(
+        "plan", "", cfg, step_provider="nonexistent"
+    )
+    assert profile_name == "anthropic"
+    assert env_dict == {}

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -526,3 +526,57 @@ class TestModelConfigProvider:
         (config_dir / "config.yaml").write_text("model:\n  provider: openai\n")
         cfg = load_config(tmp_path)
         assert cfg.model.provider == "openai"
+
+
+class TestProvidersConfigCrossReference:
+    def test_step_override_references_unknown_profile_logs_warning(self) -> None:
+        import structlog.testing
+
+        from autoskillit.config._config_dataclasses import ProvidersConfig
+
+        with structlog.testing.capture_logs() as cap_logs:
+            ProvidersConfig(
+                step_overrides={"plan": "nonexistent"},
+                profiles={},
+            )
+        warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
+        assert any("nonexistent" in str(e.get("profile", "")) for e in warning_events)
+
+    def test_recipe_override_references_unknown_profile_logs_warning(self) -> None:
+        import structlog.testing
+
+        from autoskillit.config._config_dataclasses import ProvidersConfig
+
+        with structlog.testing.capture_logs() as cap_logs:
+            ProvidersConfig(
+                recipe_overrides={"remediation": {"implement": "nonexistent"}},
+                profiles={},
+            )
+        warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
+        assert any("nonexistent" in str(e.get("profile", "")) for e in warning_events)
+
+    def test_known_profile_reference_no_warning(self) -> None:
+        import structlog.testing
+
+        from autoskillit.config._config_dataclasses import ProvidersConfig
+
+        with structlog.testing.capture_logs() as cap_logs:
+            ProvidersConfig(
+                step_overrides={"plan": "bedrock"},
+                profiles={"bedrock": {"AWS_REGION": "us-east-1"}},
+            )
+        warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
+        assert not any("unknown_profile" in e.get("event", "") for e in warning_events)
+
+    def test_anthropic_reference_no_warning(self) -> None:
+        import structlog.testing
+
+        from autoskillit.config._config_dataclasses import ProvidersConfig
+
+        with structlog.testing.capture_logs() as cap_logs:
+            ProvidersConfig(
+                step_overrides={"plan": "anthropic"},
+                profiles={},
+            )
+        warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
+        assert not any("unknown_profile" in e.get("event", "") for e in warning_events)

--- a/tests/infra/test_skill_load_guard.py
+++ b/tests/infra/test_skill_load_guard.py
@@ -268,3 +268,45 @@ def test_denies_when_no_autoskillit_dir_in_ancestors(tmp_path):
     )
     response = json.loads(out)
     assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_guard_auto_exempts_after_deny_count_threshold(tmp_path):
+    """T2-15: After DENY_THRESHOLD accumulated denials, the guard auto-writes the flag."""
+    from autoskillit.hooks.guards.skill_load_guard import DENY_THRESHOLD
+
+    session_id = "auto_exempt_test"
+    deny_dir = tmp_path / ".autoskillit" / "temp" / f"skill_guard_{session_id}_denials"
+    deny_dir.mkdir(parents=True)
+    for i in range(DENY_THRESHOLD):
+        (deny_dir / f"deny_{i}").touch()
+
+    out = _run_guard(
+        _make_event("Read", session_id=session_id),
+        tmp_dir=tmp_path,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+    )
+    assert not out.strip()
+
+    flag_path = tmp_path / ".autoskillit" / "temp" / f"skill_guard_{session_id}.flag"
+    assert flag_path.exists()
+    assert flag_path.read_text() == "__auto_exempt__"
+
+
+def test_guard_records_denial_when_below_threshold(tmp_path):
+    """T2-16: Each denial creates a file in the denial directory."""
+    session_id = "denial_record_test"
+    out = _run_guard(
+        _make_event("Read", session_id=session_id),
+        tmp_dir=tmp_path,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+    )
+    response = json.loads(out)
+    assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    deny_dir = tmp_path / ".autoskillit" / "temp" / f"skill_guard_{session_id}_denials"
+    assert deny_dir.exists()
+    assert len(list(deny_dir.iterdir())) == 1

--- a/tests/server/test_resolve_provider_profile.py
+++ b/tests/server/test_resolve_provider_profile.py
@@ -41,7 +41,7 @@ def test_step_yaml_provider_wins_when_no_config_overrides():
     cfg = _make_config(
         profiles={"bedrock": {"AWS_REGION": "eu-west-1"}},
     )
-    result = _resolve_provider_profile("bedrock", "my_recipe", cfg)
+    result = _resolve_provider_profile("implement", "my_recipe", cfg, step_provider="bedrock")
     assert result == ("bedrock", {"AWS_REGION": "eu-west-1"})
 
 
@@ -90,8 +90,8 @@ def test_non_anthropic_profile_returns_correct_env_dict():
 
 
 def test_no_recipe_name_skips_step_override():
-    # Without recipe context, Tier 1 is bypassed; Tier 3 uses step_name as the
-    # provider name. If the override had applied we'd get ("vertex", {"K": "V"}).
+    # Without recipe context, Tiers 1/2 are bypassed. Without step_provider,
+    # Tier 3 is also skipped. Falls through to Tier 4 (default).
     from autoskillit.server._guards import _resolve_provider_profile
 
     cfg = _make_config(
@@ -99,7 +99,7 @@ def test_no_recipe_name_skips_step_override():
         profiles={"vertex": {"K": "V"}, "bedrock": {"X": "Y"}},
     )
     result = _resolve_provider_profile("bedrock", "", cfg)
-    assert result == ("bedrock", {"X": "Y"})
+    assert result == ("anthropic", {})
 
 
 def test_recipe_override_wins_over_global_step_override():
@@ -176,7 +176,7 @@ def test_recipe_override_requires_recipe_context():
         profiles={"vertex": {"K": "V"}},
     )
     result = _resolve_provider_profile("implement", "", cfg)
-    assert result == ("implement", {})
+    assert result == ("anthropic", {})
 
 
 def test_recipe_override_requires_step_name():
@@ -224,3 +224,61 @@ def test_resolve_provider_profile_step_override_resolves_api_key(monkeypatch):
     assert name == "custom"
     assert None not in extras.values()
     assert extras == {"ANTHROPIC_API_KEY": "secret-value"}
+
+
+def test_tier3_step_name_not_used_as_profile_when_no_matching_profile():
+    """step_name='plan' with no 'plan' profile should fall through to Tier 4."""
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config()
+    result = _resolve_provider_profile("plan", "", cfg)
+    assert result == ("anthropic", {}), (
+        "step_name='plan' should NOT be returned as a profile name "
+        "when 'plan' is not a configured profile"
+    )
+
+
+def test_tier3_only_fires_for_explicit_provider_declaration():
+    """Tier 3 should only use step_provider (the YAML provider: field), not step_name."""
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(profiles={"bedrock": {"AWS_REGION": "us-east-1"}})
+    result = _resolve_provider_profile("implement", "", cfg, step_provider="")
+    assert result == ("anthropic", {}), (
+        "Without an explicit provider: field, Tier 3 should not fire"
+    )
+
+
+def test_tier3_uses_explicit_provider_field():
+    """When step_provider='bedrock' is explicitly set, Tier 3 resolves it."""
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(profiles={"bedrock": {"AWS_REGION": "us-east-1"}})
+    result = _resolve_provider_profile("implement", "", cfg, step_provider="bedrock")
+    assert result == ("bedrock", {"AWS_REGION": "us-east-1"})
+
+
+def test_tier3_unresolvable_step_provider_falls_to_anthropic():
+    """Unknown step_provider should warn and return anthropic, not propagate."""
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config()
+    result = _resolve_provider_profile("implement", "", cfg, step_provider="nonexistent")
+    assert result == ("anthropic", {}), "Unresolvable step_provider should fall back to anthropic"
+
+
+def test_unresolvable_step_override_logs_warning():
+    """A step_overrides value that doesn't match a profile should log a warning."""
+    import structlog.testing
+
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    with structlog.testing.capture_logs() as cap_logs:
+        cfg = _make_config(
+            step_overrides={"plan": "nonexistent_profile"},
+            profiles={},
+        )
+        result = _resolve_provider_profile("plan", "my_recipe", cfg)
+    assert result == ("nonexistent_profile", {})
+    warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
+    assert any("nonexistent_profile" in str(e.get("provider", "")) for e in warning_events)

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -47,7 +47,7 @@ async def test_run_skill_provider_extras_none_for_anthropic_sentinel(
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a: ("anthropic", {"SOME_KEY": "val"}),
+        lambda *a, **kw: ("anthropic", {"SOME_KEY": "val"}),
     )
 
     captured: dict = {}
@@ -77,7 +77,7 @@ async def test_run_skill_provider_extras_forwarded_for_non_anthropic(
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a: ("bedrock", {"AWS_REGION": "us-east-1"}),
+        lambda *a, **kw: ("bedrock", {"AWS_REGION": "us-east-1"}),
     )
 
     captured: dict = {}
@@ -107,7 +107,7 @@ async def test_run_skill_model_as_profile_resolves_provider(
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a: ("anthropic", {}),
+        lambda *a, **kw: ("anthropic", {}),
     )
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_model_as_profile",
@@ -142,7 +142,7 @@ async def test_run_skill_step_overrides_win_over_model_as_profile(
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a: ("bedrock", {"AWS_REGION": "us-east-1"}),
+        lambda *a, **kw: ("bedrock", {"AWS_REGION": "us-east-1"}),
     )
     map_called = []
     monkeypatch.setattr(
@@ -204,7 +204,7 @@ async def test_run_skill_model_as_profile_no_anthropic_model_falls_through(
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a: ("anthropic", {}),
+        lambda *a, **kw: ("anthropic", {}),
     )
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_model_as_profile",
@@ -405,3 +405,31 @@ async def test_run_skill_global_override_beats_model_overrides(
     await run_skill("/autoskillit:probe", str(tmp_path), step_name="implement")
 
     assert captured.get("model") == "haiku"
+
+
+@pytest.mark.anyio
+async def test_run_skill_no_provider_profile_injected_for_default_step(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """run_skill with step_name='plan' and no provider config must NOT
+    inject AUTOSKILLIT_PROVIDER_PROFILE into the subprocess."""
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), step_name="plan")
+
+    assert captured.get("provider_extras") is None
+    assert captured.get("profile_name") == ""

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -331,7 +331,7 @@ async def test_run_skill_injects_provider_extras_when_feature_enabled(
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a: ("vertex", {"ANTHROPIC_API_KEY": "test-key-xyz"}),
+        lambda *a, **kw: ("vertex", {"ANTHROPIC_API_KEY": "test-key-xyz"}),
     )
 
     await run_skill("/autoskillit:probe", str(tmp_path))
@@ -371,7 +371,7 @@ async def test_run_skill_provider_extras_none_when_default_profile(
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a: ("anthropic", {}),
+        lambda *a, **kw: ("anthropic", {}),
     )
 
     await run_skill("/autoskillit:probe", str(tmp_path))


### PR DESCRIPTION
## Summary

- **Root cause fix**: `_resolve_provider_profile()` Tier 3 incorrectly used `step_name` (recipe step key like "plan", "implement") as a provider profile lookup, causing spurious `AUTOSKILLIT_PROVIDER_PROFILE` injection and `skill_load_guard` deadlocks across all 132 BUNDLED_EXTENDED skills
- **New `step_provider` parameter**: Separates YAML `provider:` field value from step lookup key, matching `_resolve_model`'s established pattern of `step_name` vs `step_model`
- **Guard resilience**: Added directory-entry deny counter with auto-exempt after 5 denials to break any future deadlock scenarios
- **Config validation**: `ProvidersConfig.__post_init__` now cross-references step/recipe overrides against known profiles and logs warnings for misconfigurations
- **Warning hardening**: Promoted `logger.debug` to `logger.warning` at all tiers when profile resolution fails

### Files Changed (12)

| File | Change |
|------|--------|
| `src/autoskillit/server/_guards.py` | Add `step_provider` kwarg, fix Tier 3 gating, add warnings at all tiers |
| `src/autoskillit/server/tools/tools_execution.py` | Add `step_provider` to `run_skill` MCP tool, thread to resolver |
| `src/autoskillit/recipe/rules/rules_tools.py` | Add `"step_provider"` to `_TOOL_PARAMS["run_skill"]` frozenset |
| `src/autoskillit/hooks/guards/skill_load_guard.py` | Directory-entry deny counter + auto-exempt + `_atomic_write_flag` |
| `src/autoskillit/config/_config_dataclasses.py` | Profile cross-reference validation in `__post_init__` |
| `tests/server/test_resolve_provider_profile.py` | Fix 3 broken tests, add 6 new tests (Tier 3 contract, warnings) |
| `tests/server/test_tools_execution_provider.py` | Update 5 mock lambdas to accept `**kw` |
| `tests/server/test_tools_execution_routing.py` | Update 2 mock lambdas to accept `**kw` |
| `tests/infra/test_skill_load_guard.py` | Add auto-exempt threshold + denial recording tests |
| `tests/config/test_providers_config.py` | Add cross-reference warning tests |
| `tests/arch/test_provider_profile_contract.py` | **New** — structural contract tests for Tier 3 |
| `tests/arch/CLAUDE.md` | Register new arch test file |

## Test plan

- [x] All 20,908 tests pass (473 skipped, 15 xfailed)
- [x] Pre-commit hooks pass
- [x] New arch tests verify step_name never leaks as profile at Tier 3
- [x] Existing tests updated to match correct behavior
- [x] Mock lambdas updated for new kwarg to prevent TypeError

Closes #2964

🤖 Generated with [Claude Code](https://claude.com/claude-code)