### PR TITLE
Implementation Plan: PY8 P8-A4-WP1 — Cross-Backend Contract Test Class

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -20,6 +20,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_commands_invariants.py` | Cross-builder invariants: _HEADLESS_EXCLUSIVE_VARS membership, completion marker position |
 | `test_env_boundary.py` | Contract: every fleet-injected env var must appear in at least one filter list |
 | `test_commands_shim_contract.py` | Structural contract tests verifying commands.py builders are thin forwarding shims |
+| `test_commands_skill_session.py` | Cross-backend contract tests for build_skill_session_cmd shared invariants |
 | `test_db.py` | L1 unit tests for execution/db.py — SQL validation and authorizer |
 | `test_api_error_signal_invariants.py` | API error signal invariants: API errors detected regardless of channel (PTY vs non-PTY) |
 | `test_backend_dispatch.py` | End-to-end tests verifying run_headless_core routes command construction through ctx.backend |

--- a/tests/execution/test_backend_dispatch.py
+++ b/tests/execution/test_backend_dispatch.py
@@ -59,3 +59,47 @@ async def test_run_headless_core_uses_ctx_backend_for_command_construction(minim
     assert call_args.args[1] == "/tmp/test-cwd"
     config = call_args.args[2]
     assert config.completion_marker == "%%DONE%%"
+
+
+class TestBackendDispatchRouting:
+    @pytest.mark.anyio
+    async def test_codex_backend_pty_mode_false_reaches_runner(self, minimal_ctx):
+        backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        minimal_ctx.backend = backend
+
+        mock_runner = AsyncMock()
+        mock_result = SubprocessResult(
+            returncode=0,
+            stdout="",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+        mock_runner.return_value = mock_result
+        minimal_ctx.runner = mock_runner
+
+        with patch(
+            "autoskillit.execution.headless._headless_execute._build_skill_result"
+        ) as mock_build_result:
+            mock_build_result.return_value = SkillResult(
+                success=True,
+                result="",
+                session_id="test-session",
+                subtype="success",
+                is_error=False,
+                exit_code=0,
+                needs_retry=False,
+                retry_reason=RetryReason.NONE,
+                stderr="",
+            )
+
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test-skill",
+                "/tmp/test-cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+            )
+
+        assert mock_runner.call_args.kwargs["pty_mode"] is False

--- a/tests/execution/test_commands_skill_session.py
+++ b/tests/execution/test_commands_skill_session.py
@@ -1,0 +1,61 @@
+"""Cross-backend contract tests for build_skill_session_cmd shared invariants."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.execution.backends import CodexBackend
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+
+def _prompt_text(spec) -> str:
+    """Extract the prompt token from a CmdSpec in a backend-agnostic way."""
+    cmd = list(spec.cmd)
+    if "-p" in cmd:
+        return cmd[cmd.index("-p") + 1]
+    return cmd[-1]
+
+
+class TestBuildSkillSessionCmdSharedBehavior:
+    @pytest.mark.parametrize("backend", [ClaudeCodeBackend(), CodexBackend()])
+    def test_completion_directive_injected(self, backend) -> None:
+        spec = backend.build_skill_session_cmd(
+            "/autoskillit:investigate", "/repo", completion_marker="DONE"
+        )
+        assert "DONE" in _prompt_text(spec)
+
+    @pytest.mark.parametrize("backend", [ClaudeCodeBackend(), CodexBackend()])
+    def test_cwd_anchor_injected(self, backend) -> None:
+        spec = backend.build_skill_session_cmd(
+            "/autoskillit:investigate", "/repo", completion_marker="DONE"
+        )
+        assert "/repo" in _prompt_text(spec)
+
+    @pytest.mark.parametrize("backend", [ClaudeCodeBackend(), CodexBackend()])
+    def test_headless_env_set(self, backend) -> None:
+        spec = backend.build_skill_session_cmd(
+            "/autoskillit:investigate", "/repo", completion_marker="DONE"
+        )
+        assert spec.env["AUTOSKILLIT_HEADLESS"] == "1"
+
+    @pytest.mark.parametrize("backend", [ClaudeCodeBackend(), CodexBackend()])
+    def test_session_type_env_set(self, backend) -> None:
+        spec = backend.build_skill_session_cmd(
+            "/autoskillit:investigate", "/repo", completion_marker="DONE"
+        )
+        assert spec.env["AUTOSKILLIT_SESSION_TYPE"] == "skill"
+
+    @pytest.mark.parametrize("backend", [ClaudeCodeBackend(), CodexBackend()])
+    def test_skill_name_extracted(self, backend) -> None:
+        spec = backend.build_skill_session_cmd(
+            "/autoskillit:investigate", "/repo", completion_marker="DONE"
+        )
+        assert spec.env["AUTOSKILLIT_SKILL_NAME"] == "investigate"

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.execution.backends import CodexBackend
 from tests.execution.conftest import _mock_backend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -22,6 +23,12 @@ class TestResolvePtyMode:
         import autoskillit.execution.headless as _headless_mod
 
         minimal_ctx.backend = _mock_backend(pty_required=False)
+        assert _headless_mod._resolve_pty_mode(minimal_ctx) is False
+
+    def test_pty_mode_false_for_codex_backend(self, minimal_ctx) -> None:
+        import autoskillit.execution.headless as _headless_mod
+
+        minimal_ctx.backend = CodexBackend()
         assert _headless_mod._resolve_pty_mode(minimal_ctx) is False
 
 


### PR DESCRIPTION
## Summary

Introduce a cross-backend contract test class that proves `build_skill_session_cmd` satisfies the same prompt-injection and env-injection invariants regardless of whether `ClaudeCodeBackend` or `CodexBackend` is used. This is split across three test files:

1. **NEW** `tests/execution/test_commands_skill_session.py` — `TestBuildSkillSessionCmdSharedBehavior` with 5 parametrized tests and an autouse env-scrub fixture.
2. **MODIFIED** `tests/execution/test_backend_dispatch.py` — Add `TestBackendDispatchRouting` class with an async test asserting `pty_mode=False` reaches the runner for non-PTY backends.
3. **MODIFIED** `tests/execution/test_headless_backend_resolution.py` — Add `test_pty_mode_false_for_codex_backend` to the existing `TestResolvePtyMode` class using a real `CodexBackend()` instance.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-221757-614204/.autoskillit/temp/make-plan/py8_p8_a4_wp1_cross_backend_contract_tests_plan_2026-05-24_222800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 314 | 2.8k | 8.0M | 119.0k | 148 | 542.2k | 9m 12s |
| verify | claude-sonnet-4-6 | 1 | 132 | 19.7k | 773.2k | 65.9k | 93 | 56.0k | 7m 19s |
| implement* | MiniMax-M2.7-highspeed | 1 | 706.4k | 7.0k | 825.5k | 30.7k | 76 | 15.7k | 7m 2s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 66.8k | 3.9k | 211.9k | 30.7k | 19 | 15.3k | 1m 38s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 57.7k | 1.6k | 211.8k | 30.7k | 16 | 15.0k | 47s |
| review_pr | claude-sonnet-4-6 | 1 | 826 | 36.8k | 508.4k | 65.1k | 51 | 65.2k | 7m 57s |
| resolve_review | claude-sonnet-4-6 | 1 | 247 | 22.9k | 1.7M | 84.4k | 93 | 142.9k | 9m 54s |
| **Total** | | | 832.4k | 94.6k | 12.3M | 119.0k | | 852.3k | 43m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 113 | 7305.0 | 139.0 | 61.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **113** | 108844.0 | 7542.3 | 837.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.5k | 82.2k | 11.1M | 806.3k | 34m 23s |
| MiniMax-M2.7-highspeed | 3 | 830.9k | 12.4k | 1.2M | 46.0k | 9m 28s |