### PR TITLE
Fix Codex Interactive (cook) Skill Discovery via CODEX_HOME + Auth Symlink

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -473,7 +473,10 @@ class CodexBackend:
         if initial_prompt is not None:
             cmd.append(initial_prompt)
         base_env = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
-        env = CodexEnvPolicy().build_env(base_env, extras=env_extras, required=required_env)
+        merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}
+        if add_dirs:
+            merged_extras.setdefault("CODEX_HOME", str(add_dirs[0]))
+        env = CodexEnvPolicy().build_env(base_env, extras=merged_extras, required=required_env)
         return CmdSpec(cmd=tuple(cmd), env=env)
 
     def build_resume_cmd(

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -526,15 +526,30 @@ class DefaultSessionSkillManager:
                     "codex_config_copy_missing", src=str(codex_home_source / "config.toml")
                 )
                 raise
-            try:
-                shutil.copy2(codex_home_source / "auth.json", session_skills_dir / "auth.json")
-                logger.debug("codex_auth_copy", src=str(codex_home_source / "auth.json"))
-            except FileNotFoundError:
-                logger.warning("codex_auth_copy_missing", src=str(codex_home_source / "auth.json"))
+            auth_source = codex_home_source / "auth.json"
+            auth_dest = session_skills_dir / "auth.json"
+            if auth_source.exists():
+                try:
+                    auth_dest.symlink_to(auth_source.resolve())
+                    logger.debug("codex_auth_symlink", src=str(auth_source), dest=str(auth_dest))
+                except OSError:
+                    logger.warning("codex_auth_symlink_failed", src=str(auth_source))
+            else:
+                logger.warning("codex_auth_copy_missing", src=str(auth_source))
             env_source = codex_home_source / ".env"
             if env_source.exists():
                 shutil.copy2(env_source, session_skills_dir / ".env")
                 logger.debug("codex_env_copy", src=str(env_source))
+            sessions_target = (
+                Path.home() / ".local" / "share" / "autoskillit" / "logs" / "codex-sessions"
+            )
+            sessions_target.mkdir(parents=True, exist_ok=True)
+            sessions_link = session_skills_dir / "sessions"
+            try:
+                sessions_link.symlink_to(sessions_target)
+                logger.debug("codex_sessions_symlink", target=str(sessions_target))
+            except OSError:
+                logger.warning("codex_sessions_symlink_failed", target=str(sessions_target))
         for skill_info in self._provider.list_skills():
             if allow_only is not None and skill_info.name not in allow_only:
                 _log.debug("init_session_allow_only_skip", skill=skill_info.name)

--- a/tests/execution/backends/test_codex_interactive.py
+++ b/tests/execution/backends/test_codex_interactive.py
@@ -106,3 +106,27 @@ class TestCodexInteractiveCmdAddDirs:
     def test_empty_list_excludes_add_dir(self) -> None:
         spec = CodexBackend().build_interactive_cmd(add_dirs=[])
         assert CodexFlags.ADD_DIR not in spec.cmd
+        assert "CODEX_HOME" not in spec.env
+
+
+class TestCodexInteractiveCmdCodexHome:
+    def test_add_dirs_injects_codex_home_env(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(add_dirs=[Path("/session/dir")])
+        assert spec.env["CODEX_HOME"] == "/session/dir"
+
+    def test_codex_home_uses_first_add_dir(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(
+            add_dirs=[Path("/first"), Path("/second")],
+        )
+        assert spec.env["CODEX_HOME"] == "/first"
+
+    def test_empty_add_dirs_excludes_codex_home(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(add_dirs=[])
+        assert "CODEX_HOME" not in spec.env
+
+    def test_caller_env_extras_takes_precedence(self) -> None:
+        spec = CodexBackend().build_interactive_cmd(
+            add_dirs=[Path("/session/dir")],
+            env_extras={"CODEX_HOME": "/override"},
+        )
+        assert spec.env["CODEX_HOME"] == "/override"

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -56,13 +56,23 @@ def test_codex_init_session_copies_config_toml(make_session_skill_manager, codex
     assert copied.read_text() == "[codex]\nmodel = 'o3'\n"
 
 
-def test_codex_init_session_copies_auth_json(make_session_skill_manager, codex_env) -> None:
+def test_codex_init_session_symlinks_auth_json(make_session_skill_manager, codex_env) -> None:
     (codex_env.codex_dir / "auth.json").write_text('{"token": "test"}')
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    copied = session_path / "auth.json"
-    assert copied.exists()
-    assert copied.read_text() == '{"token": "test"}'
+    auth = session_path / "auth.json"
+    assert auth.is_symlink()
+    assert auth.resolve() == (codex_env.codex_dir / "auth.json").resolve()
+    assert auth.read_text() == '{"token": "test"}'
+
+
+def test_codex_init_session_auth_json_symlink_target_absent(
+    make_session_skill_manager, codex_env
+) -> None:
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    assert not (session_path / "auth.json").exists()
+    assert not (session_path / "auth.json").is_symlink()
 
 
 def test_codex_init_session_copies_env_if_present(make_session_skill_manager, codex_env) -> None:
@@ -86,6 +96,18 @@ def test_codex_init_session_auth_json_missing_no_crash(
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
     assert not (session_path / "auth.json").exists()
+
+
+def test_codex_init_session_creates_sessions_symlink(
+    make_session_skill_manager, codex_env
+) -> None:
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    sessions_link = session_path / "sessions"
+    assert sessions_link.is_symlink()
+    target = sessions_link.resolve()
+    assert target.is_dir()
+    assert str(target).endswith("codex-sessions")
 
 
 def test_codex_init_session_config_toml_missing_raises(


### PR DESCRIPTION
## Summary

When running `autoskillit cook` with the Codex backend, the Codex agent cannot discover bundled skills because `build_interactive_cmd` passes the ephemeral skill directory via `--add-dir` (a sandbox write-permission flag in Codex, not a skill discovery mechanism). The headless path (`build_skill_session_cmd`) already solves this by setting `CODEX_HOME=<session_dir>` in the environment. This plan applies the same pattern to the interactive path, symlinks `auth.json` to prevent OAuth re-login, and creates a `sessions/` symlink to preserve Codex session logs after ephemeral cleanup.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
● src/autoskillit/execution/backends/codex.py
● src/autoskillit/workspace/session_skills.py
● tests/execution/backends/test_codex_interactive.py
● tests/workspace/test_session_skills_codex.py

Closes #3035

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-100710-128374/.autoskillit/temp/make-plan/fix_codex_interactive_cook_skill_discovery_plan_2026-05-26_101500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 64 | 10.7k | 1.1M | 84.5k | 125 | 91.9k | 9m 11s |
| verify | claude-sonnet-4-6 | 1 | 124 | 7.7k | 633.4k | 57.3k | 44 | 49.0k | 2m 42s |
| implement* | MiniMax-M2.7-highspeed | 1 | 399.4k | 7.1k | 581.0k | 30.7k | 69 | 16.0k | 3m 38s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 105.3k | 3.8k | 273.8k | 30.7k | 23 | 15.4k | 1m 29s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 101.4k | 2.0k | 335.3k | 30.7k | 25 | 15.2k | 56s |
| review_pr | claude-sonnet-4-6 | 1 | 182 | 36.9k | 928.6k | 74.3k | 52 | 66.8k | 8m 23s |
| resolve_review | claude-sonnet-4-6 | 1 | 381 | 20.7k | 2.6M | 76.9k | 109 | 69.2k | 11m 19s |
| **Total** | | | 606.9k | 89.0k | 6.4M | 84.5k | | 323.5k | 37m 41s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 84 | 6917.0 | 190.0 | 84.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **84** | 76461.7 | 3851.8 | 1059.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 751 | 76.1k | 5.2M | 277.0k | 31m 37s |
| MiniMax-M2.7-highspeed | 3 | 606.1k | 12.9k | 1.2M | 46.6k | 6m 3s |