### PR TITLE
[FEATURE] Auto-stamp Plans and Generated Artifacts with Git Commit and Plan UUID

### DIFF
--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -95,8 +95,18 @@ def _render_issue_body(wp: dict, phase: dict, assignment: dict) -> str:
     return body
 
 
+def _stamp_front_matter(content: str, plan_id: str, source_commit: str) -> str:
+    return f"---\nplan_id: {plan_id}\nsource_commit: {source_commit}\n---\n\n{content}"
+
+
 def compile_plan(
-    output_dir: str, task_file_path: str, source_dir: str, task_label: str = "", **kwargs: Any
+    output_dir: str,
+    task_file_path: str,
+    source_dir: str,
+    task_label: str = "",
+    plan_id: str = "",
+    source_commit: str = "",
+    **kwargs: Any,
 ) -> dict[str, str]:
     task = Path(task_file_path).read_text(encoding="utf-8") if task_file_path else ""
     task_label = task_label or _derive_label(task, "")
@@ -173,6 +183,8 @@ def compile_plan(
                 },
             }
         body = _render_issue_body(wp, phase, assignment)
+        if plan_id:
+            body = _stamp_front_matter(body, plan_id, source_commit)
         issue_path = issues_dir / f"{wp_id}_issue.md"
         atomic_write(issue_path, body)
         issue_paths[wp_id] = str(issue_path)
@@ -202,17 +214,17 @@ def compile_plan(
             assignments_nested.append({**assign, "work_packages": wps_in_assign})
         phases_nested.append({**phase, "assignments": assignments_nested})
 
+    plan_payload: dict[str, Any] = {
+        "task": task,
+        "source_dir": source_dir,
+        "phases": phases_nested,
+        "execution_order": execution_order,
+    }
+    if plan_id:
+        plan_payload["plan_id"] = plan_id
+        plan_payload["source_commit"] = source_commit
     plan_json_path = root / "plan.json"
-    write_versioned_json(
-        plan_json_path,
-        {
-            "task": task,
-            "source_dir": source_dir,
-            "phases": phases_nested,
-            "execution_order": execution_order,
-        },
-        schema_version=1,
-    )
+    write_versioned_json(plan_json_path, plan_payload, schema_version=1)
 
     md_lines = [f"# Plan: {task_label}", ""]
     for phase in sorted(phase_results.values(), key=lambda p: p["phase_number"]):
@@ -230,19 +242,21 @@ def compile_plan(
             md_lines.append("")
 
     plan_md_path = root / "plan.md"
-    atomic_write(plan_md_path, "\n".join(md_lines))
+    plan_md_content = "\n".join(md_lines)
+    if plan_id:
+        plan_md_content = _stamp_front_matter(plan_md_content, plan_id, source_commit)
+    atomic_write(plan_md_path, plan_md_content)
 
+    manifest_payload: dict[str, Any] = {
+        "task": task,
+        "source_dir": source_dir,
+        "execution_order": execution_order,
+        "issues": issue_paths,
+    }
+    if plan_id:
+        manifest_payload["plan_id"] = plan_id
     manifest_path = root / "manifest.json"
-    write_versioned_json(
-        manifest_path,
-        {
-            "task": task,
-            "source_dir": source_dir,
-            "execution_order": execution_order,
-            "issues": issue_paths,
-        },
-        schema_version=1,
-    )
+    write_versioned_json(manifest_path, manifest_payload, schema_version=1)
 
     plan_parts = "\n".join(issue_paths[wp_id] for wp_id in execution_order)
 

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import secrets
+import subprocess
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TypedDict
@@ -44,14 +46,36 @@ def _ensure_sentinel_dir(tier_dir: Path, sentinel_name: str) -> Path:
     return sentinel_dir
 
 
-def create_run_dir(temp_dir: str) -> RunDirResult:
+def _capture_head_sha(source_dir: str) -> str:
+    if not source_dir:
+        return ""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=source_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if proc.returncode == 0:
+            sha = proc.stdout.strip()
+            if len(sha) == 40:
+                return sha
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+def create_run_dir(temp_dir: str, source_dir: str = "") -> RunDirResult:
     if not temp_dir:
         raise ValueError("temp_dir must be a non-empty path")
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_dir = Path(temp_dir) / "planner" / f"run-{stamp}-{secrets.token_hex(4)}"
     for sub in ("phases", "assignments", "work_packages"):
         (run_dir / sub).mkdir(parents=True, exist_ok=True)
-    return RunDirResult(planner_dir=str(run_dir))
+    plan_id = str(uuid.uuid4())
+    source_commit = _capture_head_sha(source_dir)
+    return RunDirResult(planner_dir=str(run_dir), plan_id=plan_id, source_commit=source_commit)
 
 
 def _build_index_entry(result_data: dict[str, object]) -> dict[str, object]:

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -119,6 +119,8 @@ class PlanDocument(_PlanDocumentBase, total=False):
     phases: list[PhaseShort | PhaseElaborated]
     assignments: list[AssignmentShort | AssignmentElaborated]
     work_packages: list[WPShort | WPElaborated]
+    plan_id: str
+    source_commit: str
 
 
 class PlannerManifestItem(TypedDict):
@@ -138,6 +140,8 @@ class PlannerManifest(TypedDict):
 
 class RunDirResult(TypedDict):
     planner_dir: str
+    plan_id: str
+    source_commit: str
 
 
 class TaskResolutionResult(TypedDict):

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2390,6 +2390,12 @@ callable_contracts:
     - name: source_dir
       type: directory_path
       required: true
+    - name: plan_id
+      type: str
+      required: false
+    - name: source_commit
+      type: str
+      required: false
     outputs:
     - name: plan_path
       type: file_path
@@ -2480,9 +2486,16 @@ callable_contracts:
     - name: temp_dir
       type: directory_path
       required: true
+    - name: source_dir
+      type: directory_path
+      required: false
     outputs:
     - name: planner_dir
       type: directory_path
+    - name: plan_id
+      type: str
+    - name: source_commit
+      type: str
   autoskillit.planner.finalize_wp_manifest:
     inputs:
     - name: work_packages_dir

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -41,11 +41,14 @@
       "with": {
         "callable": "autoskillit.planner.create_run_dir",
         "args": {
-          "temp_dir": "{{AUTOSKILLIT_TEMP}}"
+          "temp_dir": "{{AUTOSKILLIT_TEMP}}",
+          "source_dir": "${{ inputs.source_dir }}"
         }
       },
       "capture": {
-        "planner_dir": "${{ result.planner_dir }}"
+        "planner_dir": "${{ result.planner_dir }}",
+        "plan_id": "${{ result.plan_id }}",
+        "source_commit": "${{ result.source_commit }}"
       },
       "on_success": "resolve_task",
       "on_failure": "escalate_stop"
@@ -460,7 +463,9 @@
         "output_dir": "${{ context.planner_dir }}",
         "task_file_path": "${{ context.task_file_path }}",
         "task_label": "${{ context.task_label }}",
-        "source_dir": "${{ inputs.source_dir }}"
+        "source_dir": "${{ inputs.source_dir }}",
+        "plan_id": "${{ context.plan_id }}",
+        "source_commit": "${{ context.source_commit }}"
       },
       "on_success": "done",
       "on_failure": "escalate_stop"

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -48,8 +48,11 @@ steps:
       callable: "autoskillit.planner.create_run_dir"
       args:
         temp_dir: "{{AUTOSKILLIT_TEMP}}"
+        source_dir: "${{ inputs.source_dir }}"
     capture:
       planner_dir: "${{ result.planner_dir }}"
+      plan_id: "${{ result.plan_id }}"
+      source_commit: "${{ result.source_commit }}"
     on_success: resolve_task
     on_failure: escalate_stop
 
@@ -461,6 +464,8 @@ steps:
       task_file_path: "${{ context.task_file_path }}"
       task_label: "${{ context.task_label }}"
       source_dir: "${{ inputs.source_dir }}"
+      plan_id: "${{ context.plan_id }}"
+      source_commit: "${{ context.source_commit }}"
     on_success: done
     on_failure: escalate_stop
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -164,7 +164,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
     ("src/autoskillit/planner/consolidation.py", 333),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 269),
+    ("src/autoskillit/planner/manifests.py", 293),
     # _cmd_rpc_issues.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc_issues.py", 83),
 }

--- a/tests/planner/CLAUDE.md
+++ b/tests/planner/CLAUDE.md
@@ -20,6 +20,7 @@ Planner manifest, validation, compilation, and merge tests.
 | `test_manifests_expansion.py` | expand_assignments, expand_wps, resolve_task_input |
 | `test_merge_files.py` | merge_files and merge_tier_results (core merge operations) |
 | `test_merge_items.py` | extract_item and replace_item (item-level CRUD) |
+| `test_plan_metadata.py` | Tests for plan_id and source_commit stamping in plan.json, manifest.json, plan.md, and issue .md files |
 | `test_merge_snapshot.py` | build_plan_snapshot |
 | `test_merge_refine.py` | Refine contexts and merge_refined_assignments |
 | `test_pipeline_integration.py` | End-to-end pipeline integration tests |

--- a/tests/planner/test_plan_metadata.py
+++ b/tests/planner/test_plan_metadata.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+from autoskillit.planner.compiler import compile_plan
+from autoskillit.planner.manifests import create_run_dir
+from tests.planner.conftest import (
+    make_assignment_result,
+    make_phase_result,
+    make_wp_result,
+    write_json,
+    write_task_file,
+)
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.medium, pytest.mark.feature("planner")]
+
+
+# Helpers copied from test_compiler.py
+
+
+def _make_valid_output_dir(
+    tmp_path: Path,
+    *,
+    num_phases: int = 1,
+    with_dep_graph: bool = False,
+    dependency_chain: bool = False,
+) -> Path:
+    """Build a valid output_dir with validation.json verdict=pass."""
+    phases_dir = tmp_path / "phases"
+    assigns_dir = tmp_path / "assignments"
+    wps_dir = tmp_path / "work_packages"
+
+    for p in range(1, num_phases + 1):
+        write_json(
+            phases_dir / f"P{p}_result.json",
+            make_phase_result(p, name=f"Phase {p}"),
+        )
+        write_json(
+            assigns_dir / f"P{p}-A1_result.json",
+            make_assignment_result(
+                p,
+                1,
+                name=f"Test Assignment P{p}",
+                proposed_work_packages=[f"P{p}-A1-WP1"],
+            ),
+        )
+        deps: list[str] = []
+        if dependency_chain and p > 1:
+            deps = [f"P{p - 1}-A1-WP1"]
+        write_json(
+            wps_dir / f"P{p}-A1-WP1_result.json",
+            make_wp_result(
+                f"P{p}-A1-WP1",
+                name=f"WP P{p}-A1-WP1",
+                summary=f"Summary P{p}",
+                goal=f"Goal P{p}",
+                deliverables=[f"src/mod_p{p}.py"],
+                technical_steps=[f"step for p{p}"],
+                acceptance_criteria=[f"criterion for p{p}"],
+                depends_on=deps,
+            ),
+        )
+
+    manifest_items = [{"id": f"P{p}-A1-WP1", "status": "done"} for p in range(1, num_phases + 1)]
+    write_json(
+        wps_dir / "wp_manifest.json", {"pass_name": "work_packages", "items": manifest_items}
+    )
+
+    write_json(
+        tmp_path / "validation.json",
+        {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
+    )
+
+    if with_dep_graph:
+        write_json(
+            tmp_path / "dep_graph.json",
+            {
+                "added_backward_deps": {},
+                "forward_deps": {"P1-A1-WP1": ["P1-A1-WP2"]},
+            },
+        )
+
+    return tmp_path
+
+
+def _make_chain_3_wps(tmp_path: Path) -> Path:
+    """3 WPs: WP1 -> WP2 -> WP3."""
+    phases_dir = tmp_path / "phases"
+    assigns_dir = tmp_path / "assignments"
+    wps_dir = tmp_path / "work_packages"
+
+    write_json(
+        phases_dir / "P1_result.json",
+        make_phase_result(1, name="Foundation"),
+    )
+    write_json(
+        assigns_dir / "P1-A1_result.json",
+        make_assignment_result(
+            1,
+            1,
+            name="Test Assignment",
+            proposed_work_packages=["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+        ),
+    )
+    for i, deps in [(1, []), (2, ["P1-A1-WP1"]), (3, ["P1-A1-WP2"])]:
+        write_json(
+            wps_dir / f"P1-A1-WP{i}_result.json",
+            make_wp_result(
+                f"P1-A1-WP{i}",
+                name=f"WP {i}",
+                summary=f"Summary {i}",
+                goal=f"Goal {i}",
+                deliverables=[f"src/mod{i}.py"],
+                technical_steps=[f"step {i}"],
+                acceptance_criteria=[f"criterion {i}"],
+                depends_on=deps,
+            ),
+        )
+    manifest_items = [{"id": f"P1-A1-WP{i}", "status": "done"} for i in range(1, 4)]
+    write_json(
+        wps_dir / "wp_manifest.json", {"pass_name": "work_packages", "items": manifest_items}
+    )
+    write_json(
+        tmp_path / "validation.json",
+        {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
+    )
+    return tmp_path
+
+
+# Tests
+
+
+def test_create_run_dir_returns_valid_plan_id(tmp_path: Path) -> None:
+    result = create_run_dir(str(tmp_path))
+    plan_id = result["plan_id"]
+    parsed = uuid.UUID(plan_id, version=4)
+    assert str(parsed) == plan_id
+
+
+def test_create_run_dir_captures_source_commit(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", str(repo)], capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"], cwd=repo, capture_output=True, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, capture_output=True, check=True
+    )
+    expected = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    result = create_run_dir(str(tmp_path), source_dir=str(repo))
+    assert result["source_commit"] == expected
+    assert len(result["source_commit"]) == 40
+
+
+def test_create_run_dir_empty_source_commit_without_source_dir(tmp_path: Path) -> None:
+    result = create_run_dir(str(tmp_path))
+    assert result["source_commit"] == ""
+
+
+def test_plan_json_includes_plan_metadata(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    plan_id = str(uuid.uuid4())
+    source_commit = "a" * 40
+    compile_plan(
+        str(tmp_path),
+        write_task_file(tmp_path),
+        "/src",
+        plan_id=plan_id,
+        source_commit=source_commit,
+    )
+    plan_json = json.loads((tmp_path / "plan.json").read_text())
+    assert plan_json["plan_id"] == plan_id
+    assert plan_json["source_commit"] == source_commit
+
+
+def test_manifest_json_includes_plan_id(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    plan_id = str(uuid.uuid4())
+    compile_plan(
+        str(tmp_path), write_task_file(tmp_path), "/src", plan_id=plan_id, source_commit="b" * 40
+    )
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest["plan_id"] == plan_id
+
+
+def test_issue_md_has_yaml_front_matter(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    plan_id = str(uuid.uuid4())
+    source_commit = "c" * 40
+    compile_plan(
+        str(tmp_path),
+        write_task_file(tmp_path),
+        "/src",
+        plan_id=plan_id,
+        source_commit=source_commit,
+    )
+    issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
+    assert issue.startswith("---\n")
+    assert f"plan_id: {plan_id}" in issue
+    assert f"source_commit: {source_commit}" in issue
+
+
+def test_plan_md_has_yaml_front_matter(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    plan_id = str(uuid.uuid4())
+    source_commit = "d" * 40
+    result = compile_plan(
+        str(tmp_path),
+        write_task_file(tmp_path),
+        "/src",
+        plan_id=plan_id,
+        source_commit=source_commit,
+    )
+    plan_md = Path(result["plan_path"]).read_text()
+    assert plan_md.startswith("---\n")
+    assert f"plan_id: {plan_id}" in plan_md
+    assert f"source_commit: {source_commit}" in plan_md
+
+
+def test_front_matter_precedes_headings(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    compile_plan(
+        str(tmp_path),
+        write_task_file(tmp_path),
+        "/src",
+        plan_id=str(uuid.uuid4()),
+        source_commit="e" * 40,
+    )
+    issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
+    closing_fence = issue.index("---\n", 4)
+    first_heading = issue.index("## Goal")
+    assert closing_fence < first_heading
+
+
+def test_no_front_matter_without_plan_id(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
+    issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
+    assert not issue.startswith("---")
+    plan_json = json.loads((tmp_path / "plan.json").read_text())
+    assert "plan_id" not in plan_json
+
+
+def test_consistent_plan_id_across_all_issues(tmp_path: Path) -> None:
+    _make_chain_3_wps(tmp_path)
+    plan_id = str(uuid.uuid4())
+    source_commit = "f" * 40
+    compile_plan(
+        str(tmp_path),
+        write_task_file(tmp_path),
+        "/src",
+        plan_id=plan_id,
+        source_commit=source_commit,
+    )
+    for i in range(1, 4):
+        issue = (tmp_path / "issues" / f"P1-A1-WP{i}_issue.md").read_text()
+        assert f"plan_id: {plan_id}" in issue
+        assert f"source_commit: {source_commit}" in issue


### PR DESCRIPTION
## Summary

Add `plan_id` (UUID-4) and `source_commit` (40-char git SHA) metadata to planner-generated artifacts. Generate both values at `create_run_dir` (the `init` pipeline step), flow them through recipe context variables, and stamp them into artifacts: both fields go into `plan.json` and every generated markdown file (as YAML front matter), while `manifest.json` receives `plan_id` only (per REQ-META-004). The stamping is purely infrastructure-level — no LLM session prompts are modified.

## Requirements

### 1. Plan UUID

- Generate a UUID-4 at the earliest pipeline step that writes artifacts (e.g. `init`).
- Persist it in `plan.json` under a new top-level key `plan_id`.
- Include it in `manifest.json` so downstream tooling can correlate.
- Stamp it into the front matter of **every** generated markdown file: phase documents, assignment documents, work-package documents, and compiled issue markdown files.

### 2. Git commit SHA

- Capture `git rev-parse HEAD` (full 40-char SHA) from `source_dir` at planning start.
- Persist in `plan.json` under a new top-level key `source_commit`.
- Stamp into the front matter of every generated markdown file alongside the plan UUID.

### 3. Front matter format

All generated markdown artifacts should carry a YAML front matter block at the top:

```yaml
---
plan_id: <uuid4>
source_commit: <full-40-char-sha>
---
```

This block must be the first content in the file, before any headings or body text.

### 4. Infrastructure-level stamping

- The stamping must happen at the orchestration/pipeline layer — in the code that writes markdown files to disk.
- The LLM session must not be instructed to produce this front matter. It is a mechanical operation with deterministic values that the infrastructure already knows.
- This means the pipeline's file-writing utilities (whatever writes phase docs, WP docs, compiled issues to disk) must inject the front matter after receiving the LLM's content.

### 5. Persistence in plan.json

`plan.json` must include both fields at the top level:

```json
{
  "plan_id": "xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx",
  "source_commit": "a1b2c3d4e5f6...(40 chars)",
  ...
}
```

## Acceptance criteria

- [ ] `plan.json` includes `plan_id` (UUID-4) and `source_commit` (40-char SHA).
- [ ] `manifest.json` includes `plan_id`.
- [ ] Every generated markdown file (phase, assignment, WP, compiled issue) has YAML front matter with `plan_id` and `source_commit`.
- [ ] Front matter is injected by the pipeline infrastructure, not generated by the LLM.
- [ ] UUID is generated once per plan run and is consistent across all artifacts.
- [ ] Commit SHA matches `git rev-parse HEAD` at planning start.
- [ ] Existing planner tests continue to pass (no regression from front matter injection).
- [ ] New tests verify front matter presence and correctness in generated artifacts.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-094125-276553/.autoskillit/temp/make-plan/auto_stamp_plans_plan_2026-05-26_094500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 105 | 33.2k | 3.0M | 144.1k | 236 | 128.1k | 19m 15s |
| verify | claude-sonnet-4-6 | 1 | 84 | 11.8k | 353.5k | 49.9k | 111 | 39.9k | 7m 57s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 12.9k | 1.0M | 36.0k | 101 | 30.7k | 4m 38s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 60.1k | 3.4k | 153.7k | 30.7k | 17 | 43.2k | 57s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 85.0k | 2.0k | 304.5k | 30.7k | 23 | 15.1k | 58s |
| review_pr | claude-sonnet-4-6 | 1 | 174 | 33.6k | 804.2k | 76.1k | 59 | 78.1k | 8m 56s |
| resolve_review | claude-sonnet-4-6 | 1 | 251 | 23.1k | 1.7M | 74.7k | 82 | 66.5k | 11m 11s |
| **Total** | | | 1.3M | 120.1k | 7.4M | 144.1k | | 401.7k | 53m 54s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 390 | 2685.1 | 78.8 | 33.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **390** | 18942.1 | 1030.0 | 307.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 614 | 101.7k | 5.9M | 312.7k | 47m 21s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 18.3k | 1.5M | 89.0k | 6m 32s |