### PR TITLE
Test Coverage for Structural Gating and Copy-on-Activate

### DIFF
--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -7,7 +7,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | File | Purpose |
 |------|---------|
 | `__init__.py` | empty |
-| `test_add_dir_validation.py` | Tests for ValidatedAddDir and validate_add_dir |
+| `test_add_dir_validation.py` | Tests for ValidatedAddDir, validate_add_dir, and validate_project_local_skill_dir |
 | `test_canonical_token_usage.py` | Tests for CanonicalTokenUsage frozen dataclass — factory methods, merge, and immutability |
 | `test_capture.py` | Tests for CaptureEntrySpec and resolve_payload_field |
 | `test_branch_guard.py` | Tests for core.branch_guard — protected-branch validation |

--- a/tests/core/test_add_dir_validation.py
+++ b/tests/core/test_add_dir_validation.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from autoskillit.core import ValidatedAddDir
-from autoskillit.core.claude_conventions import LayoutError, validate_add_dir
+from autoskillit.core.claude_conventions import (
+    LayoutError,
+    validate_add_dir,
+    validate_project_local_skill_dir,
+)
 
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
@@ -58,3 +63,49 @@ class TestValidateAddDir:
         skills_ext = pkg_root() / "skills_extended"
         with pytest.raises(LayoutError):
             validate_add_dir(skills_ext)
+
+
+class TestValidateProjectLocalSkillDir:
+    """validate_project_local_skill_dir: None for codex, delegates to validate_add_dir for claude."""
+
+    @staticmethod
+    def _make_backend(name: str) -> MagicMock:
+        b = MagicMock()
+        b.name = name
+        return b
+
+    def test_claude_backend_claude_layout_returns_validated_add_dir(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / ".claude" / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Test")
+        result = validate_project_local_skill_dir(tmp_path, self._make_backend("claude-code"))
+        assert isinstance(result, ValidatedAddDir)
+
+    def test_codex_backend_returns_none(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / ".claude" / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Test")
+        result = validate_project_local_skill_dir(tmp_path, self._make_backend("codex"))
+        assert result is None
+
+    def test_claude_backend_codex_layout_returns_none(self, tmp_path: Path) -> None:
+        codex_skill = tmp_path / ".codex" / "skills" / "test-skill"
+        codex_skill.mkdir(parents=True)
+        (codex_skill / "SKILL.md").write_text("# Test")
+        result = validate_project_local_skill_dir(tmp_path, self._make_backend("claude-code"))
+        assert result is None
+
+    def test_codex_backend_claude_layout_returns_none(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / ".claude" / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Test")
+        result = validate_project_local_skill_dir(tmp_path, self._make_backend("codex"))
+        assert result is None
+
+    def test_empty_dir_returns_none_claude(self, tmp_path: Path) -> None:
+        result = validate_project_local_skill_dir(tmp_path, self._make_backend("claude-code"))
+        assert result is None
+
+    def test_empty_dir_returns_none_codex(self, tmp_path: Path) -> None:
+        result = validate_project_local_skill_dir(tmp_path, self._make_backend("codex"))
+        assert result is None

--- a/tests/workspace/CLAUDE.md
+++ b/tests/workspace/CLAUDE.md
@@ -24,10 +24,11 @@ Workspace cleanup, clone lifecycle, session skills, and worktree tests.
 | `test_session_skills_features.py` | Phase 2 tests: session_skills module — feature-gate skill filtering |
 | `test_session_skills_filtering.py` | Phase 2 tests: session_skills module — subset/disabled-category and pack filtering |
 | `test_session_skills_provider.py` | Phase 2 tests: session_skills module — provider and core manager |
+| `test_session_skills_codex.py` | Tests for Codex-specific session skill layout, config file copying, and backend regression guard |
 | `test_skill_content_substitution.py` | Tests for SkillsDirectoryProvider.get_skill_content placeholder substitution |
 | `test_skills.py` | Tests for skill resolution hierarchy |
 | `test_worktree.py` | Worktree tests |
 
 ## Architecture Notes
 
-`conftest.py` provides shared fixtures for workspace tests. The `test_clone_*.py` files are split by concern from the original test_clone.py: core clone_repo behavior, push_to_remote, remote resolution/probing, and detect helpers. The `test_session_skills_*.py` files are split by concern across five files testing different aspects of the `session_skills` module.
+`conftest.py` provides shared fixtures for workspace tests. The `test_clone_*.py` files are split by concern from the original test_clone.py: core clone_repo behavior, push_to_remote, remote resolution/probing, and detect helpers. The `test_session_skills_*.py` files are split by concern across six files testing different aspects of the `session_skills` module.

--- a/tests/workspace/conftest.py
+++ b/tests/workspace/conftest.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.workspace.session_skills import (
+    DefaultSessionSkillManager,
+    SkillsDirectoryProvider,
+)
+
 
 @pytest.fixture
 def bare_remote(tmp_path: Path) -> Path:
@@ -93,3 +98,14 @@ def git_repo(tmp_path: Path) -> Path:
         capture_output=True,
     )
     return repo
+
+
+@pytest.fixture
+def make_session_skill_manager(tmp_path: Path):
+    """Factory fixture returning a DefaultSessionSkillManager."""
+
+    def _factory(*, ephemeral_root: Path | None = None) -> DefaultSessionSkillManager:
+        provider = SkillsDirectoryProvider()
+        return DefaultSessionSkillManager(provider, ephemeral_root=ephemeral_root or tmp_path)
+
+    return _factory

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -1,0 +1,126 @@
+"""Tests for Codex-specific session skill layout and config file copying."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from autoskillit.core import ValidatedAddDir
+from autoskillit.workspace.session_skills import (
+    CODEX_SKILLS_SUBDIR,
+    _SKILLS_SUBDIR,
+)
+
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
+
+
+@pytest.fixture
+def codex_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Fake ~/.codex/ home and codex backend mock."""
+    fake_home = tmp_path / "fakehome"
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "config.toml").write_text("[codex]\nmodel = 'o3'\n")
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    backend = MagicMock()
+    backend.name = "codex"
+
+    return type("CodexEnv", (), {
+        "fake_home": fake_home,
+        "codex_dir": codex_dir,
+        "backend": backend,
+    })()
+
+
+def test_codex_init_session_creates_skills_subdir(
+    make_session_skill_manager, codex_env
+) -> None:
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    skill_files = list((session_path / CODEX_SKILLS_SUBDIR).glob("*/SKILL.md"))
+    assert len(skill_files) > 0
+    assert not (session_path / _SKILLS_SUBDIR).exists()
+
+
+def test_codex_init_session_copies_config_toml(
+    make_session_skill_manager, codex_env
+) -> None:
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    copied = session_path / "config.toml"
+    assert copied.exists()
+    assert copied.read_text() == "[codex]\nmodel = 'o3'\n"
+
+
+def test_codex_init_session_copies_auth_json(
+    make_session_skill_manager, codex_env
+) -> None:
+    (codex_env.codex_dir / "auth.json").write_text('{"token": "test"}')
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    copied = session_path / "auth.json"
+    assert copied.exists()
+    assert copied.read_text() == '{"token": "test"}'
+
+
+def test_codex_init_session_copies_env_if_present(
+    make_session_skill_manager, codex_env
+) -> None:
+    (codex_env.codex_dir / ".env").write_text("API_KEY=secret\n")
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    copied = session_path / ".env"
+    assert copied.exists()
+    assert copied.read_text() == "API_KEY=secret\n"
+
+
+def test_codex_init_session_skips_env_if_absent(
+    make_session_skill_manager, codex_env
+) -> None:
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    assert not (session_path / ".env").exists()
+
+
+def test_codex_init_session_auth_json_missing_no_crash(
+    make_session_skill_manager, codex_env
+) -> None:
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    assert not (session_path / "auth.json").exists()
+
+
+def test_codex_init_session_config_toml_missing_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_session_skill_manager
+) -> None:
+    fake_home = tmp_path / "fakehome"
+    (fake_home / ".codex").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    backend = MagicMock()
+    backend.name = "codex"
+
+    mgr = make_session_skill_manager()
+    with pytest.raises(FileNotFoundError):
+        mgr.init_session("sid", cook_session=True, backend=backend)
+
+
+def test_codex_init_session_returns_validated_add_dir(
+    make_session_skill_manager, codex_env
+) -> None:
+    mgr = make_session_skill_manager()
+    result = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    assert isinstance(result, ValidatedAddDir)
+    assert str(result).endswith("/sid")
+
+
+def test_claude_backend_still_uses_dot_claude_layout(make_session_skill_manager) -> None:
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True)
+    skill_files = list((session_path / _SKILLS_SUBDIR).glob("*/SKILL.md"))
+    assert len(skill_files) > 0
+    assert not (session_path / CODEX_SKILLS_SUBDIR).exists()

--- a/tests/workspace/test_session_skills_provider.py
+++ b/tests/workspace/test_session_skills_provider.py
@@ -6,12 +6,14 @@ import os
 import re
 import time
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
 
 from autoskillit.workspace.session_skills import (
     _SKILLS_SUBDIR,
+    CODEX_SKILLS_SUBDIR,
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
     resolve_ephemeral_root,
@@ -74,22 +76,68 @@ def test_provider_does_not_inject_for_cook_session() -> None:
     assert fm.get("disable-model-invocation") is not True
 
 
-def test_session_skill_manager_creates_ephemeral_dir(tmp_path: Path) -> None:
-    provider = SkillsDirectoryProvider()
-    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
-    session_path = mgr.init_session("test-session-abc", cook_session=False)
+@pytest.mark.parametrize(
+    ("backend_name", "skills_subdir"),
+    [
+        pytest.param(None, _SKILLS_SUBDIR, id="claude-code"),
+        pytest.param("codex", CODEX_SKILLS_SUBDIR, id="codex"),
+    ],
+)
+def test_session_skill_manager_creates_ephemeral_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_session_skill_manager,
+    backend_name: str | None,
+    skills_subdir: Path,
+) -> None:
+    backend = None
+    if backend_name == "codex":
+        fake_home = tmp_path / "fakehome"
+        codex_dir = fake_home / ".codex"
+        codex_dir.mkdir(parents=True)
+        (codex_dir / "config.toml").write_text("[codex]\n")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        backend = MagicMock()
+        backend.name = "codex"
+
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("test-session-abc", cook_session=True, backend=backend)
     assert session_path.exists()
     assert session_path.is_dir()
-    skill_files = list((session_path / _SKILLS_SUBDIR).glob("*/SKILL.md"))
+    skill_files = list((session_path / skills_subdir).glob("*/SKILL.md"))
     assert len(skill_files) > 0
+    if backend_name == "codex":
+        assert not (session_path / _SKILLS_SUBDIR).exists()
 
 
-def test_session_manager_injects_disable_for_tier2(tmp_path: Path) -> None:
-    """Non-cook init_session omits tier2 skill entirely (no directory created)."""
+@pytest.mark.parametrize(
+    ("backend_name", "skills_subdir"),
+    [
+        pytest.param(None, _SKILLS_SUBDIR, id="claude-code"),
+        pytest.param("codex", CODEX_SKILLS_SUBDIR, id="codex"),
+    ],
+)
+def test_session_manager_injects_disable_for_tier2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_session_skill_manager,
+    backend_name: str | None,
+    skills_subdir: Path,
+) -> None:
+    """Structural gating: tier2 skill directory is absent after init_session for all backends."""
     from tests._helpers import make_skills_config, make_test_config
 
-    provider = SkillsDirectoryProvider()
-    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+    backend = None
+    if backend_name == "codex":
+        fake_home = tmp_path / "fakehome"
+        codex_dir = fake_home / ".codex"
+        codex_dir.mkdir(parents=True)
+        (codex_dir / "config.toml").write_text("[codex]\n")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        backend = MagicMock()
+        backend.name = "codex"
+
+    mgr = make_session_skill_manager()
     config = make_test_config(
         skills=make_skills_config(
             tier1=["open-kitchen", "close-kitchen"],
@@ -97,9 +145,13 @@ def test_session_manager_injects_disable_for_tier2(tmp_path: Path) -> None:
             tier3=[],
         )
     )
-    session_path = mgr.init_session("test-session-xyz", cook_session=False, config=config)
-    mermaid_dir = session_path / _SKILLS_SUBDIR / "mermaid"
+    session_path = mgr.init_session(
+        "test-session-xyz", cook_session=False, config=config, backend=backend
+    )
+    mermaid_dir = session_path / skills_subdir / "mermaid"
     assert not mermaid_dir.exists()
+    if backend_name == "codex":
+        assert not (session_path / _SKILLS_SUBDIR).exists()
 
 
 def test_session_manager_no_flag_for_cook_session(tmp_path: Path) -> None:
@@ -143,6 +195,71 @@ def test_activate_skill_deps_removes_flag(tmp_path: Path) -> None:
     mermaid_md = tmp_path / "session-toggle" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
     content = mermaid_md.read_text()
     fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    assert fm_match
+    fm = yaml.safe_load(fm_match.group(1))
+    assert "disable-model-invocation" not in fm or fm.get("disable-model-invocation") is not True
+
+
+def test_activate_with_deps_materialises_absent_skill(
+    tmp_path: Path, make_session_skill_manager
+) -> None:
+    """When SKILL.md is absent (structural gating), _activate_with_deps copies it from provider."""
+    from tests._helpers import make_skills_config, make_test_config
+
+    mgr = make_session_skill_manager()
+    config = make_test_config(
+        skills=make_skills_config(
+            tier1=["open-kitchen", "close-kitchen"],
+            tier2=["mermaid"],
+            tier3=[],
+        )
+    )
+    mgr.init_session("session-materialise", cook_session=False, config=config)
+    mermaid_md = tmp_path / "session-materialise" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    assert not mermaid_md.exists()
+
+    result = mgr.activate_skill_deps("session-materialise", "mermaid")
+    assert result is True
+    assert mermaid_md.exists()
+
+    content = mermaid_md.read_text()
+    fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    assert fm_match
+    fm = yaml.safe_load(fm_match.group(1))
+    assert "disable-model-invocation" not in fm or fm.get("disable-model-invocation") is not True
+
+
+def test_activate_with_deps_already_present_removes_flag(
+    tmp_path: Path, make_session_skill_manager
+) -> None:
+    """When SKILL.md already exists with disable-model-invocation, activate removes the key."""
+    from tests._helpers import make_skills_config, make_test_config
+
+    mgr = make_session_skill_manager()
+    config = make_test_config(
+        skills=make_skills_config(
+            tier1=["open-kitchen", "close-kitchen"],
+            tier2=["mermaid"],
+            tier3=[],
+        )
+    )
+    mgr.init_session(
+        "session-flag-remove",
+        cook_session=False,
+        config=config,
+        allow_only=frozenset({"mermaid"}),
+    )
+    mermaid_md = tmp_path / "session-flag-remove" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    assert mermaid_md.exists()
+
+    content = mermaid_md.read_text()
+    injected = content.replace("---\n", "---\ndisable-model-invocation: true\n", 1)
+    mermaid_md.write_text(injected)
+
+    result = mgr.activate_skill_deps("session-flag-remove", "mermaid")
+    assert result is True
+    updated = mermaid_md.read_text()
+    fm_match = re.match(r"^---\n(.*?)\n---", updated, re.DOTALL)
     assert fm_match
     fm = yaml.safe_load(fm_match.group(1))
     assert "disable-model-invocation" not in fm or fm.get("disable-model-invocation") is not True


### PR DESCRIPTION
## Summary

Add comprehensive tests for P3 changes across four test files plus two documentation updates:
1. **tests/workspace/test_session_skills_codex.py** (NEW) — Codex-specific init_session tests: directory layout, config/auth file copying, missing-file handling, return type, and claude backend regression guard
2. **tests/workspace/test_session_skills_provider.py** (MODIFY) — Backend-parametrized structural gating tests and copy-on-activate activation tests
3. **tests/workspace/conftest.py** (MODIFY) — `make_session_skill_manager` factory fixture
4. **tests/core/test_add_dir_validation.py** (MODIFY) — `TestValidateProjectLocalSkillDir` class with 6 backend+layout combination tests
5. **tests/workspace/CLAUDE.md** (MODIFY) — Add new file entry and update session_skills file count
6. **tests/core/CLAUDE.md** (MODIFY) — Update description for test_add_dir_validation.py

No changes needed to `tests/execution/backends/test_codex_backend.py` — the required tests already exist.

Closes #2873

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-175131-328454/.autoskillit/temp/make-plan/p3_a10_wp1_test_coverage_plan_2026-05-25_180700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.4k | 34.0k | 1.6M | 103.2k | 154 | 99.0k | 17m 23s |
| verify | claude-sonnet-4-6 | 1 | 156 | 15.8k | 847.8k | 58.9k | 58 | 48.7k | 5m 27s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.9M | 22.4k | 1.6M | 30.7k | 105 | 15.9k | 6m 36s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 85.3k | 3.9k | 220.1k | 36.0k | 24 | 54.4k | 1m 30s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.5k | 1.6k | 211.9k | 30.7k | 14 | 15.2k | 44s |
| review_pr | claude-sonnet-4-6 | 1 | 190 | 39.4k | 831.5k | 77.9k | 52 | 71.0k | 9m 25s |
| resolve_review | claude-sonnet-4-6 | 1 | 581 | 34.8k | 5.3M | 104.1k | 156 | 94.0k | 20m 44s |
| **Total** | | | 2.1M | 151.6k | 10.6M | 104.1k | | 398.2k | 1h 1m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 339 | 4607.8 | 47.1 | 65.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **339** | 31305.3 | 1174.7 | 447.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.3k | 123.8k | 8.6M | 312.7k | 53m 1s |
| MiniMax-M2.7-highspeed | 3 | 2.1M | 27.8k | 2.0M | 85.6k | 8m 50s |