### PR TITLE
Add agent_backend-aware branching to _register_all()

### DIFF
--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -436,7 +436,6 @@ def _register_all(
     )
     from autoskillit.config import load_config
     from autoskillit.core import AGENT_BACKEND_CODEX, ensure_project_temp
-    from autoskillit.execution import ensure_codex_mcp_registered
 
     # Refuse to register from inside the autoskillit source tree — this would
     # plant source-tree absolute paths in the project scope.
@@ -473,6 +472,8 @@ def _register_all(
         _backend_name = "claude-code"
 
     if _backend_name == AGENT_BACKEND_CODEX:
+        from autoskillit.execution import ensure_codex_mcp_registered
+
         ensure_codex_mcp_registered()
         # P4: insert Codex hook registration here
         plugin_ok = None
@@ -481,7 +482,7 @@ def _register_all(
         _evict_stale_autoskillit_hooks(settings_path)
         sync_hooks_to_settings(settings_path)
 
-        plugin_ok = _is_plugin_installed()
+        plugin_ok = _is_plugin_installed(agent_backend=_backend_name)
         if not plugin_ok:
             _register_mcp_server(_user_claude_json_path())
         else:

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -209,7 +209,9 @@ class TestCLIInit:
         """init --scope user writes mcpServers.autoskillit to ~/.claude.json."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed", lambda **kwargs: False
+        )
         cli.init(scope="user", test_command="task test-all")
         claude_json = tmp_path / ".claude.json"
         data = json.loads(claude_json.read_text())
@@ -250,7 +252,9 @@ class TestCLIInit:
         """Running init twice does not duplicate mcpServers.autoskillit or hook entries."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed", lambda **kwargs: False
+        )
         cli.init(scope="user", test_command="task test-all")
         cli.init(scope="user", test_command="task test-all")
         claude_json = tmp_path / ".claude.json"
@@ -277,7 +281,9 @@ class TestCLIInit:
         )
         monkeypatch.chdir(project_dir)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed", lambda **kwargs: False
+        )
         cli.init(test_command="task test-all")
         # MCP server should be registered to user home, not project dir
         assert (tmp_path / ".claude.json").exists()
@@ -893,7 +899,9 @@ def test_register_all_evicts_direct_entry_when_plugin_installed(
     )
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: True)
+    monkeypatch.setattr(
+        "autoskillit.cli._init_helpers._is_plugin_installed", lambda **kwargs: True
+    )
     cli.init(scope="user", test_command="task test-all")
     data = json.loads(claude_json.read_text())
     assert "autoskillit" not in data.get("mcpServers", {})

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -117,3 +117,143 @@ class TestInitBackendResolution:
 
         assert get_backend_calls, "get_backend must have been called"
         assert get_backend_calls[0] == "claude-code"
+
+
+class TestRegisterAllBackendDispatch:
+    """Dispatch tests: codex calls ensure_codex_mcp_registered, claude-code calls _register_mcp_server."""
+
+    def _setup_register_all(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, backend_name: str
+    ) -> tuple[list, list]:
+        """Shared setup: patch all side effects, return (codex_calls, mcp_calls)."""
+        from unittest.mock import MagicMock
+
+        import autoskillit.cli._hooks as _hooks_mod
+        import autoskillit.core.paths as _core_paths
+
+        codex_calls: list = []
+        mcp_calls: list = []
+
+        monkeypatch.setattr(_hooks_mod, "sweep_all_scopes_for_orphans", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "sync_hooks_to_settings", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "_evict_stale_autoskillit_hooks", lambda p: None)
+        monkeypatch.setattr(
+            _hooks_mod, "_claude_settings_path", lambda s: tmp_path / "settings.json"
+        )
+        monkeypatch.setattr(_core_paths, "pkg_root", lambda: tmp_path / "pkg")
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._register_mcp_server",
+            lambda p: mcp_calls.append("register_mcp"),
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._user_claude_json_path",
+            lambda: tmp_path / ".claude.json",
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._create_secrets_template", lambda p: None
+        )
+        monkeypatch.setattr("autoskillit.cli._init_helpers._prompt_github_repo", lambda: None)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers.evict_direct_mcp_entry", lambda p: False
+        )
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        monkeypatch.setattr("autoskillit.core.ensure_project_temp", lambda p: tmp_path / "temp")
+        monkeypatch.setattr(
+            "autoskillit.execution.ensure_codex_mcp_registered",
+            lambda **kwargs: codex_calls.append("ensure_codex") or True,
+        )
+        # Override conftest's blanket patch on _is_plugin_installed to let real logic run
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed",
+            lambda **kwargs: False,
+        )
+
+        # Config mock
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = backend_name
+        monkeypatch.setattr("autoskillit.config.load_config", lambda p=None: mock_config)
+
+        (tmp_path / "pkg").mkdir(exist_ok=True)
+
+        return codex_calls, mcp_calls
+
+    def test_codex_backend_calls_ensure_codex_mcp_registered(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        codex_calls, mcp_calls = self._setup_register_all(monkeypatch, tmp_path, "codex")
+        _register_all("user", tmp_path)
+        assert codex_calls, "ensure_codex_mcp_registered must be called for codex backend"
+        assert not mcp_calls, "_register_mcp_server must NOT be called for codex backend"
+
+    def test_claude_code_backend_calls_register_mcp_server(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        codex_calls, mcp_calls = self._setup_register_all(monkeypatch, tmp_path, "claude-code")
+        _register_all("user", tmp_path)
+        assert mcp_calls, "_register_mcp_server must be called for claude-code backend"
+        assert not codex_calls, "ensure_codex_mcp_registered must NOT be called for claude-code"
+
+    def test_codex_backend_does_not_write_claude_json(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        claude_json_calls: list = []
+        codex_calls, mcp_calls = self._setup_register_all(monkeypatch, tmp_path, "codex")
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._user_claude_json_path",
+            lambda: claude_json_calls.append("called") or (tmp_path / ".claude.json"),
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers.evict_direct_mcp_entry",
+            lambda p: claude_json_calls.append("evict") or False,
+        )
+        _register_all("user", tmp_path)
+        assert not mcp_calls, "_register_mcp_server must NOT be called for codex"
+        # Neither _user_claude_json_path nor evict_direct_mcp_entry should be called
+        assert "evict" not in claude_json_calls
+
+    def test_init_passes_agent_backend_to_register_all(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from unittest.mock import MagicMock, patch
+
+        register_all_calls: list = []
+
+        def capture_register_all(*args, **kwargs):
+            register_all_calls.append(kwargs)
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = "codex"
+
+        mock_backend = MagicMock()
+        mock_backend.name = "codex"
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        config_dir = project_dir / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("test_check:\n  command: [pytest]\n")
+
+        monkeypatch.chdir(project_dir)
+
+        with (
+            patch(
+                "autoskillit.cli.app._check_secret_scanning",
+                lambda p: MagicMock(passed=True, bypass_accepted=False),
+            ),
+            patch("autoskillit.config.load_config", return_value=mock_config),
+            patch("autoskillit.execution.get_backend", return_value=mock_backend),
+            patch("autoskillit.cli.app._register_all", side_effect=capture_register_all),
+        ):
+            from autoskillit.cli.app import init
+
+            init(scope="user", force=False)
+
+        assert register_all_calls, "_register_all must have been called"
+        assert "backend" in register_all_calls[0]
+        assert register_all_calls[0]["backend"].name == "codex"


### PR DESCRIPTION
## Summary

The backend-aware branching in `_register_all()` is already implemented (codex path calls `ensure_codex_mcp_registered()`, claude-code path calls `_register_mcp_server()`). Two gaps remain: (1) `_is_plugin_installed()` is not explicitly passed `agent_backend`, and (2) the `ensure_codex_mcp_registered` import should be moved inside the codex branch. The primary deliverable is `TestRegisterAllBackendDispatch` — a test class verifying the dispatch behavior that currently has zero coverage.

## Requirements

- _register_all() accepts agent_backend parameter without breaking existing callers.
- agent_backend='codex' calls ensure_codex_mcp_registered() and NOT _register_mcp_server().
- agent_backend='claude-code' preserves existing logic exactly.
- _is_plugin_installed() receives agent_backend.
- Summary block prints codex-specific line when applicable.
- app.py loads config and passes cfg.agent_backend.backend.
- Import is local inside codex branch.
- codex path does not write ~/.claude.json.
- init() passes cfg.agent_backend.backend to _register_all().
- All tests carry layer('cli') and small markers.
- No existing tests duplicated.
- task test-check passes.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-201242-164540/.autoskillit/temp/make-plan/PY6_P6-A9-WP1_add_agent_backend_branching_plan_2026-05-24_201500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 72 | 12.4k | 903.7k | 70.8k | 116 | 57.0k | 8m 53s |
| verify | claude-sonnet-4-6 | 1 | 220 | 18.6k | 1.2M | 65.2k | 73 | 56.8k | 5m 53s |
| implement* | MiniMax-M2.7-highspeed | 1 | 354.1k | 5.4k | 672.1k | 30.7k | 49 | 15.7k | 2m 8s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 81.3k | 3.4k | 242.6k | 30.7k | 22 | 15.3k | 1m 7s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 57.7k | 1.6k | 242.6k | 30.7k | 17 | 15.0k | 43s |
| review_pr | claude-sonnet-4-6 | 2 | 240 | 36.9k | 944.6k | 51.0k | 68 | 88.3k | 8m 46s |
| resolve_review | claude-sonnet-4-6 | 1 | 205 | 8.7k | 963.1k | 49.4k | 53 | 39.6k | 4m 23s |
| **Total** | | | 493.8k | 86.9k | 5.2M | 70.8k | | 287.7k | 31m 56s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 145 | 4635.5 | 108.3 | 37.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **145** | 35663.7 | 1984.5 | 599.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 737 | 76.5k | 4.0M | 241.8k | 27m 57s |
| MiniMax-M2.7-highspeed | 3 | 493.1k | 10.4k | 1.2M | 46.0k | 3m 59s |