### PR TITLE
[FEATURE] PY4 P4-A5-WP1 — Wire Codex Hook Registration into _register_all()

### DIFF
--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -476,7 +476,10 @@ def _register_all(
         from autoskillit.execution import ensure_codex_mcp_registered
 
         ensure_codex_mcp_registered()
-        # P4: insert Codex hook registration here
+
+        from autoskillit.cli._hooks_codex import sync_hooks_to_codex_config
+
+        sync_hooks_to_codex_config()
         plugin_ok = None
     else:
         settings_path = _claude_settings_path(scope)
@@ -529,6 +532,7 @@ def _register_all(
         print(f"  {_Y}{'gh auth':>12}{_R}  {_D}not found — run{_R} {_G}gh auth login{_R}")
     if _backend_name == AGENT_BACKEND_CODEX:
         print(f"  {_Y}{'mcp':>12}{_R}  {_G}~/.codex/config.toml{_R}")
+        print(f"  {_Y}{'hooks':>12}{_R}  {_G}synced{_R} {_D}(codex){_R}")
     else:
         if plugin_ok:
             print(f"  {_Y}{'plugin':>12}{_R}  {_G}registered{_R}")

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -162,6 +162,10 @@ class TestRegisterAllBackendDispatch:
             "autoskillit.execution.ensure_codex_mcp_registered",
             lambda **kwargs: codex_calls.append("ensure_codex") or True,
         )
+        monkeypatch.setattr(
+            "autoskillit.cli._hooks_codex.sync_hooks_to_codex_config",
+            lambda **kwargs: True,
+        )
         # Override conftest's blanket patch on _is_plugin_installed to let real logic run
         monkeypatch.setattr(
             "autoskillit.cli._init_helpers._is_plugin_installed",
@@ -257,3 +261,92 @@ class TestRegisterAllBackendDispatch:
         assert register_all_calls, "_register_all must have been called"
         assert "backend" in register_all_calls[0]
         assert register_all_calls[0]["backend"].name == "codex"
+
+
+class TestRegisterAllCodexHookWiring:
+    """Codex hook registration is wired into _register_all()."""
+
+    def _setup(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, backend_name: str
+    ) -> tuple[list, list]:
+        """Shared setup: patch all side effects, return (codex_calls, hook_sync_calls)."""
+        from unittest.mock import MagicMock
+
+        import autoskillit.cli._hooks as _hooks_mod
+        import autoskillit.core.paths as _core_paths
+
+        codex_calls: list = []
+        hook_sync_calls: list = []
+
+        monkeypatch.setattr(_hooks_mod, "sweep_all_scopes_for_orphans", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "sync_hooks_to_settings", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "_evict_stale_autoskillit_hooks", lambda p: None)
+        monkeypatch.setattr(
+            _hooks_mod, "_claude_settings_path", lambda s: tmp_path / "settings.json"
+        )
+        monkeypatch.setattr(_core_paths, "pkg_root", lambda: tmp_path / "pkg")
+        monkeypatch.setattr("autoskillit.cli._init_helpers._register_mcp_server", lambda p: None)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._user_claude_json_path",
+            lambda: tmp_path / ".claude.json",
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._create_secrets_template", lambda p: None
+        )
+        monkeypatch.setattr("autoskillit.cli._init_helpers._prompt_github_repo", lambda: None)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers.evict_direct_mcp_entry", lambda p: False
+        )
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        monkeypatch.setattr("autoskillit.core.ensure_project_temp", lambda p: tmp_path / "temp")
+        monkeypatch.setattr(
+            "autoskillit.execution.ensure_codex_mcp_registered",
+            lambda **kwargs: codex_calls.append("ensure_codex") or True,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._hooks_codex.sync_hooks_to_codex_config",
+            lambda **kwargs: hook_sync_calls.append("sync_hooks") or True,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed",
+            lambda **kwargs: False,
+        )
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = backend_name
+        monkeypatch.setattr("autoskillit.config.load_config", lambda p=None: mock_config)
+
+        (tmp_path / "pkg").mkdir(exist_ok=True)
+
+        return codex_calls, hook_sync_calls
+
+    def test_codex_backend_calls_sync_hooks_to_codex_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        codex_calls, hook_sync_calls = self._setup(monkeypatch, tmp_path, "codex")
+        _register_all("user", tmp_path)
+        assert len(hook_sync_calls) == 1
+
+    def test_claude_code_backend_does_not_call_sync_hooks_to_codex_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        codex_calls, hook_sync_calls = self._setup(monkeypatch, tmp_path, "claude-code")
+        _register_all("user", tmp_path)
+        assert not hook_sync_calls
+
+    def test_sync_hooks_to_codex_config_exception_propagates(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        codex_calls, _ = self._setup(monkeypatch, tmp_path, "codex")
+        monkeypatch.setattr(
+            "autoskillit.cli._hooks_codex.sync_hooks_to_codex_config",
+            lambda **kwargs: (_ for _ in ()).throw(RuntimeError("hook sync failed")),
+        )
+        with pytest.raises(RuntimeError, match="hook sync failed"):
+            _register_all("user", tmp_path)


### PR DESCRIPTION
## Summary

Wire `sync_hooks_to_codex_config()` from `autoskillit.cli._hooks_codex` into the codex branch of `_register_all()` in `src/autoskillit/cli/_init_helpers.py`, so that `autoskillit init` syncs hooks to `~/.codex/config.toml` when `agent_backend='codex'`. Add a "codex hooks synced" summary print line. Add 3 tests in a new `TestRegisterAllCodexHookWiring` class.

## Requirements

## Goal

Wire the Codex hook registration function into _register_all() so that autoskillit init syncs hooks to ~/.codex/config.toml when agent_backend='codex', and update the summary print block with a 'codex hooks synced' status line.

## Context

- Phase: Hook System Porting (Milestone: 4-hook-system-porting)
- Assignment: P4-A5 (Wire Codex hook registration into _register_all(): add agent_backend parameter; branch to Codex path calling ensure_codex_mcp_registered() + sync_hooks_to_codex_config(); add CLI tests asserting Claude Code paths skipped for Codex)
- Depends on: P1-A3-WP1, P2-A3-WP1, P4-A4-WP1
- Depended on by: P4-A7-WP1

## Deliverables

- `src/autoskillit/cli/_init_helpers.py — _register_all() updated with sync_hooks_to_codex_config() call and codex summary print line`
- `tests/cli/test_init_helpers.py — TestRegisterAllCodexHookWiring class with three tests`

## Technical Steps

1. Locate the agent_backend == 'codex' branch in _register_all() (introduced by P2-A3, contains ensure_codex_mcp_registered()).
2. Add lazy import of sync_hooks_to_codex_config from autoskillit.cli._hooks_codex inside the codex block.
3. Insert sync_hooks_to_codex_config() call immediately after ensure_codex_mcp_registered().
4. Add one summary print line for codex hooks in the summary block.
5. Do not modify the claude-code path.
6. No new top-level imports.
7. Read the final signature of _register_all() as produced by P2-A3 and P4-A5-WP1.
8. Add test class TestRegisterAllCodexHookWiring to tests/cli/test_init_helpers.py.
9. Write test_codex_backend_calls_sync_hooks_to_codex_config: monkeypatch spy, call with agent_backend='codex', assert called once.
10. Write test_claude_code_backend_does_not_call_sync_hooks_to_codex_config: same spy, agent_backend='claude-code', assert NOT called.
11. Write test_sync_hooks_to_codex_config_exception_propagates: monkeypatch to raise, assert exception propagates.
12. Stub ensure_codex_mcp_registered to prevent side effects.
13. Verify conftest autouse fixture handles _is_plugin_installed and is_git_worktree.

## Acceptance Criteria

- When _register_all() is called with agent_backend='codex', sync_hooks_to_codex_config() is invoked after ensure_codex_mcp_registered().
- When _register_all() is called with agent_backend='claude-code', sync_hooks_to_codex_config() is never executed.
- Summary print block emits 'codex hooks synced' for codex backend.
- Existing 'hooks synced' line for claude-code path remains unchanged.
- No new top-level imports in _init_helpers.py.
- File passes mypy and ruff checks.
- test_codex_backend_calls_sync_hooks_to_codex_config: spy called exactly once for agent_backend='codex'.
- test_claude_code_backend_does_not_call_sync_hooks_to_codex_config: spy call count is zero for agent_backend='claude-code'.
- test_sync_hooks_to_codex_config_exception_propagates: RuntimeError propagates out of _register_all().
- All tests carry pytestmark = [pytest.mark.layer('cli'), pytest.mark.small].
- No assertions about settings.json, ~/.claude.json, or ensure_codex_mcp_registered() call presence.
- Tests pass under task test-check with no regressions.

## Conflict Resolution Table

None

Closes #2878

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-081130-515935/.autoskillit/temp/make-plan/py4_p4_a5_wp1_wire_codex_hook_registration_plan_2026-05-25_081500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 76 | 12.0k | 1.2M | 91.0k | 119 | 60.6k | 9m 0s |
| verify | claude-sonnet-4-6 | 1 | 132 | 9.5k | 734.0k | 58.9k | 41 | 42.9k | 3m 2s |
| implement* | MiniMax-M2.7-highspeed | 1 | 520.9k | 7.9k | 795.0k | 30.7k | 62 | 15.8k | 8m 25s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 57.9k | 3.1k | 181.3k | 30.7k | 15 | 15.2k | 52s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 61.4k | 2.1k | 242.7k | 30.7k | 16 | 15.0k | 52s |
| review_pr | claude-sonnet-4-6 | 1 | 92 | 28.7k | 411.9k | 63.8k | 33 | 53.1k | 5m 45s |
| resolve_review | claude-sonnet-4-6 | 1 | 245 | 17.3k | 1.6M | 72.7k | 71 | 58.3k | 6m 37s |
| **Total** | | | 640.7k | 80.7k | 5.2M | 91.0k | | 260.9k | 34m 34s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 99 | 8030.6 | 159.3 | 80.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **99** | 52180.6 | 2635.5 | 815.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 545 | 67.5k | 3.9M | 215.0k | 24m 25s |
| MiniMax-M2.7-highspeed | 3 | 640.2k | 13.2k | 1.2M | 45.9k | 10m 9s |