### PR TITLE
Implementation Plan: PY7 P7-A11-WP1 — Make _register_all() call BOTH registrations with error tolerance

### DIFF
--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -490,7 +490,12 @@ def _register_all(
 
     from autoskillit.execution import ensure_codex_mcp_registered  # noqa: PLC0415
 
-    codex_registered = ensure_codex_mcp_registered()
+    try:
+        codex_registered = ensure_codex_mcp_registered()
+        codex_status = "registered" if codex_registered else "ok"
+    except Exception:
+        codex_status = "failed"
+        logger.warning("Codex MCP registration failed", exc_info=True)
 
     # Prompt for github.default_repo if running interactively
     github_repo = None
@@ -539,8 +544,10 @@ def _register_all(
             print(f"  {_Y}{'plugin':>12}{_R}  {_G}registered via ~/.claude.json{_R}")
         print(f"  {_Y}{'hooks':>12}{_R}  {_G}synced{_R} {_D}({scope} scope){_R}")
 
-    _codex_tag = "registered" if codex_registered else "ok"
-    print(f"  {_Y}{'codex mcp':>12}{_R}  {_G}{_codex_tag}{_R}")
+    if codex_status == "failed":
+        print(f"  {_Y}{'codex mcp':>12}{_R}  {_Y}{codex_status}{_R}")
+    else:
+        print(f"  {_Y}{'codex mcp':>12}{_R}  {_G}{codex_status}{_R}")
 
     print()
     _print_next_steps(context="init")

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -531,3 +531,127 @@ class TestRegisterAllCodexMcpRegistration:
         codex_mock = self._setup(monkeypatch, tmp_path, "claude-code")
         _register_all("user", tmp_path)
         codex_mock.assert_called_once()
+
+
+class TestRegisterAllDualRegistration:
+    """Dual registration: both Claude Code and Codex MCP called unconditionally."""
+
+    def _setup(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        *,
+        plugin_ok: bool = False,
+        codex_side_effect: object = True,
+    ) -> tuple[MagicMock, MagicMock, MagicMock]:
+        """Stub collaborators; return (mcp_mock, evict_mock, codex_mock)."""
+        import autoskillit.cli._hooks as _hooks_mod
+        import autoskillit.core.paths as _core_paths
+
+        monkeypatch.setattr(_hooks_mod, "sweep_all_scopes_for_orphans", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "sync_hooks_to_settings", lambda p: None)
+        monkeypatch.setattr(_hooks_mod, "_evict_stale_autoskillit_hooks", lambda p: None)
+        monkeypatch.setattr(
+            _hooks_mod, "_claude_settings_path", lambda s: tmp_path / "settings.json"
+        )
+        monkeypatch.setattr(_core_paths, "pkg_root", lambda: tmp_path / "pkg")
+        (tmp_path / "pkg").mkdir(exist_ok=True)
+
+        mcp_mock = MagicMock()
+        monkeypatch.setattr("autoskillit.cli._init_helpers._register_mcp_server", mcp_mock)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._user_claude_json_path",
+            lambda: tmp_path / ".claude.json",
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._create_secrets_template", lambda p: None
+        )
+        monkeypatch.setattr("autoskillit.cli._init_helpers._prompt_github_repo", lambda: None)
+
+        evict_mock = MagicMock(return_value=False)
+        monkeypatch.setattr("autoskillit.cli._init_helpers.evict_direct_mcp_entry", evict_mock)
+
+        monkeypatch.setattr("sys.stdin", MagicMock(isatty=lambda: False))
+        monkeypatch.setattr("autoskillit.core.ensure_project_temp", lambda p: tmp_path / "temp")
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed",
+            lambda **kwargs: plugin_ok,
+        )
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = "claude-code"
+        monkeypatch.setattr("autoskillit.config.load_config", lambda p=None: mock_config)
+
+        if isinstance(codex_side_effect, type) and issubclass(codex_side_effect, BaseException):
+            codex_mock = MagicMock(side_effect=codex_side_effect("boom"))
+        else:
+            codex_mock = MagicMock(return_value=codex_side_effect)
+        monkeypatch.setattr("autoskillit.execution.ensure_codex_mcp_registered", codex_mock)
+
+        return mcp_mock, evict_mock, codex_mock
+
+    def test_both_called_plugin_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        mcp_mock, _evict, codex_mock = self._setup(monkeypatch, tmp_path, plugin_ok=False)
+        _register_all("user", tmp_path)
+        mcp_mock.assert_called_once()
+        codex_mock.assert_called_once()
+
+    def test_both_called_plugin_installed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        _mcp, evict_mock, codex_mock = self._setup(monkeypatch, tmp_path, plugin_ok=True)
+        _register_all("user", tmp_path)
+        evict_mock.assert_called_once()
+        codex_mock.assert_called_once()
+
+    def test_codex_exception_does_not_abort(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+
+        from autoskillit.cli._init_helpers import _register_all
+
+        _mcp, _evict, codex_mock = self._setup(
+            monkeypatch, tmp_path, codex_side_effect=RuntimeError
+        )
+        with caplog.at_level(logging.WARNING, logger="autoskillit.cli._init_helpers"):
+            _register_all("user", tmp_path)
+        codex_mock.assert_called_once()
+        captured = capsys.readouterr()
+        assert "AUTOSKILLIT" in captured.out
+        assert "failed" in captured.out
+        assert "Codex MCP registration failed" in caplog.text
+
+    def test_plugin_ok_fires_evict_and_codex(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        _mcp, evict_mock, codex_mock = self._setup(monkeypatch, tmp_path, plugin_ok=True)
+        _register_all("user", tmp_path)
+        evict_mock.assert_called_once()
+        codex_mock.assert_called_once()
+
+    def test_summary_contains_both_status_tokens(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from autoskillit.cli._init_helpers import _register_all
+
+        self._setup(monkeypatch, tmp_path, plugin_ok=False)
+        _register_all("user", tmp_path)
+        out = capsys.readouterr().out
+        assert "plugin" in out
+        assert "codex mcp" in out

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -615,22 +615,21 @@ class TestRegisterAllDualRegistration:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        import logging
+        import structlog.testing
 
         from autoskillit.cli._init_helpers import _register_all
 
         _mcp, _evict, codex_mock = self._setup(
             monkeypatch, tmp_path, codex_side_effect=RuntimeError
         )
-        with caplog.at_level(logging.WARNING, logger="autoskillit.cli._init_helpers"):
+        with structlog.testing.capture_logs() as logs:
             _register_all("user", tmp_path)
         codex_mock.assert_called_once()
         captured = capsys.readouterr()
         assert "AUTOSKILLIT" in captured.out
         assert "failed" in captured.out
-        assert "Codex MCP registration failed" in caplog.text
+        assert any("Codex MCP registration failed" in str(log.get("event", "")) for log in logs)
 
     def test_plugin_ok_fires_evict_and_codex(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Summary

Wrap the existing `ensure_codex_mcp_registered()` call in `_register_all()` with try/except to prevent Codex registration failures from aborting init. Derive a 3-state `codex_status` string and update the summary block. Add `TestRegisterAllDualRegistration` test class with 5 tests covering dual-call behavior, error tolerance, and summary output.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-175205-083312/.autoskillit/temp/make-plan/py7_p7_a11_wp1_dual_registration_plan_2026-05-25_180500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 77 | 16.5k | 1.1M | 77.4k | 99 | 55.8k | 12m 47s |
| verify | claude-sonnet-4-6 | 1 | 132 | 11.7k | 648.5k | 53.5k | 43 | 43.3k | 4m 1s |
| implement* | MiniMax-M2.7-highspeed | 1 | 265.4k | 6.7k | 488.0k | 30.7k | 36 | 16.0k | 1m 50s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 66.7k | 2.8k | 212.0k | 30.7k | 17 | 15.5k | 1m 22s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 45.1k | 1.2k | 212.0k | 30.7k | 15 | 15.1k | 36s |
| review_pr | claude-sonnet-4-6 | 1 | 172 | 37.8k | 788.8k | 77.8k | 55 | 68.0k | 8m 23s |
| resolve_review | claude-sonnet-4-6 | 1 | 165 | 7.1k | 723.9k | 46.7k | 43 | 36.4k | 3m 17s |
| **Total** | | | 377.8k | 83.7k | 4.2M | 77.8k | | 250.2k | 32m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 137 | 3562.4 | 116.5 | 48.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **137** | 30789.5 | 1826.2 | 611.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 546 | 73.0k | 3.3M | 203.6k | 28m 30s |
| MiniMax-M2.7-highspeed | 3 | 377.3k | 10.7k | 912.0k | 46.6k | 3m 48s |