### PR TITLE
Hard-Block Implement Step When Dry-Walkthrough Cannot Edit Original Plan

### DIFF
--- a/.autoskillit/config.yaml
+++ b/.autoskillit/config.yaml
@@ -21,6 +21,7 @@ safety:
 # implement_gate:
 #   marker: "Dry-walkthrough verified = TRUE"
 #   skill_names: ["/autoskillit:implement-worktree", "/autoskillit:implement-worktree-no-merge"]
+#   allowed_plan_dirs: ["make-plan", "rectify"]
 
 branching:
   default_base_branch: "develop"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,6 +213,7 @@ mcp_response:
 implement_gate:
   marker: "Dry-walkthrough verified = TRUE"
   skill_names: ["/autoskillit:implement-worktree", "/autoskillit:implement-worktree-no-merge"]
+  allowed_plan_dirs: ["make-plan", "rectify"]
 
 safety:
   reset_guard_marker: ".autoskillit-workspace"

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -327,6 +327,7 @@ safety:
 # implement_gate:
 #   marker: "Dry-walkthrough verified = TRUE"
 #   skill_names: ["/implement-worktree", "/implement-worktree-no-merge"]
+#   allowed_plan_dirs: ["make-plan", "rectify"]
 #
 # run_skill:
 #   timeout: 7200

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -69,6 +69,7 @@ class ImplementGateConfig:
             "/implement-worktree-no-merge",
         }
     )
+    allowed_plan_dirs: set[str] = field(default_factory=lambda: {"make-plan", "rectify"})
 
 
 @dataclass

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -24,6 +24,9 @@ implement_gate:
   skill_names:
     - "/autoskillit:implement-worktree"
     - "/autoskillit:implement-worktree-no-merge"
+  allowed_plan_dirs:
+    - "make-plan"
+    - "rectify"
 
 safety:
   reset_guard_marker: ".autoskillit-workspace"

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -370,6 +370,7 @@ class AutomationConfig:
             implement_gate=ImplementGateConfig(
                 marker=str(val(ig, "marker", _ig["marker"])),
                 skill_names=set(val(ig, "skill_names", _ig["skill_names"])),
+                allowed_plan_dirs=set(val(ig, "allowed_plan_dirs", _ig["allowed_plan_dirs"])),
             ),
             safety=SafetyConfig(
                 reset_guard_marker=str(val(sf, "reset_guard_marker", _sf["reset_guard_marker"])),

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -151,6 +151,16 @@ def _check_dry_walkthrough(skill_command: str, cwd: str) -> str | None:
             f"actual: {first_line[:100]!r}"
         )
 
+    allowed = _get_config().implement_gate.allowed_plan_dirs
+    if allowed and plan_path.parent.name not in allowed:
+        return gate_error_result(
+            f"Plan file is not at its original location. "
+            f"Expected parent directory to be one of {sorted(allowed)}, "
+            f"got: {plan_path.parent.name!r}. "
+            f"The implement gate requires the plan at its make-plan/ or rectify/ origin — "
+            f"copies in other directories are not accepted."
+        )
+
     return None
 
 

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -48,6 +48,7 @@ The plan file must remain a **clean, self-contained implementation instruction s
 - Reduce the plan's scope to a "simpler fix" - the plan defines the problem scope, not you
 - Consider effort as a reason for choosing one approach over another
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Write plan content, corrections, or the verification marker to any file other than the original plan file path provided as input. If the Edit tool is denied on the plan file, do NOT create a copy elsewhere — output a failure message instead.
 
 **ALWAYS:**
 - Keep the plan as clean implementation instructions only (information/background helpful to implementation is okay)
@@ -218,6 +219,30 @@ Dry-walkthrough verified = TRUE
 ```
 
 This marker indicates the plan has been validated and is ready for implementation. The implement-worktree skill checks for this marker before proceeding.
+
+### Step 6.1: Verify Stamp Landed
+
+After adding the marker line, immediately read the first line of the plan file back:
+
+1. Read the plan file
+2. Check that the first line is exactly `Dry-walkthrough verified = TRUE`
+3. If the marker is NOT present (edit was blocked by write guard or failed for any reason):
+   - Do NOT attempt to write the marker or plan content to any other file
+   - Do NOT create a copy of the plan at a different path
+   - Output this exact failure message to the terminal:
+
+   ```
+   ## Dry Walkthrough FAILED
+
+   **Plan:** {path}
+   **Status:** FAILED — Could not stamp plan file
+
+   The verification marker could not be written to the plan file.
+   This session must end as a failure. The implement step will not accept
+   an unstamped plan.
+   ```
+
+   - Stop execution immediately — do not proceed to Step 7
 
 ### Step 7: Report to Terminal
 

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -85,6 +85,10 @@ Correct orchestration on `needs_retry=true`:
    - Display warning: "WARNING: This plan has NOT been validated with a dry-walkthrough. Implementation may encounter issues that could have been caught beforehand."
    - Use `AskUserQuestion` to prompt: "Do you want to continue without dry-walkthrough validation?"
    - If user declines, abort and suggest running `/autoskillit:dry-walkthrough` first
+
+   **Note:** The server-side gate also verifies that the plan file is at its original
+   `make-plan/` or `rectify/` location. Plans copied to other directories (e.g.,
+   `dry-walkthrough/`) are rejected even if they carry the verification marker.
 3. Check `git status --porcelain` — if dirty, warn user
 4. Parse plan: phases, files per phase, verification commands
 5. **Multi-Part Plan Detection:** Examine the plan filename. If it contains `_part_` (e.g., `_part_a`, `_part_b`, `_part_1`):

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -75,6 +75,10 @@ Correct orchestration on `needs_retry=true`:
    - Display warning: "⚠️ WARNING: This plan has NOT been validated with a dry-walkthrough. Implementation may encounter issues that could have been caught beforehand."
    - Use `AskUserQuestion` to prompt: "Do you want to continue without dry-walkthrough validation?"
    - If user declines, abort and suggest running `/autoskillit:dry-walkthrough` first
+
+   **Note:** The server-side gate also verifies that the plan file is at its original
+   `make-plan/` or `rectify/` location. Plans copied to other directories (e.g.,
+   `dry-walkthrough/`) are rejected even if they carry the verification marker.
 3. Check `git status --porcelain` — if dirty, warn user
 4. Parse plan: phases, files per phase, verification commands
 5. **Multi-Part Plan Detection:** Examine the plan filename. If it contains `_part_` (e.g., `_part_a`, `_part_b`, `_part_1`):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -30,6 +30,7 @@ class TestDefaultConfig:
             "/implement-worktree",
             "/implement-worktree-no-merge",
         }
+        assert cfg.implement_gate.allowed_plan_dirs == {"make-plan", "rectify"}
         assert cfg.safety.reset_guard_marker == ".autoskillit-workspace"
         assert cfg.safety.require_dry_walkthrough is True
         assert cfg.safety.test_gate_on_merge is True
@@ -139,6 +140,7 @@ class TestLoadConfig:
             "implement_gate": {
                 "marker": "VERIFIED",
                 "skill_names": ["/my-skill"],
+                "allowed_plan_dirs": ["custom-plans"],
             },
             "safety": {
                 "reset_guard_marker": ".custom-marker",
@@ -158,6 +160,7 @@ class TestLoadConfig:
         assert cfg.reset_workspace.preserve_dirs == {".data", "logs"}
         assert cfg.implement_gate.marker == "VERIFIED"
         assert cfg.implement_gate.skill_names == {"/my-skill"}
+        assert cfg.implement_gate.allowed_plan_dirs == {"custom-plans"}
         assert cfg.safety.reset_guard_marker == ".custom-marker"
         assert cfg.safety.require_dry_walkthrough is False
         assert cfg.safety.test_gate_on_merge is False

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,9 +127,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 382),
+    ("src/autoskillit/cli/_init_helpers.py", 383),
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 401),
+    ("src/autoskillit/cli/_init_helpers.py", 402),
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_installed_plugins.py", 71),
     # _marketplace.py — marketplace.json (co-owned)

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -392,7 +392,9 @@ class TestConfigDrivenBehavior:
             implement_gate=ImplementGateConfig(marker="CUSTOM MARKER")
         )
 
-        plan = tmp_path / "plan.md"
+        plan_dir = tmp_path / "make-plan"
+        plan_dir.mkdir()
+        plan = plan_dir / "plan.md"
         plan.write_text("CUSTOM MARKER\n# Plan content")
         result = _check_dry_walkthrough(f"/implement-worktree {plan}", str(tmp_path))
         assert result is None  # passes with custom marker

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -43,7 +43,9 @@ class TestCheckDryWalkthrough:
 
     def test_dry_walkthrough_gate_passes_implement_no_merge(self, tool_ctx, tmp_path):
         """Gate allows /implement-worktree-no-merge when plan has marker."""
-        plan = tmp_path / "plan.md"
+        plan_dir = tmp_path / "make-plan"
+        plan_dir.mkdir()
+        plan = plan_dir / "plan.md"
         plan.write_text("Dry-walkthrough verified = TRUE\n# My Plan")
         result = _check_dry_walkthrough(f"/implement-worktree-no-merge {plan}", str(tmp_path))
         assert result is None
@@ -65,7 +67,9 @@ class TestCheckDryWalkthrough:
 
     def test_dry_walkthrough_gate_with_part_a_named_file_marked(self, tmp_path, tool_ctx):
         """Gate accepts _part_a.md file when marker is present."""
-        plan = tmp_path / "task_plan_2026-01-01_part_a.md"
+        plan_dir = tmp_path / "make-plan"
+        plan_dir.mkdir()
+        plan = plan_dir / "task_plan_2026-01-01_part_a.md"
         plan.write_text("Dry-walkthrough verified = TRUE\n\nContent here")
         result = _check_dry_walkthrough(f"/implement-worktree-no-merge {plan}", str(tmp_path))
         assert result is None
@@ -81,7 +85,9 @@ class TestCheckDryWalkthrough:
 
     def test_dry_walkthrough_gate_distinguishes_parts_independently(self, tmp_path, tool_ctx):
         """Gate correctly distinguishes marked part_a from unmarked part_b."""
-        part_a = tmp_path / "task_plan_part_a.md"
+        plan_dir = tmp_path / "make-plan"
+        plan_dir.mkdir()
+        part_a = plan_dir / "task_plan_part_a.md"
         part_b = tmp_path / "task_plan_part_b.md"
         part_a.write_text("Dry-walkthrough verified = TRUE\n\nPart A content")
         part_b.write_text("> **PART B ONLY.**\n\nPart B content — no marker")
@@ -94,14 +100,18 @@ class TestCheckDryWalkthrough:
 
     def test_gate_with_trailing_markdown_header_finds_plan(self, tmp_path, tool_ctx):
         """Trailing markdown headers must not corrupt the plan path."""
-        plan = tmp_path / "plan.md"
+        plan_dir = tmp_path / "make-plan"
+        plan_dir.mkdir()
+        plan = plan_dir / "plan.md"
         plan.write_text(_get_config().implement_gate.marker + "\n\nrest")
         cmd = f"/implement-worktree-no-merge {plan}\n\n## Base Branch\nimpl-926"
         assert _check_dry_walkthrough(cmd, str(tmp_path)) is None
 
     def test_gate_with_extra_token_after_path(self, tmp_path, tool_ctx):
         """Space-separated token after path must not corrupt the plan path."""
-        plan = tmp_path / "plan.md"
+        plan_dir = tmp_path / "make-plan"
+        plan_dir.mkdir()
+        plan = plan_dir / "plan.md"
         plan.write_text(_get_config().implement_gate.marker + "\n\nrest")
         cmd = f"/implement-worktree-no-merge {plan} impl-926"
         assert _check_dry_walkthrough(cmd, str(tmp_path)) is None
@@ -117,6 +127,60 @@ class TestCheckDryWalkthrough:
         message = data.get("result", "").lower()
         assert "not found" not in message, "Should fail on marker absence, not path lookup"
         assert "dry-walk" in message or "dry-walked" in message
+
+    # --- Plan-origin (allowed_plan_dirs) validation tests ---
+
+    def test_dry_walkthrough_gate_blocks_plan_at_wrong_directory(self, tool_ctx, tmp_path):
+        """Gate blocks plan file not in an allowed origin directory."""
+        wrong_dir = tmp_path / "dry-walkthrough"
+        wrong_dir.mkdir()
+        plan = wrong_dir / "plan.md"
+        plan.write_text("Dry-walkthrough verified = TRUE\n# Plan")
+        result = _check_dry_walkthrough(f"/implement-worktree-no-merge {plan}", str(tmp_path))
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert (
+            "original location" in parsed["result"].lower()
+            or "allowed" in parsed["result"].lower()
+        )
+
+    def test_dry_walkthrough_gate_allows_plan_at_make_plan_dir(self, tool_ctx, tmp_path):
+        """Gate allows plan file in the make-plan directory."""
+        plan_dir = tmp_path / "make-plan"
+        plan_dir.mkdir()
+        plan = plan_dir / "plan.md"
+        plan.write_text("Dry-walkthrough verified = TRUE\n# Plan")
+        result = _check_dry_walkthrough(f"/implement-worktree-no-merge {plan}", str(tmp_path))
+        assert result is None
+
+    def test_dry_walkthrough_gate_allows_plan_at_rectify_dir(self, tool_ctx, tmp_path):
+        """Gate allows plan file in the rectify directory."""
+        plan_dir = tmp_path / "rectify"
+        plan_dir.mkdir()
+        plan = plan_dir / "plan.md"
+        plan.write_text("Dry-walkthrough verified = TRUE\n# Plan")
+        result = _check_dry_walkthrough(f"/implement-worktree-no-merge {plan}", str(tmp_path))
+        assert result is None
+
+    def test_dry_walkthrough_gate_blocks_plan_at_arbitrary_dir(self, tool_ctx, tmp_path):
+        """Gate blocks plan at arbitrary non-origin directory."""
+        arb_dir = tmp_path / "audit-impl"
+        arb_dir.mkdir()
+        plan = arb_dir / "plan.md"
+        plan.write_text("Dry-walkthrough verified = TRUE\n# Plan")
+        result = _check_dry_walkthrough(f"/implement-worktree-no-merge {plan}", str(tmp_path))
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["subtype"] == "gate_error"
+
+    def test_implement_gate_config_default_allowed_dirs(self, tool_ctx):
+        """Default allowed_plan_dirs includes make-plan and rectify."""
+        from autoskillit.server._state import _get_config
+
+        config = _get_config()
+        assert "make-plan" in config.implement_gate.allowed_plan_dirs
+        assert "rectify" in config.implement_gate.allowed_plan_dirs
 
 
 class TestRunSkillPrefix:


### PR DESCRIPTION
## Summary

Add defense-in-depth enforcement preventing the implement step from running on a plan file that was not edited in-place at its original `make-plan/` or `rectify/` location. Three enforcement layers:

1. **Server-side hard block** (`_check_dry_walkthrough` in `_guards.py`): Validate the plan file's parent directory is one of the allowed origin directories. This is code-level enforcement that no LLM improvisation can bypass.
2. **Dry-walkthrough SKILL.md contract**: Add a post-stamp verification step and an explicit prohibition on writing plan content to any fallback location.
3. **Implement-worktree SKILL.md defense**: Add plan-path-origin documentation to both implement skill variants for model-level defense.

## Requirements

**If dry-walkthrough cannot edit the original plan file at its `make-plan/` (or `rectify/) location, the pipeline must hard-fail.** No workarounds, no improvisation, no continuing with an unverified plan.

### Enforcement points

1. **Implement step pre-check**: Before `implement-worktree` or `implement-worktree-no-merge` begins any work, it must verify that:
   - The plan file it receives is at the **original** `make-plan/` or `rectify/` path (not a copy in `dry-walkthrough/` or elsewhere)
   - The `Dry-walkthrough verified = TRUE` marker is the **first line** of that file
   - If either check fails → return immediate failure, do not proceed

2. **Dry-walkthrough output contract**: The dry-walkthrough skill must fail explicitly (not silently write to a fallback location) when the write guard blocks edits to the plan file. Currently, the skill's fallback behavior (writing findings files or copies to the allowed directory) masks the failure from the orchestrator.

3. **Sous-chef routing**: The sous-chef must not accept `on_success` routing from a verify step that wrote its output to a different path than the input plan path. If the dry-walkthrough session's output indicates it wrote to `dry-walkthrough/` instead of editing the original plan, that's a failure, not a success.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-221557-541360/.autoskillit/temp/make-plan/hard_block_implement_dry_walkthrough_plan_2026-05-24_221900.md`

Closes #2985

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 89 | 21.4k | 1.9M | 115.1k | 200 | 104.8k | 12m 17s |
| verify | claude-sonnet-4-6 | 1 | 2.0k | 8.1k | 247.0k | 45.1k | 65 | 35.0k | 5m 18s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.8M | 16.8k | 1.5M | 35.8k | 132 | 56.8k | 14m 51s |
| fix | claude-sonnet-4-6 | 1 | 158 | 5.7k | 693.4k | 49.6k | 54 | 39.4k | 7m 35s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 82.6k | 5.0k | 211.9k | 30.7k | 18 | 15.3k | 1m 55s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 39.8k | 1.9k | 181.2k | 30.7k | 14 | 15.0k | 50s |
| review_pr | claude-sonnet-4-6 | 1 | 94 | 31.2k | 413.8k | 77.1k | 37 | 73.5k | 7m 17s |
| resolve_review | claude-sonnet-4-6 | 1 | 213 | 18.3k | 1.1M | 64.1k | 79 | 104.8k | 9m 33s |
| **Total** | | | 2.0M | 108.4k | 6.2M | 115.1k | | 444.5k | 59m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 132 | 11195.5 | 430.5 | 127.3 |
| fix | 4 | 173351.2 | 9851.8 | 1417.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **136** | 45726.7 | 3268.6 | 796.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 5 | 2.6k | 84.7k | 4.3M | 357.4k | 42m 1s |
| MiniMax-M2.7-highspeed | 3 | 2.0M | 23.7k | 1.9M | 87.1k | 17m 35s |