### PR TITLE
Derive backend_override from provider_profile in run_skill()

### DIFF
--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -318,7 +318,11 @@ async def run_skill(
         profile_name_out: str = ""
         effective_model = model
 
-        from autoskillit.core import is_feature_enabled
+        from autoskillit.core import (
+            AGENT_BACKEND_CLAUDE_CODE,
+            AGENT_BACKEND_CODEX,
+            is_feature_enabled,
+        )
 
         _cfg = _get_config()
         if is_feature_enabled(
@@ -357,6 +361,17 @@ async def run_skill(
                         _step_mo = _mo_recipe_map.get("*")
                     if _step_mo:
                         effective_model = _step_mo
+
+        backend_override: str | None = (
+            AGENT_BACKEND_CLAUDE_CODE
+            if (
+                provider_extras
+                and "ANTHROPIC_BASE_URL" in provider_extras
+                and tool_ctx.backend is not None
+                and tool_ctx.backend.name == AGENT_BACKEND_CODEX
+            )
+            else None
+        )
 
         # Look up artifact validation patterns from skill contract
         expected_output_patterns: list[str] = []
@@ -551,6 +566,7 @@ async def run_skill(
                 write_watch_dirs=write_watch_dirs,
                 provider_extras=provider_extras,
                 profile_name=profile_name_out,
+                backend_override=backend_override,
                 resume_session_id=resume_session_id,
             )
             if skill_result.success:

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -433,3 +433,148 @@ async def test_run_skill_no_provider_profile_injected_for_default_step(
 
     assert captured.get("provider_extras") is None
     assert captured.get("profile_name") == ""
+
+
+@pytest.mark.anyio
+async def test_run_skill_backend_override_codex_with_anthropic_base_url(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    type(fake_backend).name = property(lambda self: "codex")
+    tool_ctx_kitchen_open.backend = fake_backend
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: (
+            "bedrock",
+            {
+                "ANTHROPIC_BASE_URL": "https://bedrock.us-east-1.amazonaws.com",
+                "AWS_REGION": "us-east-1",
+            },
+        ),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("backend_override") == "claude-code"
+
+
+@pytest.mark.anyio
+async def test_run_skill_backend_override_none_no_anthropic_base_url(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    type(fake_backend).name = property(lambda self: "codex")
+    tool_ctx_kitchen_open.backend = fake_backend
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("minimax", {"BASE_URL": "https://api.minimax.chat/v1"}),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("backend_override") is None
+
+
+@pytest.mark.anyio
+async def test_run_skill_backend_override_none_claude_code_backend(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    type(fake_backend).name = property(lambda self: "claude-code")
+    tool_ctx_kitchen_open.backend = fake_backend
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: (
+            "bedrock",
+            {"ANTHROPIC_BASE_URL": "https://bedrock.us-east-1.amazonaws.com"},
+        ),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("backend_override") is None
+
+
+@pytest.mark.anyio
+async def test_run_skill_backend_override_none_providers_disabled(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    type(fake_backend).name = property(lambda self: "codex")
+    tool_ctx_kitchen_open.backend = fake_backend
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("backend_override") is None

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -449,6 +449,8 @@ async def test_run_skill_backend_override_codex_with_anthropic_base_url(
     fake_backend = MagicMock(spec=CodingAgentBackend)
     type(fake_backend).name = property(lambda self: "codex")
     tool_ctx_kitchen_open.backend = fake_backend
+    # Skip Codex session init: copies ~/.codex/config.toml which is absent in CI
+    tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
@@ -490,6 +492,7 @@ async def test_run_skill_backend_override_none_no_anthropic_base_url(
     fake_backend = MagicMock(spec=CodingAgentBackend)
     type(fake_backend).name = property(lambda self: "codex")
     tool_ctx_kitchen_open.backend = fake_backend
+    tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
     monkeypatch.setattr(
@@ -563,6 +566,7 @@ async def test_run_skill_backend_override_none_providers_disabled(
     fake_backend = MagicMock(spec=CodingAgentBackend)
     type(fake_backend).name = property(lambda self: "codex")
     tool_ctx_kitchen_open.backend = fake_backend
+    tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
 

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -9,8 +9,8 @@ import pytest
 
 from autoskillit.core import ValidatedAddDir
 from autoskillit.workspace.session_skills import (
-    CODEX_SKILLS_SUBDIR,
     _SKILLS_SUBDIR,
+    CODEX_SKILLS_SUBDIR,
 )
 
 pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
@@ -29,16 +29,18 @@ def codex_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     backend = MagicMock()
     backend.name = "codex"
 
-    return type("CodexEnv", (), {
-        "fake_home": fake_home,
-        "codex_dir": codex_dir,
-        "backend": backend,
-    })()
+    return type(
+        "CodexEnv",
+        (),
+        {
+            "fake_home": fake_home,
+            "codex_dir": codex_dir,
+            "backend": backend,
+        },
+    )()
 
 
-def test_codex_init_session_creates_skills_subdir(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_creates_skills_subdir(make_session_skill_manager, codex_env) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
     skill_files = list((session_path / CODEX_SKILLS_SUBDIR).glob("*/SKILL.md"))
@@ -46,9 +48,7 @@ def test_codex_init_session_creates_skills_subdir(
     assert not (session_path / _SKILLS_SUBDIR).exists()
 
 
-def test_codex_init_session_copies_config_toml(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_copies_config_toml(make_session_skill_manager, codex_env) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
     copied = session_path / "config.toml"
@@ -56,9 +56,7 @@ def test_codex_init_session_copies_config_toml(
     assert copied.read_text() == "[codex]\nmodel = 'o3'\n"
 
 
-def test_codex_init_session_copies_auth_json(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_copies_auth_json(make_session_skill_manager, codex_env) -> None:
     (codex_env.codex_dir / "auth.json").write_text('{"token": "test"}')
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
@@ -67,9 +65,7 @@ def test_codex_init_session_copies_auth_json(
     assert copied.read_text() == '{"token": "test"}'
 
 
-def test_codex_init_session_copies_env_if_present(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_copies_env_if_present(make_session_skill_manager, codex_env) -> None:
     (codex_env.codex_dir / ".env").write_text("API_KEY=secret\n")
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
@@ -78,9 +74,7 @@ def test_codex_init_session_copies_env_if_present(
     assert copied.read_text() == "API_KEY=secret\n"
 
 
-def test_codex_init_session_skips_env_if_absent(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_skips_env_if_absent(make_session_skill_manager, codex_env) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
     assert not (session_path / ".env").exists()


### PR DESCRIPTION
## Summary

After provider-profile resolution in `run_skill()`, derive `backend_override` by checking if `provider_extras` contains `ANTHROPIC_BASE_URL` and the context backend is Codex. When both conditions hold, set `backend_override='claude-code'` so the executor spawns a Claude Code session instead of Codex for that step. Pass `backend_override` to `executor.run()` in all code paths.

## Changed Files

### Modified (●):
- `src/autoskillit/server/tools/tools_execution.py`
- `tests/server/test_tools_execution_provider.py`
- `tests/workspace/test_session_skills_codex.py`

Closes #2904

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-194350-691602/.autoskillit/temp/make-plan/py7_p7_a10_wp1_backend_override_plan_2026-05-25_195000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 75 | 11.0k | 1.7M | 89.3k | 123 | 77.1k | 11m 13s |
| verify | claude-sonnet-4-6 | 1 | 124 | 9.8k | 722.4k | 65.1k | 39 | 65.3k | 3m 37s |
| implement* | MiniMax-M2.7-highspeed | 1 | 758.3k | 8.6k | 1.1M | 30.7k | 83 | 43.7k | 4m 0s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 66.1k | 2.8k | 184.1k | 30.7k | 21 | 43.2k | 1m 8s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 44.5k | 1.1k | 211.9k | 30.7k | 14 | 15.1k | 38s |
| review_pr | claude-sonnet-4-6 | 1 | 693 | 25.7k | 675.0k | 66.8k | 44 | 52.8k | 5m 42s |
| resolve_review | claude-sonnet-4-6 | 1 | 117 | 7.9k | 572.4k | 50.0k | 34 | 34.5k | 3m 33s |
| **Total** | | | 869.9k | 66.8k | 5.1M | 89.3k | | 331.9k | 29m 54s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 163 | 6589.4 | 268.3 | 52.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **163** | 31362.5 | 2036.0 | 410.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.0k | 54.4k | 3.6M | 229.8k | 24m 7s |
| MiniMax-M2.7-highspeed | 3 | 868.9k | 12.5k | 1.5M | 102.1k | 5m 46s |