### PR TITLE
[FEATURE] PY8 P8-A1-WP1 — Extend RecordingSubprocessRunner.__call__ for Non-PTY Session Detection

### DIFF
--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -10,10 +10,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from autoskillit.core import (
+    AGENT_BACKEND_ENV_VAR,
     SubprocessResult,
     SubprocessRunner,
     TerminationReason,
     ValidatedAddDir,
+    atomic_write,
+    fast_dumps,
     get_logger,
 )
 from autoskillit.execution._recording_skills import (
@@ -65,12 +68,19 @@ def _extract_model(args: list[str]) -> str:
 class RecordingSubprocessRunner(SubprocessRunner):
     """Wraps a SubprocessRunner, records each session via ScenarioRecorder.
 
-    - **Session calls** (``pty_mode=True`` + ``SCENARIO_STEP_NAME`` in cmd env prefix):
-      delegates to ``ScenarioRecorder.record_step()`` which spawns the real subprocess
-      under PTY capture, then constructs a ``SubprocessResult`` from the cassette.
-    - **Non-session calls**: delegates to the inner runner, then records a summary via
-      ``recorder.record_non_session_step()`` if ``SCENARIO_STEP_NAME`` is present.
-    - **Calls without SCENARIO_STEP_NAME**: passes through to inner runner unrecorded.
+    Dispatch paths (checked in order):
+
+    1. **PTY session** (``step_name`` + ``pty_mode=True``):
+       delegates to ``ScenarioRecorder.record_step()`` which spawns the real subprocess
+       under PTY capture, then constructs a ``SubprocessResult`` from the cassette.
+    2. **Non-PTY Codex session** (``step_name`` + ``pty_mode=False`` +
+       ``AUTOSKILLIT_AGENT_BACKEND=codex``): delegates to the inner runner, writes
+       ``codex_stdout.ndjson`` and ``step_meta.json`` cassette files, then records via
+       ``recorder.record_non_session_step(tool='run_skill')``.
+    3. **Non-session command** (``step_name`` + ``pty_mode=False`` + non-Codex backend):
+       delegates to the inner runner, then records a summary via
+       ``recorder.record_non_session_step(tool='run_cmd')``.
+    4. **Untracked** (no ``step_name``): passes through to inner runner unrecorded.
 
     Public attribute ``recorder`` holds the :class:`ScenarioRecorder` instance.
     The symmetric counterpart :class:`ReplayingSubprocessRunner` exposes ``player``
@@ -118,15 +128,78 @@ class RecordingSubprocessRunner(SubprocessRunner):
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 
-        if pty_mode and step_name:
-            return await self._record_session(
-                cmd=cmd,
-                step_name=step_name,
-                model=_extract_model(cmd),
-                session_log_dir=session_log_dir,
-            )
+        if step_name:
+            if pty_mode:
+                return await self._record_session(
+                    cmd=cmd,
+                    step_name=step_name,
+                    model=_extract_model(cmd),
+                    session_log_dir=session_log_dir,
+                )
 
-        result = await self._inner(
+            # Non-PTY session step — use AUTOSKILLIT_AGENT_BACKEND as the
+            # discriminator; it is the most explicit signal and avoids cmd[0]
+            # fragility.  Codex backends are definitionally non-PTY
+            # (CodexBackend.capabilities.pty_required=False), so this branch
+            # is only reachable when pty_mode=False.
+            if (env or {}).get(AGENT_BACKEND_ENV_VAR, "") == "codex":
+                return await self._record_non_pty_session(
+                    cmd=cmd,
+                    cwd=cwd,
+                    timeout=timeout,
+                    env=env,
+                    stale_threshold=stale_threshold,
+                    completion_marker=completion_marker,
+                    session_log_dir=session_log_dir,
+                    pty_mode=pty_mode,
+                    input_data=input_data,
+                    completion_drain_timeout=completion_drain_timeout,
+                    linux_tracing_config=linux_tracing_config,
+                    idle_output_timeout=idle_output_timeout,
+                    max_suppression_seconds=max_suppression_seconds,
+                    on_pid_resolved=on_pid_resolved,
+                    enable_deadline_extension=enable_deadline_extension,
+                    max_extension_seconds=max_extension_seconds,
+                    marker_dir=marker_dir,
+                    session_id=session_id,
+                    stream_parser=stream_parser,
+                    step_name=step_name,
+                )
+
+            # Non-Codex, non-PTY with step_name: run inner + record summary.
+            result = await self._inner(
+                cmd,
+                cwd=cwd,
+                timeout=timeout,
+                env=env,
+                stale_threshold=stale_threshold,
+                completion_marker=completion_marker,
+                session_log_dir=session_log_dir,
+                pty_mode=pty_mode,
+                input_data=input_data,
+                completion_drain_timeout=completion_drain_timeout,
+                linux_tracing_config=linux_tracing_config,
+                idle_output_timeout=idle_output_timeout,
+                max_suppression_seconds=max_suppression_seconds,
+                on_pid_resolved=on_pid_resolved,
+                enable_deadline_extension=enable_deadline_extension,
+                max_extension_seconds=max_extension_seconds,
+                marker_dir=marker_dir,
+                session_id=session_id,
+                stream_parser=stream_parser,
+            )
+            self.recorder.record_non_session_step(
+                step_name=step_name,
+                tool="run_cmd",
+                result_summary={
+                    "exit_code": result.returncode,
+                    "stdout_head": (result.stdout or "")[:500],
+                },
+            )
+            return result
+
+        # No step_name: T3 boundary — pass through to inner runner unrecorded.
+        return await self._inner(
             cmd,
             cwd=cwd,
             timeout=timeout,
@@ -147,18 +220,6 @@ class RecordingSubprocessRunner(SubprocessRunner):
             session_id=session_id,
             stream_parser=stream_parser,
         )
-
-        if step_name:
-            self.recorder.record_non_session_step(
-                step_name=step_name,
-                tool="run_cmd",
-                result_summary={
-                    "exit_code": result.returncode,
-                    "stdout_head": (result.stdout or "")[:500],
-                },
-            )
-
-        return result
 
     async def _record_session(
         self,
@@ -207,6 +268,85 @@ class RecordingSubprocessRunner(SubprocessRunner):
             pid=0,
             elapsed_seconds=(step_result.cassette_duration_ms or 0) / 1000.0,
         )
+
+    async def _record_non_pty_session(
+        self,
+        *,
+        cmd: list[str],
+        cwd: Path,
+        timeout: float,
+        env: Mapping[str, str] | None,
+        stale_threshold: float,
+        completion_marker: str,
+        session_log_dir: Path | None,
+        pty_mode: bool,
+        input_data: str | None,
+        completion_drain_timeout: float,
+        linux_tracing_config: Any | None,
+        idle_output_timeout: float | None,
+        max_suppression_seconds: float | None,
+        on_pid_resolved: Callable[[int, int], None] | None,
+        enable_deadline_extension: bool,
+        max_extension_seconds: float,
+        marker_dir: Path | None,
+        session_id: str | None,
+        stream_parser: StreamParser | None,
+        step_name: str,
+    ) -> SubprocessResult:
+        """Record a non-PTY (Codex) session step via cassette files."""
+        result = await self._inner(
+            cmd,
+            cwd=cwd,
+            timeout=timeout,
+            env=env,
+            stale_threshold=stale_threshold,
+            completion_marker=completion_marker,
+            session_log_dir=session_log_dir,
+            pty_mode=pty_mode,
+            input_data=input_data,
+            completion_drain_timeout=completion_drain_timeout,
+            linux_tracing_config=linux_tracing_config,
+            idle_output_timeout=idle_output_timeout,
+            max_suppression_seconds=max_suppression_seconds,
+            on_pid_resolved=on_pid_resolved,
+            enable_deadline_extension=enable_deadline_extension,
+            max_extension_seconds=max_extension_seconds,
+            marker_dir=marker_dir,
+            session_id=session_id,
+            stream_parser=stream_parser,
+        )
+
+        if self._scenario_dir is None:
+            logger.warning(
+                "no scenario_dir set; skipping cassette write for step=%r",
+                step_name,
+            )
+        else:
+            cassette_dir = self._scenario_dir / step_name
+            cassette_dir.mkdir(parents=True, exist_ok=True)
+
+            lines = (result.stdout or "").splitlines()
+            ndjson_content = "".join(fast_dumps(line) + "\n" for line in lines)
+            (cassette_dir / "codex_stdout.ndjson").write_text(ndjson_content, encoding="utf-8")
+
+            meta = {
+                "backend": "codex",
+                "model": _extract_model(cmd),
+                "exit_code": result.returncode,
+                "duration_ms": int(result.elapsed_seconds * 1000),
+            }
+            atomic_write(cassette_dir / "step_meta.json", fast_dumps(meta, indent=True))
+
+        self.recorder.record_non_session_step(
+            step_name=step_name,
+            tool="run_skill",
+            result_summary={
+                "exit_code": result.returncode,
+                "stdout_head": (result.stdout or "")[:500],
+            },
+        )
+
+        return result
 
 
 class ReplayingSubprocessRunner(SubprocessRunner):

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -327,7 +327,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
 
             lines = (result.stdout or "").splitlines()
             ndjson_content = "".join(fast_dumps(line) + "\n" for line in lines)
-            (cassette_dir / "codex_stdout.ndjson").write_text(ndjson_content, encoding="utf-8")
+            atomic_write(cassette_dir / "codex_stdout.ndjson", ndjson_content)
 
             meta = {
                 "backend": "codex",

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -9,7 +9,14 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from autoskillit.core.types import DirectInstall, OutputFormat, SubprocessRunner, TerminationReason
+from autoskillit.core import AGENT_BACKEND_ENV_VAR
+from autoskillit.core.types import (
+    DirectInstall,
+    OutputFormat,
+    SubprocessResult,
+    SubprocessRunner,
+    TerminationReason,
+)
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.recording import (
     RecordingSubprocessRunner,
@@ -732,3 +739,173 @@ def test_build_replay_runner_detects_claude_format(tmp_path, monkeypatch):
 
     result = build_replay_runner(str(replay_dir))
     assert result.player is mock_player
+
+
+# --- T-NONPTY-DISPATCH: Non-PTY Codex step routes to _record_non_pty_session ---
+
+
+@pytest.mark.anyio
+async def test_nonpty_dispatch_routes_to_record_non_pty_session(tmp_path):
+    """pty_mode=False + step_name + AGENT_BACKEND=codex → _record_non_pty_session path."""
+    mock_recorder = Mock()
+    inner = MockSubprocessRunner()
+    inner.set_default(_make_result(returncode=0, stdout="codex output"))
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner, scenario_dir=tmp_path)
+
+    cmd = ["codex", "exec", "--model", "o3", "implement the thing"]
+    env = {
+        "SCENARIO_STEP_NAME": "codex-step",
+        AGENT_BACKEND_ENV_VAR: "codex",
+    }
+
+    result = await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=False)
+
+    assert len(inner.call_args_list) == 1
+    mock_recorder.record_step.assert_not_called()
+    mock_recorder.record_non_session_step.assert_called_once_with(
+        step_name="codex-step",
+        tool="run_skill",
+        result_summary={"exit_code": 0, "stdout_head": "codex output"[:500]},
+    )
+    assert result.returncode == 0
+
+
+# --- T-NONPTY-CASSETTES: Cassette files written under scenario_dir/step_name ---
+
+
+@pytest.mark.anyio
+async def test_nonpty_cassettes_written(tmp_path):
+    """_record_non_pty_session writes codex_stdout.ndjson and step_meta.json."""
+    import json
+
+    scenario_dir = tmp_path / "scenario"
+    mock_recorder = Mock()
+    expected = SubprocessResult(
+        returncode=0,
+        stdout="line1\nline2\n",
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=12345,
+        elapsed_seconds=2.5,
+    )
+    inner = MockSubprocessRunner()
+    inner.set_default(expected)
+    runner = RecordingSubprocessRunner(
+        recorder=mock_recorder, inner=inner, scenario_dir=scenario_dir
+    )
+
+    cmd = ["codex", "exec", "--model", "o3", "go"]
+    env = {"SCENARIO_STEP_NAME": "codex-step", AGENT_BACKEND_ENV_VAR: "codex"}
+
+    await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=False)
+
+    cassette_dir = scenario_dir / "codex-step"
+    assert (cassette_dir / "codex_stdout.ndjson").exists()
+    assert (cassette_dir / "step_meta.json").exists()
+
+    ndjson_text = (cassette_dir / "codex_stdout.ndjson").read_text().strip()
+    ndjson_lines = ndjson_text.split("\n")
+    assert len(ndjson_lines) == 2
+    assert json.loads(ndjson_lines[0]) == "line1"
+    assert json.loads(ndjson_lines[1]) == "line2"
+
+    meta = json.loads((cassette_dir / "step_meta.json").read_text())
+    assert meta == {
+        "backend": "codex",
+        "model": "o3",
+        "exit_code": 0,
+        "duration_ms": 2500,
+    }
+
+
+# --- T-NONPTY-RESULT-PASSTHROUGH: Result identity preserved ---
+
+
+@pytest.mark.anyio
+async def test_nonpty_result_passthrough(tmp_path):
+    """SubprocessResult from runner is the exact same object from inner."""
+    mock_recorder = Mock()
+    expected = _make_result(returncode=42, stdout="raw codex out")
+    inner = MockSubprocessRunner()
+    inner.set_default(expected)
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner, scenario_dir=tmp_path)
+
+    cmd = ["codex", "exec", "--model", "o3", "go"]
+    env = {"SCENARIO_STEP_NAME": "step", AGENT_BACKEND_ENV_VAR: "codex"}
+
+    result = await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=False)
+
+    assert result is expected
+    assert result.returncode == 42
+    assert result.stdout == "raw codex out"
+
+
+# --- T-PTY-UNAFFECTED: PTY path unchanged by new non-PTY branch ---
+
+
+@pytest.mark.anyio
+async def test_pty_unaffected_by_nonpty_branch(tmp_path):
+    """pty_mode=True + step_name → _record_session, not _record_non_pty_session."""
+    mock_recorder = Mock()
+    mock_recorder.record_step.return_value = FakeStepResult(
+        cassette_exit_code=0,
+        cassette_path=str(tmp_path / "cassette"),
+        cassette_duration_ms=5000,
+    )
+    inner = MockSubprocessRunner()
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+
+    cmd = ["claude", "--model", "sonnet", "--print", "do stuff"]
+    env = {"SCENARIO_STEP_NAME": "investigate", "AUTOSKILLIT_HEADLESS": "1"}
+
+    result = await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=True)
+
+    mock_recorder.record_step.assert_called_once()
+    assert inner.call_args_list == []
+    mock_recorder.record_non_session_step.assert_not_called()
+    assert result.returncode == 0
+
+
+# --- T-NONPTY-NO-STEP-NAME: No step_name → pass-through, no recording ---
+
+
+@pytest.mark.anyio
+async def test_nonpty_no_step_name_skips_recording():
+    """pty_mode=False + no SCENARIO_STEP_NAME → inner runner, no recording."""
+    mock_recorder = Mock()
+    inner = MockSubprocessRunner()
+    inner.set_default(_make_result(returncode=0))
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+
+    cmd = ["codex", "exec", "do something"]
+    env = {AGENT_BACKEND_ENV_VAR: "codex"}
+
+    await runner(cmd, cwd=Path("/tmp"), timeout=60, env=env, pty_mode=False)
+
+    assert len(inner.call_args_list) == 1
+    mock_recorder.record_step.assert_not_called()
+    mock_recorder.record_non_session_step.assert_not_called()
+
+
+# --- T-NONPTY-T3-BOUNDARY: Non-Codex non-PTY with step_name → run_cmd ---
+
+
+@pytest.mark.anyio
+async def test_nonpty_t3_boundary_non_codex_routes_to_run_cmd():
+    """pty_mode=False + step_name + no AGENT_BACKEND → record_non_session_step(run_cmd)."""
+    mock_recorder = Mock()
+    inner = MockSubprocessRunner()
+    inner.set_default(_make_result(returncode=0))
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+
+    cmd = ["task", "test-check"]
+    env = {"SCENARIO_STEP_NAME": "test-check"}
+
+    await runner(cmd, cwd=Path("/tmp"), timeout=60, env=env, pty_mode=False)
+
+    assert len(inner.call_args_list) == 1
+    mock_recorder.record_non_session_step.assert_called_once_with(
+        step_name="test-check",
+        tool="run_cmd",
+        result_summary={"exit_code": 0, "stdout_head": ""},
+    )


### PR DESCRIPTION
## Summary

Extend `RecordingSubprocessRunner.__call__` to detect Codex (non-PTY) session steps via `step_name` + `AUTOSKILLIT_AGENT_BACKEND` env var inspection, and route them to a new `_record_non_pty_session()` method. This method calls the inner runner, writes `codex_stdout.ndjson` and `step_meta.json` cassette files, records the step via `recorder.record_non_session_step(tool='run_skill')`, and returns the original `SubprocessResult` unchanged. The existing PTY and T3-boundary dispatch paths are preserved.

Closes #2909

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260524-221811-621800/.autoskillit/temp/make-plan/py8_p8_a1_wp1_extend_recording_subprocess_runner_plan_2026-05-24_222500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 83 | 25.3k | 2.1M | 108.5k | 160 | 93.1k | 17m 50s |
| verify | claude-sonnet-4-6 | 1 | 180 | 18.7k | 1.2M | 75.6k | 56 | 65.5k | 5m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.3M | 12.0k | 1.0M | 30.7k | 72 | 15.7k | 4m 38s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 105.5k | 4.0k | 242.6k | 30.7k | 21 | 15.3k | 1m 32s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 59.4k | 2.0k | 242.6k | 30.7k | 19 | 15.0k | 55s |
| review_pr | claude-sonnet-4-6 | 1 | 190 | 42.0k | 777.2k | 83.8k | 54 | 139.4k | 9m 59s |
| resolve_review | claude-sonnet-4-6 | 1 | 373 | 28.6k | 3.8M | 108.1k | 105 | 109.0k | 12m 43s |
| **Total** | | | 1.4M | 132.8k | 9.4M | 108.5k | | 453.1k | 52m 48s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 367 | 2834.8 | 42.8 | 32.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **367** | 25664.6 | 1234.7 | 361.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 826 | 114.7k | 7.9M | 407.1k | 45m 42s |
| MiniMax-M2.7-highspeed | 3 | 1.4M | 18.1k | 1.5M | 46.0k | 7m 6s |