### PR TITLE
Call ensure_codex_mcp_registered() Unconditionally

### DIFF
--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -473,10 +473,6 @@ def _register_all(
         _backend_name = "claude-code"
 
     if _backend_name == AGENT_BACKEND_CODEX:
-        from autoskillit.execution import ensure_codex_mcp_registered
-
-        ensure_codex_mcp_registered()
-
         from autoskillit.cli._hooks_codex import sync_hooks_to_codex_config
 
         sync_hooks_to_codex_config()
@@ -491,6 +487,10 @@ def _register_all(
             _register_mcp_server(_user_claude_json_path())
         else:
             evict_direct_mcp_entry(_user_claude_json_path())
+
+    from autoskillit.execution import ensure_codex_mcp_registered  # noqa: PLC0415
+
+    codex_registered = ensure_codex_mcp_registered()
 
     # Prompt for github.default_repo if running interactively
     github_repo = None
@@ -531,7 +531,6 @@ def _register_all(
     else:
         print(f"  {_Y}{'gh auth':>12}{_R}  {_D}not found — run{_R} {_G}gh auth login{_R}")
     if _backend_name == AGENT_BACKEND_CODEX:
-        print(f"  {_Y}{'mcp':>12}{_R}  {_G}~/.codex/config.toml{_R}")
         print(f"  {_Y}{'hooks':>12}{_R}  {_G}synced{_R} {_D}(codex){_R}")
     else:
         if plugin_ok:
@@ -539,6 +538,9 @@ def _register_all(
         else:
             print(f"  {_Y}{'plugin':>12}{_R}  {_G}registered via ~/.claude.json{_R}")
         print(f"  {_Y}{'hooks':>12}{_R}  {_G}synced{_R} {_D}({scope} scope){_R}")
+
+    _codex_tag = "registered" if codex_registered else "ok"
+    print(f"  {_Y}{'codex mcp':>12}{_R}  {_G}{_codex_tag}{_R}")
 
     print()
     _print_next_steps(context="init")

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -397,6 +397,17 @@ _LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | No
 }
 
 
+async def _run_codex_mcp_registration_async() -> None:
+    """Offload ensure_codex_mcp_registered() to a thread executor — fail-open."""
+    try:
+        from autoskillit.execution import ensure_codex_mcp_registered  # noqa: PLC0415
+
+        loop = _asyncio.get_running_loop()
+        await loop.run_in_executor(None, ensure_codex_mcp_registered)
+    except Exception:
+        logger.warning("codex_mcp_registration_failed", exc_info=True)
+
+
 @asynccontextmanager
 async def _autoskillit_lifespan(server: Any) -> Any:
     """Server lifecycle: write readiness sentinel, yield, then finalize recording.
@@ -433,13 +444,24 @@ async def _autoskillit_lifespan(server: Any) -> Any:
             create_background_task(_run_hook_health_check_async(), label="hook_health")
         )
         bg_tasks.append(create_background_task(_run_deferred_init(event), label="deferred_init"))
+        _boot_ctx = _get_ctx_or_none()
+
+        if _boot_ctx is not None:
+            from autoskillit.core import AGENT_BACKEND_CODEX  # noqa: PLC0415
+
+            if getattr(_boot_ctx.backend, "name", None) == AGENT_BACKEND_CODEX:
+                bg_tasks.append(
+                    create_background_task(
+                        _run_codex_mcp_registration_async(),
+                        label="codex_mcp_registration",
+                    )
+                )
+
         from autoskillit.core import session_type as _resolve_session_type
 
         _boot_fn = _LIFESPAN_BOOT_REGISTRY.get(_resolve_session_type())
-        if _boot_fn is not None:
-            _boot_ctx = _get_ctx_or_none()
-            if _boot_ctx is not None:
-                await _boot_fn(_boot_ctx)
+        if _boot_fn is not None and _boot_ctx is not None:
+            await _boot_fn(_boot_ctx)
         yield
     finally:
         for task in bg_tasks:

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -199,7 +200,7 @@ class TestRegisterAllBackendDispatch:
         codex_calls, mcp_calls = self._setup_register_all(monkeypatch, tmp_path, "claude-code")
         _register_all("user", tmp_path)
         assert mcp_calls, "_register_mcp_server must be called for claude-code backend"
-        assert not codex_calls, "ensure_codex_mcp_registered must NOT be called for claude-code"
+        assert codex_calls, "ensure_codex_mcp_registered must be called unconditionally"
 
     def test_codex_backend_does_not_write_claude_json(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -459,4 +460,74 @@ class TestRegisterAllBackendBranching:
         ):
             _register_all("user", tmp_path)
             mock_sync.assert_called()
-            mock_codex.assert_not_called()
+            mock_codex.assert_called_once()
+
+
+class TestRegisterAllCodexMcpRegistration:
+    """Unconditional ensure_codex_mcp_registered() call in _register_all()."""
+
+    def _setup(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, backend_name: str
+    ) -> MagicMock:
+        """Stub collaborators; return mock for ensure_codex_mcp_registered."""
+        import autoskillit.cli._hooks as _hooks_mod
+        import autoskillit.core.paths as _core_paths
+
+        monkeypatch.setattr(_hooks_mod, "sweep_all_scopes_for_orphans", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "sync_hooks_to_settings", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "_evict_stale_autoskillit_hooks", lambda p: None)
+        monkeypatch.setattr(
+            _hooks_mod, "_claude_settings_path", lambda s: tmp_path / "settings.json"
+        )
+        monkeypatch.setattr(_core_paths, "pkg_root", lambda: tmp_path / "pkg")
+        monkeypatch.setattr("autoskillit.cli._init_helpers._register_mcp_server", lambda p: None)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._user_claude_json_path",
+            lambda: tmp_path / ".claude.json",
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._create_secrets_template", lambda p: None
+        )
+        monkeypatch.setattr("autoskillit.cli._init_helpers._prompt_github_repo", lambda: None)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers.evict_direct_mcp_entry", lambda p: False
+        )
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        monkeypatch.setattr("autoskillit.core.ensure_project_temp", lambda p: tmp_path / "temp")
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed", lambda **kwargs: False
+        )
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = backend_name
+        monkeypatch.setattr("autoskillit.config.load_config", lambda p=None: mock_config)
+
+        if backend_name == "codex":
+            monkeypatch.setattr(
+                "autoskillit.cli._hooks_codex.sync_hooks_to_codex_config",
+                lambda **kwargs: True,
+            )
+
+        codex_mock = MagicMock(return_value=True)
+        monkeypatch.setattr("autoskillit.execution.ensure_codex_mcp_registered", codex_mock)
+
+        (tmp_path / "pkg").mkdir(exist_ok=True)
+        return codex_mock
+
+    def test_codex_backend_calls_ensure_codex_mcp_registered(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        codex_mock = self._setup(monkeypatch, tmp_path, "codex")
+        _register_all("user", tmp_path)
+        codex_mock.assert_called_once()
+
+    def test_non_codex_backend_calls_ensure_codex_mcp_registered(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        codex_mock = self._setup(monkeypatch, tmp_path, "claude-code")
+        _register_all("user", tmp_path)
+        codex_mock.assert_called_once()

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -204,3 +204,49 @@ def test_lifespan_boot_registry_covers_all_session_types() -> None:
         f"SessionType values not in _LIFESPAN_BOOT_REGISTRY: {missing}. "
         "Every SessionType must declare a boot function or None."
     )
+
+
+@pytest.mark.asyncio
+async def test_lifespan_launches_codex_registration_for_codex_backend():
+    from autoskillit.server import _autoskillit_lifespan
+
+    mock_ctx = MagicMock()
+    mock_ctx.backend.name = "codex"
+    mock_ctx.runner = MagicMock()
+
+    reg_mock = AsyncMock()
+
+    with (
+        patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx),
+        patch(
+            "autoskillit.server._lifespan._run_codex_mcp_registration_async",
+            reg_mock,
+        ),
+    ):
+        async with _autoskillit_lifespan(MagicMock()):
+            pass
+
+    reg_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_skips_codex_registration_for_non_codex_backend():
+    from autoskillit.server import _autoskillit_lifespan
+
+    mock_ctx = MagicMock()
+    mock_ctx.backend.name = "claude-code"
+    mock_ctx.runner = MagicMock()
+
+    reg_mock = AsyncMock()
+
+    with (
+        patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx),
+        patch(
+            "autoskillit.server._lifespan._run_codex_mcp_registration_async",
+            reg_mock,
+        ),
+    ):
+        async with _autoskillit_lifespan(MagicMock()):
+            pass
+
+    reg_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Move `ensure_codex_mcp_registered()` from inside the `if _backend_name == AGENT_BACKEND_CODEX` branch to after the entire backend if/else block in `_register_all()`, so every `autoskillit init` run writes the MCP server entry to `~/.codex/config.toml` regardless of configured backend. Add a summary status line for the Codex registration result. Separately, add a conditional background task in the server lifespan that calls `ensure_codex_mcp_registered()` only when the active backend is Codex. Update two existing tests whose negative assertions contradict the new unconditional behavior.

Closes #2900

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-102947-740998/.autoskillit/temp/make-plan/py7_p7_a6_wp1_call_ensure_codex_mcp_registered_unconditional_plan_2026-05-25_103500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 61 | 33.6k | 854.9k | 91.0k | 117 | 141.9k | 14m 47s |
| verify | claude-sonnet-4-6 | 1 | 124 | 13.5k | 736.2k | 68.7k | 41 | 58.5k | 4m 34s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.3M | 12.9k | 1.4M | 36.0k | 127 | 32.7k | 5m 7s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 72.5k | 2.7k | 184.2k | 30.7k | 19 | 43.3k | 1m 5s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 70.5k | 2.0k | 273.4k | 30.7k | 20 | 15.2k | 54s |
| review_pr | claude-sonnet-4-6 | 2 | 300 | 92.1k | 1.5M | 88.9k | 91 | 157.5k | 20m 5s |
| resolve_review | claude-sonnet-4-6 | 1 | 173 | 16.2k | 996.4k | 65.5k | 50 | 56.0k | 5m 32s |
| **Total** | | | 1.5M | 173.0k | 6.0M | 91.0k | | 505.1k | 52m 7s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 165 | 8385.1 | 198.1 | 78.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **165** | 36074.1 | 3061.3 | 1048.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 658 | 155.4k | 4.1M | 413.9k | 44m 59s |
| MiniMax-M2.7-highspeed | 3 | 1.5M | 17.6k | 1.8M | 91.2k | 7m 7s |