### PR TITLE
[FIX] Rectify: Issue Claim State Immunity

### DIFF
--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -318,6 +318,8 @@ class AutomationConfig:
         fr = sec("fleet")
         pvd = sec("providers")
         ab = sec("agent_backend")
+        if isinstance(ab, str):
+            ab = {"backend": ab}
         feat = sec("features")
 
         _tc = _field_defaults(TestCheckConfig)

--- a/src/autoskillit/core/types/_type_protocols_github.py
+++ b/src/autoskillit/core/types/_type_protocols_github.py
@@ -94,6 +94,8 @@ class GitHubFetcher(Protocol):
         description: str = "",
     ) -> dict[str, Any]: ...
 
+    async def close_issue(self, owner: str, repo: str, issue_number: int) -> dict[str, Any]: ...
+
 
 @runtime_checkable
 class CIWatcher(Protocol):

--- a/src/autoskillit/execution/github.py
+++ b/src/autoskillit/execution/github.py
@@ -695,3 +695,29 @@ class DefaultGitHubFetcher:
             return {"success": False, "error": f"Request error: {exc}"}
         self._label_cache.add(cache_key)
         return {"success": True, "created": True}
+
+    async def close_issue(self, owner: str, repo: str, issue_number: int) -> dict[str, Any]:
+        """Close a GitHub issue via PATCH. Returns {success}. Never raises."""
+        await self._throttle_mutating()
+        try:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
+                resp = await client.patch(
+                    f"/repos/{owner}/{repo}/issues/{issue_number}",
+                    json={"state": "closed"},
+                )
+                resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("github close_issue http error", status=exc.response.status_code)
+            return {
+                "success": False,
+                "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("github close_issue request error", error=str(exc))
+            return {"success": False, "error": f"Request error: {exc}"}
+        return {"success": True}

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -168,7 +168,7 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
     "enrich_issues": frozenset({"issue_number", "batch", "dry_run", "repo"}),
     "claim_issue": frozenset({"issue_url", "label", "allow_reentry"}),
     "release_issue": frozenset(
-        {"issue_url", "label", "target_branch", "staged_label", "fail_label"}
+        {"issue_url", "label", "target_branch", "staged_label", "fail_label", "close_issue"}
     ),
     "fetch_github_issue": frozenset({"issue_url", "include_comments"}),
     "get_issue_title": frozenset({"issue_url"}),
@@ -377,7 +377,8 @@ def _check_release_issue_requires_disposition(ctx: ValidationContext) -> list[Ru
             continue
         has_fail_label = bool(step.with_args.get("fail_label"))
         has_target_branch = bool(step.with_args.get("target_branch"))
-        if not has_fail_label and not has_target_branch:
+        has_close_issue = bool(step.with_args.get("close_issue"))
+        if not has_fail_label and not has_target_branch and not has_close_issue:
             findings.append(
                 RuleFinding(
                     rule="release-issue-requires-disposition",

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2774,6 +2774,20 @@ callable_contracts:
     - name: audit_run_dir
       type: directory_path
 
+  autoskillit.smoke_utils.detect_zero_changes:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+    - name: base_branch
+      type: str
+      required: true
+    outputs:
+    - name: has_changes
+      type: str
+    - name: commit_count
+      type: str
+
 tool_output_contracts:
   wait_for_ci:
     result_field: conclusion

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -229,7 +229,7 @@
       },
       "retries": 0,
       "on_context_limit": "retry_worktree",
-      "on_success": "test",
+      "on_success": "check_changes",
       "on_failure": "release_issue_failure",
       "note": "Extracts worktree_path from result for use in subsequent steps."
     },
@@ -249,15 +249,48 @@
       "on_result": [
         {
           "when": "${{ result.phases_implemented }} > 0",
-          "route": "test"
+          "route": "check_changes"
+        },
+        {
+          "route": "check_changes"
+        }
+      ],
+      "on_context_limit": "check_changes",
+      "on_exhausted": "release_issue_failure",
+      "on_failure": "release_issue_failure"
+    },
+    "check_changes": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.detect_zero_changes",
+        "worktree_path": "${{ context.worktree_path }}",
+        "base_branch": "${{ inputs.base_branch }}"
+      },
+      "capture": {
+        "has_changes": "${{ result.has_changes }}",
+        "commit_count": "${{ result.commit_count }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.has_changes }} == false",
+          "route": "close_issue_no_changes"
         },
         {
           "route": "test"
         }
       ],
-      "on_context_limit": "test",
-      "on_exhausted": "release_issue_failure",
       "on_failure": "release_issue_failure"
+    },
+    "close_issue_no_changes": {
+      "tool": "release_issue",
+      "optional": true,
+      "skip_when_false": "inputs.issue_url",
+      "with": {
+        "issue_url": "${{ inputs.issue_url }}",
+        "close_issue": "true"
+      },
+      "on_success": "done",
+      "on_failure": "done"
     },
     "test": {
       "tool": "test_check",
@@ -484,10 +517,9 @@
       "model": "",
       "retries": 1,
       "with": {
-        "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "prepare_pr",
-        "issue_number": "${{ context.issue_number }}"
+        "step_name": "prepare_pr"
       },
       "capture": {
         "prep_path": "${{ result.prep_path }}",
@@ -512,7 +544,7 @@
       "on_exhausted": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens slugs, writes one PR context file per lens, and writes a PR prep file. Does NOT invoke arch-lens skills. If context.issue_number is a non-empty string, append it as the 4th positional argument so prepare-pr fetches requirements from the closing issue.\n"
+      "note": "Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens slugs, writes one PR context file per lens, and writes a PR prep file. Does NOT invoke arch-lens skills.\n"
     },
     "run_arch_lenses": {
       "tool": "run_skill",
@@ -537,10 +569,9 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "compose_pr",
-        "issue_number": "${{ context.issue_number }}"
+        "step_name": "compose_pr"
       },
       "capture": {
         "pr_url": "${{ result.pr_url }}"
@@ -558,7 +589,7 @@
       "on_context_limit": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is unavailable (emits pr_url=). If context.issue_number is set, append it as the 5th positional argument for Closes #N injection in the PR body.\n"
+      "note": "Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is unavailable (emits pr_url=).\n"
     },
     "guard_pr_url": {
       "action": "route",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -233,7 +233,7 @@ steps:
       worktree_path: "${{ result.worktree_path }}"
     retries: 0
     on_context_limit: retry_worktree
-    on_success: test
+    on_success: check_changes
     on_failure: release_issue_failure
     note: "Extracts worktree_path from result for use in subsequent steps."
 
@@ -250,11 +250,36 @@ steps:
       phases_implemented: "${{ result.phases_implemented }}"
     on_result:
     - when: "${{ result.phases_implemented }} > 0"
-      route: test
-    - route: test
-    on_context_limit: test
+      route: check_changes
+    - route: check_changes
+    on_context_limit: check_changes
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
+
+  check_changes:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.detect_zero_changes"
+      worktree_path: "${{ context.worktree_path }}"
+      base_branch: "${{ inputs.base_branch }}"
+    capture:
+      has_changes: "${{ result.has_changes }}"
+      commit_count: "${{ result.commit_count }}"
+    on_result:
+    - when: "${{ result.has_changes }} == false"
+      route: close_issue_no_changes
+    - route: test
+    on_failure: release_issue_failure
+
+  close_issue_no_changes:
+    tool: release_issue
+    optional: true
+    skip_when_false: inputs.issue_url
+    with:
+      issue_url: "${{ inputs.issue_url }}"
+      close_issue: "true"
+    on_success: done
+    on_failure: done
 
   test:
     tool: test_check
@@ -449,10 +474,9 @@ steps:
     model: ""
     retries: 1
     with:
-      skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
+      skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}"
       cwd: "${{ context.work_dir }}"
       step_name: "prepare_pr"
-      issue_number: "${{ context.issue_number }}"
     capture:
       prep_path: "${{ result.prep_path }}"
       selected_lenses: "${{ result.selected_lenses }}"
@@ -471,8 +495,7 @@ steps:
     note: >
       Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens slugs,
       writes one PR context file per lens, and writes a PR prep file. Does NOT invoke
-      arch-lens skills. If context.issue_number is a non-empty string, append it as the
-      4th positional argument so prepare-pr fetches requirements from the closing issue.
+      arch-lens skills.
 
   run_arch_lenses:
     tool: run_skill
@@ -504,10 +527,9 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}"
+      skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}"
       cwd: "${{ context.work_dir }}"
       step_name: "compose_pr"
-      issue_number: "${{ context.issue_number }}"
     capture:
       pr_url: "${{ result.pr_url }}"
     on_result:
@@ -521,8 +543,7 @@ steps:
     note: >
       Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●),
       composes the PR body, and runs gh pr create. Degrades gracefully if gh is
-      unavailable (emits pr_url=). If context.issue_number is set, append it as the
-      5th positional argument for Closes #N injection in the PR body.
+      unavailable (emits pr_url=).
 
   guard_pr_url:
     action: route

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -246,7 +246,7 @@
       },
       "retries": 0,
       "on_context_limit": "retry_worktree",
-      "on_success": "test",
+      "on_success": "check_changes",
       "on_failure": "release_issue_failure"
     },
     "retry_worktree": {
@@ -267,15 +267,48 @@
       "on_result": [
         {
           "when": "${{ result.phases_implemented }} > 0",
-          "route": "test"
+          "route": "check_changes"
+        },
+        {
+          "route": "check_changes"
+        }
+      ],
+      "on_context_limit": "check_changes",
+      "on_exhausted": "release_issue_failure",
+      "on_failure": "release_issue_failure"
+    },
+    "check_changes": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.detect_zero_changes",
+        "worktree_path": "${{ context.implementation_ref }}",
+        "base_branch": "${{ inputs.base_branch }}"
+      },
+      "capture": {
+        "has_changes": "${{ result.has_changes }}",
+        "commit_count": "${{ result.commit_count }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.has_changes }} == false",
+          "route": "close_issue_no_changes"
         },
         {
           "route": "test"
         }
       ],
-      "on_context_limit": "test",
-      "on_exhausted": "release_issue_failure",
       "on_failure": "release_issue_failure"
+    },
+    "close_issue_no_changes": {
+      "tool": "release_issue",
+      "optional": true,
+      "skip_when_false": "inputs.issue_url",
+      "with": {
+        "issue_url": "${{ inputs.issue_url }}",
+        "close_issue": "true"
+      },
+      "on_success": "done",
+      "on_failure": "done"
     },
     "test": {
       "tool": "test_check",
@@ -523,10 +556,9 @@
       "model": "",
       "retries": 1,
       "with": {
-        "skill_command": "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "prepare_pr",
-        "issue_number": "${{ context.issue_number }}"
+        "step_name": "prepare_pr"
       },
       "capture": {
         "prep_path": "${{ result.prep_path }}",
@@ -551,7 +583,7 @@
       "on_exhausted": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Reads plan, runs git diff, classifies changed files, selects 1–3 arch-lens slugs, writes one PR context file per lens, and writes a PR prep file. Does NOT invoke arch-lens skills. If context.issue_number is a non-empty string, append it as the 4th positional argument so prepare-pr fetches requirements from the closing issue.\n"
+      "note": "Reads plan, runs git diff, classifies changed files, selects 1–3 arch-lens slugs, writes one PR context file per lens, and writes a PR prep file. Does NOT invoke arch-lens skills.\n"
     },
     "run_arch_lenses": {
       "tool": "run_skill",
@@ -576,10 +608,9 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "compose_pr",
-        "issue_number": "${{ context.issue_number }}"
+        "step_name": "compose_pr"
       },
       "capture": {
         "pr_url": "${{ result.pr_url }}"
@@ -597,7 +628,7 @@
       "on_context_limit": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is unavailable (emits pr_url=). If context.issue_number is set, append it as the 5th positional argument for Closes #N injection in the PR body.\n"
+      "note": "Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is unavailable (emits pr_url=).\n"
     },
     "guard_pr_url": {
       "action": "route",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -237,7 +237,7 @@ steps:
       branch_name: "${{ result.branch_name }}"
     retries: 0
     on_context_limit: retry_worktree
-    on_success: test
+    on_success: check_changes
     on_failure: release_issue_failure
 
   retry_worktree:
@@ -255,11 +255,36 @@ steps:
       phases_implemented: "${{ result.phases_implemented }}"
     on_result:
     - when: "${{ result.phases_implemented }} > 0"
-      route: test
-    - route: test
-    on_context_limit: test
+      route: check_changes
+    - route: check_changes
+    on_context_limit: check_changes
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
+
+  check_changes:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.detect_zero_changes"
+      worktree_path: "${{ context.implementation_ref }}"
+      base_branch: "${{ inputs.base_branch }}"
+    capture:
+      has_changes: "${{ result.has_changes }}"
+      commit_count: "${{ result.commit_count }}"
+    on_result:
+    - when: "${{ result.has_changes }} == false"
+      route: close_issue_no_changes
+    - route: test
+    on_failure: release_issue_failure
+
+  close_issue_no_changes:
+    tool: release_issue
+    optional: true
+    skip_when_false: inputs.issue_url
+    with:
+      issue_url: "${{ inputs.issue_url }}"
+      close_issue: "true"
+    on_success: done
+    on_failure: done
 
   test:
     tool: test_check
@@ -465,10 +490,9 @@ steps:
     model: ""
     retries: 1
     with:
-      skill_command: "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
+      skill_command: "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}"
       cwd: "${{ context.work_dir }}"
       step_name: "prepare_pr"
-      issue_number: "${{ context.issue_number }}"
     capture:
       prep_path: "${{ result.prep_path }}"
       selected_lenses: "${{ result.selected_lenses }}"
@@ -487,8 +511,7 @@ steps:
     note: >
       Reads plan, runs git diff, classifies changed files, selects 1–3 arch-lens slugs,
       writes one PR context file per lens, and writes a PR prep file. Does NOT invoke
-      arch-lens skills. If context.issue_number is a non-empty string, append it as the
-      4th positional argument so prepare-pr fetches requirements from the closing issue.
+      arch-lens skills.
 
   run_arch_lenses:
     tool: run_skill
@@ -520,10 +543,9 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}"
+      skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}"
       cwd: "${{ context.work_dir }}"
       step_name: "compose_pr"
-      issue_number: "${{ context.issue_number }}"
     capture:
       pr_url: "${{ result.pr_url }}"
     on_result:
@@ -537,8 +559,7 @@ steps:
     note: >
       Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●),
       composes the PR body, and runs gh pr create. Degrades gracefully if gh is
-      unavailable (emits pr_url=). If context.issue_number is set, append it as the
-      5th positional argument for Closes #N injection in the PR body.
+      unavailable (emits pr_url=).
 
   guard_pr_url:
     action: route

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -103,6 +103,21 @@ async def claim_and_resolve_issue(
                 }
             )
 
+        issue_state = fetch_result.get("state", "open").lower()
+        if issue_state == "closed":
+            claim_ms = int((time.monotonic() - _claim_start) * 1000)
+            return json.dumps(
+                {
+                    "success": True,
+                    "claimed": False,
+                    "reason": "issue is closed",
+                    "issue_number": issue_number,
+                    "issue_title": issue_title,
+                    "issue_slug": issue_slug,
+                    "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
+                }
+            )
+
         current_labels = _extract_label_names(fetch_result.get("labels", []))
         decision = await _try_claim_with_liveness(
             issue_url=issue_url,

--- a/src/autoskillit/server/tools/tools_issue_labels.py
+++ b/src/autoskillit/server/tools/tools_issue_labels.py
@@ -80,6 +80,16 @@ async def claim_issue(
         if not result.get("success"):
             return json.dumps({"success": False, "error": result.get("error", "fetch failed")})
 
+        issue_state = result.get("state", "open").lower()
+        if issue_state == "closed":
+            return json.dumps(
+                {
+                    "success": True,
+                    "claimed": False,
+                    "reason": "issue is closed",
+                }
+            )
+
         current_labels = _extract_label_names(result.get("labels", []))
         decision = await _try_claim_with_liveness(
             issue_url=issue_url,
@@ -154,6 +164,7 @@ async def release_issue(
     target_branch: str | None = None,
     staged_label: str | None = None,
     fail_label: str | None = None,
+    close_issue: str | None = None,
 ) -> str:
     """Remove the in-progress label from a GitHub issue to release it.
 
@@ -356,6 +367,8 @@ async def release_issue(
                         "error": f"Failed to remove label: {swap_result.get('error', '?')}",
                     }
                 )
+            if close_issue == "true":
+                await tool_ctx.github_client.close_issue(owner, repo, issue_number)
 
         return json.dumps(
             {

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -798,3 +798,18 @@ def enrich_diff_context(
         "enriched_count": str(enriched_count),
         "total_entries": str(len(entries)),
     }
+
+
+def detect_zero_changes(worktree_path: str, base_branch: str) -> dict[str, str]:
+    """Count commits since branch creation using merge-base."""
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "rev-list", "--count", f"{base_branch}..HEAD"],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    count = int(result.stdout.strip())
+    return {"has_changes": "true" if count > 0 else "false", "commit_count": str(count)}

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -810,6 +810,7 @@ def detect_zero_changes(worktree_path: str, base_branch: str) -> dict[str, str]:
         capture_output=True,
         text=True,
         check=True,
+        timeout=60,
     )
     count = int(result.stdout.strip())
     return {"has_changes": "true" if count > 0 else "false", "commit_count": str(count)}

--- a/tests/cli/test_doctor_backend_guards.py
+++ b/tests/cli/test_doctor_backend_guards.py
@@ -381,6 +381,7 @@ class TestRunDoctorBackendWiring:
         from autoskillit.core import Severity
 
         monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
         (tmp_path / ".autoskillit").mkdir()
         (tmp_path / ".autoskillit" / "config.yaml").write_text(
             "agent_backend:\n  backend: aider\n"

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -375,6 +375,7 @@ class TestRegisterAllBackendBranching:
         import autoskillit.core.paths as _core_paths
         from autoskillit.cli._init_helpers import _register_all
 
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
         self._write_config(tmp_path, "codex")
 
         monkeypatch.setattr(_hooks_mod, "sweep_all_scopes_for_orphans", lambda p: None)

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -401,6 +401,7 @@ class TestRegisterAllBackendBranching:
         import autoskillit.core.paths as _core_paths
         from autoskillit.cli._init_helpers import _register_all
 
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
         self._write_config(tmp_path, "codex")
 
         monkeypatch.setattr(_hooks_mod, "sweep_all_scopes_for_orphans", lambda p: None)

--- a/tests/config/test_agent_backend_config.py
+++ b/tests/config/test_agent_backend_config.py
@@ -77,13 +77,15 @@ class TestAgentBackendConfigLoading:
     def test_agent_backend_env_var_override(self, tmp_path, monkeypatch) -> None:
         from autoskillit.config import load_config
 
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
         monkeypatch.setenv("AUTOSKILLIT_AGENT_BACKEND__BACKEND", "codex")
         cfg = load_config(tmp_path)
         assert cfg.agent_backend.backend == "codex"
 
-    def test_agent_backend_yaml_override(self, tmp_path) -> None:
+    def test_agent_backend_yaml_override(self, tmp_path, monkeypatch) -> None:
         from autoskillit.config import load_config
 
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text(yaml.dump({"agent_backend": {"backend": "aider"}}))

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -76,6 +76,8 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_triage_contracts.py` | Contract tests for triage-issues --enrich flag and requirement enrichment behavior |
 | `test_triage_issues_contracts.py` | Contract tests for triage-issues body-file safety (gh issue edit --body-file) |
 | `test_version_consistency.py` | Cross-file version consistency: pyproject.toml, __init__.__version__, plugin.json, bundled recipe versions |
+| `test_zero_change_circuit_breaker_contracts.py` | Contract tests: zero-change circuit breaker in implementation/remediation recipes |
+| `test_fetch_issue_mock_contracts.py` | Contract test: all fetch_issue mock return values must include a 'state' field |
 
 ## Architecture Notes
 

--- a/tests/contracts/test_fetch_issue_mock_contracts.py
+++ b/tests/contracts/test_fetch_issue_mock_contracts.py
@@ -36,12 +36,14 @@ def _collect_failures(test_file: Path) -> list[str]:
     failures = []
 
     def _check_dict(dict_node: ast.Dict, lineno: int, label: str) -> None:
-        keys = {
-            k.value
-            for k in dict_node.keys
+        keys_and_values = {
+            k.value: v
+            for k, v in zip(dict_node.keys, dict_node.values)
             if isinstance(k, ast.Constant) and isinstance(k.value, str)
         }
-        if "success" in keys and "state" not in keys:
+        success_val = keys_and_values.get("success")
+        is_success_true = isinstance(success_val, ast.Constant) and success_val.value is True
+        if is_success_true and "state" not in keys_and_values:
             failures.append(f"{test_file.name}:{lineno} {label} missing 'state' key")
 
     def _check_value(value_node: ast.expr, lineno: int, label: str) -> None:

--- a/tests/contracts/test_fetch_issue_mock_contracts.py
+++ b/tests/contracts/test_fetch_issue_mock_contracts.py
@@ -1,0 +1,99 @@
+"""Contract test: all fetch_issue mock return values must include a \'state\' field."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+TESTS_DIR = Path(__file__).parents[2] / "tests"
+
+
+def _collect_failures(test_file: Path) -> list[str]:
+    source = test_file.read_text()
+    tree = ast.parse(source)
+
+    # Track dict literals assigned to named variables (for variable-based mocks)
+    variable_dicts: dict[str, tuple[int, bool]] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and isinstance(node.value, ast.Dict)
+        ):
+            var_name = node.targets[0].id
+            keys = {
+                k.value
+                for k in node.value.keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)
+            }
+            variable_dicts[var_name] = (node.lineno, "state" in keys)
+
+    failures = []
+
+    def _check_dict(dict_node: ast.Dict, lineno: int, label: str) -> None:
+        keys = {
+            k.value
+            for k in dict_node.keys
+            if isinstance(k, ast.Constant) and isinstance(k.value, str)
+        }
+        if "success" in keys and "state" not in keys:
+            failures.append(f"{test_file.name}:{lineno} {label} missing \'state\' key")
+
+    def _check_value(value_node: ast.expr, lineno: int, label: str) -> None:
+        if isinstance(value_node, ast.Dict):
+            _check_dict(value_node, lineno, label)
+        elif isinstance(value_node, ast.Name):
+            var_name = value_node.id
+            if var_name in variable_dicts:
+                var_lineno, has_state = variable_dicts[var_name]
+                if not has_state:
+                    failures.append(
+                        f"{test_file.name}:{lineno} variable \'{var_name}\' "
+                        f"(defined at line {var_lineno}) missing \'state\' key"
+                    )
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        target = node.targets[0] if node.targets else None
+
+        # Pattern 1: foo.fetch_issue.return_value = {...}
+        if (
+            isinstance(target, ast.Attribute)
+            and target.attr == "return_value"
+            and isinstance(target.value, ast.Attribute)
+            and target.value.attr == "fetch_issue"
+        ):
+            _check_value(node.value, node.lineno, ".fetch_issue.return_value =")
+
+        # Pattern 2: foo.fetch_issue = AsyncMock(return_value={...})
+        if isinstance(target, ast.Attribute) and target.attr == "fetch_issue":
+            if isinstance(node.value, ast.Call):
+                for kw in node.value.keywords:
+                    if kw.arg == "return_value":
+                        _check_value(kw.value, node.lineno, "fetch_issue AsyncMock return_value")
+
+    return failures
+
+
+def test_all_fetch_issue_mocks_include_state_field() -> None:
+    """Every fetch_issue mock return value must include a \'state\' key.
+
+    Prevents future tests from regressing to state-blind mocks, which caused the
+    food-truck re-dispatch bug to go undetected across 7 test files.
+    """
+    test_files = [f for f in TESTS_DIR.rglob("test_*.py") if "fetch_issue" in f.read_text()]
+    assert test_files, "No test files with fetch_issue found — check TESTS_DIR path"
+
+    all_failures = []
+    for test_file in test_files:
+        all_failures.extend(_collect_failures(test_file))
+
+    assert not all_failures, (
+        "fetch_issue mocks missing \'state\' key:\n" + "\n".join(all_failures)
+    )

--- a/tests/contracts/test_fetch_issue_mock_contracts.py
+++ b/tests/contracts/test_fetch_issue_mock_contracts.py
@@ -42,7 +42,7 @@ def _collect_failures(test_file: Path) -> list[str]:
             if isinstance(k, ast.Constant) and isinstance(k.value, str)
         }
         if "success" in keys and "state" not in keys:
-            failures.append(f"{test_file.name}:{lineno} {label} missing \'state\' key")
+            failures.append(f"{test_file.name}:{lineno} {label} missing 'state' key")
 
     def _check_value(value_node: ast.expr, lineno: int, label: str) -> None:
         if isinstance(value_node, ast.Dict):
@@ -53,8 +53,8 @@ def _collect_failures(test_file: Path) -> list[str]:
                 var_lineno, has_state = variable_dicts[var_name]
                 if not has_state:
                     failures.append(
-                        f"{test_file.name}:{lineno} variable \'{var_name}\' "
-                        f"(defined at line {var_lineno}) missing \'state\' key"
+                        f"{test_file.name}:{lineno} variable '{var_name}' "
+                        f"(defined at line {var_lineno}) missing 'state' key"
                     )
 
     for node in ast.walk(tree):
@@ -94,6 +94,4 @@ def test_all_fetch_issue_mocks_include_state_field() -> None:
     for test_file in test_files:
         all_failures.extend(_collect_failures(test_file))
 
-    assert not all_failures, (
-        "fetch_issue mocks missing \'state\' key:\n" + "\n".join(all_failures)
-    )
+    assert not all_failures, "fetch_issue mocks missing 'state' key:\n" + "\n".join(all_failures)

--- a/tests/contracts/test_prepare_compose_pr_contracts.py
+++ b/tests/contracts/test_prepare_compose_pr_contracts.py
@@ -72,3 +72,32 @@ def test_compose_pr_gh_degrades_gracefully():
     text = COMPOSE_PR.read_text()
     assert "gh auth status" in text
     assert "empty" in text.lower() or "pr_url =" in text
+
+
+RECIPES_DIR = Path(__file__).parents[2] / "src" / "autoskillit" / "recipes"
+
+
+def test_compose_pr_skill_command_includes_issue_number() -> None:
+    """compose_pr skill_command must structurally include context.issue_number."""
+    import yaml
+
+    data = yaml.safe_load((RECIPES_DIR / "implementation.yaml").read_text())
+    skill_command = data["steps"]["compose_pr"]["with"]["skill_command"]
+    assert "${{ context.issue_number }}" in skill_command, (
+        f"compose_pr skill_command must include"
+        f" ${{{{ context.issue_number }}}} as a positional arg, "
+        f"not rely on with: metadata. Got: {skill_command!r}"
+    )
+
+
+def test_prepare_pr_skill_command_includes_issue_number() -> None:
+    """prepare_pr skill_command must structurally include context.issue_number."""
+    import yaml
+
+    data = yaml.safe_load((RECIPES_DIR / "implementation.yaml").read_text())
+    skill_command = data["steps"]["prepare_pr"]["with"]["skill_command"]
+    assert "${{ context.issue_number }}" in skill_command, (
+        f"prepare_pr skill_command must include"
+        f" ${{{{ context.issue_number }}}} as a positional arg, "
+        f"not rely on with: metadata. Got: {skill_command!r}"
+    )

--- a/tests/contracts/test_zero_change_circuit_breaker_contracts.py
+++ b/tests/contracts/test_zero_change_circuit_breaker_contracts.py
@@ -1,0 +1,79 @@
+"""Contract tests: zero-change circuit breaker in implementation/remediation recipes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+RECIPES_DIR = Path(__file__).parents[2] / "src" / "autoskillit" / "recipes"
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load((RECIPES_DIR / f"{name}.yaml").read_text())
+
+
+def test_implementation_recipe_has_change_check_after_implement() -> None:
+    """implement step must route on_success to check_changes, not directly to test."""
+    data = _load("implementation")
+    implement_step = data["steps"]["implement"]
+    assert implement_step.get("on_success") == "check_changes", (
+        f"implement.on_success must be 'check_changes', got {implement_step.get('on_success')!r}"
+    )
+
+
+def test_implementation_recipe_check_changes_routes_false_to_close() -> None:
+    """check_changes step must route has_changes=false to close_issue_no_changes."""
+    data = _load("implementation")
+    assert "check_changes" in data["steps"], "check_changes step must exist"
+    step = data["steps"]["check_changes"]
+    on_result = step.get("on_result", [])
+    false_routes = [r.get("route") for r in on_result if "false" in r.get("when", "")]
+    assert "close_issue_no_changes" in false_routes, (
+        f"check_changes must route has_changes=false to close_issue_no_changes, got: {on_result}"
+    )
+
+
+def test_retry_worktree_all_exits_route_to_check_changes() -> None:
+    """retry_worktree: all on_result branches and on_context_limit must route to check_changes."""
+    data = _load("implementation")
+    step = data["steps"]["retry_worktree"]
+
+    on_result = step.get("on_result", [])
+    for entry in on_result:
+        assert entry.get("route") == "check_changes", (
+            f"retry_worktree on_result entry must route to check_changes, got: {entry}"
+        )
+
+    assert step.get("on_context_limit") == "check_changes", (
+        f"retry_worktree.on_context_limit must be 'check_changes', "
+        f"got {step.get('on_context_limit')!r}"
+    )
+
+
+def test_remediation_recipe_has_same_circuit_breaker() -> None:
+    """remediation.yaml must have the same zero-change circuit breaker as implementation."""
+    data = _load("remediation")
+
+    implement_step = data["steps"]["implement"]
+    assert implement_step.get("on_success") == "check_changes", (
+        f"remediation implement.on_success must be 'check_changes', "
+        f"got {implement_step.get('on_success')!r}"
+    )
+
+    assert "check_changes" in data["steps"], "remediation check_changes step must exist"
+
+    retry_step = data["steps"]["retry_worktree"]
+    on_result = retry_step.get("on_result", [])
+    for entry in on_result:
+        assert entry.get("route") == "check_changes", (
+            f"remediation retry_worktree on_result entry must route to check_changes: {entry}"
+        )
+
+    assert retry_step.get("on_context_limit") == "check_changes", (
+        f"remediation retry_worktree.on_context_limit must be 'check_changes', "
+        f"got {retry_step.get('on_context_limit')!r}"
+    )

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -241,7 +241,7 @@ class TestChannelBDrainWait:
         natural_exit_grace_seconds=0.1: script never exits naturally (time.sleep(3600)),
         so shorten grace window to reduce total test time and avoid asyncio-waitpid
         thread contention under CI load (default 3.0s grace + 3.0s kill = 6s total).
-        _session_id_timeout=0.5: 0.01s was too tight — under xdist -n 4 load the
+        _session_id_timeout=3.0: 0.5s was too tight under heavy xdist load — the
         event loop may not schedule the monitor coroutine before the timeout expires,
         preventing Phase 1 from starting and causing a spurious timed_out result.
         """
@@ -260,7 +260,7 @@ class TestChannelBDrainWait:
             natural_exit_grace_seconds=0.1,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
-            _session_id_timeout=0.5,
+            _session_id_timeout=3.0,
             _phase1_timeout=250,
         )
 

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -318,10 +318,13 @@ class TestTouchDispatchMarker:
     @pytest.mark.anyio
     async def test_touch_dispatch_marker_creates_heartbeat_loop(self, tmp_path: Path) -> None:
         """Heartbeat loop refreshes mtime until trigger is set."""
+        import os
+
         from autoskillit.fleet._api import _touch_dispatch_marker
 
         marker = tmp_path / "test.marker"
         marker.touch()
+        os.utime(marker, (0, 0))  # Set to epoch 0 so any real touch shows as newer
         original_mtime_ns = marker.stat().st_mtime_ns
 
         trigger = anyio.Event()

--- a/tests/server/test_claim_liveness.py
+++ b/tests/server/test_claim_liveness.py
@@ -32,6 +32,7 @@ def _mock_client_with_in_progress_label() -> AsyncMock:
     client = AsyncMock()
     client.fetch_issue.return_value = {
         "success": True,
+        "state": "open",
         "labels": [{"name": "in-progress"}],
     }
     client.fetch_title.return_value = {

--- a/tests/server/test_release_issue_fail_label.py
+++ b/tests/server/test_release_issue_fail_label.py
@@ -94,6 +94,7 @@ class TestClaimIssueFailLabelCleanup:
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {
             "success": True,
+            "state": "open",
             "labels": [{"name": "bug"}],
         }
         mock_client.ensure_label.return_value = {"success": True, "created": False}

--- a/tests/server/test_tools_bootstrap.py
+++ b/tests/server/test_tools_bootstrap.py
@@ -165,7 +165,7 @@ class TestClaimAndResolveIssue:
             return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
         )
         tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
-            return_value={"success": True, "labels": []}
+            return_value={"success": True, "state": "open", "labels": []}
         )
         tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(
             return_value={"success": True}
@@ -186,6 +186,7 @@ class TestClaimAndResolveIssue:
         tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
             return_value={
                 "success": True,
+                "state": "open",
                 "labels": [{"name": "in-progress"}],
             }
         )
@@ -204,6 +205,7 @@ class TestClaimAndResolveIssue:
         tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
             return_value={
                 "success": True,
+                "state": "open",
                 "labels": [{"name": "in-progress"}],
             }
         )
@@ -236,7 +238,7 @@ class TestClaimAndResolveIssue:
             return_value={"success": True, "number": 42, "title": "X", "slug": "x"}
         )
         tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
-            return_value={"success": True, "labels": []}
+            return_value={"success": True, "state": "open", "labels": []}
         )
         tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(
             return_value={"success": True}
@@ -255,7 +257,7 @@ class TestClaimAndResolveIssue:
             return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
         )
         tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
-            return_value={"success": True, "labels": []}
+            return_value={"success": True, "state": "open", "labels": []}
         )
         tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(
             return_value={"success": True}
@@ -284,7 +286,7 @@ class TestClaimAndResolveIssue:
             return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
         )
         tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
-            return_value={"success": True, "labels": []}
+            return_value={"success": True, "state": "open", "labels": []}
         )
         tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(
             return_value={"success": True}

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -47,7 +47,7 @@ class TestClaimIssueTool:
     @pytest.mark.anyio
     async def test_claim_issue_success(self, tool_ctx_kitchen_open):
         mock_client = AsyncMock()
-        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.fetch_issue.return_value = {"success": True, "state": "open", "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.add_labels.return_value = {"success": True, "labels": ["in-progress"]}
         tool_ctx_kitchen_open.github_client = mock_client
@@ -61,6 +61,7 @@ class TestClaimIssueTool:
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {
             "success": True,
+            "state": "open",
             "labels": [{"name": "in-progress"}],
         }
         tool_ctx_kitchen_open.github_client = mock_client
@@ -99,6 +100,7 @@ class TestClaimIssueTool:
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {
             "success": True,
+            "state": "open",
             "labels": [{"name": "in-progress"}],
         }
         tool_ctx_kitchen_open.github_client = mock_client
@@ -118,6 +120,7 @@ class TestClaimIssueTool:
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {
             "success": True,
+            "state": "open",
             "labels": [{"name": "in-progress"}],
         }
         tool_ctx_kitchen_open.github_client = mock_client
@@ -133,7 +136,7 @@ class TestClaimIssueTool:
     ):
         """allow_reentry=True with no pre-existing label performs normal claim."""
         mock_client = AsyncMock()
-        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.fetch_issue.return_value = {"success": True, "state": "open", "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["in-progress"]}
         tool_ctx_kitchen_open.github_client = mock_client
@@ -151,7 +154,7 @@ class TestClaimIssueTool:
     async def test_claim_issue_with_queued_label(self, tool_ctx_kitchen_open):
         """claim_issue with label=queued uses registry color/description and removes fail."""
         mock_client = AsyncMock()
-        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.fetch_issue.return_value = {"success": True, "state": "open", "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["queued"]}
         tool_ctx_kitchen_open.github_client = mock_client
@@ -175,7 +178,7 @@ class TestClaimIssueTool:
     async def test_claim_issue_default_removes_queued_and_fail(self, tool_ctx_kitchen_open):
         """claim_issue with default label removes both queued and fail labels."""
         mock_client = AsyncMock()
-        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.fetch_issue.return_value = {"success": True, "state": "open", "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["in-progress"]}
         tool_ctx_kitchen_open.github_client = mock_client

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -9,6 +9,7 @@ import pytest
 
 from autoskillit.core import RetryReason, SkillResult
 from autoskillit.pipeline.gate import DefaultGateState
+from autoskillit.server.tools.tools_issue_composite import claim_and_resolve_issue
 from autoskillit.server.tools.tools_issue_headless import (
     _build_enrich_skill_command,
     _build_headless_error_response,
@@ -394,6 +395,100 @@ async def test_release_issue_stages_when_different_branch(
     assert result["success"] is True
     assert result["staged"] is True
     assert result["staged_label"] == "staged"
+
+
+# ---------------------------------------------------------------------------
+# State guard tests (1A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_claim_and_resolve_rejects_closed_issue(tool_ctx_kitchen_open) -> None:
+    """State guard: claim_and_resolve_issue returns claimed=False for closed issues."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
+        return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
+    )
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+        return_value={"success": True, "state": "closed", "labels": []}
+    )
+
+    result = json.loads(await claim_and_resolve_issue("https://github.com/owner/repo/issues/42"))
+    assert result["success"] is True
+    assert result["claimed"] is False
+    assert result["reason"] == "issue is closed"
+
+
+@pytest.mark.anyio
+async def test_claim_issue_rejects_closed_issue(tool_ctx_kitchen_open) -> None:
+    """State guard: claim_issue returns claimed=False for closed issues."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+        return_value={"success": True, "state": "closed", "labels": []}
+    )
+
+    result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
+    assert result["success"] is True
+    assert result["claimed"] is False
+    assert result["reason"] == "issue is closed"
+
+
+@pytest.mark.anyio
+async def test_claim_and_resolve_accepts_open_issue(tool_ctx_kitchen_open) -> None:
+    """Regression guard: claim_and_resolve_issue proceeds normally for open issues."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
+        return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
+    )
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+        return_value={"success": True, "state": "open", "labels": []}
+    )
+    tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
+
+    result = json.loads(await claim_and_resolve_issue("https://github.com/owner/repo/issues/42"))
+    assert result["success"] is True
+    assert result["claimed"] is True
+
+
+# ---------------------------------------------------------------------------
+# release_issue close_issue flag tests (1E)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_release_issue_with_close_flag_closes_issue(tool_ctx_kitchen_open) -> None:
+    """close_issue='true' causes release_issue to call github_client.close_issue."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client.close_issue = AsyncMock(return_value={"success": True})
+
+    result = json.loads(
+        await release_issue(
+            "https://github.com/owner/repo/issues/42",
+            close_issue="true",
+        )
+    )
+    assert result["success"] is True
+    tool_ctx_kitchen_open.github_client.close_issue.assert_called_once_with("owner", "repo", 42)
+
+
+@pytest.mark.anyio
+async def test_release_issue_without_close_flag_does_not_close(tool_ctx_kitchen_open) -> None:
+    """Regression guard: release_issue without close_issue does not call close_issue."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
+    promotion_target = tool_ctx_kitchen_open.config.branching.promotion_target
+
+    result = json.loads(
+        await release_issue(
+            "https://github.com/owner/repo/issues/42",
+            target_branch=promotion_target,
+        )
+    )
+    assert result["success"] is True
+    tool_ctx_kitchen_open.github_client.close_issue.assert_not_called()
 
 
 def _make_mock_tool_ctx_for_project_dir(project_dir):

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -288,6 +288,7 @@ async def test_claim_issue_already_claimed_returns_not_claimed(
     """Label already present, allow_reentry=False → claimed=False."""
     issue_data = {
         "success": True,
+        "state": "open",
         "labels": [{"name": "autoskillit:in-progress"}],
     }
     tool_ctx_kitchen_open.github_client = AsyncMock()
@@ -309,6 +310,7 @@ async def test_claim_issue_reentry_allowed(tool_ctx_kitchen_open) -> None:
     """Label already present, allow_reentry=True → claimed=True, reentry=True."""
     issue_data = {
         "success": True,
+        "state": "open",
         "labels": [{"name": "autoskillit:in-progress"}],
     }
     tool_ctx_kitchen_open.github_client = AsyncMock()
@@ -329,7 +331,7 @@ async def test_claim_issue_reentry_allowed(tool_ctx_kitchen_open) -> None:
 @pytest.mark.anyio
 async def test_claim_issue_success(tool_ctx_kitchen_open) -> None:
     """Label not present → applies label, claimed=True."""
-    issue_data = {"success": True, "labels": []}
+    issue_data = {"success": True, "state": "open", "labels": []}
     tool_ctx_kitchen_open.github_client = AsyncMock()
     tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(return_value=issue_data)
     tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(return_value={"success": True})

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -42,6 +42,7 @@ class TestClaimIssueWhitelist:
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {
             "success": True,
+            "state": "open",
             "labels": [],
         }
         mock_client.ensure_label.return_value = {"success": True, "created": True}
@@ -63,7 +64,7 @@ class TestClaimIssueWhitelist:
         """claim_issue with empty allowed_labels proceeds without restriction."""
         tool_ctx_kitchen_open.config.github.allowed_labels = []
         mock_client = AsyncMock()
-        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.fetch_issue.return_value = {"success": True, "state": "open", "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["any-label"]}
         monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
@@ -81,7 +82,7 @@ class TestClaimIssueWhitelist:
         """claim_issue with label=queued succeeds when allowed_labels defaults to empty."""
         tool_ctx_kitchen_open.config.github.allowed_labels = []
         mock_client = AsyncMock()
-        mock_client.fetch_issue.return_value = {"success": True, "labels": []}
+        mock_client.fetch_issue.return_value = {"success": True, "state": "open", "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
         mock_client.swap_labels.return_value = {"success": True, "labels": ["queued"]}
         monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -9,8 +9,8 @@ import pytest
 
 from autoskillit.core import ValidatedAddDir
 from autoskillit.workspace.session_skills import (
-    CODEX_SKILLS_SUBDIR,
     _SKILLS_SUBDIR,
+    CODEX_SKILLS_SUBDIR,
 )
 
 pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
@@ -29,16 +29,18 @@ def codex_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     backend = MagicMock()
     backend.name = "codex"
 
-    return type("CodexEnv", (), {
-        "fake_home": fake_home,
-        "codex_dir": codex_dir,
-        "backend": backend,
-    })()
+    return type(
+        "CodexEnv",
+        (),
+        {
+            "fake_home": fake_home,
+            "codex_dir": codex_dir,
+            "backend": backend,
+        },
+    )()
 
 
-def test_codex_init_session_creates_skills_subdir(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_creates_skills_subdir(make_session_skill_manager, codex_env) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
     skill_files = list((session_path / CODEX_SKILLS_SUBDIR).glob("*/SKILL.md"))
@@ -46,9 +48,7 @@ def test_codex_init_session_creates_skills_subdir(
     assert not (session_path / _SKILLS_SUBDIR).exists()
 
 
-def test_codex_init_session_copies_config_toml(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_copies_config_toml(make_session_skill_manager, codex_env) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
     copied = session_path / "config.toml"
@@ -56,9 +56,7 @@ def test_codex_init_session_copies_config_toml(
     assert copied.read_text() == "[codex]\nmodel = 'o3'\n"
 
 
-def test_codex_init_session_copies_auth_json(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_copies_auth_json(make_session_skill_manager, codex_env) -> None:
     (codex_env.codex_dir / "auth.json").write_text('{"token": "test"}')
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
@@ -67,9 +65,7 @@ def test_codex_init_session_copies_auth_json(
     assert copied.read_text() == '{"token": "test"}'
 
 
-def test_codex_init_session_copies_env_if_present(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_copies_env_if_present(make_session_skill_manager, codex_env) -> None:
     (codex_env.codex_dir / ".env").write_text("API_KEY=secret\n")
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
@@ -78,9 +74,7 @@ def test_codex_init_session_copies_env_if_present(
     assert copied.read_text() == "API_KEY=secret\n"
 
 
-def test_codex_init_session_skips_env_if_absent(
-    make_session_skill_manager, codex_env
-) -> None:
+def test_codex_init_session_skips_env_if_absent(make_session_skill_manager, codex_env) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
     assert not (session_path / ".env").exists()


### PR DESCRIPTION
## Summary

The issue claiming system operates purely on label presence without ever checking or enforcing that the underlying GitHub issue is `open`. Combined with LLM-discretionary `Closes #N` injection in compose-pr, this creates a four-link failure chain where merged work can be re-dispatched indefinitely. The architectural solution introduces a **state guard at the claim boundary**, structural `Closes #N` enforcement in recipe `skill_command` templates, a zero-change circuit breaker with issue closure, and modified `release_issue` to support closing issues — making the entire class of "re-dispatch already-done work" bugs impossible at three independent layers.

Closes #3012

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_claim_state_immunity_2026-05-25_202500.md`

## Changed Files

### New (★):
- `tests/contracts/test_fetch_issue_mock_contracts.py`
- `tests/contracts/test_zero_change_circuit_breaker_contracts.py`

### Modified (●):
- `src/autoskillit/server/tools/tools_issue_composite.py`
- `src/autoskillit/server/tools/tools_issue_labels.py`
- `src/autoskillit/smoke_utils.py`
- `src/autoskillit/execution/github.py`
- `src/autoskillit/core/types/_type_protocols_github.py`
- `src/autoskillit/recipes/implementation.yaml`
- `src/autoskillit/recipes/remediation.yaml`
- `src/autoskillit/recipe/rules/rules_tools.py`
- `src/autoskillit/recipe/skill_contracts.yaml`
- `tests/server/test_claim_liveness.py`
- `tests/server/test_release_issue_fail_label.py`
- `tests/server/test_tools_bootstrap.py`
- `tests/server/test_tools_integrations.py`
- `tests/server/test_tools_issue_lifecycle.py`
- `tests/server/test_tools_label_validation.py`
- `tests/contracts/test_prepare_compose_pr_contracts.py`
- `tests/cli/test_doctor_backend_guards.py`
- `tests/cli/test_init_helpers.py`
- `tests/config/test_agent_backend_config.py`
- `tests/execution/test_process_channel_b.py`
- `tests/fleet/test_api.py`
- `tests/workspace/test_session_skills_codex.py`
- `tests/contracts/CLAUDE.md`
- `src/autoskillit/recipes/implementation.json`
- `src/autoskillit/recipes/remediation.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 2.3k | 25.5k | 2.4M | 120.0k | 301 | 94.6k | 25m 49s |
| dry_walkthrough | claude-opus-4-6 | 1 | 43 | 10.7k | 1.4M | 68.1k | 113 | 53.4k | 5m 26s |
| implement | claude-sonnet-4-6 | 1 | 478 | 41.5k | 5.7M | 136.2k | 316 | 122.0k | 30m 36s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 101.2k | 4.7k | 177.5k | 25.8k | 22 | 15.5k | 1m 29s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 99.2k | 2.2k | 203.2k | 25.8k | 23 | 15.1k | 56s |
| review_pr | claude-sonnet-4-6 | 1 | 158 | 20.7k | 727.4k | 51.3k | 59 | 46.1k | 5m 49s |
| resolve_review | claude-sonnet-4-6 | 1 | 271 | 23.5k | 2.1M | 90.7k | 116 | 76.2k | 14m 28s |
| **Total** | | | 203.7k | 128.9k | 12.7M | 136.2k | | 422.9k | 1h 24m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 550 | 10293.1 | 221.8 | 75.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **550** | 23027.5 | 768.9 | 234.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.2k | 111.2k | 10.9M | 338.9k | 1h 16m |
| claude-opus-4-6 | 1 | 43 | 10.7k | 1.4M | 53.4k | 5m 26s |
| MiniMax-M2.7-highspeed | 2 | 200.4k | 6.9k | 380.7k | 30.6k | 2m 24s |