### PR TITLE
Add and wire step_backend through _execute_claude_headless and run_headless_core into build_skill_session_cmd

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_execution.py
+++ b/src/autoskillit/core/types/_type_protocols_execution.py
@@ -64,6 +64,7 @@ class HeadlessExecutor(Protocol):
         resume_session_id: str = "",
         resume_checkpoint: SessionCheckpoint | None = None,
         resume_message: str | None = None,
+        backend_override: str | None = None,
     ) -> SkillResult: ...
 
     async def dispatch_food_truck(
@@ -97,6 +98,7 @@ class HeadlessExecutor(Protocol):
         marker_dir: Path | None = None,
         session_id: str | None = None,
         resume_message: str | None = None,
+        backend_override: str | None = None,
     ) -> SkillResult: ...
 
 

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -12,13 +12,14 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import structlog
 
 from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
     FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
+    CodingAgentBackend,
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
     SkillSessionConfig,
@@ -27,6 +28,7 @@ from autoskillit.core import (
     get_logger,
     temp_dir_display_str,
 )
+from autoskillit.execution.backends import get_backend  # noqa: F401
 from autoskillit.execution.headless._headless_evidence import (
     _adapt_agent_result,  # noqa: F401
     _apply_budget_guard,  # noqa: F401
@@ -129,6 +131,7 @@ async def run_headless_core(
     resume_session_id: str = "",
     resume_checkpoint: SessionCheckpoint | None = None,
     resume_message: str | None = None,
+    backend_override: str | None = None,
 ) -> SkillResult:
     """Shared headless runner used by run_skill.
 
@@ -170,8 +173,19 @@ async def run_headless_core(
             resume_checkpoint=resume_checkpoint,
             resume_message=resume_message,
         )
-        spec = ctx.backend.build_skill_session_cmd(skill_command, cwd, config)
-        logger.debug("run_headless_core_backend_dispatch", backend=ctx.backend.name)
+        step_backend: CodingAgentBackend | None = None
+        if backend_override is not None:
+            step_backend = get_backend(backend_override)
+            logger.info(
+                "step_backend_override_resolved",
+                override=backend_override,
+                step_backend=step_backend.name,
+                ctx_backend=ctx.backend.name,
+            )
+
+        _cmd_backend = step_backend if step_backend is not None else ctx.backend
+        spec = _cmd_backend.build_skill_session_cmd(skill_command, cwd, config)
+        logger.debug("run_headless_core_backend_dispatch", backend=_cmd_backend.name)
 
         effective_timeout = timeout if timeout is not None else cfg.timeout
         effective_stale = stale_threshold if stale_threshold is not None else cfg.stale_threshold
@@ -213,6 +227,7 @@ async def run_headless_core(
             provider_fallback_env=provider_fallback_env,
             provider_fallback_name=provider_fallback_name,
             provider_extras=provider_extras,
+            step_backend=step_backend,
         )
 
 
@@ -253,6 +268,7 @@ class DefaultHeadlessExecutor:
         resume_session_id: str = "",
         resume_checkpoint: SessionCheckpoint | None = None,
         resume_message: str | None = None,
+        backend_override: str | None = None,
     ) -> SkillResult:
         cfg = self._ctx.config.run_skill
         effective_timeout = timeout if timeout is not None else cfg.timeout
@@ -287,6 +303,7 @@ class DefaultHeadlessExecutor:
             resume_session_id=resume_session_id,
             resume_checkpoint=resume_checkpoint,
             resume_message=resume_message,
+            backend_override=backend_override,
         )
 
     async def dispatch_food_truck(
@@ -387,7 +404,9 @@ class DefaultHeadlessExecutor:
         )
 
         effective_marker_dir: Path | None = marker_dir or (
-            _resolve_session_log_dir(cwd, self._ctx) if cwd else None
+            _resolve_session_log_dir(cwd, cast(CodingAgentBackend, self._ctx.backend))
+            if cwd
+            else None
         )
 
         return await _execute_claude_headless(

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -95,6 +95,7 @@ async def _execute_claude_headless(
     max_extension_seconds: float = 7200,
     marker_dir: Path | None = None,
     session_id: str | None = None,
+    step_backend: CodingAgentBackend | None = None,
 ) -> SkillResult:
     """Shared subprocess execution for headless Claude sessions.
 
@@ -133,13 +134,17 @@ async def _execute_claude_headless(
     if runner is None:
         raise RuntimeError("No subprocess runner configured")
 
-    if ctx.backend is not None and spec.cmd:
+    _step_backend: CodingAgentBackend = (
+        step_backend if step_backend is not None else cast(CodingAgentBackend, ctx.backend)
+    )
+
+    if spec.cmd:
         _binary = Path(spec.cmd[0]).stem
         if _binary in {"claude", "codex"}:
-            _expected = "claude" if ctx.backend.name == "claude-code" else "codex"
+            _expected = "claude" if _step_backend.name == "claude-code" else "codex"
             if _binary != _expected:
                 raise RuntimeError(
-                    f"Backend coherence violation: ctx.backend.name={ctx.backend.name!r} "
+                    f"Backend coherence violation: backend.name={_step_backend.name!r} "
                     f"but subprocess binary is {_binary!r}"
                 )
 
@@ -177,9 +182,7 @@ async def _execute_claude_headless(
     _result: SubprocessResult | None = None
     result: SubprocessResult
     skill_result: SkillResult
-    _stream_parser = cast(CodingAgentBackend, ctx.backend).stream_parser(
-        completion_marker=completion_marker
-    )
+    _stream_parser = _step_backend.stream_parser(completion_marker=completion_marker)
     while True:
         try:
             _result = await runner(
@@ -187,8 +190,10 @@ async def _execute_claude_headless(
                 cwd=Path(cwd),
                 timeout=timeout,
                 env=spec.env,
-                pty_mode=_resolve_pty_mode(ctx),
-                session_log_dir=_resolve_session_log_dir(cwd, ctx),
+                pty_mode=_resolve_pty_mode(cast(CodingAgentBackend, ctx.backend)),
+                session_log_dir=_resolve_session_log_dir(
+                    cwd, cast(CodingAgentBackend, ctx.backend)
+                ),
                 completion_marker=completion_marker,
                 stale_threshold=stale_threshold,
                 completion_drain_timeout=cfg.completion_drain_timeout,
@@ -325,10 +330,7 @@ async def _execute_claude_headless(
             _git_writes_detected = _detect_branch_divergence(cwd)
 
         audit_count_before = len(ctx.audit.get_report())
-        _supports_fmt = cast(
-            "CodingAgentBackend", ctx.backend
-        ).capabilities.supports_claude_format_stdout
-        _backend = cast(CodingAgentBackend, ctx.backend)
+        _supports_fmt = _step_backend.capabilities.supports_claude_format_stdout
         skill_result = _build_skill_result(
             result,
             completion_marker=completion_marker,
@@ -342,7 +344,7 @@ async def _execute_claude_headless(
             prior_completion_markers=prior_completion_markers,
             provider_used=current_provider_name,
             supports_claude_format_stdout=_supports_fmt,
-            backend=_backend,
+            backend=_step_backend,
         )
 
         if (
@@ -358,8 +360,8 @@ async def _execute_claude_headless(
                 completion_marker,
                 cwd,
                 runner,
-                backend=ctx.backend,
-                result_parser=ctx.backend.result_parser() if ctx.backend else None,
+                backend=_step_backend,
+                result_parser=_step_backend.result_parser(),
                 provider_extras=provider_extras,
                 retry_reason=skill_result.retry_reason,
             )

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from autoskillit.core import (
     CodingAgentBackend,
@@ -17,7 +17,6 @@ from autoskillit.execution.headless._headless_git import _compute_loc_changed
 
 if TYPE_CHECKING:
     from autoskillit.config import AutomationConfig
-    from autoskillit.pipeline.context import ToolContext
 
 logger = get_logger(__name__)
 
@@ -35,13 +34,11 @@ def _session_log_dir(cwd: str) -> Path:
     return log_dir
 
 
-def _resolve_pty_mode(ctx: ToolContext) -> bool:
-    backend = cast(CodingAgentBackend, ctx.backend)
+def _resolve_pty_mode(backend: CodingAgentBackend) -> bool:
     return backend.capabilities.pty_required
 
 
-def _resolve_session_log_dir(cwd: str, ctx: ToolContext) -> Path | None:
-    backend = cast(CodingAgentBackend, ctx.backend)
+def _resolve_session_log_dir(cwd: str, backend: CodingAgentBackend) -> Path | None:
     if not backend.capabilities.channel_b_capable:
         return None
     return _session_log_dir(cwd)

--- a/tests/arch/test_backend_coherence.py
+++ b/tests/arch/test_backend_coherence.py
@@ -17,10 +17,10 @@ def test_capability_queries_match_command_backend(minimal_ctx):
     for name, cls in BACKEND_REGISTRY.items():
         backend = cls()
         minimal_ctx.backend = backend
-        assert _resolve_pty_mode(minimal_ctx) == backend.capabilities.pty_required, (
+        assert _resolve_pty_mode(backend) == backend.capabilities.pty_required, (
             f"PTY mode mismatch for {name}"
         )
-        log_dir = _resolve_session_log_dir("/tmp/fake", minimal_ctx)
+        log_dir = _resolve_session_log_dir("/tmp/fake", backend)
         if not backend.capabilities.channel_b_capable:
             assert log_dir is None, f"Expected None log_dir for {name}"
         else:

--- a/tests/arch/test_import_linter_contracts.py
+++ b/tests/arch/test_import_linter_contracts.py
@@ -31,7 +31,7 @@ EXPECTED_CROSS_LAYER_GUARDS: dict[str, frozenset[str]] = {
     "core/types/_type_protocols_recipe.py": frozenset({"recipe"}),
     "execution/headless/__init__.py": frozenset({"pipeline"}),
     "execution/headless/_headless_execute.py": frozenset({"pipeline"}),
-    "execution/headless/_headless_helpers.py": frozenset({"config", "pipeline"}),
+    "execution/headless/_headless_helpers.py": frozenset({"config"}),
     "execution/linux_tracing.py": frozenset({"config"}),
     "execution/process/__init__.py": frozenset({"config"}),
     "execution/testing.py": frozenset({"config"}),

--- a/tests/execution/test_backend_dispatch.py
+++ b/tests/execution/test_backend_dispatch.py
@@ -103,3 +103,167 @@ class TestBackendDispatchRouting:
             )
 
         assert mock_runner.call_args.kwargs["pty_mode"] is False
+
+
+class TestStepBackendOverride:
+    @pytest.mark.anyio
+    async def test_step_backend_none_falls_back_to_ctx_backend(self, minimal_ctx):
+        backend = _mock_backend()
+        minimal_ctx.backend = backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+        with patch(
+            "autoskillit.execution.headless._headless_execute._build_skill_result"
+        ) as mock_build:
+            mock_build.return_value = SkillResult(
+                success=True,
+                result="",
+                session_id="s",
+                subtype="success",
+                is_error=False,
+                exit_code=0,
+                needs_retry=False,
+                retry_reason=RetryReason.NONE,
+                stderr="",
+            )
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+            )
+        assert mock_build.call_args.kwargs["backend"] is backend
+
+    @pytest.mark.anyio
+    async def test_step_backend_override_routes_through_get_backend(self, minimal_ctx):
+        backend = _mock_backend()
+        minimal_ctx.backend = backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+        codex_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_backend.name = "codex"
+        with (
+            patch(
+                "autoskillit.execution.headless.get_backend", return_value=codex_backend
+            ) as mock_get,
+            patch("autoskillit.execution.headless._execute_claude_headless") as mock_exec,
+        ):
+            mock_exec.return_value = SkillResult(
+                success=True,
+                result="",
+                session_id="s",
+                subtype="success",
+                is_error=False,
+                exit_code=0,
+                needs_retry=False,
+                retry_reason=RetryReason.NONE,
+                stderr="",
+            )
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="codex",
+            )
+            mock_get.assert_called_once_with("codex")
+            assert mock_exec.call_args.kwargs["step_backend"] is codex_backend
+
+    @pytest.mark.anyio
+    async def test_step_backend_flows_to_stream_parser_and_build_result(self, minimal_ctx):
+        ctx_backend = _mock_backend()
+        step_backend_mock = _mock_backend(pty_required=False, channel_b_capable=False)
+        step_backend_mock.name = "codex"
+        minimal_ctx.backend = ctx_backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+        with patch(
+            "autoskillit.execution.headless._headless_execute._build_skill_result"
+        ) as mock_build:
+            mock_build.return_value = SkillResult(
+                success=True,
+                result="",
+                session_id="s",
+                subtype="success",
+                is_error=False,
+                exit_code=0,
+                needs_retry=False,
+                retry_reason=RetryReason.NONE,
+                stderr="",
+            )
+            from autoskillit.core.types import CmdSpec
+            from autoskillit.execution.headless._headless_execute import _execute_claude_headless
+
+            await _execute_claude_headless(
+                CmdSpec(cmd=("codex", "--quiet", "test"), env={}),
+                "/tmp/cwd",
+                minimal_ctx,
+                timeout=60.0,
+                stale_threshold=30.0,
+                completion_marker="%%DONE%%",
+                step_backend=step_backend_mock,
+            )
+        step_backend_mock.stream_parser.assert_called_once()
+        ctx_backend.stream_parser.assert_not_called()
+        assert mock_build.call_args.kwargs["backend"] is step_backend_mock
+
+    @pytest.mark.anyio
+    async def test_backend_override_unknown_name_raises_valueerror(self, minimal_ctx):
+        backend = _mock_backend()
+        minimal_ctx.backend = backend
+        minimal_ctx.runner = AsyncMock()
+        from autoskillit.execution.headless import run_headless_core
+
+        with pytest.raises(ValueError, match="Unknown backend"):
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="nonexistent",
+            )
+
+    def test_resolve_pty_mode_accepts_backend_directly(self):
+        backend = _mock_backend(pty_required=False)
+        from autoskillit.execution.headless._headless_helpers import _resolve_pty_mode
+
+        assert _resolve_pty_mode(backend) is False
+
+    def test_resolve_session_log_dir_accepts_backend_directly(self, monkeypatch):
+        backend = _mock_backend(channel_b_capable=False)
+        from autoskillit.execution.headless._headless_helpers import _resolve_session_log_dir
+
+        assert _resolve_session_log_dir("/tmp/cwd", backend) is None
+
+    @pytest.mark.anyio
+    async def test_protocol_accepts_backend_override(self):
+        from tests.fakes import InMemoryHeadlessExecutor
+
+        executor = InMemoryHeadlessExecutor()
+        await executor.run("/test", "/tmp", backend_override="codex")
+        assert executor.calls[0].backend_override == "codex"

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -17,19 +17,19 @@ class TestResolvePtyMode:
         import autoskillit.execution.headless as _headless_mod
 
         minimal_ctx.backend = _mock_backend(pty_required=True)
-        assert _headless_mod._resolve_pty_mode(minimal_ctx) is True
+        assert _headless_mod._resolve_pty_mode(minimal_ctx.backend) is True
 
     def test_pty_required_false_returns_false(self, minimal_ctx) -> None:
         import autoskillit.execution.headless as _headless_mod
 
         minimal_ctx.backend = _mock_backend(pty_required=False)
-        assert _headless_mod._resolve_pty_mode(minimal_ctx) is False
+        assert _headless_mod._resolve_pty_mode(minimal_ctx.backend) is False
 
     def test_pty_mode_false_for_codex_backend(self, minimal_ctx) -> None:
         import autoskillit.execution.headless as _headless_mod
 
         minimal_ctx.backend = CodexBackend()
-        assert _headless_mod._resolve_pty_mode(minimal_ctx) is False
+        assert _headless_mod._resolve_pty_mode(minimal_ctx.backend) is False
 
 
 class TestResolveSessionLogDir:
@@ -41,12 +41,12 @@ class TestResolveSessionLogDir:
             "autoskillit.execution.headless._headless_helpers._session_log_dir",
             lambda cwd: Path("/fake/log/dir"),
         )
-        result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx)
+        result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx.backend)
         assert isinstance(result, Path)
 
     def test_channel_b_capable_false_returns_none(self, minimal_ctx) -> None:
         import autoskillit.execution.headless as _headless_mod
 
         minimal_ctx.backend = _mock_backend(channel_b_capable=False)
-        result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx)
+        result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx.backend)
         assert result is None

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -467,7 +467,7 @@ async def test_dispatch_food_truck_derives_marker_dir_from_cwd(
     monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
     monkeypatch.setattr(
         "autoskillit.execution.headless._resolve_session_log_dir",
-        lambda cwd, ctx: Path("/derived/project"),
+        lambda cwd, backend: Path("/derived/project"),
     )
     monkeypatch.setattr(
         "autoskillit.execution.headless._headless_execute._capture_git_head_sha", lambda *a: ""

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -88,6 +88,7 @@ class ExecutorCall:
     resume_session_id: str = ""
     resume_checkpoint: SessionCheckpoint | None = None
     resume_message: str | None = None
+    backend_override: str | None = None
 
 
 @dataclasses.dataclass
@@ -180,6 +181,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         resume_session_id: str = "",
         resume_checkpoint: SessionCheckpoint | None = None,
         resume_message: str | None = None,
+        backend_override: str | None = None,
     ) -> SkillResult:
         self.calls.append(
             ExecutorCall(
@@ -208,6 +210,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
                 resume_session_id=resume_session_id,
                 resume_checkpoint=resume_checkpoint,
                 resume_message=resume_message,
+                backend_override=backend_override,
             )
         )
         if self._queue:


### PR DESCRIPTION
## Summary

Thread a `step_backend` parameter through the headless execution call chain so that per-step backend overrides flow from `run_headless_core` (where `config.backend_override` is resolved via `get_backend()`) through `_execute_claude_headless` (where it replaces `ctx.backend` for stream parser, format support, skill result, and contract nudge) and into `build_skill_session_cmd` (where it constructs the subprocess command). Session-global concerns (`_resolve_pty_mode`, `_resolve_session_log_dir`) remain on `ctx.backend`. The `HeadlessExecutor` protocol and `InMemoryHeadlessExecutor` fake gain a `backend_override: str | None = None` parameter on `run()`. Refactor `_resolve_pty_mode` and `_resolve_session_log_dir` to accept `CodingAgentBackend` directly instead of `ToolContext`.

Closes #2902

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-102948-545569/.autoskillit/temp/make-plan/py7_p7_a8_wp1_plan_2026-05-25_103500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 83 | 23.9k | 1.2M | 112.6k | 181 | 168.8k | 13m 13s |
| verify | claude-sonnet-4-6 | 1 | 1.6k | 16.4k | 818.0k | 59.9k | 68 | 49.6k | 7m 8s |
| implement* | MiniMax-M2.7-highspeed | 1 | 5.1M | 25.8k | 2.4M | 30.7k | 202 | 16.1k | 11m 34s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 99.6k | 3.6k | 214.9k | 30.7k | 22 | 43.3k | 1m 15s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 92.3k | 1.6k | 334.8k | 30.7k | 24 | 15.2k | 50s |
| review_pr | claude-sonnet-4-6 | 2 | 1.9k | 71.4k | 1.8M | 85.8k | 150 | 148.1k | 19m 16s |
| resolve_review | claude-sonnet-4-6 | 1 | 187 | 17.4k | 1.2M | 75.8k | 59 | 67.2k | 5m 23s |
| **Total** | | | 5.3M | 160.1k | 7.9M | 112.6k | | 508.2k | 58m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 253 | 9329.2 | 63.5 | 102.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **253** | 31071.9 | 2008.9 | 632.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.7k | 129.0k | 5.0M | 433.7k | 45m 1s |
| MiniMax-M2.7-highspeed | 3 | 5.3M | 31.0k | 2.9M | 74.6k | 13m 40s |