### PR TITLE
Append Gated Smoke Test Classes for CodexBackend Cmd Builders

### DIFF
--- a/tests/execution/test_smoke_codex.py
+++ b/tests/execution/test_smoke_codex.py
@@ -13,8 +13,12 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core import BackendEventKind, SessionEvent
-from autoskillit.execution.backends.codex import CodexResultParser, CodexStreamParser
+from autoskillit.core import BackendEventKind, DirectInstall, SessionEvent
+from autoskillit.execution.backends.codex import (
+    CodexBackend,
+    CodexResultParser,
+    CodexStreamParser,
+)
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.large]
 
@@ -85,3 +89,32 @@ class TestCodexSmokeExecution:
         )
         assert token_usage.get("input_tokens", -1) >= 0
         assert token_usage.get("output_tokens", -1) >= 0
+
+
+@_skip_unless_codex_smoke
+@pytest.mark.smoke
+class TestCodexSmokeInteractiveCmdBuild:
+    """Verify CodexBackend.build_interactive_cmd produces a valid CmdSpec."""
+
+    def test_interactive_cmd_builds_without_error(self) -> None:
+        cmd = CodexBackend().build_interactive_cmd(initial_prompt="Hello")
+        assert cmd.cmd[0] == "codex"
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd.cmd
+
+
+@_skip_unless_codex_smoke
+@pytest.mark.smoke
+class TestCodexSmokeFoodTruckCmdBuild:
+    """Verify CodexBackend.build_food_truck_cmd produces a valid CmdSpec."""
+
+    def test_food_truck_cmd_has_required_flags(self) -> None:
+        plugin_source = DirectInstall(plugin_dir=Path("/tmp/fake-plugin"))
+        cmd = CodexBackend().build_food_truck_cmd(
+            orchestrator_prompt="test",
+            plugin_source=plugin_source,
+            cwd="/tmp",
+            completion_marker="DONE",
+        )
+        assert "--json" in cmd.cmd
+        assert "--sandbox" in cmd.cmd
+        assert cmd.cmd[cmd.cmd.index("--sandbox") + 1] == "read-only"


### PR DESCRIPTION
## Summary

Append two gated smoke test classes to `tests/execution/test_smoke_codex.py` that verify `CodexBackend.build_interactive_cmd` and `CodexBackend.build_food_truck_cmd` produce structurally valid `CmdSpec` objects with expected Codex flags. Both classes are decorated with `@_skip_unless_codex_smoke` and `@pytest.mark.smoke`, matching the existing `TestCodexSmokeExecution` pattern. No subprocess spawning or network calls — pure command-construction validation.

## Changed Files

- `tests/execution/test_smoke_codex.py`

Closes #2916

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-034047-868564/.autoskillit/temp/make-plan/py8_p8_a8_wp1_plan_2026-05-26_034500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 58 | 6.3k | 547.7k | 55.6k | 40 | 58.5k | 3m 38s |
| verify | claude-sonnet-4-6 | 1 | 204 | 12.7k | 998.0k | 53.8k | 63 | 45.4k | 4m 0s |
| implement* | MiniMax-M2.7-highspeed | 1 | 222.4k | 3.3k | 460.7k | 25.8k | 36 | 15.9k | 1m 43s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 60.0k | 3.1k | 177.4k | 25.8k | 20 | 15.4k | 1m 4s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 44.2k | 1.2k | 177.4k | 25.8k | 14 | 15.2k | 35s |
| review_pr | claude-sonnet-4-6 | 1 | 182 | 22.6k | 692.2k | 50.6k | 52 | 47.8k | 5m 36s |
| resolve_review | claude-sonnet-4-6 | 1 | 187 | 10.7k | 857.2k | 52.4k | 51 | 44.4k | 7m 21s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 46.9k | 1.8k | 177.1k | 25.7k | 16 | 15.0k | 49s |
| resolve_ci | claude-sonnet-4-6 | 1 | 130 | 4.4k | 430.5k | 40.8k | 35 | 32.3k | 5m 51s |
| **Total** | | | 374.2k | 66.3k | 4.5M | 55.6k | | 290.0k | 30m 39s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 37 | 12451.9 | 431.0 | 90.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 0 | — | — | — |
| **Total** | **37** | 122111.1 | 7837.8 | 1791.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 58 | 6.3k | 547.7k | 58.5k | 3m 38s |
| claude-sonnet-4-6 | 4 | 703 | 50.5k | 3.0M | 169.9k | 22m 50s |
| MiniMax-M2.7-highspeed | 4 | 373.5k | 9.5k | 992.5k | 61.6k | 4m 11s |