### PR TITLE
feat: add food_truck_capable to BackendCapabilities

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -33,6 +33,7 @@ class BackendCapabilities:
     supports_claude_format_stdout: bool
     exit_code_is_terminal: bool
     mcp_config_capable: bool
+    food_truck_capable: bool
     completion_record_types: frozenset[str]
     session_record_types: frozenset[str]
 
@@ -46,6 +47,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     supports_claude_format_stdout=True,
     exit_code_is_terminal=False,
     mcp_config_capable=False,
+    food_truck_capable=True,
     completion_record_types=frozenset({"result"}),
     session_record_types=frozenset({"assistant"}),
 )

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -173,6 +173,7 @@ class CodexBackend:
             supports_claude_format_stdout=False,
             exit_code_is_terminal=True,
             mcp_config_capable=True,
+            food_truck_capable=False,
             completion_record_types=frozenset({"turn.completed", "turn.failed", "error"}),
             session_record_types=frozenset(),
         )

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -227,6 +227,7 @@ def test_skill_injection_disabled_omits_flags(monkeypatch: pytest.MonkeyPatch) -
         supports_claude_format_stdout=True,
         exit_code_is_terminal=False,
         mcp_config_capable=False,
+        food_truck_capable=True,
         completion_record_types=frozenset({"result"}),
         session_record_types=frozenset({"assistant"}),
     )
@@ -292,6 +293,7 @@ def test_binary_name_from_backend_used_in_which(monkeypatch: pytest.MonkeyPatch)
                 supports_claude_format_stdout=True,
                 exit_code_is_terminal=False,
                 mcp_config_capable=False,
+                food_truck_capable=True,
                 completion_record_types=frozenset({"result"}),
                 session_record_types=frozenset({"assistant"}),
             )
@@ -334,6 +336,7 @@ def test_run_interactive_session_uses_injected_backend(monkeypatch: pytest.Monke
                 supports_claude_format_stdout=True,
                 exit_code_is_terminal=False,
                 mcp_config_capable=False,
+                food_truck_capable=True,
                 completion_record_types=frozenset({"result"}),
                 session_record_types=frozenset({"assistant"}),
             )
@@ -403,6 +406,7 @@ def test_get_backend_di_used_in_session_launch(monkeypatch: pytest.MonkeyPatch) 
         supports_claude_format_stdout=True,
         exit_code_is_terminal=False,
         mcp_config_capable=False,
+        food_truck_capable=True,
         completion_record_types=frozenset({"result"}),
         session_record_types=frozenset({"assistant"}),
     )
@@ -448,6 +452,7 @@ def test_skill_injection_false_via_get_backend_forwards_system_prompt_kwarg(
         supports_claude_format_stdout=True,
         exit_code_is_terminal=False,
         mcp_config_capable=False,
+        food_truck_capable=True,
         completion_record_types=frozenset({"result"}),
         session_record_types=frozenset({"assistant"}),
     )

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -50,7 +50,7 @@ def test_backend_capabilities_slots():
 
 
 def test_backend_capabilities_field_count():
-    """10 fields: 8 bool + 2 frozenset[str]."""
+    """11 fields: 9 bool + 2 frozenset[str]."""
     from autoskillit.core import BackendCapabilities
 
     fields = dataclasses.fields(BackendCapabilities)
@@ -66,6 +66,7 @@ def test_backend_capabilities_field_count():
         "supports_claude_format_stdout",
         "exit_code_is_terminal",
         "mcp_config_capable",
+        "food_truck_capable",
     }
     assert frozenset_fields == {"completion_record_types", "session_record_types"}
 
@@ -83,6 +84,7 @@ def test_backend_capabilities_field_names_locked():
         "supports_claude_format_stdout",
         "exit_code_is_terminal",
         "mcp_config_capable",
+        "food_truck_capable",
         "completion_record_types",
         "session_record_types",
     }
@@ -102,6 +104,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.supports_claude_format_stdout is True
     assert CLAUDE_CODE_CAPABILITIES.exit_code_is_terminal is False
     assert CLAUDE_CODE_CAPABILITIES.mcp_config_capable is False
+    assert CLAUDE_CODE_CAPABILITIES.food_truck_capable is True
     assert CLAUDE_CODE_CAPABILITIES.completion_record_types == frozenset({"result"})
     assert CLAUDE_CODE_CAPABILITIES.session_record_types == frozenset({"assistant"})
 

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -267,6 +267,7 @@ class TestCodexBackendProtocol:
             ("session_resume_capable", True),
             ("skill_injection_capable", False),
             ("mcp_config_capable", True),
+            ("food_truck_capable", False),
         ],
     )
     def test_capability_flag(self, attr: str, expected: bool) -> None:


### PR DESCRIPTION
## Summary

Add a `food_truck_capable: bool` field (no default) to the frozen `BackendCapabilities` dataclass. Set it to `True` in `CLAUDE_CODE_CAPABILITIES` and `False` in `CodexBackend.capabilities`. Update all 7 construction sites and all relevant tests.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
tests/core/test_backend_capabilities.py
tests/execution/backends/test_codex_backend.py

### Modified (●):
src/autoskillit/core/types/_type_backend.py
src/autoskillit/execution/backends/codex.py
tests/cli/test_session_launch.py

Closes #2896

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-201306-327614/.autoskillit/temp/make-plan/py7_p7_a1_wp1_food_truck_capable_plan_2026-05-24_201700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 65 | 9.5k | 1.0M | 76.7k | 106 | 62.0k | 7m 26s |
| verify | claude-sonnet-4-6 | 1 | 116 | 11.8k | 764.2k | 75.9k | 36 | 67.8k | 3m 57s |
| implement* | MiniMax-M2.7-highspeed | 1 | 986.9k | 8.3k | 1.0M | 30.7k | 76 | 15.7k | 3m 5s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 64.7k | 3.8k | 211.9k | 30.7k | 20 | 15.3k | 1m 14s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 56.8k | 1.5k | 211.9k | 30.7k | 16 | 14.9k | 40s |
| review_pr | claude-sonnet-4-6 | 3 | 374 | 65.3k | 1.6M | 62.3k | 128 | 137.4k | 12m 56s |
| **Total** | | | 1.1M | 100.2k | 4.8M | 76.7k | | 313.1k | 29m 20s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 14 | 72121.6 | 1122.1 | 592.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **14** | 344476.9 | 22366.9 | 7160.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 65 | 9.5k | 1.0M | 62.0k | 7m 26s |
| claude-sonnet-4-6 | 2 | 490 | 77.1k | 2.4M | 205.2k | 16m 54s |
| MiniMax-M2.7-highspeed | 3 | 1.1M | 13.6k | 1.4M | 45.9k | 4m 59s |