### PR TITLE
PY4 P4-A7-WP1: Verify Codex Init Flow End-to-End

### DIFF
--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -313,6 +313,67 @@ class TestCLIInit:
         )
 
 
+class TestCodexInitFlow:
+    """End-to-end Codex init: config.toml hooks + MCP registration."""
+
+    @pytest.fixture(autouse=True)
+    def _pre_commit_with_scanner(self, tmp_path: Path) -> None:
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos:\n  - repo: dummy\n    hooks:\n      - id: gitleaks\n"
+        )
+
+    @pytest.fixture(autouse=True)
+    def _codex_backend_config(self, tmp_path: Path) -> None:
+        cfg_dir = tmp_path / ".autoskillit"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "config.yaml").write_text(
+            'test_check:\n  command: ["task", "test-all"]\nagent_backend:\n  backend: codex\n'
+        )
+
+    def test_codex_config_toml_hook_entries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import tomllib
+
+        from autoskillit.hook_registry import HOOKS_DIR
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        cli.init(scope="user", test_command="task test-all")
+
+        config_path = tmp_path / ".codex" / "config.toml"
+        assert config_path.exists()
+        data = tomllib.loads(config_path.read_text())
+
+        hooks = data.get("hooks", [])
+        assert len(hooks) > 0
+        hooks_dir_str = str(HOOKS_DIR)
+        hook_commands = [
+            hook.get("command", "") for entry in hooks for hook in entry.get("hooks", [])
+        ]
+        assert any(hooks_dir_str in cmd for cmd in hook_commands)
+        assert data["mcp_servers"]["autoskillit"]["command"] == "autoskillit"
+
+    def test_codex_config_toml_idempotent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import tomllib
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        cli.init(scope="user", test_command="task test-all")
+
+        config_path = tmp_path / ".codex" / "config.toml"
+        first_data = tomllib.loads(config_path.read_text())
+        first_hook_count = len(first_data.get("hooks", []))
+
+        cli.init(scope="user", test_command="task test-all")
+
+        second_data = tomllib.loads(config_path.read_text())
+        second_hook_count = len(second_data.get("hooks", []))
+        assert first_hook_count == second_hook_count
+
+
 class TestEnsureProjectTemp:
     """N5: ensure_project_temp moved from config.py to _io.py."""
 

--- a/tests/execution/backends/test_codex_env_policy.py
+++ b/tests/execution/backends/test_codex_env_policy.py
@@ -103,6 +103,10 @@ class TestCodexEnvPolicy:
         result = policy.build_env(base)
         assert result["AUTOSKILLIT_AGENT_BACKEND"] == "codex"
 
+    @pytest.mark.xfail(
+        reason="Requires P4-A1-WP1 to land: adds AUTOSKILLIT_AGENT_BACKEND to CODEX_ENV_DENYLIST",
+        strict=True,
+    )
     def test_agent_backend_not_in_base_env(self) -> None:
         policy = CodexEnvPolicy()
         base = {"AUTOSKILLIT_AGENT_BACKEND": "codex", "PATH": "/usr/bin"}

--- a/tests/execution/backends/test_codex_env_policy.py
+++ b/tests/execution/backends/test_codex_env_policy.py
@@ -4,7 +4,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS, EnvPolicy
+from autoskillit.core import AGENT_BACKEND_ENV_VAR, AUTOSKILLIT_PRIVATE_ENV_VARS, EnvPolicy
 from autoskillit.execution.backends.codex import CodexEnvPolicy
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -102,3 +102,18 @@ class TestCodexEnvPolicy:
         base = {"AUTOSKILLIT_AGENT_BACKEND": "codex", "PATH": "/usr/bin"}
         result = policy.build_env(base)
         assert result["AUTOSKILLIT_AGENT_BACKEND"] == "codex"
+
+    def test_agent_backend_not_in_base_env(self) -> None:
+        policy = CodexEnvPolicy()
+        base = {"AUTOSKILLIT_AGENT_BACKEND": "codex", "PATH": "/usr/bin"}
+        result = policy.build_env(base)
+        assert "AUTOSKILLIT_AGENT_BACKEND" not in result
+
+    def test_agent_backend_passes_through_extras(self) -> None:
+        policy = CodexEnvPolicy()
+        base = {"PATH": "/usr/bin"}
+        result = policy.build_env(base, extras={"AUTOSKILLIT_AGENT_BACKEND": "codex"})
+        assert result["AUTOSKILLIT_AGENT_BACKEND"] == "codex"
+
+    def test_agent_backend_not_in_private_env_vars(self) -> None:
+        assert AGENT_BACKEND_ENV_VAR not in AUTOSKILLIT_PRIVATE_ENV_VARS


### PR DESCRIPTION
## Summary

Add end-to-end verification tests confirming that `cli.init(scope='user', test_command='task test-all')` with a Codex backend config writes valid `~/.codex/config.toml` with `[[hooks]]` entries and `mcp_servers.autoskillit` registration, and that a second call is idempotent. Add three `CodexEnvPolicy` tests for `AGENT_BACKEND_ENV_VAR` propagation semantics. Verify T2-15 through T2-18 in `test_skill_load_guard.py` and cross-traceability comments from P4-A2.

**Dependencies:** P4-A4-WP1 (merged), P4-A5-WP1 (merged), P4-A1-WP1 (NOT merged — `test_agent_backend_not_in_base_env` will fail until it lands), P4-A2-WP1 (merged).

Closes #2880

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260525-235309-035320/.autoskillit/temp/make-plan/py4_p4-a7-wp1_verify_codex_init_flow_plan_2026-05-25_235500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 304 | 4.0k | 8.7M | 114.7k | 182 | 881.9k | 14m 50s |
| verify | claude-sonnet-4-6 | 1 | 172 | 12.9k | 1.0M | 69.6k | 56 | 69.9k | 4m 13s |
| implement* | MiniMax-M2.7-highspeed | 1 | 701.0k | 5.8k | 692.6k | 25.8k | 57 | 16.0k | 13m 58s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 136.0k | 4.5k | 280.6k | 25.8k | 30 | 15.5k | 1m 50s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 38.9k | 1.3k | 151.7k | 25.8k | 13 | 15.1k | 40s |
| review_pr | claude-sonnet-4-6 | 1 | 166 | 26.8k | 642.6k | 60.6k | 49 | 52.9k | 7m 3s |
| resolve_review | claude-sonnet-4-6 | 1 | 155 | 13.4k | 699.3k | 55.9k | 43 | 48.1k | 8m 25s |
| **Total** | | | 876.7k | 68.7k | 12.2M | 114.7k | | 1.1M | 51m 1s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 78 | 8880.0 | 204.6 | 74.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **78** | 156320.6 | 14093.7 | 880.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 797 | 57.1k | 11.1M | 1.1M | 34m 33s |
| MiniMax-M2.7-highspeed | 3 | 875.9k | 11.7k | 1.1M | 46.6k | 16m 28s |