### PR TITLE
Add Integration Tests for CodexBackend Commands

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -349,7 +349,7 @@ SUBPKG_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
             "smoke_utils",
         }
     ),
-    "backends": frozenset({"execution"}),
+    "backends": frozenset({"execution", "integration"}),
 }
 
 MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {

--- a/tests/integration/test_codex_food_truck.py
+++ b/tests/integration/test_codex_food_truck.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import CmdSpec, DirectInstall
+from autoskillit.execution.backends.codex import CodexBackend
+
+pytestmark = [pytest.mark.small]
+
+
+class TestCodexFoodTruckCommand:
+    BASE: dict[str, object] = {
+        "orchestrator_prompt": "run the plan",
+        "plugin_source": DirectInstall(plugin_dir=Path("/pkg")),
+        "cwd": "/work",
+        "completion_marker": "%%DONE%%",
+    }
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+        monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+    def test_cmd_starts_with_codex(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.cmd[0] == "codex"
+
+    def test_exec_subcommand_at_index_1(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert spec.cmd[1] == "exec"
+
+    def test_json_flag_present(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "--json" in spec.cmd
+
+    def test_sandbox_read_only(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        idx = spec.cmd.index("--sandbox")
+        assert spec.cmd[idx + 1] == "read-only"
+
+    def test_web_search_disabled_flag(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        idx = spec.cmd.index("-c")
+        assert spec.cmd[idx + 1] == "web_search=disabled"
+
+    def test_no_tools_flag(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "--tools" not in spec.cmd
+
+    def test_returns_cmd_spec(self) -> None:
+        result = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert isinstance(result, CmdSpec)

--- a/tests/integration/test_codex_interactive.py
+++ b/tests/integration/test_codex_interactive.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import NamedResume, ValidatedAddDir
+from autoskillit.execution.backends.codex import CodexBackend
+
+pytestmark = [pytest.mark.small]
+
+
+class TestCodexInteractiveLaunch:
+    def test_launch_command_correct_binary(self) -> None:
+        spec = CodexBackend().build_interactive_cmd()
+        assert spec.cmd[0] == "codex"
+
+    def test_resume_command_is_subcommand(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(
+            resume_spec=NamedResume(session_id="sess-1"),
+        )
+        assert "resume" in spec.cmd
+        assert "--resume" not in spec.cmd
+
+    def test_add_dirs_passed_through(self) -> None:
+        dirs = [ValidatedAddDir(path="/workspace/a"), ValidatedAddDir(path="/workspace/b")]
+        spec = CodexBackend().build_interactive_cmd(add_dirs=dirs)
+        indices = [i for i, v in enumerate(spec.cmd) if v == "--add-dir"]
+        assert len(indices) == 2
+        assert spec.cmd[indices[0] + 1] == "/workspace/a"
+        assert spec.cmd[indices[1] + 1] == "/workspace/b"


### PR DESCRIPTION
## Summary

Add two integration-level test files under `tests/integration/` verifying structural correctness of `CodexBackend.build_interactive_cmd()` and `CodexBackend.build_food_truck_cmd()`. Both files contain pure `CmdSpec` inspection tests (no subprocess spawning) with `pytestmark = [pytest.mark.small]` matching the `tests/integration/` convention (no layer marker).

The xfail guard specified in the issue for P6 dependency is **not needed** — `build_interactive_cmd()` is fully implemented at `src/autoskillit/execution/backends/codex.py:446-477` and existing unit tests at `tests/execution/backends/test_codex_interactive.py` pass without xfail.

Additionally, the test filter cascade must be updated so these new integration tests are triggered when `src/autoskillit/execution/backends/` changes.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-034047-229891/.autoskillit/temp/make-plan/py8_p8_a7_wp1_codex_integration_tests_plan_2026-05-26_034500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 67 | 16.7k | 1.4M | 87.6k | 136 | 92.3k | 12m 33s |
| verify | claude-sonnet-4-6 | 1 | 148 | 10.4k | 766.1k | 61.3k | 49 | 52.8k | 3m 18s |
| implement* | MiniMax-M2.7-highspeed | 1 | 655.6k | 5.4k | 772.7k | 25.8k | 67 | 38.8k | 2m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 141.1k | 4.2k | 363.0k | 31.1k | 29 | 23.5k | 1m 32s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 39.2k | 1.4k | 151.6k | 25.8k | 14 | 15.1k | 37s |
| review_pr | claude-sonnet-4-6 | 1 | 278 | 24.0k | 1.3M | 59.2k | 76 | 51.8k | 6m 29s |
| resolve_review | claude-sonnet-4-6 | 1 | 165 | 11.1k | 744.1k | 49.1k | 46 | 41.3k | 7m 50s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 47.0k | 1.8k | 154.3k | 25.7k | 16 | 37.9k | 51s |
| resolve_ci | claude-sonnet-4-6 | 1 | 76 | 4.3k | 210.4k | 30.8k | 23 | 32.1k | 5m 24s |
| **Total** | | | 883.6k | 79.2k | 5.9M | 87.6k | | 385.6k | 41m 21s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 85 | 9091.1 | 456.7 | 63.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 0 | — | — | — |
| **Total** | **85** | 69391.1 | 4536.9 | 931.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 5 | 734 | 66.5k | 4.5M | 270.3k | 35m 35s |
| MiniMax-M2.7-highspeed | 4 | 882.9k | 12.7k | 1.4M | 115.3k | 5m 46s |