### PR TITLE
feat: allow AUTOSKILLIT_AGENT_BACKEND to propagate through env scrubbers

### DIFF
--- a/src/autoskillit/core/types/_type_constants_env.py
+++ b/src/autoskillit/core/types/_type_constants_env.py
@@ -54,6 +54,12 @@ AGENT_BACKEND_ENV_VAR: str = "AUTOSKILLIT_AGENT_BACKEND"
 AGENT_BACKEND_CLAUDE_CODE: str = "claude-code"
 AGENT_BACKEND_CODEX: str = "codex"
 
+# AGENT_BACKEND_ENV_VAR is intentionally absent: it is not in
+# _HEADLESS_EXCLUSIVE_VARS (_claude_prompt.py) and removing it here
+# allows natural propagation through both scrub stages in codex.py's
+# build_skill_session_cmd (the _HEADLESS_EXCLUSIVE_VARS filter and
+# CodexEnvPolicy.build_env).  Backends inject the canonical value via
+# extras regardless.
 AUTOSKILLIT_PRIVATE_ENV_VARS: frozenset[str] = frozenset(
     {
         "AUTOSKILLIT_HEADLESS",
@@ -69,7 +75,6 @@ AUTOSKILLIT_PRIVATE_ENV_VARS: frozenset[str] = frozenset(
         "AUTOSKILLIT_CAMPAIGN_STATE_PATH",
         "AUTOSKILLIT_PROJECT_DIR",
         FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
-        AGENT_BACKEND_ENV_VAR,
         HEADLESS_AUTO_GATE_ENV_VAR,
         "AUTOSKILLIT_LAUNCH_ID",
         "AUTOSKILLIT_SKILL_NAME",

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
+    AGENT_BACKEND_ENV_VAR,
     CAMPAIGN_ID_ENV_VAR,
     CLAUDE_CODE_CAPABILITIES,
     CONTEXT_EXHAUSTION_MARKER,
@@ -518,6 +519,7 @@ class ClaudeCodeBackend:
             "AUTOSKILLIT_SESSION_TYPE": SESSION_TYPE_SKILL,
             "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
             "MCP_CONNECTION_NONBLOCKING": "0",
+            AGENT_BACKEND_ENV_VAR: AGENT_BACKEND_CLAUDE_CODE,
         }
         if exit_after_stop_delay_ms > 0:
             extras["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = str(exit_after_stop_delay_ms)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -13,6 +13,7 @@ import zstandard
 
 from autoskillit.core import (
     AGENT_BACKEND_CODEX,
+    AGENT_BACKEND_ENV_VAR,
     AUTOSKILLIT_PRIVATE_ENV_VARS,
     CAMPAIGN_ID_ENV_VAR,
     KITCHEN_SESSION_ID_ENV_VAR,
@@ -301,6 +302,7 @@ class CodexBackend:
             "AUTOSKILLIT_HEADLESS": "1",
             "AUTOSKILLIT_SESSION_TYPE": SESSION_TYPE_SKILL,
             "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
+            AGENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX,
         }
         if scenario_step_name:
             extras["SCENARIO_STEP_NAME"] = scenario_step_name

--- a/tests/core/test_claude_env.py
+++ b/tests/core/test_claude_env.py
@@ -214,3 +214,11 @@ def test_alias_identity() -> None:
     from autoskillit.core._claude_env import build_agent_env, build_claude_env
 
     assert build_agent_env is build_claude_env
+
+
+def test_agent_backend_not_scrubbed() -> None:
+    # AUTOSKILLIT_AGENT_BACKEND must not be stripped by build_agent_env so that
+    # hook subprocesses and test runners can read the session identity.
+    result = build_agent_env(base={"AUTOSKILLIT_AGENT_BACKEND": "codex", "HOME": "/tmp"})
+    assert "AUTOSKILLIT_AGENT_BACKEND" in result
+    assert result["AUTOSKILLIT_AGENT_BACKEND"] == "codex"

--- a/tests/execution/backends/test_claude_code_backend.py
+++ b/tests/execution/backends/test_claude_code_backend.py
@@ -9,6 +9,7 @@ from autoskillit.core import (
     CmdSpec,
     CodingAgentBackend,
     EnvPolicy,
+    OutputFormat,
     ResultParser,
     SessionLocator,
     StreamParser,
@@ -91,3 +92,32 @@ class TestClaudeCodeBackend:
     def test_write_tool_names_returns_write_edit(self) -> None:
         backend = ClaudeCodeBackend()
         assert backend.write_tool_names() == frozenset({"Write", "Edit"})
+
+
+class TestClaudeCodeBackendAgentBackendEnv:
+    """Tests that AUTOSKILLIT_AGENT_BACKEND is injected into skill session env."""
+
+    BASE: dict[str, object] = {
+        "skill_command": "/test-skill",
+        "cwd": "/work",
+        "completion_marker": "%%DONE%%",
+        "model": None,
+        "plugin_source": None,
+        "output_format": OutputFormat.JSON,
+    }
+
+    def test_agent_backend_env_set(self) -> None:
+        spec = ClaudeCodeBackend().build_skill_session_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_AGENT_BACKEND"] == "claude-code"
+
+    def test_agent_backend_overrides_parent_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "wrong-value")
+        spec = ClaudeCodeBackend().build_skill_session_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_AGENT_BACKEND"] == "claude-code"
+
+    def test_agent_backend_present_without_parent_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
+        spec = ClaudeCodeBackend().build_skill_session_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_AGENT_BACKEND"] == "claude-code"

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -677,3 +677,32 @@ class TestCodexBuildInteractiveCmd:
         assert CodexFlags.MODEL in spec.cmd
         idx = spec.cmd.index(CodexFlags.MODEL)
         assert spec.cmd[idx + 1] == "o3"
+
+
+class TestCodexBuildSkillSessionCmdAgentBackend:
+    """Tests that AUTOSKILLIT_AGENT_BACKEND is injected into skill session env."""
+
+    BASE: dict[str, object] = {
+        "skill_command": "/test-skill",
+        "cwd": "/work",
+        "completion_marker": "%%DONE%%",
+        "model": None,
+        "plugin_source": None,
+        "output_format": OutputFormat.JSON,
+    }
+
+    def test_agent_backend_env_set(self) -> None:
+        spec = CodexBackend().build_skill_session_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_AGENT_BACKEND"] == "codex"
+
+    def test_agent_backend_overrides_parent_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "wrong-value")
+        spec = CodexBackend().build_skill_session_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_AGENT_BACKEND"] == "codex"
+
+    def test_agent_backend_present_without_parent_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
+        spec = CodexBackend().build_skill_session_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_AGENT_BACKEND"] == "codex"

--- a/tests/execution/backends/test_codex_env_policy.py
+++ b/tests/execution/backends/test_codex_env_policy.py
@@ -94,3 +94,11 @@ class TestCodexEnvPolicy:
         policy = CodexEnvPolicy()
         with pytest.raises((FrozenInstanceError, TypeError, AttributeError)):
             policy.some_attr = "value"  # type: ignore[misc]
+
+    def test_agent_backend_not_stripped(self) -> None:
+        # AUTOSKILLIT_AGENT_BACKEND must pass through CodexEnvPolicy so that
+        # hook subprocesses and test runners can read the session identity.
+        policy = CodexEnvPolicy()
+        base = {"AUTOSKILLIT_AGENT_BACKEND": "codex", "PATH": "/usr/bin"}
+        result = policy.build_env(base)
+        assert result["AUTOSKILLIT_AGENT_BACKEND"] == "codex"

--- a/tests/execution/test_commands_skill_session.py
+++ b/tests/execution/test_commands_skill_session.py
@@ -59,3 +59,10 @@ class TestBuildSkillSessionCmdSharedBehavior:
             "/autoskillit:investigate", "/repo", completion_marker="DONE"
         )
         assert spec.env["AUTOSKILLIT_SKILL_NAME"] == "investigate"
+
+    @pytest.mark.parametrize("backend", [ClaudeCodeBackend(), CodexBackend()])
+    def test_agent_backend_present_in_env(self, backend) -> None:
+        spec = backend.build_skill_session_cmd(
+            "/autoskillit:investigate", "/repo", completion_marker="DONE"
+        )
+        assert "AUTOSKILLIT_AGENT_BACKEND" in spec.env


### PR DESCRIPTION
## Summary

Remove `AGENT_BACKEND_ENV_VAR` from the `AUTOSKILLIT_PRIVATE_ENV_VARS` frozenset so it is no longer scrubbed by `CodexEnvPolicy.build_env()` or `build_agent_env()`, and inject it unconditionally into the `extras` dict of both `ClaudeCodeBackend._build_skill_session_cmd_impl()` and `CodexBackend.build_skill_session_cmd()`. This ensures hook subprocesses always see the correct `AUTOSKILLIT_AGENT_BACKEND` value regardless of host environment state.

## Requirements

## Goal

Allow AUTOSKILLIT_AGENT_BACKEND to propagate naturally through both scrub stages in codex.py (the _HEADLESS_EXCLUSIVE_VARS stage and the CodexEnvPolicy.build_env stage) so that hook subprocesses can read the value and determine which backend is active.

## Context

- Phase: Hook System Porting (Milestone: 4-hook-system-porting)
- Assignment: P4-A1 (Propagate AUTOSKILLIT_AGENT_BACKEND to hook subprocesses: remove AGENT_BACKEND_ENV_VAR from AUTOSKILLIT_PRIVATE_ENV_VARS and inject backend value in both build_skill_session_cmd() extras dicts)
- Depends on: P3-A5-WP1
- Depended on by: P3-A5-WP1, P4-A2-WP1, P4-A7-WP1

## Deliverables

- `src/autoskillit/core/types/_type_constants.py` — AGENT_BACKEND_ENV_VAR removed from AUTOSKILLIT_PRIVATE_ENV_VARS frozenset; three-list sync comment updated to document verified absence from _HEADLESS_EXCLUSIVE_VARS
- `src/autoskillit/execution/backends/claude.py` — AGENT_BACKEND_ENV_VAR added to imports and injected into extras dict in _build_skill_session_cmd_impl()
- `src/autoskillit/execution/backends/codex.py` — AGENT_BACKEND_ENV_VAR added to imports and injected into extras dict in CodexBackend.build_skill_session_cmd()
- `tests/execution/backends/test_claude_code_backend.py` — new test class TestClaudeCodeBackendAgentBackendEnv with 3+ tests
- `tests/execution/backends/test_codex_backend.py` — new test class or extended TestCodexBuildSkillSessionCmd with 3+ tests for AUTOSKILLIT_AGENT_BACKEND

## Technical Steps

1. Remove `AGENT_BACKEND_ENV_VAR` entry from `AUTOSKILLIT_PRIVATE_ENV_VARS` frozenset in `_type_constants_env.py`
2. Update three-list sync comment to document verified absence from `_HEADLESS_EXCLUSIVE_VARS`
3. Verify no existing test asserts `AGENT_BACKEND_ENV_VAR` membership in `AUTOSKILLIT_PRIVATE_ENV_VARS`
4. Confirm dynamic-iteration tests remain valid after removal
5. In `claude.py`: add `AGENT_BACKEND_ENV_VAR` to imports and inject into `extras` dict in `_build_skill_session_cmd_impl()`
6. Confirm `AGENT_BACKEND_ENV_VAR` must NOT be added to `_HEADLESS_EXCLUSIVE_VARS`
7. In `codex.py`: add `AGENT_BACKEND_ENV_VAR` to imports and inject into `extras` dict in `CodexBackend.build_skill_session_cmd()`
8. Note: injected key will be scrubbed from filtered_base then re-applied from extras — correct layering
9. Verify P3 CODEX_HOME injection in codex.py is preserved
10. No changes to `build_food_truck_cmd()`, `build_interactive_cmd()`, `build_headless_cmd()`, or `build_resume_cmd()`
11. Add tests in `test_claude_code_backend.py` — class `TestClaudeCodeBackendAgentBackendEnv` with 3 tests
12. Add tests in `test_codex_backend.py` — class `TestCodexBuildSkillSessionCmdAgentBackend` with 3 tests
13. All tests carry `pytestmark = [pytest.mark.layer('execution'), pytest.mark.small]` via module-level
14. All tests use only `build_skill_session_cmd()` public API
15. All tests use `monkeypatch` for `os.environ` mutations

## Acceptance Criteria

- `AGENT_BACKEND_ENV_VAR` is no longer a member of `AUTOSKILLIT_PRIVATE_ENV_VARS` frozenset
- Three-list sync comment documents verification of absence from `_HEADLESS_EXCLUSIVE_VARS`
- All existing dynamic-iteration tests pass without modification
- No new test asserts `AGENT_BACKEND_ENV_VAR` membership in `AUTOSKILLIT_PRIVATE_ENV_VARS`
- `ClaudeCodeBackend._build_skill_session_cmd_impl()` extras dict contains `AGENT_BACKEND_ENV_VAR: AGENT_BACKEND_CLAUDE_CODE` unconditionally
- `CodexBackend.build_skill_session_cmd()` extras dict contains `AGENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX` unconditionally
- `AGENT_BACKEND_ENV_VAR` is NOT added to `_HEADLESS_EXCLUSIVE_VARS`
- Both backends produce correct value in all test scenarios (env set, env wrong, env missing)
- `task test-check` passes with no regressions

Closes #2874

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-175132-198766/.autoskillit/temp/make-plan/py4_p4_a1_wp1_agent_backend_propagation_plan_2026-05-25_175900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 75 | 20.9k | 1.2M | 93.9k | 120 | 84.2k | 12m 29s |
| verify | claude-sonnet-4-6 | 1 | 212 | 12.8k | 1.3M | 70.6k | 75 | 60.3k | 3m 58s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.6M | 16.6k | 1.3M | 30.7k | 144 | 16.0k | 6m 41s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 84.9k | 4.6k | 211.9k | 30.7k | 20 | 15.5k | 1m 34s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 43.7k | 2.3k | 181.3k | 30.7k | 14 | 15.2k | 47s |
| review_pr | claude-sonnet-4-6 | 1 | 142 | 26.7k | 592.0k | 62.8k | 45 | 55.6k | 6m 11s |
| resolve_review | claude-sonnet-4-6 | 1 | 189 | 9.3k | 995.8k | 54.5k | 50 | 44.8k | 6m 14s |
| **Total** | | | 1.8M | 93.2k | 5.9M | 93.9k | | 291.6k | 37m 55s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 93 | 14486.4 | 171.8 | 178.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **93** | 63396.3 | 3135.2 | 1002.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 618 | 69.7k | 4.2M | 244.9k | 28m 52s |
| MiniMax-M2.7-highspeed | 3 | 1.8M | 23.5k | 1.7M | 46.7k | 9m 2s |