### PR TITLE
Propagate error.code from Codex turn.failed events

### DIFF
--- a/src/autoskillit/execution/backends/_codex_parse.py
+++ b/src/autoskillit/execution/backends/_codex_parse.py
@@ -78,7 +78,12 @@ def _scan_codex_ndjson(stdout: str) -> _CodexParseAccumulator:
         elif event_type == "turn.failed":
             error = obj.get("error", {})
             if isinstance(error, dict):
-                acc.error_message = error.get("message", "")
+                error_msg = error.get("message", "")
+                error_code = error.get("code", "")
+                if error_code and error_code not in error_msg:
+                    acc.error_message = f"{error_msg} [{error_code}]" if error_msg else error_code
+                else:
+                    acc.error_message = error_msg
             else:
                 acc.error_message = str(error) if error else ""
             acc.saw_failure = True

--- a/tests/execution/backends/test_codex_result_parser.py
+++ b/tests/execution/backends/test_codex_result_parser.py
@@ -27,6 +27,10 @@ def _turn_failed_line(error_message: str) -> str:
     return json.dumps({"type": "turn.failed", "error": {"message": error_message}})
 
 
+def _turn_failed_code_line(code: str, message: str) -> str:
+    return json.dumps({"type": "turn.failed", "error": {"message": message, "code": code}})
+
+
 def _item_completed_message_line(text: str) -> str:
     return json.dumps(
         {
@@ -633,3 +637,32 @@ class TestCodexResultParserToolUses:
         result = CodexResultParser().parse_stdout(ndjson)
         assert len(result.raw["command_executions"]) == 1
         assert result.raw["command_executions"][0]["args"] == '{"command": "echo done"}'
+
+
+class TestScanCodexNdjsonErrorCode:
+    def test_scan_turn_failed_error_code_appended_to_message(self) -> None:
+        ndjson = _turn_failed_code_line("context_length_exceeded", "Context window exceeded")
+        acc = _scan_codex_ndjson(ndjson)
+        assert "context_length_exceeded" in acc.error_message
+
+    def test_scan_turn_failed_error_code_only_message_variant(self) -> None:
+        ndjson = _turn_failed_line("context_length_exceeded")
+        acc = _scan_codex_ndjson(ndjson)
+        assert acc.error_message == "context_length_exceeded"
+
+
+class TestCodexResultParserContextExhaustion:
+    def test_parse_stdout_message_context_exhausted(self) -> None:
+        ndjson = _turn_failed_line("context_length_exceeded")
+        result = CodexResultParser().parse_stdout(ndjson)
+        assert "context_length_exceeded" in result.error
+
+    def test_parse_stdout_code_context_exhausted(self) -> None:
+        ndjson = _turn_failed_code_line("context_length_exceeded", "Token limit reached.")
+        result = CodexResultParser().parse_stdout(ndjson)
+        assert "context_length_exceeded" in result.error
+
+    def test_parse_stdout_rate_limit_not_context_exhausted(self) -> None:
+        ndjson = _turn_failed_code_line("rate_limit_exceeded", "Rate limit exceeded.")
+        result = CodexResultParser().parse_stdout(ndjson)
+        assert "context_length_exceeded" not in result.error

--- a/tests/execution/test_adapt_agent_result.py
+++ b/tests/execution/test_adapt_agent_result.py
@@ -318,6 +318,26 @@ def test_full_round_trip_all_fields() -> None:
     assert result.seen_block_types == frozenset()
 
 
+def test_context_exhaustion_from_code_field() -> None:
+    result = _adapt_agent_result(
+        _make_agent_result(
+            raw={"subtype": "error_during_execution"},
+            error="Token limit reached. [context_length_exceeded]",
+        )
+    )
+    assert result.jsonl_context_exhausted is True
+
+
+def test_rate_limit_code_field_not_context_exhausted() -> None:
+    result = _adapt_agent_result(
+        _make_agent_result(
+            raw={"subtype": "error_during_execution"},
+            error="Rate limit exceeded. [rate_limit_exceeded]",
+        )
+    )
+    assert result.jsonl_context_exhausted is False
+
+
 class TestAdaptAgentResultFilePathKey:
     """Verify file_change entries use 'file_path' key for synthesis compatibility."""
 

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from autoskillit.core.types import (
@@ -10,6 +12,8 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
+from autoskillit.execution.backends._codex_parse import CodexResultParser
+from autoskillit.execution.headless._headless_evidence import _adapt_agent_result
 from autoskillit.execution.session._exit_classification import (
     _CODEX_API_ERROR_PATTERNS,
     classify_infra_exit,
@@ -33,6 +37,10 @@ def _sr(
         pid=12345,
         channel_confirmation=ChannelConfirmation.UNMONITORED,
     )
+
+
+def _turn_failed_ndjson(error_message: str) -> str:
+    return json.dumps({"type": "turn.failed", "error": {"message": error_message}})
 
 
 class TestClassifyInfraExit:
@@ -243,6 +251,35 @@ class TestCodexContextExhaustion:
 def test_all_infra_categories_handled(category: InfraExitCategory) -> None:
     """Every InfraExitCategory value has a distinct test above."""
     assert category.value in {"completed", "context_exhausted", "api_error", "process_killed"}
+
+
+class TestCodexContextExhaustionFromTurnFailed:
+    """Full pipeline: raw NDJSON -> CodexResultParser -> _adapt_agent_result -> classification."""
+
+    def test_turn_failed_context_length_exceeded_sets_jsonl_context_exhausted(self) -> None:
+        ndjson = _turn_failed_ndjson("context_length_exceeded")
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        assert adapted.jsonl_context_exhausted is True
+
+    def test_turn_failed_context_length_exceeded_is_context_exhausted(self) -> None:
+        ndjson = _turn_failed_ndjson("context_length_exceeded")
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        assert adapted._is_context_exhausted() is True
+
+    def test_turn_failed_context_length_exceeded_classify_returns_context_exhausted(self) -> None:
+        ndjson = _turn_failed_ndjson("context_length_exceeded")
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        result = _sr(returncode=1)
+        assert classify_infra_exit(adapted, result) == InfraExitCategory.CONTEXT_EXHAUSTED
+
+    def test_turn_failed_rate_limit_exceeded_jsonl_context_exhausted_false(self) -> None:
+        ndjson = _turn_failed_ndjson("rate_limit_exceeded")
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        assert adapted.jsonl_context_exhausted is False
 
 
 class TestRateLimitClassification:


### PR DESCRIPTION
## Summary

`_scan_codex_ndjson` in `_codex_parse.py` currently reads only `error.get("message", "")` from `turn.failed` events, discarding the `error.code` field entirely. When context exhaustion arrives as `code='context_length_exceeded'` with a human-readable message that lacks the substring, the detection chain (`_adapt_agent_result` → `jsonl_context_exhausted` → `_is_context_exhausted()`) fails silently. The fix combines both `error.message` and `error.code` into `acc.error_message` so the `"context_length_exceeded"` substring is reachable by downstream detection regardless of which field carries it.

No changes are needed to `_exit_classification.py` or `_session_model.py` — the fix is self-contained to the `turn.failed` handling block in `_codex_parse.py`.

## Requirements

### Goal

Ensure that a Codex turn.failed event whose context_length_exceeded is carried in the error.code field (not only error.message) is correctly propagated through acc.error_message so the _adapt_agent_result detection chain sets jsonl_context_exhausted=True and _is_context_exhausted() returns True.

### Deliverables

- `src/autoskillit/execution/backends/_codex_parse.py` — `_scan_codex_ndjson turn.failed` branch updated to incorporate `error.get('code','')` into `acc.error_message`
- Audit notes confirming `_exit_classification.py` and `_session_model.py` require no changes for the code-path variant
- `tests/execution/backends/test_codex_result_parser.py` — new helper `_turn_failed_code_line()` plus `TestScanCodexNdjsonErrorCode` and `TestCodexResultParserContextExhaustion` test classes
- `tests/execution/test_adapt_agent_result.py` — two additional test functions covering full-pipeline `_adapt_agent_result` + `_is_context_exhausted()` for code-field and rate-limit-false cases
- `tests/execution/test_exit_classification.py` (`TestCodexContextExhaustionFromTurnFailed` class: 4 test methods)

### Acceptance Criteria

- `_scan_codex_ndjson` called with a turn.failed line containing `error={'message':'Token limit reached.','code':'context_length_exceeded'}` produces `acc.error_message` containing the substring `'context_length_exceeded'`.
- `_scan_codex_ndjson` called with the existing `turn_failed_error.ndjson` fixture (`code='rate_limit_exceeded'`) continues to produce `acc.error_message` that is non-empty; `rate_limit_exceeded` is NOT misclassified as context exhaustion.
- `_scan_codex_ndjson` called with a turn.failed line where `error.message` already contains `'context_length_exceeded'` produces `acc.error_message` that still contains the substring (no regression on message-path variant).
- A new helper `_turn_failed_code_line(code, message)` is present in `test_codex_result_parser.py`, producing a turn.failed NDJSON line with both `'message'` and `'code'` fields.
- All new tests pass under `task test-check`.
- `TestCodexContextExhaustionFromTurnFailed` exists inside `tests/execution/test_exit_classification.py`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-102905-139444/.autoskillit/temp/make-plan/py5_p5_a5_wp1_codex_turn_failed_error_code_propagation_plan_2026-05-25_103600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 77 | 12.4k | 1.3M | 86.2k | 134 | 63.8k | 9m 56s |
| verify | claude-sonnet-4-6 | 1 | 1.0k | 6.8k | 1.0M | 94.2k | 100 | 94.5k | 5m 56s |
| implement* | MiniMax-M2.7 | 1 | 692.9k | 6.3k | 737.5k | 30.7k | 58 | 45.6k | 7m 11s |
| prepare_pr* | MiniMax-M2.7 | 1 | 47.1k | 2.8k | 248.4k | 0 | 17 | 0 | 49s |
| compose_pr* | MiniMax-M2.7 | 1 | 45.6k | 3.3k | 671.8k | 0 | 36 | 0 | 54s |
| review_pr | claude-opus-4-6 | 1 | 49 | 18.5k | 551.2k | 62.2k | 38 | 47.7k | 4m 35s |
| resolve_review | claude-opus-4-6 | 1 | 45 | 6.6k | 926.8k | 60.1k | 42 | 44.3k | 5m 40s |
| **Total** | | | 786.8k | 56.8k | 5.5M | 94.2k | | 295.9k | 35m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 97 | 7603.5 | 469.8 | 65.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **97** | 56454.9 | 3050.2 | 585.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 1.1k | 19.2k | 2.3M | 158.3k | 15m 52s |
| MiniMax-M2.7 | 3 | 785.6k | 12.5k | 1.7M | 45.6k | 8m 54s |
| claude-opus-4-6 | 2 | 94 | 25.1k | 1.5M | 92.0k | 10m 15s |