### PR TITLE
PY4 P4-A2-WP1 — Prevent skill_load_guard.py from Deadlocking Codex Sessions

### DIFF
--- a/src/autoskillit/hooks/guards/CLAUDE.md
+++ b/src/autoskillit/hooks/guards/CLAUDE.md
@@ -26,7 +26,7 @@ PreToolUse guard scripts — standalone Python processes enforcing tool-call pol
 | `skill_cmd_guard.py` | Validates `skill_command` path argument format |
 | `skill_command_guard.py` | Blocks `run_skill` with non-slash `skill_command` |
 | `unsafe_install_guard.py` | Blocks `pip install -e` targeting system Python |
-| `skill_load_guard.py` | Denies native tools until Skill tool is called in non-Anthropic headless skill sessions; exempts subagents via `agent_id` |
+| `skill_load_guard.py` | Denies native tools until Skill tool is called in non-Anthropic headless skill sessions; bypasses for Codex backend (`AUTOSKILLIT_AGENT_BACKEND=codex`) and subagents (`agent_id`) |
 | `write_guard.py` | Blocks Write/Edit/Bash/apply_patch outside allowed prefix in write-scoped sessions |
 
 ## Architecture Notes

--- a/src/autoskillit/hooks/guards/skill_load_guard.py
+++ b/src/autoskillit/hooks/guards/skill_load_guard.py
@@ -9,6 +9,11 @@ When gated, checks for ``.autoskillit/temp/skill_guard_{session_id}.flag``.
 If absent, denies with a directive message instructing the model to call
 the Skill tool first.
 
+Bypass conditions (early-exit before the gate):
+- ``agent_id`` present in hook payload — subagent exemption
+- ``AUTOSKILLIT_AGENT_BACKEND == "codex"`` (case-insensitive) — Codex backends
+  cannot respond to Skill tool directives and would deadlock
+
 Known limitation: when the model invokes Skill + native tools in a single
 parallel message, the native tools fire PreToolUse before the Skill PostToolUse
 writes the flag. This costs one wasted turn but self-resolves on the next turn.
@@ -92,6 +97,10 @@ def main() -> None:
         sys.exit(0)
 
     if data.get("agent_id"):
+        sys.exit(0)
+
+    backend = os.environ.get("AUTOSKILLIT_AGENT_BACKEND", "").strip()
+    if backend.casefold() == "codex":
         sys.exit(0)
 
     profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE", "").strip()

--- a/tests/infra/test_skill_load_guard.py
+++ b/tests/infra/test_skill_load_guard.py
@@ -23,6 +23,7 @@ def _run_guard(
     provider_profile: str | None = None,
     headless: bool = False,
     session_type: str | None = None,
+    agent_backend: str | None = None,
 ) -> str:
     """Run skill_load_guard.main(), return stdout."""
     from autoskillit.hooks.guards.skill_load_guard import main
@@ -46,6 +47,11 @@ def _run_guard(
         env_updates["AUTOSKILLIT_SESSION_TYPE"] = session_type
     else:
         env_removals.append("AUTOSKILLIT_SESSION_TYPE")
+
+    if agent_backend is not None:
+        env_updates["AUTOSKILLIT_AGENT_BACKEND"] = agent_backend
+    else:
+        env_removals.append("AUTOSKILLIT_AGENT_BACKEND")
 
     base_env = {k: v for k, v in os.environ.items() if k not in env_removals}
     base_env.update(env_updates)
@@ -310,3 +316,58 @@ def test_guard_records_denial_when_below_threshold(tmp_path):
     deny_dir = tmp_path / ".autoskillit" / "temp" / f"skill_guard_{session_id}_denials"
     assert deny_dir.exists()
     assert len(list(deny_dir.iterdir())) == 1
+
+
+def test_codex_backend_early_exit(tmp_path):
+    """T2-17: Codex backend triggers early exit even when all denial conditions are met."""
+    out = _run_guard(
+        _make_event("Read"),
+        tmp_dir=tmp_path,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+        agent_backend="codex",
+    )
+    assert not out.strip()
+
+
+@pytest.mark.parametrize("provider_profile", ["minimax", "anthropic", "", None])
+def test_codex_backend_ignores_provider_profile(tmp_path, provider_profile):
+    """T2-18: Codex bypass fires regardless of provider profile value."""
+    out = _run_guard(
+        _make_event("Read"),
+        tmp_dir=tmp_path,
+        provider_profile=provider_profile,
+        headless=True,
+        session_type="skill",
+        agent_backend="codex",
+    )
+    assert not out.strip()
+
+
+def test_non_codex_backend_still_denies(tmp_path):
+    """T2-19: claude-code backend does NOT trigger early exit - deny proceeds."""
+    out = _run_guard(
+        _make_event("Read"),
+        tmp_dir=tmp_path,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+        agent_backend="claude-code",
+    )
+    response = json.loads(out)
+    assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_absent_backend_still_denies(tmp_path):
+    """T2-20: Missing AUTOSKILLIT_AGENT_BACKEND does NOT trigger early exit."""
+    out = _run_guard(
+        _make_event("Read"),
+        tmp_dir=tmp_path,
+        provider_profile="minimax",
+        headless=True,
+        session_type="skill",
+        agent_backend=None,
+    )
+    response = json.loads(out)
+    assert response["hookSpecificOutput"]["permissionDecision"] == "deny"


### PR DESCRIPTION
## Summary

Insert an `AUTOSKILLIT_AGENT_BACKEND == 'codex'` early-exit in `skill_load_guard.py`'s `main()` immediately after the `agent_id` subagent check and before the `AUTOSKILLIT_PROVIDER_PROFILE` gate. This prevents the guard from entering its deny loop for Codex sessions, which cannot respond to `Skill` tool directives and would deadlock. Update the module docstring with a "Bypass conditions" section, extend the `_run_guard` test helper with an `agent_backend` parameter, and add four new test cases (T2-17 through T2-20) covering the Codex bypass.

**Correction from issue:** The issue prescribes test IDs T2-15 through T2-18, but T2-15 and T2-16 are already occupied by `test_guard_auto_exempts_after_deny_count_threshold` and `test_guard_records_denial_when_below_threshold`. This plan renumbers the new tests to T2-17 through T2-20 to avoid collision.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.



Closes #2875

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-222038-603552/.autoskillit/temp/make-plan/PY4_P4-A2-WP1_prevent_skill_load_guard_codex_deadlock_plan_2026-05-25_222600.md`

## Changed Files

### Modified (●):
- ● `src/autoskillit/hooks/guards/CLAUDE.md`
- ● `src/autoskillit/hooks/guards/skill_load_guard.py`
- ● `tests/infra/test_skill_load_guard.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 107 | 10.1k | 656.8k | 79.6k | 69 | 68.9k | 5m 25s |
| verify | claude-sonnet-4-6 | 1 | 84 | 6.8k | 406.8k | 55.2k | 32 | 41.0k | 2m 15s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.8M | 21.0k | 1.4M | 25.8k | 112 | 38.8k | 10m 34s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 69.3k | 3.1k | 177.5k | 25.8k | 18 | 15.5k | 1m 5s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 86.6k | 2.0k | 229.1k | 25.8k | 18 | 15.2k | 60s |
| review_pr | claude-sonnet-4-6 | 3 | 464 | 77.8k | 2.3M | 67.6k | 153 | 156.9k | 17m 47s |
| **Total** | | | 1.9M | 120.8k | 5.2M | 79.6k | | 336.4k | 38m 7s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 72 | 18968.1 | 539.5 | 291.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **72** | 71737.1 | 4672.1 | 1677.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 655 | 94.7k | 3.4M | 266.8k | 25m 27s |
| MiniMax-M2.7-highspeed | 3 | 1.9M | 26.1k | 1.8M | 69.6k | 12m 39s |