### PR TITLE
Implementation Plan: PY3 P3-A9-WP1 — Pass backend to init_session() Call Sites

### DIFF
--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -183,7 +183,11 @@ def cook(
     session_mgr = DefaultSessionSkillManager(SkillsDirectoryProvider(), ephemeral_root)
     session_mgr.cleanup_stale()
     skills_dir = session_mgr.init_session(
-        session_id_local, cook_session=True, config=config, project_dir=project_dir
+        session_id_local,
+        cook_session=True,
+        config=config,
+        project_dir=project_dir,
+        backend=backend,
     )
 
     plugin_source: MarketplaceInstall | DirectInstall

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -490,6 +490,7 @@ async def run_skill(
                 recipe_packs=tool_ctx.active_recipe_packs,
                 recipe_features=tool_ctx.active_recipe_features,
                 allow_only=allow_only,
+                backend=tool_ctx.backend,
             )
             skill_add_dirs.append(session_root)
 

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -28,7 +28,13 @@ class TestCookInteractive:
         fake_skills_dir.mkdir()
 
         def fake_init_session(
-            self, session_id: str, *, cook_session: bool = False, config=None, project_dir=None
+            self,
+            session_id: str,
+            *,
+            cook_session: bool = False,
+            config=None,
+            project_dir=None,
+            backend=None,
         ) -> Path:
             captured["cook_session"] = cook_session
             return fake_skills_dir
@@ -50,7 +56,13 @@ class TestCookInteractive:
         fake_skills_dir.mkdir()
 
         def fake_init_session(
-            self, session_id: str, *, cook_session: bool = False, config=None, project_dir=None
+            self,
+            session_id: str,
+            *,
+            cook_session: bool = False,
+            config=None,
+            project_dir=None,
+            backend=None,
         ) -> Path:
             return fake_skills_dir
 
@@ -76,7 +88,13 @@ class TestCookInteractive:
         fake_skills_dir.mkdir()
 
         def fake_init_session(
-            self, session_id: str, *, cook_session: bool = False, config=None, project_dir=None
+            self,
+            session_id: str,
+            *,
+            cook_session: bool = False,
+            config=None,
+            project_dir=None,
+            backend=None,
         ) -> Path:
             return fake_skills_dir
 
@@ -899,3 +917,39 @@ class TestCookInteractive:
         assert not hardcoded_calls, (
             "ClaudeCodeBackend must never be instantiated when get_backend is patched"
         )
+
+    def test_cook_init_session_passes_backend(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cook() forwards backend to init_session()."""
+        captured: dict = {}
+        fake_skills_dir = tmp_path / "fake-skills-backend"
+        fake_skills_dir.mkdir()
+
+        def fake_init_session(
+            self,
+            session_id: str,
+            *,
+            cook_session: bool = False,
+            config=None,
+            project_dir=None,
+            backend=None,
+        ) -> Path:
+            captured["backend"] = backend
+            return fake_skills_dir
+
+        class _FakeBackend:
+            def binary_name(self) -> str:
+                return "claude"
+
+            def build_interactive_cmd(self, **kwargs):
+                from autoskillit.core import CmdSpec
+
+                return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+        monkeypatch.setattr(DefaultSessionSkillManager, "init_session", fake_init_session)
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
+        monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/claude")
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+        cli.cook(backend=_FakeBackend())
+        assert captured["backend"] is not None

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -152,7 +152,9 @@ def test_cook_reload_loop_uses_named_resume(
     monkeypatch.setattr(
         DefaultSessionSkillManager,
         "init_session",
-        lambda self, sid, *, cook_session=False, config=None, project_dir=None: fake_skills_dir,
+        lambda self, sid, *, cook_session=False, config=None, project_dir=None, backend=None: (
+            fake_skills_dir
+        ),
     )
 
     from autoskillit import cli

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -448,11 +448,15 @@ class TestCookTerminalGuard:
         # cook() calls init_session to create a skills directory
         fake_skills_dir = tmp_path / "fake-skills"
         fake_skills_dir.mkdir()
+
+        def _fake_init_session(
+            self, session_id, *, cook_session=False, config=None, project_dir=None, backend=None
+        ):
+            return fake_skills_dir
+
         monkeypatch.setattr(
             "autoskillit.workspace.session_skills.DefaultSessionSkillManager.init_session",
-            lambda self, session_id, *, cook_session=False, config=None, project_dir=None: (
-                fake_skills_dir
-            ),
+            _fake_init_session,
         )
 
         with pytest.raises(KeyboardInterrupt):

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -286,6 +286,35 @@ async def test_run_skill_idle_output_timeout_defaults_to_none(
     assert executor.calls[0].idle_output_timeout is None
 
 
+@pytest.mark.anyio
+async def test_run_skill_passes_backend_to_init_session(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
+    """run_skill forwards tool_ctx.backend to init_session()."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    fake_validated = ValidatedAddDir(path="/fake/session/dir")
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = fake_validated
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    # Set a non-None backend on the context
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    tool_ctx_kitchen_open.backend = fake_backend
+
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/test skill", "/tmp")
+
+    mock_ssm.init_session.assert_called_once()
+    assert mock_ssm.init_session.call_args.kwargs.get("backend") is fake_backend
+
+
 class TestOutputDirParameter:
     """output_dir parameter plumbing from run_skill to executor."""
 


### PR DESCRIPTION
## Summary

Add `backend=tool_ctx.backend` to the `init_session()` call in `tools_execution.py` (the `run_skill` path) and `backend=backend` to the `init_session()` call in `_cook.py` (the cook session path). Both call sites currently omit the `backend` keyword argument, causing `init_session()` to default to `None` — which means the session skill manager always uses the Claude Code skills subdirectory layout, even when the active backend is Codex. The `init_session()` signature already accepts `backend: CodingAgentBackend | None = None` (landed in P3-A3-WP1), and both callers already have the backend value available (`tool_ctx.backend` in the server path, `backend` local variable in the CLI path).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-081130-091430/.autoskillit/temp/make-plan/py3_p3_a9_wp1_pass_backend_to_init_session_plan_2026-05-25_081500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.1k | 10.5k | 792.6k | 78.1k | 96 | 53.9k | 8m 22s |
| verify | claude-sonnet-4-6 | 1 | 124 | 8.0k | 680.4k | 64.1k | 41 | 64.3k | 2m 40s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.0M | 9.4k | 1.0M | 30.7k | 77 | 43.6k | 3m 27s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 61.4k | 3.4k | 211.9k | 30.7k | 19 | 15.3k | 1m 4s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.3k | 1.3k | 181.3k | 30.7k | 15 | 15.0k | 39s |
| review_pr | claude-sonnet-4-6 | 2 | 252 | 67.9k | 1.4M | 80.3k | 93 | 124.3k | 13m 54s |
| resolve_review | claude-sonnet-4-6 | 2 | 426 | 27.2k | 2.7M | 72.2k | 121 | 102.8k | 10m 52s |
| **Total** | | | 1.1M | 127.8k | 7.0M | 80.3k | | 419.2k | 41m 0s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 110 | 9485.4 | 395.9 | 85.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **110** | 63926.6 | 3811.0 | 1161.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.9k | 113.6k | 5.6M | 345.4k | 35m 50s |
| MiniMax-M2.7-highspeed | 3 | 1.1M | 14.1k | 1.4M | 73.9k | 5m 10s |