### PR TITLE
Build agent-eval Recipe and Supporting smoke_utils Functions

### DIFF
--- a/.autoskillit/recipes/eval/agent-eval.yaml
+++ b/.autoskillit/recipes/eval/agent-eval.yaml
@@ -1,0 +1,170 @@
+name: agent-eval
+autoskillit_version: "0.10.327"
+description: >-
+  Test agent definition variants against canary test cases. For each canary,
+  stages each variant agent file temporarily, runs it via eval-agent wrapper,
+  then invokes a judge to evaluate outputs against detection criteria. Produces
+  a comparative scorecard. Unlike skill-eval, variants are independent read-only
+  invocations and can run in parallel.
+summary: >-
+  parse_manifests > run_canaries > compile_scorecard > done
+
+ingredients:
+  canary_manifest:
+    description: >-
+      Path to JSON file defining canary test cases. Each entry has id,
+      agent_name, prompt_template, prompt_vars, reference_path,
+      reference_type, gap_description, and detection_criteria.
+    required: true
+  variant_manifest:
+    description: >-
+      Path to JSON file defining agent variants. Each entry has id, label,
+      agent_file (path to .md definition — required for all variants
+      including baseline), and description.
+    required: true
+  source_dir:
+    description: >-
+      Path to the source project directory. Used as cwd for judge-eval
+      (project-local skill discovered via cwd) and as the base for
+      staging agent files into src/autoskillit/agents/.
+    required: true
+  output_dir:
+    description: >-
+      Base directory for eval run output. Defaults to
+      {{AUTOSKILLIT_TEMP}}/agent-eval.
+    default: "{{AUTOSKILLIT_TEMP}}/agent-eval"
+  max_parallel:
+    description: >-
+      Max concurrent canary x variant evaluations (global concurrency limit).
+    default: "3"
+
+kitchen_rules:
+  - >-
+    NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write,
+    Bash, Agent, WebFetch, WebSearch, NotebookEdit) from the orchestrator. All
+    file operations are delegated through run_skill, run_cmd, or run_python.
+  - >-
+    PARALLEL EXECUTION: Canary x variant combinations are independent and
+    SHOULD run in parallel up to inputs.max_parallel. Unlike skill-eval,
+    there is no shared clone — each invocation is read-only.
+  - >-
+    VARIANT STAGING: Before each eval-agent run, stage the variant agent
+    file to {source_dir}/src/autoskillit/agents/{agent_name}-eval-{variant_id}.md
+    using run_cmd cp. After the run (success OR failure), remove the staged
+    file using run_cmd rm. Cleanup MUST execute on both paths to prevent
+    orphaned agent files in the codebase.
+  - >-
+    JUDGE CWD: Always run /judge-eval with cwd set to inputs.source_dir.
+    The judge-eval skill is project-local and discovered via CWD.
+  - >-
+    FAILED VARIANTS: If a variant run_skill fails, record the variant as
+    {"variant_id": null} in the output_paths accumulator. Do not abort the canary.
+  - >-
+    OUTPUT CAPTURE: After each variant run_skill, copy the output file to
+    {eval_run_dir}/{canary_id}/{variant_id}/output.json using run_cmd.
+  - >-
+    STATISTICAL CONFIDENCE: Each canary x variant combination runs once per
+    recipe invocation. For statistical confidence, run the recipe multiple
+    times and compare scorecards across runs.
+
+steps:
+  parse_manifests:
+    python: "autoskillit.smoke_utils.parse_agent_eval_manifests"
+    with:
+      canary_manifest: "${{ inputs.canary_manifest }}"
+      variant_manifest: "${{ inputs.variant_manifest }}"
+      output_dir: "${{ inputs.output_dir }}"
+    capture:
+      eval_run_dir: "${{ result.eval_run_dir }}"
+      canary_count: "${{ result.canary_count }}"
+      variant_count: "${{ result.variant_count }}"
+      manifest_index_path: "${{ result.manifest_index_path }}"
+    on_success: run_canaries
+    on_failure: escalate
+    note: >-
+      Deterministic step. Reads canary and variant manifest JSON files, resolves
+      prompt_template with prompt_vars (_file indirection), creates per-canary
+      resolved.json and resolved_prompt.txt, and writes manifest_index.json.
+
+  run_canaries:
+    tool: run_skill
+    with:
+      skill_command: "placeholder — see note for orchestration logic"
+    on_success: compile_scorecard
+    on_failure: escalate
+    note: >-
+      LLM-ORCHESTRATED STEP — do NOT literally run the skill_command above.
+      Instead, follow these instructions using MCP tool calls directly:
+
+
+      1. Read the manifest index: run_cmd cat {context.manifest_index_path}
+         Parse the JSON to get canary_ids, variant_ids, and directory paths.
+
+
+      2. FOR EACH CANARY x VARIANT PAIR (up to inputs.max_parallel in parallel):
+
+         a. Read the canary's resolved data:
+            run_cmd cat {eval_run_dir}/{canary_id}/resolved.json
+
+         b. Get the variant's agent_file path from the resolved data:
+            resolved["variants"][variant_id]["agent_file"]
+            Get the agent_name from resolved data:
+            resolved["agent_name"]
+
+         c. Stage the variant agent file:
+            run_cmd cp {agent_file} {inputs.source_dir}/src/autoskillit/agents/{agent_name}-eval-{variant_id}.md
+
+         d. Run the eval-agent wrapper:
+            run_skill /autoskillit:eval-agent --agent-name {agent_name}-eval-{variant_id} --prompt-file {eval_run_dir}/{canary_id}/resolved_prompt.txt
+            cwd = inputs.source_dir
+
+         e. On SUCCESS:
+            Copy output to {eval_run_dir}/{canary_id}/{variant_id}/output.json via run_cmd cp
+            Record in output_paths accumulator: {variant_id: copied_path}
+
+         f. On FAILURE:
+            Record in output_paths accumulator: {variant_id: null}
+
+         g. ALWAYS (success or failure):
+            Cleanup staged agent file:
+            run_cmd rm {inputs.source_dir}/src/autoskillit/agents/{agent_name}-eval-{variant_id}.md
+
+
+      3. After ALL VARIANTS for a canary complete:
+
+         a. run_python: autoskillit.smoke_utils.build_agent_eval_context
+            canary_id={canary_id}
+            output_paths_json={JSON string of output_paths accumulator}
+            eval_run_dir={context.eval_run_dir}
+
+         b. run_skill: /judge-eval {eval_run_dir}/{canary_id}/eval_context.json
+            cwd = inputs.source_dir
+
+
+      4. After ALL canaries complete, this step is done — proceed to
+         compile_scorecard.
+
+  compile_scorecard:
+    python: "autoskillit.smoke_utils.compile_eval_scorecard"
+    with:
+      eval_run_dir: "${{ context.eval_run_dir }}"
+      canary_manifest: "${{ inputs.canary_manifest }}"
+      variant_manifest: "${{ inputs.variant_manifest }}"
+    capture:
+      scorecard_path: "${{ result.scorecard_path }}"
+      pass_rate: "${{ result.pass_rate }}"
+      total_runs: "${{ result.total_runs }}"
+      passed_runs: "${{ result.passed_runs }}"
+    on_success: done
+    on_failure: escalate
+    note: >-
+      Deterministic step. Walks verdict.json files in the eval run directory,
+      aggregates results, and produces scorecard.json + scorecard.md.
+      Reused unchanged from skill-eval.
+
+  done:
+    action: stop
+    message: >-
+      Agent evaluation complete. Pass rate: ${{ context.pass_rate }}
+      (${{ context.passed_runs }}/${{ context.total_runs }}).
+      Scorecard: ${{ context.scorecard_path }}

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -544,12 +544,7 @@ def parse_agent_eval_manifests(
     variant_manifest: str,
     output_dir: str,
 ) -> dict[str, str]:
-    """Parse agent-eval manifests and create eval run directory structure.
-
-    Reads canary and variant manifests, resolves prompt_template with prompt_vars
-    (including _file indirection), creates per-canary resolved.json and
-    resolved_prompt.txt, and writes manifest_index.json.
-    """
+    """Parse agent-eval manifests, resolve prompt vars, and create eval run directory structure."""
     from datetime import datetime
 
     from autoskillit.core import atomic_write
@@ -625,7 +620,7 @@ def parse_agent_eval_manifests(
         except KeyError as exc:
             return {"success": "false", "error": f"Template variable not resolved: {exc}"}
 
-        (canary_dir / "resolved_prompt.txt").write_text(resolved_prompt)
+        atomic_write(canary_dir / "resolved_prompt.txt", resolved_prompt)
 
         variants_dict = {}
         for v in variants:
@@ -667,11 +662,7 @@ def build_agent_eval_context(
     output_paths_json: str,
     eval_run_dir: str,
 ) -> dict[str, str]:
-    """Assemble eval_context.json from resolved manifest and output paths.
-
-    Reads the resolved.json for the given canary, builds the eval_context dict
-    with reference and candidate entries, and writes eval_context.json.
-    """
+    """Assemble eval_context.json from resolved manifest and variant output paths."""
     from autoskillit.core import atomic_write
 
     resolved_path = Path(eval_run_dir) / canary_id / "resolved.json"

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -539,6 +539,212 @@ def parse_eval_manifests(
     }
 
 
+def parse_agent_eval_manifests(
+    canary_manifest: str,
+    variant_manifest: str,
+    output_dir: str,
+) -> dict[str, str]:
+    """Parse agent-eval manifests and create eval run directory structure.
+
+    Reads canary and variant manifests, resolves prompt_template with prompt_vars
+    (including _file indirection), creates per-canary resolved.json and
+    resolved_prompt.txt, and writes manifest_index.json.
+    """
+    from datetime import datetime
+
+    from autoskillit.core import atomic_write
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    eval_run_dir = Path(output_dir) / "runs" / timestamp
+    eval_run_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        canaries = _load_json(canary_manifest)
+        variants = _load_json(variant_manifest)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"success": "false", "error": f"Failed to read manifest: {exc}"}
+
+    canary_ids = []
+    variant_ids = []
+
+    for c in canaries:
+        cid = c.get("id")
+        if not cid:
+            return {"success": "false", "error": "Canary missing 'id' field"}
+        canary_ids.append(cid)
+
+    for v in variants:
+        vid = v.get("id")
+        if not vid:
+            return {"success": "false", "error": "Variant missing 'id' field"}
+        variant_ids.append(vid)
+
+    variant_labels = {v["id"]: v.get("label", v["id"]) for v in variants}
+
+    for canary in canaries:
+        canary_id = canary["id"]
+
+        if "agent_name" not in canary:
+            return {"success": "false", "error": f"Canary {canary_id} missing agent_name"}
+
+        if "prompt_template" not in canary:
+            return {"success": "false", "error": f"Canary {canary_id} missing prompt_template"}
+
+        canary_dir = eval_run_dir / canary_id
+        canary_dir.mkdir(parents=True, exist_ok=True)
+
+        resolved_vars = {}
+        for key, value in canary.get("prompt_vars", {}).items():
+            if key.endswith("_file"):
+                bare_key = key[:-5]
+                if bare_key in resolved_vars:
+                    return {
+                        "success": "false",
+                        "error": (
+                            f"prompt_vars collision: '{bare_key}' defined both "
+                            "directly and via _file indirection"
+                        ),
+                    }
+                try:
+                    resolved_vars[bare_key] = Path(value).read_text()
+                except OSError as exc:
+                    return {"success": "false", "error": f"Failed to read {key} file: {exc}"}
+            else:
+                if key in resolved_vars:
+                    return {
+                        "success": "false",
+                        "error": (
+                            f"prompt_vars collision: '{key}' defined both "
+                            "directly and via _file indirection"
+                        ),
+                    }
+                resolved_vars[key] = value
+
+        try:
+            resolved_prompt = str(canary["prompt_template"]).format_map(resolved_vars)
+        except KeyError as exc:
+            return {"success": "false", "error": f"Template variable not resolved: {exc}"}
+
+        (canary_dir / "resolved_prompt.txt").write_text(resolved_prompt)
+
+        variants_dict = {}
+        for v in variants:
+            vid = v["id"]
+            variants_dict[vid] = {
+                "label": v.get("label", vid),
+                "agent_file": v.get("agent_file"),
+            }
+            (canary_dir / vid).mkdir(parents=True, exist_ok=True)
+
+        resolved = dict(canary)
+        resolved["resolved_prompt"] = resolved_prompt
+        resolved["variants"] = variants_dict
+
+        atomic_write(canary_dir / "resolved.json", json.dumps(resolved, indent=2))
+
+    manifest_index: dict[str, object] = {
+        "canary_ids": canary_ids,
+        "variant_ids": variant_ids,
+        "variant_labels": variant_labels,
+    }
+    for cid in canary_ids:
+        manifest_index[f"path_{cid}"] = str(eval_run_dir / cid)
+
+    manifest_index_path = eval_run_dir / "manifest_index.json"
+    atomic_write(manifest_index_path, json.dumps(manifest_index, indent=2))
+
+    return {
+        "success": "true",
+        "eval_run_dir": str(eval_run_dir),
+        "canary_count": str(len(canary_ids)),
+        "variant_count": str(len(variant_ids)),
+        "manifest_index_path": str(manifest_index_path),
+    }
+
+
+def build_agent_eval_context(
+    canary_id: str,
+    output_paths_json: str,
+    eval_run_dir: str,
+) -> dict[str, str]:
+    """Assemble eval_context.json from resolved manifest and output paths.
+
+    Reads the resolved.json for the given canary, builds the eval_context dict
+    with reference and candidate entries, and writes eval_context.json.
+    """
+    from autoskillit.core import atomic_write
+
+    resolved_path = Path(eval_run_dir) / canary_id / "resolved.json"
+    try:
+        resolved = json.loads(resolved_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"success": "false", "error": f"Failed to read resolved.json: {exc}"}
+
+    try:
+        output_paths = json.loads(output_paths_json)
+    except json.JSONDecodeError as exc:
+        return {"success": "false", "error": f"Failed to parse output_paths_json: {exc}"}
+
+    subject = resolved.get("agent_name", "")
+
+    reference_path_raw = resolved.get("reference_path")
+    if not reference_path_raw:
+        return {
+            "success": "false",
+            "error": f"Canary {canary_id} resolved.json missing reference_path",
+        }
+    reference_path = Path(reference_path_raw).resolve()
+
+    candidates = []
+    for variant_id, path in output_paths.items():
+        variant_meta = resolved.get("variants", {}).get(variant_id, {})
+        label = variant_meta.get("label", variant_id)
+        if path is not None:
+            candidates.append(
+                {
+                    "id": variant_id,
+                    "path": str(Path(path).resolve()),
+                    "label": label,
+                    "status": "completed",
+                }
+            )
+        else:
+            candidates.append(
+                {
+                    "id": variant_id,
+                    "path": None,
+                    "label": label,
+                    "status": "failed",
+                }
+            )
+
+    codebase_root = ""
+    eval_run_path = Path(eval_run_dir)
+    for parent in eval_run_path.parents:
+        if (parent / ".git").exists():
+            codebase_root = str(parent)
+            break
+
+    eval_context = {
+        "eval_id": resolved.get("id", canary_id),
+        "subject": subject,
+        "gap_description": resolved.get("gap_description", ""),
+        "detection_criteria": resolved.get("detection_criteria", []),
+        "reference": {
+            "path": str(reference_path),
+            "label": "Input context for agent evaluation",
+            "artifact_type": resolved.get("reference_type", "patch"),
+        },
+        "candidates": candidates,
+        "codebase_root": codebase_root,
+        "eval_run_dir": str(eval_run_path.resolve()),
+    }
+
+    out_path = eval_run_path / canary_id / "eval_context.json"
+    atomic_write(out_path, json.dumps(eval_context, indent=2))
+    return {"success": "true", "eval_context_path": str(out_path)}
+
+
 def build_eval_context(
     canary_id: str,
     plan_paths_json: str,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -932,6 +932,12 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "a 16th fleet/ module (sub-package file ceiling); keeps dispatch-related helpers "
         "co-located with the execution engine that calls them",
     ),
+    "smoke_utils.py": (
+        1100,
+        "REQ-CNST-010-E7: agent-eval + skill-eval smoke functions — parse_agent_eval_manifests "
+        "and build_agent_eval_context parallel parse_eval_manifests/build_eval_context; "
+        "shared helpers extracted but residual size from two eval domains",
+    ),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -143,7 +143,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)
     ("src/autoskillit/cli/update/_update_checks_fetch.py", 58),
     # smoke_utils.py — partitions, ranges, diff metrics, queue, enriched handoff,
-    # eval resolved/manifest/scorecard/eval_context
+    # eval resolved/manifest/scorecard/eval_context, agent-eval resolved/manifest/context
     ("src/autoskillit/smoke_utils.py", 71),
     ("src/autoskillit/smoke_utils.py", 140),
     # Lines 157 and 438 are list-payload write sites (dual membership: also in list_sites
@@ -153,9 +153,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 438),
     ("src/autoskillit/smoke_utils.py", 520),
     ("src/autoskillit/smoke_utils.py", 531),
-    ("src/autoskillit/smoke_utils.py", 624),
-    ("src/autoskillit/smoke_utils.py", 700),
-    ("src/autoskillit/smoke_utils.py", 795),
+    ("src/autoskillit/smoke_utils.py", 638),
+    ("src/autoskillit/smoke_utils.py", 649),
+    ("src/autoskillit/smoke_utils.py", 735),
+    ("src/autoskillit/smoke_utils.py", 821),
+    ("src/autoskillit/smoke_utils.py", 897),
+    ("src/autoskillit/smoke_utils.py", 992),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 315),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from autoskillit.smoke_utils import (
     annotate_pr_diff,
+    build_agent_eval_context,
     build_eval_context,
     check_bug_report_non_empty,
     check_loop_iteration,
@@ -16,6 +17,7 @@ from autoskillit.smoke_utils import (
     check_review_loop,
     compile_eval_scorecard,
     enrich_diff_context,
+    parse_agent_eval_manifests,
     parse_eval_manifests,
     patch_pr_token_summary,
 )
@@ -1501,3 +1503,390 @@ def test_compile_eval_scorecard_empty_run_dir(tmp_path: Path) -> None:
     assert result["pass_rate"] == "0.0"
     assert result["passed_runs"] == "0"
     assert result["total_runs"] == "4"
+
+
+# ---------------------------------------------------------------------------
+# T_PAEM1–T_PAEM9: parse_agent_eval_manifests tests
+# ---------------------------------------------------------------------------
+
+
+# T_PAEM1
+def test_parse_agent_eval_manifests_creates_directory_tree(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "diff.patch"
+    prompt_file.write_text("+added line")
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "pr-review-auditor",
+            "prompt_template": "Review this diff:\n\n{diff_content}",
+            "prompt_vars": {"diff_content_file": str(prompt_file)},
+            "reference_path": str(prompt_file),
+            "reference_type": "patch",
+            "gap_description": "False positive on style",
+            "detection_criteria": ["Does not flag style issues"],
+        }
+    ]
+    variant_manifest = [
+        {"id": "baseline", "label": "Baseline", "agent_file": "/path/to/baseline.md"},
+    ]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "true"
+    eval_run_dir = Path(result["eval_run_dir"])
+    assert (eval_run_dir / "RA1" / "resolved.json").is_file()
+    assert (eval_run_dir / "RA1" / "resolved_prompt.txt").is_file()
+    assert (eval_run_dir / "manifest_index.json").is_file()
+
+
+# T_PAEM2
+def test_parse_agent_eval_manifests_resolves_file_vars(tmp_path: Path) -> None:
+    diff_file = tmp_path / "diff.patch"
+    diff_file.write_text("+added line\n-removed line")
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "Review:\n{diff_content}\nDimension: {dimension}",
+            "prompt_vars": {"diff_content_file": str(diff_file), "dimension": "bugs"},
+            "reference_path": str(diff_file),
+            "reference_type": "patch",
+            "detection_criteria": ["Finds the bug"],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "true"
+    eval_run_dir = Path(result["eval_run_dir"])
+    resolved_prompt = (eval_run_dir / "RA1" / "resolved_prompt.txt").read_text()
+    assert "+added line" in resolved_prompt
+    assert "Dimension: bugs" in resolved_prompt
+    resolved = json.loads((eval_run_dir / "RA1" / "resolved.json").read_text())
+    assert resolved["resolved_prompt"] == resolved_prompt
+
+
+# T_PAEM3
+def test_parse_agent_eval_manifests_writes_manifest_index(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "test",
+            "prompt_vars": {},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": ["test"],
+        }
+    ]
+    variant_manifest = [
+        {"id": "baseline", "label": "Baseline", "agent_file": "/baseline.md"},
+        {"id": "v1", "label": "Variant 1", "agent_file": "/v1.md"},
+    ]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "true"
+    index = json.loads(Path(result["manifest_index_path"]).read_text())
+    assert index["canary_ids"] == ["RA1"]
+    assert index["variant_ids"] == ["baseline", "v1"]
+    assert "baseline" in index["variant_labels"]
+
+
+# T_PAEM4
+def test_parse_agent_eval_manifests_unreadable_file_var(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "{content}",
+            "prompt_vars": {"content_file": "/nonexistent/file.txt"},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": ["test"],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "false"
+    assert "error" in result
+
+
+# T_PAEM5
+def test_parse_agent_eval_manifests_missing_prompt_template(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_vars": {},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": ["test"],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "false"
+
+
+# T_PAEM6
+def test_parse_agent_eval_manifests_resolved_has_variant_agent_files(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "test prompt",
+            "prompt_vars": {},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": ["test"],
+        }
+    ]
+    variant_manifest = [
+        {"id": "baseline", "label": "Baseline", "agent_file": "/path/baseline.md"},
+        {"id": "v1", "label": "Focused", "agent_file": "/path/v1.md"},
+    ]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "true"
+    eval_run_dir = Path(result["eval_run_dir"])
+    resolved = json.loads((eval_run_dir / "RA1" / "resolved.json").read_text())
+    assert resolved["variants"]["baseline"]["agent_file"] == "/path/baseline.md"
+    assert resolved["variants"]["v1"]["agent_file"] == "/path/v1.md"
+    assert resolved["variants"]["baseline"]["label"] == "Baseline"
+
+
+# T_PAEM7
+def test_parse_agent_eval_manifests_missing_agent_name(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "prompt_template": "test",
+            "prompt_vars": {},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": ["test"],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "false"
+    assert "agent_name" in result["error"]
+
+
+# T_PAEM8
+def test_parse_agent_eval_manifests_template_var_not_resolved(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "Review: {missing_var}",
+            "prompt_vars": {"other": "value"},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": ["test"],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "false"
+    assert "error" in result
+
+
+# T_PAEM9
+def test_parse_agent_eval_manifests_file_var_collision(tmp_path: Path) -> None:
+    diff_file = tmp_path / "diff.patch"
+    diff_file.write_text("diff content")
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "{content}",
+            "prompt_vars": {"content": "direct", "content_file": str(diff_file)},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": ["test"],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "false"
+    assert "collision" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# T_BAEC1–T_BAEC6: build_agent_eval_context tests
+# ---------------------------------------------------------------------------
+
+
+# T_BAEC1
+def test_build_agent_eval_context_writes_eval_context(tmp_path: Path) -> None:
+    eval_run_dir = tmp_path / "eval_run"
+    eval_run_dir.mkdir()
+    canary_dir = eval_run_dir / "RA1"
+    canary_dir.mkdir()
+    (canary_dir / "resolved.json").write_text(
+        json.dumps(
+            {
+                "id": "RA1",
+                "agent_name": "pr-review-auditor",
+                "gap_description": "False positive on style",
+                "detection_criteria": ["Does not flag style"],
+                "reference_path": "/path/to/diff.patch",
+                "reference_type": "patch",
+                "variants": {"baseline": {"label": "Baseline", "agent_file": "/baseline.md"}},
+            }
+        )
+    )
+    output_file = tmp_path / "output.json"
+    output_file.write_text('{"result": "ok"}')
+    result = build_agent_eval_context(
+        canary_id="RA1",
+        output_paths_json=json.dumps({"baseline": str(output_file)}),
+        eval_run_dir=str(eval_run_dir),
+    )
+    assert result["success"] == "true"
+    ctx = json.loads(Path(result["eval_context_path"]).read_text())
+    assert ctx["eval_id"] == "RA1"
+    assert ctx["subject"] == "pr-review-auditor"
+    assert ctx["reference"]["artifact_type"] == "patch"
+    assert ctx["reference"]["label"] == "Input context for agent evaluation"
+    assert len(ctx["candidates"]) == 1
+    assert ctx["candidates"][0]["status"] == "completed"
+
+
+# T_BAEC2
+def test_build_agent_eval_context_handles_null_output(tmp_path: Path) -> None:
+    eval_run_dir = tmp_path / "eval_run"
+    eval_run_dir.mkdir()
+    canary_dir = eval_run_dir / "RA1"
+    canary_dir.mkdir()
+    (canary_dir / "resolved.json").write_text(
+        json.dumps(
+            {
+                "id": "RA1",
+                "agent_name": "test-agent",
+                "gap_description": "test",
+                "detection_criteria": ["test"],
+                "reference_path": "/ref",
+                "reference_type": "patch",
+                "variants": {"v1": {"label": "V1", "agent_file": "/v1.md"}},
+            }
+        )
+    )
+    result = build_agent_eval_context(
+        canary_id="RA1",
+        output_paths_json=json.dumps({"v1": None}),
+        eval_run_dir=str(eval_run_dir),
+    )
+    assert result["success"] == "true"
+    ctx = json.loads(Path(result["eval_context_path"]).read_text())
+    assert ctx["candidates"][0]["status"] == "failed"
+    assert ctx["candidates"][0]["path"] is None
+
+
+# T_BAEC3
+def test_build_agent_eval_context_uses_agent_name_as_subject(tmp_path: Path) -> None:
+    eval_run_dir = tmp_path / "eval_run"
+    eval_run_dir.mkdir()
+    canary_dir = eval_run_dir / "RA1"
+    canary_dir.mkdir()
+    (canary_dir / "resolved.json").write_text(
+        json.dumps(
+            {
+                "id": "RA1",
+                "agent_name": "review-intent-validator",
+                "gap_description": "test",
+                "detection_criteria": ["test"],
+                "reference_path": "/ref",
+                "reference_type": "patch",
+                "variants": {},
+            }
+        )
+    )
+    result = build_agent_eval_context(
+        canary_id="RA1",
+        output_paths_json="{}",
+        eval_run_dir=str(eval_run_dir),
+    )
+    assert result["success"] == "true"
+    ctx = json.loads(Path(result["eval_context_path"]).read_text())
+    assert ctx["subject"] == "review-intent-validator"
+
+
+# T_BAEC4
+def test_build_agent_eval_context_missing_resolved(tmp_path: Path) -> None:
+    eval_run_dir = tmp_path / "eval_run"
+    eval_run_dir.mkdir()
+    result = build_agent_eval_context(
+        canary_id="RA1",
+        output_paths_json="{}",
+        eval_run_dir=str(eval_run_dir),
+    )
+    assert result["success"] == "false"
+
+
+# T_BAEC5
+def test_build_agent_eval_context_missing_reference_path(tmp_path: Path) -> None:
+    eval_run_dir = tmp_path / "eval_run"
+    eval_run_dir.mkdir()
+    canary_dir = eval_run_dir / "RA1"
+    canary_dir.mkdir()
+    (canary_dir / "resolved.json").write_text(
+        json.dumps(
+            {
+                "id": "RA1",
+                "agent_name": "test-agent",
+                "gap_description": "test",
+                "detection_criteria": ["test"],
+                "variants": {},
+            }
+        )
+    )
+    result = build_agent_eval_context(
+        canary_id="RA1",
+        output_paths_json="{}",
+        eval_run_dir=str(eval_run_dir),
+    )
+    assert result["success"] == "false"
+    assert "reference_path" in result["error"]
+
+
+# T_BAEC6
+def test_build_agent_eval_context_default_reference_type_is_patch(tmp_path: Path) -> None:
+    eval_run_dir = tmp_path / "eval_run"
+    eval_run_dir.mkdir()
+    canary_dir = eval_run_dir / "RA1"
+    canary_dir.mkdir()
+    (canary_dir / "resolved.json").write_text(
+        json.dumps(
+            {
+                "id": "RA1",
+                "agent_name": "test-agent",
+                "gap_description": "test",
+                "detection_criteria": ["test"],
+                "reference_path": "/ref",
+                "variants": {},
+            }
+        )
+    )
+    result = build_agent_eval_context(
+        canary_id="RA1",
+        output_paths_json="{}",
+        eval_run_dir=str(eval_run_dir),
+    )
+    assert result["success"] == "true"
+    ctx = json.loads(Path(result["eval_context_path"]).read_text())
+    assert ctx["reference"]["artifact_type"] == "patch"


### PR DESCRIPTION
## Summary

Add the `agent-eval.yaml` recipe and two new `smoke_utils.py` functions (`parse_agent_eval_manifests` and `build_agent_eval_context`) that together form the evaluation harness for testing agent definition variants against canary test cases. The recipe follows the same three-step pattern as `skill-eval.yaml` (parse → run canaries → compile scorecard) but differs in three key ways: (1) canary manifests use `prompt_template` + `prompt_vars` with `_file` variable indirection instead of `task_file` + `overlay_file`, (2) variant manifests reference `agent_file` paths instead of `overlay_file` paths, and (3) canary×variant combinations run in parallel (independent read-only invocations, no shared clone). The existing `compile_eval_scorecard` function is reused unchanged.

**Dependency:** This recipe depends on the `eval-agent` wrapper skill from issue #2954. The recipe will pass schema validation but is not operationally functional until `eval-agent` lands.

## Requirements

### Recipe (`agent-eval.yaml`)

Three-step flow mirroring `skill-eval.yaml`:

1. **`parse_agent_eval_manifests`** (run_python) — reads canary manifest + variant manifest JSONs, resolves `prompt_template` + `prompt_vars` (including `*_file` variable indirection where a var ending in `_file` is read from disk and inlined), creates `eval_run_dir` tree with per-canary `resolved.json` and `resolved_prompt.txt`, writes `manifest_index.json`

2. **`run_canaries`** (LLM-orchestrated) — runs all canary×variant combinations with up to `max_parallel` concurrent evaluations. Unlike skill-eval (where variants share a clone and must be sequential), agent-eval variants are independent read-only `run_skill` calls with no shared state — so variants CAN and SHOULD run in parallel across canaries.

   For each canary×variant pair (up to `max_parallel` in flight at once):
   - Stage variant agent file in `src/autoskillit/agents/` via `run_cmd cp` with unique name `{agent_name}-eval-{variant_id}.md`
   - Run `run_skill /autoskillit:eval-agent --agent-name {agent_name}-eval-{variant_id} --prompt-file {resolved_prompt_path}`
   - Copy output to `eval_run_dir/{canary_id}/{variant_id}/output.json`
   - Clean up staged agent file via `run_cmd rm` — **cleanup must also execute on the `on_failure` path** to prevent orphaned files

   After all variants for a canary complete:
   - Run `build_agent_eval_context` (run_python) to assemble `eval_context.json`
   - Run `run_skill /autoskillit:judge-eval` with `model: "opus"` override for quality assessment → `verdict.json`

3. **`compile_eval_scorecard`** (run_python, **reused unchanged** from skill-eval) — aggregates `verdict.json` files into `scorecard.json` + `scorecard.md`

### Baseline variant handling

The baseline variant MUST have an `agent_file` — it cannot be `null`. The eval-agent wrapper always invokes via `Agent(subagent_type=...)`, which requires a named agent definition file to exist. For agents being evaluated before extraction into the codebase, the baseline is the **current inline prompt extracted verbatim** into a temporary agent `.md` file stored at `~/.claude/agents/`. The `agent-eval-prep` user-wide skill handles creating this baseline file from the SKILL.md inline text.

This means the baseline comparison is: "does the same instructions perform differently as a system prompt (agent definition) vs. inline text (current SKILL.md)?"

### Ingredients

| Ingredient | Required | Default | Description |
|------------|----------|---------|-------------|
| `canary_manifest` | yes | — | Path to canary test cases JSON |
| `variant_manifest` | yes | — | Path to agent variant definitions JSON |
| `source_dir` | yes | — | Project root for agent execution cwd |
| `output_dir` | no | `{{AUTOSKILLIT_TEMP}}/agent-eval` | Base directory for run output |
| `max_parallel` | no | `"3"` | Max concurrent canary×variant evaluations (global concurrency limit, not per-canary) |

### New smoke_utils.py functions

**`parse_agent_eval_manifests(canary_manifest, variant_manifest, output_dir)`**
- Reads both manifest JSONs
- For each canary: resolves `prompt_template` by substituting `prompt_vars` (vars ending in `_file` are read from disk), writes `resolved_prompt.txt` and `resolved.json`
- Writes `manifest_index.json` with canary_ids, variant_ids, and directory paths
- Returns: `eval_run_dir`, `canary_count`, `variant_count`, `manifest_index_path`

**`build_agent_eval_context(canary_id, output_paths_json, eval_run_dir)`**
- Reads `resolved.json` for the canary
- Assembles `eval_context.json` in the format judge-eval expects
- Uses the canary's `reference_path` (the input diff/context) as the reference artifact — NOT a ground-truth output (unlike skill-eval's `build_eval_context` which requires a plan reference)
- Sets `reference.artifact_type` from the canary's `reference_type` field
- Candidates are the per-variant `output.json` files
- Returns: `eval_context_path`

Note: `build_eval_context` from skill-eval cannot be reused — it requires `reference_path` pointing to a ground-truth plan (aborts if absent) and hardcodes plan-specific labels. This new function constructs a consistent `eval_context.json` format that avoids the `judgment.json` vs `verdict.json` format inconsistency that affected skill-eval scorecards.

### Manifest schemas

**Canary manifest** — see `agent-eval-prep` skill at `~/.claude/skills/agent-eval-prep/SKILL.md` for full schema. Key fields: `id`, `description`, `agent_name`, `prompt_template`, `prompt_vars`, `reference_path`, `reference_type`, `gap_description`, `detection_criteria[]`.

**Variant manifest** — see same skill. Key fields: `id`, `label`, `agent_file` (path to `.md` definition — required for all variants including baseline), `description`.

### Provider routing

The recipe's default provider handles agent execution (configurable, e.g., MiniMax for cost). The judge step uses an explicit model override for Anthropic Opus via `providers.recipe_overrides["agent-eval"]["judge"]` or the `model` parameter on the `run_skill` call. The `providers` feature must be enabled for non-Anthropic providers (currently `default_enabled=False`, lifecycle `EXPERIMENTAL`).

### Statistical confidence

The recipe runs each canary×variant combination once per invocation. For statistical confidence (needed because single-run results are highly variable), run the recipe multiple times and compare scorecards across runs. This matches the established skill-eval pattern. There is no in-recipe aggregation of repeated runs.

## Acceptance Criteria

- [ ] Recipe exists at `.autoskillit/recipes/eval/agent-eval.yaml`
- [ ] `parse_agent_eval_manifests` function in `smoke_utils.py` with tests
- [ ] `build_agent_eval_context` function in `smoke_utils.py` with tests
- [ ] Recipe validates successfully (`recipe validate agent-eval`)
- [ ] End-to-end test: run with wp-elaborator canary (1 canary, 1 variant, n=1) produces scorecard
- [ ] `compile_eval_scorecard` reused unchanged (no modifications to existing function)
- [ ] Variant staging uses unique names (`{agent_name}-eval-{variant_id}.md`) to prevent collision with production agents
- [ ] Variant cleanup executes on both success and failure paths (no orphaned files)
- [ ] Baseline variant with `agent_file` pointing to a verbatim-extracted inline prompt works correctly
- [ ] Recipe documentation notes that repeat runs = multiple recipe invocations for statistical confidence

## Dependencies

- #2954 (eval-agent wrapper skill)
- Existing `judge-eval` skill (reused unchanged)
- Existing `compile_eval_scorecard` in `smoke_utils.py` (reused unchanged)

## References

- Skill-eval recipe: `.autoskillit/recipes/eval/skill-eval.yaml`
- Skill-eval tracking issue: #2609
- Skill-eval handoff: `.autoskillit/temp/skill-eval-handoff-v3.md`
- Agent-eval-prep skill (user-wide): `~/.claude/skills/agent-eval-prep/SKILL.md`
- Full research report: `.autoskillit/temp/subagent-optimization-report.md`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-205755-753994/.autoskillit/temp/make-plan/build_agent_eval_recipe_plan_2026-05-25_210500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.0k | 28.7k | 1.7M | 138.0k | 221 | 123.2k | 17m 21s |
| verify | claude-sonnet-4-6 | 1 | 132 | 9.7k | 703.7k | 58.6k | 41 | 44.0k | 3m 14s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 15.2k | 873.6k | 25.7k | 87 | 38.7k | 4m 48s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 116.8k | 5.3k | 180.2k | 25.7k | 20 | 38.3k | 1m 20s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 76.3k | 3.5k | 203.1k | 25.7k | 19 | 15.2k | 1m 0s |
| review_pr | claude-sonnet-4-6 | 2 | 308 | 100.2k | 2.2M | 114.3k | 125 | 183.8k | 25m 14s |
| resolve_review | claude-sonnet-4-6 | 2 | 822 | 44.1k | 5.7M | 88.4k | 227 | 134.3k | 37m 8s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 2 | 118.2k | 3.3k | 687.0k | 25.7k | 39 | 15.1k | 1m 56s |
| resolve_ci | claude-sonnet-4-6 | 3 | 400 | 57.3k | 6.0M | 112.4k | 222 | 218.8k | 41m 4s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 100 | 8.3k | 438.8k | 49.1k | 32 | 37.4k | 3m 20s |
| **Total** | | | 1.6M | 275.6k | 18.7M | 138.0k | | 848.8k | 2h 16m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 6 | 4.7k | 248.3k | 16.8M | 741.5k | 2h 7m |
| MiniMax-M2.7-highspeed | 4 | 1.5M | 27.4k | 1.9M | 107.3k | 9m 6s |