### PR TITLE
PY4 P4-A6-WP1: Annotate Every HookDef Entry with Codex Compatibility Status

### DIFF
--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -35,8 +35,46 @@ class HookDef:
             )
 
 
+# ---------------------------------------------------------------------------
+# Codex Compatibility Table
+#
+# Status values:
+#   works-as-is    — Hook works correctly under Codex without changes.
+#   degraded       — Hook runs but with reduced functionality under Codex.
+#   fix-required   — Hook needs code changes for Codex compatibility.
+#   not-applicable — Hook targets a tool/event that Codex does not support.
+#
+# Hook (primary script)                  | Status
+# ---------------------------------------|----------------
+# skill_cmd_guard (+ quota, skill_cmd)   | works-as-is
+# remove_clone_guard                     | works-as-is
+# open_kitchen_guard                     | works-as-is
+# ask_user_question_guard                | not-applicable
+# branch_protection_guard (merge)        | works-as-is
+# branch_protection_guard (push)         | works-as-is
+# unsafe_install_guard                   | works-as-is
+# pr_create_guard                        | works-as-is
+# planner_gh_discovery_guard             | works-as-is
+# generated_file_write_guard             | works-as-is
+# write_guard                            | fix-required
+# planner_result_naming_guard            | works-as-is
+# recipe_write_advisor                   | works-as-is
+# grep_pattern_lint_guard               | not-applicable
+# mcp_health_advisor                     | degraded
+# skill_orchestration_guard              | works-as-is
+# fleet_dispatch_guard (+ resume_own.)   | works-as-is
+# pretty_output_hook                     | works-as-is
+# token_summary_hook (+ quota_post)       | works-as-is
+# review_gate_post_hook                  | works-as-is
+# lint_after_edit_hook                   | degraded
+# skill_load_post_hook                   | not-applicable
+# skill_load_guard                       | fix-required
+# review_loop_gate                       | works-as-is
+# session_start_hook                     | works-as-is
+# ---------------------------------------------------------------------------
+
 HOOK_REGISTRY: list[HookDef] = [
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher="mcp__.*autoskillit.*__run_skill.*",
         scripts=[
             "guards/skill_cmd_guard.py",
@@ -44,34 +82,34 @@ HOOK_REGISTRY: list[HookDef] = [
             "guards/skill_command_guard.py",
         ],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher="mcp__.*autoskillit.*__remove_clone",
         scripts=["guards/remove_clone_guard.py"],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"mcp__.*autoskillit.*__open_kitchen.*",
         scripts=["guards/open_kitchen_guard.py"],
         timeout_seconds=5,
     ),
-    HookDef(
+    HookDef(  # codex: not-applicable
         matcher="AskUserQuestion",
         scripts=["guards/ask_user_question_guard.py"],
         timeout_seconds=5,
         session_scope="headless_only",
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"mcp__.*autoskillit.*__merge_worktree",
         scripts=["guards/branch_protection_guard.py"],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"mcp__.*autoskillit.*__push_to_remote",
         scripts=["guards/branch_protection_guard.py"],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"Bash|mcp__.*autoskillit.*__run_cmd",
         scripts=["guards/unsafe_install_guard.py"],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"Bash|mcp__.*autoskillit.*__run_cmd",
         scripts=["guards/pr_create_guard.py"],
         # Must stay in sync with _EXEMPT_SKILLS in guards/pr_create_guard.py —
@@ -89,85 +127,85 @@ HOOK_REGISTRY: list[HookDef] = [
         # stdlib-only boundary on hook scripts prevents a shared import.
         exempt_session_types=frozenset({"orchestrator"}),
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"Bash|mcp__.*autoskillit.*__run_cmd",
         scripts=["guards/planner_gh_discovery_guard.py"],
         session_scope="headless_only",
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"Write|Edit",
         scripts=["guards/generated_file_write_guard.py"],
     ),
-    HookDef(
+    HookDef(  # codex: fix-required
         matcher=r"Write|Edit|Bash|mcp__.*autoskillit.*__run_cmd",
         scripts=["guards/write_guard.py"],
         session_scope="headless_only",
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"Write|Edit",
         scripts=["guards/planner_result_naming_guard.py"],
         session_scope="headless_only",
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"Write|Edit",
         scripts=["guards/recipe_write_advisor.py"],
         session_scope="interactive_only",
     ),
-    HookDef(
+    HookDef(  # codex: not-applicable
         matcher=r"Grep",
         scripts=["guards/grep_pattern_lint_guard.py"],
     ),
-    HookDef(
+    HookDef(  # codex: degraded
         matcher=r"Bash|Write|Edit|Read|Glob|Grep",
         scripts=["guards/mcp_health_advisor.py"],
         timeout_seconds=5,
         session_scope="interactive_only",
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"mcp__.*autoskillit.*__(run_skill|run_cmd|run_python).*",
         scripts=["guards/skill_orchestration_guard.py"],
         session_scope="headless_only",
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"(mcp__.*autoskillit.*__)?dispatch_food_truck",
         scripts=["guards/fleet_dispatch_guard.py", "guards/resume_ownership_guard.py"],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         event_type="PostToolUse",
         matcher="mcp__.*autoskillit.*",
         scripts=["formatters/pretty_output_hook.py"],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         event_type="PostToolUse",
         matcher=r"mcp__.*autoskillit.*__run_skill.*",
         scripts=["token_summary_hook.py", "quota_post_hook.py"],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         event_type="PostToolUse",
         matcher=r"mcp__.*autoskillit.*__(run_skill|run_python).*",
         scripts=["review_gate_post_hook.py"],
     ),
-    HookDef(
+    HookDef(  # codex: degraded
         event_type="PostToolUse",
         matcher=r"Write|Edit",
         scripts=["lint_after_edit_hook.py"],
         session_scope="headless_only",
     ),
-    HookDef(
+    HookDef(  # codex: not-applicable
         event_type="PostToolUse",
         matcher="Skill",
         scripts=["skill_load_post_hook.py"],
     ),
-    HookDef(
+    HookDef(  # codex: fix-required
         matcher=r"Read|Write|Edit|Bash|Grep|Glob",
         scripts=["guards/skill_load_guard.py"],
         session_scope="headless_only",
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         matcher=r"mcp__.*autoskillit.*__(wait_for_ci|enqueue_pr)",
         scripts=["guards/review_loop_gate.py"],
     ),
-    HookDef(
+    HookDef(  # codex: works-as-is
         event_type="SessionStart",
         scripts=["session_start_hook.py"],
         session_scope="interactive_only",

--- a/tests/hooks/test_hook_registry.py
+++ b/tests/hooks/test_hook_registry.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
+
+import pytest
 
 from autoskillit.hook_registry import (
     HOOK_REGISTRY,
@@ -350,3 +353,94 @@ def test_find_broken_hook_scripts_dispatcher_missing(tmp_path: Path) -> None:
     broken = find_broken_hook_scripts(settings)
     assert len(broken) == 1
     assert "_dispatch.py" in broken[0]
+
+
+# ---------------------------------------------------------------------------
+# HR-CODEX: Codex compatibility annotation tests
+# ---------------------------------------------------------------------------
+
+
+# HR-CODEX-1: every HookDef entry must have a # codex: comment
+@pytest.mark.layer("hooks")
+@pytest.mark.small
+def test_hook_registry_has_codex_comments() -> None:
+    """Every HookDef entry in HOOK_REGISTRY must have a '# codex:' trailing comment."""
+    import importlib
+    from pathlib import Path
+
+    source_path = Path(importlib.import_module("autoskillit.hook_registry").__file__)
+    source = source_path.read_text(encoding="utf-8")
+
+    # Count HookDef( occurrences and # codex: occurrences
+    hookdef_lines = [line for line in source.splitlines() if "HookDef(" in line]
+    codex_lines = [line for line in source.splitlines() if "# codex:" in line]
+
+    assert len(hookdef_lines) == len(HOOK_REGISTRY), (
+        f"Expected {len(HOOK_REGISTRY)} HookDef( lines, found {len(hookdef_lines)}"
+    )
+    assert len(codex_lines) == len(HOOK_REGISTRY), (
+        f"Expected {len(HOOK_REGISTRY)} '# codex:' comments, found {len(codex_lines)}"
+    )
+
+    # Every HookDef( line must also contain # codex:
+    missing = [line.strip() for line in hookdef_lines if "# codex:" not in line]
+    assert not missing, f"HookDef lines missing '# codex:' comment: {missing}"
+
+
+# HR-CODEX-2: degraded hook set must match expected
+@pytest.mark.layer("hooks")
+@pytest.mark.small
+def test_degraded_hooks_are_expected() -> None:
+    """The set of hooks with '# codex: degraded' must equal the expected set."""
+    import importlib
+    from pathlib import Path
+
+    source_path = Path(importlib.import_module("autoskillit.hook_registry").__file__)
+    source = source_path.read_text(encoding="utf-8")
+
+    _EXPECTED_DEGRADED = {"lint_after_edit_hook", "mcp_health_advisor"}
+
+    degraded_scripts: set[str] = set()
+    lines = source.splitlines()
+    for i, line in enumerate(lines):
+        if "# codex: degraded" in line:
+            # Scan forward from HookDef( line to find the scripts= list
+            for j in range(i, min(i + 10, len(lines))):
+                if "scripts=" in lines[j]:
+                    # Extract script basenames
+                    for match in re.finditer(r'"([^"]+\.py)"', lines[j]):
+                        script = match.group(1).rsplit("/", 1)[-1].removesuffix(".py")
+                        degraded_scripts.add(script)
+                    break
+
+    assert degraded_scripts == _EXPECTED_DEGRADED, (
+        f"Expected degraded hooks {_EXPECTED_DEGRADED}, found {degraded_scripts}"
+    )
+
+
+# HR-CODEX-3: skill_load_guard.py must reference AUTOSKILLIT_AGENT_BACKEND
+@pytest.mark.layer("hooks")
+@pytest.mark.small
+def test_skill_load_guard_has_codex_bypass() -> None:
+    """skill_load_guard.py must contain AUTOSKILLIT_AGENT_BACKEND for Codex bypass."""
+    import importlib
+    from pathlib import Path
+
+    mod = importlib.import_module("autoskillit.hooks.guards.skill_load_guard")
+    source_path = Path(mod.__file__)
+    source = source_path.read_text(encoding="utf-8")
+    assert "AUTOSKILLIT_AGENT_BACKEND" in source
+
+
+# HR-CODEX-4: write_guard.py must handle apply_patch tool
+@pytest.mark.layer("hooks")
+@pytest.mark.small
+def test_write_guard_handles_apply_patch() -> None:
+    """write_guard.py must contain apply_patch handling for Codex compatibility."""
+    import importlib
+    from pathlib import Path
+
+    mod = importlib.import_module("autoskillit.hooks.guards.write_guard")
+    source_path = Path(mod.__file__)
+    source = source_path.read_text(encoding="utf-8")
+    assert "apply_patch" in source


### PR DESCRIPTION
## Summary

Add a `# codex: <status>` trailing inline comment on the opening `HookDef(` line of each of the 25 entries in `HOOK_REGISTRY`, and insert a module-level docstring block above the list constant that reproduces the complete per-hook Codex compatibility table with a legend. Add four new test functions to `tests/hooks/test_hook_registry.py` that structurally verify the annotations. No HookDef dataclass fields are added; no hash-influencing changes are made (comments are not serialized by `_canonical_registry_payload()`).

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-235308-030488/.autoskillit/temp/make-plan/py4_p4_a6_wp1_annotate_hookdef_codex_plan_2026-05-25_235700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 61 | 9.9k | 812.0k | 106.2k | 116 | 68.7k | 9m 7s |
| verify | claude-sonnet-4-6 | 1 | 100 | 13.6k | 500.4k | 59.8k | 34 | 60.0k | 4m 15s |
| implement* | MiniMax-M2.7-highspeed | 1 | 823.7k | 10.8k | 747.1k | 25.8k | 67 | 38.9k | 11m 32s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 150.8k | 3.9k | 283.5k | 25.8k | 33 | 38.3k | 1m 26s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 46.7k | 1.4k | 177.5k | 25.8k | 17 | 15.1k | 38s |
| review_pr | claude-sonnet-4-6 | 1 | 230 | 34.3k | 1.1M | 73.5k | 59 | 65.2k | 9m 53s |
| resolve_review | claude-sonnet-4-6 | 1 | 50 | 1.9k | 516.1k | 87.1k | 126 | 2.6k | 21m 12s |
| **Total** | | | 1.0M | 75.8k | 4.1M | 106.2k | | 288.8k | 58m 5s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 182 | 4104.8 | 214.0 | 59.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **182** | 22708.3 | 1587.0 | 416.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 441 | 59.7k | 2.9M | 196.4k | 44m 28s |
| MiniMax-M2.7-highspeed | 3 | 1.0M | 16.1k | 1.2M | 92.4k | 13m 36s |