### PR TITLE
Recording/Replay Accepted Degradations Design Record

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -5,3 +5,4 @@ Design specifications for planned features and skills.
 | Document | Description |
 |---|---|
 | [env-setup-design.md](env-setup-design.md) | Design spec for the dedicated `setup-environment` skill — Docker vs micromamba-host decision tree, structured output tokens, and recipe integration |
+| [recording-replay-accepted-degradations.md](recording-replay-accepted-degradations.md) | Accepted degradations in P8 recording/replay: Claude PTY cassette format incompatibility with Codex replay, and unchanged Claude session recording path |

--- a/docs/design/recording-replay-accepted-degradations.md
+++ b/docs/design/recording-replay-accepted-degradations.md
@@ -1,0 +1,62 @@
+# Design Record: Recording/Replay Accepted Degradations
+
+**Status:** Accepted
+**Date:** 2026-05-25
+**Issue:** [#2918](https://github.com/TalonT-Org/AutoSkillit/issues/2918)
+
+## Overview
+
+This document records two accepted degradations in the P8 multi-backend
+recording/replay architecture. Both are intentional design decisions, not bugs.
+
+## OLD CASSETTE FORMAT INCOMPATIBILITY
+
+Pre-P8 Claude PTY cassettes use a `stdout.jsonl` file inside a directory written
+by `api_simulator.claude.ScenarioRecorder.record_step()`. The P8 Codex recording
+path writes a different format: `codex_stdout.ndjson` plus `step_meta.json`,
+written by `RecordingSubprocessRunner._record_non_pty_session()`.
+
+**Consequence:** A pre-P8 Claude PTY cassette causes a parse error when used as a
+Codex replay target. `_detect_backend_format()` in `recording.py` detects format
+by the presence of `*/codex_stdout.ndjson` — a Claude cassette directory lacking
+this file routes to `make_scenario_player` (the Claude replay path). Attempting to
+force a Claude cassette through `CodexScenarioPlayer` fails because the expected
+`codex_stdout.ndjson` file does not exist.
+
+**Acceptability:** This is expected and acceptable. The two backends have
+fundamentally different session models (PTY-captured JSONL vs NDJSON subprocess
+stdout). Cross-backend cassette replay was never a design goal. The format
+detection gate (`_detect_backend_format`) ensures each cassette routes to the
+correct player.
+
+**Key references:**
+- `src/autoskillit/execution/recording.py` — `_detect_backend_format()` (format gate), `RecordingSubprocessRunner` (dispatch paths 1-3)
+- `src/autoskillit/execution/backends/codex_scenario_player.py` — `CodexScenarioPlayer`, `CodexStepRecord`
+
+## CLAUDE SESSION RECORDING UNCHANGED
+
+`ScenarioRecorder.record_step()` (from the external `api_simulator.claude` package)
+and the `pty_mode=True` guard in `RecordingSubprocessRunner.__call__()` are
+unmodified by P8. The Claude PTY recording path continues to function identically
+to its pre-P8 behavior.
+
+**Consequence:** No new capabilities are added to Claude session recording. Claude
+sessions are recorded using the same PTY capture mechanism and produce the same
+`stdout.jsonl` cassette format as before P8.
+
+**Acceptability:** P8's scope is adding Codex backend support. Modifying the
+proven Claude recording path would introduce unnecessary risk. The `pty_mode`
+dispatch guard (`if pty_mode:` at `recording.py` line 132) cleanly separates the
+two paths — Claude sessions take the PTY branch, Codex sessions fall through to
+the non-PTY branch.
+
+**Key references:**
+- `src/autoskillit/execution/recording.py` — `RecordingSubprocessRunner.__call__()` line 132 (`if pty_mode:`)
+- `src/autoskillit/execution/headless/_headless_helpers.py` — `_resolve_pty_mode()` (reads `backend.capabilities.pty_required`)
+
+## References
+
+- `src/autoskillit/execution/recording.py` — Record/replay subprocess runners
+- `src/autoskillit/execution/backends/codex_scenario_player.py` — Codex replay player
+- `src/autoskillit/execution/headless/_headless_helpers.py` — PTY mode resolution
+- `src/autoskillit/core/types/_type_subprocess.py` — `SubprocessRunner` protocol (`pty_mode` parameter)

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -1,4 +1,9 @@
-"""RecordingSubprocessRunner and ReplayingSubprocessRunner — scenario I/O for headless sessions."""
+"""RecordingSubprocessRunner and ReplayingSubprocessRunner — scenario I/O for headless sessions.
+
+See docs/design/recording-replay-accepted-degradations.md for accepted
+degradations: Claude PTY cassette format incompatibility with Codex replay,
+and the unchanged Claude session recording path.
+"""
 
 from __future__ import annotations
 

--- a/tests/docs/test_filename_naming.py
+++ b/tests/docs/test_filename_naming.py
@@ -19,6 +19,7 @@ ALLOWLIST = {
         "getting-started.md",
         "end-turn-hazards.md",
         "research-pipeline.md",
+        "recording-replay-accepted-degradations.md",
         "0001-prohibit-background-subagent-execution.md",
         "0002-ban-inline-shell-scripts-from-cmd.md",
     },


### PR DESCRIPTION
## Summary

Create a permanent design record documenting two accepted degradations introduced by the P8 multi-backend recording/replay architecture: (1) pre-P8 Claude PTY cassettes are incompatible with Codex replay due to format differences (`stdout.jsonl` vs `codex_stdout.ndjson`), and (2) the Claude PTY recording path (`ScenarioRecorder.record_step` and `pty_mode=True` guard) is intentionally unmodified by P8. The deliverables are a new design document, an updated module docstring in `recording.py`, a new row in the `docs/design/README.md` table, and a filename allowlist update in `tests/docs/test_filename_naming.py`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-163142-035574/.autoskillit/temp/make-plan/py8_p8_a9_wp3_design_record_plan_2026-05-25_163600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 67 | 11.1k | 954.4k | 67.7k | 94 | 67.7k | 9m 29s |
| verify | claude-sonnet-4-6 | 1 | 76 | 6.3k | 244.6k | 35.3k | 47 | 25.0k | 3m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 405.0k | 6.0k | 794.8k | 30.7k | 56 | 15.9k | 6m 24s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 65.8k | 3.4k | 184.1k | 30.7k | 18 | 43.2k | 1m 15s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 74.2k | 2.1k | 242.6k | 30.7k | 18 | 15.2k | 53s |
| review_pr | claude-sonnet-4-6 | 1 | 166 | 24.5k | 716.9k | 57.2k | 51 | 47.7k | 6m 1s |
| resolve_review | claude-sonnet-4-6 | 1 | 133 | 5.2k | 506.3k | 37.3k | 33 | 27.4k | 3m 20s |
| **Total** | | | 545.4k | 58.5k | 3.6M | 67.7k | | 242.3k | 31m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 71 | 11194.1 | 224.6 | 84.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **71** | 51318.1 | 3412.0 | 824.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 442 | 47.0k | 2.4M | 167.8k | 22m 46s |
| MiniMax-M2.7-highspeed | 3 | 545.0k | 11.5k | 1.2M | 74.4k | 8m 33s |