### PR TITLE
Implementation Plan: _detect_backend_format and build_replay_runner Format Dispatch

### DIFF
--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -43,6 +43,12 @@ REPLAY_SCENARIO_ENV = "REPLAY_SCENARIO"
 REPLAY_SCENARIO_DIR_ENV = "REPLAY_SCENARIO_DIR"
 
 
+def _detect_backend_format(scenario_dir: Path) -> str:
+    if any(scenario_dir.glob("*/codex_stdout.ndjson")):
+        return "codex"
+    return "claude"
+
+
 class ScenarioReplayError(Exception):
     """Raised when scenario replay cannot find a session or result for a step."""
 
@@ -319,23 +325,38 @@ def build_replay_runner(replay_dir: str) -> ReplayingSubprocessRunner:
             ``player.build_session_map()`` is re-raised after logging the
             scenario path for context.
     """
-    try:
-        from api_simulator.claude import make_scenario_player
-    except ImportError as exc:
-        raise RuntimeError(
-            "REPLAY_SCENARIO is set but 'api_simulator' is not installed. "
-            "Install it to enable scenario replay."
-        ) from exc
+    fmt = _detect_backend_format(Path(replay_dir))
 
     _tmp_replay_dir = tempfile.TemporaryDirectory(prefix="autoskillit-replay-")
     tmp_replay = _tmp_replay_dir.name
 
     try:
-        player = make_scenario_player(
-            scenario_dir=replay_dir,
-            output_dir=tmp_replay,
-            binary_path=str(Path(tmp_replay) / "claude"),
-        )
+        if fmt == "codex":
+            try:
+                from api_simulator.codex import CodexScenarioPlayer
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Codex scenario detected but 'api_simulator.codex' is not installed. "
+                    "Install it to enable Codex scenario replay."
+                ) from exc
+            player = CodexScenarioPlayer(
+                scenario_dir=replay_dir,
+                output_dir=tmp_replay,
+                binary_path=str(Path(tmp_replay) / "codex"),
+            )
+        else:
+            try:
+                from api_simulator.claude import make_scenario_player
+            except ImportError as exc:
+                raise RuntimeError(
+                    "REPLAY_SCENARIO is set but 'api_simulator' is not installed. "
+                    "Install it to enable scenario replay."
+                ) from exc
+            player = make_scenario_player(
+                scenario_dir=replay_dir,
+                output_dir=tmp_replay,
+                binary_path=str(Path(tmp_replay) / "claude"),
+            )
     except Exception:
         _tmp_replay_dir.cleanup()
         raise

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -15,6 +15,7 @@ from autoskillit.execution.recording import (
     RecordingSubprocessRunner,
     ReplayingSubprocessRunner,
     ScenarioReplayError,
+    _detect_backend_format,
     _extract_model,
 )
 from tests.conftest import _make_result
@@ -650,3 +651,84 @@ async def test_replaying_runner_accepts_marker_params(tmp_path):
 
     assert result.returncode == 0
     assert result.stdout == "ok"
+
+
+# --- T-DETECT-CODEX: _detect_backend_format returns 'codex' when sidecar exists ---
+
+
+def test_detect_backend_format_codex(tmp_path):
+    """_detect_backend_format returns 'codex' when any subdir contains codex_stdout.ndjson."""
+    sidecar = tmp_path / "investigate" / "codex_stdout.ndjson"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.touch()
+    assert _detect_backend_format(tmp_path) == "codex"
+
+
+# --- T-DETECT-CLAUDE: _detect_backend_format returns 'claude' when no sidecar ---
+
+
+def test_detect_backend_format_claude(tmp_path):
+    """_detect_backend_format returns 'claude' when no codex sidecar exists."""
+    assert _detect_backend_format(tmp_path) == "claude"
+
+
+# --- T-REPLAY-CODEX: build_replay_runner dispatches to CodexScenarioPlayer ---
+
+
+def test_build_replay_runner_detects_codex_format(tmp_path, monkeypatch):
+    """build_replay_runner() uses CodexScenarioPlayer when codex sidecar detected."""
+    import sys
+    import types
+    import weakref
+
+    from autoskillit.execution.recording import build_replay_runner
+
+    replay_dir = tmp_path / "replay"
+    sidecar = replay_dir / "investigate" / "codex_stdout.ndjson"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.touch()
+
+    mock_scenario = Mock()
+    mock_scenario.step_sequence = []
+    mock_codex_cls = Mock()
+    mock_codex_instance = mock_codex_cls.return_value
+    mock_codex_instance.scenario.return_value = mock_scenario
+    mock_codex_instance.build_session_map.return_value = {}
+
+    fake_codex_mod = types.ModuleType("api_simulator.codex")
+    fake_codex_mod.CodexScenarioPlayer = mock_codex_cls  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "api_simulator.codex", fake_codex_mod)
+
+    monkeypatch.setattr(weakref.finalize, "_registered_with_atexit", True)
+    monkeypatch.setattr("atexit.register", Mock())
+
+    result = build_replay_runner(str(replay_dir))
+    assert result.player is mock_codex_instance
+
+
+# --- T-REPLAY-CLAUDE: build_replay_runner dispatches to make_scenario_player ---
+
+
+def test_build_replay_runner_detects_claude_format(tmp_path, monkeypatch):
+    """build_replay_runner() uses make_scenario_player when no codex sidecar detected."""
+    import weakref
+
+    from autoskillit.execution.recording import build_replay_runner
+
+    replay_dir = tmp_path / "replay"
+    replay_dir.mkdir()
+
+    mock_scenario = Mock()
+    mock_scenario.step_sequence = []
+    mock_player = Mock()
+    mock_player.scenario.return_value = mock_scenario
+    mock_player.build_session_map.return_value = {}
+
+    monkeypatch.setattr(
+        _api_sim_claude, "make_scenario_player", Mock(return_value=mock_player), raising=False
+    )
+    monkeypatch.setattr(weakref.finalize, "_registered_with_atexit", True)
+    monkeypatch.setattr("atexit.register", Mock())
+
+    result = build_replay_runner(str(replay_dir))
+    assert result.player is mock_player


### PR DESCRIPTION
## Summary

Add a pure filesystem probe function `_detect_backend_format(scenario_dir: Path) -> str` to `recording.py` that determines the cassette backend type by globbing for `codex_stdout.ndjson` in subdirectories. Update `build_replay_runner()` to call this probe and dispatch to either `CodexScenarioPlayer` (codex format) or the existing `make_scenario_player` (claude format). Both paths share the same `ReplayingSubprocessRunner` construction tail.

Closes #2911

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-201307-760488/.autoskillit/temp/make-plan/p8_a3_wp1_detect_backend_format_plan_2026-05-24_201600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.8k | 15.4k | 1.2M | 110.8k | 216 | 73.3k | 18m 52s |
| verify | claude-sonnet-4-6 | 1 | 100 | 11.0k | 448.4k | 54.9k | 35 | 46.5k | 3m 20s |
| implement* | MiniMax-M2.7-highspeed | 1 | 364.6k | 5.6k | 488.0k | 30.7k | 43 | 15.7k | 1m 58s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 124.7k | 3.4k | 334.7k | 30.7k | 22 | 15.1k | 1m 17s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 76.9k | 2.0k | 304.0k | 30.7k | 22 | 15.0k | 48s |
| review_pr | claude-sonnet-4-6 | 1 | 198 | 26.7k | 871.5k | 61.1k | 54 | 105.0k | 7m 22s |
| resolve_review | claude-sonnet-4-6 | 1 | 229 | 14.9k | 1.3M | 62.9k | 65 | 53.2k | 7m 51s |
| **Total** | | | 569.5k | 78.9k | 5.0M | 110.8k | | 324.0k | 41m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 127 | 3842.7 | 123.7 | 44.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **127** | 39145.3 | 2550.9 | 621.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.3k | 68.0k | 3.8M | 278.1k | 37m 27s |
| MiniMax-M2.7-highspeed | 3 | 566.2k | 10.9k | 1.1M | 45.9k | 4m 2s |