### PR TITLE
Implementation Plan: PY7 P7-A3-WP1 — Add CONFIG_SHORT flag, implement build_food_truck_cmd, set food_truck_capable=True, and update flag membership tests

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -17,6 +17,7 @@ from autoskillit.core import (
     AUTOSKILLIT_PRIVATE_ENV_VARS,
     CAMPAIGN_ID_ENV_VAR,
     KITCHEN_SESSION_ID_ENV_VAR,
+    SESSION_TYPE_ORCHESTRATOR,
     SESSION_TYPE_SKILL,
     BackendCapabilities,
     BareResume,
@@ -177,7 +178,7 @@ class CodexBackend:
             supports_claude_format_stdout=False,
             exit_code_is_terminal=True,
             mcp_config_capable=True,
-            food_truck_capable=False,
+            food_truck_capable=True,
             completion_record_types=frozenset({"turn.completed", "turn.failed", "error"}),
             session_record_types=frozenset(),
         )
@@ -371,9 +372,76 @@ class CodexBackend:
         sentinel_contract: str = "",
         resume_message: str | None = None,
     ) -> CmdSpec:
-        raise NotImplementedError(
-            "Codex CLI does not support L2 orchestrator (food truck) sessions"
+        _plugin_source = plugin_source  # noqa: F841  # no-op: Codex has no --plugin-dir
+        _output_format = output_format  # noqa: F841  # no-op: --json is unconditional
+        _exit_ms = exit_after_stop_delay_ms  # noqa: F841  # no-op: Claude-only
+        _stream_ms = stream_idle_timeout_ms  # noqa: F841  # no-op: Claude-only
+
+        if resume_session_id:
+            effective_prompt = _compose_resume_prompt(
+                base_prompt=orchestrator_prompt,
+                resume_checkpoint=resume_checkpoint,
+                sentinel_contract=sentinel_contract,
+                resume_message=resume_message,
+            )
+        else:
+            effective_prompt = orchestrator_prompt
+
+        prompt = _inject_completion_reminder(
+            _inject_narration_suppression(
+                _inject_cwd_anchor(
+                    _inject_completion_directive(effective_prompt, completion_marker),
+                    cwd,
+                    temp_dir_relpath=temp_dir_relpath,
+                )
+            ),
+            completion_marker,
         )
+
+        extras: dict[str, str] = {
+            "AUTOSKILLIT_HEADLESS": "1",
+            "AUTOSKILLIT_SESSION_TYPE": SESSION_TYPE_ORCHESTRATOR,
+            "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
+        }
+        if scenario_step_name:
+            extras["SCENARIO_STEP_NAME"] = scenario_step_name
+        campaign_id = os.environ.get(CAMPAIGN_ID_ENV_VAR)
+        if campaign_id:
+            extras[CAMPAIGN_ID_ENV_VAR] = campaign_id
+        kitchen_session_id = os.environ.get(KITCHEN_SESSION_ID_ENV_VAR)
+        if kitchen_session_id:
+            extras[KITCHEN_SESSION_ID_ENV_VAR] = kitchen_session_id
+        if completion_marker:
+            extras["AUTOSKILLIT_COMPLETION_MARKER"] = completion_marker
+        if allowed_write_prefix:
+            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = allowed_write_prefix
+        if env_extras:
+            for k, v in env_extras.items():
+                if k not in ("AUTOSKILLIT_SESSION_TYPE", "AUTOSKILLIT_HEADLESS"):
+                    extras[k] = v
+
+        filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
+        env = CodexEnvPolicy().build_env(filtered_base, extras=extras)
+
+        cmd: list[str] = [
+            "codex",
+            "exec",
+            CodexFlags.JSON,
+            CodexFlags.SANDBOX,
+            "read-only",
+            CodexFlags.ASK_FOR_APPROVAL_SHORT,
+            "never",
+            CodexFlags.CONFIG_OVERRIDE,
+            "web_search=disabled",
+        ]
+        if model:
+            cmd += [CodexFlags.MODEL, model]
+        if resume_session_id:
+            cmd.append(CodexFlags.RESUME_SUBCOMMAND)
+            cmd.append(resume_session_id)
+        cmd.append(prompt)
+
+        return CmdSpec(cmd=tuple(cmd), env=env, cwd=cwd)
 
     def build_interactive_cmd(
         self,

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -99,6 +99,9 @@ class TestCodexBackend:
     def test_capabilities_session_record_types_empty(self) -> None:
         assert CodexBackend().capabilities.session_record_types == frozenset()
 
+    def test_capabilities_food_truck_true(self) -> None:
+        assert CodexBackend().capabilities.food_truck_capable is True
+
     def test_binary_name(self) -> None:
         assert CodexBackend().binary_name() == "codex"
 
@@ -268,7 +271,7 @@ class TestCodexBackendProtocol:
             ("session_resume_capable", True),
             ("skill_injection_capable", True),
             ("mcp_config_capable", True),
-            ("food_truck_capable", False),
+            ("food_truck_capable", True),
         ],
     )
     def test_capability_flag(self, attr: str, expected: bool) -> None:


### PR DESCRIPTION
## Summary

Implement `CodexBackend.build_food_truck_cmd` to replace the current `NotImplementedError` stub with a full orchestrator session command builder. The method constructs a `codex exec --json --sandbox read-only -a never -c web_search=disabled` command with prompt injections, environment assembly, and optional resume support. Also flip `food_truck_capable` to `True` in the capabilities property and update the associated test fixture.

**CONFIG_SHORT note:** The issue requests adding `CONFIG_SHORT = '-c'` to `CodexFlags`. However, `CONFIG_OVERRIDE = "-c"` already exists at `codex.py:72` (added by P2-A2). The `@unique` decorator on the enum prevents a second member with the same value. The existing `CONFIG_OVERRIDE` member satisfies the need — the food truck command will use `CodexFlags.CONFIG_OVERRIDE` for the `-c web_search=disabled` argument. No flag additions or test_all_members_present changes are needed.

## Changed Files

- `src/autoskillit/execution/backends/codex.py`
- `tests/execution/backends/test_codex_backend.py`

Closes #2898

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-203911-008053/.autoskillit/temp/make-plan/py7_p7_a3_wp1_plan_2026-05-25_204800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 59 | 14.5k | 1.2M | 98.0k | 121 | 66.3k | 12m 2s |
| verify | claude-sonnet-4-6 | 1 | 212 | 11.7k | 1.6M | 77.4k | 59 | 63.0k | 3m 37s |
| implement* | MiniMax-M2.7-highspeed | 1 | 454.2k | 5.2k | 485.4k | 25.7k | 49 | 15.9k | 2m 8s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 149.3k | 5.1k | 305.5k | 25.7k | 36 | 15.5k | 1m 47s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 53.9k | 1.5k | 202.7k | 25.7k | 16 | 15.2k | 42s |
| review_pr | claude-sonnet-4-6 | 3 | 1.4k | 77.1k | 2.0M | 64.9k | 153 | 167.9k | 18m 44s |
| resolve_review | claude-sonnet-4-6 | 3 | 1.1k | 71.6k | 8.5M | 103.6k | 303 | 273.5k | 34m 56s |
| **Total** | | | 660.1k | 186.7k | 14.4M | 103.6k | | 617.3k | 1h 13m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 79 | 6143.8 | 201.8 | 66.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **79** | 181650.2 | 7814.0 | 2363.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 2.8k | 174.9k | 13.4M | 570.7k | 1h 9m |
| MiniMax-M2.7-highspeed | 3 | 657.4k | 11.8k | 993.5k | 46.6k | 4m 38s |