### PR TITLE
[FEATURE] Three-Branch Routing for Process-State Detection (codex support)

### DIFF
--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -96,10 +96,18 @@ def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:
 
 
 def _check_claude_process_state_breakdown(*, backend: str | None = None) -> DoctorResult:
-    """Check current D-state and CPU usage of claude processes via ps."""
-    check_name = "claude_process_state"
-    if backend is not None and backend != "claude-code":
-        return DoctorResult(Severity.OK, check_name, f"Skipped (backend={backend})")
+    """Check current D-state and CPU usage of claude/codex processes via ps."""
+    if backend is None or backend == "claude-code":
+        check_name = "claude_process_state"
+        comm_filter = "claude"
+        process_label = "claude"
+    elif backend == "codex":
+        check_name = "codex_process_state"
+        comm_filter = "codex"
+        process_label = "codex"
+    else:
+        return DoctorResult(Severity.OK, "claude_process_state", f"Skipped (backend={backend})")
+
     try:
         result = subprocess.run(
             ["ps", "-axo", "pid,state,pcpu,comm"],
@@ -111,48 +119,48 @@ def _check_claude_process_state_breakdown(*, backend: str | None = None) -> Doct
         return DoctorResult(
             Severity.OK,
             check_name,
-            f"ps unavailable ({type(exc).__name__}); skipping claude process check",
+            f"ps unavailable ({type(exc).__name__}); skipping {process_label} process check",
         )
 
     if result.returncode != 0:
         return DoctorResult(
             Severity.OK,
             check_name,
-            f"ps exited {result.returncode}; skipping claude process check",
+            f"ps exited {result.returncode}; skipping {process_label} process check",
         )
 
-    claude_rows: list[tuple[int, str, float]] = []
+    rows: list[tuple[int, str, float]] = []
     for line in result.stdout.splitlines()[1:]:
         parts = line.split(maxsplit=3)
         if len(parts) < 4:
             continue
         comm = parts[3]
-        if comm != "claude":
+        if comm != comm_filter:
             continue
         try:
-            claude_rows.append((int(parts[0]), parts[1], float(parts[2])))
+            rows.append((int(parts[0]), parts[1], float(parts[2])))
         except ValueError:
             continue
 
-    if not claude_rows:
-        return DoctorResult(Severity.OK, check_name, "No claude processes running")
+    if not rows:
+        return DoctorResult(Severity.OK, check_name, f"No {process_label} processes running")
 
     breakdown: dict[str, int] = {}
-    for _, state, _ in claude_rows:
+    for _, state, _ in rows:
         breakdown[state] = breakdown.get(state, 0) + 1
 
     summary = ", ".join(f"{s}={c}" for s, c in sorted(breakdown.items()))
 
-    d_rows = [f"pid={pid} pcpu={pcpu}" for pid, state, pcpu in claude_rows if state == "D"]
+    d_rows = [f"pid={pid} pcpu={pcpu}" for pid, state, pcpu in rows if state == "D"]
     if d_rows:
         return DoctorResult(
             Severity.WARNING,
             check_name,
-            f"claude processes in D state: {', '.join(d_rows)} (breakdown: {summary})",
+            f"{process_label} processes in D state: {', '.join(d_rows)} (breakdown: {summary})",
         )
 
     return DoctorResult(
         Severity.OK,
         check_name,
-        f"claude process state breakdown: {summary}",
+        f"{process_label} process state breakdown: {summary}",
     )

--- a/tests/cli/test_doctor_backend_guards.py
+++ b/tests/cli/test_doctor_backend_guards.py
@@ -214,6 +214,90 @@ class TestCheckClaudeProcessStateBreakdownBackendGuard:
         assert "skipped" not in result.message.lower()
 
 
+class TestCheckClaudeProcessStateBreakdownCodexBackend:
+    """Tests for codex backend branch in _check_claude_process_state_breakdown."""
+
+    def _ps_result(self, stdout: str, returncode: int = 0):
+        return type(
+            "CompletedProcess",
+            (),
+            {"returncode": returncode, "stdout": stdout},
+        )()
+
+    def test_ok_when_only_sleeping_codex(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Single sleeping codex process → Severity.OK with state breakdown."""
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_claude_process_state_breakdown
+        from autoskillit.core import Severity
+
+        header = "PID STAT %CPU COMMAND\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._ps_result(header + "1234 S 0.5 codex"),
+        )
+        result = _check_claude_process_state_breakdown(backend="codex")
+        assert result.severity == Severity.OK
+        assert result.check == "codex_process_state"
+        assert "S=1" in result.message
+
+    def test_warns_on_d_state_codex(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """codex process in D state → Severity.WARNING with pid and pcpu."""
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_claude_process_state_breakdown
+        from autoskillit.core import Severity
+
+        header = "PID STAT %CPU COMMAND\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._ps_result(header + "1234 D 99.0 codex"),
+        )
+        result = _check_claude_process_state_breakdown(backend="codex")
+        assert result.severity == Severity.WARNING
+        assert result.check == "codex_process_state"
+        assert "D=1" in result.message
+        assert "99.0" in result.message
+        assert "codex processes in D state" in result.message
+
+    def test_ok_when_no_codex_processes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No codex rows in ps output → Severity.OK, 'No codex processes running'."""
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_claude_process_state_breakdown
+        from autoskillit.core import Severity
+
+        header = "PID STAT %CPU COMMAND\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._ps_result(header + "5678 S 0.1 python"),
+        )
+        result = _check_claude_process_state_breakdown(backend="codex")
+        assert result.severity == Severity.OK
+        assert result.check == "codex_process_state"
+        assert result.message == "No codex processes running"
+
+    def test_ok_when_ps_missing_codex(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FileNotFoundError from ps → Severity.OK explaining ps unavailability."""
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_claude_process_state_breakdown
+        from autoskillit.core import Severity
+
+        def _raise(*a, **kw):
+            raise FileNotFoundError("ps")
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = _check_claude_process_state_breakdown(backend="codex")
+        assert result.severity == Severity.OK
+        assert result.check == "codex_process_state"
+        assert "ps unavailable" in result.message
+        assert "FileNotFoundError" in result.message
+
+
 class TestRunDoctorBackendWiring:
     def test_run_doctor_passes_backend_to_guarded_checks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/test_doctor_split.py
+++ b/tests/cli/test_doctor_split.py
@@ -86,6 +86,7 @@ def test_doctor_backend_guards_contains_expected_classes():
     assert "TestCheckMcpServerRegisteredBackendGuard" in class_names
     assert "TestCheckClaudeProcessStateBreakdownBackendGuard" in class_names
     assert "TestRunDoctorBackendWiring" in class_names
+    assert "TestCheckClaudeProcessStateBreakdownCodexBackend" in class_names
 
 
 def test_doctor_fleet_checks_file_exists():
@@ -116,6 +117,7 @@ def test_doctor_migration_does_not_contain_backend_guard_classes():
         "TestCheckMcpServerRegisteredBackendGuard",
         "TestCheckClaudeProcessStateBreakdownBackendGuard",
         "TestRunDoctorBackendWiring",
+        "TestCheckClaudeProcessStateBreakdownCodexBackend",
     ):
         assert cls not in class_names, f"{cls} must be moved to test_doctor_backend_guards.py"
 


### PR DESCRIPTION
## Summary

Replace the early-return guard in `_check_claude_process_state_breakdown()` (lines 101–102 of `src/autoskillit/cli/doctor/_doctor_runtime.py`) with a three-branch routing block so that ps-based zombie/stopped-state detection runs for both `claude-code` and `codex` backends. The function currently skips all non-`claude-code` backends before ever calling `ps`. After this change:

- **`claude-code` / `None`**: filter `comm == "claude"`, use `check_name = "claude_process_state"` (unchanged behavior).
- **`codex`**: filter `comm == "codex"`, use `check_name = "codex_process_state"`, with codex-specific messages.
- **Other backends**: early-return `Severity.OK` with `"Skipped (backend=...)"` (unchanged behavior).

The `ps` subprocess call is shared between the `claude-code` and `codex` branches — no duplication.

Closes #2892

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-201241-549175/.autoskillit/temp/dry-walkthrough/p6_a7_wp1_three_branch_routing_plan_2026-05-24_201600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 2.0k | 11.7k | 1.5M | 86.0k | 86 | 71.4k | 7m 53s |
| verify | claude-sonnet-4-6 | 1 | 84 | 17.4k | 399.8k | 60.1k | 30 | 66.1k | 4m 53s |
| implement* | MiniMax-M2.7-highspeed | 1 | 548.9k | 8.7k | 733.6k | 30.7k | 62 | 15.7k | 3m 5s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 58.0k | 3.0k | 181.2k | 30.7k | 17 | 15.3k | 1m 2s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.0k | 1.4k | 211.9k | 30.7k | 14 | 15.0k | 39s |
| review_pr | claude-sonnet-4-6 | 3 | 396 | 49.1k | 1.8M | 57.1k | 115 | 127.4k | 12m 18s |
| resolve_review | claude-sonnet-4-6 | 1 | 205 | 11.5k | 944.6k | 52.2k | 57 | 42.3k | 4m 22s |
| **Total** | | | 655.5k | 102.6k | 5.8M | 86.0k | | 353.2k | 34m 15s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 124 | 5915.8 | 126.6 | 69.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **124** | 46420.3 | 2848.2 | 827.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 2.0k | 11.7k | 1.5M | 71.4k | 7m 53s |
| claude-sonnet-4-6 | 3 | 685 | 78.0k | 3.1M | 235.8k | 21m 34s |
| MiniMax-M2.7-highspeed | 3 | 652.9k | 13.0k | 1.1M | 46.0k | 4m 46s |