### PR TITLE
[FIX] Allow allow_only to bypass Tier 2 skill gating in ephemeral sessions

### DIFF
--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -495,26 +495,31 @@ async def run_skill(
 
             if target_name:
                 tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
-                _skill_md = (
-                    Path(session_root.path) / ".claude" / "skills" / target_name / "SKILL.md"
+                _is_known_skill = (
+                    tool_ctx.skill_resolver is not None
+                    and tool_ctx.skill_resolver.resolve(target_name) is not None
                 )
-                if not _skill_md.exists():
-                    logger.error(
-                        "target_skill_not_in_session",
-                        target=target_name,
-                        session_id=session_id,
-                        session_root=str(session_root.path),
+                if _is_known_skill:
+                    _skill_md = (
+                        Path(session_root.path) / ".claude" / "skills" / target_name / "SKILL.md"
                     )
-                    return SkillResult.crashed(
-                        exception=RuntimeError(
-                            f"Target skill {target_name!r} not available in session "
-                            f"{session_id!r}: SKILL.md not found after init_session + "
-                            f"activate_skill_deps. Check tier/feature/pack gating."
-                        ),
-                        skill_command=resolved_command,
-                        session_id=session_id,
-                        order_id=effective_order_id,
-                    ).to_json()
+                    if not _skill_md.exists():
+                        logger.error(
+                            "target_skill_not_in_session",
+                            target=target_name,
+                            session_id=session_id,
+                            session_root=str(session_root.path),
+                        )
+                        return SkillResult.crashed(
+                            exception=RuntimeError(
+                                f"Target skill {target_name!r} not available in session "
+                                f"{session_id!r}: SKILL.md not found after init_session + "
+                                f"activate_skill_deps. Check tier/feature/pack gating."
+                            ),
+                            skill_command=resolved_command,
+                            session_id=session_id,
+                            order_id=effective_order_id,
+                        ).to_json()
         _local_dir = validate_project_local_skill_dir(Path(cwd), tool_ctx.backend)
         if _local_dir is not None:
             skill_add_dirs.append(_local_dir)

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -496,11 +496,7 @@ async def run_skill(
             if target_name:
                 tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
                 _skill_md = (
-                    Path(session_root.path)
-                    / ".claude"
-                    / "skills"
-                    / target_name
-                    / "SKILL.md"
+                    Path(session_root.path) / ".claude" / "skills" / target_name / "SKILL.md"
                 )
                 if not _skill_md.exists():
                     logger.error(

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -495,6 +495,30 @@ async def run_skill(
 
             if target_name:
                 tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
+                _skill_md = (
+                    Path(session_root.path)
+                    / ".claude"
+                    / "skills"
+                    / target_name
+                    / "SKILL.md"
+                )
+                if not _skill_md.exists():
+                    logger.error(
+                        "target_skill_not_in_session",
+                        target=target_name,
+                        session_id=session_id,
+                        session_root=str(session_root.path),
+                    )
+                    return SkillResult.crashed(
+                        exception=RuntimeError(
+                            f"Target skill {target_name!r} not available in session "
+                            f"{session_id!r}: SKILL.md not found after init_session + "
+                            f"activate_skill_deps. Check tier/feature/pack gating."
+                        ),
+                        skill_command=resolved_command,
+                        session_id=session_id,
+                        order_id=effective_order_id,
+                    ).to_json()
         _local_dir = validate_project_local_skill_dir(Path(cwd), tool_ctx.backend)
         if _local_dir is not None:
             skill_add_dirs.append(_local_dir)

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -75,6 +75,10 @@ When `run_skill` returns `needs_retry=true` for **any step**:
 - **If `retry_reason: path_contamination`** → fall through to `on_failure`. The session wrote
   files outside its working directory. This is a CWD boundary violation, not a context limit.
   Do NOT route to `on_context_limit` even if defined.
+- **If `retry_reason: contract_recovery` AND `has_progress_evidence` is true AND the step
+  defines `on_context_limit`** → follow `on_context_limit`. The session wrote files but omitted
+  the structured output token. Partial progress is confirmed on disk.
+- **If `retry_reason: contract_recovery` AND `has_progress_evidence` is false** → fall through to `on_failure`.
 - **If `retry_reason: thinking_stall` AND `lifespan_started` is true AND the step defines
   `on_context_limit`** → follow `on_context_limit`. The model consumed tokens (thinking
   blocks) but produced no final output. Prior tool calls suggest partial progress on disk.
@@ -128,6 +132,8 @@ Summary: `needs_retry=true` + `retry_reason=resume` + `subtype=stale` → re-exe
          `needs_retry=true` + `retry_reason=completed_no_flush` + no `on_context_limit` → `on_failure`.
          `needs_retry=true` + `retry_reason=empty_output` → `on_failure`.
          `needs_retry=true` + `retry_reason=path_contamination` → `on_failure`.
+         `needs_retry=true` + `retry_reason=contract_recovery` + `has_progress_evidence=true` + step has `on_context_limit` → follow `on_context_limit`.
+         `needs_retry=true` + `retry_reason=contract_recovery` + `has_progress_evidence=false` → `on_failure`.
          `needs_retry=true` + `retry_reason=thinking_stall` + `lifespan_started=true` + step has `on_context_limit` → follow `on_context_limit`.
          `needs_retry=true` + `retry_reason=thinking_stall` + `lifespan_started=false` → `on_failure`.
          `needs_retry=true` + `retry_reason=idle_stall` + `lifespan_started=true` + step has `on_context_limit` → follow `on_context_limit`.

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -531,7 +531,7 @@ class DefaultSessionSkillManager:
                     _log.debug("init_session_subset_skip", skill=skill_info.name)
                 continue
             gated = (not cook_session) and (skill_info.name in tier2_skills)
-            if gated:
+            if gated and (allow_only is None or skill_info.name not in allow_only):
                 _log.debug("init_session_tier2_omit", skill=skill_info.name)
                 continue
             skill_dir = skills_base / skill_info.name

--- a/tests/contracts/test_sous_chef_routing.py
+++ b/tests/contracts/test_sous_chef_routing.py
@@ -365,7 +365,6 @@ def test_skill_md_covers_all_prompts_routing_reasons() -> None:
         if reason in {
             RetryReason.NONE,
             RetryReason.BUDGET_EXHAUSTED,
-            RetryReason.CONTRACT_RECOVERY,
             RetryReason.CLONE_CONTAMINATION,
         }:
             continue

--- a/tests/contracts/test_target_skill_invocability.py
+++ b/tests/contracts/test_target_skill_invocability.py
@@ -35,10 +35,12 @@ def _make_session(
     if config is None:
         config = load_config()
     session_id = "test-session-001"
+    closure = mgr.compute_skill_closure(target_skill)
     mgr.init_session(
         session_id,
         cook_session=False,
         config=config,
+        allow_only=closure if closure else None,
     )
     tier2 = frozenset(config.skills.tier2)
     if target_skill in tier2:
@@ -54,9 +56,6 @@ def _read_skill_md(tmp_path: Path, session_id: str, skill_name: str) -> str:
 class TestTargetSkillNotGatedAfterActivation:
     """Tier 2 target skills must have disable-model-invocation removed after activation."""
 
-    @pytest.mark.skip(
-        reason="P3-A2: tier2 skills omitted from init_session; activate path rewrite pending"
-    )
     def test_tier2_target_skill_not_gated_after_activation(self, tmp_path: Path) -> None:
         config = load_config()
         tier2 = list(config.skills.tier2)
@@ -67,9 +66,6 @@ class TestTargetSkillNotGatedAfterActivation:
         content = _read_skill_md(tmp_path, "test-session-001", target)
         assert "disable-model-invocation: true" not in content
 
-    @pytest.mark.skip(
-        reason="P3-A2: tier2 skills omitted from init_session; activate path rewrite pending"
-    )
     def test_other_tier2_skills_remain_gated(self, tmp_path: Path) -> None:
         config = load_config()
         tier2 = list(config.skills.tier2)
@@ -134,16 +130,19 @@ class TestResolvedNamespaceMatchesSkillLocation:
 class TestDepSkillsNotGatedAfterActivation:
     """After activating a target with activate_deps, dependency skills are also ungated."""
 
-    @pytest.mark.skip(
-        reason="P3-A2: tier2 skills omitted from init_session; activate path rewrite pending"
-    )
     def test_dep_skills_not_gated_after_activation(self, tmp_path: Path) -> None:
         """After activating make-plan, arch-lens-* and mermaid skills are ungated."""
         config = load_config()
         provider = SkillsDirectoryProvider()
         mgr = DefaultSessionSkillManager(provider, tmp_path)
         session_id = "test-dep-activation"
-        mgr.init_session(session_id, cook_session=False, config=config)
+        closure = mgr.compute_skill_closure("make-plan")
+        mgr.init_session(
+            session_id,
+            cook_session=False,
+            config=config,
+            allow_only=closure if closure else None,
+        )
         mgr.activate_skill_deps(session_id, "make-plan")
 
         skills_base = tmp_path / session_id / ".claude" / "skills"
@@ -214,7 +213,13 @@ class TestAllRecipeSkillCommandsInvocable:
                 # Verify activation: after init_session + activate_skill_deps, target is invocable
                 session_id = f"test-{yaml_path.stem}-{step_name}"
                 mgr = DefaultSessionSkillManager(provider, tmp_path)
-                mgr.init_session(session_id, cook_session=False, config=config)
+                closure = mgr.compute_skill_closure(name)
+                mgr.init_session(
+                    session_id,
+                    cook_session=False,
+                    config=config,
+                    allow_only=closure if closure else None,
+                )
                 if name in tier2:
                     mgr.activate_skill_deps(session_id, name)
                 skill_md_path = tmp_path / session_id / ".claude" / "skills" / name / "SKILL.md"

--- a/tests/workspace/test_session_skills_provider.py
+++ b/tests/workspace/test_session_skills_provider.py
@@ -120,7 +120,6 @@ def test_session_manager_no_flag_for_cook_session(tmp_path: Path) -> None:
     assert mermaid_md.exists()
 
 
-@pytest.mark.skip(reason="P3-A2: copy-on-activate rewrite")
 def test_activate_skill_deps_removes_flag(tmp_path: Path) -> None:
     from tests._helpers import make_skills_config, make_test_config
 
@@ -133,7 +132,12 @@ def test_activate_skill_deps_removes_flag(tmp_path: Path) -> None:
             tier3=[],
         )
     )
-    mgr.init_session("session-toggle", cook_session=False, config=config)
+    mgr.init_session(
+        "session-toggle",
+        cook_session=False,
+        config=config,
+        allow_only=frozenset({"mermaid"}),
+    )
     result = mgr.activate_skill_deps("session-toggle", "mermaid")
     assert result is True
     mermaid_md = tmp_path / "session-toggle" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
@@ -163,6 +167,30 @@ def test_init_session_gated_tier2_skill_dir_absent(tmp_path: Path) -> None:
     assert not (skills_base / "mermaid").exists()
     # Non-gated BUNDLED_EXTENDED skills are written (BUNDLED skills go via --plugin-dir, not here)
     assert (skills_base / "implement-worktree" / "SKILL.md").exists()
+
+
+def test_init_session_tier2_skill_present_when_in_allow_only(tmp_path: Path) -> None:
+    """Tier2 skill in allow_only is written; tier2 skill NOT in allow_only is absent."""
+    from tests._helpers import make_skills_config, make_test_config
+
+    provider = SkillsDirectoryProvider()
+    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+    config = make_test_config(
+        skills=make_skills_config(
+            tier1=["open-kitchen", "close-kitchen"],
+            tier2=["mermaid", "make-plan"],
+            tier3=[],
+        )
+    )
+    session_path = mgr.init_session(
+        "test-allow",
+        cook_session=False,
+        config=config,
+        allow_only=frozenset({"mermaid"}),
+    )
+    skills_base = session_path / _SKILLS_SUBDIR
+    assert (skills_base / "mermaid" / "SKILL.md").exists()
+    assert not (skills_base / "make-plan").exists()
 
 
 def test_cleanup_stale_removes_old_dirs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`init_session()` in `workspace/session_skills.py` unconditionally skips Tier 2 skills when building ephemeral session directories for headless `run_skill` sessions. This causes "Unknown skill" errors for **103+ skills** across all major recipes (implementation, remediation, research, planner, full-audit). The model improvises manually, wasting tokens and producing lower-quality results. The failure is masked by `contract_recovery`, allowing pipelines to continue despite broken skill access.

The fix adds an `allow_only` bypass to the tier2 gate in `init_session`, adds a fail-fast SKILL.md existence guard after `activate_skill_deps` in `tools_execution.py`, adds `contract_recovery` routing rules to the sous-chef SKILL.md, and un-skips 4 previously-disabled contract tests after verifying they now pass.

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260524-190358-941051/.autoskillit/temp/rectify/plan.md`

## Changed Files

### Modified (●):

- `src/autoskillit/server/tools/tools_execution.py`
- `src/autoskillit/skills/sous-chef/SKILL.md`
- `src/autoskillit/workspace/session_skills.py`
- `tests/contracts/test_sous_chef_routing.py`
- `tests/contracts/test_target_skill_invocability.py`
- `tests/workspace/test_session_skills_provider.py`

## Key Changes

1. **`workspace/session_skills.py`**: Modified the Tier 2 gating logic to check `allow_only` — skills explicitly requested via `allow_only` bypass the Tier 2 gate even in ephemeral sessions.

2. **`server/tools/tools_execution.py`**: Added a fail-fast guard after `activate_skill_deps` that verifies the target skill's `SKILL.md` exists before launching the session. Returns `SkillResult.crashed()` immediately if missing.

3. **`skills/sous-chef/SKILL.md`**: Added `contract_recovery` routing rules to the Context Limit Routing section, enabling sessions that wrote files but omitted the structured output token to route to `on_context_limit` instead of improvising.

4. **Contract tests**: Un-skipped 4 tests and updated session initialization helpers to pass `allow_only` matching the production flow in `tools_execution.py`. Added a new companion test `test_init_session_tier2_skill_present_when_in_allow_only`.

Closes #2976

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-opus-4-6 | 1 | 70 | 14.1k | 2.5M | 86.3k | 84 | 86.8k | 6m 13s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 2.0k | 7.4k | 435.9k | 77.0k | 161 | 66.2k | 7m 8s |
| implement | claude-opus-4-6 | 1 | 112 | 13.5k | 2.5M | 70.6k | 109 | 54.5k | 6m 41s |
| prepare_pr* | MiniMax-M2.7 | 1 | 74.9k | 4.5k | 482.5k | 0 | 38 | 0 | 2m 37s |
| compose_pr* | MiniMax-M2.7 | 1 | 66.5k | 2.6k | 403.7k | 0 | 34 | 0 | 1m 40s |
| review_pr | claude-opus-4-6 | 1 | 49 | 24.6k | 609.3k | 70.0k | 36 | 55.5k | 6m 10s |
| resolve_review | claude-opus-4-6 | 1 | 30 | 4.5k | 488.3k | 49.6k | 26 | 59.8k | 6m 5s |
| **Total** | | | 143.7k | 71.2k | 7.4M | 86.3k | | 322.9k | 36m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 88 | 28660.8 | 619.0 | 153.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **88** | 84039.7 | 3669.7 | 809.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 4 | 261 | 56.6k | 6.1M | 256.7k | 25m 11s |
| claude-sonnet-4-6 | 1 | 2.0k | 7.4k | 435.9k | 66.2k | 7m 8s |
| MiniMax-M2.7 | 2 | 141.4k | 7.1k | 886.2k | 0 | 4m 17s |