### PR TITLE
[FIX] Rectify: Recipe output_dir Template Bypass

### DIFF
--- a/src/autoskillit/recipe/rules/rules_temp_path.py
+++ b/src/autoskillit/recipe/rules/rules_temp_path.py
@@ -1,4 +1,9 @@
-"""Lint rule: reject bare {{AUTOSKILLIT_TEMP}}/ paths without a context-variable scope prefix."""
+"""Lint rule: reject bare {{AUTOSKILLIT_TEMP}}/ paths in non-output_dir fields.
+
+output_dir values are allowed to use relative {{AUTOSKILLIT_TEMP}}/suffix paths
+(server-resolvable via cwd). Other fields (command, env, list args) still require
+a ${{ context.* }} scope prefix to avoid cross-run collisions.
+"""
 
 from __future__ import annotations
 
@@ -12,7 +17,8 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 from autoskillit.recipe.schema import RecipeStep
 
 _BARE_TEMP_RE = re.compile(r"\{\{AUTOSKILLIT_TEMP\}\}/")
-_CONTEXT_SCOPED_RE = re.compile(r"\$\{\{\s*context\.\w+\s*\}\}")
+_BARE_TEMP_EXACT_RE = re.compile(r"^\{\{AUTOSKILLIT_TEMP\}\}$")
+_CONTEXT_SCOPED_RE = re.compile(r"\$\{\{\s*(?:context|inputs)\.\w+\s*\}\}")
 _SKIP_KEYS = frozenset({"step_name", "callable", "pass_name"})
 
 
@@ -32,12 +38,17 @@ def _iter_path_values(step: RecipeStep) -> Iterator[tuple[str, str]]:
                     yield f"{key}[{i}]", item
 
 
+def _is_dry_walkthrough_step(step: RecipeStep) -> bool:
+    skill_cmd = (step.with_args or {}).get("skill_command", "")
+    return "dry-walkthrough" in skill_cmd
+
+
 @semantic_rule(
     name="non-unique-output-path",
     description=(
-        "Recipe steps must scope output paths through a per-run context variable. "
-        "Bare {{AUTOSKILLIT_TEMP}}/ paths are shared across runs and cause "
-        "stale-artifact failures."
+        "Non-output_dir fields must scope paths through a per-run context variable. "
+        "output_dir may use relative {{AUTOSKILLIT_TEMP}}/suffix (server-resolvable) "
+        "but must include a unique suffix unless it is a dry-walkthrough step."
     ),
     severity=Severity.ERROR,
 )
@@ -45,18 +56,42 @@ def _check_non_unique_output_path(ctx: ValidationContext) -> list[RuleFinding]:
     findings = []
     for step_name, step in ctx.recipe.steps.items():
         for key, val in _iter_path_values(step):
-            if _BARE_TEMP_RE.search(val) and not _CONTEXT_SCOPED_RE.search(val):
-                findings.append(
-                    RuleFinding(
-                        rule="non-unique-output-path",
-                        severity=Severity.ERROR,
-                        step_name=step_name,
-                        message=(
-                            f"Step '{step_name}' uses a bare '{{{{AUTOSKILLIT_TEMP}}}}/' "
-                            f"path in '{key}' without a context-variable scope prefix. "
-                            "Capture a unique per-run directory in the init step "
-                            "and reference it via ${{{{ context.run_dir }}}} or similar."
-                        ),
+            if key == "output_dir":
+                if _CONTEXT_SCOPED_RE.search(val):
+                    continue
+                if _BARE_TEMP_RE.search(val):
+                    continue
+                if _BARE_TEMP_EXACT_RE.search(val):
+                    if _is_dry_walkthrough_step(step):
+                        continue
+                    findings.append(
+                        RuleFinding(
+                            rule="non-unique-output-path",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Step '{step_name}' uses bare '{{{{AUTOSKILLIT_TEMP}}}}' "
+                                f"in output_dir without a unique suffix. "
+                                "Add a skill-specific subdirectory "
+                                "(e.g., '{{{{AUTOSKILLIT_TEMP}}}}/skill-name')."
+                            ),
+                        )
                     )
-                )
+            else:
+                if _BARE_TEMP_RE.search(val) and not _CONTEXT_SCOPED_RE.search(val):
+                    findings.append(
+                        RuleFinding(
+                            rule="non-unique-output-path",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Step '{step_name}' uses a bare "
+                                f"'{{{{AUTOSKILLIT_TEMP}}}}/' path in '{key}' "
+                                "without a context-variable scope prefix. "
+                                "Capture a unique per-run directory in the init step "
+                                "and reference it via "
+                                "${{{{ context.run_dir }}}} or similar."
+                            ),
+                        )
+                    )
     return findings

--- a/src/autoskillit/recipes/implement-findings.json
+++ b/src/autoskillit/recipes/implement-findings.json
@@ -98,7 +98,7 @@
         "skill_command": "/autoskillit:build-execution-map ${{ context.remaining_urls_json }} ${{ inputs.base_branch }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "run_bem_internally",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/build-execution-map"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/build-execution-map"
       },
       "capture": {
         "execution_map_path": "${{ result.execution_map }}"

--- a/src/autoskillit/recipes/implement-findings.yaml
+++ b/src/autoskillit/recipes/implement-findings.yaml
@@ -101,7 +101,7 @@ steps:
       skill_command: "/autoskillit:build-execution-map ${{ context.remaining_urls_json }} ${{ inputs.base_branch }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: "run_bem_internally"
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/build-execution-map
+      output_dir: "{{AUTOSKILLIT_TEMP}}/build-execution-map"
     capture:
       execution_map_path: "${{ result.execution_map }}"
     on_success: load_bem_from_file

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -151,7 +151,7 @@
         "skill_command": "/autoskillit:make-groups ${{ inputs.source_doc }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "group",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/make-groups"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/make-groups"
       },
       "capture": {
         "group_files": "${{ result.group_files }}"
@@ -191,7 +191,7 @@
         "skill_command": "/autoskillit:review-approach ${{ context.plan_path }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-approach"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-approach"
       },
       "capture": {
         "review_path": "${{ result.review_path }}"
@@ -211,7 +211,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "verify",
         "review_path": "${{ context.review_path }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}"
       },
       "on_success": "implement",
       "on_failure": "release_issue_failure",
@@ -457,7 +457,7 @@
         "skill_command": "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.base_sha }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "audit_impl",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/audit-impl"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-impl"
       },
       "capture": {
         "remediation_path": "${{ result.remediation_path }}"
@@ -602,7 +602,7 @@
         "callable": "autoskillit.smoke_utils.annotate_pr_diff",
         "pr_number": "${{ context.pr_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr",
         "base_branch": "${{ inputs.base_branch }}",
         "local_review_rounds": "${{ inputs.local_review_rounds }}",
         "current_iteration": "${{ context.review_loop_count }}"
@@ -629,7 +629,7 @@
         "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review_pr",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr"
       },
       "capture": {
         "review_verdict": "${{ result.verdict }}"
@@ -1002,7 +1002,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "diagnose_ci",
         "ci_failed_jobs": "${{ context.ci_failed_jobs }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
       },
       "capture": {
         "diagnosis_path": "${{ result.diagnosis_path }}"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -140,7 +140,7 @@ steps:
       skill_command: "/autoskillit:make-groups ${{ inputs.source_doc }}"
       cwd: "${{ context.work_dir }}"
       step_name: "group"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/make-groups
+      output_dir: "{{AUTOSKILLIT_TEMP}}/make-groups"
     capture:
       group_files: "${{ result.group_files }}"
     on_success: plan
@@ -200,7 +200,7 @@ steps:
       skill_command: "/autoskillit:review-approach ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-approach
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-approach"
     capture:
       review_path: "${{ result.review_path }}"
     retries: 1
@@ -218,7 +218,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "verify"
       review_path: "${{ context.review_path }}"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}
+      output_dir: "{{AUTOSKILLIT_TEMP}}"
     on_success: implement
     on_failure: release_issue_failure
     note: "SEQUENTIAL EXECUTION: For each plan_part, run the FULL cycle — verify → implement → test → merge — for that part before advancing to the next part. Never run verify for all parts first. If review produced a report, context.review_path is available — pass it as an additional arg to dry-walkthrough."
@@ -424,7 +424,7 @@ steps:
       skill_command: "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.base_sha }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "audit_impl"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/audit-impl
+      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
     capture:
       remediation_path: "${{ result.remediation_path }}"
     on_result:
@@ -563,7 +563,7 @@ steps:
       callable: "autoskillit.smoke_utils.annotate_pr_diff"
       pr_number: "${{ context.pr_number }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
       base_branch: "${{ inputs.base_branch }}"
       local_review_rounds: "${{ inputs.local_review_rounds }}"
       current_iteration: "${{ context.review_loop_count }}"
@@ -589,7 +589,7 @@ steps:
       skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
     capture:
       review_verdict: "${{ result.verdict }}"
     on_result:
@@ -941,7 +941,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "diagnose_ci"
       ci_failed_jobs: "${{ context.ci_failed_jobs }}"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci
+      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
     capture:
       diagnosis_path: "${{ result.diagnosis_path }}"
     on_success: resolve_ci

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -188,7 +188,7 @@
         "skill_command": "/autoskillit:review-approach ${{ context.plan_path }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-approach"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-approach"
       },
       "capture": {
         "review_path": "${{ result.review_path }}"
@@ -208,7 +208,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "verify",
         "review_path": "${{ context.review_path }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}"
       },
       "on_success": "implement",
       "on_failure": "release_issue_failure",
@@ -448,7 +448,7 @@
         "skill_command": "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.base_sha }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "audit_impl",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/audit-impl"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-impl"
       },
       "capture": {
         "remediation_path": "${{ result.remediation_path }}"
@@ -595,7 +595,7 @@
         "callable": "autoskillit.smoke_utils.annotate_pr_diff",
         "pr_number": "${{ context.pr_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr",
         "base_branch": "${{ inputs.base_branch }}",
         "local_review_rounds": "${{ inputs.local_review_rounds }}",
         "current_iteration": "${{ context.review_loop_count }}"
@@ -622,7 +622,7 @@
         "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review_pr",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr"
       },
       "capture": {
         "review_verdict": "${{ result.verdict }}"
@@ -1668,7 +1668,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "diagnose_ci",
         "ci_failed_jobs": "${{ context.ci_failed_jobs }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
       },
       "capture": {
         "diagnosis_path": "${{ result.diagnosis_path }}"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -197,7 +197,7 @@ steps:
       skill_command: "/autoskillit:review-approach ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-approach
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-approach"
     capture:
       review_path: "${{ result.review_path }}"
     retries: 1
@@ -215,7 +215,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "verify"
       review_path: "${{ context.review_path }}"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}
+      output_dir: "{{AUTOSKILLIT_TEMP}}"
     on_success: implement
     on_failure: release_issue_failure
     on_context_limit: implement
@@ -415,7 +415,7 @@ steps:
       skill_command: "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.base_sha }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "audit_impl"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/audit-impl
+      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
     capture:
       remediation_path: "${{ result.remediation_path }}"
     on_result:
@@ -554,7 +554,7 @@ steps:
       callable: "autoskillit.smoke_utils.annotate_pr_diff"
       pr_number: "${{ context.pr_number }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
       base_branch: "${{ inputs.base_branch }}"
       local_review_rounds: "${{ inputs.local_review_rounds }}"
       current_iteration: "${{ context.review_loop_count }}"
@@ -580,7 +580,7 @@ steps:
       skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
     capture:
       review_verdict: "${{ result.verdict }}"
     on_result:
@@ -1522,7 +1522,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "diagnose_ci"
       ci_failed_jobs: "${{ context.ci_failed_jobs }}"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci
+      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
     capture:
       diagnosis_path: "${{ result.diagnosis_path }}"
     on_success: resolve_ci

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -126,7 +126,7 @@
         "callable": "autoskillit.smoke_utils.fetch_merge_queue_data",
         "base_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/merge-prs"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/merge-prs"
       },
       "capture": {
         "merge_queue_data_path": "${{ result.merge_queue_data_path }}"
@@ -142,7 +142,7 @@
         "skill_command": "/autoskillit:analyze-prs ${{ inputs.base_branch }} merge_queue_data_path=${{ context.merge_queue_data_path }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "analyze_prs",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/analyze-prs"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/analyze-prs"
       },
       "capture": {
         "pr_order_file": "${{ result.pr_order_file }}",
@@ -736,7 +736,7 @@
         "skill_command": "/autoskillit:diagnose-ci '${{ context.current_pr_number }}' - - - ${{ context.ci_event }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "diagnose_queue_ci",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
       },
       "capture": {
         "diagnosis_path": "${{ result.diagnosis_path }}"
@@ -812,7 +812,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "merge_pr",
         "pr_order_file": "${{ context.pr_order_file }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/merge-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/merge-pr"
       },
       "capture": {
         "needs_plan": "${{ result.needs_plan }}",
@@ -872,7 +872,7 @@
         "skill_command": "/autoskillit:dry-walkthrough ${{ context.pr_plan_path }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "verify",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}"
       },
       "on_success": "implement",
       "on_failure": "register_clone_failure",
@@ -1230,7 +1230,7 @@
         "skill_command": "/autoskillit:audit-impl \"${{ context.all_plan_paths }}\" ${{ context.batch_branch }} ${{ inputs.base_branch }} \"${{ context.all_conflict_report_paths }}\"",
         "cwd": "${{ context.work_dir }}",
         "step_name": "audit_impl",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/audit-impl"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-impl"
       },
       "capture": {
         "verdict": "${{ result.verdict }}",
@@ -1263,7 +1263,7 @@
         "batch_branch": "${{ context.batch_branch }}",
         "base_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/open-integration-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/open-integration-pr"
       },
       "capture": {
         "domain_partitions_path": "${{ result.domain_partitions_path }}"
@@ -1279,7 +1279,7 @@
         "skill_command": "/autoskillit:open-integration-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} ${{ context.pr_order_file }} ${{ context.verdict }} \"${{ context.all_conflict_report_paths }}\" domain_partitions_path=${{ context.domain_partitions_path }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "open_integration_pr",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/open-integration-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/open-integration-pr"
       },
       "capture": {
         "pr_url": "${{ result.pr_url }}"
@@ -1390,7 +1390,7 @@
         "callable": "autoskillit.smoke_utils.annotate_pr_diff",
         "pr_number": "${{ context.review_pr_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr",
         "local_review_rounds": "0"
       },
       "capture": {
@@ -1409,7 +1409,7 @@
         "skill_command": "/autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review_pr_integration",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr"
       },
       "capture": {
         "review_verdict": "${{ result.verdict }}"
@@ -1559,7 +1559,7 @@
         "skill_command": "/autoskillit:diagnose-ci ${{ context.batch_branch }} - - - ${{ context.ci_event }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "diagnose_ci",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
       },
       "capture": {
         "diagnosis_path": "${{ result.diagnosis_path }}"

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -140,7 +140,7 @@ steps:
       callable: "autoskillit.smoke_utils.fetch_merge_queue_data"
       base_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/merge-prs"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/merge-prs"
     capture:
       merge_queue_data_path: "${{ result.merge_queue_data_path }}"
     on_success: analyze_prs
@@ -158,7 +158,7 @@ steps:
       skill_command: "/autoskillit:analyze-prs ${{ inputs.base_branch }} merge_queue_data_path=${{ context.merge_queue_data_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "analyze_prs"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/analyze-prs
+      output_dir: "{{AUTOSKILLIT_TEMP}}/analyze-prs"
     capture:
       pr_order_file: "${{ result.pr_order_file }}"
       batch_branch: "${{ result.batch_branch }}"
@@ -667,7 +667,7 @@ steps:
       skill_command: "/autoskillit:diagnose-ci '${{ context.current_pr_number }}' - - - ${{ context.ci_event }}"
       cwd: "${{ context.work_dir }}"
       step_name: "diagnose_queue_ci"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci
+      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
     capture:
       diagnosis_path: "${{ result.diagnosis_path }}"
     on_success: register_clone_failure
@@ -746,7 +746,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "merge_pr"
       pr_order_file: "${{ context.pr_order_file }}"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/merge-pr
+      output_dir: "{{AUTOSKILLIT_TEMP}}/merge-pr"
     capture:
       needs_plan: "${{ result.needs_plan }}"
       escalation_required: "${{ result.escalation_required }}"
@@ -806,7 +806,7 @@ steps:
       skill_command: "/autoskillit:dry-walkthrough ${{ context.pr_plan_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "verify"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}
+      output_dir: "{{AUTOSKILLIT_TEMP}}"
     on_success: implement
     on_failure: register_clone_failure
     retries: 5
@@ -1163,7 +1163,7 @@ steps:
       skill_command: "/autoskillit:audit-impl \"${{ context.all_plan_paths }}\" ${{ context.batch_branch }} ${{ inputs.base_branch }} \"${{ context.all_conflict_report_paths }}\""
       cwd: "${{ context.work_dir }}"
       step_name: "audit_impl"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/audit-impl
+      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
     capture:
       verdict: "${{ result.verdict }}"
       remediation_path: "${{ result.remediation_path }}"
@@ -1202,7 +1202,7 @@ steps:
       batch_branch: "${{ context.batch_branch }}"
       base_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/open-integration-pr"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/open-integration-pr"
     capture:
       domain_partitions_path: "${{ result.domain_partitions_path }}"
     on_success: open_integration_pr
@@ -1220,7 +1220,7 @@ steps:
       skill_command: "/autoskillit:open-integration-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} ${{ context.pr_order_file }} ${{ context.verdict }} \"${{ context.all_conflict_report_paths }}\" domain_partitions_path=${{ context.domain_partitions_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "open_integration_pr"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/open-integration-pr
+      output_dir: "{{AUTOSKILLIT_TEMP}}/open-integration-pr"
     capture:
       pr_url: "${{ result.pr_url }}"
     on_success: wait_for_review_pr_mergeability
@@ -1327,7 +1327,7 @@ steps:
       callable: "autoskillit.smoke_utils.annotate_pr_diff"
       pr_number: "${{ context.review_pr_number }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
       local_review_rounds: "0"
     capture:
       annotated_diff_path: "${{ result.annotated_diff_path }}"
@@ -1348,7 +1348,7 @@ steps:
       skill_command: "/autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr_integration"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
     capture:
       review_verdict: "${{ result.verdict }}"
     on_result:
@@ -1481,7 +1481,7 @@ steps:
       skill_command: "/autoskillit:diagnose-ci ${{ context.batch_branch }} - - - ${{ context.ci_event }}"
       cwd: "${{ context.work_dir }}"
       step_name: "diagnose_ci"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci
+      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
     capture:
       diagnosis_path: "${{ result.diagnosis_path }}"
     on_success: register_clone_failure

--- a/src/autoskillit/recipes/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.json
@@ -33,7 +33,7 @@
         "skill_command": "/autoskillit:promote-to-main ${{ inputs.batch_branch }} ${{ inputs.base_branch }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "promote",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/promote-to-main"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/promote-to-main"
       },
       "capture": {
         "pr_url": "${{ result.pr_url }}",

--- a/src/autoskillit/recipes/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.yaml
@@ -34,7 +34,7 @@ steps:
       skill_command: "/autoskillit:promote-to-main ${{ inputs.batch_branch }} ${{ inputs.base_branch }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: "promote"
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/promote-to-main
+      output_dir: "{{AUTOSKILLIT_TEMP}}/promote-to-main"
     capture:
       pr_url: "${{ result.pr_url }}"
       verdict: "${{ result.verdict }}"

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -181,7 +181,7 @@
       "with": {
         "skill_command": "/autoskillit:rectify ${{ context.investigation_path }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/rectify",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/rectify",
         "step_name": "rectify"
       },
       "capture": {
@@ -202,7 +202,7 @@
         "skill_command": "/autoskillit:review-approach ${{ context.plan_path }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-approach"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-approach"
       },
       "capture": {
         "review_path": "${{ result.review_path }}"
@@ -220,7 +220,7 @@
       "with": {
         "skill_command": "/autoskillit:dry-walkthrough ${{ context.plan_path }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}",
         "review_path": "${{ context.review_path }}",
         "step_name": "dry_walkthrough"
       },
@@ -380,7 +380,7 @@
         "skill_command": "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.branch_name }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "audit_impl",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/audit-impl"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-impl"
       },
       "capture": {
         "remediation_path": "${{ result.remediation_path }}"
@@ -634,7 +634,7 @@
         "callable": "autoskillit.smoke_utils.annotate_pr_diff",
         "pr_number": "${{ context.pr_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr",
         "base_branch": "${{ inputs.base_branch }}",
         "local_review_rounds": "${{ inputs.local_review_rounds }}",
         "current_iteration": "${{ context.review_loop_count }}"
@@ -661,7 +661,7 @@
         "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review_pr",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr"
       },
       "capture": {
         "review_verdict": "${{ result.verdict }}"
@@ -1694,7 +1694,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "diagnose_ci",
         "ci_failed_jobs": "${{ context.ci_failed_jobs }}",
-        "output_dir": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
       },
       "capture": {
         "diagnosis_path": "${{ result.diagnosis_path }}"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -179,7 +179,7 @@ steps:
     with:
       skill_command: "/autoskillit:rectify ${{ context.investigation_path }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/rectify"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/rectify"
       step_name: "rectify"
     capture:
       plan_path: "${{ result.plan_path }}"
@@ -198,7 +198,7 @@ steps:
       skill_command: "/autoskillit:review-approach ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-approach
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-approach"
     capture:
       review_path: "${{ result.review_path }}"
     retries: 1
@@ -214,7 +214,7 @@ steps:
     with:
       skill_command: "/autoskillit:dry-walkthrough ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}"
+      output_dir: "{{AUTOSKILLIT_TEMP}}"
       review_path: "${{ context.review_path }}"
       step_name: "dry_walkthrough"
     on_success: implement
@@ -338,7 +338,7 @@ steps:
       skill_command: "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.branch_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "audit_impl"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/audit-impl
+      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
     capture:
       remediation_path: "${{ result.remediation_path }}"
     on_result:
@@ -570,7 +570,7 @@ steps:
       callable: "autoskillit.smoke_utils.annotate_pr_diff"
       pr_number: "${{ context.pr_number }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
       base_branch: "${{ inputs.base_branch }}"
       local_review_rounds: "${{ inputs.local_review_rounds }}"
       current_iteration: "${{ context.review_loop_count }}"
@@ -596,7 +596,7 @@ steps:
       skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/review-pr
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
     capture:
       review_verdict: "${{ result.verdict }}"
     on_result:
@@ -1524,7 +1524,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "diagnose_ci"
       ci_failed_jobs: "${{ context.ci_failed_jobs }}"
-      output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/diagnose-ci
+      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
     capture:
       diagnosis_path: "${{ result.diagnosis_path }}"
     on_success: resolve_ci

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -50,7 +50,7 @@
         "skill_command": "/autoskillit:scope ${{ inputs.task }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "scope",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/scope"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/scope"
       },
       "capture": {
         "scope_report": "${{ result.scope_report }}",
@@ -80,7 +80,7 @@
         "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.selected_directions }} ${{ context.revision_guidance }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_experiment",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/plan-experiment"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/plan-experiment"
       },
       "optional_context_refs": [
         "revision_guidance",
@@ -99,7 +99,7 @@
         "skill_command": "/autoskillit:review-design ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "review_design",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/review-design"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-design"
       },
       "capture": {
         "verdict": "${{ result.verdict }}",
@@ -140,7 +140,7 @@
         "skill_command": "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_visualization",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/plan-visualization"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/plan-visualization"
       },
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
@@ -191,7 +191,7 @@
         "skill_command": "/autoskillit:resolve-design-review ${{ context.evaluation_dashboard }} ${{ context.experiment_plan }} ${{ context.revision_guidance }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "resolve_design_review",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/resolve-design-review"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/resolve-design-review"
       },
       "optional_context_refs": [
         "evaluation_dashboard",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -61,7 +61,7 @@ steps:
       skill_command: "/autoskillit:scope ${{ inputs.task }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: scope
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/scope
+      output_dir: "{{AUTOSKILLIT_TEMP}}/scope"
     capture:
       scope_report: "${{ result.scope_report }}"
       scope_directions: "${{ result.scope_directions }}"
@@ -87,7 +87,7 @@ steps:
       skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.selected_directions }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: plan_experiment
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/plan-experiment
+      output_dir: "{{AUTOSKILLIT_TEMP}}/plan-experiment"
     optional_context_refs: [revision_guidance, selected_directions]
     capture:
       experiment_plan: "${{ result.experiment_plan }}"
@@ -101,7 +101,7 @@ steps:
       skill_command: "/autoskillit:review-design ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: review_design
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/review-design
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-design"
     capture:
       verdict: "${{ result.verdict }}"
       experiment_type: "${{ result.experiment_type }}"
@@ -129,7 +129,7 @@ steps:
       skill_command: "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: plan_visualization
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/plan-visualization
+      output_dir: "{{AUTOSKILLIT_TEMP}}/plan-visualization"
     capture:
       visualization_plan_path: "${{ result.visualization_plan_path }}"
       report_plan_path: "${{ result.report_plan_path }}"
@@ -174,7 +174,7 @@ steps:
       skill_command: "/autoskillit:resolve-design-review ${{ context.evaluation_dashboard }} ${{ context.experiment_plan }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: resolve_design_review
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/resolve-design-review
+      output_dir: "{{AUTOSKILLIT_TEMP}}/resolve-design-review"
     optional_context_refs: [evaluation_dashboard, experiment_plan, revision_guidance]
     capture:
       revision_guidance: "${{ result.revision_guidance }}"

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -78,7 +78,7 @@
         "skill_command": "/autoskillit:stage-data ${{ inputs.experiment_plan }}",
         "cwd": "${{ inputs.worktree_path }}",
         "step_name": "stage_data",
-        "output_dir": "${{ inputs.worktree_path }}/{{AUTOSKILLIT_TEMP}}/stage-data"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/stage-data"
       },
       "capture": {
         "verdict": "${{ result.verdict }}",
@@ -106,7 +106,7 @@
         "skill_command": "/autoskillit:download-data ${{ inputs.experiment_plan }}",
         "cwd": "${{ inputs.worktree_path }}",
         "step_name": "download_data",
-        "output_dir": "${{ inputs.worktree_path }}/{{AUTOSKILLIT_TEMP}}/download-data"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/download-data"
       },
       "capture": {
         "verdict": "${{ result.verdict }}",
@@ -130,7 +130,7 @@
         "skill_command": "/autoskillit:make-groups ${{ inputs.experiment_plan }}",
         "cwd": "${{ inputs.worktree_path }}",
         "step_name": "decompose",
-        "output_dir": "${{ inputs.worktree_path }}/{{AUTOSKILLIT_TEMP}}/make-groups"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/make-groups"
       },
       "capture": {
         "group_files": "${{ result.group_files }}"
@@ -188,7 +188,7 @@
         "skill_command": "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} implement_phase",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "troubleshoot_implement_failure",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
       },
       "capture": {
         "is_fixable": "${{ result.is_fixable }}",
@@ -306,7 +306,7 @@
         "skill_command": "/autoskillit:audit-impl ${{ context.group_files }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "audit_impl",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/audit-impl"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-impl"
       },
       "capture": {
         "remediation_path": "${{ result.remediation_path }}"
@@ -405,7 +405,7 @@
         "skill_command": "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} run_experiment",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "troubleshoot_run_failure",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
       },
       "capture": {
         "run_is_fixable": "${{ result.is_fixable }}",
@@ -532,7 +532,7 @@
         "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/generate-report"
       },
       "capture": {
         "report_path": "${{ result.report_path }}"
@@ -549,7 +549,7 @@
         "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report_inconclusive",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/generate-report"
       },
       "capture": {
         "report_path": "${{ result.report_path }}"

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -89,7 +89,7 @@ steps:
       skill_command: "/autoskillit:stage-data ${{ inputs.experiment_plan }}"
       cwd: "${{ inputs.worktree_path }}"
       step_name: stage_data
-      output_dir: ${{ inputs.worktree_path }}/{{AUTOSKILLIT_TEMP}}/stage-data
+      output_dir: "{{AUTOSKILLIT_TEMP}}/stage-data"
     capture:
       verdict: "${{ result.verdict }}"
       resource_report: "${{ result.resource_report }}"
@@ -119,7 +119,7 @@ steps:
       skill_command: "/autoskillit:download-data ${{ inputs.experiment_plan }}"
       cwd: "${{ inputs.worktree_path }}"
       step_name: download_data
-      output_dir: ${{ inputs.worktree_path }}/{{AUTOSKILLIT_TEMP}}/download-data
+      output_dir: "{{AUTOSKILLIT_TEMP}}/download-data"
     capture:
       verdict: "${{ result.verdict }}"
       download_report: "${{ result.download_report }}"
@@ -145,7 +145,7 @@ steps:
       skill_command: "/autoskillit:make-groups ${{ inputs.experiment_plan }}"
       cwd: "${{ inputs.worktree_path }}"
       step_name: decompose
-      output_dir: ${{ inputs.worktree_path }}/{{AUTOSKILLIT_TEMP}}/make-groups
+      output_dir: "{{AUTOSKILLIT_TEMP}}/make-groups"
     capture:
       group_files: "${{ result.group_files }}"
     on_success: plan_phase
@@ -213,7 +213,7 @@ steps:
       skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} implement_phase"
       cwd: "${{ inputs.source_dir }}"
       step_name: troubleshoot_implement_failure
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment
+      output_dir: "{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
     capture:
       is_fixable: "${{ result.is_fixable }}"
       retry_delay: "${{ result.retry_delay }}"
@@ -308,7 +308,7 @@ steps:
       skill_command: "/autoskillit:audit-impl ${{ context.group_files }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
       step_name: audit_impl
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/audit-impl
+      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
     capture:
       remediation_path: "${{ result.remediation_path }}"
     on_result:
@@ -394,7 +394,7 @@ steps:
       skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} run_experiment"
       cwd: "${{ inputs.source_dir }}"
       step_name: troubleshoot_run_failure
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment
+      output_dir: "{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
     capture:
       run_is_fixable: "${{ result.is_fixable }}"
       run_retry_delay: "${{ result.retry_delay }}"
@@ -497,7 +497,7 @@ steps:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}"
       cwd: "${{ context.worktree_path }}"
       step_name: generate_report
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report
+      output_dir: "{{AUTOSKILLIT_TEMP}}/generate-report"
     capture:
       report_path: "${{ result.report_path }}"
     on_success: test
@@ -512,7 +512,7 @@ steps:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}"
       cwd: "${{ context.worktree_path }}"
       step_name: generate_report_inconclusive
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report
+      output_dir: "{{AUTOSKILLIT_TEMP}}/generate-report"
     capture:
       report_path: "${{ result.report_path }}"
     on_success: test

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -201,7 +201,7 @@
         "skill_command": "/autoskillit:review-research-pr ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "review_research_pr",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/review-research-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-research-pr"
       },
       "capture": {
         "review_verdict": "${{ result.verdict }}"
@@ -229,7 +229,7 @@
         "skill_command": "/autoskillit:audit-claims ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "audit_claims",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/audit-claims"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-claims"
       },
       "capture": {
         "audit_verdict": "${{ result.verdict }}"
@@ -379,7 +379,7 @@
         "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "re_generate_report",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/generate-report"
       },
       "capture": {
         "report_path": "${{ result.report_path }}"

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -182,7 +182,7 @@ steps:
       skill_command: "/autoskillit:review-research-pr ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}"
       cwd: "${{ context.worktree_path }}"
       step_name: review_research_pr
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/review-research-pr
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-research-pr"
     capture:
       review_verdict: "${{ result.verdict }}"
     pass_through: [verdict]
@@ -209,7 +209,7 @@ steps:
       skill_command: "/autoskillit:audit-claims ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}"
       cwd: "${{ context.worktree_path }}"
       step_name: audit_claims
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/audit-claims
+      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-claims"
     capture:
       audit_verdict: "${{ result.verdict }}"
     pass_through: [verdict]
@@ -345,7 +345,7 @@ steps:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}"
       cwd: "${{ context.worktree_path }}"
       step_name: re_generate_report
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report
+      output_dir: "{{AUTOSKILLIT_TEMP}}/generate-report"
     capture:
       report_path: "${{ result.report_path }}"
     on_success: re_stage_bundle

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -76,7 +76,7 @@
         "skill_command": "/autoskillit:scope ${{ inputs.task }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "scope",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/scope"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/scope"
       },
       "capture": {
         "scope_report": "${{ result.scope_report }}",
@@ -106,7 +106,7 @@
         "skill_command": "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.selected_directions }} ${{ context.revision_guidance }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_experiment",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/plan-experiment"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/plan-experiment"
       },
       "optional_context_refs": [
         "revision_guidance",
@@ -125,7 +125,7 @@
         "skill_command": "/autoskillit:review-design ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "review_design",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/review-design"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-design"
       },
       "capture": {
         "verdict": "${{ result.verdict }}",
@@ -167,7 +167,7 @@
         "skill_command": "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "plan_visualization",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/plan-visualization"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/plan-visualization"
       },
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
@@ -221,7 +221,7 @@
         "skill_command": "/autoskillit:resolve-design-review ${{ context.evaluation_dashboard }} ${{ context.experiment_plan }} ${{ context.revision_guidance }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "resolve_design_review",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/resolve-design-review"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/resolve-design-review"
       },
       "optional_context_refs": [
         "evaluation_dashboard",
@@ -275,7 +275,7 @@
         "skill_command": "/autoskillit:stage-data ${{ context.experiment_plan }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "stage_data",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/stage-data"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/stage-data"
       },
       "capture": {
         "verdict": "${{ result.verdict }}",
@@ -303,7 +303,7 @@
         "skill_command": "/autoskillit:download-data ${{ context.experiment_plan }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "download_data",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/download-data"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/download-data"
       },
       "capture": {
         "verdict": "${{ result.verdict }}",
@@ -327,7 +327,7 @@
         "skill_command": "/autoskillit:setup-environment ${{ context.worktree_path }} ${{ context.experiment_plan }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "setup_environment",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/setup-environment"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/setup-environment"
       },
       "capture": {
         "verdict": "${{ result.verdict }}"
@@ -353,7 +353,7 @@
         "skill_command": "/autoskillit:make-groups ${{ context.experiment_plan }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "decompose",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/make-groups"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/make-groups"
       },
       "capture": {
         "group_files": "${{ result.group_files }}"
@@ -425,7 +425,7 @@
         "skill_command": "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} implement_phase",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "troubleshoot_implement_failure",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
       },
       "capture": {
         "is_fixable": "${{ result.is_fixable }}",
@@ -543,7 +543,7 @@
         "skill_command": "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "audit_impl",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/audit-impl"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-impl"
       },
       "capture": {
         "remediation_path": "${{ result.remediation_path }}"
@@ -605,7 +605,7 @@
         "skill_command": "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} run_experiment",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "troubleshoot_run_failure",
-        "output_dir": "${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
       },
       "capture": {
         "run_is_fixable": "${{ result.is_fixable }}",
@@ -733,7 +733,7 @@
         "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/generate-report"
       },
       "capture": {
         "report_path": "${{ result.report_path }}"
@@ -750,7 +750,7 @@
         "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "generate_report",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/generate-report"
       },
       "capture": {
         "report_path": "${{ result.report_path }}"
@@ -914,7 +914,7 @@
         "skill_command": "/autoskillit:review-research-pr ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "review_research_pr",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/review-research-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-research-pr"
       },
       "capture": {
         "review_verdict": "${{ result.verdict }}"
@@ -939,7 +939,7 @@
         "skill_command": "/autoskillit:audit-claims ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "audit_claims",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/audit-claims"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-claims"
       },
       "capture": {
         "audit_verdict": "${{ result.verdict }}"
@@ -1076,7 +1076,7 @@
         "skill_command": "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "re_generate_report",
-        "output_dir": "${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/generate-report"
       },
       "capture": {
         "report_path": "${{ result.report_path }}"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -117,7 +117,7 @@ steps:
       skill_command: "/autoskillit:scope ${{ inputs.task }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: scope
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/scope
+      output_dir: "{{AUTOSKILLIT_TEMP}}/scope"
     capture:
       scope_report: "${{ result.scope_report }}"
       scope_directions: "${{ result.scope_directions }}"
@@ -143,7 +143,7 @@ steps:
       skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.selected_directions }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: plan_experiment
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/plan-experiment
+      output_dir: "{{AUTOSKILLIT_TEMP}}/plan-experiment"
     optional_context_refs: [revision_guidance, selected_directions]
     capture:
       experiment_plan: "${{ result.experiment_plan }}"
@@ -157,7 +157,7 @@ steps:
       skill_command: "/autoskillit:review-design ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: review_design
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/review-design
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-design"
     capture:
       verdict: "${{ result.verdict }}"
       experiment_type: "${{ result.experiment_type }}"
@@ -186,7 +186,7 @@ steps:
       skill_command: "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: plan_visualization
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/plan-visualization
+      output_dir: "{{AUTOSKILLIT_TEMP}}/plan-visualization"
     capture:
       visualization_plan_path: "${{ result.visualization_plan_path }}"
       report_plan_path: "${{ result.report_plan_path }}"
@@ -233,7 +233,7 @@ steps:
       skill_command: "/autoskillit:resolve-design-review ${{ context.evaluation_dashboard }} ${{ context.experiment_plan }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: resolve_design_review
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/resolve-design-review
+      output_dir: "{{AUTOSKILLIT_TEMP}}/resolve-design-review"
     optional_context_refs: [evaluation_dashboard, experiment_plan, revision_guidance]
     capture:
       revision_guidance: "${{ result.revision_guidance }}"
@@ -286,7 +286,7 @@ steps:
       skill_command: "/autoskillit:stage-data ${{ context.experiment_plan }}"
       cwd: "${{ context.worktree_path }}"
       step_name: stage_data
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/stage-data
+      output_dir: "{{AUTOSKILLIT_TEMP}}/stage-data"
     capture:
       verdict: "${{ result.verdict }}"
       resource_report: "${{ result.resource_report }}"
@@ -316,7 +316,7 @@ steps:
       skill_command: "/autoskillit:download-data ${{ context.experiment_plan }}"
       cwd: "${{ context.worktree_path }}"
       step_name: download_data
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/download-data
+      output_dir: "{{AUTOSKILLIT_TEMP}}/download-data"
     capture:
       verdict: "${{ result.verdict }}"
       download_report: "${{ result.download_report }}"
@@ -342,7 +342,7 @@ steps:
       skill_command: "/autoskillit:setup-environment ${{ context.worktree_path }} ${{ context.experiment_plan }}"
       cwd: "${{ context.worktree_path }}"
       step_name: setup_environment
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/setup-environment
+      output_dir: "{{AUTOSKILLIT_TEMP}}/setup-environment"
     capture:
       verdict: "${{ result.verdict }}"
     on_result:
@@ -370,7 +370,7 @@ steps:
       skill_command: "/autoskillit:make-groups ${{ context.experiment_plan }}"
       cwd: "${{ context.worktree_path }}"
       step_name: decompose
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/make-groups
+      output_dir: "{{AUTOSKILLIT_TEMP}}/make-groups"
     capture:
       group_files: "${{ result.group_files }}"
     on_success: capture_impl_base
@@ -452,7 +452,7 @@ steps:
       skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} implement_phase"
       cwd: "${{ inputs.source_dir }}"
       step_name: troubleshoot_implement_failure
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment
+      output_dir: "{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
     capture:
       is_fixable: "${{ result.is_fixable }}"
       retry_delay: "${{ result.retry_delay }}"
@@ -547,7 +547,7 @@ steps:
       skill_command: "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
       step_name: audit_impl
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/audit-impl
+      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
     capture:
       remediation_path: "${{ result.remediation_path }}"
     on_result:
@@ -601,7 +601,7 @@ steps:
       skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} run_experiment"
       cwd: "${{ inputs.source_dir }}"
       step_name: troubleshoot_run_failure
-      output_dir: ${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment
+      output_dir: "{{AUTOSKILLIT_TEMP}}/troubleshoot-experiment"
     capture:
       run_is_fixable: "${{ result.is_fixable }}"
       run_retry_delay: "${{ result.retry_delay }}"
@@ -704,7 +704,7 @@ steps:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: generate_report
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report
+      output_dir: "{{AUTOSKILLIT_TEMP}}/generate-report"
     capture:
       report_path: "${{ result.report_path }}"
     on_success: test
@@ -719,7 +719,7 @@ steps:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: generate_report
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report
+      output_dir: "{{AUTOSKILLIT_TEMP}}/generate-report"
     capture:
       report_path: "${{ result.report_path }}"
     on_success: test
@@ -868,7 +868,7 @@ steps:
       skill_command: "/autoskillit:review-research-pr ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}"
       cwd: "${{ context.worktree_path }}"
       step_name: review_research_pr
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/review-research-pr
+      output_dir: "{{AUTOSKILLIT_TEMP}}/review-research-pr"
     capture:
       review_verdict: "${{ result.verdict }}"
     pass_through: [verdict]
@@ -894,7 +894,7 @@ steps:
       skill_command: "/autoskillit:audit-claims ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}"
       cwd: "${{ context.worktree_path }}"
       step_name: audit_claims
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/audit-claims
+      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-claims"
     capture:
       audit_verdict: "${{ result.verdict }}"
     pass_through: [verdict]
@@ -1022,7 +1022,7 @@ steps:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }} --experiment-type '${{ context.experiment_type }}' --methodology-traditions '${{ context.methodology_tradition }}' --design-review-verdict '${{ context.verdict }}' --disambiguation-rule-applied '${{ context.disambiguation_rule_applied }}' --tier-c-lens '${{ context.tier_c_lens }}' --classification-timestamp '${{ context.classification_timestamp }}' --group-manifest '${{ context.group_manifest }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: re_generate_report
-      output_dir: ${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/generate-report
+      output_dir: "{{AUTOSKILLIT_TEMP}}/generate-report"
     capture:
       report_path: "${{ result.report_path }}"
     on_success: re_stage_bundle

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -78,6 +78,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_recipe_ci_watch_event.py` | Tests for CI watch event in recipe steps |
 | `test_recipe_dry_walkthrough_scope.py` | Regression test: dry-walkthrough output_dir must not scope to /dry-walkthrough subdirectory (#2919) |
 | `test_recipe_order.py` | Tests for BUNDLED_RECIPE_ORDER stable display order registry |
+| `test_recipe_output_dir_resolvability.py` | Guard: recipe output_dir values must be server-resolvable (no ${{ }} templates) |
 | `test_report_frontmatter_schema.py` | Tests for report.md YAML frontmatter audit-trail schema |
 | `test_recipe_scripts.py` | Tests for recipe script callables |
 | `test_recipe_temp_substitution.py` | Tests for {{AUTOSKILLIT_TEMP}} substitution in recipe steps |

--- a/tests/recipe/test_recipe_dry_walkthrough_scope.py
+++ b/tests/recipe/test_recipe_dry_walkthrough_scope.py
@@ -38,3 +38,21 @@ def test_dry_walkthrough_output_dir_does_not_scope_to_subdirectory(
             f"/dry-walkthrough subdirectory — dry-walkthrough edits plan files "
             f"at make-plan/ or rectify/ locations (issue #2919)"
         )
+
+
+@pytest.mark.parametrize("recipe_name", _RECIPES_WITH_DRY_WALKTHROUGH)
+def test_dry_walkthrough_output_dir_is_server_resolvable(
+    recipe_name: str,
+) -> None:
+    """dry-walkthrough output_dir must be free of ${{ }} templates."""
+    recipe_path = pkg_root() / "recipes" / f"{recipe_name}.yaml"
+    recipe = load_recipe(recipe_path)
+    for step_name, step in recipe.steps.items():
+        cmd = (step.with_args or {}).get("skill_command", "")
+        if "dry-walkthrough" not in cmd:
+            continue
+        output_dir = (step.with_args or {}).get("output_dir", "")
+        assert "${{" not in output_dir, (
+            f"{recipe_name}.{step_name}: output_dir '{output_dir}' contains "
+            f"${{{{ }}}} — server auto-fill cannot resolve this."
+        )

--- a/tests/recipe/test_recipe_output_dir_resolvability.py
+++ b/tests/recipe/test_recipe_output_dir_resolvability.py
@@ -1,0 +1,64 @@
+"""Verify recipe output_dir values are server-resolvable after serve-time substitution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.recipe import load_recipe
+from autoskillit.recipe.repository import DefaultRecipeRepository
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
+
+RELATIVE_OUTPUT_DIR_RECIPES = [
+    "implementation",
+    "implementation-groups",
+    "remediation",
+    "merge-prs",
+    "research",
+    "research-design",
+    "research-implement",
+    "research-review",
+    "promote-to-main-wrapper",
+    "implement-findings",
+]
+
+ABSOLUTE_OUTPUT_DIR_RECIPES = ["planner"]
+
+
+@pytest.mark.parametrize("recipe_name", RELATIVE_OUTPUT_DIR_RECIPES)
+def test_output_dir_values_are_server_resolvable(recipe_name: str) -> None:
+    """Every output_dir in with_args must NOT contain ${{ }} after serve-time substitution."""
+    repo = DefaultRecipeRepository()
+    recipe_info = repo.find(recipe_name, Path.cwd())
+    assert recipe_info is not None, f"Recipe {recipe_name} not found"
+    recipe = load_recipe(recipe_info.path)
+    for step_name, step in recipe.steps.items():
+        if "output_dir" in step.with_args:
+            output_dir = step.with_args["output_dir"]
+            assert "${{" not in output_dir, (
+                f"Recipe '{recipe_name}', step '{step_name}': output_dir "
+                f"'{output_dir}' contains unresolvable ${{{{ }}}} template. "
+                f"Use a relative path (e.g., '.autoskillit/temp/skill-name') instead."
+            )
+
+
+@pytest.mark.parametrize("recipe_name", ABSOLUTE_OUTPUT_DIR_RECIPES)
+def test_absolute_output_dir_recipes_have_template_refs(recipe_name: str) -> None:
+    """Absolute-path recipes MUST have ${{ }} in output_dir — they rely on LLM cooperation."""
+    repo = DefaultRecipeRepository()
+    recipe_info = repo.find(recipe_name, Path.cwd())
+    assert recipe_info is not None
+    recipe = load_recipe(recipe_info.path)
+    has_output_dir = False
+    for step_name, step in recipe.steps.items():
+        if "output_dir" in step.with_args:
+            has_output_dir = True
+            output_dir = step.with_args["output_dir"]
+            assert "${{" in output_dir, (
+                f"Recipe '{recipe_name}', step '{step_name}': output_dir "
+                f"'{output_dir}' is NOT a ${{{{ }}}} template but recipe is in "
+                f"ABSOLUTE_OUTPUT_DIR_RECIPES — update the test categorization."
+            )
+    assert has_output_dir, f"Recipe '{recipe_name}' has no output_dir in with_args"

--- a/tests/recipe/test_rules_temp_path.py
+++ b/tests/recipe/test_rules_temp_path.py
@@ -28,8 +28,7 @@ class TestNonUniqueOutputPath:
         )
         findings = run_semantic_rules(wf)
         assert not any(
-            f.rule == "non-unique-output-path" and f.step_name == "init_step"
-            for f in findings
+            f.rule == "non-unique-output-path" and f.step_name == "init_step" for f in findings
         )
 
     def test_bare_temp_path_without_suffix_in_output_dir_errors(self) -> None:
@@ -68,8 +67,7 @@ class TestNonUniqueOutputPath:
         )
         findings = run_semantic_rules(wf)
         assert not any(
-            f.rule == "non-unique-output-path" and f.step_name == "verify"
-            for f in findings
+            f.rule == "non-unique-output-path" and f.step_name == "verify" for f in findings
         )
 
     def test_bare_temp_path_in_cmd_errors(self) -> None:

--- a/tests/recipe/test_rules_temp_path.py
+++ b/tests/recipe/test_rules_temp_path.py
@@ -12,7 +12,7 @@ pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 class TestNonUniqueOutputPath:
-    def test_bare_temp_path_in_output_dir_errors(self) -> None:
+    def test_relative_temp_path_with_suffix_in_output_dir_passes(self) -> None:
         wf = _make_workflow(
             {
                 "init_step": {
@@ -27,8 +27,50 @@ class TestNonUniqueOutputPath:
             }
         )
         findings = run_semantic_rules(wf)
+        assert not any(
+            f.rule == "non-unique-output-path" and f.step_name == "init_step"
+            for f in findings
+        )
+
+    def test_bare_temp_path_without_suffix_in_output_dir_errors(self) -> None:
+        wf = _make_workflow(
+            {
+                "init_step": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": "/autoskillit:make-plan task",
+                        "output_dir": "{{AUTOSKILLIT_TEMP}}",
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(wf)
         errors = [f for f in findings if f.rule == "non-unique-output-path"]
         assert any(f.severity == Severity.ERROR and f.step_name == "init_step" for f in errors)
+
+    def test_bare_temp_path_without_suffix_in_output_dir_passes_for_dry_walkthrough(
+        self,
+    ) -> None:
+        wf = _make_workflow(
+            {
+                "verify": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": "/autoskillit:dry-walkthrough plan.md",
+                        "output_dir": "{{AUTOSKILLIT_TEMP}}",
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(wf)
+        assert not any(
+            f.rule == "non-unique-output-path" and f.step_name == "verify"
+            for f in findings
+        )
 
     def test_bare_temp_path_in_cmd_errors(self) -> None:
         wf = _make_workflow(

--- a/tests/server/test_tools_execution_step_resolution.py
+++ b/tests/server/test_tools_execution_step_resolution.py
@@ -138,3 +138,62 @@ async def test_run_skill_logs_warning_when_output_dir_resolved_from_recipe(
         await run_skill("/dry-walkthrough ...", str(tmp_path), step_name="verify")
 
     assert any(entry.get("event") == "output_dir_resolved_from_recipe" for entry in cap)
+
+
+@pytest.mark.anyio
+async def test_run_skill_skips_auto_fill_when_output_dir_has_template(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """When recipe step output_dir has ${{ }}, auto-fill MUST skip AND fallback
+    to resolve_skill_temp_dir — producing the correct skill-scoped prefix."""
+    from autoskillit.recipe.schema import RecipeStep
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.active_recipe_steps = {
+        "verify": RecipeStep(
+            name="verify",
+            with_args={
+                "output_dir": "${{ context.work_dir }}/.autoskillit/temp",
+                "skill_command": "/autoskillit:dry-walkthrough path/to/plan.md",
+            },
+        )
+    }
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill(
+        skill_command="/autoskillit:dry-walkthrough path/to/plan.md",
+        cwd=str(tmp_path),
+        step_name="verify",
+    )
+    expected = str(tmp_path / ".autoskillit" / "temp" / "dry-walkthrough") + "/"
+    assert executor.calls[0].allowed_write_prefix == expected
+
+
+@pytest.mark.anyio
+async def test_run_skill_auto_fills_relative_output_dir_from_recipe(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """When recipe step output_dir is a server-resolvable relative path,
+    auto-fill MUST resolve it against cwd and produce the correct prefix."""
+    from autoskillit.recipe.schema import RecipeStep
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.active_recipe_steps = {
+        "verify": RecipeStep(
+            name="verify",
+            with_args={"output_dir": ".autoskillit/temp"},
+        )
+    }
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill(
+        skill_command="/autoskillit:dry-walkthrough path/to/plan.md",
+        cwd=str(tmp_path),
+        step_name="verify",
+    )
+    expected = str(tmp_path / ".autoskillit" / "temp") + "/"
+    assert executor.calls[0].allowed_write_prefix == expected


### PR DESCRIPTION
## Summary

The dry-walkthrough step fails to stamp `Dry-walkthrough verified = TRUE` on the original plan file during pipeline runs because the recipe's `output_dir` value (`${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}`) contains a `${{ }}` runtime template that triggers a skip guard in the server-side auto-fill logic. When the LLM omits `output_dir` from the `run_skill` call, the server cannot auto-fill it and falls back to a narrow skill-specific prefix that blocks writes to the plan file. The fix: change `output_dir` to a relative path (`"{{AUTOSKILLIT_TEMP}}"`) resolvable by the server without LLM cooperation, and add a lint rule to prevent `${{ }}` templates in `output_dir` values going forward.

## Requirements

## Problem

The dry-walkthrough step fails to stamp `Dry-walkthrough verified = TRUE` on the original plan file during pipeline runs. Instead, it writes findings or a stamped copy to `.autoskillit/temp/dry-walkthrough/` while the original plan at `.autoskillit/temp/make-plan/` remains unmodified.

This is a **non-deterministic** failure — it depends on whether the LLM orchestrator (food truck) forwards the `output_dir` parameter when calling `run_skill`. When it does, everything works. When it omits it, the write guard blocks edits to the plan file.

## Root Cause

The recipe's verify step defines:

```yaml
output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}
```

At recipe-serve time, `{{AUTOSKILLIT_TEMP}}` resolves to `.autoskillit/temp`, but `${{ context.work_dir }}` is a **runtime template** intended for the LLM orchestrator. The server-side auto-fill in `tools_execution.py:398` explicitly skips values containing `${{`:

```python
if "${{" not in _recipe_output_dir:
    output_dir = _recipe_output_dir   # ← SKIPPED because "${{" is present
```

When the LLM omits `output_dir` from the `run_skill` call, the server cannot auto-fill it. It falls back to `resolve_skill_temp_dir()` (`core/io.py:91-101`), which returns `{cwd}/.autoskillit/temp/dry-walkthrough/` — the **narrow** skill-specific prefix that blocks edits to `make-plan/` files.

### Failure Chain

1. Recipe step defines `output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}`
2. `{{AUTOSKILLIT_TEMP}}` → `.autoskillit/temp` (resolved at serve time)
3. `${{ context.work_dir }}` remains unresolved (LLM runtime template)
4. LLM omits `output_dir` when calling `run_skill`
5. Server-side auto-fill skips it (line 398: `"${{"` detected in value)
6. Fallback: `resolve_skill_temp_dir(cwd, skill_command)` → `{cwd}/.autoskillit/temp/dry-walkthrough/`
7. Write guard prefix = `.autoskillit/temp/dry-walkthrough/`
8. Edit to `.autoskillit/temp/make-plan/*.md` → **BLOCKED**
9. Skill writes to allowed directory instead, original plan never stamped

### Why the d85432f7f Fix Didn't Fully Work

Commit d85432f7f correctly widened `output_dir` from `.../dry-walkthrough` to `.../{{AUTOSKILLIT_TEMP}}`. The value is correct — **if** the LLM passes it to `run_skill`. But the `${{ context.work_dir }}` prefix prevents server-side auto-fill from kicking in when the LLM omits it. The fix only works when the LLM correctly resolves and forwards the parameter, which is non-deterministic.

## Observed Behavior (Pipeline Run 2026-05-24)

- **Pipeline A** (p6_a5_wp1): Write guard blocked Edit. Session wrote `walkthrough-findings-p6_a5_wp1.md` to `dry-walkthrough/` subdirectory. Original plan not stamped. Food truck LLM manually stamped it between steps (outside any headless session).
- **Pipeline B** (p6_a7_wp1): Write guard blocked Edit. Session wrote a complete stamped copy to `dry-walkthrough/` subdirectory. Food truck then pointed `implement-worktree-no-merge` at this copy instead of the original plan — compounding failure.
- **Pipeline C** (p7+ waves): LLM correctly forwarded `output_dir` — stamping worked as expected.

## Affected Files

- `src/autoskillit/server/tools/tools_execution.py:393-404` — server-side auto-fill skip logic
- `src/autoskillit/core/io.py:91-101` — `resolve_skill_temp_dir` fallback returns narrow prefix
- `src/autoskillit/recipes/implementation.yaml:218` — `output_dir` with unresolvable template
- Same pattern in `implementation-groups.yaml`, `remediation.yaml`, `merge-prs.yaml`

## Recommended Fix

**Option A (simplest):** Change the recipe YAML `output_dir` to a relative path:

```yaml
# Before:
output_dir: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}
# After:
output_dir: "{{AUTOSKILLIT_TEMP}}"
```

The server already resolves relative paths against `cwd` at `tools_execution.py:425-426`:
```python
if not resolved_dir.is_absolute():
    resolved_dir = Path(cwd) / output_dir
```

This sidesteps the `${{ }}` problem entirely. After `{{AUTOSKILLIT_TEMP}}` resolves at serve time, the value becomes `.autoskillit/temp` (no `${{`), so server-side auto-fill works.

**Option B:** In the server-side auto-fill, substitute `${{ context.work_dir }}` with the `cwd` parameter (always available and semantically equivalent) before checking for `${{`.

**Option A is preferred** — it's a simpler change with no auto-fill logic modifications.

## Test Gap

- `test_recipe_dry_walkthrough_scope.py` only checks that `output_dir` doesn't end with `/dry-walkthrough`. It doesn't verify the value is server-resolvable (i.e., free of `${{ }}` templates).
- Add a test that asserts `output_dir` values in dry-walkthrough steps do not contain `${{ }}` templates, or that the server-side auto-fill correctly resolves them.

Closes #2984

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260524-210429-424381/.autoskillit/temp/rectify/rectify_output_dir_template_bypass_2026-05-24_210429.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 6.0k | 30.0k | 2.9M | 130.1k | 364 | 139.0k | 24m 34s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 72 | 16.9k | 2.4M | 92.2k | 238 | 92.6k | 10m 9s |
| implement | claude-opus-4-6 | 1 | 127 | 28.0k | 6.0M | 99.7k | 183 | 83.3k | 10m 49s |
| prepare_pr* | MiniMax-M2.7 | 1 | 51.4k | 5.4k | 265.4k | 0 | 18 | 0 | 1m 54s |
| compose_pr* | MiniMax-M2.7 | 1 | 44.2k | 2.7k | 326.7k | 0 | 19 | 0 | 1m 10s |
| review_pr | claude-opus-4-6 | 1 | 49 | 14.5k | 838.8k | 101.2k | 68 | 85.6k | 5m 20s |
| resolve_review | claude-opus-4-6 | 1 | 54 | 10.9k | 1.6M | 72.4k | 52 | 56.7k | 5m 28s |
| **Total** | | | 101.9k | 108.3k | 14.4M | 130.1k | | 457.3k | 59m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 519 | 11551.7 | 160.6 | 54.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **519** | 27701.0 | 881.1 | 208.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 6.0k | 46.9k | 5.3M | 231.6k | 34m 44s |
| claude-opus-4-6 | 3 | 230 | 53.4k | 8.5M | 225.7k | 21m 39s |
| MiniMax-M2.7 | 2 | 95.6k | 8.1k | 592.1k | 0 | 3m 5s |