### PR TITLE
Rectify: Contract Recovery Routing Gap — Zero-Changes Branch Immunity

### DIFF
--- a/src/autoskillit/cli/_prompts_orchestrator.py
+++ b/src/autoskillit/cli/_prompts_orchestrator.py
@@ -212,6 +212,13 @@ CONTEXT LIMIT ROUTING — run_skill only (check BEFORE on_failure):
     via CLI). Partial progress may exist on disk. Follow on_context_limit.
   - If "has_progress_evidence" is false OR the step has no on_context_limit: fall through
     to on_failure — no recoverable progress evidence.
+- When run_skill returns "needs_retry: true" AND "retry_reason: contract_recovery":
+  - The model ran to completion and wrote artifacts but the structured output tokens
+    failed pattern validation. Infrastructure nudge was attempted but could not recover.
+  - If "has_progress_evidence" is true in the result AND the step defines on_context_limit:
+    partial progress exists on disk. Follow on_context_limit.
+  - If "has_progress_evidence" is false OR the step has no on_context_limit: fall through
+    to on_failure — no recoverable progress evidence.
 - WORKTREE-STALE CARVE-OUT: When the step invokes a worktree-creating skill
   (implement-worktree-no-merge, implement-worktree, implement-experiment) and returns
   retry_reason=stale (or retry_reason=resume with subtype=stale), re-execute the step

--- a/src/autoskillit/config/_config_loader.py
+++ b/src/autoskillit/config/_config_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -161,6 +162,12 @@ def _make_dynaconf(project_dir: Path | None = None) -> Dynaconf:
         tmp.write(dump_yaml_str(merged))
         tmp_path = Path(tmp.name)
 
+    # AUTOSKILLIT_AGENT_BACKEND flat env var (used by hook subprocesses to detect
+    # the active backend) clashes with Dynaconf: a flat section override replaces
+    # the agent_backend dict, suppressing nested env vars and file config. Pop it
+    # before Dynaconf loads and restore it after so that AUTOSKILLIT_AGENT_BACKEND__BACKEND
+    # (nested) and YAML file config are not silently overridden.
+    _flat_backend = os.environ.pop("AUTOSKILLIT_AGENT_BACKEND", None)
     try:
         d = Dynaconf(
             envvar_prefix="AUTOSKILLIT",
@@ -173,6 +180,8 @@ def _make_dynaconf(project_dir: Path | None = None) -> Dynaconf:
         d.as_dict()  # trigger eager load so the temp file can be safely deleted
     finally:
         tmp_path.unlink(missing_ok=True)
+        if _flat_backend is not None:
+            os.environ["AUTOSKILLIT_AGENT_BACKEND"] = _flat_backend
 
     return d
 

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -565,7 +565,9 @@ class AutomationConfig:
                 ),
             ),
             agent_backend=AgentBackendConfig(
-                backend=str(val(ab, "backend", _ab["backend"])),
+                backend=str(
+                    ab if isinstance(ab, str) and ab else val(ab, "backend", _ab["backend"])
+                ),
             ),
             features=_features_dict,
             experimental_enabled=_exp_enabled,

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -336,6 +336,7 @@ class DefaultHeadlessExecutor:
         marker_dir: Path | None = None,
         session_id: str | None = None,
         resume_message: str | None = None,
+        backend_override: str | None = None,
     ) -> SkillResult:
         if self._ctx.backend is not None and not self._ctx.backend.capabilities.food_truck_capable:
             raise RuntimeError(

--- a/src/autoskillit/hooks/formatters/_fmt_execution.py
+++ b/src/autoskillit/hooks/formatters/_fmt_execution.py
@@ -59,6 +59,8 @@ def _fmt_run_skill(data: dict, pipeline: bool) -> str:
         lines.append(f"needs_retry: {data.get('needs_retry', False)}")
         if data.get("retry_reason") and data["retry_reason"] != "none":
             lines.append(f"retry_reason: {data['retry_reason']}")
+        if data.get("needs_retry") and "has_progress_evidence" in data:
+            lines.append(f"has_progress_evidence: {data['has_progress_evidence']}")
         worktree = data.get("worktree_path", "")
         if worktree:
             lines.append(f"worktree_path: {worktree}")
@@ -83,6 +85,8 @@ def _fmt_run_skill(data: dict, pipeline: bool) -> str:
     retry_reason = data.get("retry_reason", "none")
     if retry_reason and retry_reason != "none":
         lines.append(f"retry_reason: {retry_reason}")
+    if data.get("needs_retry") and "has_progress_evidence" in data:
+        lines.append(f"has_progress_evidence: {data['has_progress_evidence']}")
     worktree = data.get("worktree_path", "")
     if worktree:
         lines.append(f"worktree_path: {worktree}")
@@ -216,6 +220,9 @@ _FMT_RUN_SKILL_RENDERED: frozenset[str] = frozenset(
         "result",
         "stderr",
         "token_usage",
+        "has_progress_evidence",
+        "provider_used",
+        "provider_fallback",
     }
 )
 _FMT_RUN_SKILL_SUPPRESSED: frozenset[str] = frozenset(
@@ -231,6 +238,10 @@ _FMT_RUN_SKILL_SUPPRESSED: frozenset[str] = frozenset(
         "lifespan_started",
         "order_id",
         "infra_exit_category",
+        "api_retry_count",
+        "api_retry_last_error",
+        "api_retry_last_status",
+        "api_retry_exhausted",
     }
 )
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -480,10 +480,14 @@ skills:
       type: string
     expected_output_patterns:
     - "prep_path\\s*=\\s*/.+"
-    - "selected_lenses\\s*=\\s*\\S+"
-    - "lens_context_paths\\s*=\\s*/.+"
+    - "selected_lenses[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
+    - "lens_context_paths[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     pattern_examples:
     - "prep_path = /abs/path/pr_prep_2026-04-07_120000.md\nselected_lenses = module-dependency,process-flow\nlens_context_paths = /abs/ctx1.md,/abs/ctx2.md\n%%ORDER_UP%%"
+    - "prep_path = /abs/path/prep.md\nselected_lenses = none\nlens_context_paths = none\n%%ORDER_UP%%"
+    negative_examples:
+    - "prep_path = /abs/path/prep.md\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
+    - "prep_path = /abs/path/prep.md\nselected_lenses = \nlens_context_paths\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
     - "prep_path\\s*=\\s*/.+"
@@ -1489,10 +1493,14 @@ skills:
       type: string
     expected_output_patterns:
     - "prep_path\\s*=\\s*/.+"
-    - "selected_lenses\\s*=\\s*\\S+"
-    - "lens_context_paths\\s*=\\s*/.+"
+    - "selected_lenses[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
+    - "lens_context_paths[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     pattern_examples:
     - "prep_path = /abs/path/pr_prep_2026-04-07_101349.md\nselected_lenses = fair-comparison,estimand-clarity\nlens_context_paths = /abs/ctx1.md,/abs/ctx2.md\n%%ORDER_UP%%"
+    - "prep_path = /abs/path/prep.md\nselected_lenses = none\nlens_context_paths = none\n%%ORDER_UP%%"
+    negative_examples:
+    - "prep_path = /abs/path/prep.md\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
+    - "prep_path = /abs/path/prep.md\nselected_lenses = \nlens_context_paths\n%%ORDER_UP%%"
     write_behavior: always
 
   compose-research-pr:
@@ -1545,7 +1553,7 @@ skills:
       type: string
     expected_output_patterns:
     - "verdict\\s*=\\s*(GO|REVISE|STOP)"
-    - "(?:experiment_type\\s*=\\s*\\S+|verdict\\s*=\\s*STOP)"
+    - "(?:experiment_type[ \\t]*=[ \\t]*(\\S[^\\n]*|none)|verdict[ \\t]*=[ \\t]*STOP)"
     pattern_examples:
     - "verdict = GO\nexperiment_type = benchmark\nevaluation_dashboard = /tmp/eval.md\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
     - "verdict = REVISE\nexperiment_type = benchmark\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
@@ -2794,6 +2802,25 @@ callable_contracts:
       type: str
     - name: commit_count
       type: str
+  autoskillit.smoke_utils.check_commits_ahead:
+    inputs:
+    - name: cwd
+      type: directory_path
+      required: true
+    - name: base_branch
+      type: string
+      required: true
+    outputs:
+    - name: has_commits
+      type: string
+  autoskillit.smoke_utils.close_issue_already_done:
+    inputs:
+    - name: issue_url
+      type: string
+      required: true
+    outputs:
+    - name: closed
+      type: string
 
 tool_output_contracts:
   wait_for_ci:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -22,7 +22,7 @@ skills:
     - name: retry_delay
       type: integer
     expected_output_patterns:
-    - "is_fixable\\s*=\\s*(true|false)"
+    - "is_fixable[ \\t]*=[ \\t]*(true|false)"
     pattern_examples:
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = stale_timeout\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = transient_api\nis_fixable = true\nretry_delay = 120\n%%ORDER_UP%%"
@@ -50,8 +50,8 @@ skills:
     - name: is_fixable
       type: string
     expected_output_patterns:
-    - "diagnosis_path\\s*=\\s*(?:/.+)?"
-    - "failure_subtype\\s*=\\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
+    - "diagnosis_path[ \\t]*=[ \\t]*(?:/.+)?"
+    - "failure_subtype[ \\t]*=[ \\t]*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
     pattern_examples:
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = deterministic\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = flaky\nis_fixable = false\n%%ORDER_UP%%"
@@ -80,8 +80,8 @@ skills:
     - name: revision_guidance
       type: file_path
     expected_output_patterns:
-    - "resolution\\s*=\\s*(revised|failed)"
-    - "(?:revision_guidance\\s*=\\s*/.+|resolution\\s*=\\s*failed)"
+    - "resolution[ \\t]*=[ \\t]*(revised|failed)"
+    - "(?:revision_guidance[ \\t]*=[ \\t]*/.+|resolution[ \\t]*=[ \\t]*failed)"
     pattern_examples:
     - "resolution = revised\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
     - "resolution = failed\n%%ORDER_UP%%"
@@ -113,7 +113,7 @@ skills:
       type: integer
     write_behavior: conditional
     write_expected_when:
-    - "verdict\\s*=\\s*real_fix"
+    - "verdict[ \\t]*=[ \\t]*real_fix"
   resolve-merge-conflicts:
     inputs:
     - name: worktree_path
@@ -137,12 +137,12 @@ skills:
     - name: escalation_reason
       type: string
     expected_output_patterns:
-    - "worktree_path\\s*=\\s*/.+"
+    - "worktree_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "worktree_path = /tmp/worktrees/impl-foo-20260316\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "conflict_report_path\\s*=\\s*/.+"
+    - "conflict_report_path[ \\t]*=[ \\t]*/.+"
   resolve-review:
     inputs:
     - name: feature_branch
@@ -174,7 +174,7 @@ skills:
       required: false
     write_behavior: conditional
     write_expected_when:
-    - "verdict\\s*=\\s*real_fix"
+    - "verdict[ \\t]*=[ \\t]*real_fix"
   dry-walkthrough:
     inputs:
     - name: plan_path
@@ -193,7 +193,7 @@ skills:
     - name: branch_name
       type: string
     expected_output_patterns:
-    - "worktree_path\\s*=\\s*/.+"
+    - "worktree_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "worktree_path = /tmp/worktrees/impl-foo-20260316\n%%ORDER_UP%%"
     write_behavior: always
@@ -208,7 +208,7 @@ skills:
     - name: branch_name
       type: string
     expected_output_patterns:
-    - "worktree_path\\s*=\\s*/.+"
+    - "worktree_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "worktree_path = /tmp/worktrees/impl-foo-20260316\n%%ORDER_UP%%"
     write_behavior: always
@@ -221,7 +221,7 @@ skills:
     - name: investigation_path
       type: file_path
     expected_output_patterns:
-    - "investigation_path\\s*=\\s*/.+"
+    - "investigation_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "investigation_path = /tmp/investigation.md\n%%ORDER_UP%%"
     read_only: true
@@ -238,7 +238,7 @@ skills:
     - name: group_files
       type: file_path_list
     expected_output_patterns:
-    - "groups_path\\s*=\\s*/.+"
+    - "groups_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "groups_path = /tmp/groups.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -253,7 +253,7 @@ skills:
     - name: plan_parts
       type: file_path_list
     expected_output_patterns:
-    - "plan_path\\s*=\\s*/.+"
+    - "plan_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "plan_path = /tmp/plan.md\n%%ORDER_UP%%"
     write_behavior: always
@@ -263,7 +263,7 @@ skills:
     - name: recipe_path
       type: file_path
     expected_output_patterns:
-    - "recipe_path\\s*=\\s*/.+"
+    - "recipe_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "recipe_path = /tmp/recipe.yaml\n%%ORDER_UP%%"
     write_behavior: always
@@ -273,7 +273,7 @@ skills:
     - name: campaign_path
       type: file_path
     expected_output_patterns:
-    - "campaign_path\\s*=\\s*/.+"
+    - "campaign_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "campaign_path = /home/user/project/.autoskillit/recipes/campaigns/my-campaign.yaml\n%%ORDER_UP%%"
     write_behavior: always
@@ -308,7 +308,7 @@ skills:
     - name: plan_parts
       type: file_path_list
     expected_output_patterns:
-    - "plan_path\\s*=\\s*/.+"
+    - "plan_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "plan_path = /tmp/plan.md\n%%ORDER_UP%%"
     write_behavior: always
@@ -328,12 +328,12 @@ skills:
     - name: phases_implemented
       type: integer
     expected_output_patterns:
-    - "worktree_path\\s*=\\s*/.+"
+    - "worktree_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "worktree_path = /tmp/worktrees/impl-foo-20260316\nbranch_name = feature/123\nphases_implemented = 2\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "phases_implemented\\s*=\\s*[1-9][0-9]*"
+    - "phases_implemented[ \\t]*=[ \\t]*[1-9][0-9]*"
   review-approach:
     inputs:
     - name: plan_path
@@ -343,7 +343,7 @@ skills:
     - name: review_path
       type: file_path
     expected_output_patterns:
-    - "review_path\\s*=\\s*/.+"
+    - "review_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "review_path = /tmp/review.md\n%%ORDER_UP%%"
   audit-friction:
@@ -366,7 +366,7 @@ skills:
     - name: remediation_path
       type: file_path
     expected_output_patterns:
-    - "verdict\\s*=\\s*(GO|NO GO)"
+    - "verdict[ \\t]*=[ \\t]*(GO|NO GO)"
     pattern_examples:
     - "verdict = GO\n%%ORDER_UP%%"
     - "verdict = NO GO\nremediation_path = /tmp/remediation.md\n%%ORDER_UP%%"
@@ -397,7 +397,7 @@ skills:
     - name: queue_mode
       type: string
     expected_output_patterns:
-    - "pr_order_file\\s*=\\s*.+"
+    - "pr_order_file[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     pattern_examples:
     - "pr_order_file = /tmp/pr_order.json\n%%ORDER_UP%%"
   merge-pr:
@@ -429,7 +429,7 @@ skills:
     - name: conflict_report_path
       type: file_path
     expected_output_patterns:
-    - "merged\\s*=\\s*(true|false)"
+    - "merged[ \\t]*=[ \\t]*(true|false)"
     pattern_examples:
     - "merged = true\n%%ORDER_UP%%"
     - "merged = false\n%%ORDER_UP%%"
@@ -479,7 +479,7 @@ skills:
     - name: lens_context_paths
       type: string
     expected_output_patterns:
-    - "prep_path\\s*=\\s*/.+"
+    - "prep_path[ \\t]*=[ \\t]*/.+"
     - "selected_lenses[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     - "lens_context_paths[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     pattern_examples:
@@ -490,7 +490,7 @@ skills:
     - "prep_path = /abs/path/prep.md\nselected_lenses = \nlens_context_paths\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "prep_path\\s*=\\s*/.+"
+    - "prep_path[ \\t]*=[ \\t]*/.+"
 
   compose-pr:
     inputs:
@@ -513,13 +513,13 @@ skills:
     - name: pr_url
       type: string
     expected_output_patterns:
-    - "pr_url\\s*=\\s*(https://github\\.com/.*/pull/\\d+)?"
+    - "pr_url[ \\t]*=[ \\t]*(https://github\\.com/.*/pull/\\d+)?"
     pattern_examples:
     - "pr_url = https://github.com/owner/repo/pull/42\n%%ORDER_UP%%"
     - "pr_url = \n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "pr_url\\s*=\\s*https://"
+    - "pr_url[ \\t]*=[ \\t]*https://"
 
   open-integration-pr:
     inputs:
@@ -560,7 +560,7 @@ skills:
     - name: recipe_distribution
       type: string
     expected_output_patterns:
-    - "triage_report\\s*=\\s*.+"
+    - "triage_report[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     pattern_examples:
     - "triage_report = .autoskillit/temp/triage-issues/triage_report_20260310_120000.md\n%%ORDER_UP%%"
 
@@ -598,8 +598,8 @@ skills:
       type: string
       description: "Written when mode=local. Path to local_findings_{pr_number}.json output."
     expected_output_patterns:
-    - "verdict\\s*=\\s*(approved|approved_with_comments|changes_requested|needs_human)"
-    - "(?:%%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%%|verdict\\s*=\\s*approved_with_comments)"
+    - "verdict[ \\t]*=[ \\t]*(approved|approved_with_comments|changes_requested|needs_human)"
+    - "(?:%%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%%|verdict[ \\t]*=[ \\t]*approved_with_comments)"
     pattern_examples:
     - "verdict = approved\n%%REVIEW_GATE::CLEAR%%\n%%ORDER_UP%%"
     - "verdict = approved_with_comments\n%%ORDER_UP%%"
@@ -621,7 +621,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -640,7 +640,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -659,7 +659,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -678,7 +678,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -697,7 +697,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -716,7 +716,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -735,7 +735,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -754,7 +754,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -773,7 +773,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -792,7 +792,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -811,7 +811,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -830,7 +830,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -849,7 +849,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -868,7 +868,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -887,7 +887,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -906,7 +906,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -925,7 +925,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -944,7 +944,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -963,7 +963,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -982,7 +982,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1001,7 +1001,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1020,7 +1020,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1039,7 +1039,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1058,7 +1058,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1077,7 +1077,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1096,7 +1096,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1115,7 +1115,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1134,7 +1134,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1153,7 +1153,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1172,7 +1172,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1191,7 +1191,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1267,8 +1267,8 @@ skills:
     - name: scope_directions
       type: file_path
     expected_output_patterns:
-    - "scope_report\\s*=\\s*/.+"
-    - "scope_directions\\s*=\\s*/.+"
+    - "scope_report[ \\t]*=[ \\t]*/.+"
+    - "scope_directions[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "scope_report = /tmp/scope_report.md\nscope_directions = /tmp/scope_directions.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -1288,7 +1288,7 @@ skills:
     - name: selected_directions
       type: file_path
     expected_output_patterns:
-    - "selected_directions\\s*=\\s*/.+"
+    - "selected_directions[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "selected_directions = /tmp/selected_directions.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -1308,7 +1308,7 @@ skills:
     - name: experiment_plan
       type: file_path
     expected_output_patterns:
-    - "experiment_plan\\s*=\\s*/.+"
+    - "experiment_plan[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "experiment_plan = /tmp/experiment_plan.md\n%%ORDER_UP%%"
     write_behavior: always
@@ -1338,8 +1338,8 @@ skills:
     - name: visualization_plan_trace_path
       type: file_path
     expected_output_patterns:
-    - "visualization_plan_path\\s*=\\s*/.+"
-    - "report_plan_path\\s*=\\s*/.+"
+    - "visualization_plan_path[ \\t]*=[ \\t]*/.+"
+    - "report_plan_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "visualization_plan_path = /tmp/plan-visualization/visualization-plan.md\nreport_plan_path = /tmp/plan-visualization/report-plan.md\n%%ORDER_UP%%"
     write_behavior: always
@@ -1355,8 +1355,8 @@ skills:
     - name: resource_report
       type: file_path
     expected_output_patterns:
-    - "verdict\\s*=\\s*(PASS|WARN|FAIL)"
-    - "resource_report\\s*=\\s*/.+"
+    - "verdict[ \\t]*=[ \\t]*(PASS|WARN|FAIL)"
+    - "resource_report[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "verdict = PASS\nresource_report = /tmp/stage-data/resource_feasibility_2026-04-13_120000.md\n%%ORDER_UP%%"
     write_behavior: always
@@ -1372,8 +1372,8 @@ skills:
     - name: download_report
       type: file_path
     expected_output_patterns:
-    - "verdict\\s*=\\s*(PASS|WARN|FAIL)"
-    - "download_report\\s*=\\s*\\S+/download-data/.+"
+    - "verdict[ \\t]*=[ \\t]*(PASS|WARN|FAIL)"
+    - "download_report[ \\t]*=[ \\t]*\\S+/download-data/.+"
     pattern_examples:
     - "verdict = PASS\ndownload_report = /tmp/download-data/download_report_2026-05-10_120000.md\n%%ORDER_UP%%"
     - "verdict = WARN\ndownload_report = /tmp/download-data/download_report_2026-05-10_120000.md\n%%ORDER_UP%%"
@@ -1396,9 +1396,9 @@ skills:
     - name: verdict
       type: string
     expected_output_patterns:
-    - "env_mode\\s*=\\s*(none|docker|micromamba-host|unavailable)"
-    - "env_report\\s*=\\s*/.+"
-    - "verdict\\s*=\\s*(PASS|WARN|FAIL)"
+    - "env_mode[ \\t]*=[ \\t]*(none|docker|micromamba-host|unavailable)"
+    - "env_report[ \\t]*=[ \\t]*/.+"
+    - "verdict[ \\t]*=[ \\t]*(PASS|WARN|FAIL)"
     pattern_examples:
     - "env_mode = none\nenv_report = /tmp/setup-environment/env_setup_report.md\nverdict = PASS\n%%ORDER_UP%%"
     - "env_mode = docker\nenv_report = /tmp/setup-environment/env_setup_report.md\nverdict = PASS\n%%ORDER_UP%%"
@@ -1417,7 +1417,7 @@ skills:
     - name: branch_name
       type: string
     expected_output_patterns:
-    - "worktree_path\\s*=\\s*/.+"
+    - "worktree_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "worktree_path = /tmp/worktrees/research-20260101-120000\n%%ORDER_UP%%"
     write_behavior: always
@@ -1441,9 +1441,9 @@ skills:
     - name: blocked_hypotheses
       type: string
     expected_output_patterns:
-    - "results_path\\s*=\\s*/.+"
-    - "group_manifest\\s*=\\s*/.+"
-    - "verdict\\s*=\\s*(CONCLUSIVE|INCONCLUSIVE|BLOCKED)"
+    - "results_path[ \\t]*=[ \\t]*/.+"
+    - "group_manifest[ \\t]*=[ \\t]*/.+"
+    - "verdict[ \\t]*=[ \\t]*(CONCLUSIVE|INCONCLUSIVE|BLOCKED)"
     pattern_examples:
     - "results_path = /tmp/run-experiment/results.md group_manifest = /tmp/run-experiment/group_manifest.json verdict = CONCLUSIVE\n%%ORDER_UP%%"
     - "results_path = /tmp/run-experiment/results.md group_manifest = /tmp/run-experiment/group_manifest.json verdict = INCONCLUSIVE\n%%ORDER_UP%%"
@@ -1465,7 +1465,7 @@ skills:
     - name: report_path
       type: file_path
     expected_output_patterns:
-    - "report_path\\s*=\\s*/.+"
+    - "report_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "report_path = /tmp/research/report.md\n%%ORDER_UP%%"
     write_behavior: always
@@ -1492,7 +1492,7 @@ skills:
     - name: lens_context_paths
       type: string
     expected_output_patterns:
-    - "prep_path\\s*=\\s*/.+"
+    - "prep_path[ \\t]*=[ \\t]*/.+"
     - "selected_lenses[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     - "lens_context_paths[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     pattern_examples:
@@ -1524,7 +1524,7 @@ skills:
     - name: pr_url
       type: string
     expected_output_patterns:
-    - "pr_url\\s*=\\s*(https://github\\.com/.*/pull/\\d+)?"
+    - "pr_url[ \\t]*=[ \\t]*(https://github\\.com/.*/pull/\\d+)?"
     pattern_examples:
     - "pr_url = https://github.com/owner/repo/pull/42\n%%ORDER_UP%%"
     - "pr_url = \n%%ORDER_UP%%"
@@ -1552,7 +1552,7 @@ skills:
     - name: classification_timestamp
       type: string
     expected_output_patterns:
-    - "verdict\\s*=\\s*(GO|REVISE|STOP)"
+    - "verdict[ \\t]*=[ \\t]*(GO|REVISE|STOP)"
     - "(?:experiment_type[ \\t]*=[ \\t]*(\\S[^\\n]*|none)|verdict[ \\t]*=[ \\t]*STOP)"
     pattern_examples:
     - "verdict = GO\nexperiment_type = benchmark\nevaluation_dashboard = /tmp/eval.md\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
@@ -1580,7 +1580,7 @@ skills:
       type: string
       allowed_values: [approved, changes_requested, needs_human]
     expected_output_patterns:
-    - "verdict\\s*=\\s*(approved|changes_requested|needs_human)"
+    - "verdict[ \\t]*=[ \\t]*(approved|changes_requested|needs_human)"
     pattern_examples:
     - "verdict = approved\n%%ORDER_UP%%"
     - "verdict = changes_requested\n%%ORDER_UP%%"
@@ -1602,7 +1602,7 @@ skills:
       type: string
       allowed_values: [approved, changes_requested, needs_human]
     expected_output_patterns:
-    - "verdict\\s*=\\s*(approved|changes_requested|needs_human)"
+    - "verdict[ \\t]*=[ \\t]*(approved|changes_requested|needs_human)"
     pattern_examples:
     - "verdict = approved\n%%ORDER_UP%%"
     - "verdict = changes_requested\n%%ORDER_UP%%"
@@ -1629,7 +1629,7 @@ skills:
     - name: fixes_applied
       type: integer
     expected_output_patterns:
-    - "needs_rerun\\s*=\\s*(true|false)"
+    - "needs_rerun[ \\t]*=[ \\t]*(true|false)"
     pattern_examples:
     - "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%"
     - "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
@@ -1637,7 +1637,7 @@ skills:
     - "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "verdict\\s*=\\s*real_fix"
+    - "verdict[ \\t]*=[ \\t]*real_fix"
 
   resolve-research-review:
     inputs:
@@ -1660,7 +1660,7 @@ skills:
     - name: fixes_applied
       type: integer
     expected_output_patterns:
-    - "needs_rerun\\s*=\\s*(true|false)"
+    - "needs_rerun[ \\t]*=[ \\t]*(true|false)"
     pattern_examples:
     - "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%"
     - "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
@@ -1668,7 +1668,7 @@ skills:
     - "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "verdict\\s*=\\s*real_fix"
+    - "verdict[ \\t]*=[ \\t]*real_fix"
 
   vis-lens-always-on:
     inputs:
@@ -1685,7 +1685,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1704,7 +1704,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1723,7 +1723,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1742,7 +1742,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1761,7 +1761,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1780,7 +1780,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1799,7 +1799,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1818,7 +1818,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
@@ -1837,7 +1837,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
   vis-lens-caption-annot:
@@ -1855,7 +1855,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
   vis-lens-story-arc:
@@ -1873,7 +1873,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
   vis-lens-reproducibility:
@@ -1891,7 +1891,7 @@ skills:
     - name: diagram_path
       type: file_path
     expected_output_patterns:
-    - "diagram_path\\s*=\\s*/.+"
+    - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
   build-execution-map:
@@ -1914,7 +1914,7 @@ skills:
     - name: review_approach_candidates
       type: string
     expected_output_patterns:
-    - "execution_map\\s*=\\s*/.+"
+    - "execution_map[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "execution_map = /tmp/build-execution-map/execution_map_2026-04-22_190000.json\nexecution_map_report = /tmp/build-execution-map/execution_map_report_2026-04-22_190000.md\ngroup_count = 3\ntotal_issues = 5\ndispatched_count = 4\ndeferred_count = 1\nhas_deferred = true"
     write_behavior: always
@@ -1936,12 +1936,12 @@ skills:
     - name: html_path
       type: file_path
     expected_output_patterns:
-    - "html_path\\s*=\\s*\\S+"
+    - "html_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
     - "html_path = /tmp/research/report.html\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "html_path\\s*=\\s*\\S+"
+    - "html_path[ \\t]*=[ \\t]*\\S+"
   planner-analyze:
     inputs: []
     outputs: []
@@ -1966,7 +1966,7 @@ skills:
       type: int
       required: true
     expected_output_patterns:
-    - "phase_manifest_path\\s*=\\s*\\S+"
+    - "phase_manifest_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
     - "phase_manifest_path = /tmp/autoskillit/planner/run-20260101-120000/phases/phase_manifest.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -1985,7 +1985,7 @@ skills:
       - name: elab_result_path
         type: file_path
     expected_output_patterns:
-      - "elab_result_path\\s*=\\s*\\S+"
+      - "elab_result_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "elab_result_path = /tmp/autoskillit/planner/run-20260101-120000/phases/P1_result.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -2001,7 +2001,7 @@ skills:
       - name: phase_assignments_result_dir
         type: directory_path
     expected_output_patterns:
-      - "phase_assignments_result_dir\\s*=\\s*\\S+"
+      - "phase_assignments_result_dir[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "phase_assignments_result_dir = /tmp/autoskillit/planner/run-20260101-120000/assignments\n%%ORDER_UP%%"
     write_behavior: always
@@ -2017,7 +2017,7 @@ skills:
       - name: phase_wps_result_dir
         type: directory_path
     expected_output_patterns:
-      - "phase_wps_result_dir\\s*=\\s*\\S+"
+      - "phase_wps_result_dir[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "phase_wps_result_dir = /tmp/autoskillit/planner/run-20260101-120000/work_packages\n%%ORDER_UP%%"
     write_behavior: always
@@ -2046,7 +2046,7 @@ skills:
       - name: refined_plan_path
         type: file_path
     expected_output_patterns:
-      - "refined_plan_path\\s*=\\s*\\S+"
+      - "refined_plan_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "refined_plan_path = /tmp/autoskillit/planner/run-20260101-120000/refined_plan.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -2065,7 +2065,7 @@ skills:
       - name: phase_refined_path
         type: file_path
     expected_output_patterns:
-      - "phase_refined_path\\s*=\\s*\\S+"
+      - "phase_refined_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "phase_refined_path = /tmp/autoskillit/planner/run-20260101-120000/refine_contexts/P1_result.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -2087,7 +2087,7 @@ skills:
       - name: refined_wps_path
         type: file_path
     expected_output_patterns:
-      - "refined_wps_path\\s*=\\s*\\S+"
+      - "refined_wps_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "refined_wps_path = /tmp/autoskillit/planner/run-20260101-120000/refined_wps.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -2118,8 +2118,8 @@ skills:
       - name: alignment_finding_count
         type: str
     expected_output_patterns:
-      - "alignment_findings_path\\s*=\\s*\\S+"
-      - "alignment_finding_count\\s*=\\s*\\d+"
+      - "alignment_findings_path[ \\t]*=[ \\t]*\\S+"
+      - "alignment_finding_count[ \\t]*=[ \\t]*\\d+"
     pattern_examples:
       - "alignment_findings_path = /tmp/autoskillit/planner/run-20260101-120000/task_alignment.json\nalignment_finding_count = 0\n%%ORDER_UP%%"
     write_behavior: always
@@ -2135,7 +2135,7 @@ skills:
       - name: review_approach_assessment_path
         type: file_path
     expected_output_patterns:
-      - "review_approach_assessment_path\\s*=\\s*\\S+"
+      - "review_approach_assessment_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "review_approach_assessment_path = /tmp/autoskillit/planner/run-20260101-120000/review_approach_assessment.json\n%%ORDER_UP%%"
     write_behavior: always
@@ -2145,7 +2145,7 @@ skills:
       - name: audit_report_path
         type: file_path
     expected_output_patterns:
-      - "audit_report_path\\s*=\\s*\\S+"
+      - "audit_report_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "audit_report_path = /tmp/autoskillit/audit-tests/test_audit_2026-04-28_120000.md\n%%ORDER_UP%%"
     write_behavior: always
@@ -2160,13 +2160,13 @@ skills:
       - name: verdict
         type: string
     expected_output_patterns:
-      - "validated_report_path\\s*=\\s*\\S+"
-      - "verdict\\s*=\\s*\\S+"
+      - "validated_report_path[ \\t]*=[ \\t]*\\S+"
+      - "verdict[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "validated_report_path = /tmp/autoskillit/validate-audit-2026-04-28_120000/validated_report_tests.md\nverdict = validated"
     write_behavior: conditional
     write_expected_when:
-      - "verdict\\s*=\\s*validated"
+      - "verdict[ \\t]*=[ \\t]*validated"
   validate-test-audit:
     inputs:
       - name: audit_report_path
@@ -2178,13 +2178,13 @@ skills:
       - name: verdict
         type: str
     expected_output_patterns:
-      - "validated_report_path\\s*=\\s*\\S+"
-      - "verdict\\s*=\\s*\\S+"
+      - "validated_report_path[ \\t]*=[ \\t]*\\S+"
+      - "verdict[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
       - "validated_report_path = /tmp/autoskillit/validate-audit-2026-05-05_140000/validated_report_tests.md\nverdict = validated"
     write_behavior: conditional
     write_expected_when:
-      - "verdict\\s*=\\s*validated"
+      - "verdict[ \\t]*=[ \\t]*validated"
   file-audit-issues:
     inputs:
       - name: run_dir
@@ -2197,7 +2197,7 @@ skills:
         type: integer
     expected_output_patterns:
       - "issue_urls\\s*="
-      - "issue_count\\s*=\\s*\\d+"
+      - "issue_count[ \\t]*=[ \\t]*\\d+"
     pattern_examples:
       - "issue_urls = https://github.com/org/repo/issues/100,https://github.com/org/repo/issues/101\nissue_count = 2"
     write_behavior: always
@@ -2220,14 +2220,14 @@ skills:
     - name: pr_body_path
       type: file_path
     expected_output_patterns:
-    - "verdict\\s*=\\s*(created|dry_run|preflight_failed)"
+    - "verdict[ \\t]*=[ \\t]*(created|dry_run|preflight_failed)"
     pattern_examples:
     - "pr_url = https://github.com/org/repo/pull/42\nverdict = created\ncategory_summary = 14 fixes, 3 features\n%%ORDER_UP%%"
     - "pr_url = \nverdict = dry_run\ncategory_summary = 14 fixes, 3 features\n%%ORDER_UP%%"
     - "pr_url = \nverdict = preflight_failed\ncategory_summary = \n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "verdict\\s*=\\s*created"
+    - "verdict[ \\t]*=[ \\t]*created"
   analyze-pipeline-health:
     inputs:
     - name: kitchen_id

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -397,6 +397,37 @@
       "on_failure": "release_issue_failure",
       "note": "After merge, route to next_or_done to process remaining parts before pushing. By default (open_pr=true), merge_target is the feature branch named from run_name. When open_pr=false, merge_target equals base_branch — merges go directly to base. dirty_tree and test_gate failures route to fix (resolve-failures) for recovery; all other failures route to release_issue_failure.\n"
     },
+    "check_has_commits": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_commits_ahead",
+        "cwd": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.has_commits }}",
+          "route": "push"
+        },
+        {
+          "route": "close_issue_already_done"
+        }
+      ],
+      "on_failure": "release_issue_failure"
+    },
+    "close_issue_already_done": {
+      "description": "Close issue as already-implemented when branch has zero commits ahead of base",
+      "tool": "run_python",
+      "optional": true,
+      "skip_when_false": "inputs.issue_url",
+      "with": {
+        "callable": "autoskillit.smoke_utils.close_issue_already_done",
+        "issue_url": "${{ inputs.issue_url }}"
+      },
+      "on_success": "register_clone_success",
+      "on_failure": "register_clone_success",
+      "note": "Zero commits ahead of base means the feature is already merged. Remove in-progress label, close issue with \"already implemented\" comment, and route to clone cleanup.\n"
+    },
     "push": {
       "tool": "push_to_remote",
       "with": {
@@ -406,7 +437,7 @@
       },
       "on_success": "prepare_pr",
       "on_failure": "release_issue_failure",
-      "note": "Runs once at the end, after audit_impl passes. Pushes merge_target branch from the clone to the upstream remote. By default (open_pr=true), this pushes the feature branch; when open_pr=false, pushes base_branch. Uses the pre-resolved remote_url captured at clone time, preserving clone isolation. On success, routes to prepare_pr (which opens the PR by default; skipped when open_pr=false). On failure, release_issue_failure registers the clone and escalates.\n"
+      "note": "Runs once at the end, after check_has_commits confirms commits exist. Pushes merge_target branch from the clone to the upstream remote. By default (open_pr=true), this pushes the feature branch; when open_pr=false, pushes base_branch. Uses the pre-resolved remote_url captured at clone time, preserving clone isolation. On success, routes to prepare_pr (which opens the PR by default; skipped when open_pr=false). On failure, release_issue_failure registers the clone and escalates.\n"
     },
     "fix": {
       "tool": "run_skill",
@@ -499,7 +530,7 @@
       "on_result": [
         {
           "when": "${{ result.verdict }} == GO",
-          "route": "push"
+          "route": "check_has_commits"
         },
         {
           "when": "result.error",
@@ -513,7 +544,7 @@
       "on_context_limit": "escalate_stop",
       "optional": true,
       "skip_when_false": "inputs.audit",
-      "note": "Only execute if inputs.audit is 'true'. If false, skip directly to push. Captures verdict and remediation_path. Routes GO → push, NO GO → remediate which re-enters the plan step with the remediation file. All parts have been merged at this point — no worktree exists. Uses context.base_sha (a stable commit SHA captured before any merge began) as implementation_ref. A SHA names a git object and survives git branch -D unconditionally. The diff git diff base_sha..base_branch (two-dot, SHA on the left) covers the full implementation.\n"
+      "note": "Only execute if inputs.audit is 'true'. If false, skip directly to check_has_commits. Captures verdict and remediation_path. Routes GO → push, NO GO → remediate which re-enters the plan step with the remediation file. All parts have been merged at this point — no worktree exists. Uses context.base_sha (a stable commit SHA captured before any merge began) as implementation_ref. A SHA names a git object and survives git branch -D unconditionally. The diff git diff base_sha..base_branch (two-dot, SHA on the left) covers the full implementation.\n"
     },
     "remediate": {
       "action": "route",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -371,6 +371,33 @@ steps:
       dirty_tree and test_gate failures route to fix (resolve-failures) for recovery;
       all other failures route to release_issue_failure.
 
+  check_has_commits:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_commits_ahead"
+      cwd: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
+    on_result:
+    - when: "${{ result.has_commits }}"
+      route: push
+    - route: close_issue_already_done
+    on_failure: release_issue_failure
+
+  close_issue_already_done:
+    description: "Close issue as already-implemented when branch has zero commits ahead of base"
+    tool: run_python
+    optional: true
+    skip_when_false: "inputs.issue_url"
+    with:
+      callable: "autoskillit.smoke_utils.close_issue_already_done"
+      issue_url: "${{ inputs.issue_url }}"
+    on_success: register_clone_success
+    on_failure: register_clone_success
+    note: >
+      Zero commits ahead of base means the feature is already merged.
+      Remove in-progress label, close issue with "already implemented" comment,
+      and route to clone cleanup.
+
   push:
     tool: push_to_remote
     with:
@@ -380,7 +407,7 @@ steps:
     on_success: prepare_pr
     on_failure: release_issue_failure
     note: >
-      Runs once at the end, after audit_impl passes.
+      Runs once at the end, after check_has_commits confirms commits exist.
       Pushes merge_target branch from the clone to the upstream remote.
       By default (open_pr=true), this pushes the feature branch; when open_pr=false, pushes base_branch.
       Uses the pre-resolved remote_url captured at clone time, preserving clone isolation.
@@ -453,7 +480,7 @@ steps:
       remediation_path: "${{ result.remediation_path }}"
     on_result:
     - when: "${{ result.verdict }} == GO"
-      route: push
+      route: check_has_commits
     - when: "result.error"
       route: escalate_stop
     - route: remediate
@@ -462,7 +489,7 @@ steps:
     optional: true
     skip_when_false: "inputs.audit"
     note: >
-      Only execute if inputs.audit is 'true'. If false, skip directly to push.
+      Only execute if inputs.audit is 'true'. If false, skip directly to check_has_commits.
       Captures verdict and remediation_path. Routes GO → push, NO GO → remediate
       which re-enters the plan step with the remediation file.
       All parts have been merged at this point — no worktree exists.

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -545,10 +545,41 @@
           "route": "dry_walkthrough"
         },
         {
-          "route": "push"
+          "route": "check_has_commits"
         }
       ],
-      "note": "Routing step — no tool call. The agent evaluates what comes next: 1. If more plan_parts remain for the current plan → go to dry_walkthrough with next part. 2. If all plan_parts are complete → go to push. Unlike implementation.yaml (which routes done → audit_impl → push), remediation runs audit_impl pre-merge (GO → commit_guard), so the fallthrough here goes directly to push.\n"
+      "note": "Routing step — no tool call. The agent evaluates what comes next: 1. If more plan_parts remain for the current plan → go to dry_walkthrough with next part. 2. If all plan_parts are complete → go to check_has_commits. Unlike implementation.yaml (which routes done → audit_impl → push), remediation runs audit_impl pre-merge (GO → commit_guard), so the fallthrough here goes directly to check_has_commits → push (or close_issue_already_done if zero commits ahead of base).\n"
+    },
+    "check_has_commits": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_commits_ahead",
+        "cwd": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.has_commits }}",
+          "route": "push"
+        },
+        {
+          "route": "close_issue_already_done"
+        }
+      ],
+      "on_failure": "release_issue_failure"
+    },
+    "close_issue_already_done": {
+      "description": "Close issue as already-implemented when branch has zero commits ahead of base",
+      "tool": "run_python",
+      "optional": true,
+      "skip_when_false": "inputs.issue_url",
+      "with": {
+        "callable": "autoskillit.smoke_utils.close_issue_already_done",
+        "issue_url": "${{ inputs.issue_url }}"
+      },
+      "on_success": "register_clone_success",
+      "on_failure": "register_clone_success",
+      "note": "Zero commits ahead of base means the feature is already merged. Remove in-progress label, close issue with \"already implemented\" comment, and route to clone cleanup.\n"
     },
     "push": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -469,13 +469,42 @@ steps:
     on_result:
     - when: "${{ result.next }} == more_parts"
       route: dry_walkthrough
-    - route: push
+    - route: check_has_commits
     note: >
       Routing step — no tool call. The agent evaluates what comes next:
       1. If more plan_parts remain for the current plan → go to dry_walkthrough with next part.
-      2. If all plan_parts are complete → go to push.
+      2. If all plan_parts are complete → go to check_has_commits.
       Unlike implementation.yaml (which routes done → audit_impl → push), remediation runs
-      audit_impl pre-merge (GO → commit_guard), so the fallthrough here goes directly to push.
+      audit_impl pre-merge (GO → commit_guard), so the fallthrough here goes directly to
+      check_has_commits → push (or close_issue_already_done if zero commits ahead of base).
+
+
+  check_has_commits:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_commits_ahead"
+      cwd: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
+    on_result:
+    - when: "${{ result.has_commits }}"
+      route: push
+    - route: close_issue_already_done
+    on_failure: release_issue_failure
+
+  close_issue_already_done:
+    description: "Close issue as already-implemented when branch has zero commits ahead of base"
+    tool: run_python
+    optional: true
+    skip_when_false: "inputs.issue_url"
+    with:
+      callable: "autoskillit.smoke_utils.close_issue_already_done"
+      issue_url: "${{ inputs.issue_url }}"
+    on_success: register_clone_success
+    on_failure: register_clone_success
+    note: >
+      Zero commits ahead of base means the feature is already merged.
+      Remove in-progress label, close issue with "already implemented" comment,
+      and route to clone cleanup.
 
   push:
     tool: push_to_remote

--- a/src/autoskillit/server/tools/_types.py
+++ b/src/autoskillit/server/tools/_types.py
@@ -52,6 +52,13 @@ class RunSkillResult(_RunSkillResultBase, total=False):
     worktree_path: str
     order_id: str
     infra_exit_category: str
+    has_progress_evidence: bool
+    provider_fallback: bool
+    provider_used: str
+    api_retry_count: int
+    api_retry_last_error: str
+    api_retry_last_status: int
+    api_retry_exhausted: bool
 
 
 class _RunCmdResultBase(TypedDict):

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -227,6 +227,9 @@ async def run_skill(
     - "zero_writes": skill made no writes despite write expectation — route to on_failure.
     - "thinking_stall": model produced thinking blocks only, no text/tool output — route to
       on_context_limit if lifespan_started, else on_failure.
+    - "contract_recovery": model completed and wrote artifacts but structured output failed
+      pattern validation and nudge could not recover — route to on_context_limit if
+      has_progress_evidence, else on_failure.
 
     This is the correct MCP tool to delegate work to a headless session during
     pipeline execution. NEVER use native tools (Read, Grep, Glob, Edit, Write,

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -248,3 +248,12 @@ selected_lenses = module-dependency,process-flow
 lens_context_paths = /abs/ctx_module-dependency_{ts}.md,/abs/ctx_process-flow_{ts}.md
 %%ORDER_UP::<hex>%%
 ```
+
+When the branch has zero changed files (feature already merged), emit:
+
+```
+prep_path = /absolute/path/{{AUTOSKILLIT_TEMP}}/prepare-pr/pr_prep_{ts}.md
+selected_lenses = none
+lens_context_paths = none
+%%ORDER_UP::<hex>%%
+```

--- a/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
@@ -257,7 +257,17 @@ lens_context_paths = /abs/ctx_fair-comparison_{ts}.md,/abs/ctx_estimand-clarity_
 %%ORDER_UP::<hex>%%
 ```
 
+When the branch has zero changed files (feature already merged), emit:
+
+```
+prep_path = /absolute/path/{{AUTOSKILLIT_TEMP}}/prepare-research-pr/pr_prep_{ts}.md
+selected_lenses = none
+lens_context_paths = none
+%%ORDER_UP::<hex>%%
+```
+
 Where:
-- `selected_lenses` is a comma-separated list of lens slugs (no spaces)
+- `selected_lenses` is a comma-separated list of lens slugs (no spaces), or `none` when
+  the branch has zero changed files
 - `lens_context_paths` is a comma-separated list of absolute context file paths in the
-  same order as `selected_lenses`
+  same order as `selected_lenses`, or `none` when the branch has zero changed files

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -850,6 +850,7 @@ def close_issue_already_done(issue_url: str) -> dict[str, str]:
         ["gh", "issue", "edit", issue_url, "--remove-label", "in-progress"],
         capture_output=True,
         check=False,
+        timeout=60,
     )
     subprocess.run(
         [
@@ -862,5 +863,6 @@ def close_issue_already_done(issue_url: str) -> dict[str, str]:
         ],
         capture_output=True,
         check=False,
+        timeout=60,
     )
     return {"closed": "true"}

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -814,3 +814,52 @@ def detect_zero_changes(worktree_path: str, base_branch: str) -> dict[str, str]:
     )
     count = int(result.stdout.strip())
     return {"has_changes": "true" if count > 0 else "false", "commit_count": str(count)}
+
+
+def check_commits_ahead(cwd: str, base_branch: str) -> dict[str, str]:
+    """Return {"has_commits": "true"/"false"} based on commits ahead of base_branch.
+
+    Used by the check_has_commits recipe guard to short-circuit pipelines on
+    zero-changes branches (feature already merged).
+    """
+    if not base_branch:
+        raise ValueError("base_branch must be non-empty")
+    import subprocess  # noqa: PLC0415
+
+    result = subprocess.run(
+        ["git", "rev-list", "--count", f"{base_branch}..HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    count = int(result.stdout.strip())
+    return {"has_commits": "true" if count > 0 else "false"}
+
+
+def close_issue_already_done(issue_url: str) -> dict[str, str]:
+    """Remove in-progress label and close issue as already-implemented.
+
+    Called by close_issue_already_done recipe step when check_has_commits
+    detects zero commits ahead of base (feature already merged).
+    """
+    import subprocess  # noqa: PLC0415
+
+    subprocess.run(
+        ["gh", "issue", "edit", issue_url, "--remove-label", "in-progress"],
+        capture_output=True,
+        check=False,
+    )
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "close",
+            issue_url,
+            "--comment",
+            "Closing: branch has zero commits ahead of base — feature already implemented.",
+        ],
+        capture_output=True,
+        check=False,
+    )
+    return {"closed": "true"}

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -832,6 +832,7 @@ def check_commits_ahead(cwd: str, base_branch: str) -> dict[str, str]:
         capture_output=True,
         text=True,
         check=True,
+        timeout=30,
     )
     count = int(result.stdout.strip())
     return {"has_commits": "true" if count > 0 else "false"}

--- a/tests/arch/test_file_size_budgets.py
+++ b/tests/arch/test_file_size_budgets.py
@@ -18,7 +18,7 @@ def test_pretty_output_below_budget() -> None:
     budgets = {
         "pretty_output_hook.py": 350,
         "_fmt_primitives.py": 200,
-        "_fmt_execution.py": 315,
+        "_fmt_execution.py": 325,
         "_fmt_status.py": 250,
         "_fmt_recipe.py": 300,
     }

--- a/tests/cli/test_routing_completeness.py
+++ b/tests/cli/test_routing_completeness.py
@@ -16,12 +16,10 @@ pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 # Reasons excluded from orchestrator-prompt routing check:
 # - NONE: not a retry scenario, no routing needed
 # - BUDGET_EXHAUSTED: caps other reasons; orchestrator never sees it directly
-# - CONTRACT_RECOVERY: handled by infrastructure nudge in headless/__init__.py
 # - CLONE_CONTAMINATION: handled by clone_guard infrastructure
 _ROUTING_EXCLUDED = {
     RetryReason.NONE,
     RetryReason.BUDGET_EXHAUSTED,
-    RetryReason.CONTRACT_RECOVERY,
     RetryReason.CLONE_CONTAMINATION,
 }
 
@@ -37,6 +35,7 @@ _EXPECTED_ROUTES: dict[RetryReason, tuple[str, str | None]] = {
     RetryReason.IDLE_STALL: ("on_context_limit", "lifespan_started"),
     RetryReason.EARLY_STOP: ("on_context_limit", "has_progress_evidence"),
     RetryReason.ZERO_WRITES: ("on_context_limit", "has_progress_evidence"),
+    RetryReason.CONTRACT_RECOVERY: ("on_context_limit", "has_progress_evidence"),
 }
 
 

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -524,7 +524,7 @@ class TestGroupDApiContractPreservation:
         )
 
     def test_req_api_004_headless_subprocess_result_under_type_checking(self):
-        """execution/headless/_headless_execute.py must import SubprocessResult only under TYPE_CHECKING."""
+        """_headless_execute.py must import SubprocessResult only under TYPE_CHECKING."""
         source = (self._pkg_root() / "execution" / "headless" / "_headless_execute.py").read_text()
         assert "SubprocessResult" in source, (
             "SubprocessResult reference vanished from _headless_execute.py entirely"

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -408,3 +408,88 @@ def test_setup_environment_env_mode_examples_cover_all_modes(
     example_text = "\n".join(examples)
     for mode in ("none", "docker", "micromamba-host", "unavailable"):
         assert f"env_mode = {mode}" in example_text, f"missing example for env_mode={mode}"
+
+
+def test_negative_examples_rejected(skills: dict[str, Any]) -> None:
+    """For every skill with negative_examples, each negative example must fail at least
+    one pattern.
+
+    Negative examples represent outputs that MUST NOT pass contract validation.
+    If all patterns match a negative example, the contract has a false positive.
+    """
+    failures = []
+    for skill_name, contract in skills.items():
+        patterns = contract.get("expected_output_patterns", [])
+        neg_examples = contract.get("negative_examples", [])
+        if not patterns or not neg_examples:
+            continue
+        for neg_ex in neg_examples:
+            if all(re.search(p, neg_ex) for p in patterns):
+                failures.append(
+                    f"Skill '{skill_name}': negative example matched ALL patterns "
+                    f"(must fail at least one):\n  {neg_ex!r}"
+                )
+    assert not failures, "Negative examples passed all contract patterns:\n" + "\n".join(failures)
+
+
+# Matches both \s* and [ \t]* whitespace quantifier forms as they appear in loaded YAML strings.
+_TOKEN_VALUE_RE = re.compile(r"^([\w-]+)(?:\\s\*|\[ \\t\]\*)=(?:\\s\*|\[ \\t\]\*)(.+)$")
+
+
+def test_patterns_reject_empty_token_values(skills: dict[str, Any]) -> None:
+    """Mandatory value patterns must reject the empty-value case.
+
+    For each pattern with an extractable token=value form, verify that
+    an empty value (\'{token} = \\n\') does not produce a false match.
+    Patterns whose value group allows empty (re.fullmatch succeeds) are exempt.
+    """
+    failures = []
+    for skill_name, contract in skills.items():
+        for pattern in contract.get("expected_output_patterns", []):
+            m = _TOKEN_VALUE_RE.match(pattern)
+            if not m:
+                continue
+            token_name, value_group = m.group(1), m.group(2)
+            try:
+                if re.fullmatch(value_group, ""):
+                    continue
+            except re.error:
+                continue
+            synthetic = f"{token_name} = \n"
+            if re.search(pattern, synthetic):
+                failures.append(
+                    f"Skill '{skill_name}': pattern {pattern!r} matched empty value "
+                    f"synthetic input {synthetic!r}"
+                )
+    assert not failures, (
+        "Patterns matched empty token values (mandatory patterns must reject empty values):\n"
+        + "\n".join(failures)
+    )
+
+
+def test_cross_newline_patterns_anchored(skills: dict[str, Any]) -> None:
+    r"""Patterns using \s* adjacent to = must not match cross-newline token values.
+
+    A pattern like 'token\s*=\s*\S+' with \s* (which matches newlines) allows
+    cross-newline false positives: 'token = \nother_token = value' matches because
+    \s* consumes the newline and \S+ latches onto 'other_token'. Patterns using
+    [ \t]* (horizontal whitespace only) are exempt.
+    """
+    failures = []
+    for skill_name, contract in skills.items():
+        for pattern in contract.get("expected_output_patterns", []):
+            m = _TOKEN_VALUE_RE.match(pattern)
+            if not m:
+                continue
+            token_name = m.group(1)
+            if "\\s*" not in pattern:
+                continue
+            synthetic = f"{token_name} = \nother_token = something\n%%ORDER_UP%%"
+            if re.search(pattern, synthetic):
+                failures.append(
+                    f"Skill '{skill_name}': pattern {pattern!r} matched cross-newline "
+                    r"input (\s* consumes newlines — use [ \t]* instead)"
+                )
+    assert not failures, (
+        r"Patterns with \s* matched cross-newline inputs:" + "\n" + "\n".join(failures)
+    )

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -391,7 +391,9 @@ def test_review_gate_clear_pattern_in_review_pr_contracts(skills):
 def test_skill_contracts_yaml_includes_setup_environment(skills: dict[str, Any]) -> None:
     """setup-environment must be registered with env_mode and verdict patterns."""
     _assert_skill_has_patterns(
-        skills, "setup-environment", r"env_mode[ \t]*=[ \t]*(none|docker|micromamba-host|unavailable)"
+        skills,
+        "setup-environment",
+        r"env_mode[ \t]*=[ \t]*(none|docker|micromamba-host|unavailable)",
     )
     contract = skills["setup-environment"]
     patterns = contract["expected_output_patterns"]

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -205,13 +205,13 @@ def test_exp_lens_context_path_remains_optional(skills: dict[str, Any], skill_na
 
 def test_skill_contracts_yaml_includes_prepare_research_pr(skills):
     """prepare-research-pr must be registered with prep_path output pattern."""
-    _assert_skill_has_patterns(skills, "prepare-research-pr", r"prep_path\s*=\s*/.+")
+    _assert_skill_has_patterns(skills, "prepare-research-pr", r"prep_path[ \t]*=[ \t]*/.+")
 
 
 def test_skill_contracts_yaml_includes_compose_research_pr(skills):
     """compose-research-pr must be registered with pr_url output pattern."""
     _assert_skill_has_patterns(
-        skills, "compose-research-pr", r"pr_url\s*=\s*(https://github\.com/.*/pull/\d+)?"
+        skills, "compose-research-pr", r"pr_url[ \t]*=[ \t]*(https://github\.com/.*/pull/\d+)?"
     )
 
 
@@ -353,7 +353,7 @@ def test_review_gate_loop_required_pattern_in_review_pr_contracts(skills):
     assert "review-pr" in skills
     patterns = skills["review-pr"].get("expected_output_patterns", [])
     conditional_pattern = (
-        "(?:%%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%%|verdict\\s*=\\s*approved_with_comments)"
+        "(?:%%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%%|verdict[ \\t]*=[ \\t]*approved_with_comments)"
     )
     assert conditional_pattern in patterns, (
         f"review-pr gate pattern must use OR-conditional form so that approved_with_comments "
@@ -391,7 +391,7 @@ def test_review_gate_clear_pattern_in_review_pr_contracts(skills):
 def test_skill_contracts_yaml_includes_setup_environment(skills: dict[str, Any]) -> None:
     """setup-environment must be registered with env_mode and verdict patterns."""
     _assert_skill_has_patterns(
-        skills, "setup-environment", r"env_mode\s*=\s*(none|docker|micromamba-host|unavailable)"
+        skills, "setup-environment", r"env_mode[ \t]*=[ \t]*(none|docker|micromamba-host|unavailable)"
     )
     contract = skills["setup-environment"]
     patterns = contract["expected_output_patterns"]

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -19,7 +19,7 @@ from tests.conftest import _make_result
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
-FIXTURE_CONDITIONAL_PATTERN = r"verdict\s*=\s*real_fix"
+FIXTURE_CONDITIONAL_PATTERN = r"verdict[ \t]*=[ \t]*real_fix"
 
 
 def _ndjson_with_tool_uses(tool_names: list[str]) -> str:
@@ -179,7 +179,7 @@ class TestZeroWriteDetection:
             skill_command="/autoskillit:resolve-failures /tmp/wt /tmp/plan.md main",
             write_behavior=WriteBehaviorSpec(
                 mode="conditional",
-                expected_when=(r"verdict\s*=\s*real_fix",),
+                expected_when=(r"verdict[ \t]*=[ \t]*real_fix",),
             ),
             backend=ClaudeCodeBackend(),
         )
@@ -210,7 +210,7 @@ class TestZeroWriteDetection:
             skill_command="/autoskillit:resolve-failures /tmp/wt /tmp/plan.md main",
             write_behavior=WriteBehaviorSpec(
                 mode="conditional",
-                expected_when=(r"verdict\s*=\s*real_fix",),
+                expected_when=(r"verdict[ \t]*=[ \t]*real_fix",),
             ),
             backend=ClaudeCodeBackend(),
         )
@@ -240,7 +240,7 @@ class TestZeroWriteDetection:
             skill_command="/autoskillit:resolve-failures /tmp/wt /tmp/plan.md main",
             write_behavior=WriteBehaviorSpec(
                 mode="conditional",
-                expected_when=(r"verdict\s*=\s*real_fix",),
+                expected_when=(r"verdict[ \t]*=[ \t]*real_fix",),
             ),
             backend=ClaudeCodeBackend(),
         )
@@ -781,7 +781,7 @@ class TestGitWritesDetection:
             skill_command="/autoskillit:resolve-failures /tmp/wt /tmp/plan.md main",
             write_behavior=WriteBehaviorSpec(
                 mode="conditional",
-                expected_when=(r"verdict\s*=\s*real_fix",),
+                expected_when=(r"verdict[ \t]*=[ \t]*real_fix",),
             ),
             git_writes_detected=True,
             backend=ClaudeCodeBackend(),

--- a/tests/infra/conftest.py
+++ b/tests/infra/conftest.py
@@ -7,6 +7,7 @@ in test_pretty_output_hook_infra.py.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import NamedTuple
 
 
@@ -14,6 +15,22 @@ class FormatterCoverageDef(NamedTuple):
     typed_dict: type
     rendered: frozenset[str]
     suppressed: frozenset[str]
+    json_producer: Callable[[], dict] | None = None
+
+
+def _run_skill_json_producer() -> dict:
+    """Return union of all JSON keys from SkillResult.to_json() outputs."""
+    import dataclasses
+    import json
+
+    from autoskillit.core.types._type_results import SkillResult
+
+    r1 = SkillResult.crashed(Exception("test"))
+    r2 = dataclasses.replace(r1, worktree_path="/tmp/test-worktree")
+    result: dict = {}
+    for r in (r1, r2):
+        result.update(json.loads(r.to_json()))
+    return result
 
 
 def _build_registry() -> dict[str, FormatterCoverageDef]:
@@ -59,6 +76,7 @@ def _build_registry() -> dict[str, FormatterCoverageDef]:
             typed_dict=RunSkillResult,
             rendered=_FMT_RUN_SKILL_RENDERED,
             suppressed=_FMT_RUN_SKILL_SUPPRESSED,
+            json_producer=_run_skill_json_producer,
         ),
         "run_cmd": FormatterCoverageDef(
             typed_dict=RunCmdResult,

--- a/tests/infra/test_pretty_output_hook_infra.py
+++ b/tests/infra/test_pretty_output_hook_infra.py
@@ -16,6 +16,10 @@ from tests.infra._pretty_output_helpers import (
     _wrap_for_claude_code,
     _wrap_plain_str_for_claude_code,
 )
+from tests.infra.conftest import (
+    _FORMATTER_COVERAGE_REGISTRY,
+    FormatterCoverageDef,
+)
 
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
 
@@ -250,4 +254,29 @@ def test_typeddict_covers_to_json_keys() -> None:
     assert not missing, (
         f"SkillResult.to_json() emits keys absent from RunSkillResult TypedDict: "
         f"{sorted(missing)}. Add them to server/tools/_types.py RunSkillResult."
+    )
+
+
+@pytest.mark.parametrize(
+    "tool_name,entry",
+    list(_FORMATTER_COVERAGE_REGISTRY.items()),
+    ids=list(_FORMATTER_COVERAGE_REGISTRY),
+)
+def test_typeddict_covers_json_producer_keys(tool_name: str, entry: FormatterCoverageDef) -> None:
+    """Each formatter with a json_producer must have TypedDict keys covering all JSON keys.
+
+    Entries without json_producer are skipped. This generalizes test_typeddict_covers_to_json_keys
+    to all formatter registry entries, enabling future formatters to opt in by declaring a
+    json_producer in their FormatterCoverageDef.
+    """
+    import typing
+
+    if entry.json_producer is None:
+        pytest.skip("no json_producer declared for this formatter")
+    json_keys = set(entry.json_producer().keys())
+    typeddict_keys = set(typing.get_type_hints(entry.typed_dict))
+    missing = json_keys - typeddict_keys
+    assert not missing, (
+        f"{tool_name}: json_producer keys absent from TypedDict: {sorted(missing)}. "
+        "Add them to the TypedDict in server/tools/_types.py."
     )

--- a/tests/infra/test_pretty_output_hook_infra.py
+++ b/tests/infra/test_pretty_output_hook_infra.py
@@ -222,3 +222,32 @@ def test_fmt_run_skill_contradictory_subtype_never_renders_fail_success():
     assert f"{cross} success" not in interactive_out, (
         f"Interactive mode rendered contradictory '{cross} success': {interactive_out!r}"
     )
+
+
+def test_typeddict_covers_to_json_keys() -> None:
+    """RunSkillResult TypedDict must cover every key emitted by SkillResult.to_json().
+
+    Uses two instances to cover both conditional (worktree_path) and unconditional
+    fields. Any field added to to_json() without a matching TypedDict entry will fail
+    this test, preventing silent drift between the typed contract and the wire format.
+    """
+    import dataclasses
+    import json
+    import typing
+
+    from autoskillit.core.types._type_results import SkillResult
+    from autoskillit.server.tools._types import RunSkillResult
+
+    r1 = SkillResult.crashed(Exception("test"))
+    r2 = dataclasses.replace(r1, worktree_path="/tmp/test-worktree")
+
+    all_json_keys: set[str] = set()
+    for r in (r1, r2):
+        all_json_keys.update(json.loads(r.to_json()).keys())
+
+    typeddict_keys = set(typing.get_type_hints(RunSkillResult))
+    missing = all_json_keys - typeddict_keys
+    assert not missing, (
+        f"SkillResult.to_json() emits keys absent from RunSkillResult TypedDict: "
+        f"{sorted(missing)}. Add them to server/tools/_types.py RunSkillResult."
+    )

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -151,12 +151,12 @@ def test_remediation_next_or_done_routes_more_parts_to_dry_walkthrough(recipe) -
 
 
 def test_remediation_next_or_done_routes_done_to_push(recipe) -> None:
-    """T_REM_MP3: next_or_done fallthrough must route to push (all parts complete)."""
+    """T_REM_MP3: next_or_done fallthrough must route to check_has_commits (all parts complete)."""
     step = recipe.steps["next_or_done"]
     assert step.on_result is not None
     conds = step.on_result.conditions
-    assert any(c.route == "push" for c in conds), (
-        "next_or_done must have a fallthrough condition routing to push"
+    assert any(c.route == "check_has_commits" for c in conds), (
+        "next_or_done must have a fallthrough condition routing to check_has_commits"
     )
 
 


### PR DESCRIPTION
## Summary

A zero-changes branch (feature already implemented) triggers a three-part failure chain: contract pattern gap (regex requires non-empty path), recovery dead-end (nudge/synthesis skip non-path tokens), and orchestrator visibility gap (`has_progress_evidence` not rendered + `contract_recovery` not documented as a routing rule). The root architectural weakness is that three independent safety systems — contract validation, result recovery, and orchestrator routing — each silently assume conditions that can be violated by a legitimate edge case, and no structural test cross-validates these assumptions against each other.

The immunity plan addresses this through four structural changes: (1) a contract pattern corpus test that exercises patterns against negative examples (catching regex bugs at CI time), (2) a TypedDict-to-JSON completeness test that closes the field drift gap across all 11 formatters, (3) explicit `contract_recovery` routing in the orchestrator prompt (eliminating the undocumented routing gap), and (4) a zero-commits recipe guard that prevents the edge case from reaching the contract pipeline entirely.

## Requirements

### Required Fix — All Three Root Causes

This issue requires fixes for all three root causes. No follow-up — everything ships together.

### Fix 1: Zero-commits detection step in the recipe (RC1 — primary)

Add a zero-commits check after `push` and before `prepare_pr` in `implementation.yaml` (and `remediation.yaml`). When `git rev-list --count base..HEAD` returns 0, route to a "close issue as already-done" path instead of proceeding to `prepare_pr`. This eliminates the zero-changes scenario from ever reaching the PR creation pipeline.

Implementation: add an `action` step (e.g., `check_has_commits`) that uses `run_python` or a shell guard to check `git rev-list --count $base..$head`. Route to a new `close_issue_already_done` step (which removes the fail label and closes the issue with a comment) when the count is 0, and to `prepare_pr` when non-zero.

### Fix 2: Contract pattern + cross-newline bug (RC1 + incidental)

Fix the `lens_context_paths` and `selected_lenses` patterns in `skill_contracts.yaml` for both `prepare-pr` (lines 481-484) and `prepare-research-pr` (lines 1490-1493):

- **`lens_context_paths`**: Change from `lens_context_paths\s*=\s*/.+` to `lens_context_paths\s*=\s*(\S.*|none)` — allows either a non-whitespace value or the explicit sentinel `none`. The sentinel preserves the contract's defensive role (a crashed session that omits the token entirely still fails) while supporting the zero-changes case.
- **`selected_lenses`**: Change from `selected_lenses\s*=\s*\S+` to `selected_lenses\s*=\s*(\S.*|none)` — same treatment, and fixes the cross-newline false-positive by anchoring the match to the same line via `\S.*` (which requires at least one non-whitespace char immediately after `=\s*`, preventing the `\s` from eating through the newline).
- Update `pattern_examples` to include a zero-lenses example: `selected_lenses = none\nlens_context_paths = none`
- Update the `prepare-pr` and `prepare-research-pr` SKILL.md files to document the `none` sentinel for the zero-changes case.

### Fix 3: Orchestrator `contract_recovery` visibility (RC3)

Three paired changes:

1. **`_prompts_orchestrator.py`**: Add `contract_recovery` to the "CONTEXT LIMIT ROUTING" section (lines 157-226) with the same rule text from sous-chef SKILL.md lines 78-81. Also add to `run_skill` tool docstring in `tools_execution.py`.

2. **`_fmt_execution.py` + `_types.py`**: Add `has_progress_evidence: bool` to `RunSkillResult` TypedDict in `_types.py`, then add `has_progress_evidence` to `_FMT_RUN_SKILL_RENDERED` and emit it in `_fmt_run_skill()` when `needs_retry=True`. The TypedDict update is a prerequisite — the `test_coverage_registry_entries_are_valid` meta-test enforces that `_FMT_RUN_SKILL_RENDERED | _FMT_RUN_SKILL_SUPPRESSED` matches the TypedDict fields.

Closes #3011

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260525-195431-262786/.autoskillit/temp/rectify/rectify_contract_recovery_routing_gap_2026-05-25_195431.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 670 | 11.4k | 30.0M | 160.0k | 373 | 2.0M | 34m 57s |
| dry_walkthrough | claude-sonnet-4-6 | 1 | 66 | 18.3k | 1.8M | 80.9k | 158 | 81.2k | 10m 0s |
| implement | claude-sonnet-4-6 | 1 | 748 | 82.1k | 11.3M | 162.9k | 257 | 164.2k | 25m 30s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 118.1k | 5.9k | 211.6k | 31.1k | 26 | 52.2k | 1m 50s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 89.5k | 2.6k | 254.9k | 25.8k | 22 | 15.2k | 1m 0s |
| review_pr | claude-sonnet-4-6 | 3 | 472 | 73.0k | 3.1M | 121.9k | 205 | 245.3k | 23m 27s |
| resolve_review | claude-sonnet-4-6 | 3 | 1.1k | 73.1k | 9.3M | 122.7k | 318 | 241.6k | 38m 20s |
| ci_conflict_fix | claude-sonnet-4-6 | 2 | 520 | 37.6k | 3.0M | 64.6k | 185 | 101.8k | 16m 39s |
| **Total** | | | 211.2k | 304.0k | 58.8M | 162.9k | | 2.9M | 2h 31m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 476 | 23644.0 | 344.9 | 172.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 2303 | 1323.0 | 44.2 | 16.3 |
| **Total** | **2779** | 21174.9 | 1058.2 | 109.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 6 | 3.6k | 295.5k | 58.4M | 2.9M | 2h 28m |
| MiniMax-M2.7-highspeed | 2 | 207.6k | 8.5k | 466.5k | 67.4k | 2m 51s |