### PR TITLE
PY7 P7-A12-WP1 — Define TestCodexBuildFoodTruckCmd

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -129,7 +129,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_claude_session_locator.py` | Tests for ClaudeSessionLocator |
 | `test_claude_stream_parser.py` | Tests for ClaudeStreamParser |
 | `test_backend_registry.py` | Tests for backend registry |
-| `test_codex_backend.py` | Tests for CodexFlags, CodexBackend protocol conformance, headless/resume command builders, skill session cmd config adapter |
+| `test_codex_backend.py` | Tests for CodexFlags, CodexBackend protocol conformance, headless/resume command builders, skill session cmd config adapter, food truck cmd builder |
 | `test_codex_interactive.py` | Parametrized structural validation of CodexBackend.build_interactive_cmd — resume variants, model, system_prompt suppression, add_dirs |
 | `test_codex_session_locator.py` | Tests for CodexSessionLocator: locate_session walk, read_session decompression, env/codex_home priority, protocol conformance |
 | `test_codex_env_policy.py` | Tests for CodexEnvPolicy three-layer scrub |

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -7,6 +7,9 @@ import pytest
 
 from autoskillit.core import (
     AGENT_BACKEND_CODEX,
+    CAMPAIGN_ID_ENV_VAR,
+    KITCHEN_SESSION_ID_ENV_VAR,
+    SESSION_TYPE_ORCHESTRATOR,
     SESSION_TYPE_SKILL,
     BackendCapabilities,
     CmdSpec,
@@ -709,3 +712,148 @@ class TestCodexBuildSkillSessionCmdAgentBackend:
         monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
         spec = CodexBackend().build_skill_session_cmd(**self.BASE)
         assert spec.env["AUTOSKILLIT_AGENT_BACKEND"] == "codex"
+
+
+class TestCodexBuildFoodTruckCmd:
+    BASE: dict[str, object] = {
+        "orchestrator_prompt": "dispatch the work",
+        "plugin_source": DirectInstall(plugin_dir=Path("/pkg")),
+        "cwd": "/work",
+        "completion_marker": "%%DONE%%",
+    }
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+        monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+    # --- Structural / flag tests (non-resume) ---
+
+    def test_cmd_0_is_codex(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.cmd[0] == "codex"
+
+    def test_cmd_1_is_exec(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.cmd[1] == "exec"
+
+    def test_json_flag_present(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "--json" in spec.cmd
+
+    def test_sandbox_read_only(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "--sandbox" in spec.cmd
+        idx = spec.cmd.index("--sandbox")
+        assert spec.cmd[idx + 1] == "read-only"
+
+    def test_config_override_web_search_disabled(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "-c" in spec.cmd
+        idx = spec.cmd.index("-c")
+        assert spec.cmd[idx + 1] == "web_search=disabled"
+
+    def test_approval_never(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "-a" in spec.cmd
+        idx = spec.cmd.index("-a")
+        assert spec.cmd[idx + 1] == "never"
+
+    def test_no_add_dir_flag(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "--add-dir" not in spec.cmd
+
+    def test_no_plugin_dir_flag(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "--plugin-dir" not in spec.cmd
+
+    def test_prompt_is_last_token(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "dispatch the work" in spec.cmd[-1]
+
+    def test_returns_cmdspec_with_tuple_cmd(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert isinstance(spec, CmdSpec)
+        assert isinstance(spec.cmd, tuple)
+
+    # --- Env var tests ---
+
+    def test_headless_env_set(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_HEADLESS"] == "1"
+
+    def test_session_type_orchestrator(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_SESSION_TYPE"] == SESSION_TYPE_ORCHESTRATOR
+
+    def test_campaign_id_present_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_ID", "camp-123")
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.env[CAMPAIGN_ID_ENV_VAR] == "camp-123"
+
+    def test_campaign_id_absent_when_not_set(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert CAMPAIGN_ID_ENV_VAR not in spec.env
+
+    def test_kitchen_session_id_present_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_KITCHEN_SESSION_ID", "ks-456")
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.env[KITCHEN_SESSION_ID_ENV_VAR] == "ks-456"
+
+    def test_kitchen_session_id_absent_when_not_set(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert KITCHEN_SESSION_ID_ENV_VAR not in spec.env
+
+    def test_completion_marker_env_set(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_COMPLETION_MARKER"] == "%%DONE%%"
+
+    def test_provider_profile_absent(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "AUTOSKILLIT_PROVIDER_PROFILE" not in spec.env
+
+    # --- Resume path tests ---
+
+    def test_resume_subcommand_present(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(
+            **{**self.BASE, "resume_session_id": "sess-abc"},
+        )
+        assert "resume" in spec.cmd
+
+    def test_resume_session_id_follows_resume(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(
+            **{**self.BASE, "resume_session_id": "sess-abc"},
+        )
+        idx = spec.cmd.index("resume")
+        assert spec.cmd[idx + 1] == "sess-abc"
+
+    def test_resume_prompt_is_last(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(
+            **{**self.BASE, "resume_session_id": "sess-abc"},
+        )
+        assert "dispatch the work" in spec.cmd[-1]
+
+    def test_resume_json_flag_present(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(
+            **{**self.BASE, "resume_session_id": "sess-abc"},
+        )
+        assert "--json" in spec.cmd
+
+    def test_resume_cmd_structure(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(
+            **{**self.BASE, "resume_session_id": "sess-abc"},
+        )
+        assert spec.cmd[0] == "codex"
+        assert spec.cmd[1] == "exec"
+        assert "--json" in spec.cmd
+        resume_idx = spec.cmd.index("resume")
+        assert spec.cmd[resume_idx + 1] == "sess-abc"
+        assert "dispatch the work" in spec.cmd[-1]
+
+    def test_no_resume_when_none(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "resume" not in spec.cmd
+
+    def test_non_resume_json_present(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "--json" in spec.cmd


### PR DESCRIPTION
## Summary

Add a `TestCodexBuildFoodTruckCmd` test class to `tests/execution/backends/test_codex_backend.py` that validates the command structure, environment variables, flag presence/absence, and resume-path behavior of `CodexBackend.build_food_truck_cmd`. The class uses a `BASE` class-attribute dict for required kwargs, an autouse `_clean_env` fixture to strip campaign/kitchen env vars, and ~20 focused test methods covering structural assertions, env var injection, and resume subcommand placement.

## Requirements

**Goal**

Define TestCodexBuildFoodTruckCmd with BASE fixture, _clean_env, and structural/flag tests for build_food_truck_cmd.

**Context**

- Phase: Codex Food Truck and Per-Step Backend Mixing (Milestone: 7-codex-food-truck-and-per-step-backend-mixing)
- Assignment: P7-A12 (Add unit tests for CodexBackend.build_food_truck_cmd command structure (sandbox read-only, web_search disabled, env vars, resume subcommand path))
- Depends on: P7-A3-WP1
- Depended on by: P8-A6-WP1

**Deliverables**

- `TestCodexBuildFoodTruckCmd class with BASE fixture, _clean_env, and structural tests`
- `tests/execution/backends/test_codex_backend.py — env var test methods in TestCodexBuildFoodTruckCmd`
- `tests/execution/backends/test_codex_backend.py — resume-path test methods in TestCodexBuildFoodTruckCmd`

**Acceptance Criteria**

- spec.cmd[0] == 'codex'
- spec.cmd[1] == 'exec'
- '--json' in spec.cmd
- '--sandbox' followed by 'read-only'
- '-c' followed by 'web_search=disabled'
- '-a' followed by 'never'
- '--add-dir' not in spec.cmd
- '--plugin-dir' not in spec.cmd
- prompt is last token
- isinstance(spec, CmdSpec)
- isinstance(spec.cmd, tuple)
- AUTOSKILLIT_HEADLESS == '1'
- AUTOSKILLIT_SESSION_TYPE == SESSION_TYPE_ORCHESTRATOR
- CAMPAIGN_ID present/absent based on env
- KITCHEN_SESSION_ID present/absent based on env
- AUTOSKILLIT_COMPLETION_MARKER set correctly
- AUTOSKILLIT_PROVIDER_PROFILE absent when not supplied
- 'resume' present when resume_session_id supplied
- session_id follows 'resume'
- '--json' always present
- 'resume' absent when resume_session_id is None

Closes #2906

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-222057-105440/.autoskillit/temp/make-plan/py7_p7_a12_wp1_plan_2026-05-25_222500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 62 | 13.0k | 1.7M | 97.9k | 139 | 73.4k | 12m 31s |
| verify | claude-sonnet-4-6 | 1 | 148 | 11.1k | 815.8k | 59.9k | 49 | 45.6k | 3m 37s |
| implement* | MiniMax-M2.7-highspeed | 1 | 562.5k | 6.3k | 589.8k | 25.8k | 53 | 16.1k | 2m 36s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 72.2k | 3.9k | 208.6k | 31.1k | 23 | 23.9k | 1m 25s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 58.9k | 1.9k | 203.3k | 25.8k | 16 | 15.2k | 53s |
| review_pr | claude-sonnet-4-6 | 1 | 164 | 37.7k | 961.8k | 81.6k | 58 | 68.1k | 7m 54s |
| resolve_review | claude-sonnet-4-6 | 1 | 267 | 16.5k | 1.7M | 69.2k | 74 | 55.2k | 6m 19s |
| **Total** | | | 694.2k | 90.4k | 6.2M | 97.9k | | 297.4k | 35m 16s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 150 | 3931.9 | 107.2 | 41.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **150** | 41217.1 | 1982.7 | 602.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 641 | 78.3k | 5.2M | 242.3k | 30m 22s |
| MiniMax-M2.7-highspeed | 3 | 693.5k | 12.2k | 1.0M | 55.1k | 4m 53s |