### PR TITLE
PY7 P7-A15-WP1: Verify run_skill() Backend Override Derivation for Codex-Backend Contexts

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -33,6 +33,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_github_api_tracking_http.py` | GitHub API tracking HTTP tests |
 | `test_github_headers.py` | Tests for the shared github_headers helper and its adoption by all three classes |
 | `test_headless_add_dirs.py` | Tests for run_headless_core multi-path --add-dir support (T-OVR-012..013) |
+| `test_headless_backend_mixing.py` | Integration tests for per-step backend mixing — Codex ctx.backend bypassed when backend_override='claude-code', CmdSpec env verification, DefaultHeadlessExecutor end-to-end |
 | `test_headless_backend_resolution.py` | Tests for _resolve_pty_mode and _resolve_session_log_dir capability-driven helpers |
 | `test_headless_backend_override.py` | Tests verifying run_headless_core delegates build_skill_session_cmd, env policy, and stream_parser to the backend resolved from backend_override |
 | `test_headless_core.py` | Tests for headless_runner.py extracted helpers |

--- a/tests/execution/test_headless_backend_mixing.py
+++ b/tests/execution/test_headless_backend_mixing.py
@@ -1,0 +1,188 @@
+"""Integration tests for per-step backend mixing in the execution layer.
+
+Verifies that when backend_override='claude-code' is active, the Codex ctx.backend
+is bypassed and ClaudeCodeBackend handles command construction and env policy.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autoskillit.core.types import (
+    CmdSpec,
+    RetryReason,
+    SkillResult,
+    SubprocessResult,
+    TerminationReason,
+)
+
+from .conftest import _mock_backend
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def _stub_result() -> SkillResult:
+    return SkillResult(
+        success=True,
+        result="",
+        session_id="test-session",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+    )
+
+
+class TestBackendMixingCommandRouting:
+    """Codex ctx.backend bypassed when backend_override='claude-code'."""
+
+    @pytest.mark.anyio
+    async def test_codex_ctx_backend_not_called_when_override_claude_code(self, minimal_ctx):
+        codex_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_backend.name = "codex"
+        minimal_ctx.backend = codex_backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        claude_code_backend = _mock_backend()
+        claude_code_backend.name = "claude-code"
+
+        with (
+            patch(
+                "autoskillit.execution.headless.get_backend",
+                return_value=claude_code_backend,
+            ),
+            patch(
+                "autoskillit.execution.headless._execute_claude_headless",
+            ) as mock_exec,
+        ):
+            mock_exec.return_value = _stub_result()
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="claude-code",
+            )
+
+            claude_code_backend.build_skill_session_cmd.assert_called_once()
+            codex_backend.build_skill_session_cmd.assert_not_called()
+
+
+class TestBackendMixingEnvPolicy:
+    """CmdSpec.env from override backend contains ANTHROPIC_BASE_URL."""
+
+    @pytest.mark.anyio
+    async def test_override_cmd_spec_env_contains_anthropic_base_url(self, minimal_ctx):
+        codex_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_backend.name = "codex"
+        minimal_ctx.backend = codex_backend
+
+        claude_code_backend = _mock_backend()
+        claude_code_backend.name = "claude-code"
+        claude_code_backend.build_skill_session_cmd.return_value = CmdSpec(
+            cmd=("claude", "--print", "test-skill"),
+            env={
+                "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1/anthropic",
+                "ANTHROPIC_API_KEY": "minimax-key",
+                "AUTOSKILLIT_HEADLESS": "1",
+            },
+        )
+
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        captured_spec = None
+
+        async def capture_exec(spec, *args, **kwargs):
+            nonlocal captured_spec
+            captured_spec = spec
+            return _stub_result()
+
+        with (
+            patch(
+                "autoskillit.execution.headless.get_backend",
+                return_value=claude_code_backend,
+            ),
+            patch(
+                "autoskillit.execution.headless._execute_claude_headless",
+                side_effect=capture_exec,
+            ),
+        ):
+            from autoskillit.execution.headless import run_headless_core
+
+            await run_headless_core(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                minimal_ctx,
+                completion_marker="%%DONE%%",
+                backend_override="claude-code",
+            )
+
+        assert captured_spec is not None
+        assert captured_spec.env["ANTHROPIC_BASE_URL"] == ("https://api.minimax.chat/v1/anthropic")
+
+
+class TestDefaultExecutorBackendMixing:
+    """DefaultHeadlessExecutor.run() end-to-end with backend_override."""
+
+    @pytest.mark.anyio
+    async def test_default_executor_end_to_end_backend_override(self, minimal_ctx):
+        codex_backend = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_backend.name = "codex"
+        minimal_ctx.backend = codex_backend
+        minimal_ctx.runner = AsyncMock(
+            return_value=SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+
+        claude_code_backend = _mock_backend()
+        claude_code_backend.name = "claude-code"
+
+        with (
+            patch(
+                "autoskillit.execution.headless.get_backend",
+                return_value=claude_code_backend,
+            ) as mock_get_backend,
+            patch(
+                "autoskillit.execution.headless._execute_claude_headless",
+            ) as mock_exec,
+        ):
+            mock_exec.return_value = _stub_result()
+            from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+            executor = DefaultHeadlessExecutor(minimal_ctx)
+            await executor.run(
+                "/autoskillit:test",
+                "/tmp/cwd",
+                backend_override="claude-code",
+            )
+
+            mock_get_backend.assert_called_once_with("claude-code")
+            claude_code_backend.build_skill_session_cmd.assert_called_once()
+            codex_backend.build_skill_session_cmd.assert_not_called()

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -67,6 +67,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_execution_results.py` | Tests for run_skill result shapes, failure paths, timing, flush telemetry, and gate checks |
 | `test_tools_execution_routing.py` | Tests for run_skill routing, executor delegation, and session skill management |
 | `test_tools_execution_step_resolution.py` | Tests for server-side recipe step parameter resolution in run_skill (output_dir, stale_threshold, idle_output_timeout auto-filled from cached recipe step definitions) |
+| `test_tools_execution_backend_mixing.py` | Integration tests for per-step backend mixing in run_skill() — Codex backend + ANTHROPIC_BASE_URL derives backend_override='claude-code' |
 | `test_tools_execution_write_prefix.py` | Tests for allowed_write_prefix computation decoupled from read_only |
 | `test_tools_git.py` | Tests for merge_worktree core flow: happy path, test gate, rebase abort, bypass prevention |
 | `test_tools_git_branch.py` | Tests for create_unique_branch and check_pr_mergeable tools |

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -1,0 +1,100 @@
+"""Integration tests for per-step backend mixing in run_skill().
+
+Verifies that run_skill() correctly derives backend_override='claude-code'
+when a Codex-primary context dispatches a step through a provider profile
+containing ANTHROPIC_BASE_URL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.server.tools.tools_execution import run_skill
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_codex_backend_minimax_profile_with_anthropic_base_url_derives_override(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """Codex backend + minimax profile with ANTHROPIC_BASE_URL -> backend_override='claude-code'."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    type(fake_backend).name = property(lambda self: "codex")
+    tool_ctx_kitchen_open.backend = fake_backend
+    tool_ctx_kitchen_open.session_skill_manager = None
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: (
+            "minimax",
+            {
+                "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1/anthropic",
+                "ANTHROPIC_API_KEY": "minimax-key-placeholder",
+            },
+        ),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert len(executor.calls) == 1
+    assert captured.get("backend_override") == "claude-code"
+
+
+@pytest.mark.anyio
+async def test_codex_backend_non_anthropic_profile_without_base_url_no_override(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """Codex backend + non-Anthropic profile without ANTHROPIC_BASE_URL -> no override."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    type(fake_backend).name = property(lambda self: "codex")
+    tool_ctx_kitchen_open.backend = fake_backend
+    tool_ctx_kitchen_open.session_skill_manager = None
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: (
+            "minimax",
+            {"BASE_URL": "https://api.minimax.chat/v1"},
+        ),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert len(executor.calls) == 1
+    assert "backend_override" in captured
+    assert captured["backend_override"] is None


### PR DESCRIPTION
## Summary

Add two new test files verifying the per-step backend mixing integration path: when a Codex-primary session dispatches a skill step through a provider profile containing `ANTHROPIC_BASE_URL`, `run_skill()` derives `backend_override='claude-code'` and the execution layer routes command construction to `ClaudeCodeBackend` instead of the context's Codex backend. No production code is modified. Both `tests/server/CLAUDE.md` and `tests/execution/CLAUDE.md` are updated with entries for the new files.

Closes #2908

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-222110-149933/.autoskillit/temp/make-plan/py7_p7_a15_wp1_plan_2026-05-25_222700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.4k | 21.9k | 1.4M | 107.9k | 211 | 93.0k | 14m 23s |
| verify | claude-sonnet-4-6 | 1 | 100 | 15.3k | 513.7k | 60.0k | 92 | 45.7k | 7m 49s |
| implement* | MiniMax-M2.7-highspeed | 1 | 626.8k | 9.7k | 641.3k | 25.8k | 84 | 46.9k | 5m 39s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 75.8k | 3.9k | 177.5k | 25.8k | 21 | 15.4k | 1m 28s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 48.5k | 1.5k | 177.5k | 25.8k | 15 | 15.2k | 49s |
| review_pr | claude-sonnet-4-6 | 2 | 324 | 72.6k | 1.7M | 82.1k | 100 | 128.6k | 15m 46s |
| resolve_review | claude-sonnet-4-6 | 2 | 928 | 72.4k | 9.8M | 134.7k | 276 | 188.2k | 36m 6s |
| **Total** | | | 755.8k | 197.3k | 14.4M | 134.7k | | 533.0k | 1h 22m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 290 | 2211.4 | 161.6 | 33.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **290** | 49819.2 | 1837.9 | 680.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 4.7k | 182.3k | 13.5M | 455.4k | 1h 14m |
| MiniMax-M2.7-highspeed | 3 | 751.1k | 15.1k | 996.3k | 77.5k | 7m 56s |