### PR TITLE
[FIX] Fix dict key in _adapt_agent_result's file_change_entries from 'path' to 'file_path'

### DIFF
--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -101,7 +101,7 @@ def _adapt_agent_result(agent_result: AgentSessionResult) -> ClaudeSessionResult
     mcp_tool_calls: list[dict[str, Any]] = raw.get("mcp_tool_calls", [])
     file_change_paths: list[str] = raw.get("file_changes", [])
     file_change_entries = [
-        {"name": "file_change", "type": "file_change", "path": p} for p in file_change_paths
+        {"name": "file_change", "type": "file_change", "file_path": p} for p in file_change_paths
     ]
     tool_uses = command_executions + mcp_tool_calls + file_change_entries
 

--- a/tests/execution/test_adapt_agent_result.py
+++ b/tests/execution/test_adapt_agent_result.py
@@ -172,8 +172,8 @@ def test_tool_uses_concatenation() -> None:
     assert result.tool_uses == [
         {"name": "cmd"},
         {"name": "mcp"},
-        {"name": "file_change", "type": "file_change", "path": "a.py"},
-        {"name": "file_change", "type": "file_change", "path": "b.py"},
+        {"name": "file_change", "type": "file_change", "file_path": "a.py"},
+        {"name": "file_change", "type": "file_change", "file_path": "b.py"},
     ]
 
 
@@ -185,10 +185,10 @@ def test_tool_uses_missing_sources_default_empty() -> None:
 def test_file_change_entry_shape() -> None:
     result = _adapt_agent_result(_make_agent_result(raw={"file_changes": ["x.py"]}))
     entry = result.tool_uses[0]
-    assert set(entry.keys()) == {"name", "type", "path"}
+    assert set(entry.keys()) == {"name", "type", "file_path"}
     assert entry["name"] == "file_change"
     assert entry["type"] == "file_change"
-    assert entry["path"] == "x.py"
+    assert entry["file_path"] == "x.py"
 
 
 def test_assistant_messages_from_raw() -> None:
@@ -310,9 +310,34 @@ def test_full_round_trip_all_fields() -> None:
     assert result.tool_uses == [
         {"name": "bash", "cmd": "ls"},
         {"name": "read", "path": "/tmp"},
-        {"name": "file_change", "type": "file_change", "path": "main.py"},
+        {"name": "file_change", "type": "file_change", "file_path": "main.py"},
     ]
     assert result.jsonl_context_exhausted is False
     assert result.stop_reasons == ["end_turn"]
     assert result.has_thinking_only_turn is False
     assert result.seen_block_types == frozenset()
+
+
+class TestAdaptAgentResultFilePathKey:
+    """Verify file_change entries use 'file_path' key for synthesis compatibility."""
+
+    def test_file_change_entry_has_file_path_key(self) -> None:
+        result = _adapt_agent_result(_make_agent_result(raw={"file_changes": ["x.py"]}))
+        entry = result.tool_uses[0]
+        assert set(entry.keys()) == {"name", "type", "file_path"}
+        assert entry["file_path"] == "x.py"
+
+    def test_file_path_key_enables_primary_synthesis_branch(self) -> None:
+        from autoskillit.execution.headless import _synthesize_from_write_artifacts
+
+        agent = _make_agent_result(raw={"file_changes": ["/abs/output.md"]})
+        adapted = _adapt_agent_result(agent)
+        recovered = _synthesize_from_write_artifacts(
+            adapted,
+            [r"plan_path\s*=\s*/.+"],
+            write_call_count=0,
+            file_changes=["/abs/output.md"],
+            write_tool_names=frozenset({"file_change"}),
+        )
+        assert recovered is not None
+        assert "plan_path = /abs/output.md" in recovered.result

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -813,7 +813,9 @@ class TestSynthesizeFromWriteArtifacts:
 
         session = make_headless_session(
             result="",
-            tool_uses=[{"name": "file_change", "type": "file_change", "path": "/codex/output.md"}],
+            tool_uses=[
+                {"name": "file_change", "type": "file_change", "file_path": "/codex/output.md"}
+            ],
         )
         result = _synthesize_from_write_artifacts(
             session,


### PR DESCRIPTION
## Summary

`_adapt_agent_result` (in `_headless_evidence.py:104`) builds `file_change` tool_use entries with key `"path"`, but `_synthesize_from_write_artifacts` (in `_headless_recovery.py:150`) reads `t.get("file_path", "")`. This mismatch means the synthesis path resolution always gets an empty string for Codex `file_change` entries, so write artifact recovery silently fails.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-174903-445043/.autoskillit/temp/make-plan/plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 35 | 4.7k | 630.6k | 47.3k | 28 | 32.7k | 2m 20s |
| verify | claude-sonnet-4-6 | 1 | 74 | 7.1k | 305.6k | 45.8k | 24 | 29.9k | 2m 27s |
| implement* | MiniMax-M2.7-highspeed | 1 | 239.9k | 4.7k | 549.4k | 30.7k | 51 | 15.7k | 1m 53s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 100.8k | 2.4k | 334.7k | 30.7k | 22 | 15.2k | 1m 9s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 53.4k | 1.2k | 242.6k | 30.7k | 18 | 15.0k | 38s |
| review_pr | claude-sonnet-4-6 | 1 | 68 | 13.8k | 290.5k | 51.5k | 28 | 36.9k | 3m 18s |
| resolve_review | claude-sonnet-4-6 | 1 | 277 | 14.6k | 1.8M | 67.8k | 79 | 51.9k | 7m 21s |
| **Total** | | | 394.6k | 48.6k | 4.1M | 67.8k | | 197.2k | 19m 7s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 41 | 13401.1 | 382.1 | 115.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **41** | 100663.9 | 4809.9 | 1185.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 35 | 4.7k | 630.6k | 32.7k | 2m 20s |
| claude-sonnet-4-6 | 3 | 419 | 35.6k | 2.4M | 118.7k | 13m 7s |
| MiniMax-M2.7-highspeed | 3 | 394.1k | 8.4k | 1.1M | 45.9k | 3m 39s |