### PR TITLE
PY6 P6-A5-WP1: Extend _version_snapshot.py with Codex-specific version and plugin helpers

### DIFF
--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -19,7 +19,11 @@ from pathlib import Path
 from typing import Any
 
 from ._install_detect import parse_direct_url
-from .types._type_constants_env import AGENT_BACKEND_CLAUDE_CODE, AGENT_BACKEND_ENV_VAR
+from .types._type_constants_env import (
+    AGENT_BACKEND_CLAUDE_CODE,
+    AGENT_BACKEND_CODEX,
+    AGENT_BACKEND_ENV_VAR,
+)
 
 logger = logging.getLogger(__name__)  # noqa: TID251 — IL-0 module, no autoskillit imports allowed
 
@@ -35,6 +39,8 @@ def collect_version_snapshot() -> dict[str, Any]:
         claude_code_version: output of `claude --version`, or "".
         plugins: list of {"ref": ..., "version"?: ...} dicts
             read from ~/.claude/plugins/installed_plugins.json.
+        codex_version: output of `codex --version`, or "".
+        codex_plugins: list of plugin dicts from `codex plugin list --json`, or [].
     """
     install = _install_info()
     return {
@@ -43,6 +49,8 @@ def collect_version_snapshot() -> dict[str, Any]:
         "commit_id": install.get("commit_id"),
         "claude_code_version": _claude_code_version(),
         "plugins": _plugins(),
+        "codex_version": _codex_version(),
+        "codex_plugins": _codex_plugins(),
     }
 
 
@@ -87,6 +95,51 @@ def _claude_code_version() -> str:
     except Exception:
         logger.warning("Failed to run claude --version", exc_info=True)
         return ""
+
+
+def _codex_version() -> str:
+    """Run ``codex --version`` and return the stripped output, or "" on error."""
+    backend = os.environ.get(AGENT_BACKEND_ENV_VAR, AGENT_BACKEND_CLAUDE_CODE)
+    if backend != AGENT_BACKEND_CODEX:
+        return ""
+    try:
+        result = subprocess.run(
+            ["codex", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip() or result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return ""
+    except Exception:
+        logger.warning("Failed to run codex --version", exc_info=True)
+        return ""
+
+
+def _codex_plugins() -> list[dict[str, Any]]:
+    """Run ``codex plugin list --json`` and return parsed plugin list, or [] on error."""
+    backend = os.environ.get(AGENT_BACKEND_ENV_VAR, AGENT_BACKEND_CLAUDE_CODE)
+    if backend != AGENT_BACKEND_CODEX:
+        return []
+    try:
+        result = subprocess.run(
+            ["codex", "plugin", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if not result.stdout.strip():
+            return []
+        parsed = json.loads(result.stdout)
+        if not isinstance(parsed, list):
+            return []
+        return parsed
+    except subprocess.TimeoutExpired:
+        return []
+    except Exception:
+        logger.warning("Failed to run codex plugin list", exc_info=True)
+        return []
 
 
 def _plugins() -> list[dict[str, Any]]:

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -482,6 +482,7 @@ class SessionIndexEntry(TypedDict):
     tracked_comm_drift: bool
     autoskillit_version: str
     claude_code_version: str
+    codex_version: str
     recipe_name: str
     recipe_content_hash: str
     recipe_composite_hash: str

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -497,6 +497,7 @@ def flush_session_log(
         "tracked_comm_drift": _tracked_comm_drift,
         "autoskillit_version": versions.get("autoskillit_version", "") if versions else "",
         "claude_code_version": versions.get("claude_code_version", "") if versions else "",
+        "codex_version": versions.get("codex_version", "") if versions else "",
         "recipe_name": recipe_identity.name,
         "recipe_content_hash": recipe_identity.content_hash,
         "recipe_composite_hash": recipe_identity.composite_hash,

--- a/tests/core/test_backend_gating_core.py
+++ b/tests/core/test_backend_gating_core.py
@@ -6,10 +6,14 @@ for non-claude-code backends without performing any I/O.
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from autoskillit.core._version_snapshot import (
     _claude_code_version,
+    _codex_plugins,
+    _codex_version,
     _plugins,
     collect_version_snapshot,
 )
@@ -68,3 +72,78 @@ def test_claude_code_version_still_runs_for_claude_code_backend(monkeypatch):
     monkeypatch.setattr(mod.subprocess, "run", _fake_run)
     _claude_code_version()
     assert len(called) == 1
+
+
+def test_codex_version_returns_empty_for_non_codex_backend(monkeypatch):
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "headless")
+
+    def _no_call(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(mod.subprocess, "run", _no_call)
+    assert _codex_version() == ""
+
+
+def test_codex_version_graceful_on_timeout(monkeypatch):
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "codex")
+
+    def _raise(*args, **kwargs):
+        raise subprocess.TimeoutExpired("codex", 5)
+
+    monkeypatch.setattr(mod.subprocess, "run", _raise)
+    assert _codex_version() == ""
+
+
+def test_codex_version_graceful_on_file_not_found_for_codex_backend(monkeypatch):
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "codex")
+
+    def _raise(*args, **kwargs):
+        raise FileNotFoundError("codex not found")
+
+    monkeypatch.setattr(mod.subprocess, "run", _raise)
+    assert _codex_version() == ""
+
+
+def test_codex_plugins_returns_empty_for_non_codex_backend(monkeypatch):
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "headless")
+
+    def _no_call(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(mod.subprocess, "run", _no_call)
+    assert _codex_plugins() == []
+
+
+def test_codex_plugins_graceful_on_subprocess_error(monkeypatch):
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "codex")
+
+    def _raise(*args, **kwargs):
+        raise FileNotFoundError("codex not found")
+
+    monkeypatch.setattr(mod.subprocess, "run", _raise)
+    assert _codex_plugins() == []
+
+
+def test_codex_version_not_called_without_backend_env(monkeypatch):
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
+    called = []
+
+    def _fake_run(*args, **kwargs):
+        called.append(args)
+        raise FileNotFoundError("codex not found")
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    assert _codex_version() == ""
+    assert len(called) == 0

--- a/tests/core/test_session_index_schema.py
+++ b/tests/core/test_session_index_schema.py
@@ -20,6 +20,7 @@ _REQUIRED_INDEX_FIELDS = {
     "file_changes_count",
     "api_retry_count",
     "api_retry_exhausted",
+    "codex_version",
 }
 
 

--- a/tests/core/test_version_snapshot.py
+++ b/tests/core/test_version_snapshot.py
@@ -27,6 +27,8 @@ def test_collect_version_snapshot_returns_required_keys():
         "commit_id",
         "claude_code_version",
         "plugins",
+        "codex_version",
+        "codex_plugins",
     }
 
 

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -504,6 +504,8 @@ _VERSIONS = {
     "commit_id": None,
     "claude_code_version": "1.0.5",
     "plugins": [],
+    "codex_version": "",
+    "codex_plugins": [],
 }
 
 
@@ -547,6 +549,18 @@ def test_sessions_jsonl_includes_claude_code_version(tmp_path):
     ]
     entry = next(e for e in entries if e["session_id"] == "vs-005")
     assert entry["claude_code_version"] == "1.0.5"
+
+
+def test_sessions_jsonl_includes_codex_version(tmp_path):
+    versions_with_codex = {**_VERSIONS, "codex_version": "0.1.0"}
+    _flush(tmp_path, session_id="vs-cdx-001", versions=versions_with_codex)
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / "sessions.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    entry = next(e for e in entries if e["session_id"] == "vs-cdx-001")
+    assert entry["codex_version"] == "0.1.0"
 
 
 def test_sessions_jsonl_autoskillit_version_empty_when_no_versions(tmp_path):


### PR DESCRIPTION
## Summary

Add `_codex_version()` and `_codex_plugins()` helper functions to `src/autoskillit/core/_version_snapshot.py` that mirror the existing `_claude_code_version()` / `_plugins()` pattern but are gated on `AGENT_BACKEND_CODEX` instead of `AGENT_BACKEND_CLAUDE_CODE`. Expose both new keys (`codex_version`, `codex_plugins`) through `collect_version_snapshot()`. Propagate `codex_version` into `SessionIndexEntry` and `flush_session_log`'s `index_entry` dict. Add comprehensive backend-gating and error-handling tests.

## Changed Files

- src/autoskillit/core/_version_snapshot.py
- src/autoskillit/core/types/_type_results.py
- src/autoskillit/execution/session_log.py
- tests/core/test_backend_gating_core.py
- tests/core/test_session_index_schema.py
- tests/core/test_version_snapshot.py
- tests/execution/test_session_log_fields.py

Closes #2890

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-201240-588872/.autoskillit/temp/make-plan/p6_a5_wp1_extend_version_snapshot_plan_2026-05-24_201500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 72 | 17.1k | 933.5k | 93.5k | 114 | 83.0k | 10m 7s |
| verify | claude-sonnet-4-6 | 1 | 140 | 10.1k | 724.5k | 61.2k | 47 | 61.7k | 3m 24s |
| implement* | MiniMax-M2.7-highspeed | 1 | 670.9k | 9.3k | 830.7k | 35.8k | 82 | 30.6k | 3m 49s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 135.9k | 5.0k | 276.2k | 30.7k | 27 | 43.0k | 1m 34s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 36.6k | 1.3k | 181.2k | 30.7k | 13 | 14.9k | 33s |
| review_pr | claude-sonnet-4-6 | 1 | 92 | 38.0k | 342.0k | 68.2k | 36 | 128.9k | 7m 23s |
| resolve_review | claude-sonnet-4-6 | 1 | 205 | 11.5k | 925.3k | 52.3k | 54 | 53.4k | 7m 18s |
| **Total** | | | 844.0k | 92.2k | 4.2M | 93.5k | | 415.6k | 34m 9s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 153 | 5429.4 | 200.2 | 60.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **153** | 27539.3 | 2716.7 | 602.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 509 | 76.7k | 2.9M | 327.0k | 28m 12s |
| MiniMax-M2.7-highspeed | 3 | 843.4k | 15.5k | 1.3M | 88.6k | 5m 56s |