### PR TITLE
Parametrized Test Suite for CodexBackend.build_interactive_cmd

### DIFF
--- a/tests/cli/CLAUDE.md
+++ b/tests/cli/CLAUDE.md
@@ -29,6 +29,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_cook_workspace.py` | Tests: cook CLI workspace init and clean commands |
 | `test_doctor.py` | Tests for CLI doctor command and related utilities |
 | `test_doctor_backend_guards.py` | Tests for doctor backend guard checks (stale MCP, MCP registered, process state) and run_doctor backend wiring |
+| `test_doctor_codex_mcp.py` | Tests for _check_mcp_server_registered Codex branch — monkeypatch-based, no filesystem I/O |
 | `test_doctor_fleet_checks.py` | Tests for fleet doctor checks — Group M ambient env/infra/campaign, Group N feature gates and registry |
 | `test_doctor_migration.py` | Tests for doctor quota cache schema, install classification, version consistency, and drift |
 | `test_doctor_scripts.py` | Tests for doctor script/recipe version health checks |

--- a/tests/cli/test_doctor_codex_mcp.py
+++ b/tests/cli/test_doctor_codex_mcp.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.cli.doctor._doctor_mcp import _check_mcp_server_registered
+from autoskillit.core import Severity
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+
+
+class TestCheckMcpServerRegisteredCodexBranch:
+    def test_ok_when_valid_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import autoskillit.execution as _exec_mod
+
+        monkeypatch.setattr(
+            _exec_mod,
+            "_read_codex_config",
+            lambda path: {
+                "mcp_servers": {
+                    "autoskillit": {
+                        "command": "autoskillit",
+                        "env": {"AUTOSKILLIT_HEADLESS": "1"},
+                    }
+                }
+            },
+        )
+        result = _check_mcp_server_registered(backend="codex")
+        assert result.severity == Severity.OK
+
+    def test_warning_when_missing_entry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import autoskillit.execution as _exec_mod
+
+        monkeypatch.setattr(
+            _exec_mod,
+            "_read_codex_config",
+            lambda path: {"mcp_servers": {}},
+        )
+        result = _check_mcp_server_registered(backend="codex")
+        assert result.severity == Severity.WARNING
+
+    def test_warning_when_absent_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import autoskillit.execution as _exec_mod
+
+        monkeypatch.setattr(
+            _exec_mod,
+            "_read_codex_config",
+            lambda path: {},
+        )
+        result = _check_mcp_server_registered(backend="codex")
+        assert result.severity == Severity.WARNING
+
+    def test_non_codex_backend_skip(self) -> None:
+        result = _check_mcp_server_registered(backend="other")
+        assert result.severity == Severity.OK
+        assert "skipped" in result.message.lower()

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -49,4 +49,5 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_type_results_execution.py` | Tests for _type_results_execution.py — execution-scoped types |
 | `test_validated_worktree_path.py` | Tests for ValidatedWorktreePath construction contracts |
 | `test_version_snapshot.py` | Tests for core/_version_snapshot.py |
+| `test_version_snapshot_codex_routing.py` | Codex version snapshot routing tests — verifies collect_version_snapshot() routes codex_version correctly by AUTOSKILLIT_AGENT_BACKEND |
 | `test_backend_gating_core.py` | Backend gating tests for _version_snapshot.py — verifies empty fallbacks for non-claude-code backends |

--- a/tests/core/test_version_snapshot_codex_routing.py
+++ b/tests/core/test_version_snapshot_codex_routing.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from autoskillit.core._version_snapshot import collect_version_snapshot
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+@pytest.fixture(autouse=True)
+def _clear_snapshot_cache():
+    collect_version_snapshot.cache_clear()
+    yield
+    collect_version_snapshot.cache_clear()
+
+
+def test_codex_version_populated_when_backend_is_codex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "codex")
+
+    def _fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="1.2.3", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    result = collect_version_snapshot()
+    assert result["codex_version"] != ""
+
+
+def test_codex_version_empty_for_claude_code_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "claude-code")
+
+    def _fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    result = collect_version_snapshot()
+    assert result["codex_version"] == ""
+
+
+def test_codex_version_empty_when_backend_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
+
+    def _no_codex_call(cmd, **kwargs):
+        if cmd[0] == "codex":
+            raise AssertionError("codex should not be called when backend is unset")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", _no_codex_call)
+    result = collect_version_snapshot()
+    assert result["codex_version"] == ""
+
+
+def test_no_cross_contamination_claude_code_version_empty_for_codex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND", "codex")
+
+    def _fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="1.2.3", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    result = collect_version_snapshot()
+    assert result["claude_code_version"] == ""
+
+
+def test_codex_version_key_present_in_snapshot_result() -> None:
+    result = collect_version_snapshot()
+    assert "codex_version" in result

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -129,6 +129,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_claude_stream_parser.py` | Tests for ClaudeStreamParser |
 | `test_backend_registry.py` | Tests for backend registry |
 | `test_codex_backend.py` | Tests for CodexFlags, CodexBackend protocol conformance, headless/resume command builders, skill session cmd config adapter |
+| `test_codex_interactive.py` | Parametrized structural validation of CodexBackend.build_interactive_cmd — resume variants, model, system_prompt suppression, add_dirs |
 | `test_codex_session_locator.py` | Tests for CodexSessionLocator: locate_session walk, read_session decompression, env/codex_home priority, protocol conformance |
 | `test_codex_env_policy.py` | Tests for CodexEnvPolicy three-layer scrub |
 | `test_codex_mcp_registration.py` | Tests for ensure_codex_mcp_registered: file creation, TOML fields, idempotency, foreign section preservation, dir creation |

--- a/tests/execution/backends/test_codex_interactive.py
+++ b/tests/execution/backends/test_codex_interactive.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import BareResume, CmdSpec, NamedResume, NoResume
+from autoskillit.execution.backends.codex import CodexBackend, CodexFlags
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestCodexInteractiveCmdBaseStructure:
+    def test_no_resume_base_command(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(resume_spec=NoResume())
+        assert spec.cmd[0] == "codex"
+        assert CodexFlags.DANGEROUSLY_BYPASS in spec.cmd
+        assert "resume" not in spec.cmd
+
+    @pytest.mark.parametrize(
+        "resume_spec",
+        [NoResume(), BareResume(), NamedResume(session_id="s1")],
+        ids=["NoResume", "BareResume", "NamedResume"],
+    )
+    def test_returns_cmd_spec_with_tuple(self, resume_spec) -> None:
+        spec = CodexBackend().build_interactive_cmd(resume_spec=resume_spec)
+        assert isinstance(spec, CmdSpec)
+        assert isinstance(spec.cmd, tuple)
+
+
+class TestCodexInteractiveCmdResumeVariants:
+    def test_no_resume_excludes_resume_subcommand(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(resume_spec=NoResume())
+        assert CodexFlags.RESUME_SUBCOMMAND not in spec.cmd
+
+    def test_named_resume_includes_resume_with_session_id(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(
+            resume_spec=NamedResume(session_id="abc123"),
+        )
+        assert CodexFlags.RESUME_SUBCOMMAND in spec.cmd
+        idx = list(spec.cmd).index(CodexFlags.RESUME_SUBCOMMAND)
+        assert spec.cmd[idx + 1] == "abc123"
+
+    def test_bare_resume_includes_resume_without_session_id(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(resume_spec=BareResume())
+        assert CodexFlags.RESUME_SUBCOMMAND in spec.cmd
+        idx = list(spec.cmd).index(CodexFlags.RESUME_SUBCOMMAND)
+        assert spec.cmd[idx + 1] == CodexFlags.DANGEROUSLY_BYPASS
+
+
+class TestCodexInteractiveCmdModelFlag:
+    def test_model_kwarg_produces_model_flag_pair(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(model="o3-pro")
+        idx = list(spec.cmd).index(CodexFlags.MODEL)
+        assert spec.cmd[idx + 1] == "o3-pro"
+
+    def test_no_model_kwarg_excludes_model_flag(self) -> None:
+        spec = CodexBackend().build_interactive_cmd()
+        assert "--model" not in spec.cmd
+
+
+class TestCodexInteractiveCmdSystemPrompt:
+    def test_system_prompt_with_no_resume_produces_config_override(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(
+            system_prompt="do stuff",
+            resume_spec=NoResume(),
+        )
+        assert CodexFlags.CONFIG_OVERRIDE in spec.cmd
+        idx = list(spec.cmd).index(CodexFlags.CONFIG_OVERRIDE)
+        assert spec.cmd[idx + 1] == "developer_instructions=do stuff"
+
+    def test_system_prompt_with_named_resume_suppressed(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(
+            system_prompt="do stuff",
+            resume_spec=NamedResume(session_id="s1"),
+        )
+        assert CodexFlags.CONFIG_OVERRIDE not in spec.cmd
+
+    def test_system_prompt_with_bare_resume_suppressed(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(
+            system_prompt="do stuff",
+            resume_spec=BareResume(),
+        )
+        assert CodexFlags.CONFIG_OVERRIDE not in spec.cmd
+
+    def test_no_system_prompt_with_no_resume_excludes_config_override(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(resume_spec=NoResume())
+        assert CodexFlags.CONFIG_OVERRIDE not in spec.cmd
+
+
+class TestCodexInteractiveCmdAddDirs:
+    def test_single_dir_produces_add_dir_pair(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(add_dirs=[Path("/a")])
+        idx = list(spec.cmd).index(CodexFlags.ADD_DIR)
+        assert spec.cmd[idx + 1] == "/a"
+
+    def test_two_dirs_produce_two_add_dir_pairs_in_order(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(
+            add_dirs=[Path("/a"), Path("/b")],
+        )
+        indices = [i for i, v in enumerate(spec.cmd) if v == CodexFlags.ADD_DIR]
+        assert len(indices) == 2
+        assert spec.cmd[indices[0] + 1] == "/a"
+        assert spec.cmd[indices[1] + 1] == "/b"
+
+    def test_empty_list_excludes_add_dir(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(add_dirs=[])
+        assert CodexFlags.ADD_DIR not in spec.cmd


### PR DESCRIPTION
## Summary

Create three new test files that structurally validate `CodexBackend.build_interactive_cmd` command variants (NoResume, BareResume, NamedResume), Codex version snapshot routing through `collect_version_snapshot()`, and the doctor MCP server registration check for the Codex backend. All tests are small (no I/O, no subprocess) and use monkeypatching for isolation.

**Deliverables:**
1. `tests/execution/backends/test_codex_interactive.py` — 5 test classes validating command structure
2. `tests/core/test_version_snapshot_codex_routing.py` — 5 routing tests through `collect_version_snapshot()`
3. `tests/cli/test_doctor_codex_mcp.py` — 4 test cases for the Codex branch in `_check_mcp_server_registered`

Closes #2895

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-175133-048213/.autoskillit/temp/make-plan/py6_p6_a10_wp1_codex_interactive_tests_plan_2026-05-25_180500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.2k | 27.3k | 1.4M | 118.4k | 172 | 103.1k | 15m 31s |
| verify | claude-sonnet-4-6 | 1 | 553 | 16.9k | 1.2M | 72.0k | 84 | 61.8k | 5m 22s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 13.5k | 917.6k | 30.7k | 96 | 15.9k | 8m 35s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 66.8k | 3.0k | 181.2k | 30.7k | 18 | 15.4k | 1m 9s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 83.2k | 2.0k | 304.0k | 30.7k | 22 | 15.2k | 56s |
| review_pr | claude-sonnet-4-6 | 1 | 142 | 42.6k | 760.5k | 88.9k | 49 | 79.8k | 8m 44s |
| resolve_review | claude-sonnet-4-6 | 1 | 141 | 15.7k | 755.2k | 62.9k | 103 | 53.5k | 12m 40s |
| **Total** | | | 1.2M | 120.9k | 5.6M | 118.4k | | 344.8k | 53m 0s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 249 | 3685.2 | 64.1 | 54.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **249** | 22368.1 | 1384.7 | 485.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 2.1k | 102.5k | 4.2M | 298.2k | 42m 19s |
| MiniMax-M2.7-highspeed | 3 | 1.2M | 18.5k | 1.4M | 46.6k | 10m 40s |