### PR TITLE
[FEATURE] Replace --add-dir with CODEX_HOME env var in CodexBackend

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -168,7 +168,7 @@ class CodexBackend:
             channel_b_capable=False,
             pty_required=False,
             session_resume_capable=True,
-            skill_injection_capable=False,
+            skill_injection_capable=True,
             supports_thinking_blocks=False,
             supports_claude_format_stdout=False,
             exit_code_is_terminal=True,
@@ -322,6 +322,8 @@ class CodexBackend:
         if profile_name:
             extras["AUTOSKILLIT_PROVIDER_PROFILE"] = profile_name
             extras["AUTOSKILLIT_COMPLETION_MARKER"] = completion_marker
+        if add_dirs:
+            extras["CODEX_HOME"] = add_dirs[0].path
 
         filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
         env = CodexEnvPolicy().build_env(filtered_base, extras=extras)
@@ -337,8 +339,6 @@ class CodexBackend:
         ]
         if model:
             cmd += [CodexFlags.MODEL, model]
-        for validated_dir in add_dirs:
-            cmd += [CodexFlags.ADD_DIR, validated_dir.path]
         if resume_session_id:
             cmd.append(CodexFlags.RESUME_SUBCOMMAND)
             cmd.append(resume_session_id)

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -70,8 +70,8 @@ class TestCodexBackend:
     def test_capabilities_channel_b_false(self) -> None:
         assert CodexBackend().capabilities.channel_b_capable is False
 
-    def test_capabilities_skill_injection_false(self) -> None:
-        assert CodexBackend().capabilities.skill_injection_capable is False
+    def test_capabilities_skill_injection_true(self) -> None:
+        assert CodexBackend().capabilities.skill_injection_capable is True
 
     def test_capabilities_pty_required_false(self) -> None:
         assert CodexBackend().capabilities.pty_required is False
@@ -265,7 +265,7 @@ class TestCodexBackendProtocol:
             ("channel_b_capable", False),
             ("pty_required", False),
             ("session_resume_capable", True),
-            ("skill_injection_capable", False),
+            ("skill_injection_capable", True),
             ("mcp_config_capable", True),
             ("food_truck_capable", False),
         ],
@@ -433,18 +433,27 @@ class TestCodexBuildSkillSessionCmd:
         spec2 = CodexBackend().build_skill_session_cmd(**self.BASE)
         assert "AUTOSKILLIT_ALLOWED_WRITE_PREFIX" not in spec2.env
 
-    def test_add_dirs_forwarded(self) -> None:
-        dirs = [
-            ValidatedAddDir(path="/extra"),
-            ValidatedAddDir(path="/more"),
-        ]
+    def test_codex_home_env_set(self) -> None:
+        dirs = [ValidatedAddDir(path="/extra")]
         spec = CodexBackend().build_skill_session_cmd(
             **{**self.BASE, "add_dirs": dirs},
         )
-        add_dir_indices = [i for i, v in enumerate(spec.cmd) if v == "--add-dir"]
-        assert len(add_dir_indices) == 2
-        assert spec.cmd[add_dir_indices[0] + 1] == "/extra"
-        assert spec.cmd[add_dir_indices[1] + 1] == "/more"
+        assert spec.env["CODEX_HOME"] == "/extra"
+
+    def test_codex_home_not_set_by_default(self) -> None:
+        spec = CodexBackend().build_skill_session_cmd(**self.BASE)
+        assert "CODEX_HOME" not in spec.env
+
+    def test_no_add_dir_flag_with_add_dirs(self) -> None:
+        dirs = [ValidatedAddDir(path="/extra")]
+        spec = CodexBackend().build_skill_session_cmd(
+            **{**self.BASE, "add_dirs": dirs},
+        )
+        assert "--add-dir" not in spec.cmd
+
+    def test_no_add_dir_flag_without_add_dirs(self) -> None:
+        spec = CodexBackend().build_skill_session_cmd(**self.BASE)
+        assert "--add-dir" not in spec.cmd
 
     def test_model_forwarded(self) -> None:
         spec = CodexBackend().build_skill_session_cmd(


### PR DESCRIPTION
## Summary

Replace the `--add-dir` CLI flag loop in `CodexBackend.build_skill_session_cmd()` with a `CODEX_HOME` environment variable injection, flip `skill_injection_capable` to `True` in the Codex capabilities, and replace the deleted test with four focused assertion tests. The scope is limited to `build_skill_session_cmd()` — `build_headless_cmd()` intentionally retains `--add-dir` behavior (it serves a different call path with raw string paths, not `ValidatedAddDir` objects).

## Requirements

## Goal

Replace --add-dir with CODEX_HOME env var in build_skill_session_cmd(), flip skill_injection_capable to True, and add CODEX_HOME env assertion tests

## Context

- Phase: Codex Skill Delivery (Milestone: 3-codex-skill-delivery)
- Assignment: P3-A5 (Update CodexBackend.build_skill_session_cmd() to set CODEX_HOME env var)
- Depends on: P2-A2-WP1
- Depended on by: P3-A10-WP1, P4-A1-WP1

## Deliverables

- `src/autoskillit/execution/backends/codex.py — --add-dir loop removed, CODEX_HOME conditional added`
- `tests/execution/backends/test_codex_backend.py — test_add_dirs_forwarded deleted`
- `src/autoskillit/execution/backends/codex.py — skill_injection_capable flipped to True`
- `tests/execution/backends/test_codex_backend.py — test rename owned by P3-A10-WP1`
- `tests/execution/backends/test_codex_backend.py — four new tests replacing test_add_dirs_forwarded`

## Technical Steps

1. In the extras dict construction block, add: if add_dirs: extras['CODEX_HOME'] = add_dirs[0].path.
2. Delete the for-loop at lines 684-685 that appends CodexFlags.ADD_DIR.
3. Delete test_add_dirs_forwarded (lines 443-454) from test_codex_backend.py.
4. Verify no other references to CodexFlags.ADD_DIR in build_skill_session_cmd() remain.
5. Confirm empty add_dirs results in no CODEX_HOME key.
6. Change skill_injection_capable=False to skill_injection_capable=True at codex.py line 516.
7. Update test_capabilities_skill_injection_false (line 73) to assert True and rename to test_capabilities_skill_injection_true.
8. Update parametrize entry at line 276 from False to True.
9. Verify no other test files assert False for CodexBackend.
10. P3-A5 must complete before P4-A1 and P4-A2 begin (they depend on this WP).
11. Remove test_add_dirs_forwarded from TestCodexBuildSkillSessionCmd.
12. Add test_codex_home_env_set: assert spec.env['CODEX_HOME'] == add_dirs[0].path when non-empty.
13. Add test_codex_home_not_set_by_default: assert 'CODEX_HOME' not in spec.env when empty.
14. Add test_no_add_dir_flag_with_add_dirs: assert '--add-dir' not in spec.cmd when non-empty.
15. Add test_no_add_dir_flag_without_add_dirs: assert '--add-dir' not in spec.cmd when empty.
16. Keep pytestmark = [pytest.mark.layer('execution'), pytest.mark.small].

## Acceptance Criteria

- --add-dir does not appear in spec.cmd regardless of add_dirs content.
- spec.env['CODEX_HOME'] == first add_dirs entry path when non-empty.
- CODEX_HOME absent from spec.env when add_dirs is empty.
- test_add_dirs_forwarded removed.
- All remaining tests pass.
- CodexBackend().capabilities.skill_injection_capable is True.
- All tests in test_codex_backend.py pass with updated assertions.
- tests/core/test_backend_capabilities.py passes without modification.
- Must be merged before P4-A1 and P4-A2 implementations begin.
- test_codex_home_env_set passes: CODEX_HOME == add_dirs[0].path.
- test_codex_home_not_set_by_default passes: CODEX_HOME absent.
- test_no_add_dir_flag_with_add_dirs passes: --add-dir absent.
- test_no_add_dir_flag_without_add_dirs passes: --add-dir absent.
- All other tests unmodified.

Closes #2869

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-081051-749593/.autoskillit/temp/make-plan/py3_p3_a5_wp1_codex_home_env_var_plan_2026-05-25_081300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.8k | 9.0k | 942.1k | 80.9k | 112 | 54.2k | 8m 54s |
| verify | claude-sonnet-4-6 | 1 | 140 | 7.7k | 766.0k | 57.1k | 43 | 41.1k | 2m 43s |
| implement* | MiniMax-M2.7-highspeed | 1 | 389.3k | 6.1k | 703.0k | 30.7k | 61 | 15.8k | 2m 38s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 70.4k | 3.9k | 242.7k | 30.7k | 19 | 15.1k | 1m 14s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 51.1k | 2.1k | 212.0k | 30.7k | 15 | 15.0k | 43s |
| review_pr | claude-sonnet-4-6 | 3 | 934 | 74.1k | 1.5M | 72.5k | 138 | 151.3k | 17m 20s |
| resolve_review | claude-sonnet-4-6 | 3 | 847 | 48.1k | 6.2M | 90.4k | 244 | 181.2k | 22m 21s |
| **Total** | | | 514.6k | 151.1k | 10.6M | 90.4k | | 473.8k | 55m 55s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 39 | 18026.4 | 404.5 | 156.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **39** | 273052.8 | 12148.2 | 3873.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.7k | 138.9k | 9.5M | 427.8k | 51m 19s |
| MiniMax-M2.7-highspeed | 3 | 510.8k | 12.1k | 1.2M | 46.0k | 4m 35s |