### PR TITLE
Implementation Plan: PY7 P7-A14-WP1 — Verify run_headless_core delegates build_skill_session_cmd to backend from SkillSessionConfig.backend_override

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -34,6 +34,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_github_headers.py` | Tests for the shared github_headers helper and its adoption by all three classes |
 | `test_headless_add_dirs.py` | Tests for run_headless_core multi-path --add-dir support (T-OVR-012..013) |
 | `test_headless_backend_resolution.py` | Tests for _resolve_pty_mode and _resolve_session_log_dir capability-driven helpers |
+| `test_headless_backend_override.py` | Tests verifying run_headless_core delegates build_skill_session_cmd, env policy, and stream_parser to the backend resolved from backend_override |
 | `test_headless_core.py` | Tests for headless_runner.py extracted helpers |
 | `test_headless_debug_logging.py` | Tests for debug logging instrumentation in headless.py |
 | `test_headless_dispatch.py` | Tests for headless.py dispatch flow: food truck dispatch, pack injection, executor protocol |

--- a/tests/execution/test_headless_backend_override.py
+++ b/tests/execution/test_headless_backend_override.py
@@ -1,0 +1,291 @@
+"""Tests verifying run_headless_core delegates to backend from backend_override."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autoskillit.core.types import (
+    CmdSpec,
+    RetryReason,
+    SkillResult,
+    SubprocessResult,
+    TerminationReason,
+)
+
+from .conftest import _mock_backend
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def _stub_result() -> SkillResult:
+    return SkillResult(
+        success=True,
+        result="",
+        session_id="test-session",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+    )
+
+
+class TestBackendOverrideCommandRouting:
+    """Verify build_skill_session_cmd is called on the override backend, not ctx.backend."""
+
+    @pytest.mark.anyio
+    async def test_backend_override_routes_to_claude_code_backend(self, minimal_ctx):
+        """When backend_override=claude-code, the claude-code mock's cmd builder is called."""
+        codex_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_backend.name = "codex"
+        minimal_ctx.backend = codex_backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        claude_code_backend = _mock_backend()
+        claude_code_backend.name = "claude-code"
+
+        with (
+            patch("autoskillit.execution.headless.get_backend", return_value=claude_code_backend),
+            patch("autoskillit.execution.headless._execute_claude_headless") as mock_exec,
+        ):
+            mock_exec.return_value = _stub_result()
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="claude-code",
+            )
+
+            claude_code_backend.build_skill_session_cmd.assert_called_once()
+            codex_backend.build_skill_session_cmd.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_backend_override_none_uses_ctx_backend(self, minimal_ctx):
+        """When backend_override=None, ctx.backend's build_skill_session_cmd is called."""
+        backend = _mock_backend()
+        minimal_ctx.backend = backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        with patch(
+            "autoskillit.execution.headless._headless_execute._build_skill_result"
+        ) as mock_build:
+            mock_build.return_value = _stub_result()
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+            )
+
+            backend.build_skill_session_cmd.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_backend_override_codex_uses_codex_backend(self, minimal_ctx):
+        """When backend_override='codex', codex mock's build_skill_session_cmd is called."""
+        claude_code_backend = _mock_backend()
+        claude_code_backend.name = "claude-code"
+        minimal_ctx.backend = claude_code_backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        codex_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_backend.name = "codex"
+
+        with (
+            patch("autoskillit.execution.headless.get_backend", return_value=codex_backend),
+            patch("autoskillit.execution.headless._execute_claude_headless") as mock_exec,
+        ):
+            mock_exec.return_value = _stub_result()
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="codex",
+            )
+
+            codex_backend.build_skill_session_cmd.assert_called_once()
+            claude_code_backend.build_skill_session_cmd.assert_not_called()
+
+
+class TestBackendOverrideEnvPolicy:
+    """Tests verifying spec.env reflects the override backend's env policy."""
+
+    @pytest.mark.anyio
+    async def test_claude_code_step_backend_includes_anthropic_key(self, minimal_ctx, monkeypatch):
+        """Claude-code override backend includes ANTHROPIC_API_KEY in spec.env."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        codex_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_backend.name = "codex"
+        minimal_ctx.backend = codex_backend
+
+        claude_code_backend = _mock_backend()
+        claude_code_backend.name = "claude-code"
+        claude_code_backend.build_skill_session_cmd.return_value = CmdSpec(
+            cmd=("claude", "--print", "test-skill"),
+            env={"ANTHROPIC_API_KEY": "test-key", "AUTOSKILLIT_HEADLESS": "1"},
+        )
+
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        captured_spec = None
+
+        async def capture_exec(spec, *args, **kwargs):
+            nonlocal captured_spec
+            captured_spec = spec
+            return _stub_result()
+
+        with (
+            patch("autoskillit.execution.headless.get_backend", return_value=claude_code_backend),
+            patch(
+                "autoskillit.execution.headless._execute_claude_headless", side_effect=capture_exec
+            ),
+        ):
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="claude-code",
+            )
+
+        assert captured_spec is not None
+        assert captured_spec.env.get("ANTHROPIC_API_KEY") == "test-key"
+
+    @pytest.mark.anyio
+    async def test_codex_step_backend_strips_anthropic_key(self, minimal_ctx, monkeypatch):
+        """Codex override backend strips ANTHROPIC_API_KEY from spec.env."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        claude_code_backend = _mock_backend()
+        claude_code_backend.name = "claude-code"
+        minimal_ctx.backend = claude_code_backend
+
+        codex_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_backend.name = "codex"
+        codex_backend.build_skill_session_cmd.return_value = CmdSpec(
+            cmd=("codex", "--quiet", "test-skill"),
+            env={"AUTOSKILLIT_HEADLESS": "1"},
+        )
+
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        captured_spec = None
+
+        async def capture_exec(spec, *args, **kwargs):
+            nonlocal captured_spec
+            captured_spec = spec
+            return _stub_result()
+
+        with (
+            patch("autoskillit.execution.headless.get_backend", return_value=codex_backend),
+            patch(
+                "autoskillit.execution.headless._execute_claude_headless", side_effect=capture_exec
+            ),
+        ):
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="codex",
+            )
+
+        assert captured_spec is not None
+        assert "ANTHROPIC_API_KEY" not in captured_spec.env
+
+
+class TestBackendOverrideParserSelection:
+    """Tests verifying stream_parser is called on the override backend, not ctx.backend."""
+
+    @pytest.mark.anyio
+    async def test_step_backend_parser_used_not_ctx_backend(self, minimal_ctx):
+        """When backend_override is set, step_backend.stream_parser is called."""
+        ctx_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        ctx_backend.name = "codex"
+        step_backend = _mock_backend()
+        step_backend.name = "claude-code"
+        minimal_ctx.backend = ctx_backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        with (
+            patch("autoskillit.execution.headless.get_backend", return_value=step_backend),
+            patch(
+                "autoskillit.execution.headless._headless_execute._build_skill_result"
+            ) as mock_build,
+        ):
+            mock_build.return_value = _stub_result()
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="claude-code",
+            )
+
+            step_backend.stream_parser.assert_called_once()
+            ctx_backend.stream_parser.assert_not_called()


### PR DESCRIPTION
## Summary

Add `tests/execution/test_headless_backend_override.py` with three test classes (6 tests total) that verify `run_headless_core` routes `build_skill_session_cmd`, env policy, and `stream_parser` invocations through the backend resolved from `backend_override` rather than `ctx.backend`.

The tests use mock backends (via the existing `_mock_backend()` helper from `tests/execution/conftest.py`) configured with distinguishable `CmdSpec.env` return values. Each mock's `build_skill_session_cmd` return value carries a unique env signature — the Claude-code mock includes `ANTHROPIC_API_KEY` while the Codex mock omits it — allowing env policy tests to confirm routing by inspecting `spec.env` contents.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([run_headless_core called])

    subgraph Override ["Backend Override Resolution"]
        direction TB
        CHECK{"backend_override<br/>━━━━━━━━━━<br/>is not None?"}
        GET["get_backend(override)<br/>━━━━━━━━━━<br/>resolve step_backend"]
        FALLBACK["_cmd_backend = ctx.backend<br/>━━━━━━━━━━<br/>no override"]
        SELECT["_cmd_backend = step_backend<br/>━━━━━━━━━━<br/>override resolved"]
    end

    subgraph Command ["Command Construction"]
        direction TB
        BUILD["_cmd_backend.build_skill_session_cmd<br/>━━━━━━━━━━<br/>produces CmdSpec with env"]
    end

    subgraph Execute ["Execution Path"]
        direction TB
        EXEC["_execute_claude_headless<br/>━━━━━━━━━━<br/>spec, step_backend kwarg"]
        PARSER["_step_backend.stream_parser<br/>━━━━━━━━━━<br/>override's parser used"]
        RESULT["_build_skill_result<br/>━━━━━━━━━━<br/>backend=_step_backend"]
    end

    subgraph Tests ["★ New Test Classes"]
        direction TB
        T1["★ TestBackendOverrideCommandRouting<br/>━━━━━━━━━━<br/>3 tests: which backend's<br/>build_skill_session_cmd called"]
        T2["★ TestBackendOverrideEnvPolicy<br/>━━━━━━━━━━<br/>2 tests: spec.env reflects<br/>override backend's policy"]
        T3["★ TestBackendOverrideParserSelection<br/>━━━━━━━━━━<br/>1 test: step_backend.stream_parser<br/>called, ctx.backend's not"]
    end

    DONE([SkillResult returned])

    START --> CHECK
    CHECK -->|"Yes"| GET
    CHECK -->|"No"| FALLBACK
    GET --> SELECT
    FALLBACK --> BUILD
    SELECT --> BUILD
    BUILD --> EXEC
    EXEC --> PARSER
    PARSER --> RESULT
    RESULT --> DONE

    T1 -.->|"asserts on"| BUILD
    T2 -.->|"captures spec.env from"| EXEC
    T3 -.->|"asserts on"| PARSER

    class START,DONE terminal;
    class CHECK stateNode;
    class GET,SELECT,FALLBACK handler;
    class BUILD phase;
    class EXEC,PARSER,RESULT handler;
    class T1,T2,T3 newComponent;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Entry and exit points |
| Teal | State | Decision / routing nodes |
| Orange | Handler | Processing nodes |
| Purple | Phase | Command construction |
| Green | New | Test classes being added |

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([run_headless_core called])

    subgraph Override ["Backend Override Resolution"]
        direction TB
        CHECK{"backend_override<br/>━━━━━━━━━━<br/>is not None?"}
        GET["get_backend(override)<br/>━━━━━━━━━━<br/>resolve step_backend"]
        FALLBACK["_cmd_backend = ctx.backend<br/>━━━━━━━━━━<br/>no override"]
        SELECT["_cmd_backend = step_backend<br/>━━━━━━━━━━<br/>override resolved"]
    end

    subgraph Command ["Command Construction"]
        direction TB
        BUILD["_cmd_backend.build_skill_session_cmd<br/>━━━━━━━━━━<br/>produces CmdSpec with env"]
    end

    subgraph Execute ["Execution Path"]
        direction TB
        EXEC["_execute_claude_headless<br/>━━━━━━━━━━<br/>spec, step_backend kwarg"]
        PARSER["_step_backend.stream_parser<br/>━━━━━━━━━━<br/>override's parser used"]
        RESULT["_build_skill_result<br/>━━━━━━━━━━<br/>backend=_step_backend"]
    end

    subgraph Tests ["★ New Test Classes"]
        direction TB
        T1["★ TestBackendOverrideCommandRouting<br/>━━━━━━━━━━<br/>3 tests: which backend's<br/>build_skill_session_cmd called"]
        T2["★ TestBackendOverrideEnvPolicy<br/>━━━━━━━━━━<br/>2 tests: spec.env reflects<br/>override backend's policy"]
        T3["★ TestBackendOverrideParserSelection<br/>━━━━━━━━━━<br/>1 test: step_backend.stream_parser<br/>called, ctx.backend's not"]
    end

    DONE([SkillResult returned])

    START --> CHECK
    CHECK -->|"Yes"| GET
    CHECK -->|"No"| FALLBACK
    GET --> SELECT
    FALLBACK --> BUILD
    SELECT --> BUILD
    BUILD --> EXEC
    EXEC --> PARSER
    PARSER --> RESULT
    RESULT --> DONE

    T1 -.->|"asserts on"| BUILD
    T2 -.->|"captures spec.env from"| EXEC
    T3 -.->|"asserts on"| PARSER

    class START,DONE terminal;
    class CHECK stateNode;
    class GET,SELECT,FALLBACK handler;
    class BUILD phase;
    class EXEC,PARSER,RESULT handler;
    class T1,T2,T3 newComponent;
```

### Error Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([run_headless_core called])

    subgraph Override ["Backend Override Resolution"]
        direction TB
        CHECK{"backend_override<br/>━━━━━━━━━━<br/>is not None?"}
        GET["get_backend(override)<br/>━━━━━━━━━━<br/>resolve step_backend"]
        FALLBACK["_cmd_backend = ctx.backend<br/>━━━━━━━━━━<br/>no override"]
        SELECT["_cmd_backend = step_backend<br/>━━━━━━━━━━<br/>override resolved"]
    end

    subgraph Command ["Command Construction"]
        direction TB
        BUILD["_cmd_backend.build_skill_session_cmd<br/>━━━━━━━━━━<br/>produces CmdSpec with env"]
    end

    subgraph Execute ["Execution Path"]
        direction TB
        EXEC["_execute_claude_headless<br/>━━━━━━━━━━<br/>spec, step_backend kwarg"]
        PARSER["_step_backend.stream_parser<br/>━━━━━━━━━━<br/>override's parser used"]
        RESULT["_build_skill_result<br/>━━━━━━━━━━<br/>backend=_step_backend"]
    end

    subgraph Tests ["★ New Test Classes"]
        direction TB
        T1["★ TestBackendOverrideCommandRouting<br/>━━━━━━━━━━<br/>3 tests: which backend's<br/>build_skill_session_cmd called"]
        T2["★ TestBackendOverrideEnvPolicy<br/>━━━━━━━━━━<br/>2 tests: spec.env reflects<br/>override backend's policy"]
        T3["★ TestBackendOverrideParserSelection<br/>━━━━━━━━━━<br/>1 test: step_backend.stream_parser<br/>called, ctx.backend's not"]
    end

    DONE([SkillResult returned])

    START --> CHECK
    CHECK -->|"Yes"| GET
    CHECK -->|"No"| FALLBACK
    GET --> SELECT
    FALLBACK --> BUILD
    SELECT --> BUILD
    BUILD --> EXEC
    EXEC --> PARSER
    PARSER --> RESULT
    RESULT --> DONE

    T1 -.->|"asserts on"| BUILD
    T2 -.->|"captures spec.env from"| EXEC
    T3 -.->|"asserts on"| PARSER

    class START,DONE terminal;
    class CHECK stateNode;
    class GET,SELECT,FALLBACK handler;
    class BUILD phase;
    class EXEC,PARSER,RESULT handler;
    class T1,T2,T3 newComponent;
```

Closes #2907

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-203921-731221/.autoskillit/temp/make-plan/py7_p7_a14_wp1_plan_2026-05-25_204700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 59 | 22.2k | 1.5M | 102.8k | 139 | 88.5k | 12m 35s |
| verify | claude-sonnet-4-6 | 1 | 3.1k | 17.1k | 543.1k | 63.5k | 84 | 48.9k | 6m 40s |
| implement* | MiniMax-M2.7-highspeed | 1 | 877.6k | 11.6k | 768.1k | 25.7k | 82 | 15.9k | 4m 17s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 87.5k | 3.1k | 228.4k | 25.7k | 22 | 15.4k | 1m 4s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 86.9k | 4.5k | 202.7k | 25.7k | 19 | 15.2k | 1m 15s |
| review_pr | claude-sonnet-4-6 | 1 | 148 | 42.4k | 882.9k | 86.9k | 55 | 73.2k | 9m 4s |
| resolve_review | claude-sonnet-4-6 | 1 | 149 | 14.9k | 900.1k | 75.5k | 43 | 118.9k | 6m 13s |
| **Total** | | | 1.1M | 115.8k | 5.0M | 102.8k | | 376.2k | 41m 11s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 292 | 2630.5 | 54.6 | 39.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **292** | 17263.9 | 1288.4 | 396.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.5k | 96.6k | 3.8M | 329.6k | 34m 34s |
| MiniMax-M2.7-highspeed | 3 | 1.1M | 19.2k | 1.2M | 46.6k | 6m 37s |