### PR TITLE
Planner Scope Bleed — Inseparability Rules + Subsumption Detection

### DIFF
--- a/src/autoskillit/agents/wp-elaborator.md
+++ b/src/autoskillit/agents/wp-elaborator.md
@@ -23,6 +23,12 @@ Read the task description from the task file path provided in your prompt. Every
 
 Produce exactly 1-5 deliverables (hard constraint). If the WP naturally spans more than 5 files, group related files into logical deliverables (e.g., "test suite for module X" rather than individual test files).
 
+## Inseparability Rules
+
+1. If this WP implements a new method/class, its unit tests MUST be in this WP's deliverables
+2. If this WP changes a function signature, all call-site updates within the same phase MUST be in this WP (cross-phase call-site updates remain as separate WPs with explicit `depends_on`)
+3. If this WP adds a flag/enum member, the corresponding test updates MUST be in this WP
+
 ## Output Format
 
 Return your result as a single JSON object between ```json and ``` fences. The JSON must contain all of the following fields:

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -12,7 +12,7 @@ import regex as re
 from autoskillit.core import atomic_write, write_versioned_json
 from autoskillit.planner._dag_ops import break_cycles_greedy_fas, filter_self_references
 from autoskillit.planner._sort_utils import _natural_sort_key
-from autoskillit.planner.lifecycle import record_lifecycle_event
+from autoskillit.planner.lifecycle import load_lifecycle_registry, record_lifecycle_event
 from autoskillit.planner.schema import validate_wp_result
 
 _ASSIGNMENT_RE = re.compile(r"^(P\d+-A\d+)-")
@@ -134,7 +134,7 @@ def _rewrite_deps(
 
 
 def _cluster_by_shared_files(wps: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
-    """Cluster WPs that share at least one files_touched entry."""
+    """Cluster WPs that share files_touched or have API producer/consumer relationships."""
     parent: dict[str, str] = {wp["id"]: wp["id"] for wp in wps}
 
     def find(x: str) -> str:
@@ -155,6 +155,16 @@ def _cluster_by_shared_files(wps: list[dict[str, Any]]) -> list[list[dict[str, A
     for wp_ids in file_to_wps.values():
         for i in range(1, len(wp_ids)):
             union(wp_ids[0], wp_ids[i])
+
+    # Pass 2: API producer/consumer relationships
+    api_producers: dict[str, list[str]] = {}
+    for wp in wps:
+        for api in wp.get("apis_defined", []):
+            api_producers.setdefault(api, []).append(wp["id"])
+    for wp in wps:
+        for api in wp.get("apis_consumed", []):
+            for producer_id in api_producers.get(api, []):
+                union(wp["id"], producer_id)
 
     clusters: dict[str, list[dict[str, Any]]] = {}
     for wp in wps:
@@ -289,6 +299,14 @@ def consolidate_wps(
     broken_edges = break_cycles_greedy_fas(output_wps)
 
     planner_path = Path(planner_dir)
+
+    # Clean up depends_on references to voided WPs
+    registry = load_lifecycle_registry(planner_path)
+    voided_wp_ids = set(registry.get("voided_wps", {}).keys())
+    if voided_wp_ids:
+        for wp in output_wps:
+            wp["depends_on"] = [d for d in wp.get("depends_on", []) if d not in voided_wp_ids]
+
     consolidated_path = planner_path / "consolidated_wps.json"
     write_versioned_json(
         consolidated_path,
@@ -327,6 +345,12 @@ def consolidate_wps(
                 if absorbed_id in source_to_merged
             }
             record_lifecycle_event(planner_path, "absorbed", absorbed_data)
+
+        # Delete voided WP result files
+        for voided_id in voided_wp_ids:
+            result_file = wp_dir / f"{voided_id}_result.json"
+            if result_file.exists():
+                result_file.unlink()
 
     if broken_edges:
         edges_path = planner_path / "broken_cycle_edges.json"

--- a/src/autoskillit/planner/lifecycle.py
+++ b/src/autoskillit/planner/lifecycle.py
@@ -18,7 +18,12 @@ def record_lifecycle_event(planner_dir: Path, key: str, data: list[str] | dict[s
     wp_dir.mkdir(parents=True, exist_ok=True)
     registry_path = wp_dir / _REGISTRY_FILENAME
 
-    existing: dict[str, Any] = {"voided_phases": [], "voided_assignments": [], "absorbed": {}}
+    existing: dict[str, Any] = {
+        "voided_phases": [],
+        "voided_assignments": [],
+        "absorbed": {},
+        "voided_wps": {},
+    }
     if registry_path.exists():
         loaded = read_versioned_json(registry_path, LIFECYCLE_REGISTRY_VERSION)
         if loaded:
@@ -26,6 +31,7 @@ def record_lifecycle_event(planner_dir: Path, key: str, data: list[str] | dict[s
                 "voided_phases": loaded.get("voided_phases", []),
                 "voided_assignments": loaded.get("voided_assignments", []),
                 "absorbed": loaded.get("absorbed", {}),
+                "voided_wps": loaded.get("voided_wps", {}),
             }
         else:
             logger.warning(
@@ -57,6 +63,7 @@ def load_lifecycle_registry(planner_dir: Path) -> dict[str, Any]:
                 "voided_phases": loaded.get("voided_phases", []),
                 "voided_assignments": loaded.get("voided_assignments", []),
                 "absorbed": loaded.get("absorbed", {}),
+                "voided_wps": loaded.get("voided_wps", {}),
             }
 
     legacy_path = wp_dir / _LEGACY_FILENAME
@@ -68,6 +75,7 @@ def load_lifecycle_registry(planner_dir: Path) -> dict[str, Any]:
                 "voided_phases": [],
                 "voided_assignments": [],
                 "absorbed": loaded.get("absorbed", {}),
+                "voided_wps": {},
             }
 
-    return {"voided_phases": [], "voided_assignments": [], "absorbed": {}}
+    return {"voided_phases": [], "voided_assignments": [], "absorbed": {}, "voided_wps": {}}

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -190,11 +190,22 @@ def _check_assignment_completeness(
                     absorbed_pairs.add((int(parts[0][1:]), int(parts[1][1:])))
                 except ValueError:
                     logger.warning("malformed_absorbed_id", absorbed_id=absorbed_id)
+    voided_wp_pairs: set[tuple[int, int]] = set()
+    if lifecycle_registry and isinstance(lifecycle_registry.get("voided_wps"), dict):
+        for voided_id in lifecycle_registry["voided_wps"]:
+            parts = voided_id.split("-")
+            if len(parts) >= 2:
+                try:
+                    voided_wp_pairs.add((int(parts[0][1:]), int(parts[1][1:])))
+                except ValueError:
+                    logger.warning("malformed_voided_wp_id", voided_wp_id=voided_id)
     for assign_id, assign in assignment_results.items():
         if assign_id in voided_assign_ids:
             continue
         pair = (assign["phase_number"], assign["assignment_number"])
         if pair in absorbed_pairs:
+            continue
+        if pair in voided_wp_pairs:
             continue
         if pair not in wp_pairs:
             findings.append(
@@ -207,11 +218,15 @@ def _check_assignment_completeness(
     return findings
 
 
-def _check_dep_references(wp_results: dict[str, dict]) -> list[ValidationFinding]:
+def _check_dep_references(
+    wp_results: dict[str, dict],
+    lifecycle_registry: dict[str, Any] | None = None,
+) -> list[ValidationFinding]:
+    voided_wp_ids = set((lifecycle_registry or {}).get("voided_wps", {}).keys())
     findings: list[ValidationFinding] = []
     for wp_id, wp in wp_results.items():
         for dep in wp.get("depends_on", []):
-            if dep not in wp_results:
+            if dep not in wp_results and dep not in voided_wp_ids:
                 findings.append(
                     {
                         "message": f"WP {wp_id} depends on unknown WP {dep}",
@@ -426,7 +441,7 @@ def validate_plan(output_dir: str) -> dict[str, str]:
     all_findings.extend(
         _check_assignment_completeness(assignment_results, wp_results, lifecycle_registry)
     )
-    all_findings.extend(_check_dep_references(wp_results))
+    all_findings.extend(_check_dep_references(wp_results, lifecycle_registry))
     all_findings.extend(_check_dep_id_format(wp_results))
     all_findings.extend(_check_dag_acyclic(wp_results))
     all_findings.extend(_check_sizing_bounds(wp_results))

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -387,7 +387,8 @@
         "output_dir": "${{ context.planner_dir }}"
       },
       "capture": {
-        "verdict": "${{ result.verdict }}"
+        "verdict": "${{ result.verdict }}",
+        "warning_count": "${{ result.warning_count }}"
       },
       "on_success": "check_verdict",
       "on_failure": "escalate_stop"
@@ -467,7 +468,7 @@
     },
     "done": {
       "action": "stop",
-      "message": "Planning complete. Plan artifacts written to ${{ context.planner_dir }}/. Use compile output to create GitHub issues and milestones. Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"planning complete\"}"
+      "message": "Planning complete. Plan artifacts written to ${{ context.planner_dir }}/. Validation warnings: ${{ context.warning_count }}. Use compile output to create GitHub issues and milestones. Emit the L3 result sentinel JSON block now with success=true. Example sentinel: {\"success\": true, \"reason\": \"planning complete\"}"
     },
     "escalate_stop": {
       "action": "stop",

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -403,6 +403,7 @@ steps:
       output_dir: "${{ context.planner_dir }}"
     capture:
       verdict: "${{ result.verdict }}"
+      warning_count: "${{ result.warning_count }}"
     on_success: check_verdict
     on_failure: escalate_stop
 
@@ -468,6 +469,7 @@ steps:
     action: stop
     message: >-
       Planning complete. Plan artifacts written to ${{ context.planner_dir }}/.
+      Validation warnings: ${{ context.warning_count }}.
       Use compile output to create GitHub issues and milestones.
       Emit the L3 result sentinel JSON block now with success=true.
       Example sentinel: {"success": true, "reason": "planning complete"}

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -91,6 +91,7 @@ Each L0 receives a self-contained prompt that:
 4. Instructs the L0 to use Grep/Glob/Read for codebase analysis (no sub-subagents)
 5. Instructs the L0 to decompose into 1–5 work packages
 6. Instructs the L0 to return results as JSON between triple-backtick json fences
+7. Includes inseparability rules: "Do not propose a separate WP for tests of code introduced in a sibling WP. Tests for new code belong in the same WP as the implementation. If a WP changes a function signature, all call-site updates within the same assignment belong in that WP."
 
 Each L0 MUST:
 - Use Grep/Glob/Read for codebase analysis (no sub-subagent spawning — they are actual leaf nodes)

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -53,7 +53,7 @@ suggestions, resolves conflicts, and writes `refined_wps.json`.
 
 **ALWAYS:**
 - Spawn one L0 per phase (NOT per WP) — each L0 reviews ALL WPs in its phase against the full WP set
-- Validate each L0 response for `phase_id`, `wp_changes` (array), `cross_phase_deps` (array), `deliverable_conflicts` (array), `api_mismatches` (array)
+- Validate each L0 response for `phase_id`, `wp_changes` (array), `cross_phase_deps` (array), `deliverable_conflicts` (array), `api_mismatches` (array), `subsumption_pairs` (array)
 - Log `WARNING` to stdout for any L0 response that fails validation (skip that phase)
 - Log `CRITICAL` to stdout for any L0 subagent that fails entirely (proceed with N-1 suggestions)
 - When two WPs claim the same deliverable file, assign ownership to the WP with the numerically earlier ID using natural sort (e.g., `P1-A1-WP1` beats `P2-A1-WP1`)
@@ -113,9 +113,11 @@ For each phase, build a context packet containing:
 - The full serialized `combined_wps.json` content (all WPs visible for cross-phase awareness)
 - The `PhaseElaborated` entry for the phase from `$2`
 - The `AssignmentElaborated` entries for all assignments in this phase from `$3`
+- The `overlap_notes` field from the `AssignmentElaborated` entries for this phase (use as a prior signal — if an assignment's overlap_notes flag a relationship with another assignment, scrutinize their WPs for subsumption)
 - The `target_phase_id`
 - The list of WP IDs assigned to this L0 (the WPs in this phase)
 - Instructions: review this phase's WPs against the full WP set; return structured suggestions only — do NOT edit files
+- Use `overlap_notes` from assignment elaboration as a prior signal — if an assignment's overlap_notes flag a relationship with another assignment, scrutinize their WPs for subsumption and report matches in `subsumption_pairs`
 
 ### Step 3: Spawn parallel L0 subagents
 
@@ -139,6 +141,9 @@ deliverable_conflicts = [
 api_mismatches = [
   {"consumer_wp": "P2-A1-WP1", "producer_wp": "P1-A1-WP2", "api": "SessionModel.create", "mismatch": "Consumer expects (user_id, token) but producer defines (user_id)"}
 ]
+subsumption_pairs = [
+  {"consumer_wp": "P6-A3-WP1", "subsumed_wp": "P8-A5-WP1", "reason": "WP1 implements build_interactive_cmd and will naturally produce tests; WP2's sole purpose is to add those tests"}
+]
 ```
 
 Each L0 receives instructions to use Grep/Glob/Read for codebase analysis but NOT
@@ -152,6 +157,7 @@ For each L0 response:
 - `cross_phase_deps` must be a valid JSON array (may be empty `[]`)
 - `deliverable_conflicts` must be a valid JSON array (may be empty `[]`)
 - `api_mismatches` must be a valid JSON array (may be empty `[]`)
+- `subsumption_pairs` must be a valid JSON array (may be empty `[]`)
 
 On `phase_id` mismatch (field present but does not match expected ID):
 ```
@@ -169,6 +175,17 @@ CRITICAL: L0 for {phase_id} failed — proceeding with N-1 suggestions
 ```
 
 ### Step 5: Resolve conflicts
+
+Collect all `subsumption_pairs` from validated L0 responses. For each pair:
+1. Promote the subsumed WP's unique deliverables to the consumer WP (those not already in the consumer's list)
+2. Append the subsumed WP's unique acceptance criteria to the consumer WP
+3. Remove the subsumed WP from the output WP list
+4. Update all `depends_on` references: any WP that depended on the subsumed WP should instead depend on the consumer WP
+5. Write voided_wps entry to `$4/work_packages/lifecycle_registry.json`:
+   Read existing registry (or create with defaults `{"voided_phases": [], "voided_assignments": [], "absorbed": {}, "voided_wps": {}}`).
+   Add to `voided_wps`: `{subsumed_id: {"merged_into": consumer_id, "reason": reason}}`.
+   Write back with `schema_version: 1`.
+6. Log: `WP SUBSUMED: {subsumed_id} → {consumer_id} ({reason})`
 
 Collect all `deliverable_conflicts` from validated L0 responses. For each
 conflict where two WPs claim the same deliverable file, assign ownership to the

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -159,10 +159,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 821),
     ("src/autoskillit/smoke_utils.py", 897),
     ("src/autoskillit/smoke_utils.py", 992),
-    # planner/consolidation.py — write-back of merged WP dicts to per-file results
-    ("src/autoskillit/planner/consolidation.py", 315),
-    # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
+    # planner/consolidation.py — individual WP result file writes (merged and absorbed WPs)
     ("src/autoskillit/planner/consolidation.py", 333),
+    # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
+    ("src/autoskillit/planner/consolidation.py", 357),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 269),
     # _cmd_rpc_issues.py — emit_fallback_map: BEM fallback execution map (recipe-internal)

--- a/tests/planner/test_consolidation_writeback.py
+++ b/tests/planner/test_consolidation_writeback.py
@@ -420,3 +420,87 @@ def test_consolidate_wps_wp_index_in_work_packages(tmp_path: Path) -> None:
 
     assert (tmp_path / "work_packages" / "wp_index.json").exists()
     assert not (tmp_path / "wp_index.json").exists()
+
+
+def test_lifecycle_registry_includes_voided_wps(tmp_path: Path) -> None:
+    """voided_wps key is supported by lifecycle registry read/write."""
+    from autoskillit.planner.lifecycle import load_lifecycle_registry, record_lifecycle_event
+
+    record_lifecycle_event(
+        tmp_path,
+        "voided_wps",
+        {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
+    )
+    registry = load_lifecycle_registry(tmp_path)
+    assert "voided_wps" in registry
+    assert "P1-A2-WP1" in registry["voided_wps"]
+    assert registry["voided_wps"]["P1-A2-WP1"]["merged_into"] == "P1-A1-WP1"
+
+    empty_registry = load_lifecycle_registry(tmp_path / "nonexistent")
+    assert empty_registry["voided_wps"] == {}
+
+
+def test_consolidate_wps_deletes_voided_wp_result_files(tmp_path: Path) -> None:
+    """Voided WP result files are deleted and depends_on references are cleaned."""
+    wp1 = make_wp_result("P1-A1-WP1", depends_on=["P1-A2-WP1"])
+    wp3 = make_wp_result("P1-A1-WP2")
+    refined_wps = make_refined_wps(tmp_path, [wp1, wp3])
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir(parents=True, exist_ok=True)
+    # Write WP2 result file (leftover from elaboration, pre-refinement)
+    write_json(wp_dir / "P1-A2-WP1_result.json", make_wp_result("P1-A2-WP1"))
+
+    # Record voided_wps in lifecycle registry
+    from autoskillit.planner.lifecycle import record_lifecycle_event
+
+    record_lifecycle_event(
+        tmp_path,
+        "voided_wps",
+        {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
+    )
+
+    consolidate_wps(str(refined_wps), str(tmp_path))
+
+    # Voided WP result file should be deleted
+    assert not (wp_dir / "P1-A2-WP1_result.json").exists()
+
+    # depends_on should be cleaned
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    wp1_out = next(wp for wp in consolidated["work_packages"] if wp["id"] == "P1-A1-WP1")
+    assert "P1-A2-WP1" not in wp1_out["depends_on"]
+
+
+def test_fallback_groups_api_relationship_clustering(tmp_path: Path) -> None:
+    """WPs with API producer/consumer relationships are clustered in fallback."""
+    wps = [
+        make_wp_result(
+            "P1-A1-WP1",
+            apis_defined=["module.func_a"],
+            files_touched=["src/a.py"],
+            deliverables=["src/a.py"],
+        ),
+        make_wp_result(
+            "P1-A1-WP2",
+            apis_consumed=["module.func_a"],
+            files_touched=["src/b.py"],
+            deliverables=["src/b.py"],
+        ),
+        make_wp_result("P1-A1-WP3", files_touched=["src/c.py"], deliverables=["src/c.py"]),
+        make_wp_result("P1-A1-WP4", files_touched=["src/d.py"], deliverables=["src/d.py"]),
+        make_wp_result("P1-A1-WP5", files_touched=["src/e.py"], deliverables=["src/e.py"]),
+    ]
+    refined_wps = make_refined_wps(tmp_path, wps)
+
+    consolidate_wps(str(refined_wps), str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    output_ids = [wp["id"] for wp in consolidated["work_packages"]]
+
+    # WP1 and WP2 should be merged (API relationship)
+    assert "P1-A1-WP1" in output_ids  # primary (earlier ID)
+    assert "P1-A1-WP2" not in output_ids  # absorbed into WP1
+    # WP3, WP4, WP5 remain unmerged
+    assert "P1-A1-WP3" in output_ids
+    assert "P1-A1-WP4" in output_ids
+    assert "P1-A1-WP5" in output_ids

--- a/tests/planner/test_elaborate_assignments_contract.py
+++ b/tests/planner/test_elaborate_assignments_contract.py
@@ -141,6 +141,13 @@ class TestSkillMdPresence:
             "'You are a READ-ONLY analysis agent' or 'Do NOT use Write, Edit, or Bash'."
         )
 
+    def test_skill_md_has_inseparability_rules(self, skill_md: str) -> None:
+        """SKILL.md must include inseparability rules for WP decomposition."""
+        assert "inseparability" in skill_md.lower(), (
+            "SKILL.md must include inseparability rules that prevent splitting "
+            "implementation from its tests into separate WPs."
+        )
+
     def test_l0_prompt_template_contains_json_only_framing(self, skill_md: str) -> None:
         lower = skill_md.lower()
         has_json_only = (

--- a/tests/planner/test_elaborate_wps_contract.py
+++ b/tests/planner/test_elaborate_wps_contract.py
@@ -195,6 +195,18 @@ class TestSkillMdPresence:
             "'You are a READ-ONLY analysis agent' or 'Do NOT use Write, Edit, or Bash'."
         )
 
+    def test_wp_elaborator_has_inseparability_rules(self) -> None:
+        """wp-elaborator.md agent definition must include inseparability rules."""
+        agent_path = (
+            Path(__file__).parent.parent.parent / "src/autoskillit/agents/wp-elaborator.md"
+        )
+        assert agent_path.exists(), f"wp-elaborator.md not found at {agent_path}"
+        content = agent_path.read_text()
+        assert "Inseparability" in content, (
+            "wp-elaborator.md must include an 'Inseparability Rules' section "
+            "preventing impl/test WP splits."
+        )
+
     def test_l0_prompt_template_contains_json_only_framing(self, skill_md: str) -> None:
         lower = skill_md.lower()
         has_json_only = (

--- a/tests/planner/test_refine_wps_contract.py
+++ b/tests/planner/test_refine_wps_contract.py
@@ -143,6 +143,20 @@ class TestSkillMdPresence:
                 f"SKILL.md must document L0 structured response field: {field}."
             )
 
+    def test_skill_md_has_subsumption_pairs_field(self, skill_md: str) -> None:
+        """SKILL.md must document the subsumption_pairs L0 response field."""
+        assert "subsumption_pairs" in skill_md, (
+            "SKILL.md must document 'subsumption_pairs' as an L0 structured "
+            "response field for subsumption detection."
+        )
+
+    def test_skill_md_has_overlap_notes_context(self, skill_md: str) -> None:
+        """SKILL.md must reference overlap_notes in L0 context packets."""
+        assert "overlap_notes" in skill_md, (
+            "SKILL.md must document 'overlap_notes' injection from assignment "
+            "elaboration results into L0 context packets."
+        )
+
     def test_skill_md_has_batch_limit_spec(self, skill_md: str) -> None:
         """SKILL.md must specify the L0 batch ceiling of 6."""
         assert "Spawn more than 6" in skill_md, (

--- a/tests/planner/test_validation_checks.py
+++ b/tests/planner/test_validation_checks.py
@@ -16,7 +16,10 @@ from autoskillit.planner.validation import (
     validate_plan,
 )
 from tests.planner.conftest import (
+    make_assignment_result,
     make_minimal_output_dir,
+    make_phase_result,
+    make_wp_result,
     write_json,
 )
 
@@ -359,6 +362,92 @@ def test_validate_plan_reads_finalized_manifest(tmp_path: Path) -> None:
     make_minimal_output_dir(tmp_path)
     wp_dir = tmp_path / "work_packages"
     finalize_wp_manifest(str(wp_dir), str(tmp_path))
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"
+
+
+def test_check_dep_references_skips_voided_wp_ids() -> None:
+    """Deps to voided WPs are not flagged as dangling references."""
+    from autoskillit.planner.validation import _check_dep_references
+
+    wp_results = {
+        "P1-A1-WP1": {"depends_on": ["P1-A2-WP1"]},
+    }
+    lifecycle_registry = {
+        "voided_wps": {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
+    }
+    findings = _check_dep_references(wp_results, lifecycle_registry)
+    assert len(findings) == 0
+
+
+def test_check_dep_references_still_flags_truly_dangling() -> None:
+    """Deps to unknown WPs not in voided_wps are still flagged."""
+    from autoskillit.planner.validation import _check_dep_references
+
+    wp_results = {
+        "P1-A1-WP1": {"depends_on": ["P1-A2-WP1", "P1-A3-WP1"]},
+    }
+    lifecycle_registry = {
+        "voided_wps": {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
+    }
+    findings = _check_dep_references(wp_results, lifecycle_registry)
+    assert len(findings) == 1
+    assert "P1-A3-WP1" in findings[0]["message"]
+
+
+def test_check_assignment_completeness_all_wps_voided(tmp_path: Path) -> None:
+    """Assignments with all WPs voided are exempt from completeness check."""
+    from autoskillit.planner.validation import _check_assignment_completeness
+
+    assignment_results = {
+        "P1-A1": {"phase_number": 1, "assignment_number": 1},
+        "P1-A2": {"phase_number": 1, "assignment_number": 2},
+    }
+    wp_results = {
+        "P1-A1-WP1": {"id": "P1-A1-WP1", "depends_on": []},
+    }
+    lifecycle_registry = {
+        "voided_assignments": [],
+        "absorbed": {},
+        "voided_wps": {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
+    }
+    findings = _check_assignment_completeness(assignment_results, wp_results, lifecycle_registry)
+    assert len(findings) == 0
+
+
+def test_validate_plan_with_voided_wps_passes(tmp_path: Path) -> None:
+    """Full validate_plan passes when voided WPs are properly registered."""
+    from autoskillit.planner.lifecycle import record_lifecycle_event
+
+    # Create minimal output structure using proper helpers
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir(parents=True)
+    write_json(phases_dir / "P1_result.json", make_phase_result(1))
+
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir(parents=True)
+    write_json(assignments_dir / "P1-A1_result.json", make_assignment_result(1, 1))
+    write_json(assignments_dir / "P1-A2_result.json", make_assignment_result(1, 2))
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir(parents=True)
+    write_json(
+        wp_dir / "P1-A1-WP1_result.json", make_wp_result("P1-A1-WP1", deliverables=["src/a.py"])
+    )
+
+    # Void the second WP
+    record_lifecycle_event(
+        tmp_path,
+        "voided_wps",
+        {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
+    )
+    # Delete its result file
+    wp2_file = tmp_path / "work_packages" / "P1-A2-WP1_result.json"
+    if wp2_file.exists():
+        wp2_file.unlink()
+
+    from autoskillit.planner.validation import validate_plan
 
     result = validate_plan(str(tmp_path))
     assert result["verdict"] == "pass"


### PR DESCRIPTION
## Summary

Add two complementary planner-time defenses against redundant WPs:

1. **Inseparability rules** in assignment decomposition and WP elaboration prompts prevent splitting implementation from its tests into separate WPs (addresses Type B — 2 of 6 confirmed instances).
2. **Subsumption detection** in `planner-refine-wps` with lifecycle registry infrastructure (`voided_wps`) allows detecting and voiding WPs whose acceptance criteria are fully subsumed by sibling WPs (addresses Type A — 4 of 6 — and Type C — 1 of 6).

Supporting changes: wire unused `overlap_notes` signal into refine-wps context, add API-relationship clustering to consolidation fallback, surface validation warning count in planner done step.

Closes #3028

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-092837-712834/.autoskillit/temp/make-plan/planner_scope_bleed_inseparability_subsumption_plan_2026-05-26_094000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 98 | 31.7k | 3.7M | 127.5k | 129 | 111.9k | 17m 40s |
| verify | claude-sonnet-4-6 | 1 | 124 | 28.0k | 1.1M | 117.4k | 48 | 117.6k | 8m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 6.2M | 36.1k | 2.7M | 30.7k | 214 | 43.8k | 24m 34s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 194.0k | 5.6k | 335.1k | 30.7k | 27 | 15.5k | 1m 45s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 45.8k | 1.1k | 212.2k | 30.7k | 14 | 15.2k | 35s |
| review_pr | claude-sonnet-4-6 | 2 | 308 | 82.6k | 1.6M | 100.4k | 93 | 171.4k | 21m 39s |
| resolve_review | claude-sonnet-4-6 | 2 | 742 | 49.0k | 4.0M | 82.2k | 163 | 135.0k | 19m 34s |
| **Total** | | | 6.5M | 234.2k | 13.6M | 127.5k | | 610.4k | 1h 34m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 306 | 8938.7 | 143.1 | 118.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **306** | 44569.4 | 1994.8 | 765.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 98 | 31.7k | 3.7M | 111.9k | 17m 40s |
| claude-sonnet-4-6 | 3 | 1.2k | 159.6k | 6.7M | 424.0k | 50m 8s |
| MiniMax-M2.7-highspeed | 3 | 6.5M | 42.9k | 3.3M | 74.5k | 26m 55s |