### PR TITLE
Condense test_check MCP Tool Output

### DIFF
--- a/src/autoskillit/execution/CLAUDE.md
+++ b/src/autoskillit/execution/CLAUDE.md
@@ -23,7 +23,7 @@ backends/ (see backends/CLAUDE.md).
 | `ci.py` | GitHub Actions CI watcher (httpx, never raises) |
 | `github.py` | GitHub issue fetcher |
 | `remote_resolver.py` | Upstream > origin, clone-aware remote resolution |
-| `testing.py` | Pytest output parsing + pass/fail adjudication |
+| `testing.py` | Pytest output parsing, pass/fail adjudication, output condensation |
 | `clone_guard.py` | Clone contamination guard — detect and revert direct changes to clone CWD |
 | `pr_analysis.py` | `extract_linked_issues`, `DOMAIN_PATHS`, `partition_files_by_domain` |
 

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -125,6 +125,7 @@ from autoskillit.execution.session_log import (
 from autoskillit.execution.testing import (
     DefaultTestRunner,
     check_test_passed,
+    condense_test_output,
     parse_pytest_summary,
 )
 
@@ -180,6 +181,7 @@ __all__ = [
     "parse_pytest_summary",
     "check_test_passed",
     "DefaultTestRunner",
+    "condense_test_output",
     # ci
     "DefaultCIWatcher",
     # merge_queue

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -222,12 +222,19 @@ def _strip_progress_noise(stdout: str) -> str:
 def condense_test_output(result: TestResult) -> tuple[str, str]:
     """Condense test output for MCP response consumption.
 
-    On pass: returns only the summary line and empty stderr.
+    On pass: if a pytest-style summary line is found, returns only the summary
+    and clears stderr (which contains only install noise). For non-pytest runners
+    that emit results to stderr, stderr is preserved.
     On fail: strips progress noise from stdout, preserves stderr.
     """
     if result.passed:
-        summary = extract_summary_line(result.stdout) or ""
-        return summary, ""
+        summary = extract_summary_line(result.stdout)
+        if summary is not None:
+            # Pytest-style output: summary found; stderr is install noise only.
+            return summary, ""
+        # Non-pytest runner: no summary in stdout; preserve stderr as it may
+        # contain the primary result (e.g. cargo nextest: "PASS [0.5s] 5 tests").
+        return "", result.stderr
 
     stdout = _strip_progress_noise(result.stdout)
     return stdout, result.stderr

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -169,6 +169,70 @@ def parse_pytest_summary(stdout: str) -> dict[str, int]:
     return {}
 
 
+def extract_summary_line(stdout: str) -> str | None:
+    """Extract the raw test summary line from stdout.
+
+    Uses the same two-pass detection as parse_pytest_summary but returns
+    the raw line text (with = delimiters stripped) instead of parsed counts.
+    Returns None if no summary line is found (non-pytest runner).
+    """
+    lines = stdout.splitlines()
+
+    for line in reversed(lines):
+        stripped = line.strip()
+        if stripped.startswith("=") and stripped.endswith("="):
+            if _OUTCOME_PATTERN.search(stripped):
+                return stripped.strip("= ")
+
+    for line in reversed(lines):
+        stripped = line.strip()
+        if _BARE_TIME_ANCHOR.search(stripped):
+            if _OUTCOME_PATTERN.search(stripped):
+                return stripped
+
+    return None
+
+
+_PROGRESS_PCT_RE = re.compile(r"\[\s*\d+%\]\s*$")
+
+
+def _is_progress_line(line: str) -> bool:
+    """Detect test runner progress indicator lines.
+
+    Runner-agnostic heuristic: matches lines that are predominantly dots
+    or end with a percentage bracket like [ 72%].
+    """
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if _PROGRESS_PCT_RE.search(stripped):
+        return True
+    non_ws = stripped.replace(" ", "")
+    if non_ws and non_ws.count(".") / len(non_ws) > 0.6:
+        return True
+    return False
+
+
+def _strip_progress_noise(stdout: str) -> str:
+    """Remove progress indicator lines from test output."""
+    lines = stdout.splitlines()
+    return "\n".join(line for line in lines if not _is_progress_line(line))
+
+
+def condense_test_output(result: TestResult) -> tuple[str, str]:
+    """Condense test output for MCP response consumption.
+
+    On pass: returns only the summary line and empty stderr.
+    On fail: strips progress noise from stdout, preserves stderr.
+    """
+    if result.passed:
+        summary = extract_summary_line(result.stdout) or ""
+        return summary, ""
+
+    stdout = _strip_progress_noise(result.stdout)
+    return stdout, result.stderr
+
+
 def check_test_passed(returncode: int, stdout: str, stderr: str = "") -> bool:
     """Determine test pass/fail with cross-validation.
 

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -22,6 +22,9 @@ from autoskillit.execution import (
     check_and_sleep_if_needed as check_and_sleep_if_needed,
 )
 from autoskillit.execution import (
+    condense_test_output as condense_test_output,
+)
+from autoskillit.execution import (
     fetch_repo_merge_state as fetch_repo_merge_state,
 )
 from autoskillit.execution import (

--- a/src/autoskillit/server/tools/tools_workspace.py
+++ b/src/autoskillit/server/tools/tools_workspace.py
@@ -14,6 +14,7 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import get_logger, truncate_text
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
+from autoskillit.server._misc import condense_test_output
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
 
@@ -101,10 +102,11 @@ async def test_check(
                     extra={"worktree": worktree_path},
                 )
 
+            condensed_stdout, condensed_stderr = condense_test_output(test_result)
             response = {
                 "passed": test_result.passed,
-                "stdout": truncate_text(test_result.stdout),
-                "stderr": truncate_text(test_result.stderr),
+                "stdout": truncate_text(condensed_stdout),
+                "stderr": truncate_text(condensed_stderr),
             }
             if test_result.duration_seconds is not None:
                 response["duration_seconds"] = round(test_result.duration_seconds, 2)

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -13,9 +13,12 @@ from autoskillit.core.types import (
 )
 from autoskillit.execution.testing import (
     DefaultTestRunner,
+    _is_progress_line,
     _read_sidecar_base_branch,
     _resolve_base_ref,
     build_sanitized_env,
+    condense_test_output,
+    extract_summary_line,
 )
 from autoskillit.execution.testing import (
     parse_pytest_summary as _parse_pytest_summary,
@@ -977,3 +980,101 @@ def test_check_infrastructure_custom_command_in_path(tmp_path):
     runner = MockSubprocessRunner()
     tester = DefaultTestRunner(config=config, runner=runner)
     assert tester.check_infrastructure(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Output condensation tests (T1-T9)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSummaryLine:
+    """T1-T3: extract_summary_line returns stripped summary or None."""
+
+    def test_equals_delimited(self):
+        """T1: =-delimited summary returns stripped text."""
+        stdout = "...\n= 14514 passed, 427 skipped in 77.23s =\n"
+        result = extract_summary_line(stdout)
+        assert result == "14514 passed, 427 skipped in 77.23s"
+
+    def test_bare_q_format(self):
+        """T2: bare -q summary returns bare text."""
+        stdout = "...\n3 failed, 97 passed in 2.31s\n"
+        result = extract_summary_line(stdout)
+        assert result == "3 failed, 97 passed in 2.31s"
+
+    def test_no_summary_returns_none(self):
+        """T3: non-pytest output returns None."""
+        stdout = "All tests passed\nDone.\n"
+        assert extract_summary_line(stdout) is None
+
+
+class TestIsProgressLine:
+    """T4-T6: _is_progress_line identifies dot-heavy and percentage lines."""
+
+    def test_dots(self):
+        """T4: dot-heavy lines are progress lines."""
+        assert _is_progress_line(
+            "........................................................................"
+        )
+        assert _is_progress_line("...F...F....")
+        assert not _is_progress_line("FAILED tests/test_foo.py::test_bar - AssertionError")
+
+    def test_percentage_bracket(self):
+        """T5: percentage bracket lines are progress lines."""
+        assert _is_progress_line("............ [ 72%]")
+        assert _is_progress_line("...F...      [100%]")
+        assert not _is_progress_line("assert x == 42  # [expected]")
+
+    def test_rejects_diagnostics(self):
+        """T6: tracebacks and error messages are not progress lines."""
+        assert not _is_progress_line("    assert result == expected")
+        assert not _is_progress_line("E       AssertionError: 1 != 2")
+        assert not _is_progress_line("tests/test_foo.py:42: AssertionError")
+        assert not _is_progress_line("FAILED tests/test_foo.py::test_bar")
+        assert not _is_progress_line("=== FAILURES ===")
+
+
+class TestCondenseTestOutput:
+    """T7-T9: condense_test_output condenses output appropriately."""
+
+    def test_pass_returns_summary_and_empty_stderr(self):
+        """T7: pass returns summary line and empty stderr."""
+        from autoskillit.core import TestResult
+
+        result = TestResult(
+            passed=True,
+            stdout="...\n= 5 passed in 1.23s =\n",
+            stderr="Installing packages...\nvenv created\n",
+        )
+        stdout, stderr = condense_test_output(result)
+        assert stdout == "5 passed in 1.23s"
+        assert stderr == ""
+
+    def test_fail_strips_progress_preserves_tracebacks(self):
+        """T8: fail strips progress lines, preserves diagnostics."""
+        from autoskillit.core import TestResult
+
+        raw = (
+            "....... [ 10%]\n"
+            "....... [ 20%]\n"
+            "FAILED tests/test_foo.py::test_bar\n"
+            "    assert 1 == 2\n"
+            "E   AssertionError\n"
+            "= 1 failed, 99 passed in 5.0s =\n"
+        )
+        result = TestResult(passed=False, stdout=raw, stderr="some error\n")
+        stdout, stderr = condense_test_output(result)
+        assert "[ 10%]" not in stdout
+        assert "[ 20%]" not in stdout
+        assert "FAILED tests/test_foo.py::test_bar" in stdout
+        assert "AssertionError" in stdout
+        assert stderr == "some error\n"
+
+    def test_pass_no_summary_returns_empty(self):
+        """T9: pass with no summary returns empty stdout and stderr."""
+        from autoskillit.core import TestResult
+
+        result = TestResult(passed=True, stdout="ok\n", stderr="")
+        stdout, stderr = condense_test_output(result)
+        assert stdout == ""
+        assert stderr == ""

--- a/tests/infra/test_pretty_output_formatters.py
+++ b/tests/infra/test_pretty_output_formatters.py
@@ -825,3 +825,32 @@ def test_make_run_skill_event_custom_provider_values() -> None:
     payload = json.loads(event["tool_response"])
     assert payload["provider_used"] == "anthropic"
     assert payload["provider_fallback"] is True
+
+
+# T12-T13: _fmt_test_check handles pre-condensed output
+
+
+def test_fmt_test_check_handles_condensed_pass_output():
+    """T12: _fmt_test_check works with pre-condensed passing output."""
+    from autoskillit.hooks.formatters._fmt_execution import _fmt_test_check
+
+    data = {"passed": True, "stdout": "10 passed in 1.0s", "stderr": "", "duration_seconds": 1.0}
+    result = _fmt_test_check(data, False)
+    assert "10 passed in 1.0s" in result
+    assert "PASS" in result
+
+
+def test_fmt_test_check_handles_condensed_fail_output():
+    """T13: _fmt_test_check works with pre-condensed failing output."""
+    from autoskillit.hooks.formatters._fmt_execution import _fmt_test_check
+
+    data = {
+        "passed": False,
+        "stdout": "FAILED test_x.py::test_y\nE  assert False\n= 1 failed =",
+        "stderr": "",
+        "duration_seconds": 2.0,
+    }
+    result = _fmt_test_check(data, False)
+    assert "FAILED test_x.py::test_y" in result
+    assert "assert False" in result
+    assert "FAIL" in result

--- a/tests/server/test_tools_workspace.py
+++ b/tests/server/test_tools_workspace.py
@@ -360,6 +360,27 @@ class TestTestCheck:
         assert "does not exist" in result["error"]
         assert result["infrastructure_missing"] is True
 
+    @pytest.mark.anyio
+    async def test_test_check_condenses_passing_output(self, tool_ctx):
+        """T10: passing output is condensed to bare summary line."""
+        raw_stdout = "...... [ 50%]\n...... [100%]\n= 10 passed in 1.0s =\n"
+        tool_ctx.runner.push(_make_result(0, raw_stdout, "venv noise\n"))
+        result = json.loads(await test_check(worktree_path=self.wt))
+        assert result["passed"] is True
+        assert result["stdout"] == "10 passed in 1.0s"
+        assert result["stderr"] == ""
+
+    @pytest.mark.anyio
+    async def test_test_check_preserves_failure_diagnostics(self, tool_ctx):
+        """T11: failing output preserves diagnostics, strips progress."""
+        raw_stdout = "...... [ 50%]\nFAILED test_x.py::test_y\nE  assert False\n= 1 failed =\n"
+        tool_ctx.runner.push(_make_result(1, raw_stdout, ""))
+        result = json.loads(await test_check(worktree_path=self.wt))
+        assert result["passed"] is False
+        assert "[ 50%]" not in result["stdout"]
+        assert "FAILED test_x.py::test_y" in result["stdout"]
+        assert "assert False" in result["stdout"]
+
 
 class TestTestCheckInfrastructure:
     """T1-T5: Infrastructure pre-flight checks in test_check."""


### PR DESCRIPTION
## Summary

Add output condensation to the `test_check` MCP tool handler so orchestrators receive minimal, actionable output instead of thousands of tokens of progress noise. On passing runs, return only the summary line in stdout and empty stderr. On failing runs, strip generic progress indicators (dot-lines, percentage markers) from stdout while preserving tracebacks and error messages. The condensation is runner-agnostic — it uses generic heuristics rather than pytest-specific patterns.

## Changed Files

### Modified (●):
● src/autoskillit/execution/CLAUDE.md
● src/autoskillit/execution/__init__.py
● src/autoskillit/execution/testing.py
● src/autoskillit/server/_misc.py
● src/autoskillit/server/tools/tools_workspace.py
● tests/execution/test_testing.py
● tests/infra/test_pretty_output_formatters.py
● tests/server/test_tools_workspace.py

Closes #2975

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-201019-220202/.autoskillit/temp/make-plan/test_check_output_condensation_plan_2026-05-24_201700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 69 | 21.2k | 1.5M | 139.4k | 163 | 103.1k | 13m 5s |
| verify | claude-sonnet-4-6 | 1 | 1.1k | 10.6k | 382.6k | 50.2k | 69 | 41.7k | 4m 0s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.2M | 16.4k | 1.2M | 30.7k | 103 | 43.5k | 5m 43s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 78.3k | 3.8k | 184.1k | 30.7k | 20 | 42.9k | 1m 17s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 36.6k | 1.3k | 181.2k | 30.7k | 14 | 14.9k | 37s |
| review_pr | claude-sonnet-4-6 | 2 | 338 | 64.6k | 1.4M | 69.4k | 102 | 123.2k | 15m 52s |
| resolve_review | claude-sonnet-4-6 | 2 | 370 | 29.4k | 2.0M | 59.8k | 122 | 97.1k | 16m 54s |
| **Total** | | | 2.3M | 147.2k | 6.8M | 139.4k | | 466.4k | 57m 32s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 228 | 5247.7 | 190.6 | 71.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **228** | 29684.1 | 2045.7 | 645.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.9k | 125.8k | 5.2M | 365.1k | 49m 53s |
| MiniMax-M2.7-highspeed | 3 | 2.3M | 21.4k | 1.6M | 101.3k | 7m 38s |