### PR TITLE
Harden CI Workflows — setup-uv v8 Migration, Patch-Bump Race Fix, Release Auth

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -8,17 +8,17 @@ The correct input parameter for pinning the uv version is `version`, not `uv-ver
 
 ```yaml
 # CORRECT — SHA-pinned with version comment
-- uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+- uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
   with:
     version: "0.9.21"
 
 # WRONG — floating tag, vulnerable to tag mutation
-- uses: astral-sh/setup-uv@v7
+- uses: astral-sh/setup-uv@v8
   with:
     version: "0.9.21"
 
 # WRONG — silently ignored, installs latest uv instead of pinned version
-- uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+- uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
   with:
     uv-version: "0.9.21"
 ```
@@ -31,7 +31,7 @@ Jobs that do not run `uv sync` MUST disable setup-uv caching to avoid poisoning 
 wheel cache consumed by downstream jobs:
 
 ```yaml
-- uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+- uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
   with:
     version: "0.9.21"
     enable-cache: false   # required for jobs that skip uv sync

--- a/.github/workflows/patch-bump-develop.yml
+++ b/.github/workflows/patch-bump-develop.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: patch-bump-develop
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   bump-patch:
@@ -24,12 +24,11 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.21"
+          enable-cache: false
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Compute new patch version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.21"
+          enable-cache: false
 
       - name: Compute new minor version
         id: version
@@ -53,6 +54,8 @@ jobs:
       - name: Sync plugin.json and recipe versions
         run: python3 scripts/sync_versions.py
 
+      - name: Configure git auth for private deps
+        run: git config --global url."https://${{ secrets.GH_USER }}:${{ secrets.GH_PAT }}@github.com/TalonT-Org/".insteadOf "https://github.com/TalonT-Org/"
       - name: Regenerate uv.lock
         run: uv lock
 

--- a/.github/workflows/test-filter-audit.yml
+++ b/.github/workflows/test-filter-audit.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 10  # Need history for HEAD~5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.21"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.21"
           enable-cache: false
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.21"
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -5,6 +5,10 @@ on:
     types: [closed]
     branches: [main]
 
+
+concurrency:
+  group: version-bump-promote
+  cancel-in-progress: false
 jobs:
   minor-bump-on-promote:
     permissions:
@@ -22,12 +26,11 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.21"
+          enable-cache: false
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Compute new minor version
         id: version

--- a/docs/version-pipeline.md
+++ b/docs/version-pipeline.md
@@ -19,7 +19,7 @@ Pre-commit enforcement: `sync_versions.py --check` (exits 1 if any artifact is o
 - **Action:** `MAJOR.MINOR.(PATCH+1)` on `develop`
 - **Calls `sync_versions.py`:** yes
 - **Staged files:** `pyproject.toml`, `src/autoskillit/.claude-plugin/plugin.json`, `uv.lock`
-- **Concurrency:** serialized (`cancel-in-progress: false`)
+- **Concurrency:** cancel-in-progress (`cancel-in-progress: true`) — safe because each run independently reads the current version
 
 ### `version-bump.yml`
 
@@ -29,6 +29,7 @@ Pre-commit enforcement: `sync_versions.py --check` (exits 1 if any artifact is o
   - `develop` → `MAJOR.(MINOR+1).1` (forward-bumped to stay ahead of main)
 - **Calls `sync_versions.py`:** yes (on both `main` and `develop` in sequence)
 - **Guard:** rejects if `new_develop <= old_develop` (downgrade protection)
+- **Concurrency:** serialized (`cancel-in-progress: false`) — must complete both main and develop pushes atomically
 
 ### `release.yml`
 

--- a/tests/infra/test_release_workflows.py
+++ b/tests/infra/test_release_workflows.py
@@ -225,7 +225,36 @@ class TestVersionBumpWorkflow:
             "no force-push means no protection changes are needed"
         )
 
+    def test_has_concurrency_group(self):
+        """version-bump.yml must declare a concurrency group to serialize runs."""
+        wf = _load(VERSION_BUMP_WORKFLOW)
+        assert wf.get("concurrency") is not None, (
+            "version-bump.yml must declare a concurrency group — "
+            "without it, simultaneous promotions race on the two-phase push"
+        )
 
+    def test_concurrency_group_name(self):
+        """Concurrency group name must be a fixed string."""
+        wf = _load(VERSION_BUMP_WORKFLOW)
+        concurrency = wf.get("concurrency", {})
+        group = concurrency.get("group", "")
+        assert group == "version-bump-promote", (
+            f"concurrency.group must be 'version-bump-promote' (got {group!r})"
+        )
+
+    def test_concurrency_cancel_in_progress_is_false(self):
+        """cancel-in-progress must be false — two-phase workflow must not be cancelled mid-run."""
+        wf = _load(VERSION_BUMP_WORKFLOW)
+        concurrency = wf.get("concurrency", {})
+        cancel = concurrency.get("cancel-in-progress", None)
+        assert cancel is False, (
+            f"concurrency.cancel-in-progress must be false (got {cancel!r}) — "
+            "true would cancel between main and develop pushes, "
+            "leaving permanently inconsistent state"
+        )
+
+
+# ── patch-bump-develop.yml ────────────────────────────────────────────────────
 # ── patch-bump-develop.yml ────────────────────────────────────────────────────
 
 
@@ -356,15 +385,16 @@ class TestPatchBumpDevelopWorkflow:
             "a fixed group name ensures all simultaneous batch runs queue behind one another"
         )
 
-    def test_concurrency_cancel_in_progress_is_false(self):
-        """cancel-in-progress must be false so every queued run executes its bump."""
+    def test_concurrency_cancel_in_progress_is_true(self):
+        """cancel-in-progress must be true to prevent non-fast-forward races."""
         wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         concurrency = wf.get("concurrency", {})
         cancel = concurrency.get("cancel-in-progress", None)
-        assert cancel is False, (
-            f"concurrency.cancel-in-progress must be false (got {cancel!r}) — "
-            "true would cancel intermediate runs, silently skipping version bumps "
-            "for all but the last PR in a merge queue batch"
+        assert cancel is True, (
+            f"concurrency.cancel-in-progress must be true (got {cancel!r}) — "
+            "false causes non-fast-forward rejections when multiple PRs merge "
+            "within seconds; true is safe because each run independently reads "
+            "the current version from develop"
         )
 
 


### PR DESCRIPTION
## Summary

Harden all 5 CI workflow files, `.github/CLAUDE.md`, structural tests, and versioning docs to address issues surfaced during the 2026-05-26 GitHub Actions outage investigation. Changes span seven areas: (1) migrate `setup-uv` from v7 SHA to v8.1.0 immutable-release SHA across all workflows, (2) fix `patch-bump-develop.yml` race condition via `cancel-in-progress: true`, (3) add serialized concurrency guard to `version-bump.yml` with `cancel-in-progress: false` (queued, not cancelled — its two-phase architecture requires both pushes to complete), (4) add private dependency git auth to `release.yml`, (5) enforce `enable-cache: false` on `uv lock`-only jobs, (6) remove unnecessary Rust toolchain from `uv lock`-only jobs, and (7) update `.github/CLAUDE.md` examples, structural tests, and docs to match.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-082645-426759/.autoskillit/temp/make-plan/harden_ci_workflows_plan_2026-05-26_083000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 73 | 16.9k | 902.1k | 74.9k | 78 | 81.2k | 9m 31s |
| verify | claude-opus-4-6 | 1 | 52 | 14.7k | 1.6M | 76.5k | 51 | 60.5k | 5m 11s |
| implement* | MiniMax-M2.7 | 1 | 93.7k | 13.4k | 2.5M | 0 | 103 | 0 | 7m 31s |
| prepare_pr* | MiniMax-M2.7 | 1 | 48.6k | 3.4k | 366.2k | 0 | 25 | 0 | 1m 29s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.2k | 1.6k | 357.7k | 0 | 20 | 0 | 55s |
| review_pr | claude-opus-4-6 | 1 | 50 | 21.6k | 602.7k | 65.7k | 35 | 50.9k | 5m 27s |
| resolve_review | claude-opus-4-6 | 1 | 54 | 10.4k | 951.2k | 66.1k | 39 | 50.7k | 8m 7s |
| **Total** | | | 181.7k | 81.9k | 7.3M | 76.5k | | 243.3k | 38m 14s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 4 | 229 | 63.6k | 4.1M | 243.3k | 28m 18s |
| MiniMax-M2.7 | 3 | 181.5k | 18.3k | 3.2M | 0 | 9m 56s |