### PR TITLE
[FEATURE] Extend CodexFlags with DANGEROUSLY_BYPASS and implement build_interactive_cmd

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -18,7 +18,9 @@ from autoskillit.core import (
     KITCHEN_SESSION_ID_ENV_VAR,
     SESSION_TYPE_SKILL,
     BackendCapabilities,
+    BareResume,
     CmdSpec,
+    NamedResume,
     NoResume,
     OutputFormat,
     PluginSource,
@@ -67,6 +69,7 @@ class CodexFlags(StrEnum):
     RESUME_SUBCOMMAND = "resume"
     LAST = "--last"
     CONFIG_OVERRIDE = "-c"
+    DANGEROUSLY_BYPASS = "--dangerously-bypass-approvals-and-sandbox"
 
 
 CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
@@ -382,7 +385,26 @@ class CodexBackend:
         env_extras: Mapping[str, str] | None = None,
         required_env: frozenset[str] | None = None,
     ) -> CmdSpec:
-        raise NotImplementedError("Codex interactive mode is implemented in P6-A3")
+        cmd: list[str] = []
+        match resume_spec:
+            case NoResume():
+                cmd = ["codex", CodexFlags.DANGEROUSLY_BYPASS]
+            case NamedResume(session_id=sid):
+                cmd = ["codex", CodexFlags.RESUME_SUBCOMMAND, sid, CodexFlags.DANGEROUSLY_BYPASS]
+            case BareResume():
+                cmd = ["codex", CodexFlags.RESUME_SUBCOMMAND, CodexFlags.DANGEROUSLY_BYPASS]
+        if model:
+            cmd += [CodexFlags.MODEL, model]
+        # plugin_source: explicit no-op for Codex
+        for d in add_dirs:
+            cmd += [CodexFlags.ADD_DIR, str(d)]
+        if system_prompt is not None and isinstance(resume_spec, NoResume):
+            cmd += [CodexFlags.CONFIG_OVERRIDE, f"developer_instructions={system_prompt}"]
+        if initial_prompt is not None:
+            cmd.append(initial_prompt)
+        base_env = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
+        env = CodexEnvPolicy().build_env(base_env, extras=env_extras, required=required_env)
+        return CmdSpec(cmd=tuple(cmd), env=env)
 
     def build_resume_cmd(
         self,

--- a/tests/contracts/test_backend_protocol.py
+++ b/tests/contracts/test_backend_protocol.py
@@ -261,11 +261,12 @@ def test_build_interactive_cmd_satisfies_protocol_claude():
     assert isinstance(ClaudeCodeBackend(), CodingAgentBackend)
 
 
-def test_build_interactive_cmd_codex_raises_not_implemented():
+def test_build_interactive_cmd_codex_returns_cmd_spec():
+    from autoskillit.core import CmdSpec
     from autoskillit.execution.backends import CodexBackend
 
-    with pytest.raises(NotImplementedError, match="P6-A3"):
-        CodexBackend().build_interactive_cmd()
+    spec = CodexBackend().build_interactive_cmd()
+    assert isinstance(spec, CmdSpec)
 
 
 def test_build_interactive_cmd_signature_shape():

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -54,6 +54,7 @@ class TestCodexFlags:
             "RESUME_SUBCOMMAND",
             "LAST",
             "CONFIG_OVERRIDE",
+            "DANGEROUSLY_BYPASS",
         }
         actual = {m.name for m in CodexFlags}
         assert actual == expected
@@ -179,9 +180,9 @@ class TestCodexBackendCommands:
         spec = CodexBackend().build_resume_cmd(resume_session_id="s1", prompt="go")
         assert "--json" in spec.cmd
 
-    def test_build_interactive_cmd_raises(self) -> None:
-        with pytest.raises(NotImplementedError):
-            CodexBackend().build_interactive_cmd()
+    def test_build_interactive_cmd_returns_cmd_spec(self) -> None:
+        spec = CodexBackend().build_interactive_cmd()
+        assert isinstance(spec, CmdSpec)
 
 
 class TestCodexBackendFactories:
@@ -599,3 +600,80 @@ class TestCodexBuildSkillSessionCmdConfigAdapter:
         )
         assert isinstance(spec, CmdSpec)
         assert any("/test-skill" in s for s in spec.cmd)
+
+
+class TestCodexBuildInteractiveCmd:
+    def test_dangerously_bypass_value(self) -> None:
+        assert str(CodexFlags.DANGEROUSLY_BYPASS) == "--dangerously-bypass-approvals-and-sandbox"
+
+    def test_no_resume_produces_correct_base_command(self) -> None:
+        spec = CodexBackend().build_interactive_cmd()
+        assert spec.cmd[0] == "codex"
+        assert CodexFlags.DANGEROUSLY_BYPASS in spec.cmd
+        assert CodexFlags.RESUME_SUBCOMMAND not in spec.cmd
+
+    def test_named_resume_produces_resume_subcommand_with_session_id(self) -> None:
+        from autoskillit.core import NamedResume
+
+        spec = CodexBackend().build_interactive_cmd(resume_spec=NamedResume(session_id="abc"))
+        assert spec.cmd[0] == "codex"
+        assert spec.cmd[1] == CodexFlags.RESUME_SUBCOMMAND
+        assert spec.cmd[2] == "abc"
+        assert CodexFlags.DANGEROUSLY_BYPASS in spec.cmd
+
+    def test_bare_resume_produces_resume_subcommand_without_session_id(self) -> None:
+        from autoskillit.core import BareResume
+
+        spec = CodexBackend().build_interactive_cmd(resume_spec=BareResume())
+        assert spec.cmd[0] == "codex"
+        assert spec.cmd[1] == CodexFlags.RESUME_SUBCOMMAND
+        assert CodexFlags.DANGEROUSLY_BYPASS in spec.cmd
+        assert "abc" not in spec.cmd
+
+    def test_system_prompt_with_no_resume_appends_config_override(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(system_prompt="foo")
+        assert CodexFlags.CONFIG_OVERRIDE in spec.cmd
+        idx = spec.cmd.index(CodexFlags.CONFIG_OVERRIDE)
+        assert spec.cmd[idx + 1] == "developer_instructions=foo"
+
+    def test_system_prompt_with_named_resume_does_not_append_config_override(self) -> None:
+        from autoskillit.core import NamedResume
+
+        spec = CodexBackend().build_interactive_cmd(
+            resume_spec=NamedResume(session_id="s1"), system_prompt="foo"
+        )
+        assert CodexFlags.CONFIG_OVERRIDE not in spec.cmd
+
+    def test_add_dirs_appends_add_dir_for_each_entry(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(add_dirs=["/a", "/b"])
+        assert (CodexFlags.ADD_DIR, "/a") == (
+            spec.cmd[spec.cmd.index(CodexFlags.ADD_DIR)],
+            spec.cmd[spec.cmd.index(CodexFlags.ADD_DIR) + 1],
+        )
+
+    def test_initial_prompt_is_final_element(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(initial_prompt="hello")
+        assert spec.cmd[-1] == "hello"
+
+    def test_plugin_source_is_silently_ignored(self) -> None:
+        from pathlib import Path
+
+        from autoskillit.core import DirectInstall
+
+        spec = CodexBackend().build_interactive_cmd(
+            plugin_source=DirectInstall(plugin_dir=Path("/x"))
+        )
+        assert "--plugin-dir" not in spec.cmd
+        assert "/x" not in spec.cmd
+
+    def test_env_excludes_headless_vars(self, monkeypatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setenv("HOME", "/home/user")
+        spec = CodexBackend().build_interactive_cmd()
+        assert "ANTHROPIC_API_KEY" not in spec.env
+
+    def test_model_flag_appended_when_provided(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(model="o3")
+        assert CodexFlags.MODEL in spec.cmd
+        idx = spec.cmd.index(CodexFlags.MODEL)
+        assert spec.cmd[idx + 1] == "o3"


### PR DESCRIPTION
## Summary

Add `CodexFlags.DANGEROUSLY_BYPASS = '--dangerously-bypass-approvals-and-sandbox'` to the CodexFlags StrEnum, update the membership guard test, and implement `CodexBackend.build_interactive_cmd` with resume-as-subcommand routing, `-c developer_instructions` for system prompt, `--add-dir` for write grants, and headless-env exclusion filtering.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-163141-302328/.autoskillit/temp/make-plan/py6_p6_a3_wp1_codex_flags_dangerously_bypass_plan_2026-05-25_163500.md`

Closes #2887

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 87 | 12.0k | 1.7M | 103.9k | 113 | 77.8k | 9m 33s |
| verify | claude-sonnet-4-6 | 1 | 220 | 12.5k | 1.6M | 77.3k | 74 | 77.5k | 4m 17s |
| implement* | MiniMax-M2.7-highspeed | 1 | 731.4k | 8.5k | 767.0k | 30.7k | 60 | 43.7k | 3m 8s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 106.0k | 2.9k | 245.5k | 30.7k | 21 | 43.3k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.7k | 1.6k | 211.9k | 30.7k | 17 | 15.2k | 41s |
| review_pr | claude-sonnet-4-6 | 1 | 110 | 32.5k | 467.4k | 68.2k | 38 | 61.1k | 6m 42s |
| resolve_review | claude-sonnet-4-6 | 1 | 221 | 12.4k | 1.3M | 58.5k | 66 | 49.1k | 7m 41s |
| **Total** | | | 885.8k | 82.4k | 6.2M | 103.9k | | 367.7k | 33m 16s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 115 | 6670.0 | 380.4 | 74.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **115** | 54027.8 | 3197.0 | 716.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 638 | 69.4k | 5.0M | 265.4k | 28m 15s |
| MiniMax-M2.7-highspeed | 3 | 885.2k | 13.0k | 1.2M | 102.2k | 5m 0s |