### PR TITLE
Extend SkillSessionConfig with backend_override

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -77,6 +77,7 @@ class SkillSessionConfig:
     resume_session_id: str = ""
     resume_checkpoint: SessionCheckpoint | None = None
     resume_message: str | None = None
+    backend_override: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/core/test_backend_dataclasses.py
+++ b/tests/core/test_backend_dataclasses.py
@@ -245,6 +245,7 @@ def test_skill_session_config_fields_exhaustive():
         "resume_session_id",
         "resume_checkpoint",
         "resume_message",
+        "backend_override",
     }
 
 
@@ -267,6 +268,7 @@ def test_skill_session_config_defaults():
     assert cfg.resume_session_id == ""
     assert cfg.resume_checkpoint is None
     assert cfg.resume_message is None
+    assert cfg.backend_override is None
 
 
 def test_skill_session_config_field_types():
@@ -297,3 +299,4 @@ def test_skill_session_config_field_types():
     assert hints["resume_session_id"] is str
     assert hints["resume_checkpoint"] == SessionCheckpoint | None
     assert hints["resume_message"] == str | None
+    assert hints["backend_override"] == str | None


### PR DESCRIPTION
## Summary

Add an optional `backend_override: str | None = None` field to the `SkillSessionConfig` frozen dataclass in `core/types/_type_backend.py`. This field will allow `run_headless_core` (in a downstream WP) to route a specific skill session through a named backend different from `ctx.backend`. The field uses only `str | None` — a stdlib type — preserving the IL-0 hard constraint. Three existing exhaustive tests are updated to cover the new 16th field.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-221810-972483/.autoskillit/temp/make-plan/py7_p7_a7_wp1_backend_override_plan_2026-05-24_222300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 58 | 4.4k | 517.6k | 50.7k | 39 | 36.7k | 3m 15s |
| verify | claude-sonnet-4-6 | 1 | 76 | 5.3k | 266.9k | 40.9k | 24 | 30.9k | 2m 4s |
| implement* | MiniMax-M2.7-highspeed | 1 | 240.1k | 2.9k | 549.4k | 30.7k | 37 | 15.7k | 1m 41s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 87.7k | 2.9k | 303.8k | 30.7k | 20 | 15.2k | 1m 17s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 88.8k | 1.9k | 303.9k | 30.7k | 22 | 15.0k | 57s |
| review_pr | claude-sonnet-4-6 | 3 | 336 | 37.7k | 1.3M | 48.9k | 105 | 117.9k | 9m 14s |
| **Total** | | | 417.1k | 55.0k | 3.3M | 50.7k | | 231.4k | 18m 30s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 4 | 137348.2 | 3924.8 | 723.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **4** | 813128.0 | 57858.2 | 13759.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 58 | 4.4k | 517.6k | 36.7k | 3m 15s |
| claude-sonnet-4-6 | 2 | 412 | 42.9k | 1.6M | 148.8k | 11m 19s |
| MiniMax-M2.7-highspeed | 3 | 416.6k | 7.6k | 1.2M | 46.0k | 3m 55s |