### PR TITLE
[FEATURE] PY3 P3-A2-WP1 — Copy-on-Activate in _activate_with_deps()

### DIFF
--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -611,9 +611,16 @@ class DefaultSessionSkillManager:
             return False
         activated.add(skill_name)
 
-        skill_md = self._root / session_id / _SKILLS_SUBDIR / skill_name / "SKILL.md"
+        skill_dir = self._root / session_id / self._skills_subdir / skill_name
+        skill_md = skill_dir / "SKILL.md"
         if not skill_md.exists():
-            return False
+            try:
+                fetched = self._provider.get_skill_content(skill_name, gated=False)
+            except FileNotFoundError:
+                return False
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            atomic_write(skill_md, fetched)
+            logger.debug("activate_deps_materialise", skill=skill_name)
 
         content = skill_md.read_text()
         new_content = _remove_disable_model_invocation(content)
@@ -633,18 +640,25 @@ class DefaultSessionSkillManager:
 
     def _activate_pack_deps(self, session_id: str, pack_name: str, activated: set[str]) -> None:
         """Activate all session skills whose category matches *pack_name*."""
-        skills_base = self._root / session_id / _SKILLS_SUBDIR
-        if not skills_base.is_dir():
-            return
-        for skill_dir in sorted(skills_base.iterdir()):
-            if not skill_dir.is_dir():
+        skills_base = self._root / session_id / self._skills_subdir
+        on_disk: set[str] = set()
+        if skills_base.is_dir():
+            for skill_dir in sorted(skills_base.iterdir()):
+                if not skill_dir.is_dir():
+                    continue
+                name = skill_dir.name
+                on_disk.add(name)
+                if name in activated:
+                    continue
+                info = self._provider.resolver.resolve(name)
+                if info and pack_name in info.categories:
+                    self._activate_with_deps(session_id, name, activated, _is_root=False)
+        for info in self._provider.list_skills():
+            if pack_name not in info.categories:
                 continue
-            name = skill_dir.name
-            if name in activated:
+            if info.name in on_disk or info.name in activated:
                 continue
-            info = self._provider.resolver.resolve(name)
-            if info and pack_name in info.categories:
-                self._activate_with_deps(session_id, name, activated, _is_root=False)
+            self._activate_with_deps(session_id, info.name, activated, _is_root=False)
 
     def cleanup_session(self, session_id: str) -> bool:
         """Remove the session skill directory for a completed session.

--- a/tests/workspace/test_session_skills_deps.py
+++ b/tests/workspace/test_session_skills_deps.py
@@ -111,6 +111,7 @@ class TestActivateDepsResolution:
             )
 
         resolver.resolve.side_effect = resolve_fn
+        provider.list_skills.return_value = []
 
         mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
         result = mgr.activate_skill_deps(session_id, "make-plan")
@@ -140,6 +141,7 @@ class TestActivateDepsResolution:
 
         provider = MagicMock()
         provider.resolver.resolve.return_value = None
+        provider.list_skills.return_value = []
 
         mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
         result = mgr.activate_skill_deps(session_id, "parent-skill")
@@ -191,6 +193,7 @@ class TestActivateDepsResolution:
             )
 
         resolver.resolve.side_effect = resolve_fn
+        provider.list_skills.return_value = []
 
         mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
         mgr.activate_skill_deps(session_id, "make-plan")
@@ -335,3 +338,169 @@ class TestActivateDepsResolution:
         root_md = tmp_path / session_id / ".claude" / "skills" / "root-skill" / "SKILL.md"
         root_content = root_md.read_text()
         assert "%%ORDER_UP%%" in root_content
+
+
+class TestCopyOnActivate:
+    def test_copy_on_activate_single_absent_skill(self, tmp_path: Path) -> None:
+        """Absence of SKILL.md triggers provider fetch; content is ungated after materialisation."""
+        from unittest.mock import MagicMock
+
+        session_id = "test-copy-on-activate"
+        provider = MagicMock()
+
+        def get_skill_content(name: str, gated: bool = False) -> str:
+            if name == "absent-skill" and gated is False:
+                return "---\nname: absent-skill\ndisable-model-invocation: true\n---\n# Body"
+            raise FileNotFoundError(name)
+
+        provider.get_skill_content.side_effect = get_skill_content
+
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+        result = mgr.activate_skill_deps(session_id, "absent-skill")
+
+        assert result is True
+        skill_md = tmp_path / session_id / ".claude" / "skills" / "absent-skill" / "SKILL.md"
+        assert skill_md.exists()
+        provider.get_skill_content.assert_called_once_with("absent-skill", gated=False)
+        assert "disable-model-invocation" not in skill_md.read_text()
+
+    def test_copy_on_activate_unknown_skill_returns_false(self, tmp_path: Path) -> None:
+        """Unknown skill raises FileNotFoundError and activate returns False."""
+        from unittest.mock import MagicMock
+
+        session_id = "test-unknown-skill"
+        provider = MagicMock()
+        provider.get_skill_content.side_effect = FileNotFoundError("not found")
+
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+        result = mgr.activate_skill_deps(session_id, "nonexistent-skill")
+
+        assert result is False
+        skills_dir = tmp_path / session_id / ".claude" / "skills"
+        assert not skills_dir.exists() or not any(skills_dir.iterdir())
+
+    def test_copy_on_activate_transitive_absent_dep(self, tmp_path: Path) -> None:
+        """Transitive dep absent from disk is fetched and ungated after materialisation."""
+        from unittest.mock import MagicMock
+
+        session_id = "test-transitive-absent"
+        _write_skill_md(
+            tmp_path,
+            session_id,
+            "root-skill",
+            "---\nname: root-skill\nactivate_deps: [dep-skill]\n"
+            "disable-model-invocation: true\n---\n# Root",
+        )
+
+        def get_skill_content(name: str, gated: bool = False) -> str:
+            if name == "dep-skill" and not gated:
+                return "---\nname: dep-skill\ndisable-model-invocation: true\n---\n# Dep Body"
+            raise FileNotFoundError(name)
+
+        provider = MagicMock()
+        provider.get_skill_content.side_effect = get_skill_content
+        provider.resolver.resolve.return_value = None
+
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+        result = mgr.activate_skill_deps(session_id, "root-skill")
+
+        assert result is True
+        dep_md = tmp_path / session_id / ".claude" / "skills" / "dep-skill" / "SKILL.md"
+        assert dep_md.exists()
+        assert "disable-model-invocation" not in dep_md.read_text()
+        root_md = tmp_path / session_id / ".claude" / "skills" / "root-skill" / "SKILL.md"
+        assert "disable-model-invocation" not in root_md.read_text()
+
+    def test_copy_on_activate_absent_pack_member(self, tmp_path: Path) -> None:
+        """list_skills() discovers pack members absent from disk and copy-on-activates them."""
+        from unittest.mock import MagicMock
+
+        from autoskillit.core.types import SkillSource
+        from autoskillit.workspace.skills import SkillInfo
+
+        session_id = "test-absent-pack-member"
+        _write_skill_md(
+            tmp_path,
+            session_id,
+            "parent-skill",
+            "---\nname: parent-skill\nactivate_deps: [arch-lens]\n"
+            "disable-model-invocation: true\n---\n# Parent",
+        )
+        _write_skill_md(
+            tmp_path,
+            session_id,
+            "arch-lens-a",
+            "---\nname: arch-lens-a\ncategories: [arch-lens]\n"
+            "disable-model-invocation: true\n---\n# Lens A",
+        )
+
+        def get_skill_content(name: str, gated: bool = False) -> str:
+            if name == "arch-lens-b" and not gated:
+                return (
+                    "---\nname: arch-lens-b\ncategories: [arch-lens]\n"
+                    "disable-model-invocation: true\n---\n# Lens B"
+                )
+            raise FileNotFoundError(name)
+
+        provider = MagicMock()
+        provider.get_skill_content.side_effect = get_skill_content
+        provider.list_skills.return_value = [
+            SkillInfo(
+                name="arch-lens-a",
+                source=SkillSource.BUNDLED_EXTENDED,
+                path=tmp_path / session_id / ".claude" / "skills" / "arch-lens-a" / "SKILL.md",
+                categories=frozenset({"arch-lens"}),
+            ),
+            SkillInfo(
+                name="arch-lens-b",
+                source=SkillSource.BUNDLED_EXTENDED,
+                path=tmp_path / ".claude" / "skills" / "arch-lens-b" / "SKILL.md",
+                categories=frozenset({"arch-lens"}),
+            ),
+        ]
+
+        def resolve_fn(name: str) -> SkillInfo | None:
+            if name == "arch-lens-a":
+                return SkillInfo(
+                    name="arch-lens-a",
+                    source=SkillSource.BUNDLED_EXTENDED,
+                    path=tmp_path / session_id / ".claude" / "skills" / "arch-lens-a" / "SKILL.md",
+                    categories=frozenset({"arch-lens"}),
+                )
+            return None
+
+        provider.resolver.resolve.side_effect = resolve_fn
+
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+        result = mgr.activate_skill_deps(session_id, "parent-skill")
+
+        assert result is True
+        a_md = tmp_path / session_id / ".claude" / "skills" / "arch-lens-a" / "SKILL.md"
+        assert a_md.exists()
+        assert "disable-model-invocation" not in a_md.read_text()
+        b_md = tmp_path / session_id / ".claude" / "skills" / "arch-lens-b" / "SKILL.md"
+        assert b_md.exists()
+        assert "disable-model-invocation" not in b_md.read_text()
+
+    def test_activate_skill_deps_removes_flag_structural_gating(self, tmp_path: Path) -> None:
+        """Materialised skill content has disable-model-invocation removed after ungating."""
+        from unittest.mock import MagicMock
+
+        session_id = "test-structural-gating"
+        provider = MagicMock()
+
+        def get_skill_content(name: str, gated: bool = False) -> str:
+            if name == "gated-skill" and gated is False:
+                return "---\nname: gated-skill\ndisable-model-invocation: true\n---\n# Gated Body"
+            raise FileNotFoundError(name)
+
+        provider.get_skill_content.side_effect = get_skill_content
+
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+        result = mgr.activate_skill_deps(session_id, "gated-skill")
+
+        assert result is True
+        skill_md = tmp_path / session_id / ".claude" / "skills" / "gated-skill" / "SKILL.md"
+        content = skill_md.read_text()
+        assert "disable-model-invocation" not in content
+        assert "# Gated Body" in content


### PR DESCRIPTION
## Summary

Replace the unconditional `return False` on missing SKILL.md in `_activate_with_deps()` with a copy-on-activate branch that fetches ungated skill content from the provider and materialises it into the ephemeral directory. Extend `_activate_pack_deps()` to discover and materialise absent pack-member skills via `list_skills()`. Switch both methods from the module-level `_SKILLS_SUBDIR` constant to `self._skills_subdir` for Codex backend compatibility.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-081051-068651/.autoskillit/temp/make-plan/py3_p3_a2_wp1_copy_on_activate_plan_2026-05-25_081500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 94 | 20.9k | 1.7M | 90.2k | 128 | 95.3k | 15m 54s |
| verify | claude-sonnet-4-6 | 1 | 140 | 7.8k | 797.3k | 59.8k | 44 | 43.7k | 2m 37s |
| implement* | MiniMax-M2.7-highspeed | 1 | 950.3k | 14.8k | 917.8k | 30.7k | 79 | 15.8k | 4m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 63.6k | 2.1k | 211.9k | 30.7k | 15 | 15.3k | 50s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 105.7k | 1.8k | 334.7k | 30.7k | 23 | 14.9k | 55s |
| review_pr | claude-sonnet-4-6 | 2 | 300 | 69.3k | 1.7M | 87.1k | 103 | 177.7k | 15m 28s |
| resolve_review | claude-sonnet-4-6 | 2 | 576 | 53.8k | 5.7M | 134.7k | 175 | 190.0k | 22m 45s |
| **Total** | | | 1.1M | 170.4k | 11.3M | 134.7k | | 552.7k | 1h 3m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 207 | 4433.8 | 76.2 | 71.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **207** | 54627.0 | 2670.2 | 823.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.1k | 151.7k | 9.8M | 506.7k | 56m 45s |
| MiniMax-M2.7-highspeed | 3 | 1.1M | 18.8k | 1.5M | 46.0k | 6m 30s |