### PR TITLE
[FEATURE] Data-Layer Foundation for CodexScenarioPlayer

### DIFF
--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -12,3 +12,4 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 | `codex.py` | `CodexFlags`, `CodexBackend`, `CodexEnvPolicy`, `CodexSessionLocator` (parse/config moved to `_codex_parse.py` / `_codex_config.py`) |
 | `_codex_config.py` | TOML serialization with `[[key]]` array-of-tables support, MCP registration (`ensure_codex_mcp_registered`, `_serialize_toml`) |
 | `_codex_parse.py` | `CodexStreamParser`, `CodexResultParser`, `_scan_codex_ndjson`, `_CodexParseAccumulator` |
+| `codex_scenario_player.py` | `CodexScenarioPlayer`, `make_codex_scenario_player`, `CodexStepRecord`, `CodexScenario`, `_load_manifest`, `_FakeCodexCLI`, `_write_shim_script` — scenario replay data layer for Codex backend |

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -21,6 +21,10 @@ from .codex import (
     CodexFlags,
     CodexSessionLocator,
 )
+from .codex_scenario_player import (
+    CodexScenarioPlayer,
+    make_codex_scenario_player,
+)
 
 BACKEND_REGISTRY: dict[str, type[CodingAgentBackend]] = {
     "claude-code": ClaudeCodeBackend,
@@ -49,8 +53,10 @@ __all__ = [
     "CodexEnvPolicy",
     "CodexFlags",
     "CodexResultParser",
+    "CodexScenarioPlayer",
     "CodexSessionLocator",
     "CodexStreamParser",
     "ensure_codex_mcp_registered",
     "get_backend",
+    "make_codex_scenario_player",
 ]

--- a/src/autoskillit/execution/backends/codex_scenario_player.py
+++ b/src/autoskillit/execution/backends/codex_scenario_player.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import stat
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/autoskillit/execution/backends/codex_scenario_player.py
+++ b/src/autoskillit/execution/backends/codex_scenario_player.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from autoskillit.core.io import atomic_write
+
 __all__ = ["CodexScenarioPlayer", "make_codex_scenario_player"]
 
 
@@ -52,7 +54,7 @@ sys.exit(0)
 
 def _write_shim_script(output_dir: Path, binary_path: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
-    binary_path.write_text(f"#!/usr/bin/env python3\n{_CODEX_SHIM_SCRIPT}")
+    atomic_write(binary_path, f"#!/usr/bin/env python3\n{_CODEX_SHIM_SCRIPT}")
     binary_path.chmod(binary_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
 

--- a/src/autoskillit/execution/backends/codex_scenario_player.py
+++ b/src/autoskillit/execution/backends/codex_scenario_player.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = ["CodexScenarioPlayer", "make_codex_scenario_player"]
+
+
+@dataclass(frozen=True, slots=True)
+class _CodexRunResult:
+    stdout: str
+
+
+@dataclass(frozen=True, slots=True)
+class CodexStepRecord:
+    step_name: str
+    exit_code: int
+    duration_ms: int
+    model: str
+    stdout_path: Path | None
+    result_summary: dict[str, Any] | None = None
+
+    @property
+    def session_dir(self) -> Path | None:
+        if self.stdout_path is None:
+            return None
+        return self.stdout_path.parent
+
+
+@dataclass(frozen=True, slots=True)
+class CodexScenario:
+    step_sequence: tuple[CodexStepRecord, ...]
+
+
+class _FakeCodexCLI:
+    def __init__(self, stdout_path: Path) -> None:
+        self._stdout_path = stdout_path
+
+    def run(self) -> _CodexRunResult:
+        return _CodexRunResult(stdout=self._stdout_path.read_text(encoding="utf-8"))
+
+
+_CODEX_SHIM_SCRIPT = """\
+import os, sys
+sys.stdout.write(os.environ["CODEX_REPLAY_CASSETTE"])
+sys.exit(0)
+"""
+
+
+def _write_shim_script(output_dir: Path, binary_path: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    binary_path.write_text(f"#!/usr/bin/env python3\n{_CODEX_SHIM_SCRIPT}")
+    binary_path.chmod(binary_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _load_manifest(scenario_dir: Path) -> CodexScenario:
+    raw = json.loads((scenario_dir / "scenario.json").read_text(encoding="utf-8"))
+    steps: list[CodexStepRecord] = []
+    for entry in raw:
+        stdout_path_raw = entry.get("stdout_path")
+        stdout_path = scenario_dir / stdout_path_raw if stdout_path_raw is not None else None
+        steps.append(
+            CodexStepRecord(
+                step_name=entry["step_name"],
+                exit_code=entry["exit_code"],
+                duration_ms=entry["duration_ms"],
+                model=entry["model"],
+                stdout_path=stdout_path,
+                result_summary=entry.get("result_summary"),
+            )
+        )
+    return CodexScenario(step_sequence=tuple(steps))
+
+
+class CodexScenarioPlayer:
+    def __init__(
+        self,
+        scenario_dir: str | Path,
+        output_dir: str | Path,
+        binary_path: str | Path,
+    ) -> None:
+        self._scenario_dir = Path(scenario_dir)
+        self._output_dir = Path(output_dir)
+        self._binary_path = Path(binary_path)
+        _write_shim_script(self._output_dir, self._binary_path)
+
+    def scenario(self) -> CodexScenario:
+        return _load_manifest(self._scenario_dir)
+
+    def build_session_map(self) -> dict[str, list[tuple[_FakeCodexCLI, CodexStepRecord]]]:
+        scenario = self.scenario()
+        session_map: dict[str, list[tuple[_FakeCodexCLI, CodexStepRecord]]] = {}
+        for record in scenario.step_sequence:
+            if record.stdout_path is None:
+                continue
+            cli = _FakeCodexCLI(record.stdout_path)
+            session_map.setdefault(record.step_name, []).append((cli, record))
+        return session_map
+
+
+def make_codex_scenario_player(
+    scenario_dir: str,
+    output_dir: str,
+    binary_path: str,
+) -> CodexScenarioPlayer:
+    return CodexScenarioPlayer(
+        scenario_dir=scenario_dir,
+        output_dir=output_dir,
+        binary_path=binary_path,
+    )

--- a/src/autoskillit/execution/backends/codex_scenario_player.py
+++ b/src/autoskillit/execution/backends/codex_scenario_player.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core.io import atomic_write
+from autoskillit.core import atomic_write
 
 __all__ = ["CodexScenarioPlayer", "make_codex_scenario_player"]
 

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -49,9 +49,11 @@ class TestBackendRegistry:
             "CodexEnvPolicy",
             "CodexFlags",
             "CodexResultParser",
+            "CodexScenarioPlayer",
             "CodexSessionLocator",
             "CodexStreamParser",
             "ensure_codex_mcp_registered",
             "get_backend",
+            "make_codex_scenario_player",
         }
         assert set(all_exports) == expected

--- a/tests/execution/backends/test_backends_split_integrity.py
+++ b/tests/execution/backends/test_backends_split_integrity.py
@@ -60,6 +60,22 @@ class TestCodexParseModuleExists:
         assert callable(_scan_codex_ndjson)
 
 
+class TestCodexScenarioPlayerModuleExists:
+    """codex_scenario_player symbols are importable."""
+
+    def test_codex_scenario_player_importable(self):
+        from autoskillit.execution.backends.codex_scenario_player import CodexScenarioPlayer
+
+        assert CodexScenarioPlayer is not None
+
+    def test_make_codex_scenario_player_importable(self):
+        from autoskillit.execution.backends.codex_scenario_player import (
+            make_codex_scenario_player,
+        )
+
+        assert callable(make_codex_scenario_player)
+
+
 class TestBackendsPublicAPISurfacePreserved:
     """All __all__ symbols from backends/__init__ are importable."""
 
@@ -82,3 +98,13 @@ class TestBackendsPublicAPISurfacePreserved:
         from autoskillit.execution.backends import get_backend
 
         assert callable(get_backend)
+
+    def test_codex_scenario_player_importable_from_backends(self):
+        from autoskillit.execution.backends import CodexScenarioPlayer
+
+        assert CodexScenarioPlayer is not None
+
+    def test_make_codex_scenario_player_importable_from_backends(self):
+        from autoskillit.execution.backends import make_codex_scenario_player
+
+        assert callable(make_codex_scenario_player)

--- a/tests/execution/backends/test_codex_scenario_player.py
+++ b/tests/execution/backends/test_codex_scenario_player.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autoskillit.execution.backends.codex_scenario_player import (
+    CodexScenario,
+    CodexScenarioPlayer,
+    CodexStepRecord,
+    _CodexRunResult,
+    _FakeCodexCLI,
+    _load_manifest,
+    _write_shim_script,
+    make_codex_scenario_player,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
+
+
+def _write_scenario(tmp_path: Path, steps: list[dict[str, Any]]) -> Path:
+    scenario_file = tmp_path / "scenario.json"
+    scenario_file.write_text(json.dumps(steps))
+    return scenario_file
+
+
+def _make_step_dict(
+    step_name: str,
+    exit_code: int = 0,
+    duration_ms: int = 100,
+    model: str = "o3",
+    stdout_path: str | None = None,
+    result_summary: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    d: dict[str, Any] = {
+        "step_name": step_name,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+        "model": model,
+        "stdout_path": stdout_path,
+    }
+    if result_summary is not None:
+        d["result_summary"] = result_summary
+    return d
+
+
+class TestCodexStepRecordFields:
+    def test_is_frozen_dataclass(self) -> None:
+        record = CodexStepRecord(
+            step_name="s1", exit_code=0, duration_ms=100, model="o3", stdout_path=None
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            record.step_name = "other"  # type: ignore[misc]
+
+    def test_required_fields(self) -> None:
+        record = CodexStepRecord(
+            step_name="s1", exit_code=1, duration_ms=200, model="gpt-4", stdout_path=Path("/a")
+        )
+        assert record.step_name == "s1"
+        assert record.exit_code == 1
+        assert record.duration_ms == 200
+        assert record.model == "gpt-4"
+        assert record.stdout_path == Path("/a")
+
+    def test_result_summary_default_none(self) -> None:
+        record = CodexStepRecord(
+            step_name="s1", exit_code=0, duration_ms=100, model="o3", stdout_path=None
+        )
+        assert record.result_summary is None
+
+    def test_result_summary_explicit(self) -> None:
+        summary = {"exit_code": 0, "stdout_head": "ok"}
+        record = CodexStepRecord(
+            step_name="s1",
+            exit_code=0,
+            duration_ms=100,
+            model="o3",
+            stdout_path=None,
+            result_summary=summary,
+        )
+        assert record.result_summary == summary
+
+
+class TestSessionDirProperty:
+    def test_none_for_non_session(self) -> None:
+        record = CodexStepRecord(
+            step_name="s1", exit_code=0, duration_ms=100, model="o3", stdout_path=None
+        )
+        assert record.session_dir is None
+
+    def test_parent_for_session(self) -> None:
+        record = CodexStepRecord(
+            step_name="s1",
+            exit_code=0,
+            duration_ms=100,
+            model="o3",
+            stdout_path=Path("/a/b/c.ndjson"),
+        )
+        assert record.session_dir == Path("/a/b")
+
+
+class TestCodexScenarioFields:
+    def test_is_frozen_dataclass(self) -> None:
+        scenario = CodexScenario(step_sequence=())
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            scenario.step_sequence = ()  # type: ignore[misc]
+
+    def test_iterable_step_sequence(self) -> None:
+        r1 = CodexStepRecord(
+            step_name="s1", exit_code=0, duration_ms=100, model="o3", stdout_path=None
+        )
+        scenario = CodexScenario(step_sequence=(r1,))
+        items = list(scenario.step_sequence)
+        assert len(items) == 1
+        assert isinstance(items[0], CodexStepRecord)
+
+
+class TestLoadManifest:
+    def test_two_steps_mixed(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session_a"
+        session_dir.mkdir()
+        stdout_file = session_dir / "codex_stdout.ndjson"
+        stdout_file.write_text('{"type":"test"}')
+
+        _write_scenario(
+            tmp_path,
+            [
+                _make_step_dict("step_a", stdout_path="session_a/codex_stdout.ndjson"),
+                _make_step_dict(
+                    "step_b",
+                    stdout_path=None,
+                    result_summary={"exit_code": 0, "stdout_head": "ok"},
+                ),
+            ],
+        )
+
+        scenario = _load_manifest(tmp_path)
+        assert isinstance(scenario, CodexScenario)
+        assert len(scenario.step_sequence) == 2
+
+        s1 = scenario.step_sequence[0]
+        assert s1.step_name == "step_a"
+        assert s1.stdout_path == tmp_path / "session_a" / "codex_stdout.ndjson"
+        assert s1.result_summary is None
+
+        s2 = scenario.step_sequence[1]
+        assert s2.step_name == "step_b"
+        assert s2.stdout_path is None
+        assert s2.result_summary == {"exit_code": 0, "stdout_head": "ok"}
+
+
+class TestScenarioMethod:
+    def test_returns_scenario(self, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        out.mkdir()
+        _write_scenario(
+            tmp_path,
+            [_make_step_dict("s1", stdout_path=None)],
+        )
+        player = CodexScenarioPlayer(
+            scenario_dir=tmp_path, output_dir=out, binary_path=out / "codex"
+        )
+        scenario = player.scenario()
+        assert isinstance(scenario, CodexScenario)
+        assert len(scenario.step_sequence) == 1
+        assert scenario.step_sequence[0].step_name == "s1"
+
+
+class TestBuildSessionMap:
+    def test_dict_structure(self, tmp_path: Path) -> None:
+        session_a = tmp_path / "session_a"
+        session_a.mkdir()
+        (session_a / "stdout.ndjson").write_text("data")
+
+        session_b = tmp_path / "session_b"
+        session_b.mkdir()
+        (session_b / "stdout.ndjson").write_text("data2")
+
+        _write_scenario(
+            tmp_path,
+            [
+                _make_step_dict("step_a", stdout_path="session_a/stdout.ndjson"),
+                _make_step_dict("step_b", stdout_path="session_b/stdout.ndjson"),
+                _make_step_dict("step_c", stdout_path=None),
+            ],
+        )
+
+        out = tmp_path / "out"
+        out.mkdir()
+        player = CodexScenarioPlayer(
+            scenario_dir=tmp_path, output_dir=out, binary_path=out / "codex"
+        )
+        smap = player.build_session_map()
+
+        assert isinstance(smap, dict)
+        assert "step_a" in smap
+        assert "step_b" in smap
+        assert "step_c" not in smap
+
+        for key, entries in smap.items():
+            assert isinstance(entries, list)
+            for cli, meta in entries:
+                assert isinstance(cli, _FakeCodexCLI)
+                assert isinstance(meta, CodexStepRecord)
+
+
+class TestFakeCodexCLIRun:
+    def test_reads_cassette(self, tmp_path: Path) -> None:
+        cassette = tmp_path / "cassette.ndjson"
+        cassette.write_text("hello world\n")
+        cli = _FakeCodexCLI(stdout_path=cassette)
+        result = cli.run()
+        assert isinstance(result, _CodexRunResult)
+        assert result.stdout == "hello world\n"
+
+
+class TestWriteShimScript:
+    def test_creates_executable(self, tmp_path: Path) -> None:
+        binary = tmp_path / "codex"
+        _write_shim_script(output_dir=tmp_path, binary_path=binary)
+        assert binary.exists()
+        assert binary.is_file()
+        assert not binary.is_symlink()
+        assert os.access(binary, os.X_OK)
+        assert binary.read_text().startswith("#!/")
+
+
+class TestShimScriptExecution:
+    def test_cassette_echo(self, tmp_path: Path) -> None:
+        binary = tmp_path / "codex"
+        _write_shim_script(output_dir=tmp_path, binary_path=binary)
+        env = {**os.environ, "CODEX_REPLAY_CASSETTE": "replay_data_here"}
+        result = subprocess.run(
+            [sys.executable, str(binary)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout == "replay_data_here"
+
+
+class TestMakeFactory:
+    def test_returns_player(self, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        out.mkdir()
+        _write_scenario(tmp_path, [_make_step_dict("s1", stdout_path=None)])
+        player = make_codex_scenario_player(
+            scenario_dir=str(tmp_path),
+            output_dir=str(out),
+            binary_path=str(out / "codex"),
+        )
+        assert isinstance(player, CodexScenarioPlayer)
+
+
+class TestModuleExports:
+    def test_all_exports(self) -> None:
+        import autoskillit.execution.backends.codex_scenario_player as mod
+
+        assert sorted(mod.__all__) == ["CodexScenarioPlayer", "make_codex_scenario_player"]


### PR DESCRIPTION
## Summary

Create `src/autoskillit/execution/backends/codex_scenario_player.py` — an IL-1 module containing frozen dataclasses (`CodexStepRecord`, `CodexScenario`), a manifest reader (`_load_manifest`), a fake CLI (`_FakeCodexCLI`), a shim script writer (`_write_shim_script`), the `CodexScenarioPlayer` class, and a `make_codex_scenario_player` factory. These types mirror the duck-typed interface consumed by `build_replay_runner()` in `recording.py` (lines 307–383). The module imports only from stdlib — no `autoskillit.core` imports needed.

Additionally: create tests, update `backends/__init__.py` re-exports, update `test_backend_registry.py` expected set, add split-integrity coverage in `test_backends_split_integrity.py`, and update `backends/CLAUDE.md`.

## Requirements

## Goal
Provide the data-layer foundation for CodexScenarioPlayer: frozen dataclasses that mirror the interface consumed by build_replay_runner() in recording.py, plus a manifest reader that deserialises scenario.json into those types.

## Context
- Phase: Recording, Replay, and Full Test Coverage (Milestone: 8-recording-replay-and-full-test-coverage)
- Assignment: P8-A2 (Implement CodexScenarioPlayer in execution/backends/codex_scenario_player.py)
- Depends on: None
- Depended on by: P8-A3-WP1, P8-A9-WP1

## Deliverables
- `src/autoskillit/execution/backends/codex_scenario_player.py — CodexStepRecord, CodexScenario dataclasses and _load_manifest() function`
- `src/autoskillit/execution/backends/codex_scenario_player.py (contains _FakeCodexCLI, _CodexRunResult, _write_shim_script, _CODEX_SHIM_SCRIPT)`
- `src/autoskillit/execution/backends/codex_scenario_player.py — CodexScenarioPlayer class and make_codex_scenario_player factory`
- `tests/execution/backends/test_codex_scenario_player.py`

## Acceptance Criteria
- CodexStepRecord is a frozen dataclass with exactly the fields: step_name: str, exit_code: int, duration_ms: int, model: str, stdout_path: Path | None, result_summary: dict[str, Any] | None = None.
- CodexStepRecord.session_dir returns None when stdout_path is None, and returns a non-None Path when stdout_path is not None.
- CodexScenario is a frozen dataclass whose step_sequence is iterable and yields CodexStepRecord objects.
- _load_manifest reads scenario_dir/scenario.json, deserialises each array element into a CodexStepRecord, resolves stdout_path relative to scenario_dir when non-null.
- _load_manifest populates result_summary from the JSON object value so that build_replay_runner()'s 'record.result_summary or {}' does not raise AttributeError.
- The module imports only from stdlib and autoskillit.core (IL-0).
- The interface is structurally compatible with build_replay_runner() in recording.py.
- _FakeCodexCLI(stdout_path=p).run() returns an object whose .stdout equals the text content of file at p.
- _write_shim_script creates binary_path as a file (not symlink) with shebang and is executable.
- When binary_path is invoked as subprocess with CODEX_REPLAY_CASSETTE set, stdout equals that string and exit code is 0.
- CodexScenarioPlayer.__init__ calls _write_shim_script exactly once.
- CodexScenarioPlayer.scenario() returns a CodexScenario by delegating to _load_manifest.
- build_session_map() returns dict with session step_names as keys, excluding stdout_path=None steps.
- build_session_map() returns plain lists (not deques) so build_replay_runner can wrap in deque().
- make_codex_scenario_player accepts strings, coerces to Path, returns CodexScenarioPlayer.
- __all__ exports CodexScenarioPlayer and make_codex_scenario_player.

Closes #2910

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-221757-090350/.autoskillit/temp/make-plan/py8_p8_a2_wp1_plan_2026-05-24_223000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.6k | 24.7k | 1.3M | 106.2k | 151 | 89.0k | 13m 39s |
| verify | claude-sonnet-4-6 | 1 | 116 | 8.2k | 580.2k | 55.0k | 41 | 44.9k | 2m 45s |
| implement* | MiniMax-M2.7-highspeed | 1 | 694.2k | 10.1k | 886.9k | 30.7k | 62 | 15.8k | 3m 52s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 127.9k | 5.8k | 273.2k | 30.7k | 22 | 15.2k | 2m 1s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 31.6k | 1.9k | 150.5k | 30.7k | 12 | 14.9k | 43s |
| review_pr | claude-sonnet-4-6 | 1 | 134 | 34.3k | 652.7k | 84.9k | 44 | 75.3k | 7m 55s |
| resolve_review | claude-sonnet-4-6 | 1 | 333 | 28.6k | 2.7M | 92.9k | 98 | 152.0k | 12m 22s |
| **Total** | | | 856.9k | 113.5k | 6.5M | 106.2k | | 407.2k | 43m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 415 | 2137.2 | 38.1 | 24.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **415** | 15621.8 | 981.2 | 273.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.1k | 95.8k | 5.2M | 361.2k | 36m 42s |
| MiniMax-M2.7-highspeed | 3 | 853.7k | 17.8k | 1.3M | 46.0k | 6m 37s |