### PR TITLE
Implementation Plan: Propagate Pipeline Health Diagnostics from L2 Food Trucks to L3 Campaign Sessions

### DIFF
--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
-from autoskillit.core import FLEET_MENU_TOOLS, get_logger, is_feature_enabled
+from autoskillit.core import DISPATCH_ID_ENV_VAR, FLEET_MENU_TOOLS, get_logger, is_feature_enabled
 
 logger = get_logger(__name__)
 
@@ -138,5 +139,9 @@ def resolve_ingredient_defaults(project_dir: Path) -> dict[str, str]:
         resolved["local_review_rounds"] = "0"
         resolved["adversarial_review_level"] = "auto"
         resolved["post_run_diagnostics"] = "false"
+
+    # Fleet dispatch detection — reads env vars, not config, so must run unconditionally.
+    resolved["is_fleet_dispatch"] = "true" if os.environ.get(DISPATCH_ID_ENV_VAR) else "false"
+    resolved["dispatch_id"] = os.environ.get(DISPATCH_ID_ENV_VAR, "")
 
     return resolved

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2233,6 +2233,12 @@ skills:
     - name: kitchen_id
       type: string
       required: true
+    - name: dispatch_id
+      type: string
+      required: false
+    - name: diagnostics_log_dir
+      type: string
+      required: false
     outputs: []
     read_only: true
 callable_contracts:
@@ -2263,14 +2269,17 @@ callable_contracts:
     - name: prev_issues_fixed_count
       type: str
       required: false
+
+  autoskillit.smoke_utils.consolidate_health_reports:
+    inputs:
+    - name: diagnostics_log_dir
+      type: str
+      required: true
+    - name: kitchen_id
+      type: str
+      required: true
     outputs:
-    - name: next_iteration
-      type: str
-    - name: max_exceeded
-      type: str
-    - name: zero_progress
-      type: str
-    - name: prev_issues_fixed_count
+    - name: summary
       type: str
   autoskillit.smoke_utils.check_review_loop:
     inputs:

--- a/src/autoskillit/recipes/campaigns/promote-to-main.json
+++ b/src/autoskillit/recipes/campaigns/promote-to-main.json
@@ -11,7 +11,8 @@
     "full-audit",
     "bem-wrapper",
     "implement-findings",
-    "promote-to-main-wrapper"
+    "promote-to-main-wrapper",
+    "consolidate-health-reports"
   ],
   "ingredients": {
     "source_dir": {
@@ -34,6 +35,21 @@
     "model_context_window": {
       "description": "Model context window in tokens; set to 1000000 for Opus 1M",
       "default": "200000",
+      "hidden": true
+    },
+    "post_run_diagnostics": {
+      "description": "Run diagnostic analysis after pipeline completion",
+      "default": "false",
+      "hidden": true
+    },
+    "kitchen_id": {
+      "description": "Kitchen session identifier (auto-injected)",
+      "default": "",
+      "hidden": true
+    },
+    "diagnostics_log_dir": {
+      "description": "Resolved diagnostics log directory path (auto-injected)",
+      "default": "",
       "hidden": true
     }
   },
@@ -105,6 +121,20 @@
       },
       "depends_on": [
         "implement-findings"
+      ]
+    },
+    {
+      "name": "consolidate-diagnostics",
+      "recipe": "consolidate-health-reports",
+      "task": "Consolidate pipeline health reports from all dispatches in this campaign.",
+      "skip_when": "${{ inputs.post_run_diagnostics }} == false",
+      "ingredients": {
+        "kitchen_id": "${{ inputs.kitchen_id }}",
+        "diagnostics_log_dir": "${{ inputs.diagnostics_log_dir }}"
+      },
+      "capture": {},
+      "depends_on": [
+        "promote"
       ]
     }
   ],

--- a/src/autoskillit/recipes/campaigns/promote-to-main.yaml
+++ b/src/autoskillit/recipes/campaigns/promote-to-main.yaml
@@ -14,6 +14,7 @@ allowed_recipes:
   - bem-wrapper
   - implement-findings
   - promote-to-main-wrapper
+  - consolidate-health-reports
 
 ingredients:
   source_dir:
@@ -32,6 +33,18 @@ ingredients:
   model_context_window:
     description: "Model context window in tokens; set to 1000000 for Opus 1M"
     default: "200000"
+    hidden: true
+  post_run_diagnostics:
+    description: Run diagnostic analysis after pipeline completion
+    default: "false"
+    hidden: true
+  kitchen_id:
+    description: Kitchen session identifier (auto-injected)
+    default: ""
+    hidden: true
+  diagnostics_log_dir:
+    description: Resolved diagnostics log directory path (auto-injected)
+    default: ""
     hidden: true
 
 dispatches:
@@ -89,6 +102,17 @@ dispatches:
       verdict: "${{ result.verdict }}"
     depends_on:
       - implement-findings
+
+  - name: consolidate-diagnostics
+    recipe: consolidate-health-reports
+    task: "Consolidate pipeline health reports from all dispatches in this campaign."
+    skip_when: "${{ inputs.post_run_diagnostics }} == false"
+    ingredients:
+      kitchen_id: "${{ inputs.kitchen_id }}"
+      diagnostics_log_dir: "${{ inputs.diagnostics_log_dir }}"
+    capture: {}
+    depends_on:
+      - promote
 
 kitchen_rules:
   - "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write,

--- a/src/autoskillit/recipes/consolidate-health-reports.json
+++ b/src/autoskillit/recipes/consolidate-health-reports.json
@@ -1,0 +1,52 @@
+{
+  "name": "consolidate-health-reports",
+  "description": "Read per-dispatch health report JSON files from the diagnostics log directory, filter by campaign_id (kitchen_id), and produce a consolidated summary for the L3 campaign dispatcher.",
+  "kind": "food-truck",
+  "recipe_version": "1.0.0",
+  "dispatch_only": true,
+  "requires_packs": [
+    "github"
+  ],
+  "categories": [
+    "orchestration-family"
+  ],
+  "kitchen_rules": [
+    "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent, WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated through run_python.",
+    "This recipe is a food truck dispatched by a campaign. Emit the L3 sentinel JSON block exactly as instructed in the done step message."
+  ],
+  "ingredients": {
+    "kitchen_id": {
+      "description": "Kitchen session identifier (auto-injected, equals campaign_id)",
+      "default": "",
+      "hidden": true
+    },
+    "diagnostics_log_dir": {
+      "description": "Resolved diagnostics log directory path (auto-injected)",
+      "default": "",
+      "hidden": true
+    }
+  },
+  "steps": {
+    "consolidate": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.consolidate_health_reports",
+        "diagnostics_log_dir": "${{ inputs.diagnostics_log_dir }}",
+        "kitchen_id": "${{ inputs.kitchen_id }}"
+      },
+      "capture": {
+        "summary": "${{ result.summary }}"
+      },
+      "on_success": "done",
+      "on_failure": "done_empty"
+    },
+    "done_empty": {
+      "action": "stop",
+      "message": "Health report consolidation encountered an error. Emit the L3 sentinel JSON block now with the available information. Example sentinel: {\"success\": true, \"health_summary\": \"Consolidation failed — see L2 session logs for individual reports.\"}"
+    },
+    "done": {
+      "action": "stop",
+      "message": "Health reports consolidated. Emit your L3 sentinel JSON block now. The sentinel must include: success=true, health_summary=${{ context.summary }}. Example sentinel: {\"success\": true, \"health_summary\": \"Pipeline health check: 3 dispatches analyzed, no issues found.\"}"
+    }
+  }
+}

--- a/src/autoskillit/recipes/consolidate-health-reports.yaml
+++ b/src/autoskillit/recipes/consolidate-health-reports.yaml
@@ -1,0 +1,55 @@
+name: consolidate-health-reports
+description: >-
+  Read per-dispatch health report JSON files from the diagnostics log directory,
+  filter by campaign_id (kitchen_id), and produce a consolidated summary for
+  the L3 campaign dispatcher.
+kind: food-truck
+recipe_version: "1.0.0"
+dispatch_only: true
+requires_packs:
+- github
+categories:
+  - orchestration-family
+
+kitchen_rules:
+  - "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent,
+    WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated
+    through run_python."
+  - "This recipe is a food truck dispatched by a campaign. Emit the L3 sentinel JSON
+    block exactly as instructed in the done step message."
+
+ingredients:
+  kitchen_id:
+    description: Kitchen session identifier (auto-injected, equals campaign_id)
+    default: ""
+    hidden: true
+  diagnostics_log_dir:
+    description: Resolved diagnostics log directory path (auto-injected)
+    default: ""
+    hidden: true
+
+steps:
+  consolidate:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.consolidate_health_reports"
+      diagnostics_log_dir: "${{ inputs.diagnostics_log_dir }}"
+      kitchen_id: "${{ inputs.kitchen_id }}"
+    capture:
+      summary: "${{ result.summary }}"
+    on_success: done
+    on_failure: done_empty
+
+  done_empty:
+    action: stop
+    message: >-
+      Health report consolidation encountered an error. Emit the L3 sentinel
+      JSON block now with the available information.
+      Example sentinel: {"success": true, "health_summary": "Consolidation failed — see L2 session logs for individual reports."}
+
+  done:
+    action: stop
+    message: >-
+      Health reports consolidated. Emit your L3 sentinel JSON block now.
+      The sentinel must include: success=true, health_summary=${{ context.summary }}.
+      Example sentinel: {"success": true, "health_summary": "Pipeline health check: 3 dispatches analyzed, no issues found."}

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -93,6 +93,21 @@
       "description": "Kitchen session identifier (auto-injected)",
       "default": "",
       "hidden": true
+    },
+    "is_fleet_dispatch": {
+      "description": "Whether running as an L2 food truck dispatch (auto-injected)",
+      "default": "false",
+      "hidden": true
+    },
+    "dispatch_id": {
+      "description": "Fleet dispatch identifier (auto-injected, empty in non-fleet sessions)",
+      "default": "",
+      "hidden": true
+    },
+    "diagnostics_log_dir": {
+      "description": "Resolved diagnostics log directory path (auto-injected)",
+      "default": "",
+      "hidden": true
     }
   },
   "kitchen_rules": [
@@ -1075,7 +1090,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },
@@ -1945,7 +1960,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },
@@ -1999,7 +2014,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },
@@ -2015,7 +2030,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1,9 +1,14 @@
 name: implementation
 description: Plan, implement, test, and merge a task end-to-end
-summary: "bootstrap_clone > (claim_and_resolve?) > (create_and_publish?) > make-plan > (review-approach?) > dry-walkthrough > implement > test > merge (per plan part) > (audit-impl?) > (open_pr?) > push > cleanup"
-recipe_version: "1.0.0"
-requires_packs: [github, ci, clone, telemetry]
-
+summary: bootstrap_clone > (claim_and_resolve?) > (create_and_publish?) > make-plan
+  > (review-approach?) > dry-walkthrough > implement > test > merge (per plan part)
+  > (audit-impl?) > (open_pr?) > push > cleanup
+recipe_version: 1.0.0
+requires_packs:
+- github
+- ci
+- clone
+- telemetry
 ingredients:
   task:
     description: What to implement
@@ -11,1735 +16,1770 @@ ingredients:
   source_dir:
     description: Source repository
     required: false
-    default: ""
+    default: ''
   run_name:
     description: Run name prefix
-    default: "impl"
+    default: impl
   base_branch:
     description: Merge target
-    default: ""
+    default: ''
   review_approach:
     description: Research approaches first
-    default: "false"
+    default: 'false'
   audit:
     description: Post-merge quality gate
-    default: "false"
+    default: 'false'
   open_pr:
     description: PR instead of direct merge
-    default: "true"
+    default: 'true'
   arch_lenses:
     description: Generate architecture lens diagrams for the PR
-    default: "false"
+    default: 'false'
   auto_merge:
-    description: >-
-      Automatically merge the PR after required checks pass —
-      via merge queue when available, direct merge otherwise
-    default: "true"
+    description: Automatically merge the PR after required checks pass — via merge
+      queue when available, direct merge otherwise
+    default: 'true'
   batch_dispatch:
-    description: >-
-      Pack multiple parallel-safe issues per food truck. When "true", the fleet
-      dispatcher batches parallel-safe issues (up to max_issues_per_food_truck)
+    description: Pack multiple parallel-safe issues per food truck. When "true", the
+      fleet dispatcher batches parallel-safe issues (up to max_issues_per_food_truck)
       into implement-findings food trucks with comma-separated issue_urls.
-    default: "false"
+    default: 'false'
   review_max_retries:
-    description: Maximum number of review-resolve retry cycles before proceeding to CI
-    default: "3"
+    description: Maximum number of review-resolve retry cycles before proceeding to
+      CI
+    default: '3'
   local_review_rounds:
-    description: >-
-      Number of review-resolve cycles to run locally before switching to
+    description: Number of review-resolve cycles to run locally before switching to
       GitHub-backed review. 0 disables local mode entirely.
     type: integer
-    default: "2"
+    default: '2'
   adversarial_review_level:
-    description: >-
-      Controls adversarial review depth in make-plan. "auto" estimates complexity
-      and gates agents accordingly. "full" always runs all 3 agents. "none" skips
-      adversarial review entirely.
-    default: "auto"
+    description: Controls adversarial review depth in make-plan. "auto" estimates
+      complexity and gates agents accordingly. "full" always runs all 3 agents. "none"
+      skips adversarial review entirely.
+    default: auto
     hidden: true
   issue_url:
     description: GitHub issue to close on merge
     required: false
   upfront_claimed:
-    description: "Set to 'true' when process-issues has already claimed this issue upfront. Allows claim_issue defense step to pass through without aborting."
-    default: "false"
+    description: Set to 'true' when process-issues has already claimed this issue
+      upfront. Allows claim_issue defense step to pass through without aborting.
+    default: 'false'
     hidden: true
   run_mode:
-    description: >-
-      Execution mode when processing multiple issues. Options: sequential (default,
-      one issue at a time) or parallel (all issues simultaneously with wavefront
-      step scheduling — fast steps for all pipelines before any slow step).
-    default: "sequential"
+    description: 'Execution mode when processing multiple issues. Options: sequential
+      (default, one issue at a time) or parallel (all issues simultaneously with wavefront
+      step scheduling — fast steps for all pipelines before any slow step).'
+    default: sequential
     hidden: true
   max_parallel:
-    description: >-
-      Maximum number of issues to run in parallel within a single execution-map
-      group. Groups exceeding this cap are split into sequential sub-groups.
-      Passed to build-execution-map. Must be a positive integer (expressed as a
-      string).
-    default: "6"
+    description: Maximum number of issues to run in parallel within a single execution-map
+      group. Groups exceeding this cap are split into sequential sub-groups. Passed
+      to build-execution-map. Must be a positive integer (expressed as a string).
+    default: '6'
     hidden: true
   post_run_diagnostics:
     description: Run diagnostic analysis after pipeline completion
-    default: "false"
+    default: 'false'
     hidden: true
   kitchen_id:
     description: Kitchen session identifier (auto-injected)
-    default: ""
+    default: ''
     hidden: true
-
+  is_fleet_dispatch:
+    description: Whether running as an L2 food truck dispatch (auto-injected)
+    default: 'false'
+    hidden: true
+  dispatch_id:
+    description: Fleet dispatch identifier (auto-injected, empty in non-fleet sessions)
+    default: ''
+    hidden: true
+  diagnostics_log_dir:
+    description: Resolved diagnostics log directory path (auto-injected)
+    default: ''
+    hidden: true
 kitchen_rules:
-- "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent, WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated through run_skill."
-- "Route to on_failure — never investigate or fix directly from the orchestrator."
-- "Process plan parts sequentially. Complete the full cycle (verify → implement → test → merge) for one part before starting the next. Do NOT run verify for all parts upfront."
-- "By default (open_pr=true), a feature branch is created with a unique name derived from inputs.run_name and context.issue_number (e.g. impl/124) or a date suffix (e.g. impl/20260304) when no issue is available. All worktree merges target the feature branch (context.merge_target), not base_branch directly. The push step publishes the feature branch, then prepare_pr → run_arch_lenses → compose_pr opens a PR to base_branch. When open_pr=false, merges target base_branch directly and prepare_pr is skipped."
-- "When arch_lenses=true (and open_pr=true), prepare_pr routes through run_arch_lenses before compose_pr, adding architecture lens diagrams to the PR. By default arch_lenses is off and prepare_pr routes directly to compose_pr."
-- "SOURCE ISOLATION: After bootstrap_clone returns, the source_dir is strictly off-limits. Never run any command in source_dir — no git checkout, git fetch, git reset, git pull, run_cmd, run_skill, or any other operation. All work — skill invocations, git operations, file reads — happens exclusively in the clone (work_dir). source_dir is used ONLY to read the remote URL inside push_to_remote."
-- "MERGE ROUTING: check_repo_merge_state performs a single GraphQL round-trip to detect queue_available, merge_group_trigger, and auto_merge_available for the target branch. route_queue_mode then routes to: enable_auto_merge → wait_for_queue ONLY when queue_available=true AND merge_group_trigger=true; direct_merge → wait_for_direct_merge (no queue or trigger missing, autoMergeAllowed=true); or immediate_merge → wait_for_immediate_merge (no queue, autoMergeAllowed=false). Never call gh pr merge directly via run_cmd — all merges go through these named recipe steps so CI enforcement and conflict routing are preserved."
-
+- NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent,
+  WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated
+  through run_skill.
+- Route to on_failure — never investigate or fix directly from the orchestrator.
+- Process plan parts sequentially. Complete the full cycle (verify → implement → test
+  → merge) for one part before starting the next. Do NOT run verify for all parts
+  upfront.
+- By default (open_pr=true), a feature branch is created with a unique name derived
+  from inputs.run_name and context.issue_number (e.g. impl/124) or a date suffix (e.g.
+  impl/20260304) when no issue is available. All worktree merges target the feature
+  branch (context.merge_target), not base_branch directly. The push step publishes
+  the feature branch, then prepare_pr → run_arch_lenses → compose_pr opens a PR to
+  base_branch. When open_pr=false, merges target base_branch directly and prepare_pr
+  is skipped.
+- When arch_lenses=true (and open_pr=true), prepare_pr routes through run_arch_lenses
+  before compose_pr, adding architecture lens diagrams to the PR. By default arch_lenses
+  is off and prepare_pr routes directly to compose_pr.
+- 'SOURCE ISOLATION: After bootstrap_clone returns, the source_dir is strictly off-limits.
+  Never run any command in source_dir — no git checkout, git fetch, git reset, git
+  pull, run_cmd, run_skill, or any other operation. All work — skill invocations,
+  git operations, file reads — happens exclusively in the clone (work_dir). source_dir
+  is used ONLY to read the remote URL inside push_to_remote.'
+- 'MERGE ROUTING: check_repo_merge_state performs a single GraphQL round-trip to detect
+  queue_available, merge_group_trigger, and auto_merge_available for the target branch.
+  route_queue_mode then routes to: enable_auto_merge → wait_for_queue ONLY when queue_available=true
+  AND merge_group_trigger=true; direct_merge → wait_for_direct_merge (no queue or
+  trigger missing, autoMergeAllowed=true); or immediate_merge → wait_for_immediate_merge
+  (no queue, autoMergeAllowed=false). Never call gh pr merge directly via run_cmd
+  — all merges go through these named recipe steps so CI enforcement and conflict
+  routing are preserved.'
 steps:
   clone:
     tool: bootstrap_clone
     with:
-      source_dir: "${{ inputs.source_dir }}"
-      run_name: "${{ inputs.run_name }}"
-      base_branch: "${{ inputs.base_branch }}"
-      step_name: "bootstrap_clone"
+      source_dir: ${{ inputs.source_dir }}
+      run_name: ${{ inputs.run_name }}
+      base_branch: ${{ inputs.base_branch }}
+      step_name: bootstrap_clone
     capture:
-      work_dir: "${{ result.work_dir }}"
-      remote_url: "${{ result.remote_url }}"
-      base_sha: "${{ result.base_sha }}"
-      merge_target: "${{ result.merge_target }}"
+      work_dir: ${{ result.work_dir }}
+      remote_url: ${{ result.remote_url }}
+      base_sha: ${{ result.base_sha }}
+      merge_target: ${{ result.merge_target }}
     on_success: claim_and_resolve
     on_failure: escalate_stop
-    note: >
-      Clones source_dir and captures base_sha + merge_target in one turn.
-      Returns work_dir, remote_url, base_sha (SHA of base_branch before any merge),
-      and merge_target (set to base_branch as fallback; overridden by create_and_publish
-      when open_pr=true). On failure, escalate_stop immediately (no clone to remove).
+    note: 'Clones source_dir and captures base_sha + merge_target in one turn. Returns
+      work_dir, remote_url, base_sha (SHA of base_branch before any merge), and merge_target
+      (set to base_branch as fallback; overridden by create_and_publish when open_pr=true).
+      On failure, escalate_stop immediately (no clone to remove).
 
+      '
   claim_and_resolve:
     tool: claim_and_resolve_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
-      issue_url: "${{ inputs.issue_url }}"
-      allow_reentry: "${{ inputs.upfront_claimed }}"
+      issue_url: ${{ inputs.issue_url }}
+      allow_reentry: ${{ inputs.upfront_claimed }}
     capture:
-      issue_number: "${{ result.issue_number }}"
-      issue_title: "${{ result.issue_title }}"
-      issue_slug: "${{ result.issue_slug }}"
-      claimed: "${{ result.claimed }}"
+      issue_number: ${{ result.issue_number }}
+      issue_title: ${{ result.issue_title }}
+      issue_slug: ${{ result.issue_slug }}
+      claimed: ${{ result.claimed }}
     on_result:
-    - when: "${{ result.claimed }} == true"
+    - when: ${{ result.claimed }} == true
       route: create_and_publish
     - route: escalate_stop
     on_failure: escalate_stop
-    note: >
-      Fetches issue title/slug and claims the issue in one turn.
-      Returns issue_number, issue_title, issue_slug, and claimed boolean.
-      When claimed=false (another session owns it), routes to escalate_stop.
-      issue_slug and issue_number are passed to create_and_publish for branch naming.
+    note: 'Fetches issue title/slug and claims the issue in one turn. Returns issue_number,
+      issue_title, issue_slug, and claimed boolean. When claimed=false (another session
+      owns it), routes to escalate_stop. issue_slug and issue_number are passed to
+      create_and_publish for branch naming.
 
+      '
   create_and_publish:
     tool: create_and_publish_branch
     optional: true
     skip_when_false: inputs.open_pr
     with:
-      issue_slug: "${{ context.issue_slug }}"
-      run_name: "${{ inputs.run_name }}"
-      issue_number: "${{ context.issue_number }}"
-      work_dir: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "create_and_publish_branch"
+      issue_slug: ${{ context.issue_slug }}
+      run_name: ${{ inputs.run_name }}
+      issue_number: ${{ context.issue_number }}
+      work_dir: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: create_and_publish_branch
     capture:
-      merge_target: "${{ result.merge_target }}"
+      merge_target: ${{ result.merge_target }}
     on_success: plan
     on_failure: release_issue_failure
-    note: >
-      Computes branch name, creates it (with collision suffix if needed), and pushes
-      to origin in one turn. Overrides merge_target with the feature branch name.
-      merge_worktree requires refs/remotes/origin/{branch} to exist after fetch (step 5.5).
-      When open_pr=false, this step is skipped and merge_target remains as base_branch.
+    note: 'Computes branch name, creates it (with collision suffix if needed), and
+      pushes to origin in one turn. Overrides merge_target with the feature branch
+      name. merge_worktree requires refs/remotes/origin/{branch} to exist after fetch
+      (step 5.5). When open_pr=false, this step is skipped and merge_target remains
+      as base_branch.
 
+      '
   plan:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:make-plan ${{ inputs.task }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "plan"
-      issue_url: "${{ inputs.issue_url }}"
-      issue_title: "${{ context.issue_title }}"
-      adversarial_review_level: "${{ inputs.adversarial_review_level }}"
+      skill_command: /autoskillit:make-plan ${{ inputs.task }}
+      cwd: ${{ context.work_dir }}
+      step_name: plan
+      issue_url: ${{ inputs.issue_url }}
+      issue_title: ${{ context.issue_title }}
+      adversarial_review_level: ${{ inputs.adversarial_review_level }}
     capture:
-      plan_path: "${{ result.plan_path }}"
-      all_plan_paths: "${{ result.plan_path }}"
+      plan_path: ${{ result.plan_path }}
+      all_plan_paths: ${{ result.plan_path }}
     capture_list:
-      plan_parts: "${{ result.plan_parts }}"
+      plan_parts: ${{ result.plan_parts }}
     retries: 0
     on_success: review
     on_failure: release_issue_failure
-    note: >
-      Produces plan in {{AUTOSKILLIT_TEMP}}/make-plan/. Glob plan_dir for *_part_*.md or single plan file.
-      plan_parts context key contains the full ordered list of part files (sorted alphabetically).
-      For a single-part plan, plan_parts has one entry equal to plan_path.
-      REMEDIATION MODE: context.remediation_path is available when the orchestrator
-      re-enters plan from the remediate step; pass it inline in the skill_command
-      rather than as a named with: key.
-      ACCUMULATION: all_plan_paths accumulates across any re-entries to the plan step
-      (e.g. remediation). For a single-pass run, all_plan_paths equals plan_path
-      (the capture block handles this automatically).
-      ISSUE CONTEXT: If inputs.issue_url is a non-empty string, append it to the
-      skill_command so the make-plan skill can detect and fetch the issue itself:
-      "/autoskillit:make-plan {task}\n\nGitHub Issue: {inputs.issue_url}"
-      The skill detects the URL pattern and calls fetch_github_issue internally.
-      ADVERSARIAL REVIEW LEVEL: If inputs.adversarial_review_level is a non-empty
-      string, append it to the skill_command:
-      "/autoskillit:make-plan {task}\n\nadversarial_review_level={inputs.adversarial_review_level}"
+    note: 'Produces plan in {{AUTOSKILLIT_TEMP}}/make-plan/. Glob plan_dir for *_part_*.md
+      or single plan file. plan_parts context key contains the full ordered list of
+      part files (sorted alphabetically). For a single-part plan, plan_parts has one
+      entry equal to plan_path. REMEDIATION MODE: context.remediation_path is available
+      when the orchestrator re-enters plan from the remediate step; pass it inline
+      in the skill_command rather than as a named with: key. ACCUMULATION: all_plan_paths
+      accumulates across any re-entries to the plan step (e.g. remediation). For a
+      single-pass run, all_plan_paths equals plan_path (the capture block handles
+      this automatically). ISSUE CONTEXT: If inputs.issue_url is a non-empty string,
+      append it to the skill_command so the make-plan skill can detect and fetch the
+      issue itself: "/autoskillit:make-plan {task}\n\nGitHub Issue: {inputs.issue_url}"
+      The skill detects the URL pattern and calls fetch_github_issue internally. ADVERSARIAL
+      REVIEW LEVEL: If inputs.adversarial_review_level is a non-empty string, append
+      it to the skill_command: "/autoskillit:make-plan {task}\n\nadversarial_review_level={inputs.adversarial_review_level}"
 
+      '
   review:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:review-approach ${{ context.plan_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "review"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-approach"
+      skill_command: /autoskillit:review-approach ${{ context.plan_path }}
+      cwd: ${{ context.work_dir }}
+      step_name: review
+      output_dir: '{{AUTOSKILLIT_TEMP}}/review-approach'
     capture:
-      review_path: "${{ result.review_path }}"
+      review_path: ${{ result.review_path }}
     retries: 1
     on_success: verify
     on_failure: release_issue_failure
     on_context_limit: verify
-    skip_when_false: "inputs.review_approach"
-    note: "Only execute this step if review_approach input is 'true'. Otherwise skip directly to verify."
-
+    skip_when_false: inputs.review_approach
+    note: Only execute this step if review_approach input is 'true'. Otherwise skip
+      directly to verify.
   verify:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:dry-walkthrough ${{ context.plan_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "verify"
-      review_path: "${{ context.review_path }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}"
+      skill_command: /autoskillit:dry-walkthrough ${{ context.plan_path }}
+      cwd: ${{ context.work_dir }}
+      step_name: verify
+      review_path: ${{ context.review_path }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}'
     on_success: implement
     on_failure: release_issue_failure
     on_context_limit: implement
-    note: "SEQUENTIAL EXECUTION: For each plan_part, run the FULL cycle — verify → implement → test → merge — for that part before advancing to the next part. Never run verify for all parts first. If review produced a report, context.review_path is available — pass it as an additional arg to dry-walkthrough."
-
+    note: 'SEQUENTIAL EXECUTION: For each plan_part, run the FULL cycle — verify →
+      implement → test → merge — for that part before advancing to the next part.
+      Never run verify for all parts first. If review produced a report, context.review_path
+      is available — pass it as an additional arg to dry-walkthrough.'
   implement:
     tool: run_skill
-    model: ""
+    model: ''
     stale_threshold: 2400
     with:
-      skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "implement"
+      skill_command: /autoskillit:implement-worktree-no-merge ${{ context.plan_path
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: implement
     capture:
-      worktree_path: "${{ result.worktree_path }}"
+      worktree_path: ${{ result.worktree_path }}
     retries: 0
     on_context_limit: retry_worktree
     on_success: check_changes
     on_failure: release_issue_failure
-    note: "Extracts worktree_path from result for use in subsequent steps."
-
+    note: Extracts worktree_path from result for use in subsequent steps.
   retry_worktree:
     tool: run_skill
-    model: ""
+    model: ''
     stale_threshold: 2400
     with:
-      skill_command: "/autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path }}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: "retry_worktree"
+      skill_command: /autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path
+        }}
+      cwd: ${{ context.worktree_path }}
+      step_name: retry_worktree
     capture:
-      worktree_path: "${{ result.worktree_path }}"
-      phases_implemented: "${{ result.phases_implemented }}"
+      worktree_path: ${{ result.worktree_path }}
+      phases_implemented: ${{ result.phases_implemented }}
     on_result:
-    - when: "${{ result.phases_implemented }} > 0"
+    - when: ${{ result.phases_implemented }} > 0
       route: check_changes
     - route: check_changes
     on_context_limit: check_changes
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
-
   check_changes:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.detect_zero_changes"
-      worktree_path: "${{ context.worktree_path }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.smoke_utils.detect_zero_changes
+      worktree_path: ${{ context.worktree_path }}
+      base_branch: ${{ inputs.base_branch }}
     capture:
-      has_changes: "${{ result.has_changes }}"
-      commit_count: "${{ result.commit_count }}"
+      has_changes: ${{ result.has_changes }}
+      commit_count: ${{ result.commit_count }}
     on_result:
-    - when: "${{ result.has_changes }} == false"
+    - when: ${{ result.has_changes }} == false
       route: close_issue_no_changes
     - route: test
     on_failure: release_issue_failure
-
   close_issue_no_changes:
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
-      issue_url: "${{ inputs.issue_url }}"
-      close_issue: "true"
+      issue_url: ${{ inputs.issue_url }}
+      close_issue: 'true'
     on_success: done
     on_failure: done
-
   test:
     tool: test_check
     with:
-      worktree_path: "${{ context.worktree_path }}"
+      worktree_path: ${{ context.worktree_path }}
     on_success: check_merge_fix_loop
     on_failure: fix
-
   check_merge_fix_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.merge_fix_count }}"
-      max_iterations: "3"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.merge_fix_count }}
+      max_iterations: '3'
     capture:
-      merge_fix_count: "${{ result.next_iteration }}"
+      merge_fix_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
     - route: commit_guard
     on_failure: release_issue_failure
     optional_context_refs:
     - merge_fix_count
-    note: >
-      Iteration guard for the merge→fix→test cycle. Caps the loop at 3
-      iterations (enough for legitimate flake recovery but not enough to
-      burn 30+ minutes on structurally unresolvable conflicts).
+    note: 'Iteration guard for the merge→fix→test cycle. Caps the loop at 3 iterations
+      (enough for legitimate flake recovery but not enough to burn 30+ minutes on
+      structurally unresolvable conflicts).
 
+      '
   commit_guard:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.commit_guard"
-      worktree_path: "${{ context.worktree_path }}"
+      callable: autoskillit.recipe._cmd_rpc.commit_guard
+      worktree_path: ${{ context.worktree_path }}
     on_success: main_repo_guard
     on_failure: main_repo_guard
-    note: >
-      Belt-and-suspenders guard: auto-commits any uncommitted changes before merge.
-      Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes,
-      or any other source. Routes to main_repo_guard to handle dirty main repo state.
+    note: 'Belt-and-suspenders guard: auto-commits any uncommitted changes before
+      merge. Catches dirty state from context-exhausted skills, cascading pre-commit
+      auto-fixes, or any other source. Routes to main_repo_guard to handle dirty main
+      repo state.
 
+      '
   main_repo_guard:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.main_repo_guard"
-      clone_path: "${{ context.work_dir }}"
+      callable: autoskillit.recipe._cmd_rpc.main_repo_guard
+      clone_path: ${{ context.work_dir }}
     on_success: merge
     on_failure: merge
-    note: >
-      Stashes uncommitted changes in the main repo before merge. Catches dirty state
-      from infrastructure-terminated sessions that left artifacts in the clone.
-      Routes to merge on both success and failure (merge's dirty_main_repo gate
-      handles persistent issues).
+    note: 'Stashes uncommitted changes in the main repo before merge. Catches dirty
+      state from infrastructure-terminated sessions that left artifacts in the clone.
+      Routes to merge on both success and failure (merge''s dirty_main_repo gate handles
+      persistent issues).
 
+      '
   merge:
     tool: merge_worktree
     with:
-      worktree_path: "${{ context.worktree_path }}"
-      base_branch: "${{ context.merge_target }}"
+      worktree_path: ${{ context.worktree_path }}
+      base_branch: ${{ context.merge_target }}
     capture:
-      cleanup_succeeded: "${{ result.cleanup_succeeded }}"
-      worktree_path: "${{ result.worktree_path }}"
+      cleanup_succeeded: ${{ result.cleanup_succeeded }}
+      worktree_path: ${{ result.worktree_path }}
     on_result:
-    - when: "result.failed_step == 'dirty_tree'"
+    - when: result.failed_step == 'dirty_tree'
       route: fix
-    - when: "result.failed_step == 'test_gate'"
+    - when: result.failed_step == 'test_gate'
       route: fix
-    - when: "result.failed_step == 'post_rebase_test_gate'"
+    - when: result.failed_step == 'post_rebase_test_gate'
       route: fix
-    - when: "result.failed_step == 'rebase'"
+    - when: result.failed_step == 'rebase'
       route: rebase_conflict_fix
-    - when: "result.failed_step == 'dirty_main_repo'"
+    - when: result.failed_step == 'dirty_main_repo'
       route: check_merge_fix_loop
-    - when: "result.error"
+    - when: result.error
       route: release_issue_failure
     - route: next_or_done
     on_failure: release_issue_failure
-    note: >
-      After merge, route to next_or_done to process remaining parts before pushing.
+    note: 'After merge, route to next_or_done to process remaining parts before pushing.
       By default (open_pr=true), merge_target is the feature branch named from run_name.
-      When open_pr=false, merge_target equals base_branch — merges go directly to base.
-      dirty_tree and test_gate failures route to fix (resolve-failures) for recovery;
-      all other failures route to release_issue_failure.
+      When open_pr=false, merge_target equals base_branch — merges go directly to
+      base. dirty_tree and test_gate failures route to fix (resolve-failures) for
+      recovery; all other failures route to release_issue_failure.
 
+      '
   check_has_commits:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_commits_ahead"
-      cwd: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.smoke_utils.check_commits_ahead
+      cwd: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.has_commits }}"
+    - when: ${{ result.has_commits }}
       route: push
     - route: close_issue_already_done
     on_failure: release_issue_failure
-
   close_issue_already_done:
-    description: "Close issue as already-implemented when branch has zero commits ahead of base"
+    description: Close issue as already-implemented when branch has zero commits ahead
+      of base
     tool: run_python
     optional: true
-    skip_when_false: "inputs.issue_url"
+    skip_when_false: inputs.issue_url
     with:
-      callable: "autoskillit.smoke_utils.close_issue_already_done"
-      issue_url: "${{ inputs.issue_url }}"
+      callable: autoskillit.smoke_utils.close_issue_already_done
+      issue_url: ${{ inputs.issue_url }}
     on_success: register_clone_success
     on_failure: register_clone_success
-    note: >
-      Zero commits ahead of base means the feature is already merged.
-      Remove in-progress label, close issue with "already implemented" comment,
-      and route to clone cleanup.
+    note: 'Zero commits ahead of base means the feature is already merged. Remove
+      in-progress label, close issue with "already implemented" comment, and route
+      to clone cleanup.
 
+      '
   push:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
     on_success: prepare_pr
     on_failure: release_issue_failure
-    note: >
-      Runs once at the end, after check_has_commits confirms commits exist.
-      Pushes merge_target branch from the clone to the upstream remote.
-      By default (open_pr=true), this pushes the feature branch; when open_pr=false, pushes base_branch.
-      Uses the pre-resolved remote_url captured at clone time, preserving clone isolation.
-      On success, routes to prepare_pr (which opens the PR by default; skipped when open_pr=false).
-      On failure, release_issue_failure registers the clone and escalates.
+    note: 'Runs once at the end, after check_has_commits confirms commits exist. Pushes
+      merge_target branch from the clone to the upstream remote. By default (open_pr=true),
+      this pushes the feature branch; when open_pr=false, pushes base_branch. Uses
+      the pre-resolved remote_url captured at clone time, preserving clone isolation.
+      On success, routes to prepare_pr (which opens the PR by default; skipped when
+      open_pr=false). On failure, release_issue_failure registers the clone and escalates.
 
+      '
   fix:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: "fix"
+      skill_command: /autoskillit:resolve-failures ${{ context.worktree_path }} ${{
+        context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.worktree_path }}
+      step_name: fix
     capture:
-      verdict: "${{ result.verdict }}"
-      fixes_applied: "${{ result.fixes_applied }}"
+      verdict: ${{ result.verdict }}
+      fixes_applied: ${{ result.fixes_applied }}
     on_result:
-    - when: "${{ result.verdict }} == 'real_fix'"
+    - when: ${{ result.verdict }} == 'real_fix'
       route: test
-    - when: "${{ result.verdict }} == 'already_green'"
+    - when: ${{ result.verdict }} == 'already_green'
       route: test
-    - when: "${{ result.verdict }} == 'flake_suspected'"
+    - when: ${{ result.verdict }} == 'flake_suspected'
       route: test
-    - when: "${{ result.verdict }} == 'ci_only_failure'"
+    - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
-    - when: "${{ result.verdict }} == 'no_test_infrastructure'"
+    - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: test
-    note: "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
-
+    note: Fixes test failures without merging. Routes back to test for re-validation
+      before merge_worktree. on_context_limit routes needs_retry=True to test (worktree
+      may already be green) instead of re-running fix blindly.
   rebase_conflict_fix:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: "rebase_conflict_fix"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.worktree_path
+        }} ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.worktree_path }}
+      step_name: rebase_conflict_fix
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: test
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-
   next_or_done:
     action: route
     on_result:
-    - when: "${{ result.next }} == more_parts"
+    - when: ${{ result.next }} == more_parts
       route: verify
     - route: audit_impl
-    note: >
-      Routing step — no tool call. The agent evaluates what comes next:
-      1. If more plan_parts remain for the current plan → go to verify with next part.
-      2. If all plan_parts are complete → go to audit_impl.
+    note: 'Routing step — no tool call. The agent evaluates what comes next: 1. If
+      more plan_parts remain for the current plan → go to verify with next part. 2.
+      If all plan_parts are complete → go to audit_impl.
 
+      '
   audit_impl:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.base_sha }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "audit_impl"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
+      skill_command: /autoskillit:audit-impl ${{ context.plan_path }} ${{ context.base_sha
+        }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: audit_impl
+      output_dir: '{{AUTOSKILLIT_TEMP}}/audit-impl'
     capture:
-      remediation_path: "${{ result.remediation_path }}"
+      remediation_path: ${{ result.remediation_path }}
     on_result:
-    - when: "${{ result.verdict }} == GO"
+    - when: ${{ result.verdict }} == GO
       route: check_has_commits
-    - when: "result.error"
+    - when: result.error
       route: escalate_stop
     - route: remediate
     on_failure: escalate_stop
     on_context_limit: escalate_stop
     optional: true
-    skip_when_false: "inputs.audit"
-    note: >
-      Only execute if inputs.audit is 'true'. If false, skip directly to check_has_commits.
-      Captures verdict and remediation_path. Routes GO → push, NO GO → remediate
-      which re-enters the plan step with the remediation file.
-      All parts have been merged at this point — no worktree exists.
-      Uses context.base_sha (a stable commit SHA captured before any merge began)
-      as implementation_ref. A SHA names a git object and survives git branch -D
-      unconditionally. The diff git diff base_sha..base_branch (two-dot, SHA on the
-      left) covers the full implementation.
+    skip_when_false: inputs.audit
+    note: 'Only execute if inputs.audit is ''true''. If false, skip directly to check_has_commits.
+      Captures verdict and remediation_path. Routes GO → push, NO GO → remediate which
+      re-enters the plan step with the remediation file. All parts have been merged
+      at this point — no worktree exists. Uses context.base_sha (a stable commit SHA
+      captured before any merge began) as implementation_ref. A SHA names a git object
+      and survives git branch -D unconditionally. The diff git diff base_sha..base_branch
+      (two-dot, SHA on the left) covers the full implementation.
 
+      '
   remediate:
     action: route
     with:
-      remediation_path: "${{ context.remediation_path }}"
+      remediation_path: ${{ context.remediation_path }}
     on_success: plan
-
   prepare_pr:
     tool: run_skill
-    model: ""
+    model: ''
     retries: 1
     with:
-      skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "prepare_pr"
+      skill_command: /autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name
+        }} ${{ inputs.base_branch }} ${{ context.issue_number }}
+      cwd: ${{ context.work_dir }}
+      step_name: prepare_pr
     capture:
-      prep_path: "${{ result.prep_path }}"
-      selected_lenses: "${{ result.selected_lenses }}"
-      lens_context_paths: "${{ result.lens_context_paths }}"
+      prep_path: ${{ result.prep_path }}
+      selected_lenses: ${{ result.selected_lenses }}
+      lens_context_paths: ${{ result.lens_context_paths }}
     on_result:
-    - when: "${{ result.prep_path }} and ${{ inputs.arch_lenses }} == 'true'"
+    - when: ${{ result.prep_path }} and ${{ inputs.arch_lenses }} == 'true'
       route: run_arch_lenses
-    - when: "${{ result.prep_path }}"
+    - when: ${{ result.prep_path }}
       route: compose_pr
     - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: prepare_pr
     on_exhausted: release_issue_failure
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens slugs,
-      writes one PR context file per lens, and writes a PR prep file. Does NOT invoke
-      arch-lens skills.
+    skip_when_false: inputs.open_pr
+    note: 'Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens
+      slugs, writes one PR context file per lens, and writes a PR prep file. Does
+      NOT invoke arch-lens skills.
 
+      '
   run_arch_lenses:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:arch-lens-{slug} {context_path}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "run_arch_lenses"
+      skill_command: /autoskillit:arch-lens-{slug} {context_path}
+      cwd: ${{ context.work_dir }}
+      step_name: run_arch_lenses
     capture_list:
-      all_diagram_paths: "${{ result.diagram_path }}"
+      all_diagram_paths: ${{ result.diagram_path }}
     retries: 0
     on_success: compose_pr
     on_failure: compose_pr
     on_context_limit: compose_pr
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      LENS ITERATION: context.selected_lenses contains comma-separated arch-lens slugs
-      (e.g. "module-dependency,process-flow"). context.lens_context_paths contains the
-      corresponding comma-separated context file paths (same order as slugs). For each
-      lens slug, run:
-        /autoskillit:arch-lens-{slug} {matching_context_path}
-      Run all selected lenses in parallel (all run_skill calls in a single message).
-      Accumulate each diagram_path value into context.all_diagram_paths via capture_list.
-      If a lens fails, continue with remaining lenses — compose_pr handles empty lists
-      gracefully by omitting the Architecture Impact section.
-
+    skip_when_false: inputs.open_pr
+    note: "LENS ITERATION: context.selected_lenses contains comma-separated arch-lens\
+      \ slugs (e.g. \"module-dependency,process-flow\"). context.lens_context_paths\
+      \ contains the corresponding comma-separated context file paths (same order\
+      \ as slugs). For each lens slug, run:\n  /autoskillit:arch-lens-{slug} {matching_context_path}\n\
+      Run all selected lenses in parallel (all run_skill calls in a single message).\
+      \ Accumulate each diagram_path value into context.all_diagram_paths via capture_list.\
+      \ If a lens fails, continue with remaining lenses — compose_pr handles empty\
+      \ lists gracefully by omitting the Architecture Impact section.\n"
   compose_pr:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "compose_pr"
+      skill_command: /autoskillit:compose-pr ${{ context.prep_path }} "${{ context.all_diagram_paths
+        }}" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: compose_pr
     capture:
-      pr_url: "${{ result.pr_url }}"
+      pr_url: ${{ result.pr_url }}
     on_result:
-    - when: "${{ result.pr_url }}"
+    - when: ${{ result.pr_url }}
       route: guard_pr_url
     - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●),
-      composes the PR body, and runs gh pr create. Degrades gracefully if gh is
+    skip_when_false: inputs.open_pr
+    note: 'Reads the PR prep file, validates arch-lens diagrams (must contain ★ or
+      ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is
       unavailable (emits pr_url=).
 
+      '
   guard_pr_url:
     action: route
     on_result:
-    - when: "${{ context.pr_url }}"
+    - when: ${{ context.pr_url }}
       route: extract_pr_number
     - route: release_issue_failure
-    note: Guard — skip PR extraction if pr_url is empty (graceful degradation from compose_pr).
-
+    note: Guard — skip PR extraction if pr_url is empty (graceful degradation from
+      compose_pr).
   extract_pr_number:
     tool: run_cmd
     with:
-      cmd: "gh pr view '${{ context.merge_target }}' --json number -q .number"
-      cwd: "${{ context.work_dir }}"
-      step_name: "extract_pr_number"
+      cmd: gh pr view '${{ context.merge_target }}' --json number -q .number
+      cwd: ${{ context.work_dir }}
+      step_name: extract_pr_number
     capture:
-      pr_number: "${{ result.stdout | trim }}"
+      pr_number: ${{ result.stdout | trim }}
     on_success: annotate_pr_diff
     on_failure: release_issue_failure
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Extracts the PR number as a string for downstream steps.
-      pr_number is required by the queue finale steps (enable_auto_merge, wait_for_queue).
+    skip_when_false: inputs.open_pr
+    note: 'Extracts the PR number as a string for downstream steps. pr_number is required
+      by the queue finale steps (enable_auto_merge, wait_for_queue).
 
+      '
   annotate_pr_diff:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.annotate_pr_diff"
-      pr_number: "${{ context.pr_number }}"
-      cwd: "${{ context.work_dir }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
-      base_branch: "${{ inputs.base_branch }}"
-      local_review_rounds: "${{ inputs.local_review_rounds }}"
-      current_iteration: "${{ context.review_loop_count }}"
+      callable: autoskillit.smoke_utils.annotate_pr_diff
+      pr_number: ${{ context.pr_number }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'
+      base_branch: ${{ inputs.base_branch }}
+      local_review_rounds: ${{ inputs.local_review_rounds }}
+      current_iteration: ${{ context.review_loop_count }}
     capture:
-      annotated_diff_path: "${{ result.annotated_diff_path }}"
-      hunk_ranges_path: "${{ result.hunk_ranges_path }}"
-      diff_metrics_path: "${{ result.diff_metrics_path }}"
-      review_mode: "${{ result.review_mode }}"
+      annotated_diff_path: ${{ result.annotated_diff_path }}
+      hunk_ranges_path: ${{ result.hunk_ranges_path }}
+      diff_metrics_path: ${{ result.diff_metrics_path }}
+      review_mode: ${{ result.review_mode }}
     on_success: review_pr
     on_failure: review_pr
     optional: true
-    skip_when_false: "inputs.open_pr"
+    skip_when_false: inputs.open_pr
     optional_context_refs:
     - review_loop_count
-    note: >
-      Pre-computes annotated diff with [LNNN] markers and hunk ranges JSON for
+    note: 'Pre-computes annotated diff with [LNNN] markers and hunk ranges JSON for
       review-pr. On failure, falls through to review_pr which uses empty fallback.
 
+      '
   review_pr:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "review_pr"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
+      skill_command: /autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch
+        }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{
+        context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path
+        }} mode=${{ context.review_mode }}
+      cwd: ${{ context.work_dir }}
+      step_name: review_pr
+      output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'
     capture:
-      review_verdict: "${{ result.verdict }}"
+      review_verdict: ${{ result.verdict }}
     on_result:
-    - when: "${{ result.verdict }} == changes_requested"
+    - when: ${{ result.verdict }} == changes_requested
       route: enrich_diff_context
-    - when: "${{ result.verdict }} == approved_with_comments"
+    - when: ${{ result.verdict }} == approved_with_comments
       route: enrich_diff_context
-    - when: "${{ result.verdict }} == needs_human"
+    - when: ${{ result.verdict }} == needs_human
       route: check_review_loop
-    - when: "${{ result.verdict }} == approved"
+    - when: ${{ result.verdict }} == approved
       route: check_review_loop
-    - when: "true"
+    - when: 'true'
       route: check_review_loop
     on_failure: check_repo_ci_event
     on_context_limit: check_repo_ci_event
     optional: true
-    skip_when_false: "inputs.open_pr"
+    skip_when_false: inputs.open_pr
     optional_context_refs:
     - review_loop_count
     - review_mode
-    note: >
-      Runs after compose_pr creates the PR. Invokes the review-pr skill as a
+    note: 'Runs after compose_pr creates the PR. Invokes the review-pr skill as a
       headless session to leave inline review comments on the PR. The skill finds
       the open PR by feature branch name (context.merge_target). Captures verdict
       as review_verdict and routes via on_result: changes_requested/approved_with_comments
-      → enrich_diff_context → resolve_review; all other verdicts (including approved, needs_human)
-      → check_review_loop (mandatory waypoint to increment review_loop_count).
+      → enrich_diff_context → resolve_review; all other verdicts (including approved,
+      needs_human) → check_review_loop (mandatory waypoint to increment review_loop_count).
       On tool-level failure (MCP error, gh unavailable), routes to check_repo_ci_event
       (no review to resolve). Skipped when open_pr=false.
 
+      '
   enrich_diff_context:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.enrich_diff_context"
-      pr_number: "${{ context.pr_number }}"
-      work_dir: "${{ context.work_dir }}"
+      callable: autoskillit.smoke_utils.enrich_diff_context
+      pr_number: ${{ context.pr_number }}
+      work_dir: ${{ context.work_dir }}
     on_success: resolve_review
     on_failure: resolve_review
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Enriches the review-pr diff_context handoff file with deterministic
-      code_region extraction from the annotated diff. On failure, falls through
-      to resolve_review which uses fallback file-read behavior.
+    skip_when_false: inputs.open_pr
+    note: 'Enriches the review-pr diff_context handoff file with deterministic code_region
+      extraction from the annotated diff. On failure, falls through to resolve_review
+      which uses fallback file-read behavior.
 
+      '
   resolve_review:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_review"
+      skill_command: /autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch
+        }} mode=${{ context.review_mode }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_review
     capture:
-      verdict: "${{ result.verdict }}"
+      verdict: ${{ result.verdict }}
     retries: 2
     on_exhausted: release_issue_failure
     on_context_limit: re_push_review
     on_result:
-    - when: "${{ result.verdict }} == 'real_fix'"
+    - when: ${{ result.verdict }} == 'real_fix'
       route: re_push_review
-    - when: "${{ result.verdict }} == 'already_green'"
+    - when: ${{ result.verdict }} == 'already_green'
       route: re_push_review
-    - when: "${{ result.verdict }} == 'flake_suspected'"
+    - when: ${{ result.verdict }} == 'flake_suspected'
       route: re_push_review
-    - when: "${{ result.verdict }} == 'ci_only_failure'"
+    - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
     on_failure: release_issue_failure
     optional_context_refs:
     - review_mode
-    note: >
-      Runs when review_pr reports issues (verdict=changes_requested). The clone
+    note: 'Runs when review_pr reports issues (verdict=changes_requested). The clone
       (context.work_dir) has the feature branch (context.merge_target) checked out.
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
       commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
-      flake_suspected all route to re_push_review (retry bounded by retries: 2);
-      ci_only_failure escalates to release_issue_failure.
+      flake_suspected all route to re_push_review (retry bounded by retries: 2); ci_only_failure
+      escalates to release_issue_failure.
 
+      '
   re_push_review:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
     on_success: check_review_loop
     on_failure: release_issue_failure
-    note: >
-      Pushes the review-fixed feature branch back to the remote after resolve_review
+    note: 'Pushes the review-fixed feature branch back to the remote after resolve_review
       succeeds. Routes to check_review_loop to determine if another review-resolve
       cycle is needed (bounded by review_max_retries). On push failure, escalates
       via release_issue_failure.
 
+      '
   check_review_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_review_loop"
-      pr_number: "${{ context.pr_number }}"
-      current_iteration: "${{ context.review_loop_count }}"
-      max_iterations: "${{ inputs.review_max_retries }}"
-      previous_verdict: "${{ context.review_verdict }}"
-      local_review_rounds: "${{ inputs.local_review_rounds }}"
+      callable: autoskillit.smoke_utils.check_review_loop
+      pr_number: ${{ context.pr_number }}
+      current_iteration: ${{ context.review_loop_count }}
+      max_iterations: ${{ inputs.review_max_retries }}
+      previous_verdict: ${{ context.review_verdict }}
+      local_review_rounds: ${{ inputs.local_review_rounds }}
     capture:
-      review_loop_count: "${{ result.next_iteration }}"
+      review_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false"
+    - when: ${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false
       route: annotate_pr_diff
     - route: check_repo_ci_event
     on_failure: check_repo_ci_event
     optional_context_refs:
     - review_loop_count
     - review_verdict
-    note: >
-      Compound iteration + blocking guard. Routes back to annotate_pr_diff only when
-      had_blocking=true AND max_exceeded=false. had_blocking is true when
-      previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds
-      AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS). approved_with_comments yields had_blocking=false
+    note: 'Compound iteration + blocking guard. Routes back to annotate_pr_diff only
+      when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested
+      OR (local_review_rounds > 0 AND iteration < local_review_rounds AND verdict
+      not in LOCAL_ROUND_EXEMPT_VERDICTS). approved_with_comments yields had_blocking=false
       unconditionally because its resolve pass is one-shot, regardless of local_review_rounds.
 
+      '
   check_repo_ci_event:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.merge_target }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "check_repo_ci_event"
+      branch: ${{ context.merge_target }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: check_repo_ci_event
     capture:
-      ci_event: "${{ result.ci_event }}"
-      ci_applicable: "${{ result.ci_applicable }}"
+      ci_event: ${{ result.ci_event }}
+      ci_applicable: ${{ result.ci_applicable }}
     on_success: route_ci_applicable
     on_failure: ci_watch
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Derives ci_event for the feature branch BEFORE ci_watch runs.
-      Uses context.merge_target (feature branch) so push.branches filter
-      is evaluated against the actual branch being pushed, not the base branch.
-      Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).
+    skip_when_false: inputs.open_pr
+    note: 'Derives ci_event for the feature branch BEFORE ci_watch runs. Uses context.merge_target
+      (feature branch) so push.branches filter is evaluated against the actual branch
+      being pushed, not the base branch. Non-blocking: on_failure routes to ci_watch
+      with ci_event=null (match-any).
 
+      '
   route_ci_applicable:
     action: route
     on_result:
-    - when: "${{ context.ci_applicable }} == false"
+    - when: ${{ context.ci_applicable }} == false
       route: check_repo_merge_state
     - route: check_pr_state
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Short-circuits CI wait when no workflow trigger matches the feature branch.
-      ci_applicable=false means neither push nor merge_group triggers apply,
-      so wait_for_ci would exhaust its timeout budget with zero CI runs.
+    skip_when_false: inputs.open_pr
+    note: 'Short-circuits CI wait when no workflow trigger matches the feature branch.
+      ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci
+      would exhaust its timeout budget with zero CI runs.
 
+      '
   check_pr_state:
     tool: check_pr_mergeable
     with:
-      pr_number: "${{ context.pr_number }}"
-      cwd: "${{ context.work_dir }}"
+      pr_number: ${{ context.pr_number }}
+      cwd: ${{ context.work_dir }}
     on_result:
-    - when: "${{ result.mergeable_status }} == 'CONFLICTING'"
+    - when: ${{ result.mergeable_status }} == 'CONFLICTING'
       route: ci_conflict_fix
     - route: ci_watch
     on_failure: ci_watch
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Pre-CI-watch gate: checks PR mergeable state before entering the CI
-      polling loop. CONFLICTING PRs cannot trigger pull_request workflows
-      (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would
-      produce a guaranteed no_runs. Routes CONFLICTING directly to ci_conflict_fix
-      (resolve-merge-conflicts) — GitHub's CONFLICTING status is authoritative,
-      no stale-base exit-code discrimination needed (mirrors merge-prs.yaml
-      check_mergeability pattern). Routes MERGEABLE/UNKNOWN to ci_watch.
+    skip_when_false: inputs.open_pr
+    note: 'Pre-CI-watch gate: checks PR mergeable state before entering the CI polling
+      loop. CONFLICTING PRs cannot trigger pull_request workflows (GitHub cannot create
+      refs/pull/N/merge), so routing to ci_watch would produce a guaranteed no_runs.
+      Routes CONFLICTING directly to ci_conflict_fix (resolve-merge-conflicts) — GitHub''s
+      CONFLICTING status is authoritative, no stale-base exit-code discrimination
+      needed (mirrors merge-prs.yaml check_mergeability pattern). Routes MERGEABLE/UNKNOWN
+      to ci_watch.
 
+      '
   ci_watch:
     tool: wait_for_ci
     with:
-      branch: "${{ context.merge_target }}"
-      event: "${{ context.ci_event }}"
+      branch: ${{ context.merge_target }}
+      event: ${{ context.ci_event }}
       timeout_seconds: 600
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
     capture:
-      ci_conclusion: "${{ result.conclusion }}"
-      ci_failed_jobs: "${{ result.failed_jobs }}"
+      ci_conclusion: ${{ result.conclusion }}
+      ci_failed_jobs: ${{ result.failed_jobs }}
     on_result:
-    - when: "${{ result.conclusion }} == 'success'"
+    - when: ${{ result.conclusion }} == 'success'
       route: check_repo_merge_state
-    - when: "${{ result.conclusion }} == 'no_runs'"
+    - when: ${{ result.conclusion }} == 'no_runs'
       route: handle_no_ci_runs
-    - when: "${{ result.conclusion }} == 'timed_out'"
+    - when: ${{ result.conclusion }} == 'timed_out'
       route: check_ci_timed_out_loop
     - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Waits for the GitHub Actions CI run on context.merge_target to complete
+    skip_when_false: inputs.open_pr
+    note: 'Waits for the GitHub Actions CI run on context.merge_target to complete
       using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output
-      (conclusion + failed job names) for downstream resolve_ci.
-      Skipped when open_pr=false — no remote feature branch is opened in that mode.
-      Routes on result.conclusion: success → check_repo_merge_state,
-      no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push +
-      re-poll; handle_no_ci_runs reached only when push fails),
-      timed_out → check_ci_timed_out_loop (iteration guard), failure → detect_ci_conflict.
+      (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false
+      — no remote feature branch is opened in that mode. Routes on result.conclusion:
+      success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger
+      fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached
+      only when push fails), timed_out → check_ci_timed_out_loop (iteration guard),
+      failure → detect_ci_conflict.
 
+      '
   check_ci_timed_out_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_timed_out_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_timed_out_loop_count }}
+      max_iterations: '2'
     capture:
-      ci_timed_out_loop_count: "${{ result.next_iteration }}"
+      ci_timed_out_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: detect_ci_conflict
     - route: ci_watch
     on_failure: detect_ci_conflict
     optional_context_refs:
     - ci_timed_out_loop_count
-    note: >
-      Caps the ci_watch re-poll loop at 2 iterations.
-      After 2 timed_out results (1200s total), routes to detect_ci_conflict
-      instead of spinning indefinitely.
+    note: 'Caps the ci_watch re-poll loop at 2 iterations. After 2 timed_out results
+      (1200s total), routes to detect_ci_conflict instead of spinning indefinitely.
 
+      '
   handle_no_ci_runs:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.merge_target }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "handle_no_ci_runs"
+      branch: ${{ context.merge_target }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: handle_no_ci_runs
     capture:
-      ci_event: "${{ result.ci_event }}"
-      ci_applicable: "${{ result.ci_applicable }}"
+      ci_event: ${{ result.ci_event }}
+      ci_applicable: ${{ result.ci_applicable }}
     on_success: check_ci_loop
     on_failure: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    note: >
-      Intercepts no_runs conclusion from wait_for_ci. Re-derives ci_event using
-      check_repo_merge_state (the original event may have been wrong for this
-      branch's workflow configuration) and routes to check_ci_loop for iteration
-      guard before retrying ci_watch. retries: 1 bounds the tool-call retry;
-      check_ci_loop bounds the outer loop at 2 iterations.
+    note: 'Intercepts no_runs conclusion from wait_for_ci. Re-derives ci_event using
+      check_repo_merge_state (the original event may have been wrong for this branch''s
+      workflow configuration) and routes to check_ci_loop for iteration guard before
+      retrying ci_watch. retries: 1 bounds the tool-call retry; check_ci_loop bounds
+      the outer loop at 2 iterations.
 
+      '
   check_ci_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_loop_count }}
+      max_iterations: '2'
     capture:
-      ci_loop_count: "${{ result.next_iteration }}"
+      ci_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: check_active_trigger_loop
     - route: ci_watch
     on_failure: check_ci_already_passed
     optional_context_refs:
     - ci_loop_count
-    note: >
-      Iteration guard for the ci_watch / handle_no_ci_runs cycle. Caps the
-      loop at 2 iterations (initial + 1 retry after re-deriving ci_event).
-      On budget exhaustion, routes to check_active_trigger_loop which caps
-      the active trigger to a single attempt before escalating.
+    note: 'Iteration guard for the ci_watch / handle_no_ci_runs cycle. Caps the loop
+      at 2 iterations (initial + 1 retry after re-deriving ci_event). On budget exhaustion,
+      routes to check_active_trigger_loop which caps the active trigger to a single
+      attempt before escalating.
 
+      '
   check_active_trigger_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.active_trigger_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.active_trigger_count }}
+      max_iterations: '2'
     capture:
-      active_trigger_count: "${{ result.next_iteration }}"
+      active_trigger_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: check_ci_already_passed
     - route: trigger_ci_actively
     on_failure: check_ci_already_passed
     optional_context_refs:
     - active_trigger_count
-    note: >
-      Bounds the trigger_ci_actively remediation to a single attempt. If
-      ci_watch still returns no_runs after the active trigger, escalates
-      to escalate_stop_no_ci rather than re-triggering indefinitely.
+    note: 'Bounds the trigger_ci_actively remediation to a single attempt. If ci_watch
+      still returns no_runs after the active trigger, escalates to escalate_stop_no_ci
+      rather than re-triggering indefinitely.
 
+      '
   trigger_ci_actively:
     tool: run_cmd
     with:
-      cmd: "gh pr close ${{ context.pr_number }} && sleep 2 && gh pr reopen ${{ context.pr_number }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "trigger_ci_actively"
+      cmd: gh pr close ${{ context.pr_number }} && sleep 2 && gh pr reopen ${{ context.pr_number
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: trigger_ci_actively
     on_success: ci_watch
     on_failure: check_ci_already_passed
     retries: 1
     on_exhausted: check_ci_already_passed
-    note: >
-      Active CI trigger remediation: closes and reopens the PR to force GitHub
-      webhook re-delivery. This re-creates the pull_request event and the
-      refs/pull/N/merge ref (if the PR is mergeable). Routes back to ci_watch
-      for one final attempt. If the close/reopen fails or the subsequent
-      ci_watch still returns no_runs, escalates to escalate_stop_no_ci.
+    note: 'Active CI trigger remediation: closes and reopens the PR to force GitHub
+      webhook re-delivery. This re-creates the pull_request event and the refs/pull/N/merge
+      ref (if the PR is mergeable). Routes back to ci_watch for one final attempt.
+      If the close/reopen fails or the subsequent ci_watch still returns no_runs,
+      escalates to escalate_stop_no_ci.
 
+      '
   check_ci_already_passed:
     tool: wait_for_ci
     with:
-      branch: "${{ context.merge_target }}"
-      event: "${{ context.ci_event }}"
+      branch: ${{ context.merge_target }}
+      event: ${{ context.ci_event }}
       timeout_seconds: 30
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
-    skip_when_false: "inputs.open_pr"
+    skip_when_false: inputs.open_pr
     on_result:
-    - when: "${{ result.conclusion }} == success"
+    - when: ${{ result.conclusion }} == success
       route: check_repo_merge_state
-    - when: "${{ result.conclusion }} == failure"
+    - when: ${{ result.conclusion }} == failure
       route: detect_ci_conflict
-    - when: "${{ result.conclusion }} == timed_out"
+    - when: ${{ result.conclusion }} == timed_out
       route: ci_watch
     - route: mark_issue_failed_no_ci
     on_failure: mark_issue_failed_no_ci
-    note: >
-      Safety net before terminal escalation: re-polls CI with a short timeout
-      to detect if CI has already passed or failed despite the watcher failing
-      to observe it. Uses wait_for_ci as the authoritative signal (30s timeout
-      for immediate state detection). success → merge gate, failure → conflict
-      remediation, timed_out (still pending) → ci_watch for re-poll,
-      no_runs → terminal escalation path.
+    note: 'Safety net before terminal escalation: re-polls CI with a short timeout
+      to detect if CI has already passed or failed despite the watcher failing to
+      observe it. Uses wait_for_ci as the authoritative signal (30s timeout for immediate
+      state detection). success → merge gate, failure → conflict remediation, timed_out
+      (still pending) → ci_watch for re-poll, no_runs → terminal escalation path.
 
+      '
   mark_issue_failed_no_ci:
-    description: "Swap in-progress → fail label before CI failure escalation"
+    description: Swap in-progress → fail label before CI failure escalation
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
-      fail_label: "fail"
+      fail_label: fail
     on_success: register_clone_no_ci
     on_failure: register_clone_no_ci
-
   register_clone_no_ci:
-    description: "Register clone as preserved (no-CI error pipeline)"
+    description: Register clone as preserved (no-CI error pipeline)
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "error"
+      clone_path: ${{ context.work_dir }}
+      status: error
       step_name: register_clone_no_ci
     on_success: run_diagnostic_no_ci
     on_failure: run_diagnostic_no_ci
-
   run_diagnostic_no_ci:
-    description: "Run post-pipeline diagnostic analysis on session logs (no-CI path)"
+    description: Run post-pipeline diagnostic analysis on session logs (no-CI path)
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: escalate_stop_no_ci
     on_failure: escalate_stop_no_ci
     on_context_limit: escalate_stop_no_ci
-    note: >
-      Diagnostic failure never blocks pipeline completion.
+    note: 'Diagnostic failure never blocks pipeline completion.
 
+      '
   escalate_stop_no_ci:
     action: stop
-    message: >-
-      CI safety net: statusCheckRollup returned no checks for PR
-      ${{ context.pr_number }}. This typically means no workflow is
-      configured to trigger on this branch pattern. Check .github/workflows/
-      trigger configuration. This is NOT a test failure — CI never started.
-      Emit the L3 result sentinel JSON block now with success=false.
-      Example sentinel: {"success": false, "reason": "no CI checks configured"}
-
+    message: 'CI safety net: statusCheckRollup returned no checks for PR ${{ context.pr_number
+      }}. This typically means no workflow is configured to trigger on this branch
+      pattern. Check .github/workflows/ trigger configuration. This is NOT a test
+      failure — CI never started. Emit the L3 result sentinel JSON block now with
+      success=false. Example sentinel: {"success": false, "reason": "no CI checks
+      configured"}'
   check_repo_merge_state:
     tool: check_repo_merge_state
     block: pre_queue_gate
     with:
-      branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "check_repo_merge_state"
+      branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: check_repo_merge_state
     capture:
-      queue_available: "${{ result.queue_available }}"
-      merge_group_trigger: "${{ result.merge_group_trigger }}"
-      auto_merge_available: "${{ result.auto_merge_available }}"
-      ci_event: "${{ result.ci_event }}"
-      ci_applicable: "${{ result.ci_applicable }}"
+      queue_available: ${{ result.queue_available }}
+      merge_group_trigger: ${{ result.merge_group_trigger }}
+      auto_merge_available: ${{ result.auto_merge_available }}
+      ci_event: ${{ result.ci_event }}
+      ci_applicable: ${{ result.ci_applicable }}
     on_success: route_queue_mode
     on_failure: immediate_merge
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Single GraphQL round-trip that captures queue_available, merge_group_trigger,
-      auto_merge_available, and ci_event for the target branch. Consolidates the former three
-      sequential run_cmd steps (check_merge_queue, check_merge_group_trigger,
+    skip_when_false: inputs.open_pr
+    note: 'Single GraphQL round-trip that captures queue_available, merge_group_trigger,
+      auto_merge_available, and ci_event for the target branch. Consolidates the former
+      three sequential run_cmd steps (check_merge_queue, check_merge_group_trigger,
       check_auto_merge) into one MCP tool call. On failure (network error, auth failure),
-      falls through to immediate_merge (non-queue direct merge path).
-      Skipped when open_pr=false — no PR was opened.
+      falls through to immediate_merge (non-queue direct merge path). Skipped when
+      open_pr=false — no PR was opened.
 
+      '
   route_queue_mode:
     block: pre_queue_gate
     action: route
     on_result:
-    - when: "${{ inputs.auto_merge }} != 'true'"
+    - when: ${{ inputs.auto_merge }} != 'true'
       route: patch_token_summary
-    - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true"
+    - when: ${{ context.queue_available }} == true and ${{ context.merge_group_trigger
+        }} == true
       route: enqueue_to_queue
-    - when: "${{ context.auto_merge_available }} == true"
+    - when: ${{ context.auto_merge_available }} == true
       route: direct_merge
     - route: immediate_merge
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   enqueue_to_queue:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: wait_for_queue
     on_failure: verify_queue_enrollment
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Submits the PR to the merge queue via the unified enqueue_pr tool.
-      The tool resolves the enrollment strategy internally based on
-      auto_merge_available. On failure, probes the queue via
-      verify_queue_enrollment to distinguish a transient enqueue error from a
-      PR that is already merged or still in queue.
+    skip_when_false: inputs.open_pr
+    note: 'Submits the PR to the merge queue via the unified enqueue_pr tool. The
+      tool resolves the enrollment strategy internally based on auto_merge_available.
+      On failure, probes the queue via verify_queue_enrollment to distinguish a transient
+      enqueue error from a PR that is already merged or still in queue.
 
+      '
   verify_queue_enrollment:
-    description: "Probe merge queue after enqueue command failure to determine actual state"
+    description: Probe merge queue after enqueue command failure to determine actual
+      state
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       timeout_seconds: 60
       poll_interval: 10
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: release_issue_success
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: diagnose_ci
-    - when: "${{ result.pr_state }} == not_enrolled"
+    - when: ${{ result.pr_state }} == not_enrolled
       route: release_issue_failure
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: wait_for_queue
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: diagnose_ci
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: wait_for_queue
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: wait_for_queue
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_unconfirmed
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    note: >
-      Short probe (60s) after enqueue_to_queue failure. If the PR is already
-      merged, route to release_issue_success. If the queue already confirms CI
-      failure (ejected_ci_failure or dropped_merge_group_ci), route directly to
-      diagnose_ci. If enrollment was attempted but the PR never appeared in the
-      queue (not_enrolled), route to release_issue_failure — this is a repo
-      configuration error. For other active queue states (dropped_healthy, ejected,
-      stalled), route to wait_for_queue for full 900s authoritative watch. If the
-      probe timed out or returned an unexpected state, escalate via
-      register_clone_unconfirmed.
+    note: 'Short probe (60s) after enqueue_to_queue failure. If the PR is already
+      merged, route to release_issue_success. If the queue already confirms CI failure
+      (ejected_ci_failure or dropped_merge_group_ci), route directly to diagnose_ci.
+      If enrollment was attempted but the PR never appeared in the queue (not_enrolled),
+      route to release_issue_failure — this is a repo configuration error. For other
+      active queue states (dropped_healthy, ejected, stalled), route to wait_for_queue
+      for full 900s authoritative watch. If the probe timed out or returned an unexpected
+      state, escalate via register_clone_unconfirmed.
 
+      '
   wait_for_queue:
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
       timeout_seconds: 900
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
     capture:
-      queue_pr_state: "${{ result.pr_state }}"
+      queue_pr_state: ${{ result.pr_state }}
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: release_issue_success
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: diagnose_ci
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: diagnose_ci
-    - when: "${{ result.pr_state }} == not_enrolled"
+    - when: ${{ result.pr_state }} == not_enrolled
       route: release_issue_failure
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: check_dropped_healthy_loop
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: check_eject_limit
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: reenroll_stalled_pr
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_unconfirmed
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Waits up to 15 minutes for the PR to merge through the queue.
-      merged → release_issue_success to transition issue state then register_clone_success.
-      ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
-      not_enrolled → release_issue_failure (enrollment failed; repo configuration error).
-      ejected → conflict fix cycle then re-enter.
-      stalled → lightweight re-enrollment via enqueue_pr.
-      timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).
+    skip_when_false: inputs.open_pr
+    note: 'Waits up to 15 minutes for the PR to merge through the queue. merged →
+      release_issue_success to transition issue state then register_clone_success.
+      ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix
+      this). not_enrolled → release_issue_failure (enrollment failed; repo configuration
+      error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment
+      via enqueue_pr. timeout → register_clone_unconfirmed (release claim without
+      staged label; merge unconfirmed).
 
+      '
   reenroll_stalled_pr:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: check_stall_loop
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   check_stall_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.stall_loop_count }}"
-      max_iterations: "3"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.stall_loop_count }}
+      max_iterations: '3'
     capture:
-      stall_loop_count: "${{ result.next_iteration }}"
+      stall_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_unconfirmed
     - route: wait_for_queue
     on_failure: register_clone_unconfirmed
     optional_context_refs:
     - stall_loop_count
-    note: >
-      Iteration guard for the wait_for_queue / reenroll_stalled_pr cycle.
-      Caps stall re-enrollment at 3 attempts. On budget exhaustion, routes
-      to register_clone_unconfirmed (merge outcome unconfirmed).
+    note: 'Iteration guard for the wait_for_queue / reenroll_stalled_pr cycle. Caps
+      stall re-enrollment at 3 attempts. On budget exhaustion, routes to register_clone_unconfirmed
+      (merge outcome unconfirmed).
 
+      '
   check_eject_limit:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.check_eject_limit"
-      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count"
-      max_ejects: "3"
+      callable: autoskillit.recipe._cmd_rpc.check_eject_limit
+      counter_file: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count
+      max_ejects: '3'
     on_result:
-    - when: "${{ result.status }} == EJECT_LIMIT_EXCEEDED"
+    - when: ${{ result.status }} == EJECT_LIMIT_EXCEEDED
       route: release_issue_failure
     - route: queue_ejected_fix
     on_failure: release_issue_failure
-    note: >
-      Circuit breaker for the queue ejection loop. Tracks ejection count in a
-      file-based counter under {{AUTOSKILLIT_TEMP}}/. After 3 ejections, routes
-      to release_issue_failure to prevent infinite re-enqueue cycles.
+    note: 'Circuit breaker for the queue ejection loop. Tracks ejection count in a
+      file-based counter under {{AUTOSKILLIT_TEMP}}/. After 3 ejections, routes to
+      release_issue_failure to prevent infinite re-enqueue cycles.
 
+      '
   check_dropped_healthy_loop:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop"
-      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count"
-      max_drops: "2"
+      callable: autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop
+      counter_file: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count
+      max_drops: '2'
     on_result:
-    - when: "${{ result.status }} == DROPPED_LIMIT_EXCEEDED"
+    - when: ${{ result.status }} == DROPPED_LIMIT_EXCEEDED
       route: release_issue_failure
     - route: reenter_merge_queue_cheap
     on_failure: release_issue_failure
-    note: >
-      Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive
+    note: 'Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive
       unexplained drops with healthy PR-branch CI, escalates to release_issue_failure
       instead of looping. Matches the check_eject_limit pattern used for the ejected
-      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed
-      directly to diagnose_ci and never reaches this step.
+      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed directly
+      to diagnose_ci and never reaches this step.
 
+      '
   queue_ejected_fix:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.queue_ejected_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.queue_ejected_fix
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.status }} == clean"
+    - when: ${{ result.status }} == clean
       route: re_push_queue_fix
     - route: resolve_queue_merge_conflicts
     on_failure: resolve_queue_merge_conflicts
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Attempts a cheap rebase before invoking the full conflict-resolution skill.
+    skip_when_false: inputs.open_pr
+    note: 'Attempts a cheap rebase before invoking the full conflict-resolution skill.
       On a clean rebase (stdout "clean"), skips the skill and proceeds directly to
-      re_push_queue_fix. On conflict, aborts the rebase and routes to
-      resolve_queue_merge_conflicts for goal-aware resolution.
+      re_push_queue_fix. On conflict, aborts the rebase and routes to resolve_queue_merge_conflicts
+      for goal-aware resolution.
 
+      '
   resolve_queue_merge_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_queue_merge_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_queue_merge_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: re_push_queue_fix
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Resolves rebase conflicts on the feature branch after queue ejection.
-      Only reached when the cheap rebase in queue_ejected_fix encountered conflicts.
-      escalation_required=true → release_issue_failure for human review.
+    skip_when_false: inputs.open_pr
+    note: 'Resolves rebase conflicts on the feature branch after queue ejection. Only
+      reached when the cheap rebase in queue_ejected_fix encountered conflicts. escalation_required=true
+      → release_issue_failure for human review.
 
+      '
   re_push_queue_fix:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
     capture:
-      push_error_type: "${{ result.error_type }}"
+      push_error_type: ${{ result.error_type }}
     retries: 2
     on_exhausted: register_clone_unconfirmed
     on_success: ci_watch_post_queue_fix
     on_failure: classify_push_failure
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   classify_push_failure:
     action: route
     on_result:
-    - when: "${{ context.push_error_type }} == queued_branch"
+    - when: ${{ context.push_error_type }} == queued_branch
       route: wait_dequeue_retry
     - route: release_issue_failure
-
   wait_dequeue_retry:
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      timeout_seconds: "60"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      timeout_seconds: '60'
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: release_issue_success
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: register_clone_unconfirmed
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: register_clone_unconfirmed
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: register_clone_unconfirmed
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: re_push_queue_fix
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: register_clone_unconfirmed
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_unconfirmed
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
     optional_context_refs:
     - push_error_type
-
   ci_watch_post_queue_fix:
     tool: wait_for_ci
     with:
-      branch: "${{ context.merge_target }}"
-      event: "${{ context.ci_event }}"
+      branch: ${{ context.merge_target }}
+      event: ${{ context.ci_event }}
       timeout_seconds: 600
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
     capture:
-      ci_conclusion: "${{ result.conclusion }}"
-      ci_failed_jobs: "${{ result.failed_jobs }}"
+      ci_conclusion: ${{ result.conclusion }}
+      ci_failed_jobs: ${{ result.failed_jobs }}
     on_result:
-    - when: "${{ result.conclusion }} == 'success'"
+    - when: ${{ result.conclusion }} == 'success'
       route: reenter_merge_queue
-    - when: "${{ result.conclusion }} == 'no_runs'"
+    - when: ${{ result.conclusion }} == 'no_runs'
       route: release_issue_failure
-    - when: "${{ result.conclusion }} == 'timed_out'"
+    - when: ${{ result.conclusion }} == 'timed_out'
       route: check_ci_post_queue_loop
     - route: detect_ci_conflict
     on_failure: detect_ci_conflict
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Validates CI on the rebased feature branch after queue ejection fix and re-push.
-      Routes on result.conclusion: success → reenter_merge_queue,
-      no_runs → release_issue_failure (auto_trigger fires first: empty commit +
-      force-push + re-poll; no_runs reached only when trigger recovery fails),
-      timed_out → check_ci_post_queue_loop, failure → detect_ci_conflict.
+    skip_when_false: inputs.open_pr
+    note: 'Validates CI on the rebased feature branch after queue ejection fix and
+      re-push. Routes on result.conclusion: success → reenter_merge_queue, no_runs
+      → release_issue_failure (auto_trigger fires first: empty commit + force-push
+      + re-poll; no_runs reached only when trigger recovery fails), timed_out → check_ci_post_queue_loop,
+      failure → detect_ci_conflict.
 
+      '
   check_ci_post_queue_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_post_queue_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_post_queue_loop_count }}
+      max_iterations: '2'
     capture:
-      ci_post_queue_loop_count: "${{ result.next_iteration }}"
+      ci_post_queue_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
     - route: ci_watch_post_queue_fix
     on_failure: release_issue_failure
     optional_context_refs:
     - ci_post_queue_loop_count
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Iteration guard for the ci_watch_post_queue_fix timed_out self-loop.
-      Caps at 2 iterations (initial + 1 retry). On budget exhaustion,
-      routes to release_issue_failure — this is already a post-ejection
-      retry path so further escalation is not warranted.
+    skip_when_false: inputs.open_pr
+    note: 'Iteration guard for the ci_watch_post_queue_fix timed_out self-loop. Caps
+      at 2 iterations (initial + 1 retry). On budget exhaustion, routes to release_issue_failure
+      — this is already a post-ejection retry path so further escalation is not warranted.
 
+      '
   reenter_merge_queue:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: wait_for_queue
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Re-submits the PR after conflict resolution. Routes back to wait_for_queue.
+    skip_when_false: inputs.open_pr
+    note: 'Re-submits the PR after conflict resolution. Routes back to wait_for_queue.
       If re-entry fails, release_issue_failure preserves the clone for debugging.
 
+      '
   reenter_merge_queue_cheap:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: wait_for_queue
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Re-submits a healthy PR into the merge queue after auto_merge was cleared
-      externally (DROPPED_HEALTHY state). No conflict-resolution CI wait needed.
-      Routes back to wait_for_queue on success.
+    skip_when_false: inputs.open_pr
+    note: 'Re-submits a healthy PR into the merge queue after auto_merge was cleared
+      externally (DROPPED_HEALTHY state). No conflict-resolution CI wait needed. Routes
+      back to wait_for_queue on success.
 
+      '
   direct_merge:
     tool: run_cmd
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
-      cwd: "${{ context.work_dir }}"
-      step_name: "direct_merge"
+      cmd: gh pr merge '${{ context.pr_number }}' --squash --auto
+      cwd: ${{ context.work_dir }}
+      step_name: direct_merge
     on_success: wait_for_direct_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Enables GitHub native auto-merge for direct merge (no merge queue). GitHub
-      merges automatically once all required checks pass. On failure, escalates
-      via release_issue_failure so the issue claim is released and the pipeline
-      reports an error rather than silently succeeding.
+    skip_when_false: inputs.open_pr
+    note: 'Enables GitHub native auto-merge for direct merge (no merge queue). GitHub
+      merges automatically once all required checks pass. On failure, escalates via
+      release_issue_failure so the issue claim is released and the pipeline reports
+      an error rather than silently succeeding.
 
+      '
   wait_for_direct_merge:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.wait_for_direct_merge"
-      pr_number: "${{ context.pr_number }}"
-      max_polls: "90"
-      poll_interval: "10"
+      callable: autoskillit.recipe._cmd_rpc.wait_for_direct_merge
+      pr_number: ${{ context.pr_number }}
+      max_polls: '90'
+      poll_interval: '10'
     on_result:
-    - when: "${{ result.state }} == merged"
+    - when: ${{ result.state }} == merged
       route: release_issue_success
-    - when: "${{ result.state }} == closed"
+    - when: ${{ result.state }} == closed
       route: direct_merge_conflict_fix
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Polls GitHub PR state every 10 s for up to 15 minutes (90 iterations).
-      merged → release_issue_success (issue labelled, cleanup runs).
-      closed → PR was closed (likely conflict) — route to conflict fix.
-      timeout / unexpected → register_clone_unconfirmed.
+    skip_when_false: inputs.open_pr
+    note: 'Polls GitHub PR state every 10 s for up to 15 minutes (90 iterations).
+      merged → release_issue_success (issue labelled, cleanup runs). closed → PR was
+      closed (likely conflict) — route to conflict fix. timeout / unexpected → register_clone_unconfirmed.
 
+      '
   direct_merge_conflict_fix:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.status }} == clean"
+    - when: ${{ result.status }} == clean
       route: re_push_direct_fix
     - route: resolve_direct_merge_conflicts
     on_failure: resolve_direct_merge_conflicts
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Attempts a cheap rebase before invoking the full conflict-resolution skill.
-      On clean rebase, proceeds to re_push_direct_fix. On conflict, routes to
-      resolve_direct_merge_conflicts for goal-aware resolution.
+    skip_when_false: inputs.open_pr
+    note: 'Attempts a cheap rebase before invoking the full conflict-resolution skill.
+      On clean rebase, proceeds to re_push_direct_fix. On conflict, routes to resolve_direct_merge_conflicts
+      for goal-aware resolution.
 
+      '
   resolve_direct_merge_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_direct_merge_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_direct_merge_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: re_push_direct_fix
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Resolves rebase conflicts after direct-merge rejection.
-      Only reached when the cheap rebase in direct_merge_conflict_fix encountered conflicts.
-      escalation_required=true → release_issue_failure for human review.
+    skip_when_false: inputs.open_pr
+    note: 'Resolves rebase conflicts after direct-merge rejection. Only reached when
+      the cheap rebase in direct_merge_conflict_fix encountered conflicts. escalation_required=true
+      → release_issue_failure for human review.
 
+      '
   re_push_direct_fix:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
     on_success: redirect_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   redirect_merge:
     tool: run_cmd
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
-      cwd: "${{ context.work_dir }}"
-      step_name: "redirect_merge"
+      cmd: gh pr merge '${{ context.pr_number }}' --squash --auto
+      cwd: ${{ context.work_dir }}
+      step_name: redirect_merge
     on_success: wait_for_direct_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Re-enables auto-merge after conflict resolution and re-push.
-      Routes back to wait_for_direct_merge to poll for completion.
-      On failure, release_issue_failure preserves the clone for debugging.
+    skip_when_false: inputs.open_pr
+    note: 'Re-enables auto-merge after conflict resolution and re-push. Routes back
+      to wait_for_direct_merge to poll for completion. On failure, release_issue_failure
+      preserves the clone for debugging.
 
+      '
   immediate_merge:
     tool: run_cmd
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
-      cwd: "${{ context.work_dir }}"
-      step_name: "immediate_merge"
+      cmd: gh pr merge '${{ context.pr_number }}' --squash
+      cwd: ${{ context.work_dir }}
+      step_name: immediate_merge
     on_success: wait_for_immediate_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Merges the PR immediately using plain --squash when autoMergeAllowed=false.
-      Unlike direct_merge, no --auto flag is used — GitHub executes the merge
-      synchronously rather than queueing it for when checks pass. On failure,
-      escalates via release_issue_failure so the issue claim is released and the
-      pipeline reports an error rather than silently succeeding.
+    skip_when_false: inputs.open_pr
+    note: 'Merges the PR immediately using plain --squash when autoMergeAllowed=false.
+      Unlike direct_merge, no --auto flag is used — GitHub executes the merge synchronously
+      rather than queueing it for when checks pass. On failure, escalates via release_issue_failure
+      so the issue claim is released and the pipeline reports an error rather than
+      silently succeeding.
 
+      '
   wait_for_immediate_merge:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.wait_for_immediate_merge"
-      pr_number: "${{ context.pr_number }}"
-      max_polls: "30"
-      poll_interval: "10"
+      callable: autoskillit.recipe._cmd_rpc.wait_for_immediate_merge
+      pr_number: ${{ context.pr_number }}
+      max_polls: '30'
+      poll_interval: '10'
     on_result:
-    - when: "${{ result.state }} == merged"
+    - when: ${{ result.state }} == merged
       route: release_issue_success
-    - when: "${{ result.state }} == closed"
+    - when: ${{ result.state }} == closed
       route: immediate_merge_conflict_fix
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Polls GitHub PR state every 10s for up to 5 minutes (30 iterations).
-      Since immediate_merge uses --squash without --auto, the merge completes
-      synchronously — this poll is a confirmation window.
-      merged → release_issue_success.
-      closed → PR was rejected (stale base or conflict) — route to conflict fix.
-      timeout → register_clone_unconfirmed.
+    skip_when_false: inputs.open_pr
+    note: 'Polls GitHub PR state every 10s for up to 5 minutes (30 iterations). Since
+      immediate_merge uses --squash without --auto, the merge completes synchronously
+      — this poll is a confirmation window. merged → release_issue_success. closed
+      → PR was rejected (stale base or conflict) — route to conflict fix. timeout
+      → register_clone_unconfirmed.
 
+      '
   immediate_merge_conflict_fix:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.status }} == clean"
+    - when: ${{ result.status }} == clean
       route: re_push_immediate_fix
     - route: resolve_immediate_merge_conflicts
     on_failure: resolve_immediate_merge_conflicts
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Attempts a cheap rebase before invoking the full conflict-resolution skill.
-      On clean rebase, proceeds to re_push_immediate_fix. On conflict, routes to
-      resolve_immediate_merge_conflicts for goal-aware resolution.
+    skip_when_false: inputs.open_pr
+    note: 'Attempts a cheap rebase before invoking the full conflict-resolution skill.
+      On clean rebase, proceeds to re_push_immediate_fix. On conflict, routes to resolve_immediate_merge_conflicts
+      for goal-aware resolution.
 
+      '
   resolve_immediate_merge_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_immediate_merge_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_immediate_merge_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: re_push_immediate_fix
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Resolves rebase conflicts after immediate-merge rejection.
-      Only reached when the cheap rebase in immediate_merge_conflict_fix encountered conflicts.
+    skip_when_false: inputs.open_pr
+    note: 'Resolves rebase conflicts after immediate-merge rejection. Only reached
+      when the cheap rebase in immediate_merge_conflict_fix encountered conflicts.
       escalation_required=true → release_issue_failure for human review.
 
+      '
   re_push_immediate_fix:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
     on_success: remerge_immediate
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   remerge_immediate:
     tool: run_cmd
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
-      cwd: "${{ context.work_dir }}"
-      step_name: "remerge_immediate"
+      cmd: gh pr merge '${{ context.pr_number }}' --squash
+      cwd: ${{ context.work_dir }}
+      step_name: remerge_immediate
     on_success: wait_for_immediate_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Re-attempts plain squash merge after conflict resolution and re-push.
-      Routes back to wait_for_immediate_merge to confirm completion.
-      On failure, release_issue_failure preserves the clone for debugging.
+    skip_when_false: inputs.open_pr
+    note: 'Re-attempts plain squash merge after conflict resolution and re-push. Routes
+      back to wait_for_immediate_merge to confirm completion. On failure, release_issue_failure
+      preserves the clone for debugging.
 
+      '
   diagnose_ci:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:diagnose-ci ${{ context.merge_target }} - - - ${{ context.ci_event }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "diagnose_ci"
-      ci_failed_jobs: "${{ context.ci_failed_jobs }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+      skill_command: /autoskillit:diagnose-ci ${{ context.merge_target }} - - - ${{
+        context.ci_event }}
+      cwd: ${{ context.work_dir }}
+      step_name: diagnose_ci
+      ci_failed_jobs: ${{ context.ci_failed_jobs }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-ci'
     capture:
-      diagnosis_path: "${{ result.diagnosis_path }}"
+      diagnosis_path: ${{ result.diagnosis_path }}
     on_success: resolve_ci
     on_failure: resolve_ci
     on_context_limit: resolve_ci
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Runs when ci_watch reports a CI failure. Fetches CI logs via gh API and writes
-      a structured diagnosis to {{AUTOSKILLIT_TEMP}}/diagnose-ci/. Routes to resolve_ci on success
-      OR failure (best-effort: resolve-failures proceeds even without a diagnosis).
-      diagnosis_path is passed to resolve_ci for targeted remediation context.
+    skip_when_false: inputs.open_pr
+    note: 'Runs when ci_watch reports a CI failure. Fetches CI logs via gh API and
+      writes a structured diagnosis to {{AUTOSKILLIT_TEMP}}/diagnose-ci/. Routes to
+      resolve_ci on success OR failure (best-effort: resolve-failures proceeds even
+      without a diagnosis). diagnosis_path is passed to resolve_ci for targeted remediation
+      context.
 
+      '
   resolve_ci:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_ci"
+      skill_command: /autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path
+        }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs
+        }} ${{ context.diagnosis_path }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_ci
     capture:
-      verdict: "${{ result.verdict }}"
+      verdict: ${{ result.verdict }}
     retries: 2
     on_exhausted: release_issue_failure
     on_context_limit: re_push
     on_result:
-    - when: "${{ result.verdict }} == 'real_fix'"
+    - when: ${{ result.verdict }} == 'real_fix'
       route: re_push
-    - when: "${{ result.verdict }} == 'already_green'"
+    - when: ${{ result.verdict }} == 'already_green'
       route: pre_resolve_rebase
-    - when: "${{ result.verdict }} == 'flake_suspected'"
+    - when: ${{ result.verdict }} == 'flake_suspected'
       route: re_push
-    - when: "${{ result.verdict }} == 'ci_only_failure'"
+    - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
-    - when: "${{ result.verdict }} == 'no_test_infrastructure'"
+    - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     - route: release_issue_failure
     on_failure: release_issue_failure
-    note: >
-      Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci
+    note: 'Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci
       structured output to avoid redundant CI failure re-investigation. Routes via
       on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses
-      (sibling fix may have landed), flake_suspected retries via re_push (bounded by
-      retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates to human.
-      Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
+      (sibling fix may have landed), flake_suspected retries via re_push (bounded
+      by retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates
+      to human. Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
+      '
   pre_resolve_rebase:
     tool: run_cmd
     with:
-      cmd: |
-        REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
+        | grep -qv "^file://" && echo upstream || echo origin) &&
+
         git -C ${{ context.work_dir }} fetch "$REMOTE" &&
+
         git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-      step_name: "pre_resolve_rebase"
+
+        '
+      step_name: pre_resolve_rebase
     retries: 1
     on_success: check_ci_rebase_loop
     on_failure: release_issue_failure
-    note: >
-      Rebases the feature branch against integration head when resolve_ci emits
-      already_green — the worktree was already clean because a sibling pipeline's
+    note: 'Rebases the feature branch against integration head when resolve_ci emits
+      already_green — the worktree was already clean because a sibling pipeline''s
       fix already landed on integration. Pulling it in before re-running diagnose_ci
       gives the pipeline a real chance at emitting real_fix and reaching re_push.
 
+      '
   check_ci_rebase_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_rebase_count }}"
-      max_iterations: "3"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_rebase_count }}
+      max_iterations: '3'
     capture:
-      ci_rebase_count: "${{ result.next_iteration }}"
+      ci_rebase_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
     - route: diagnose_ci
     on_failure: release_issue_failure
     optional_context_refs:
     - ci_rebase_count
-    note: >
-      Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci cycle.
-      Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green
+    note: 'Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci
+      cycle. Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green
       after 3 rebases, a structural issue requires human intervention.
 
+      '
   re_push:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
     on_success: check_repo_ci_event
     on_failure: release_issue_failure
-    note: >
-      Pushes the CI-fixed feature branch back to the remote after resolve_ci succeeds.
-      Routes to check_repo_ci_event to derive ci_event before ci_watch verifies the fix.
-      On push failure, escalates via release_issue_failure.
+    note: 'Pushes the CI-fixed feature branch back to the remote after resolve_ci
+      succeeds. Routes to check_repo_ci_event to derive ci_event before ci_watch verifies
+      the fix. On push failure, escalates via release_issue_failure.
 
+      '
   detect_ci_conflict:
     tool: run_cmd
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://"
+        && echo upstream || echo origin) &&
+
         git fetch "$REMOTE" ${{ inputs.base_branch }} &&
+
         ! git merge-base --is-ancestor "$REMOTE"/${{ inputs.base_branch }} HEAD
-      cwd: "${{ context.work_dir }}"
-      step_name: "detect_ci_conflict"
+
+        '
+      cwd: ${{ context.work_dir }}
+      step_name: detect_ci_conflict
     on_success: ci_conflict_fix
     on_failure: diagnose_ci
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Stale-base triage gate for CI FAILURE paths only. Do NOT route
-      check_pr_mergeable CONFLICTING here — GitHub's CONFLICTING status is
-      authoritative and should route directly to ci_conflict_fix.
-      Valid callers: ci_watch, check_ci_timed_out_loop, check_ci_already_passed,
-      ci_watch_post_queue_fix. Exit 0 (base NOT ancestor) → ci_conflict_fix.
-      Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.
+    skip_when_false: inputs.open_pr
+    note: 'Stale-base triage gate for CI FAILURE paths only. Do NOT route check_pr_mergeable
+      CONFLICTING here — GitHub''s CONFLICTING status is authoritative and should
+      route directly to ci_conflict_fix. Valid callers: ci_watch, check_ci_timed_out_loop,
+      check_ci_already_passed, ci_watch_post_queue_fix. Exit 0 (base NOT ancestor)
+      → ci_conflict_fix. Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.
 
+      '
   ci_conflict_fix:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "ci_conflict_fix"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: ci_conflict_fix
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: re_push
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Resolves a stale-base CI failure by rebasing the feature branch onto the latest
-      integration HEAD. Mirrors queue_ejected_fix: on clean rebase or goal-aware conflict
-      resolution, routes to re_push to re-trigger CI on the rebased branch. On escalation
-      (LOW confidence conflicts) or tool failure, routes to release_issue_failure.
+    skip_when_false: inputs.open_pr
+    note: 'Resolves a stale-base CI failure by rebasing the feature branch onto the
+      latest integration HEAD. Mirrors queue_ejected_fix: on clean rebase or goal-aware
+      conflict resolution, routes to re_push to re-trigger CI on the rebased branch.
+      On escalation (LOW confidence conflicts) or tool failure, routes to release_issue_failure.
       retries: 1 bounds the loop; after 2 total attempts, escalates.
 
+      '
   release_issue_success:
-    description: "Transition issue from in-progress to staged after successful pipeline completion"
+    description: Transition issue from in-progress to staged after successful pipeline
+      completion
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
@@ -1748,145 +1788,144 @@ steps:
       target_branch: ${{ inputs.base_branch }}
     on_success: patch_token_summary
     on_failure: patch_token_summary
-    note: >
-      Called on the success path after PR merge is confirmed.
-      Passes target_branch so release_issue can determine whether to apply the
-      staged label (non-default target) or just remove in-progress (default target).
-      optional=true ensures pipeline still reaches register_clone_success if this step errors.
+    note: 'Called on the success path after PR merge is confirmed. Passes target_branch
+      so release_issue can determine whether to apply the staged label (non-default
+      target) or just remove in-progress (default target). optional=true ensures pipeline
+      still reaches register_clone_success if this step errors.
 
+      '
   patch_token_summary:
-    description: "Collect all pipeline token data and patch the PR body with complete summary"
+    description: Collect all pipeline token data and patch the PR body with complete
+      summary
     tool: run_python
     optional: true
-    skip_when_false: "inputs.open_pr"
+    skip_when_false: inputs.open_pr
     with:
-      callable: "autoskillit.smoke_utils.patch_pr_token_summary"
+      callable: autoskillit.smoke_utils.patch_pr_token_summary
       timeout: 60
-      pr_url: "${{ context.pr_url }}"
-      cwd: "${{ context.work_dir }}"
+      pr_url: ${{ context.pr_url }}
+      cwd: ${{ context.work_dir }}
     on_success: register_clone_success
     on_failure: register_clone_success
-    note: >
-      Patches PR body with complete token summary; failure never blocks pipeline completion.
+    note: 'Patches PR body with complete token summary; failure never blocks pipeline
+      completion.
 
+      '
   register_clone_unconfirmed:
-    description: "Register clone as preserved — merge unconfirmed, in-progress label retained"
+    description: Register clone as preserved — merge unconfirmed, in-progress label
+      retained
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "unconfirmed"
+      clone_path: ${{ context.work_dir }}
+      status: unconfirmed
       step_name: register_clone_unconfirmed
     on_success: run_diagnostic_unconfirmed
     on_failure: run_diagnostic_unconfirmed
-    note: >
-      Called when a merge-wait step times out before merge is confirmed.
-      Does NOT call release_issue — the in-progress label stays on the issue
-      so operators can see the PR is still actively queued. The clone is
-      preserved (status: unconfirmed) for human inspection.
+    note: 'Called when a merge-wait step times out before merge is confirmed. Does
+      NOT call release_issue — the in-progress label stays on the issue so operators
+      can see the PR is still actively queued. The clone is preserved (status: unconfirmed)
+      for human inspection.
 
+      '
   run_diagnostic_unconfirmed:
-    description: "Run post-pipeline diagnostic analysis on session logs (unconfirmed path)"
+    description: Run post-pipeline diagnostic analysis on session logs (unconfirmed
+      path)
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: done_unconfirmed
     on_failure: done_unconfirmed
     on_context_limit: done_unconfirmed
-    note: >
-      Diagnostic failure never blocks pipeline completion.
+    note: 'Diagnostic failure never blocks pipeline completion.
 
+      '
   done_unconfirmed:
     action: stop
-    message: >-
-      Implementation pipeline finished but merge was not confirmed within the timeout
-      window. The PR is still open and the clone has been preserved for inspection.
-      The in-progress label remains on the issue. Human operator should verify merge
-      status.
-      Emit the L3 result sentinel JSON block now with success=true and
-      reason="merge_unconfirmed".
-      Example sentinel:
-      {"success": true, "reason": "merge_unconfirmed"}
-
+    message: 'Implementation pipeline finished but merge was not confirmed within
+      the timeout window. The PR is still open and the clone has been preserved for
+      inspection. The in-progress label remains on the issue. Human operator should
+      verify merge status. Emit the L3 result sentinel JSON block now with success=true
+      and reason="merge_unconfirmed". Example sentinel: {"success": true, "reason":
+      "merge_unconfirmed"}'
   release_issue_failure:
-    description: "Release the in-progress claim after pipeline failure"
+    description: Release the in-progress claim after pipeline failure
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
-      fail_label: "fail"
+      fail_label: fail
     on_success: register_clone_failure
     on_failure: register_clone_failure
-
   register_clone_success:
-    description: "Register clone as cleanup candidate for batch deletion"
+    description: Register clone as cleanup candidate for batch deletion
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "success"
+      clone_path: ${{ context.work_dir }}
+      status: success
       step_name: register_clone_success
     on_success: run_diagnostic
     on_failure: run_diagnostic
-
   register_clone_failure:
-    description: "Register clone as preserved (error pipeline)"
+    description: Register clone as preserved (error pipeline)
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "error"
+      clone_path: ${{ context.work_dir }}
+      status: error
       step_name: register_clone_failure
     on_success: run_diagnostic_error
     on_failure: run_diagnostic_error
-
   run_diagnostic:
-    description: "Run post-pipeline diagnostic analysis on session logs"
+    description: Run post-pipeline diagnostic analysis on session logs
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: done
     on_failure: done
     on_context_limit: done
-    note: >
-      Diagnostic failure never blocks pipeline completion. Both on_failure and
+    note: 'Diagnostic failure never blocks pipeline completion. Both on_failure and
       on_context_limit route to the same terminal as on_success.
 
+      '
   run_diagnostic_error:
-    description: "Run post-pipeline diagnostic analysis on session logs (error path)"
+    description: Run post-pipeline diagnostic analysis on session logs (error path)
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: escalate_stop
     on_failure: escalate_stop
     on_context_limit: escalate_stop
-    note: >
-      Diagnostic failure never blocks pipeline completion.
+    note: 'Diagnostic failure never blocks pipeline completion.
 
+      '
   done:
     action: stop
-    message: >-
-      Implementation pipeline complete. All tasks have been planned, implemented, tested, and merged.
-      Emit the L3 result sentinel JSON block now with success=true.
-      Example sentinel: {"success": true, "reason": "implementation complete"}
-
+    message: 'Implementation pipeline complete. All tasks have been planned, implemented,
+      tested, and merged. Emit the L3 result sentinel JSON block now with success=true.
+      Example sentinel: {"success": true, "reason": "implementation complete"}'
   escalate_stop:
     action: stop
-    message: >-
-      Pipeline failed — human intervention needed. Check the worktree and plan for details.
-      Emit the L3 result sentinel JSON block now with success=false.
-      Example sentinel: {"success": false, "reason": "implementation pipeline failed"}
-
+    message: 'Pipeline failed — human intervention needed. Check the worktree and
+      plan for details. Emit the L3 result sentinel JSON block now with success=false.
+      Example sentinel: {"success": false, "reason": "implementation pipeline failed"}'

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -41,6 +41,21 @@
       "description": "Kitchen session identifier (auto-injected)",
       "default": "",
       "hidden": true
+    },
+    "is_fleet_dispatch": {
+      "description": "Whether running as an L2 food truck dispatch (auto-injected)",
+      "default": "false",
+      "hidden": true
+    },
+    "dispatch_id": {
+      "description": "Fleet dispatch identifier (auto-injected, empty in non-fleet sessions)",
+      "default": "",
+      "hidden": true
+    },
+    "diagnostics_log_dir": {
+      "description": "Resolved diagnostics log directory path (auto-injected)",
+      "default": "",
+      "hidden": true
     }
   },
   "kitchen_rules": [
@@ -1620,7 +1635,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },
@@ -1636,7 +1651,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1,1098 +1,1157 @@
 name: merge-prs
 description: Merge open PRs into an integration branch
-summary: "clone > setup_remote > analyze_prs > create_batch_branch > [loop per PR: merge_pr or (plan > verify > implement > test > push_worktree_branch > create_conflict_pr > wait_for_conflict_ci > merge_conflict_pr)] > push_batch_branch > collect_artifacts > check_impl_plans > (audit_impl?) > open_integration_pr > wait_for_review_pr_mergeability > check_mergeability > (resolve_integration_conflicts > force_push_after_rebase)? > review_pr_integration > (resolve_review_integration > re_push_review_integration)? > ci_watch_pr > cleanup"
-recipe_version: "1.0.0"
-requires_packs: [github, ci, clone, telemetry]
-
+summary: 'clone > setup_remote > analyze_prs > create_batch_branch > [loop per PR:
+  merge_pr or (plan > verify > implement > test > push_worktree_branch > create_conflict_pr
+  > wait_for_conflict_ci > merge_conflict_pr)] > push_batch_branch > collect_artifacts
+  > check_impl_plans > (audit_impl?) > open_integration_pr > wait_for_review_pr_mergeability
+  > check_mergeability > (resolve_integration_conflicts > force_push_after_rebase)?
+  > review_pr_integration > (resolve_review_integration > re_push_review_integration)?
+  > ci_watch_pr > cleanup'
+recipe_version: 1.0.0
+requires_packs:
+- github
+- ci
+- clone
+- telemetry
 ingredients:
   source_dir:
     description: Source repository
     required: false
-    default: ""
+    default: ''
   run_name:
     description: Run name prefix
-    default: "pr-merge"
+    default: pr-merge
   base_branch:
     description: Branch that PRs target
     required: false
-    default: ""
+    default: ''
   audit:
     description: Post-merge quality gate
-    default: "false"
+    default: 'false'
   plans_dir:
     description: Plan files for audit
-    default: "{{AUTOSKILLIT_TEMP}}/merge-prs"
+    default: '{{AUTOSKILLIT_TEMP}}/merge-prs'
   post_run_diagnostics:
     description: Run diagnostic analysis after pipeline completion
-    default: "false"
+    default: 'false'
     hidden: true
   kitchen_id:
     description: Kitchen session identifier (auto-injected)
-    default: ""
+    default: ''
     hidden: true
-
+  is_fleet_dispatch:
+    description: Whether running as an L2 food truck dispatch (auto-injected)
+    default: 'false'
+    hidden: true
+  dispatch_id:
+    description: Fleet dispatch identifier (auto-injected, empty in non-fleet sessions)
+    default: ''
+    hidden: true
+  diagnostics_log_dir:
+    description: Resolved diagnostics log directory path (auto-injected)
+    default: ''
+    hidden: true
 kitchen_rules:
-- "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent, WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated through run_skill and run_cmd."
-- "Route to on_failure when a step fails — do not investigate or fix directly."
-- "SEQUENTIAL LOOP: Process one PR at a time through the full merge cycle before advancing to the next PR. Never batch-assess all PRs before starting merges."
-- "SEQUENTIAL EXECUTION: complete full cycle (verify → implement → test → push_worktree_branch → create_conflict_pr → wait_for_conflict_ci → merge_conflict_pr) per plan part before advancing to the next part or PR."
-- "INTEGRATION BRANCH: Two distinct branches exist. inputs.base_branch is the target branch that PRs point to (e.g. main, develop). context.batch_branch is the per-run batch branch (e.g. pr-batch/pr-merge-{ts}) created from base_branch for this pipeline run. All PR merges and worktree merges target context.batch_branch. The final review PR opens from context.batch_branch into inputs.base_branch."
-- "PR QUEUE: The agent reads context.pr_order_file once at analyze_prs and maintains an ordered queue. context.current_pr_number tracks the current PR. advance_queue_pr captures the next PR number at the recipe level after each successful merge."
-- "COMPLEX PR PATH: When merge_pr returns needs_plan=true, context.task is set to the conflict_report_path. Pass context.task to make-plan. The plan+implement cycle creates a worktree from the integration branch; the worktree branch is then pushed to origin and merged into the integration batch branch via GitHub PR (push_worktree_branch → create_conflict_pr → wait_for_conflict_ci → merge_conflict_pr)."
-- "SOURCE ISOLATION: After clone_repo returns, the source_dir is strictly off-limits. Never run any command in source_dir — no git checkout, git fetch, git reset, git pull, run_cmd, run_skill, or any other operation. All work — skill invocations, git operations, file reads — happens exclusively in the clone (work_dir). source_dir is used ONLY to read the remote URL inside push_to_remote."
-- "GITHUB API MERGE: All PR merges into the integration branch go through GitHub's merge interface (gh pr merge --squash). This enforces the branch ruleset required status checks. Never use merge_worktree or local git merge to merge into the integration batch branch."
-- "PUSH DISCIPLINE: push_worktree_branch (inside the complex PR cycle), publish_batch_branch / push_batch_branch, force_push_and_wait_mergeability (authorized for conflict-resolution rebases), and push_rebased_next_pr (authorized for proactive pre-enqueue rebase) are the only authorized push steps. Never add ad-hoc run_cmd git push calls elsewhere in the loop."
-- "QUEUE MODE: When context.queue_mode == true, PRs merge directly into base_branch via the merge queue. The batch branch (context.batch_branch) is the same as base_branch. Never invoke create_batch_branch, publish_batch_branch, merge_pr, or push_batch_branch in queue mode."
-- "QUEUE LOOP: In queue mode, context.current_pr_number tracks the current PR being waited on. Initialized by get_first_pr_number from pr_order_file[0]. advance_queue_pr looks up the current number in pr_order_file and captures the next entry's number."
-- "CONFLICT REPORT PATHS: context.all_conflict_report_paths accumulates conflict_report_path values from resolve_ejected_conflicts and resolve_integration_conflicts via capture_list. Pass it as the 5th argument to open_integration_pr and 4th argument to audit_impl. It is empty string when no conflict resolution occurred — downstream skills treat empty string as absent."
-
+- NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent,
+  WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated
+  through run_skill and run_cmd.
+- Route to on_failure when a step fails — do not investigate or fix directly.
+- 'SEQUENTIAL LOOP: Process one PR at a time through the full merge cycle before advancing
+  to the next PR. Never batch-assess all PRs before starting merges.'
+- 'SEQUENTIAL EXECUTION: complete full cycle (verify → implement → test → push_worktree_branch
+  → create_conflict_pr → wait_for_conflict_ci → merge_conflict_pr) per plan part before
+  advancing to the next part or PR.'
+- 'INTEGRATION BRANCH: Two distinct branches exist. inputs.base_branch is the target
+  branch that PRs point to (e.g. main, develop). context.batch_branch is the per-run
+  batch branch (e.g. pr-batch/pr-merge-{ts}) created from base_branch for this pipeline
+  run. All PR merges and worktree merges target context.batch_branch. The final review
+  PR opens from context.batch_branch into inputs.base_branch.'
+- 'PR QUEUE: The agent reads context.pr_order_file once at analyze_prs and maintains
+  an ordered queue. context.current_pr_number tracks the current PR. advance_queue_pr
+  captures the next PR number at the recipe level after each successful merge.'
+- 'COMPLEX PR PATH: When merge_pr returns needs_plan=true, context.task is set to
+  the conflict_report_path. Pass context.task to make-plan. The plan+implement cycle
+  creates a worktree from the integration branch; the worktree branch is then pushed
+  to origin and merged into the integration batch branch via GitHub PR (push_worktree_branch
+  → create_conflict_pr → wait_for_conflict_ci → merge_conflict_pr).'
+- 'SOURCE ISOLATION: After clone_repo returns, the source_dir is strictly off-limits.
+  Never run any command in source_dir — no git checkout, git fetch, git reset, git
+  pull, run_cmd, run_skill, or any other operation. All work — skill invocations,
+  git operations, file reads — happens exclusively in the clone (work_dir). source_dir
+  is used ONLY to read the remote URL inside push_to_remote.'
+- 'GITHUB API MERGE: All PR merges into the integration branch go through GitHub''s
+  merge interface (gh pr merge --squash). This enforces the branch ruleset required
+  status checks. Never use merge_worktree or local git merge to merge into the integration
+  batch branch.'
+- 'PUSH DISCIPLINE: push_worktree_branch (inside the complex PR cycle), publish_batch_branch
+  / push_batch_branch, force_push_and_wait_mergeability (authorized for conflict-resolution
+  rebases), and push_rebased_next_pr (authorized for proactive pre-enqueue rebase)
+  are the only authorized push steps. Never add ad-hoc run_cmd git push calls elsewhere
+  in the loop.'
+- 'QUEUE MODE: When context.queue_mode == true, PRs merge directly into base_branch
+  via the merge queue. The batch branch (context.batch_branch) is the same as base_branch.
+  Never invoke create_batch_branch, publish_batch_branch, merge_pr, or push_batch_branch
+  in queue mode.'
+- 'QUEUE LOOP: In queue mode, context.current_pr_number tracks the current PR being
+  waited on. Initialized by get_first_pr_number from pr_order_file[0]. advance_queue_pr
+  looks up the current number in pr_order_file and captures the next entry''s number.'
+- 'CONFLICT REPORT PATHS: context.all_conflict_report_paths accumulates conflict_report_path
+  values from resolve_ejected_conflicts and resolve_integration_conflicts via capture_list.
+  Pass it as the 5th argument to open_integration_pr and 4th argument to audit_impl.
+  It is empty string when no conflict resolution occurred — downstream skills treat
+  empty string as absent.'
 steps:
   clone:
     python: autoskillit.workspace.clone.clone_repo
     with:
-      source_dir: "${{ inputs.source_dir }}"
-      run_name: "${{ inputs.run_name }}"
+      source_dir: ${{ inputs.source_dir }}
+      run_name: ${{ inputs.run_name }}
     capture:
-      work_dir: "${{ result.clone_path }}"
-      remote_url: "${{ result.remote_url }}"
+      work_dir: ${{ result.clone_path }}
+      remote_url: ${{ result.remote_url }}
     on_success: setup_remote
     on_failure: escalate_stop
-    note: >
-      Clones source_dir into ../autoskillit-runs/<run_name>-<timestamp>/.
-      Captures work_dir used as cwd by all subsequent steps.
-      On failure, escalate_stop is reached immediately — no clone to remove.
+    note: 'Clones source_dir into ../autoskillit-runs/<run_name>-<timestamp>/. Captures
+      work_dir used as cwd by all subsequent steps. On failure, escalate_stop is reached
+      immediately — no clone to remove.
 
+      '
   setup_remote:
     tool: run_cmd
     with:
-      cmd: "git remote set-url origin \"${{ context.remote_url }}\""
-      cwd: "${{ context.work_dir }}"
-      step_name: "setup_remote"
+      cmd: git remote set-url origin "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      step_name: setup_remote
     on_success: check_repo_ci_event
     on_failure: register_clone_failure
-    note: >
-      The clone's origin initially points to a file:// URL (set by clone_repo for isolation).
-      This step replaces it with the actual GitHub remote URL so that gh CLI commands
-      (gh pr merge, gh pr view, etc.) can identify the correct GitHub repository.
-      Skills that contact remotes (resolve-merge-conflicts, retry-worktree, implement-worktree)
-      now use REMOTE=$(upstream || origin) internally and do not depend on this step.
+    note: 'The clone''s origin initially points to a file:// URL (set by clone_repo
+      for isolation). This step replaces it with the actual GitHub remote URL so that
+      gh CLI commands (gh pr merge, gh pr view, etc.) can identify the correct GitHub
+      repository. Skills that contact remotes (resolve-merge-conflicts, retry-worktree,
+      implement-worktree) now use REMOTE=$(upstream || origin) internally and do not
+      depend on this step.
 
+      '
   check_repo_ci_event:
     tool: check_repo_merge_state
     block: pre_merge_prs_ci_gate
     with:
-      branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "check_repo_ci_event"
+      branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: check_repo_ci_event
     capture:
-      ci_event: "${{ result.ci_event }}"
-      auto_merge_available: "${{ result.auto_merge_available }}"
+      ci_event: ${{ result.ci_event }}
+      auto_merge_available: ${{ result.auto_merge_available }}
     on_success: check_integration_exists
     on_failure: check_integration_exists
-    note: >
-      Detects whether the repository's CI triggers on push or merge_group events
-      for the base branch. Each downstream wait_for_ci step re-derives ci_event
-      for its own watched branch via a dedicated derive_*_ci_event step. The global
-      ci_event captured here is used by diagnostic skill invocations.
-      ci_applicable is captured per-branch by derive_conflict_ci_event instead.
-      Routes to check_integration_exists regardless of outcome —
-      non-blocking gate: ci_event defaults to null (match-any) on failure.
+    note: 'Detects whether the repository''s CI triggers on push or merge_group events
+      for the base branch. Each downstream wait_for_ci step re-derives ci_event for
+      its own watched branch via a dedicated derive_*_ci_event step. The global ci_event
+      captured here is used by diagnostic skill invocations. ci_applicable is captured
+      per-branch by derive_conflict_ci_event instead. Routes to check_integration_exists
+      regardless of outcome — non-blocking gate: ci_event defaults to null (match-any)
+      on failure.
 
+      '
   check_integration_exists:
     tool: run_cmd
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin)
+      cmd: 'REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://"
+        && echo upstream || echo origin)
+
         git ls-remote --exit-code --heads "$REMOTE" "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_integration_exists"
+
+        '
+      cwd: ${{ context.work_dir }}
+      step_name: check_integration_exists
     on_success: fetch_merge_queue_data
     on_failure: confirm_create_integration
-    note: >
-      Checks whether base_branch exists on the remote. Exit code 0 means the
-      branch exists — proceed to analyze_prs. Non-zero exit means the branch
-      is absent — route to user confirmation before creating it. Idempotent:
-      re-running after the branch is created skips through on_success.
+    note: 'Checks whether base_branch exists on the remote. Exit code 0 means the
+      branch exists — proceed to analyze_prs. Non-zero exit means the branch is absent
+      — route to user confirmation before creating it. Idempotent: re-running after
+      the branch is created skips through on_success.
 
+      '
   confirm_create_integration:
     action: confirm
-    message: >-
-      The branch '${{ inputs.base_branch }}' does not exist on the remote.
-      Create it now from the repository's default branch?
-      Type yes to create it or no to abort.
+    message: The branch '${{ inputs.base_branch }}' does not exist on the remote.
+      Create it now from the repository's default branch? Type yes to create it or
+      no to abort.
     on_success: create_persistent_integration
     on_failure: escalate_stop
-    note: >
-      User approval gate. On yes: create_persistent_integration creates and
-      pushes the branch. On no: escalate_stop — the pipeline cannot
-      proceed without the target branch.
+    note: 'User approval gate. On yes: create_persistent_integration creates and pushes
+      the branch. On no: escalate_stop — the pipeline cannot proceed without the target
+      branch.
 
+      '
   create_persistent_integration:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.create_persistent_integration"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.create_persistent_integration
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_success: fetch_merge_queue_data
     on_failure: register_clone_failure
-    note: >
-      Creates base_branch from the repository's default branch (auto-detected
+    note: 'Creates base_branch from the repository''s default branch (auto-detected
       via origin/HEAD, falls back to main). Only executes when the user confirmed
-      branch creation in confirm_create_integration. Once created, subsequent
-      pipeline runs skip directly from check_integration_exists to analyze_prs.
+      branch creation in confirm_create_integration. Once created, subsequent pipeline
+      runs skip directly from check_integration_exists to analyze_prs.
 
+      '
   fetch_merge_queue_data:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.fetch_merge_queue_data"
-      base_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/merge-prs"
+      callable: autoskillit.smoke_utils.fetch_merge_queue_data
+      base_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/merge-prs'
     capture:
-      merge_queue_data_path: "${{ result.merge_queue_data_path }}"
+      merge_queue_data_path: ${{ result.merge_queue_data_path }}
     on_success: analyze_prs
     on_failure: analyze_prs
-    note: >
-      Pre-fetches GitHub merge queue data server-side (where autoskillit is always
-      installed). Writes parsed queue entries to disk as JSON. On failure, falls
-      through to analyze_prs which uses the fallback empty QUEUE_ENTRIES path
-      (QUEUE_MODE=false). Eliminates the autoskillit import in analyze-prs SKILL.md.
+    note: 'Pre-fetches GitHub merge queue data server-side (where autoskillit is always
+      installed). Writes parsed queue entries to disk as JSON. On failure, falls through
+      to analyze_prs which uses the fallback empty QUEUE_ENTRIES path (QUEUE_MODE=false).
+      Eliminates the autoskillit import in analyze-prs SKILL.md.
 
+      '
   analyze_prs:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:analyze-prs ${{ inputs.base_branch }} merge_queue_data_path=${{ context.merge_queue_data_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "analyze_prs"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/analyze-prs"
+      skill_command: /autoskillit:analyze-prs ${{ inputs.base_branch }} merge_queue_data_path=${{
+        context.merge_queue_data_path }}
+      cwd: ${{ context.work_dir }}
+      step_name: analyze_prs
+      output_dir: '{{AUTOSKILLIT_TEMP}}/analyze-prs'
     capture:
-      pr_order_file: "${{ result.pr_order_file }}"
-      batch_branch: "${{ result.batch_branch }}"
-      queue_mode: "${{ result.queue_mode }}"
+      pr_order_file: ${{ result.pr_order_file }}
+      batch_branch: ${{ result.batch_branch }}
+      queue_mode: ${{ result.queue_mode }}
     on_success: route_by_queue_mode
     on_failure: register_clone_failure
-    note: >
-      Captures pr_order_file (path to JSON with ordered PRs + complexity tags),
-      batch_branch (e.g. integration/pr-merge-20250228-143052), and
-      queue_mode ("true" when a GitHub merge queue with MERGEABLE entries is active
-      on base_branch; "false" otherwise). If the skill reports pr_count=0 (no open
-      PRs), skip directly to cleanup_success — no integration branch is needed.
-      merge_queue_data_path is pre-computed by fetch_merge_queue_data step.
+    note: 'Captures pr_order_file (path to JSON with ordered PRs + complexity tags),
+      batch_branch (e.g. integration/pr-merge-20250228-143052), and queue_mode ("true"
+      when a GitHub merge queue with MERGEABLE entries is active on base_branch; "false"
+      otherwise). If the skill reports pr_count=0 (no open PRs), skip directly to
+      cleanup_success — no integration branch is needed. merge_queue_data_path is
+      pre-computed by fetch_merge_queue_data step.
 
+      '
   route_by_queue_mode:
     action: route
     on_result:
-    - when: "${{ context.queue_mode }} == true"
+    - when: ${{ context.queue_mode }} == true
       route: get_first_pr_number
     - route: create_batch_branch
-    note: >
-      Routes to queue mode (get_first_pr_number) when analyze-prs detected a merge queue
-      on the target branch. Falls back to the classic batch-branch path otherwise.
-      context.queue_mode is captured from analyze_prs result.
+    note: 'Routes to queue mode (get_first_pr_number) when analyze-prs detected a
+      merge queue on the target branch. Falls back to the classic batch-branch path
+      otherwise. context.queue_mode is captured from analyze_prs result.
 
+      '
   get_first_pr_number:
     tool: run_cmd
     with:
-      cmd: "jq -r '.[0].number' '${{ context.pr_order_file }}'"
-      cwd: "${{ context.work_dir }}"
-      step_name: "get_first_pr_number"
+      cmd: jq -r '.[0].number' '${{ context.pr_order_file }}'
+      cwd: ${{ context.work_dir }}
+      step_name: get_first_pr_number
     capture:
-      current_pr_number: "${{ result.stdout | trim }}"
+      current_pr_number: ${{ result.stdout | trim }}
     on_success: get_current_pr_branch
     on_failure: register_clone_failure
-    note: >
-      Queue mode only. Extracts the first PR's number from pr_order_file to initialize
-      context.current_pr_number before the sequential enqueue loop.
+    note: 'Queue mode only. Extracts the first PR''s number from pr_order_file to
+      initialize context.current_pr_number before the sequential enqueue loop.
 
+      '
   get_current_pr_branch:
     tool: run_cmd
     with:
-      cmd: "gh pr view '${{ context.current_pr_number }}' --json headRefName -q .headRefName"
-      cwd: "${{ context.work_dir }}"
-      step_name: "get_current_pr_branch"
+      cmd: gh pr view '${{ context.current_pr_number }}' --json headRefName -q .headRefName
+      cwd: ${{ context.work_dir }}
+      step_name: get_current_pr_branch
     capture:
-      current_pr_branch: "${{ result.stdout | trim }}"
+      current_pr_branch: ${{ result.stdout | trim }}
     on_success: capture_pr_head_sha
     on_failure: register_clone_failure
-    note: >
-      Fetches the headRefName for the current PR to be enqueued. Captured as
-      current_pr_branch for use by wait_ci_pre_enqueue. Follows the same
-      pattern as get_ejected_pr_branch and get_next_pr_branch.
+    note: 'Fetches the headRefName for the current PR to be enqueued. Captured as
+      current_pr_branch for use by wait_ci_pre_enqueue. Follows the same pattern as
+      get_ejected_pr_branch and get_next_pr_branch.
 
+      '
   capture_pr_head_sha:
     tool: run_cmd
     with:
-      cmd: "gh pr view '${{ context.current_pr_number }}' --json headRefOid -q .headRefOid"
-      cwd: "${{ context.work_dir }}"
-      step_name: "capture_pr_head_sha"
+      cmd: gh pr view '${{ context.current_pr_number }}' --json headRefOid -q .headRefOid
+      cwd: ${{ context.work_dir }}
+      step_name: capture_pr_head_sha
     capture:
-      current_pr_head_sha: "${{ result.stdout | trim }}"
+      current_pr_head_sha: ${{ result.stdout | trim }}
     on_success: derive_pre_enqueue_ci_event
     on_failure: register_clone_failure
-
   derive_pre_enqueue_ci_event:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.current_pr_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "derive_pre_enqueue_ci_event"
+      branch: ${{ context.current_pr_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: derive_pre_enqueue_ci_event
     capture:
-      pre_enqueue_ci_event: "${{ result.ci_event }}"
+      pre_enqueue_ci_event: ${{ result.ci_event }}
     on_success: wait_ci_pre_enqueue
     on_failure: wait_ci_pre_enqueue
-    note: >
-      Re-derives ci_event for the actual PR branch before the pre-enqueue CI wait.
-      The global check_repo_ci_event evaluates CI triggers against inputs.base_branch
+    note: 'Re-derives ci_event for the actual PR branch before the pre-enqueue CI
+      wait. The global check_repo_ci_event evaluates CI triggers against inputs.base_branch
       (main), but wait_ci_pre_enqueue watches context.current_pr_branch where different
       CI rules may apply. Non-blocking: on_failure routes to wait_ci_pre_enqueue with
       pre_enqueue_ci_event=null (match-any fallback).
 
+      '
   wait_ci_pre_enqueue:
     tool: wait_for_ci
     with:
-      branch: "${{ context.current_pr_branch }}"
-      head_sha: "${{ context.current_pr_head_sha }}"
-      cwd: "${{ context.work_dir }}"
-      event: "${{ context.pre_enqueue_ci_event }}"
+      branch: ${{ context.current_pr_branch }}
+      head_sha: ${{ context.current_pr_head_sha }}
+      cwd: ${{ context.work_dir }}
+      event: ${{ context.pre_enqueue_ci_event }}
       timeout_seconds: 600
-      remote_url: "${{ context.remote_url }}"
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
-      step_name: "wait_ci_pre_enqueue"
+      step_name: wait_ci_pre_enqueue
     on_result:
-    - when: "${{ result.conclusion }} == success"
+    - when: ${{ result.conclusion }} == success
       route: enqueue_current_pr
-    - when: "${{ result.conclusion }} == no_runs"
+    - when: ${{ result.conclusion }} == no_runs
       route: register_clone_failure
-    - when: "${{ result.conclusion }} == timed_out"
+    - when: ${{ result.conclusion }} == timed_out
       route: register_clone_failure
-    - when: "${{ result.conclusion }} == failure"
+    - when: ${{ result.conclusion }} == failure
       route: register_clone_failure
     - route: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Waits for CI to pass on the PR branch before attempting queue enrollment.
-      Prevents premature enqueue rejection by GitHub when required status
-      checks have not yet completed.
+    note: 'Waits for CI to pass on the PR branch before attempting queue enrollment.
+      Prevents premature enqueue rejection by GitHub when required status checks have
+      not yet completed.
 
+      '
   enqueue_current_pr:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.current_pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.current_pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: wait_queue_pr
     on_failure: verify_queue_enrollment
-    note: >
-      Queue mode only. Submits a single PR to the merge queue via the unified
-      enqueue_pr tool. Called once per PR in the sequential enqueue loop:
-      get_first_pr_number → get_current_pr_branch → wait_ci_pre_enqueue →
-      enqueue_current_pr → wait_queue_pr → (merged) → advance_queue_pr →
-      get_current_pr_branch → wait_ci_pre_enqueue → enqueue_current_pr → ...
+    note: 'Queue mode only. Submits a single PR to the merge queue via the unified
+      enqueue_pr tool. Called once per PR in the sequential enqueue loop: get_first_pr_number
+      → get_current_pr_branch → wait_ci_pre_enqueue → enqueue_current_pr → wait_queue_pr
+      → (merged) → advance_queue_pr → get_current_pr_branch → wait_ci_pre_enqueue
+      → enqueue_current_pr → ...
 
+      '
   wait_queue_pr:
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.current_pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
+      pr_number: ${{ context.current_pr_number }}
+      target_branch: ${{ inputs.base_branch }}
       timeout_seconds: 900
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
     capture:
-      queue_pr_state: "${{ result.pr_state }}"
+      queue_pr_state: ${{ result.pr_state }}
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: advance_queue_pr
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: diagnose_queue_ci
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: diagnose_queue_ci
-    - when: "${{ result.pr_state }} == not_enrolled"
+    - when: ${{ result.pr_state }} == not_enrolled
       route: register_clone_failure
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: check_eject_limit
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: reenroll_stalled_queue_pr
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: check_dropped_healthy_loop
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_failure
     - route: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Queue mode monitor. All non-error PRState values are explicitly routed.
+    note: 'Queue mode monitor. All non-error PRState values are explicitly routed.
       ejected_ci_failure and dropped_merge_group_ci both route to diagnose_queue_ci;
       ejected_ci_failure must precede ejected (both match CLOSED state).
 
+      '
   check_eject_limit:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.check_eject_limit"
-      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count"
-      max_ejects: "3"
+      callable: autoskillit.recipe._cmd_rpc.check_eject_limit
+      counter_file: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count
+      max_ejects: '3'
     on_result:
-    - when: "${{ result.status }} == EJECT_LIMIT_EXCEEDED"
+    - when: ${{ result.status }} == EJECT_LIMIT_EXCEEDED
       route: register_clone_failure
     - route: get_ejected_pr_branch
     on_failure: register_clone_failure
-    note: >
-      Circuit breaker for the queue ejection loop. After 3 ejections, routes
+    note: 'Circuit breaker for the queue ejection loop. After 3 ejections, routes
       to register_clone_failure to prevent infinite re-enqueue cycles.
 
+      '
   check_dropped_healthy_loop:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop"
-      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count"
-      max_drops: "2"
+      callable: autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop
+      counter_file: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count
+      max_drops: '2'
     on_result:
-    - when: "${{ result.status }} == DROPPED_LIMIT_EXCEEDED"
+    - when: ${{ result.status }} == DROPPED_LIMIT_EXCEEDED
       route: register_clone_failure
     - route: reenter_queue
     on_failure: register_clone_failure
-    note: >
-      Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive
+    note: 'Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive
       unexplained drops with healthy PR-branch CI, escalates to register_clone_failure
       instead of looping. Matches the check_eject_limit pattern used for the ejected
-      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed
-      directly to diagnose_queue_ci and never reaches this step.
+      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed directly
+      to diagnose_queue_ci and never reaches this step.
 
+      '
   get_ejected_pr_branch:
     tool: run_cmd
     with:
-      cmd: "gh pr view '${{ context.current_pr_number }}' --json headRefName -q .headRefName"
-      cwd: "${{ context.work_dir }}"
-      step_name: "get_ejected_pr_branch"
+      cmd: gh pr view '${{ context.current_pr_number }}' --json headRefName -q .headRefName
+      cwd: ${{ context.work_dir }}
+      step_name: get_ejected_pr_branch
     capture:
-      ejected_pr_branch: "${{ result.stdout | trim }}"
+      ejected_pr_branch: ${{ result.stdout | trim }}
     on_success: attempt_cheap_rebase
     on_failure: register_clone_failure
-
   attempt_cheap_rebase:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.attempt_cheap_rebase"
-      work_dir: "${{ context.work_dir }}"
-      ejected_pr_branch: "${{ context.ejected_pr_branch }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.attempt_cheap_rebase
+      work_dir: ${{ context.work_dir }}
+      ejected_pr_branch: ${{ context.ejected_pr_branch }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.status }} == clean"
+    - when: ${{ result.status }} == clean
       route: push_ejected_fix
     - route: resolve_ejected_conflicts
     on_failure: resolve_ejected_conflicts
-    note: >
-      Attempts a trivial rebase before invoking the full resolve-merge-conflicts skill.
-      Uses ejected_pr_branch captured by get_ejected_pr_branch. On clean rebase,
+    note: 'Attempts a trivial rebase before invoking the full resolve-merge-conflicts
+      skill. Uses ejected_pr_branch captured by get_ejected_pr_branch. On clean rebase,
       skips the skill and proceeds directly to push_ejected_fix. On conflict, aborts
       the rebase and routes to resolve_ejected_conflicts for goal-aware resolution.
 
+      '
   resolve_ejected_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts '${{ context.ejected_pr_branch }}' '${{ inputs.base_branch }}'"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_ejected_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts '${{ context.ejected_pr_branch
+        }}' '${{ inputs.base_branch }}'
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_ejected_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     capture_list:
-      all_conflict_report_paths: "${{ result.conflict_report_path }}"
+      all_conflict_report_paths: ${{ result.conflict_report_path }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: register_clone_failure
     - route: push_ejected_fix
     on_failure: register_clone_failure
     retries: 0
     on_exhausted: register_clone_failure
-    note: >
-      Resolves git-level rebase conflicts between the ejected PR's branch and the
-      current base_branch HEAD. Uses the same resolve-merge-conflicts skill as the
-      classic path's integration conflict resolution.
+    note: 'Resolves git-level rebase conflicts between the ejected PR''s branch and
+      the current base_branch HEAD. Uses the same resolve-merge-conflicts skill as
+      the classic path''s integration conflict resolution.
 
+      '
   push_ejected_fix:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.ejected_pr_branch }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.ejected_pr_branch }}
+      force: 'true'
     capture:
-      push_error_type: "${{ result.error_type }}"
+      push_error_type: ${{ result.error_type }}
     retries: 2
     on_exhausted: register_clone_failure
     on_success: derive_post_queue_ci_event
     on_failure: classify_push_failure
-
   derive_post_queue_ci_event:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.ejected_pr_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "derive_post_queue_ci_event"
+      branch: ${{ context.ejected_pr_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: derive_post_queue_ci_event
     capture:
-      post_queue_ci_event: "${{ result.ci_event }}"
+      post_queue_ci_event: ${{ result.ci_event }}
     on_success: ci_watch_post_queue_fix
     on_failure: ci_watch_post_queue_fix
-    note: >
-      Re-derives ci_event for the actual ejected PR branch before the post-queue-fix CI wait.
-      The global check_repo_ci_event evaluates CI triggers against inputs.base_branch
-      (main), but ci_watch_post_queue_fix watches context.ejected_pr_branch where different
-      CI rules may apply. Non-blocking: on_failure routes to ci_watch_post_queue_fix with
-      post_queue_ci_event=null (match-any fallback).
+    note: 'Re-derives ci_event for the actual ejected PR branch before the post-queue-fix
+      CI wait. The global check_repo_ci_event evaluates CI triggers against inputs.base_branch
+      (main), but ci_watch_post_queue_fix watches context.ejected_pr_branch where
+      different CI rules may apply. Non-blocking: on_failure routes to ci_watch_post_queue_fix
+      with post_queue_ci_event=null (match-any fallback).
 
+      '
   classify_push_failure:
     action: route
     on_result:
-    - when: "${{ context.push_error_type }} == queued_branch"
+    - when: ${{ context.push_error_type }} == queued_branch
       route: wait_dequeue_retry
     - route: register_clone_failure
-
   wait_dequeue_retry:
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.current_pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      timeout_seconds: "60"
+      pr_number: ${{ context.current_pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      timeout_seconds: '60'
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: advance_queue_pr
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: register_clone_failure
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: register_clone_failure
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: register_clone_failure
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: push_ejected_fix
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: register_clone_failure
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_failure
     - route: register_clone_failure
     on_failure: register_clone_failure
     optional_context_refs:
     - push_error_type
-
   ci_watch_post_queue_fix:
     tool: wait_for_ci
     with:
-      branch: "${{ context.ejected_pr_branch }}"
-      event: "${{ context.post_queue_ci_event }}"
+      branch: ${{ context.ejected_pr_branch }}
+      event: ${{ context.post_queue_ci_event }}
       timeout_seconds: 600
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
     capture:
-      ci_conclusion: "${{ result.conclusion }}"
-      ci_failed_jobs: "${{ result.failed_jobs }}"
+      ci_conclusion: ${{ result.conclusion }}
+      ci_failed_jobs: ${{ result.failed_jobs }}
     on_result:
-    - when: "${{ result.conclusion }} == 'success'"
+    - when: ${{ result.conclusion }} == 'success'
       route: reenter_queue
-    - when: "${{ result.conclusion }} == 'no_runs'"
+    - when: ${{ result.conclusion }} == 'no_runs'
       route: register_clone_failure
-    - when: "${{ result.conclusion }} == 'timed_out'"
+    - when: ${{ result.conclusion }} == 'timed_out'
       route: check_ci_post_queue_loop
     - route: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Validates CI passes on the rebased branch before re-entering the merge queue.
-      Prevents re-enqueue of a broken branch that would be ejected again.
-      Routes on result.conclusion: success → reenter_queue,
-      no_runs → register_clone_failure (auto_trigger fires first: empty commit +
-      force-push + re-poll; no_runs reached only when trigger recovery fails),
-      timed_out → check_ci_post_queue_loop, failure → register_clone_failure.
+    note: 'Validates CI passes on the rebased branch before re-entering the merge
+      queue. Prevents re-enqueue of a broken branch that would be ejected again. Routes
+      on result.conclusion: success → reenter_queue, no_runs → register_clone_failure
+      (auto_trigger fires first: empty commit + force-push + re-poll; no_runs reached
+      only when trigger recovery fails), timed_out → check_ci_post_queue_loop, failure
+      → register_clone_failure.
 
+      '
   check_ci_post_queue_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_post_queue_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_post_queue_loop_count }}
+      max_iterations: '2'
     capture:
-      ci_post_queue_loop_count: "${{ result.next_iteration }}"
+      ci_post_queue_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_failure
     - route: ci_watch_post_queue_fix
     on_failure: register_clone_failure
     optional_context_refs:
     - ci_post_queue_loop_count
-    note: >
-      Iteration guard for the ci_watch_post_queue_fix timed_out self-loop.
-      Caps at 2 iterations. On budget exhaustion, routes to register_clone_failure.
+    note: 'Iteration guard for the ci_watch_post_queue_fix timed_out self-loop. Caps
+      at 2 iterations. On budget exhaustion, routes to register_clone_failure.
 
+      '
   verify_queue_enrollment:
-    description: "Probe merge queue after enqueue command failure"
+    description: Probe merge queue after enqueue command failure
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.current_pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      pr_number: ${{ context.current_pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       timeout_seconds: 60
       poll_interval: 10
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: advance_queue_pr
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: diagnose_queue_ci
-    - when: "${{ result.pr_state }} == not_enrolled"
+    - when: ${{ result.pr_state }} == not_enrolled
       route: register_clone_failure
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: wait_queue_pr
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: diagnose_queue_ci
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: wait_queue_pr
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: wait_queue_pr
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_failure
     - route: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Short probe (60s) after enqueue_current_pr failure. Distinguishes
-      transient enqueue errors from actual configuration failures. Recoverable
-      states route to wait_queue_pr; terminal failures route to
-      register_clone_failure.
+    note: 'Short probe (60s) after enqueue_current_pr failure. Distinguishes transient
+      enqueue errors from actual configuration failures. Recoverable states route
+      to wait_queue_pr; terminal failures route to register_clone_failure.
 
+      '
   reenter_queue:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.current_pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.current_pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: wait_queue_pr
     on_failure: verify_queue_enrollment
-    note: >
-      Re-submits the fixed PR to the merge queue after conflict resolution.
-      Routes back to wait_queue_pr to continue monitoring.
+    note: 'Re-submits the fixed PR to the merge queue after conflict resolution. Routes
+      back to wait_queue_pr to continue monitoring.
 
+      '
   advance_queue_pr:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.advance_queue_pr"
-      current_pr_number: "${{ context.current_pr_number }}"
-      pr_order_file: "${{ context.pr_order_file }}"
+      callable: autoskillit.recipe._cmd_rpc.advance_queue_pr
+      current_pr_number: ${{ context.current_pr_number }}
+      pr_order_file: ${{ context.pr_order_file }}
     capture:
-      current_pr_number: "${{ result.current_pr_number }}"
+      current_pr_number: ${{ result.current_pr_number }}
     on_result:
-    - when: "${{ result.current_pr_number }} == done"
+    - when: ${{ result.current_pr_number }} == done
       route: collect_and_check_impl_plans
     - route: get_next_pr_branch
     on_failure: register_clone_failure
-    note: >
-      Advances to the next PR by looking up the current PR number in pr_order_file
-      and returning the next entry. Outputs the next PR number (or "done").
-      The capture block sets current_pr_number at the recipe level — no agent-managed
-      variable updates. Routes to get_next_pr_branch for proactive rebase, or
-      collect_and_check_impl_plans when done.
+    note: 'Advances to the next PR by looking up the current PR number in pr_order_file
+      and returning the next entry. Outputs the next PR number (or "done"). The capture
+      block sets current_pr_number at the recipe level — no agent-managed variable
+      updates. Routes to get_next_pr_branch for proactive rebase, or collect_and_check_impl_plans
+      when done.
 
+      '
   get_next_pr_branch:
     tool: run_cmd
     with:
-      cmd: |
-        gh pr view '${{ context.current_pr_number }}' --json headRefName -q .headRefName
-      cwd: "${{ context.work_dir }}"
-      step_name: "get_next_pr_branch"
+      cmd: 'gh pr view ''${{ context.current_pr_number }}'' --json headRefName -q
+        .headRefName
+
+        '
+      cwd: ${{ context.work_dir }}
+      step_name: get_next_pr_branch
     capture:
-      next_pr_branch: "${{ result.stdout | trim }}"
+      next_pr_branch: ${{ result.stdout | trim }}
     on_success: proactive_rebase_next_pr
     on_failure: get_current_pr_branch
-    note: >
-      Fetches the headRefName for the next PR to be enqueued. Captured as next_pr_branch
+    note: 'Fetches the headRefName for the next PR to be enqueued. Captured as next_pr_branch
       for use by proactive_rebase_next_pr. On failure (e.g. transient gh CLI error),
       falls through to get_current_pr_branch to enforce the CI gate before enqueue.
 
+      '
   proactive_rebase_next_pr:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.proactive_rebase_next_pr"
-      work_dir: "${{ context.work_dir }}"
-      next_pr_branch: "${{ context.next_pr_branch }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.proactive_rebase_next_pr
+      work_dir: ${{ context.work_dir }}
+      next_pr_branch: ${{ context.next_pr_branch }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.status }} == clean"
+    - when: ${{ result.status }} == clean
       route: push_rebased_next_pr
     - route: resolve_proactive_rebase_conflicts
     on_failure: get_current_pr_branch
-    note: >
-      Attempts a proactive rebase of the next PR branch onto the current base_branch HEAD
-      before submitting to the merge queue. On clean rebase, skips conflict resolution
+    note: 'Attempts a proactive rebase of the next PR branch onto the current base_branch
+      HEAD before submitting to the merge queue. On clean rebase, skips conflict resolution
       entirely and proceeds to push. On conflict, routes to resolve_proactive_rebase_conflicts.
-      On git command failure, falls through to get_current_pr_branch to enforce the CI gate.
+      On git command failure, falls through to get_current_pr_branch to enforce the
+      CI gate.
 
+      '
   resolve_proactive_rebase_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts '${{ context.next_pr_branch }}' '${{ inputs.base_branch }}'"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_proactive_rebase_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts '${{ context.next_pr_branch
+        }}' '${{ inputs.base_branch }}'
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_proactive_rebase_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
-      conflict_escalation_reason: "${{ result.escalation_reason }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
+      conflict_escalation_reason: ${{ result.escalation_reason }}
     capture_list:
-      all_conflict_report_paths: "${{ result.conflict_report_path }}"
+      all_conflict_report_paths: ${{ result.conflict_report_path }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: register_clone_failure
     - route: push_rebased_next_pr
     on_failure: register_clone_failure
     retries: 0
     on_exhausted: get_current_pr_branch
-    note: >
-      Resolves git-level rebase conflicts between the next PR's branch and the current
-      base_branch HEAD. Similar to resolve_ejected_conflicts but operates proactively
-      before queue submission. Unresolvable conflicts (escalation_required=true) hard-stop
-      at register_clone_failure. Retry exhaustion falls through to get_current_pr_branch
+    note: 'Resolves git-level rebase conflicts between the next PR''s branch and the
+      current base_branch HEAD. Similar to resolve_ejected_conflicts but operates
+      proactively before queue submission. Unresolvable conflicts (escalation_required=true)
+      hard-stop at register_clone_failure. Retry exhaustion falls through to get_current_pr_branch
       to enforce the CI gate before enqueue.
 
+      '
   push_rebased_next_pr:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.next_pr_branch }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.next_pr_branch }}
+      force: 'true'
     on_success: get_current_pr_branch
     on_failure: register_clone_failure
-    note: >
-      Force-pushes the proactively rebased next PR branch. force=true is required because
-      rebase rewrites SHAs (non-fast-forward). Routes to get_current_pr_branch to enforce
-      the CI gate before enqueue.
+    note: 'Force-pushes the proactively rebased next PR branch. force=true is required
+      because rebase rewrites SHAs (non-fast-forward). Routes to get_current_pr_branch
+      to enforce the CI gate before enqueue.
 
+      '
   diagnose_queue_ci:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:diagnose-ci '${{ context.current_pr_number }}' - - - ${{ context.ci_event }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "diagnose_queue_ci"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+      skill_command: /autoskillit:diagnose-ci '${{ context.current_pr_number }}' -
+        - - ${{ context.ci_event }}
+      cwd: ${{ context.work_dir }}
+      step_name: diagnose_queue_ci
+      output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-ci'
     capture:
-      diagnosis_path: "${{ result.diagnosis_path }}"
+      diagnosis_path: ${{ result.diagnosis_path }}
     on_success: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Best-effort CI diagnosis for ejected_ci_failure state. The PR was ejected
-      due to CI failure in the merge queue, not a conflict. After diagnosis,
-      routes to register_clone_failure — CI failures in queue mode are not
-      auto-recoverable without human intervention.
+    note: 'Best-effort CI diagnosis for ejected_ci_failure state. The PR was ejected
+      due to CI failure in the merge queue, not a conflict. After diagnosis, routes
+      to register_clone_failure — CI failures in queue mode are not auto-recoverable
+      without human intervention.
 
+      '
   reenroll_stalled_queue_pr:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.current_pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.current_pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: check_queue_stall_loop
     on_failure: register_clone_failure
-    note: >
-      Uses the unified enqueue_pr tool to re-enroll a stalled PR in the
-      merge queue. Routes back to check_queue_stall_loop (bounded iteration guard)
-      instead of directly to wait_queue_pr.
+    note: 'Uses the unified enqueue_pr tool to re-enroll a stalled PR in the merge
+      queue. Routes back to check_queue_stall_loop (bounded iteration guard) instead
+      of directly to wait_queue_pr.
 
+      '
   check_queue_stall_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.queue_stall_loop_count }}"
-      max_iterations: "3"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.queue_stall_loop_count }}
+      max_iterations: '3'
     capture:
-      queue_stall_loop_count: "${{ result.next_iteration }}"
+      queue_stall_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_failure
     - route: wait_queue_pr
     on_failure: register_clone_failure
     optional_context_refs:
     - queue_stall_loop_count
-    note: >
-      Iteration guard for the wait_queue_pr / reenroll_stalled_queue_pr cycle.
-      Caps stall re-enrollment at 3 attempts. On budget exhaustion, routes
-      to register_clone_failure (merge outcome unconfirmed).
+    note: 'Iteration guard for the wait_queue_pr / reenroll_stalled_queue_pr cycle.
+      Caps stall re-enrollment at 3 attempts. On budget exhaustion, routes to register_clone_failure
+      (merge outcome unconfirmed).
 
+      '
   create_batch_branch:
     tool: run_cmd
     with:
-      cmd: "git checkout ${{ inputs.base_branch }} && git pull && git checkout -b ${{ context.batch_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "create_batch_branch"
+      cmd: git checkout ${{ inputs.base_branch }} && git pull && git checkout -b ${{
+        context.batch_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: create_batch_branch
     on_success: publish_batch_branch
     on_failure: register_clone_failure
-    note: >
-      Creates the integration branch from the latest base_branch HEAD.
-      context.batch_branch was computed by analyze_prs.
+    note: 'Creates the integration branch from the latest base_branch HEAD. context.batch_branch
+      was computed by analyze_prs.
 
+      '
   publish_batch_branch:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.batch_branch }}"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.batch_branch }}
     on_success: merge_pr
     on_failure: register_clone_failure
-    note: >
-      Publishes the integration branch to origin immediately after creation so
-      that merge_worktree can verify refs/remotes/origin/batch_branch exists
-      before rebasing. The branch is re-pushed at push_batch_branch after all
-      merges complete to update the remote with accumulated merge commits.
+    note: 'Publishes the integration branch to origin immediately after creation so
+      that merge_worktree can verify refs/remotes/origin/batch_branch exists before
+      rebasing. The branch is re-pushed at push_batch_branch after all merges complete
+      to update the remote with accumulated merge commits.
 
+      '
   merge_pr:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:merge-pr {pr_number} {complexity}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "merge_pr"
-      pr_order_file: "${{ context.pr_order_file }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/merge-pr"
+      skill_command: /autoskillit:merge-pr {pr_number} {complexity}
+      cwd: ${{ context.work_dir }}
+      step_name: merge_pr
+      pr_order_file: ${{ context.pr_order_file }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/merge-pr'
     capture:
-      needs_plan: "${{ result.needs_plan }}"
-      escalation_required: "${{ result.escalation_required }}"
-      escalation_reason: "${{ result.escalation_reason }}"
-      task: "${{ result.conflict_report_path }}"
-      current_pr_number: "${{ result.pr_number }}"
-      merged: "${{ result.merged }}"
+      needs_plan: ${{ result.needs_plan }}
+      escalation_required: ${{ result.escalation_required }}
+      escalation_reason: ${{ result.escalation_reason }}
+      task: ${{ result.conflict_report_path }}
+      current_pr_number: ${{ result.pr_number }}
+      merged: ${{ result.merged }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: escalate_stop
-    - when: "${{ result.needs_plan }} == true"
+    - when: ${{ result.needs_plan }} == true
       route: plan
-    - when: "${{ result.merged }} == false"
+    - when: ${{ result.merged }} == false
       route: register_clone_failure
     - route: next_part_or_next_pr
     on_failure: register_clone_failure
     retries: 5
     on_exhausted: register_clone_failure
     on_context_limit: register_clone_failure
-    note: >
-      The agent reads context.pr_order_file at context.current_pr_number to get the
-      current PR's complexity. Appends number and complexity to skill_command:
-        /autoskillit:merge-pr {pr_number} {complexity}
-      escalation_required=true → ambiguous conflict, human intervention needed → escalate_stop.
-      needs_plan=true → conflict_report_path set as context.task → plan.
-      merged=false (timeout/conflict) → register_clone_failure.
-      merged=true + fallthrough → PR merged directly → next_part_or_next_pr.
-
+    note: "The agent reads context.pr_order_file at context.current_pr_number to get\
+      \ the current PR's complexity. Appends number and complexity to skill_command:\n\
+      \  /autoskillit:merge-pr {pr_number} {complexity}\nescalation_required=true\
+      \ → ambiguous conflict, human intervention needed → escalate_stop. needs_plan=true\
+      \ → conflict_report_path set as context.task → plan. merged=false (timeout/conflict)\
+      \ → register_clone_failure. merged=true + fallthrough → PR merged directly →\
+      \ next_part_or_next_pr.\n"
   plan:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:make-plan ${{ context.task }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "plan"
+      skill_command: /autoskillit:make-plan ${{ context.task }}
+      cwd: ${{ context.work_dir }}
+      step_name: plan
     capture:
-      pr_plan_path: "${{ result.plan_path }}"
+      pr_plan_path: ${{ result.plan_path }}
     capture_list:
-      plan_parts: "${{ result.plan_parts }}"
-      all_plan_paths: "${{ result.plan_path }}"
+      plan_parts: ${{ result.plan_parts }}
+      all_plan_paths: ${{ result.plan_path }}
     retries: 0
     on_success: verify
     on_failure: register_clone_failure
-    note: >
-      Glob plan_dir for *_part_*.md or single plan file. Sort alphabetically
-      into plan_parts[]. For a single-part plan, plan_parts has one entry equal
-      to plan_path.
-      PRIMARY PATH: context.task = conflict_report_path from merge_pr.
-      REMEDIATION MODE: context.remediation_path is set when re-entering from
-      the remediate step; pass it inline in the skill_command instead of
-      context.task.
+    note: 'Glob plan_dir for *_part_*.md or single plan file. Sort alphabetically
+      into plan_parts[]. For a single-part plan, plan_parts has one entry equal to
+      plan_path. PRIMARY PATH: context.task = conflict_report_path from merge_pr.
+      REMEDIATION MODE: context.remediation_path is set when re-entering from the
+      remediate step; pass it inline in the skill_command instead of context.task.
 
+      '
   verify:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:dry-walkthrough ${{ context.pr_plan_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "verify"
-      output_dir: "{{AUTOSKILLIT_TEMP}}"
+      skill_command: /autoskillit:dry-walkthrough ${{ context.pr_plan_path }}
+      cwd: ${{ context.work_dir }}
+      step_name: verify
+      output_dir: '{{AUTOSKILLIT_TEMP}}'
     on_success: implement
     on_failure: register_clone_failure
     retries: 5
     on_exhausted: register_clone_failure
     on_context_limit: register_clone_failure
-    note: >
-      SEQUENTIAL: For each plan_part, run the full cycle
-      (verify → implement → test → push_worktree_branch → create_conflict_pr
-      → wait_for_conflict_ci → merge_conflict_pr) before advancing.
+    note: 'SEQUENTIAL: For each plan_part, run the full cycle (verify → implement
+      → test → push_worktree_branch → create_conflict_pr → wait_for_conflict_ci →
+      merge_conflict_pr) before advancing.
 
+      '
   implement:
     tool: run_skill
-    model: ""
+    model: ''
     stale_threshold: 2400
     with:
-      skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.pr_plan_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "implement"
+      skill_command: /autoskillit:implement-worktree-no-merge ${{ context.pr_plan_path
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: implement
     capture:
-      worktree_path: "${{ result.worktree_path }}"
-      worktree_branch_name: "${{ result.branch_name }}"
+      worktree_path: ${{ result.worktree_path }}
+      worktree_branch_name: ${{ result.branch_name }}
     on_success: test
     on_failure: register_clone_failure
     retries: 0
     on_exhausted: retry_worktree
     on_context_limit: retry_worktree
-
   retry_worktree:
     tool: run_skill
-    model: ""
+    model: ''
     stale_threshold: 2400
     with:
-      skill_command: "/autoskillit:retry-worktree ${{ context.pr_plan_path }} ${{ context.worktree_path }}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: "retry_worktree"
+      skill_command: /autoskillit:retry-worktree ${{ context.pr_plan_path }} ${{ context.worktree_path
+        }}
+      cwd: ${{ context.worktree_path }}
+      step_name: retry_worktree
     capture:
-      worktree_path: "${{ result.worktree_path }}"
-      worktree_branch_name: "${{ result.branch_name }}"
+      worktree_path: ${{ result.worktree_path }}
+      worktree_branch_name: ${{ result.branch_name }}
     on_success: test
     on_failure: register_clone_failure
     retries: 3
     on_exhausted: register_clone_failure
     on_context_limit: register_clone_failure
-
   test:
     tool: test_check
     with:
-      worktree_path: "${{ context.worktree_path }}"
+      worktree_path: ${{ context.worktree_path }}
     on_success: push_worktree_branch
     on_failure: fix
-
   push_worktree_branch:
     tool: run_cmd
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin)
+      cmd: 'REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://"
+        && echo upstream || echo origin)
+
         git push "$REMOTE" HEAD:${{ context.worktree_branch_name }} --force-with-lease
-      cwd: "${{ context.worktree_path }}"
-      step_name: "push_worktree_branch"
+
+        '
+      cwd: ${{ context.worktree_path }}
+      step_name: push_worktree_branch
     on_success: create_conflict_pr
     on_failure: register_clone_failure
-    note: >
-      Pushes the conflict-resolution worktree branch to origin so GitHub can run CI.
-      Uses --force-with-lease to prevent clobbering concurrent updates.
-      context.worktree_branch_name is captured from implement step output (result.branch_name).
-      Both a lease violation (concurrent push) and a network failure route to
-      register_clone_failure — the recipe cannot distinguish between the two, so no safe
-      retry is possible without re-evaluating the worktree state.
+    note: 'Pushes the conflict-resolution worktree branch to origin so GitHub can
+      run CI. Uses --force-with-lease to prevent clobbering concurrent updates. context.worktree_branch_name
+      is captured from implement step output (result.branch_name). Both a lease violation
+      (concurrent push) and a network failure route to register_clone_failure — the
+      recipe cannot distinguish between the two, so no safe retry is possible without
+      re-evaluating the worktree state.
 
+      '
   create_conflict_pr:
     tool: run_cmd
     with:
-      cmd: >
-        gh pr create
-        --base "${{ context.batch_branch }}"
-        --head "${{ context.worktree_branch_name }}"
-        --title "chore: conflict resolution for PR ${{ context.current_pr_number }}"
-        --body "Auto-generated conflict resolution branch. Closes after merge."
-        --json number --jq '.number'
-      cwd: "${{ context.work_dir }}"
-      step_name: "create_conflict_pr"
+      cmd: 'gh pr create --base "${{ context.batch_branch }}" --head "${{ context.worktree_branch_name
+        }}" --title "chore: conflict resolution for PR ${{ context.current_pr_number
+        }}" --body "Auto-generated conflict resolution branch. Closes after merge."
+        --json number --jq ''.number''
+
+        '
+      cwd: ${{ context.work_dir }}
+      step_name: create_conflict_pr
     capture:
-      conflict_pr_number: "${{ result.stdout | trim }}"
+      conflict_pr_number: ${{ result.stdout | trim }}
     on_success: derive_conflict_ci_event
     on_failure: register_clone_failure
-    note: >
-      Creates a GitHub PR from the worktree branch into the integration batch branch.
-      Captures conflict_pr_number for the subsequent gh pr merge call.
-      The --json number --jq '.number' flags constrain gh output to a bare integer,
+    note: 'Creates a GitHub PR from the worktree branch into the integration batch
+      branch. Captures conflict_pr_number for the subsequent gh pr merge call. The
+      --json number --jq ''.number'' flags constrain gh output to a bare integer,
       but if gh emits unexpected warnings to stdout the trimmed value may be malformed
       and propagate silently to merge_conflict_pr. Verify conflict_pr_number is a
       non-empty integer before use.
 
+      '
   derive_conflict_ci_event:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.worktree_branch_name }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "derive_conflict_ci_event"
+      branch: ${{ context.worktree_branch_name }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: derive_conflict_ci_event
     capture:
-      conflict_ci_event: "${{ result.ci_event }}"
-      conflict_ci_applicable: "${{ result.ci_applicable }}"
+      conflict_ci_event: ${{ result.ci_event }}
+      conflict_ci_applicable: ${{ result.ci_applicable }}
     on_success: route_conflict_ci
     on_failure: route_conflict_ci
-    note: >
-      Re-derives ci_event for the ACTUAL conflict resolution branch, not inputs.base_branch.
-      The original check_repo_ci_event evaluates CI triggers against main, but conflict PRs
-      target pr-batch/* branches where different CI rules may apply. Non-blocking: on_failure
-      routes to route_conflict_ci with conflict_ci_event=null (match-any fallback).
+    note: 'Re-derives ci_event for the ACTUAL conflict resolution branch, not inputs.base_branch.
+      The original check_repo_ci_event evaluates CI triggers against main, but conflict
+      PRs target pr-batch/* branches where different CI rules may apply. Non-blocking:
+      on_failure routes to route_conflict_ci with conflict_ci_event=null (match-any
+      fallback).
 
+      '
   route_conflict_ci:
     action: route
     on_result:
-    - when: "${{ context.conflict_ci_applicable }} == false"
+    - when: ${{ context.conflict_ci_applicable }} == false
       route: guard_ci_skip_conflict
     - route: wait_for_conflict_ci
-    note: >
-      Short-circuits CI wait when no workflow trigger matches the conflict resolution
+    note: 'Short-circuits CI wait when no workflow trigger matches the conflict resolution
       branch. ci_applicable=false means neither push nor merge_group triggers apply,
       so wait_for_ci would exhaust its timeout budget with zero CI runs.
 
+      '
   guard_ci_skip_conflict:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_skip_conflict_count }}"
-      max_iterations: "50"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_skip_conflict_count }}
+      max_iterations: '50'
     capture:
-      ci_skip_conflict_count: "${{ result.next_iteration }}"
+      ci_skip_conflict_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_failure
     - route: merge_conflict_pr
     on_failure: register_clone_failure
     optional_context_refs:
     - ci_skip_conflict_count
-    note: >
-      Structural bound for the ci_applicable=false shortcut path. Uses
-      check_loop_iteration to satisfy the unbounded-cycle semantic rule — the
-      on_result exit to register_clone_failure provides a structural termination
-      guarantee. Cap of 50 matches check_pr_merge_loop budget; in practice never
-      exceeded because the PR merge loop terminates when all PRs are processed.
+    note: 'Structural bound for the ci_applicable=false shortcut path. Uses check_loop_iteration
+      to satisfy the unbounded-cycle semantic rule — the on_result exit to register_clone_failure
+      provides a structural termination guarantee. Cap of 50 matches check_pr_merge_loop
+      budget; in practice never exceeded because the PR merge loop terminates when
+      all PRs are processed.
 
+      '
   wait_for_conflict_ci:
     tool: wait_for_ci
     with:
-      branch: "${{ context.worktree_branch_name }}"
-      event: "${{ context.conflict_ci_event }}"
+      branch: ${{ context.worktree_branch_name }}
+      event: ${{ context.conflict_ci_event }}
       timeout_seconds: 600
-      cwd: "${{ context.worktree_path }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.worktree_path }}
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
     on_result:
-    - when: "${{ result.conclusion }} == 'success'"
+    - when: ${{ result.conclusion }} == 'success'
       route: merge_conflict_pr
-    - when: "${{ result.conclusion }} == 'no_runs'"
+    - when: ${{ result.conclusion }} == 'no_runs'
       route: handle_conflict_no_runs
-    - when: "${{ result.conclusion }} == 'timed_out'"
+    - when: ${{ result.conclusion }} == 'timed_out'
       route: check_conflict_ci_loop
     - route: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Waits for CI to pass on the worktree branch before merging.
-      600 second timeout matches the merge-pr skill poll timeout.
-      Uses conflict_ci_event (derived for the actual worktree branch) instead of
-      the global ci_event (derived for inputs.base_branch). Routes on result.conclusion:
-      success → merge_conflict_pr, no_runs → handle_conflict_no_runs (recovery path),
-      timed_out → check_conflict_ci_loop (iteration guard), failure → register_clone_failure.
+    note: 'Waits for CI to pass on the worktree branch before merging. 600 second
+      timeout matches the merge-pr skill poll timeout. Uses conflict_ci_event (derived
+      for the actual worktree branch) instead of the global ci_event (derived for
+      inputs.base_branch). Routes on result.conclusion: success → merge_conflict_pr,
+      no_runs → handle_conflict_no_runs (recovery path), timed_out → check_conflict_ci_loop
+      (iteration guard), failure → register_clone_failure.
 
+      '
   check_conflict_ci_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.conflict_ci_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.conflict_ci_loop_count }}
+      max_iterations: '2'
     capture:
-      conflict_ci_loop_count: "${{ result.next_iteration }}"
+      conflict_ci_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_failure
     - route: wait_for_conflict_ci
     on_failure: register_clone_failure
     optional_context_refs:
     - conflict_ci_loop_count
-    note: >
-      Caps the wait_for_conflict_ci re-poll loop at 2 iterations.
-      After 2 timed_out results (1200s total), routes to register_clone_failure
-      instead of spinning indefinitely.
+    note: 'Caps the wait_for_conflict_ci re-poll loop at 2 iterations. After 2 timed_out
+      results (1200s total), routes to register_clone_failure instead of spinning
+      indefinitely.
 
+      '
   handle_conflict_no_runs:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.worktree_branch_name }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "handle_conflict_no_runs"
+      branch: ${{ context.worktree_branch_name }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: handle_conflict_no_runs
     capture:
-      conflict_ci_event: "${{ result.ci_event }}"
-      conflict_ci_applicable: "${{ result.ci_applicable }}"
+      conflict_ci_event: ${{ result.ci_event }}
+      conflict_ci_applicable: ${{ result.ci_applicable }}
     on_success: merge_conflict_pr
     on_failure: register_clone_failure
     retries: 1
     on_exhausted: register_clone_failure
-    note: >
-      Intercepts no_runs from wait_for_conflict_ci. Re-derives ci_event for the worktree
-      branch. Since this step is reached only after auto_trigger has already attempted to
-      trigger CI (empty commit + force-push) and wait_for_conflict_ci still saw no_runs,
-      the branch genuinely has no applicable CI. Routes unconditionally to merge_conflict_pr
-      on tool success — skipping CI is correct because all recovery options have been
-      exhausted. retries: 1 bounds the tool-call retry for transient API failures.
+    note: 'Intercepts no_runs from wait_for_conflict_ci. Re-derives ci_event for the
+      worktree branch. Since this step is reached only after auto_trigger has already
+      attempted to trigger CI (empty commit + force-push) and wait_for_conflict_ci
+      still saw no_runs, the branch genuinely has no applicable CI. Routes unconditionally
+      to merge_conflict_pr on tool success — skipping CI is correct because all recovery
+      options have been exhausted. retries: 1 bounds the tool-call retry for transient
+      API failures.
 
+      '
   merge_conflict_pr:
     tool: run_cmd
     with:
-      cmd: "gh pr merge \"${{ context.conflict_pr_number }}\" --squash --delete-branch"
-      cwd: "${{ context.work_dir }}"
-      step_name: "merge_conflict_pr"
+      cmd: gh pr merge "${{ context.conflict_pr_number }}" --squash --delete-branch
+      cwd: ${{ context.work_dir }}
+      step_name: merge_conflict_pr
     on_success: next_part_or_next_pr
     on_failure: register_clone_failure
-    note: >
-      Merges the conflict-resolution PR into the integration batch branch via GitHub API.
-      Uses --squash to keep integration history linear.
-      Uses --delete-branch to clean up the temporary worktree branch on GitHub.
-      Non-auto merge (explicit --squash without --auto) is correct here because
-      wait_for_conflict_ci already confirmed CI has passed.
+    note: 'Merges the conflict-resolution PR into the integration batch branch via
+      GitHub API. Uses --squash to keep integration history linear. Uses --delete-branch
+      to clean up the temporary worktree branch on GitHub. Non-auto merge (explicit
+      --squash without --auto) is correct here because wait_for_conflict_ci already
+      confirmed CI has passed.
 
+      '
   fix:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.pr_plan_path }} ${{ context.batch_branch }}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: "fix"
-      base_branch: "${{ inputs.base_branch }}"
+      skill_command: /autoskillit:resolve-failures ${{ context.worktree_path }} ${{
+        context.pr_plan_path }} ${{ context.batch_branch }}
+      cwd: ${{ context.worktree_path }}
+      step_name: fix
+      base_branch: ${{ inputs.base_branch }}
     capture:
-      verdict: "${{ result.verdict }}"
-      fixes_applied: "${{ result.fixes_applied }}"
+      verdict: ${{ result.verdict }}
+      fixes_applied: ${{ result.fixes_applied }}
     on_result:
-    - when: "${{ result.verdict }} == 'real_fix'"
+    - when: ${{ result.verdict }} == 'real_fix'
       route: check_test_fix_loop
-    - when: "${{ result.verdict }} == 'already_green'"
+    - when: ${{ result.verdict }} == 'already_green'
       route: check_test_fix_loop
-    - when: "${{ result.verdict }} == 'flake_suspected'"
+    - when: ${{ result.verdict }} == 'flake_suspected'
       route: check_test_fix_loop
-    - when: "${{ result.verdict }} == 'ci_only_failure'"
+    - when: ${{ result.verdict }} == 'ci_only_failure'
       route: register_clone_failure
-    - when: "${{ result.verdict }} == 'no_test_infrastructure'"
+    - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: register_clone_failure
     on_failure: register_clone_failure
     retries: 3
     on_exhausted: register_clone_failure
     on_context_limit: register_clone_failure
-    note: >
-      Fixes test failures without merging. Routes back to check_test_fix_loop for
-      iteration guard before re-validation before the GitHub-API merge sequence.
-      The base_branch with: key is present for contract compatibility only; the
-      merge target is always the integration branch.
+    note: 'Fixes test failures without merging. Routes back to check_test_fix_loop
+      for iteration guard before re-validation before the GitHub-API merge sequence.
+      The base_branch with: key is present for contract compatibility only; the merge
+      target is always the integration branch.
 
+      '
   check_test_fix_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.test_fix_loop_count }}"
-      max_iterations: "3"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.test_fix_loop_count }}
+      max_iterations: '3'
     capture:
-      test_fix_loop_count: "${{ result.next_iteration }}"
+      test_fix_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_failure
     - route: test
     on_failure: register_clone_failure
     optional_context_refs:
     - test_fix_loop_count
-    note: >
-      Guards the test → fix → test cycle. Caps at 3 fix-retest iterations.
-      If tests still fail after 3 fix attempts, escalates to clone failure.
+    note: 'Guards the test → fix → test cycle. Caps at 3 fix-retest iterations. If
+      tests still fail after 3 fix attempts, escalates to clone failure.
 
+      '
   next_part_or_next_pr:
     action: route
     on_result:
@@ -1101,80 +1160,86 @@ steps:
         more_parts: verify
         more_prs: check_pr_merge_loop
         all_done: push_batch_branch
-    note: >
-      Routing step — no tool call. The agent evaluates what comes next:
-      1. If more plan_parts remain for the current PR → verify (next part).
-      2. If all parts done, advance current_pr_number. If more PRs remain → check_pr_merge_loop.
-      3. If all PRs processed → push_batch_branch.
+    note: 'Routing step — no tool call. The agent evaluates what comes next: 1. If
+      more plan_parts remain for the current PR → verify (next part). 2. If all parts
+      done, advance current_pr_number. If more PRs remain → check_pr_merge_loop. 3.
+      If all PRs processed → push_batch_branch.
 
+      '
   check_pr_merge_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.pr_merge_loop_count }}"
-      max_iterations: "50"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.pr_merge_loop_count }}
+      max_iterations: '50'
     capture:
-      pr_merge_loop_count: "${{ result.next_iteration }}"
+      pr_merge_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_failure
     - route: merge_pr
     on_failure: register_clone_failure
     optional_context_refs:
     - pr_merge_loop_count
-    note: >
-      Guards the merge_pr → next_part_or_next_pr outer loop. The loop is
-      data-bounded by the finite pr_order_file list; this provides a structural
-      bound for the cycle validator. 50 iterations allows large batch runs.
-      Unlike retry loops (capped at 3–15 attempts), this cap is an outer
-      iteration over data items (PRs to merge), not a retry count — hence the
-      higher bound is safe: it tracks distinct work units, not repeated attempts
-      on the same operation.
+    note: 'Guards the merge_pr → next_part_or_next_pr outer loop. The loop is data-bounded
+      by the finite pr_order_file list; this provides a structural bound for the cycle
+      validator. 50 iterations allows large batch runs. Unlike retry loops (capped
+      at 3–15 attempts), this cap is an outer iteration over data items (PRs to merge),
+      not a retry count — hence the higher bound is safe: it tracks distinct work
+      units, not repeated attempts on the same operation.
 
+      '
   push_batch_branch:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.batch_branch }}"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.batch_branch }}
     on_success: collect_and_check_impl_plans
     on_failure: register_clone_failure
-    note: >
-      Single push after ALL PR merges complete. Uses push_to_remote MCP tool
+    note: 'Single push after ALL PR merges complete. Uses push_to_remote MCP tool
       (consistent with all other push steps) rather than run_cmd git push.
 
+      '
   collect_and_check_impl_plans:
     tool: run_cmd
     with:
-      cmd: |
-        mkdir -p ${{ inputs.plans_dir }} && find {{AUTOSKILLIT_TEMP}}/make-plan/ -name '*_plan_*.md' -exec cp {} ${{ inputs.plans_dir }}/ \; 2>/dev/null || true
-        find ${{ inputs.plans_dir }} -maxdepth 1 -name '*_plan_*.md' ! -name 'pr_analysis_plan_*.md' 2>/dev/null | wc -l | tr -d ' \n'
-      cwd: "${{ context.work_dir }}"
-      step_name: "collect_and_check_impl_plans"
+      cmd: 'mkdir -p ${{ inputs.plans_dir }} && find {{AUTOSKILLIT_TEMP}}/make-plan/
+        -name ''*_plan_*.md'' -exec cp {} ${{ inputs.plans_dir }}/ \; 2>/dev/null
+        || true
+
+        find ${{ inputs.plans_dir }} -maxdepth 1 -name ''*_plan_*.md'' ! -name ''pr_analysis_plan_*.md''
+        2>/dev/null | wc -l | tr -d '' \n''
+
+        '
+      cwd: ${{ context.work_dir }}
+      step_name: collect_and_check_impl_plans
     on_result:
-    - when: "${{ result.stdout | trim }} == 0"
+    - when: ${{ result.stdout | trim }} == 0
       route: compute_domain_partitions
     - route: audit_impl
     on_failure: audit_impl
-    note: >
-      Copies plan files from {{AUTOSKILLIT_TEMP}}/make-plan/ into plans_dir, then counts
-      implementation plan files (excluding pr_analysis_plan_*.md). The copy uses || true
-      so the count always runs even if no source files exist. The final stdout line is the
-      count, used for on_result routing: 0 → compute_domain_partitions (no plans generated,
-      all PRs merged cleanly), non-zero → audit_impl (conflict reports or make-plan outputs
-      are present). Replaces the former collect_artifacts + check_impl_plans two-step pair.
+    note: 'Copies plan files from {{AUTOSKILLIT_TEMP}}/make-plan/ into plans_dir,
+      then counts implementation plan files (excluding pr_analysis_plan_*.md). The
+      copy uses || true so the count always runs even if no source files exist. The
+      final stdout line is the count, used for on_result routing: 0 → compute_domain_partitions
+      (no plans generated, all PRs merged cleanly), non-zero → audit_impl (conflict
+      reports or make-plan outputs are present). Replaces the former collect_artifacts
+      + check_impl_plans two-step pair.
 
+      '
   audit_impl:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:audit-impl \"${{ context.all_plan_paths }}\" ${{ context.batch_branch }} ${{ inputs.base_branch }} \"${{ context.all_conflict_report_paths }}\""
-      cwd: "${{ context.work_dir }}"
-      step_name: "audit_impl"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
+      skill_command: /autoskillit:audit-impl "${{ context.all_plan_paths }}" ${{ context.batch_branch
+        }} ${{ inputs.base_branch }} "${{ context.all_conflict_report_paths }}"
+      cwd: ${{ context.work_dir }}
+      step_name: audit_impl
+      output_dir: '{{AUTOSKILLIT_TEMP}}/audit-impl'
     capture:
-      verdict: "${{ result.verdict }}"
-      remediation_path: "${{ result.remediation_path }}"
+      verdict: ${{ result.verdict }}
+      remediation_path: ${{ result.remediation_path }}
     on_result:
       field: verdict
       routes:
@@ -1183,404 +1248,411 @@ steps:
     on_failure: register_clone_failure
     on_context_limit: register_clone_failure
     optional: true
-    skip_when_false: "inputs.audit"
-    note: >
-      DEPENDENCY: context.all_plan_paths is only populated if the plan step executed
+    skip_when_false: inputs.audit
+    note: 'DEPENDENCY: context.all_plan_paths is only populated if the plan step executed
       at least once. The check_impl_plans gate ensures this step is only reached when
       implementation plan files exist (i.e. make-plan was invoked), so all_plan_paths
-      is guaranteed to be set when audit_impl runs.
-      Gated by check_impl_plans — only reached when implementation plan files exist in
-      plans_dir. Only execute if inputs.audit is 'true'; if false, skip directly to
-      open_integration_pr. Passes context.all_plan_paths (comma-separated list of plan file
-      paths accumulated across the PR loop) as plans_input. audit-impl splits on commas
-      and audits each plan file.
-      implementation_ref is context.batch_branch (no worktree remains).
-      GO → open_integration_pr. NO GO → remediate (re-enters plan with remediation file).
+      is guaranteed to be set when audit_impl runs. Gated by check_impl_plans — only
+      reached when implementation plan files exist in plans_dir. Only execute if inputs.audit
+      is ''true''; if false, skip directly to open_integration_pr. Passes context.all_plan_paths
+      (comma-separated list of plan file paths accumulated across the PR loop) as
+      plans_input. audit-impl splits on commas and audits each plan file. implementation_ref
+      is context.batch_branch (no worktree remains). GO → open_integration_pr. NO
+      GO → remediate (re-enters plan with remediation file).
 
+      '
   remediate:
     action: route
     with:
-      remediation_path: "${{ context.remediation_path }}"
+      remediation_path: ${{ context.remediation_path }}
     on_success: plan
-
   compute_domain_partitions:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.compute_domain_partitions"
-      batch_branch: "${{ context.batch_branch }}"
-      base_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/open-integration-pr"
+      callable: autoskillit.smoke_utils.compute_domain_partitions
+      batch_branch: ${{ context.batch_branch }}
+      base_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/open-integration-pr'
     capture:
-      domain_partitions_path: "${{ result.domain_partitions_path }}"
+      domain_partitions_path: ${{ result.domain_partitions_path }}
     on_success: open_integration_pr
     on_failure: open_integration_pr
-    note: >
-      Pre-computes domain partitions for open-integration-pr server-side (where
+    note: 'Pre-computes domain partitions for open-integration-pr server-side (where
       autoskillit is always installed). Writes the JSON result to disk. On failure,
       falls through to open_integration_pr which uses an empty domain_partitions_path
       fallback. Eliminates the autoskillit import in open-integration-pr SKILL.md.
 
+      '
   open_integration_pr:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:open-integration-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} ${{ context.pr_order_file }} ${{ context.verdict }} \"${{ context.all_conflict_report_paths }}\" domain_partitions_path=${{ context.domain_partitions_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "open_integration_pr"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/open-integration-pr"
+      skill_command: /autoskillit:open-integration-pr ${{ context.batch_branch }}
+        ${{ inputs.base_branch }} ${{ context.pr_order_file }} ${{ context.verdict
+        }} "${{ context.all_conflict_report_paths }}" domain_partitions_path=${{ context.domain_partitions_path
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: open_integration_pr
+      output_dir: '{{AUTOSKILLIT_TEMP}}/open-integration-pr'
     capture:
-      pr_url: "${{ result.pr_url }}"
+      pr_url: ${{ result.pr_url }}
     on_success: wait_for_review_pr_mergeability
     on_failure: register_clone_failure
-
   wait_for_review_pr_mergeability:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.wait_for_review_pr_mergeability"
-      pr_url: "${{ context.pr_url }}"
-      max_polls: "12"
-      poll_interval: "15"
+      callable: autoskillit.recipe._cmd_rpc.wait_for_review_pr_mergeability
+      pr_url: ${{ context.pr_url }}
+      max_polls: '12'
+      poll_interval: '15'
     capture:
-      review_pr_number: "${{ result.pr_number }}"
+      review_pr_number: ${{ result.pr_number }}
     on_success: check_mergeability
     on_failure: register_clone_failure
-    note: >
-      Extracts the review PR number from context.pr_url and polls GitHub until the
-      mergeable field is no longer UNKNOWN (GitHub computes this asynchronously after PR
-      creation). Polls up to 12 times with 15-second intervals (3 minutes maximum).
-      Captures review_pr_number for use by check_mergeability and check_mergeability_post_rebase.
+    note: 'Extracts the review PR number from context.pr_url and polls GitHub until
+      the mergeable field is no longer UNKNOWN (GitHub computes this asynchronously
+      after PR creation). Polls up to 12 times with 15-second intervals (3 minutes
+      maximum). Captures review_pr_number for use by check_mergeability and check_mergeability_post_rebase.
 
+      '
   check_mergeability:
     tool: check_pr_mergeable
     with:
-      pr_number: "${{ context.review_pr_number }}"
-      cwd: "${{ context.work_dir }}"
+      pr_number: ${{ context.review_pr_number }}
+      cwd: ${{ context.work_dir }}
     on_result:
-    - when: "${{ result.mergeable_status }} == MERGEABLE"
+    - when: ${{ result.mergeable_status }} == MERGEABLE
       route: annotate_pr_diff
-    - when: "${{ result.mergeable_status }} == CONFLICTING"
+    - when: ${{ result.mergeable_status }} == CONFLICTING
       route: resolve_integration_conflicts
     - route: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Authoritative mergeability check via check_pr_mergeable MCP tool (REQ-MERGE-001).
-      Routes MERGEABLE directly to review cycle. Routes CONFLICTING to automated
-      conflict resolution. Any other state (UNKNOWN after timeout, tool error) escalates
-      to register_clone_failure (REQ-MERGE-005).
+    note: 'Authoritative mergeability check via check_pr_mergeable MCP tool (REQ-MERGE-001).
+      Routes MERGEABLE directly to review cycle. Routes CONFLICTING to automated conflict
+      resolution. Any other state (UNKNOWN after timeout, tool error) escalates to
+      register_clone_failure (REQ-MERGE-005).
 
+      '
   resolve_integration_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.batch_branch }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_integration_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.batch_branch
+        }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_integration_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
-      conflict_escalation_reason: "${{ result.escalation_reason }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
+      conflict_escalation_reason: ${{ result.escalation_reason }}
     capture_list:
-      all_conflict_report_paths: "${{ result.conflict_report_path }}"
+      all_conflict_report_paths: ${{ result.conflict_report_path }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: register_clone_failure
     - route: force_push_and_wait_mergeability
     retries: 0
     on_failure: register_clone_failure
-    note: >
-      Automated conflict resolution when the integration PR is CONFLICTING (REQ-MERGE-003).
+    note: 'Automated conflict resolution when the integration PR is CONFLICTING (REQ-MERGE-003).
       Rebases context.batch_branch onto inputs.base_branch and resolves merge conflicts.
       Single attempt only — no retries — to prevent looping on unresolvable conflicts.
       On failure, escalates to register_clone_failure with diagnostics (REQ-MERGE-004).
 
+      '
   force_push_and_wait_mergeability:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.force_push_and_wait_mergeability"
-      work_dir: "${{ context.work_dir }}"
-      batch_branch: "${{ context.batch_branch }}"
-      review_pr_number: "${{ context.review_pr_number }}"
-      max_polls: "12"
-      poll_interval: "15"
+      callable: autoskillit.recipe._cmd_rpc.force_push_and_wait_mergeability
+      work_dir: ${{ context.work_dir }}
+      batch_branch: ${{ context.batch_branch }}
+      review_pr_number: ${{ context.review_pr_number }}
+      max_polls: '12'
+      poll_interval: '15'
     on_success: check_mergeability_post_rebase
     on_failure: register_clone_failure
-    note: >
-      Force-pushes the rebased integration branch (--force-with-lease rejects if remote
-      diverged), then polls GitHub until the PR's mergeable field is no longer UNKNOWN.
-      Polls up to 12 times with 15-second intervals (3 minutes maximum). The && chaining
-      preserves causal ordering: the poll loop only runs after a successful push. Any
-      failure (push rejected or mergeability timeout) routes to register_clone_failure.
+    note: 'Force-pushes the rebased integration branch (--force-with-lease rejects
+      if remote diverged), then polls GitHub until the PR''s mergeable field is no
+      longer UNKNOWN. Polls up to 12 times with 15-second intervals (3 minutes maximum).
+      The && chaining preserves causal ordering: the poll loop only runs after a successful
+      push. Any failure (push rejected or mergeability timeout) routes to register_clone_failure.
       Replaces the former force_push_after_rebase + wait_for_post_rebase_mergeability
       two-step pair. Satisfies REQ-MERGE-002.
 
+      '
   check_mergeability_post_rebase:
     tool: check_pr_mergeable
     with:
-      pr_number: "${{ context.review_pr_number }}"
-      cwd: "${{ context.work_dir }}"
+      pr_number: ${{ context.review_pr_number }}
+      cwd: ${{ context.work_dir }}
     on_result:
-    - when: "${{ result.mergeable_status }} == MERGEABLE"
+    - when: ${{ result.mergeable_status }} == MERGEABLE
       route: annotate_pr_diff
     - route: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Re-checks mergeability after the rebase and force-push. MERGEABLE proceeds to the
-      review cycle. Any other state means automated resolution did not succeed — escalates
-      to register_clone_failure for human intervention (REQ-MERGE-004). No second conflict
-      resolution attempt — one cycle only.
+    note: 'Re-checks mergeability after the rebase and force-push. MERGEABLE proceeds
+      to the review cycle. Any other state means automated resolution did not succeed
+      — escalates to register_clone_failure for human intervention (REQ-MERGE-004).
+      No second conflict resolution attempt — one cycle only.
 
+      '
   annotate_pr_diff:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.annotate_pr_diff"
-      pr_number: "${{ context.review_pr_number }}"
-      cwd: "${{ context.work_dir }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
-      local_review_rounds: "0"
+      callable: autoskillit.smoke_utils.annotate_pr_diff
+      pr_number: ${{ context.review_pr_number }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'
+      local_review_rounds: '0'
     capture:
-      annotated_diff_path: "${{ result.annotated_diff_path }}"
-      hunk_ranges_path: "${{ result.hunk_ranges_path }}"
-      diff_metrics_path: "${{ result.diff_metrics_path }}"
+      annotated_diff_path: ${{ result.annotated_diff_path }}
+      hunk_ranges_path: ${{ result.hunk_ranges_path }}
+      diff_metrics_path: ${{ result.diff_metrics_path }}
     on_success: review_pr_integration
     on_failure: review_pr_integration
-    note: >
-      Pre-computes annotated diff and hunk ranges for review-pr server-side (where
+    note: 'Pre-computes annotated diff and hunk ranges for review-pr server-side (where
       autoskillit is always installed). Writes both files to disk. On failure, falls
       through to review_pr_integration which uses empty VALID_LINE_RANGES fallback.
       Eliminates the autoskillit import in review-pr SKILL.md.
 
+      '
   review_pr_integration:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "review_pr_integration"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
+      skill_command: /autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch
+        }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{
+        context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: review_pr_integration
+      output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'
     capture:
-      review_verdict: "${{ result.verdict }}"
+      review_verdict: ${{ result.verdict }}
     on_result:
-    - when: "${{ result.verdict }} == changes_requested"
+    - when: ${{ result.verdict }} == changes_requested
       route: resolve_review_integration
-    - when: "${{ result.verdict }} == approved_with_comments"
+    - when: ${{ result.verdict }} == approved_with_comments
       route: resolve_review_integration
-    - when: "${{ result.verdict }} == needs_human"
+    - when: ${{ result.verdict }} == needs_human
       route: derive_batch_ci_event
-    - when: "${{ result.verdict }} == approved"
+    - when: ${{ result.verdict }} == approved
       route: derive_batch_ci_event
-    - when: "true"
+    - when: 'true'
       route: derive_batch_ci_event
     on_failure: resolve_review_integration
-    note: >
-      Automated review of the integration PR (REQ-REVIEW-001). Invokes review-pr against
-      context.batch_branch. All four verdicts have explicit routes: changes_requested
+    note: 'Automated review of the integration PR (REQ-REVIEW-001). Invokes review-pr
+      against context.batch_branch. All four verdicts have explicit routes: changes_requested
       → resolve_review_integration, approved_with_comments → resolve_review_integration,
       needs_human → derive_batch_ci_event (human reviews inline), approved → derive_batch_ci_event.
       On tool-level failure, routes to resolve_review_integration (matches implementation.yaml
       pattern). needs_human is explicitly routed to satisfy the unrouted-verdict-value
       semantic rule.
 
+      '
   resolve_review_integration:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-review ${{ context.batch_branch }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_review_integration"
+      skill_command: /autoskillit:resolve-review ${{ context.batch_branch }} ${{ inputs.base_branch
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_review_integration
     capture:
-      verdict: "${{ result.verdict }}"
+      verdict: ${{ result.verdict }}
     retries: 2
     on_exhausted: register_clone_failure
     on_context_limit: re_push_review_integration
     on_result:
-    - when: "${{ result.verdict }} == 'real_fix'"
+    - when: ${{ result.verdict }} == 'real_fix'
       route: re_push_review_integration
-    - when: "${{ result.verdict }} == 'already_green'"
+    - when: ${{ result.verdict }} == 'already_green'
       route: re_push_review_integration
-    - when: "${{ result.verdict }} == 'flake_suspected'"
+    - when: ${{ result.verdict }} == 'flake_suspected'
       route: register_clone_failure
-    - when: "${{ result.verdict }} == 'ci_only_failure'"
+    - when: ${{ result.verdict }} == 'ci_only_failure'
       route: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Resolves review findings on the integration PR (REQ-REVIEW-002). Fetches inline and
-      summary review comments from GitHub and applies fixes. Retries up to 2 times (3 total
-      attempts) before escalating to register_clone_failure (REQ-REVIEW-005). Routes via
-      on_result: verdict dispatch — real_fix/already_green push fixes; flake_suspected/
-      ci_only_failure escalate to register_clone_failure.
+    note: 'Resolves review findings on the integration PR (REQ-REVIEW-002). Fetches
+      inline and summary review comments from GitHub and applies fixes. Retries up
+      to 2 times (3 total attempts) before escalating to register_clone_failure (REQ-REVIEW-005).
+      Routes via on_result: verdict dispatch — real_fix/already_green push fixes;
+      flake_suspected/ ci_only_failure escalate to register_clone_failure.
 
+      '
   re_push_review_integration:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.batch_branch }}"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.batch_branch }}
     on_success: derive_batch_ci_event
     on_failure: register_clone_failure
-    note: >
-      Pushes the review-fixed integration branch to the remote (REQ-REVIEW-003). Routes to
-      derive_batch_ci_event for branch-specific CI event derivation before final CI validation.
-      On push failure, escalates to register_clone_failure.
+    note: 'Pushes the review-fixed integration branch to the remote (REQ-REVIEW-003).
+      Routes to derive_batch_ci_event for branch-specific CI event derivation before
+      final CI validation. On push failure, escalates to register_clone_failure.
 
+      '
   derive_batch_ci_event:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.batch_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "derive_batch_ci_event"
+      branch: ${{ context.batch_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: derive_batch_ci_event
     capture:
-      batch_ci_event: "${{ result.ci_event }}"
+      batch_ci_event: ${{ result.ci_event }}
     on_success: ci_watch_pr
     on_failure: ci_watch_pr
-    note: >
-      Re-derives ci_event for the actual batch branch before the final CI watch.
+    note: 'Re-derives ci_event for the actual batch branch before the final CI watch.
       The global check_repo_ci_event evaluates CI triggers against inputs.base_branch
       (main), but ci_watch_pr watches context.batch_branch where different CI rules
-      may apply. Non-blocking: on_failure routes to ci_watch_pr with
-      batch_ci_event=null (match-any fallback).
+      may apply. Non-blocking: on_failure routes to ci_watch_pr with batch_ci_event=null
+      (match-any fallback).
 
+      '
   ci_watch_pr:
     tool: wait_for_ci
     with:
-      branch: "${{ context.batch_branch }}"
-      event: "${{ context.batch_ci_event }}"
+      branch: ${{ context.batch_branch }}
+      event: ${{ context.batch_ci_event }}
       timeout_seconds: 600
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      pr_url: "${{ context.pr_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      pr_url: ${{ context.pr_url }}
       auto_trigger: true
     on_result:
-    - when: "${{ result.conclusion }} == 'success'"
+    - when: ${{ result.conclusion }} == 'success'
       route: patch_token_summary
-    - when: "${{ result.conclusion }} == 'timed_out'"
+    - when: ${{ result.conclusion }} == 'timed_out'
       route: check_ci_watch_pr_loop
     - route: register_clone_failure
     on_failure: diagnose_ci
-    note: >
-      Waits for the GitHub Actions CI run on context.batch_branch to complete
+    note: 'Waits for the GitHub Actions CI run on context.batch_branch to complete
       using the wait_for_ci MCP tool (timeout: 300 s). Routes on result.conclusion:
-      success → patch_token_summary, timed_out → check_ci_watch_pr_loop (iteration guard),
-      no_runs/failure → register_clone_failure.
-      Tool-level failure routes to diagnose_ci for log capture.
+      success → patch_token_summary, timed_out → check_ci_watch_pr_loop (iteration
+      guard), no_runs/failure → register_clone_failure. Tool-level failure routes
+      to diagnose_ci for log capture.
 
+      '
   check_ci_watch_pr_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_watch_pr_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_watch_pr_loop_count }}
+      max_iterations: '2'
     capture:
-      ci_watch_pr_loop_count: "${{ result.next_iteration }}"
+      ci_watch_pr_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_failure
     - route: ci_watch_pr
     on_failure: register_clone_failure
     optional_context_refs:
     - ci_watch_pr_loop_count
-    note: >
-      Caps the ci_watch_pr re-poll loop at 2 iterations.
+    note: 'Caps the ci_watch_pr re-poll loop at 2 iterations.
 
+      '
   diagnose_ci:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:diagnose-ci ${{ context.batch_branch }} - - - ${{ context.ci_event }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "diagnose_ci"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+      skill_command: /autoskillit:diagnose-ci ${{ context.batch_branch }} - - - ${{
+        context.ci_event }}
+      cwd: ${{ context.work_dir }}
+      step_name: diagnose_ci
+      output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-ci'
     capture:
-      diagnosis_path: "${{ result.diagnosis_path }}"
+      diagnosis_path: ${{ result.diagnosis_path }}
     on_success: register_clone_failure
     on_failure: register_clone_failure
-    note: >
-      Runs when ci_watch_pr reports CI failure on the integration branch.
-      Fetches logs and writes a diagnosis to {{AUTOSKILLIT_TEMP}}/diagnose-ci/ for human inspection.
+    note: 'Runs when ci_watch_pr reports CI failure on the integration branch. Fetches
+      logs and writes a diagnosis to {{AUTOSKILLIT_TEMP}}/diagnose-ci/ for human inspection.
       diagnosis_path is captured for observability — no automated remediation for
       integration CI, so always routes to register_clone_failure.
 
+      '
   patch_token_summary:
-    description: "Collect all pipeline token data and patch the PR body with complete summary"
+    description: Collect all pipeline token data and patch the PR body with complete
+      summary
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.patch_pr_token_summary"
+      callable: autoskillit.smoke_utils.patch_pr_token_summary
       timeout: 60
-      pr_url: "${{ context.pr_url }}"
-      cwd: "${{ context.work_dir }}"
+      pr_url: ${{ context.pr_url }}
+      cwd: ${{ context.work_dir }}
     on_success: register_clone_success
     on_failure: register_clone_success
-    note: >
-      Patches PR body with complete token summary; failure never blocks pipeline completion.
+    note: 'Patches PR body with complete token summary; failure never blocks pipeline
+      completion.
 
+      '
   register_clone_success:
-    description: "Register clone as cleanup candidate for batch deletion"
+    description: Register clone as cleanup candidate for batch deletion
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "success"
+      clone_path: ${{ context.work_dir }}
+      status: success
       step_name: register_clone_success
     on_success: run_diagnostic
     on_failure: run_diagnostic
-
   register_clone_failure:
-    description: "Register clone as preserved (error pipeline)"
+    description: Register clone as preserved (error pipeline)
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "error"
+      clone_path: ${{ context.work_dir }}
+      status: error
       step_name: register_clone_failure
     on_success: run_diagnostic_error
     on_failure: run_diagnostic_error
-
   run_diagnostic:
-    description: "Run post-pipeline diagnostic analysis on session logs"
+    description: Run post-pipeline diagnostic analysis on session logs
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: done
     on_failure: done
     on_context_limit: done
-    note: >
-      Diagnostic failure never blocks pipeline completion. Both on_failure and
+    note: 'Diagnostic failure never blocks pipeline completion. Both on_failure and
       on_context_limit route to the same terminal as on_success.
 
+      '
   run_diagnostic_error:
-    description: "Run post-pipeline diagnostic analysis on session logs (error path)"
+    description: Run post-pipeline diagnostic analysis on session logs (error path)
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: escalate_stop
     on_failure: escalate_stop
     on_context_limit: escalate_stop
-    note: >
-      Diagnostic failure never blocks pipeline completion.
+    note: 'Diagnostic failure never blocks pipeline completion.
 
+      '
   done:
     action: stop
-    message: >-
-      PR consolidation complete.
-      Emit the L3 result sentinel JSON block now with success=true.
-      Example sentinel: {"success": true, "reason": "merge complete"}
-
+    message: 'PR consolidation complete. Emit the L3 result sentinel JSON block now
+      with success=true. Example sentinel: {"success": true, "reason": "merge complete"}'
   escalate_stop:
     action: stop
-    message: >-
-      Pipeline failed — human intervention needed. Check the integration branch and {{AUTOSKILLIT_TEMP}}/merge-prs/ for details.
-      Emit the L3 result sentinel JSON block now with success=false.
-      Example sentinel: {"success": false, "reason": "merge-prs pipeline failed"}
-    note: >
-      context.task may be null when reached via escalation_required=true from merge_pr
-      (merge-pr does not set conflict_report_path on escalation paths). Do not rely on
-      context.task being populated when handling this stop.
+    message: 'Pipeline failed — human intervention needed. Check the integration branch
+      and {{AUTOSKILLIT_TEMP}}/merge-prs/ for details. Emit the L3 result sentinel
+      JSON block now with success=false. Example sentinel: {"success": false, "reason":
+      "merge-prs pipeline failed"}'
+    note: 'context.task may be null when reached via escalation_required=true from
+      merge_pr (merge-pr does not set conflict_report_path on escalation paths). Do
+      not rely on context.task being populated when handling this stop.
 
+      '

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -102,6 +102,21 @@
       "description": "Investigation depth mode",
       "default": "standard",
       "hidden": true
+    },
+    "is_fleet_dispatch": {
+      "description": "Whether running as an L2 food truck dispatch (auto-injected)",
+      "default": "false",
+      "hidden": true
+    },
+    "dispatch_id": {
+      "description": "Fleet dispatch identifier (auto-injected, empty in non-fleet sessions)",
+      "default": "",
+      "hidden": true
+    },
+    "diagnostics_log_dir": {
+      "description": "Resolved diagnostics log directory path (auto-injected)",
+      "default": "",
+      "hidden": true
     }
   },
   "steps": {
@@ -1101,7 +1116,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },
@@ -1943,7 +1958,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },
@@ -2025,7 +2040,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },
@@ -2041,7 +2056,7 @@
       "optional": true,
       "skip_when_false": "inputs.post_run_diagnostics",
       "with": {
-        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}",
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "post_run_diagnostics"
       },

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1,17 +1,39 @@
 name: remediation
 description: Investigate a bug, plan a fix, open a PR
-summary: "bootstrap_clone > (claim_and_resolve?) > (create_and_publish?) > investigate > rectify > dry-walkthrough > implement > test > merge (per plan part) > (audit-impl?) > (open_pr?) > push > cleanup"
-recipe_version: "1.0.0"
-requires_packs: [github, ci, clone, telemetry]
-
+summary: bootstrap_clone > (claim_and_resolve?) > (create_and_publish?) > investigate
+  > rectify > dry-walkthrough > implement > test > merge (per plan part) > (audit-impl?)
+  > (open_pr?) > push > cleanup
+recipe_version: 1.0.0
+requires_packs:
+- github
+- ci
+- clone
+- telemetry
 kitchen_rules:
-- "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent, WebFetch, WebSearch, NotebookEdit) from the orchestrator. All code changes and investigation happen through headless sessions via run_skill."
-- "Route to on_failure when a step fails — the downstream skill (e.g., resolve-failures) has diagnostic access that the orchestrator does not. Do not investigate or attempt to fix failures directly."
-- "SEQUENTIAL EXECUTION: complete full cycle per part before advancing. For each plan_part, run the full cycle (dry_walkthrough → implement → test → merge) before starting the next part."
-- "By default (open_pr=true), a feature branch is created with a unique name derived from inputs.run_name and context.issue_number (e.g. investigate/42) or a date suffix (e.g. investigate/20260304) when no issue is available. All worktree merges target the feature branch (context.merge_target), not base_branch directly. The push step publishes the feature branch, then prepare_pr → run_arch_lenses → compose_pr opens a PR to base_branch. When open_pr=false, merges target base_branch directly and prepare_pr is skipped."
-- "When arch_lenses=true (and open_pr=true), prepare_pr routes through run_arch_lenses before compose_pr, adding architecture lens diagrams to the PR. By default arch_lenses is off and prepare_pr routes directly to compose_pr."
-- "SOURCE ISOLATION: After bootstrap_clone returns, the source_dir is strictly off-limits. Never run any command in source_dir — no git checkout, git fetch, git reset, git pull, run_cmd, run_skill, or any other operation. All work — skill invocations, git operations, file reads — happens exclusively in the clone (work_dir). source_dir is used ONLY to read the remote URL inside push_to_remote."
-
+- NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent,
+  WebFetch, WebSearch, NotebookEdit) from the orchestrator. All code changes and investigation
+  happen through headless sessions via run_skill.
+- Route to on_failure when a step fails — the downstream skill (e.g., resolve-failures)
+  has diagnostic access that the orchestrator does not. Do not investigate or attempt
+  to fix failures directly.
+- 'SEQUENTIAL EXECUTION: complete full cycle per part before advancing. For each plan_part,
+  run the full cycle (dry_walkthrough → implement → test → merge) before starting
+  the next part.'
+- By default (open_pr=true), a feature branch is created with a unique name derived
+  from inputs.run_name and context.issue_number (e.g. investigate/42) or a date suffix
+  (e.g. investigate/20260304) when no issue is available. All worktree merges target
+  the feature branch (context.merge_target), not base_branch directly. The push step
+  publishes the feature branch, then prepare_pr → run_arch_lenses → compose_pr opens
+  a PR to base_branch. When open_pr=false, merges target base_branch directly and
+  prepare_pr is skipped.
+- When arch_lenses=true (and open_pr=true), prepare_pr routes through run_arch_lenses
+  before compose_pr, adding architecture lens diagrams to the PR. By default arch_lenses
+  is off and prepare_pr routes directly to compose_pr.
+- 'SOURCE ISOLATION: After bootstrap_clone returns, the source_dir is strictly off-limits.
+  Never run any command in source_dir — no git checkout, git fetch, git reset, git
+  pull, run_cmd, run_skill, or any other operation. All work — skill invocations,
+  git operations, file reads — happens exclusively in the clone (work_dir). source_dir
+  is used ONLY to read the remote URL inside push_to_remote.'
 ingredients:
   task:
     description: Bug, error, or question to investigate
@@ -19,1774 +41,1785 @@ ingredients:
   source_dir:
     description: Source repository
     required: false
-    default: ""
+    default: ''
   run_name:
     description: Run name prefix
-    default: "remediation"
+    default: remediation
   base_branch:
     description: Merge target
-    default: ""
+    default: ''
   audit:
     description: Post-merge quality gate
-    default: "false"
+    default: 'false'
   review_approach:
     description: Research approaches first
-    default: "false"
+    default: 'false'
   open_pr:
     description: PR instead of direct merge
-    default: "true"
+    default: 'true'
   arch_lenses:
     description: Generate architecture lens diagrams for the PR
-    default: "false"
+    default: 'false'
   auto_merge:
-    description: >-
-      Automatically merge the PR after required checks pass —
-      via merge queue when available, direct merge otherwise
-    default: "true"
+    description: Automatically merge the PR after required checks pass — via merge
+      queue when available, direct merge otherwise
+    default: 'true'
   review_max_retries:
-    description: Maximum number of review-resolve retry cycles before proceeding to CI
-    default: "3"
+    description: Maximum number of review-resolve retry cycles before proceeding to
+      CI
+    default: '3'
   local_review_rounds:
-    description: >-
-      Number of review-resolve cycles to run locally before switching to
+    description: Number of review-resolve cycles to run locally before switching to
       GitHub-backed review. 0 disables local mode entirely.
     type: integer
-    default: "2"
+    default: '2'
   adversarial_review_level:
-    description: >-
-      Controls adversarial review depth in make-plan. "auto" estimates complexity
-      and gates agents accordingly. "full" always runs all 3 agents. "none" skips
-      adversarial review entirely.
-    default: "auto"
+    description: Controls adversarial review depth in make-plan. "auto" estimates
+      complexity and gates agents accordingly. "full" always runs all 3 agents. "none"
+      skips adversarial review entirely.
+    default: auto
     hidden: true
   issue_url:
     description: GitHub issue to close on merge
     required: false
   upfront_claimed:
-    description: "Set to 'true' when process-issues has already claimed this issue upfront. Allows claim_issue defense step to pass through without aborting."
-    default: "false"
+    description: Set to 'true' when process-issues has already claimed this issue
+      upfront. Allows claim_issue defense step to pass through without aborting.
+    default: 'false'
     hidden: true
   run_mode:
-    description: >-
-      Execution mode when processing multiple issues. Options: sequential (default,
-      one issue at a time) or parallel (all issues simultaneously with wavefront
-      step scheduling — fast steps for all pipelines before any slow step).
-    default: "sequential"
+    description: 'Execution mode when processing multiple issues. Options: sequential
+      (default, one issue at a time) or parallel (all issues simultaneously with wavefront
+      step scheduling — fast steps for all pipelines before any slow step).'
+    default: sequential
     hidden: true
   max_parallel:
-    description: >-
-      Maximum number of issues to run in parallel within a single execution-map
-      group. Groups exceeding this cap are split into sequential sub-groups.
-      Passed to build-execution-map. Must be a positive integer (expressed as a
-      string).
-    default: "6"
+    description: Maximum number of issues to run in parallel within a single execution-map
+      group. Groups exceeding this cap are split into sequential sub-groups. Passed
+      to build-execution-map. Must be a positive integer (expressed as a string).
+    default: '6'
     hidden: true
   post_run_diagnostics:
     description: Run diagnostic analysis after pipeline completion
-    default: "false"
+    default: 'false'
     hidden: true
   kitchen_id:
     description: Kitchen session identifier (auto-injected)
-    default: ""
+    default: ''
     hidden: true
   depth:
-    description: "Investigation depth mode"
-    default: "standard"
+    description: Investigation depth mode
+    default: standard
     hidden: true
-
+  is_fleet_dispatch:
+    description: Whether running as an L2 food truck dispatch (auto-injected)
+    default: 'false'
+    hidden: true
+  dispatch_id:
+    description: Fleet dispatch identifier (auto-injected, empty in non-fleet sessions)
+    default: ''
+    hidden: true
+  diagnostics_log_dir:
+    description: Resolved diagnostics log directory path (auto-injected)
+    default: ''
+    hidden: true
 steps:
   clone:
     tool: bootstrap_clone
     with:
-      source_dir: "${{ inputs.source_dir }}"
-      run_name: "${{ inputs.run_name }}"
-      base_branch: "${{ inputs.base_branch }}"
-      step_name: "bootstrap_clone"
+      source_dir: ${{ inputs.source_dir }}
+      run_name: ${{ inputs.run_name }}
+      base_branch: ${{ inputs.base_branch }}
+      step_name: bootstrap_clone
     capture:
-      work_dir: "${{ result.work_dir }}"
-      remote_url: "${{ result.remote_url }}"
-      merge_target: "${{ result.merge_target }}"
+      work_dir: ${{ result.work_dir }}
+      remote_url: ${{ result.remote_url }}
+      merge_target: ${{ result.merge_target }}
     on_success: claim_and_resolve
     on_failure: escalate_stop
-    note: >
-      Clones source_dir and captures merge_target in one turn.
-      Returns work_dir, remote_url, and merge_target (set to base_branch as fallback;
-      overridden by create_and_publish when open_pr=true). On failure, escalate_stop
-      immediately (no clone to remove).
+    note: 'Clones source_dir and captures merge_target in one turn. Returns work_dir,
+      remote_url, and merge_target (set to base_branch as fallback; overridden by
+      create_and_publish when open_pr=true). On failure, escalate_stop immediately
+      (no clone to remove).
 
+      '
   claim_and_resolve:
     tool: claim_and_resolve_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
-      issue_url: "${{ inputs.issue_url }}"
-      allow_reentry: "${{ inputs.upfront_claimed }}"
+      issue_url: ${{ inputs.issue_url }}
+      allow_reentry: ${{ inputs.upfront_claimed }}
     capture:
-      issue_number: "${{ result.issue_number }}"
-      issue_title: "${{ result.issue_title }}"
-      issue_slug: "${{ result.issue_slug }}"
-      claimed: "${{ result.claimed }}"
+      issue_number: ${{ result.issue_number }}
+      issue_title: ${{ result.issue_title }}
+      issue_slug: ${{ result.issue_slug }}
+      claimed: ${{ result.claimed }}
     on_result:
-    - when: "${{ result.claimed }} == true"
+    - when: ${{ result.claimed }} == true
       route: create_and_publish
     - route: escalate_stop
     on_failure: escalate_stop
-    note: >
-      Fetches issue title/slug and claims the issue in one turn.
-      Returns issue_number, issue_title, issue_slug, and claimed boolean.
-      When claimed=false (another session owns it), routes to escalate_stop.
-      issue_slug and issue_number are passed to create_and_publish for branch naming.
+    note: 'Fetches issue title/slug and claims the issue in one turn. Returns issue_number,
+      issue_title, issue_slug, and claimed boolean. When claimed=false (another session
+      owns it), routes to escalate_stop. issue_slug and issue_number are passed to
+      create_and_publish for branch naming.
 
+      '
   create_and_publish:
     tool: create_and_publish_branch
     optional: true
     skip_when_false: inputs.open_pr
     with:
-      issue_slug: "${{ context.issue_slug }}"
-      run_name: "${{ inputs.run_name }}"
-      issue_number: "${{ context.issue_number }}"
-      work_dir: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "create_and_publish_branch"
+      issue_slug: ${{ context.issue_slug }}
+      run_name: ${{ inputs.run_name }}
+      issue_number: ${{ context.issue_number }}
+      work_dir: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: create_and_publish_branch
     capture:
-      merge_target: "${{ result.merge_target }}"
+      merge_target: ${{ result.merge_target }}
     on_success: investigate
     on_failure: release_issue_failure
-    note: >
-      Computes branch name, creates it (with collision suffix if needed), and pushes
-      to origin in one turn. Overrides merge_target with the feature branch name.
-      merge_worktree requires refs/remotes/origin/{branch} to exist after fetch.
+    note: 'Computes branch name, creates it (with collision suffix if needed), and
+      pushes to origin in one turn. Overrides merge_target with the feature branch
+      name. merge_worktree requires refs/remotes/origin/{branch} to exist after fetch.
       When open_pr=false, this step is skipped and merge_target remains as base_branch.
 
+      '
   investigate:
     tool: run_skill
-    model: "${{ 'opus[1m]' if inputs.depth == 'deep' else 'sonnet' }}"
+    model: ${{ 'opus[1m]' if inputs.depth == 'deep' else 'sonnet' }}
     with:
-      skill_command: "/autoskillit:investigate ${{ '--depth deep ' if inputs.depth == 'deep' else '' }}${{ inputs.task }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "investigate"
-      issue_url: "${{ inputs.issue_url }}"
-      issue_title: "${{ context.issue_title }}"
+      skill_command: /autoskillit:investigate ${{ '--depth deep ' if inputs.depth
+        == 'deep' else '' }}${{ inputs.task }}
+      cwd: ${{ context.work_dir }}
+      step_name: investigate
+      issue_url: ${{ inputs.issue_url }}
+      issue_title: ${{ context.issue_title }}
     capture:
-      investigation_path: "${{ result.investigation_path }}"
+      investigation_path: ${{ result.investigation_path }}
     on_success: rectify
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
-    note: >
-      ISSUE CONTEXT: If inputs.issue_url is a non-empty string, append it to the
-      skill_command so the investigate skill can detect and fetch the issue itself:
-      "/autoskillit:investigate {task}\n\nGitHub Issue: {inputs.issue_url}"
-      The skill detects the URL pattern and calls fetch_github_issue internally.
-      DEPTH: When inputs.depth == 'deep', passes --depth deep flag and sets model
-      to opus[1m] for the main skill session. Subagents within the skill always
-      use model: sonnet regardless of depth setting.
+    note: 'ISSUE CONTEXT: If inputs.issue_url is a non-empty string, append it to
+      the skill_command so the investigate skill can detect and fetch the issue itself:
+      "/autoskillit:investigate {task}\n\nGitHub Issue: {inputs.issue_url}" The skill
+      detects the URL pattern and calls fetch_github_issue internally. DEPTH: When
+      inputs.depth == ''deep'', passes --depth deep flag and sets model to opus[1m]
+      for the main skill session. Subagents within the skill always use model: sonnet
+      regardless of depth setting.
 
+      '
   rectify:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:rectify ${{ context.investigation_path }}"
-      cwd: "${{ context.work_dir }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/rectify"
-      step_name: "rectify"
+      skill_command: /autoskillit:rectify ${{ context.investigation_path }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/rectify'
+      step_name: rectify
     capture:
-      plan_path: "${{ result.plan_path }}"
+      plan_path: ${{ result.plan_path }}
     capture_list:
-      plan_parts: "${{ result.plan_parts }}"
+      plan_parts: ${{ result.plan_parts }}
     retries: 0
     on_success: review
     on_failure: release_issue_failure
-    note: >
-      Glob plan_dir for *_part_*.md or single plan file. Sort alphabetically into plan_parts[].
+    note: 'Glob plan_dir for *_part_*.md or single plan file. Sort alphabetically
+      into plan_parts[].
 
+      '
   review:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:review-approach ${{ context.plan_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "review"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-approach"
+      skill_command: /autoskillit:review-approach ${{ context.plan_path }}
+      cwd: ${{ context.work_dir }}
+      step_name: review
+      output_dir: '{{AUTOSKILLIT_TEMP}}/review-approach'
     capture:
-      review_path: "${{ result.review_path }}"
+      review_path: ${{ result.review_path }}
     retries: 1
     on_success: dry_walkthrough
     on_failure: release_issue_failure
     on_context_limit: dry_walkthrough
-    skip_when_false: "inputs.review_approach"
-    note: "Only execute this step if review_approach input is 'true'. Otherwise skip directly to dry_walkthrough."
-
+    skip_when_false: inputs.review_approach
+    note: Only execute this step if review_approach input is 'true'. Otherwise skip
+      directly to dry_walkthrough.
   dry_walkthrough:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:dry-walkthrough ${{ context.plan_path }}"
-      cwd: "${{ context.work_dir }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}"
-      review_path: "${{ context.review_path }}"
-      step_name: "dry_walkthrough"
+      skill_command: /autoskillit:dry-walkthrough ${{ context.plan_path }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}'
+      review_path: ${{ context.review_path }}
+      step_name: dry_walkthrough
     on_success: implement
     on_failure: release_issue_failure
     retries: 3
     on_exhausted: release_issue_failure
     note: Dry walkthrough retries on failure. It never routes back to a previous step.
-
   implement:
     tool: run_skill
-    model: ""
+    model: ''
     stale_threshold: 2400
     with:
-      skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "implement"
+      skill_command: /autoskillit:implement-worktree-no-merge ${{ context.plan_path
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: implement
     capture:
-      implementation_ref: "${{ result.worktree_path }}"
-      worktree_path: "${{ result.worktree_path }}"
-      branch_name: "${{ result.branch_name }}"
+      implementation_ref: ${{ result.worktree_path }}
+      worktree_path: ${{ result.worktree_path }}
+      branch_name: ${{ result.branch_name }}
     retries: 0
     on_context_limit: retry_worktree
     on_success: check_changes
     on_failure: release_issue_failure
-
   retry_worktree:
     tool: run_skill
-    model: ""
+    model: ''
     stale_threshold: 2400
     with:
-      skill_command: "/autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path }}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: "retry_worktree"
+      skill_command: /autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path
+        }}
+      cwd: ${{ context.worktree_path }}
+      step_name: retry_worktree
     capture:
-      implementation_ref: "${{ result.worktree_path }}"
-      worktree_path: "${{ result.worktree_path }}"
-      branch_name: "${{ result.branch_name }}"
-      phases_implemented: "${{ result.phases_implemented }}"
+      implementation_ref: ${{ result.worktree_path }}
+      worktree_path: ${{ result.worktree_path }}
+      branch_name: ${{ result.branch_name }}
+      phases_implemented: ${{ result.phases_implemented }}
     on_result:
-    - when: "${{ result.phases_implemented }} > 0"
+    - when: ${{ result.phases_implemented }} > 0
       route: check_changes
     - route: check_changes
     on_context_limit: check_changes
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
-
   check_changes:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.detect_zero_changes"
-      worktree_path: "${{ context.implementation_ref }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.smoke_utils.detect_zero_changes
+      worktree_path: ${{ context.implementation_ref }}
+      base_branch: ${{ inputs.base_branch }}
     capture:
-      has_changes: "${{ result.has_changes }}"
-      commit_count: "${{ result.commit_count }}"
+      has_changes: ${{ result.has_changes }}
+      commit_count: ${{ result.commit_count }}
     on_result:
-    - when: "${{ result.has_changes }} == false"
+    - when: ${{ result.has_changes }} == false
       route: close_issue_no_changes
     - route: test
     on_failure: release_issue_failure
-
   close_issue_no_changes:
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
-      issue_url: "${{ inputs.issue_url }}"
-      close_issue: "true"
+      issue_url: ${{ inputs.issue_url }}
+      close_issue: 'true'
     on_success: done
     on_failure: done
-
   test:
     tool: test_check
     with:
-      worktree_path: "${{ context.implementation_ref }}"
+      worktree_path: ${{ context.implementation_ref }}
     on_success: check_merge_fix_loop
     on_failure: assess
-
   check_merge_fix_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.merge_fix_count }}"
-      max_iterations: "3"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.merge_fix_count }}
+      max_iterations: '3'
     capture:
-      merge_fix_count: "${{ result.next_iteration }}"
+      merge_fix_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
     - route: audit_impl
     on_failure: release_issue_failure
     optional_context_refs:
     - merge_fix_count
-    note: >
-      Iteration guard for the merge→assess→test cycle. Caps the loop at 3
-      iterations (enough for legitimate flake recovery but not enough to
-      burn 30+ minutes on structurally unresolvable conflicts).
+    note: 'Iteration guard for the merge→assess→test cycle. Caps the loop at 3 iterations
+      (enough for legitimate flake recovery but not enough to burn 30+ minutes on
+      structurally unresolvable conflicts).
 
+      '
   assess:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: "assess"
+      skill_command: /autoskillit:resolve-failures ${{ context.worktree_path }} ${{
+        context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.worktree_path }}
+      step_name: assess
     capture:
-      verdict: "${{ result.verdict }}"
-      fixes_applied: "${{ result.fixes_applied }}"
+      verdict: ${{ result.verdict }}
+      fixes_applied: ${{ result.fixes_applied }}
     on_result:
-    - when: "${{ result.verdict }} == 'real_fix'"
+    - when: ${{ result.verdict }} == 'real_fix'
       route: test
-    - when: "${{ result.verdict }} == 'already_green'"
+    - when: ${{ result.verdict }} == 'already_green'
       route: test
-    - when: "${{ result.verdict }} == 'flake_suspected'"
+    - when: ${{ result.verdict }} == 'flake_suspected'
       route: test
-    - when: "${{ result.verdict }} == 'ci_only_failure'"
+    - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
-    - when: "${{ result.verdict }} == 'no_test_infrastructure'"
+    - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     on_context_limit: test
     on_failure: release_issue_failure
     on_exhausted: release_issue_failure
-
   rebase_conflict_fix:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: "rebase_conflict_fix"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.worktree_path
+        }} ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.worktree_path }}
+      step_name: rebase_conflict_fix
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: test
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-
   audit_impl:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.branch_name }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "audit_impl"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"
+      skill_command: /autoskillit:audit-impl ${{ context.plan_path }} ${{ context.branch_name
+        }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: audit_impl
+      output_dir: '{{AUTOSKILLIT_TEMP}}/audit-impl'
     capture:
-      remediation_path: "${{ result.remediation_path }}"
+      remediation_path: ${{ result.remediation_path }}
     on_result:
-    - when: "${{ result.verdict }} == GO"
+    - when: ${{ result.verdict }} == GO
       route: commit_guard
-    - when: "result.error"
+    - when: result.error
       route: escalate_stop
     - route: remediate
     on_failure: escalate_stop
     on_context_limit: escalate_stop
     optional: true
-    skip_when_false: "inputs.audit"
-    note: Only run if inputs.audit = true. If inputs.audit = false, skip directly to commit_guard.
-
+    skip_when_false: inputs.audit
+    note: Only run if inputs.audit = true. If inputs.audit = false, skip directly
+      to commit_guard.
   remediate:
     action: route
     with:
-      remediation_path: "${{ context.remediation_path }}"
+      remediation_path: ${{ context.remediation_path }}
     on_success: make_plan
-
   make_plan:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:make-plan ${{ context.remediation_path }}"
-      task: "${{ inputs.task }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "make_plan"
-      adversarial_review_level: "${{ inputs.adversarial_review_level }}"
+      skill_command: /autoskillit:make-plan ${{ context.remediation_path }}
+      task: ${{ inputs.task }}
+      cwd: ${{ context.work_dir }}
+      step_name: make_plan
+      adversarial_review_level: ${{ inputs.adversarial_review_level }}
     capture:
-      plan_path: "${{ result.plan_path }}"
+      plan_path: ${{ result.plan_path }}
     capture_list:
-      plan_parts: "${{ result.plan_parts }}"
+      plan_parts: ${{ result.plan_parts }}
     retries: 0
     on_success: dry_walkthrough
     on_failure: release_issue_failure
-    note: >
-      ADVERSARIAL REVIEW LEVEL: If inputs.adversarial_review_level is a non-empty
-      string, append it to the skill_command:
-      "/autoskillit:make-plan {task}\n\nadversarial_review_level={inputs.adversarial_review_level}"
+    note: 'ADVERSARIAL REVIEW LEVEL: If inputs.adversarial_review_level is a non-empty
+      string, append it to the skill_command: "/autoskillit:make-plan {task}\n\nadversarial_review_level={inputs.adversarial_review_level}"
 
+      '
   commit_guard:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.commit_guard"
-      worktree_path: "${{ context.implementation_ref }}"
+      callable: autoskillit.recipe._cmd_rpc.commit_guard
+      worktree_path: ${{ context.implementation_ref }}
     on_success: main_repo_guard
     on_failure: main_repo_guard
-    note: >
-      Belt-and-suspenders guard: auto-commits any uncommitted changes before merge.
-      Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes,
-      or any other source. Routes to main_repo_guard to handle dirty main repo state.
+    note: 'Belt-and-suspenders guard: auto-commits any uncommitted changes before
+      merge. Catches dirty state from context-exhausted skills, cascading pre-commit
+      auto-fixes, or any other source. Routes to main_repo_guard to handle dirty main
+      repo state.
 
+      '
   main_repo_guard:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.main_repo_guard"
-      clone_path: "${{ context.work_dir }}"
+      callable: autoskillit.recipe._cmd_rpc.main_repo_guard
+      clone_path: ${{ context.work_dir }}
     on_success: merge
     on_failure: merge
-    note: >
-      Stashes uncommitted changes in the main repo before merge. Catches dirty state
-      from infrastructure-terminated sessions that left artifacts in the clone.
-      Routes to merge on both success and failure (merge's dirty_main_repo gate
-      handles persistent issues).
+    note: 'Stashes uncommitted changes in the main repo before merge. Catches dirty
+      state from infrastructure-terminated sessions that left artifacts in the clone.
+      Routes to merge on both success and failure (merge''s dirty_main_repo gate handles
+      persistent issues).
 
+      '
   merge:
     tool: merge_worktree
     with:
-      worktree_path: "${{ context.implementation_ref }}"
-      base_branch: "${{ context.merge_target }}"
+      worktree_path: ${{ context.implementation_ref }}
+      base_branch: ${{ context.merge_target }}
     capture:
-      cleanup_succeeded: "${{ result.cleanup_succeeded }}"
-      worktree_path: "${{ result.worktree_path }}"
+      cleanup_succeeded: ${{ result.cleanup_succeeded }}
+      worktree_path: ${{ result.worktree_path }}
     on_result:
-    - when: "result.failed_step == 'dirty_tree'"
+    - when: result.failed_step == 'dirty_tree'
       route: assess
-    - when: "result.failed_step == 'test_gate'"
+    - when: result.failed_step == 'test_gate'
       route: assess
-    - when: "result.failed_step == 'post_rebase_test_gate'"
+    - when: result.failed_step == 'post_rebase_test_gate'
       route: assess
-    - when: "result.failed_step == 'rebase'"
+    - when: result.failed_step == 'rebase'
       route: rebase_conflict_fix
-    - when: "result.failed_step == 'dirty_main_repo'"
+    - when: result.failed_step == 'dirty_main_repo'
       route: check_merge_fix_loop
-    - when: "result.error"
+    - when: result.error
       route: release_issue_failure
     - route: next_or_done
     on_failure: release_issue_failure
-    note: >
-      After merge, route to next_or_done to process remaining parts before pushing.
+    note: 'After merge, route to next_or_done to process remaining parts before pushing.
 
+      '
   next_or_done:
     action: route
     on_result:
-    - when: "${{ result.next }} == more_parts"
+    - when: ${{ result.next }} == more_parts
       route: dry_walkthrough
     - route: check_has_commits
-    note: >
-      Routing step — no tool call. The agent evaluates what comes next:
-      1. If more plan_parts remain for the current plan → go to dry_walkthrough with next part.
-      2. If all plan_parts are complete → go to check_has_commits.
-      Unlike implementation.yaml (which routes done → audit_impl → push), remediation runs
-      audit_impl pre-merge (GO → commit_guard), so the fallthrough here goes directly to
-      check_has_commits → push (or close_issue_already_done if zero commits ahead of base).
+    note: 'Routing step — no tool call. The agent evaluates what comes next: 1. If
+      more plan_parts remain for the current plan → go to dry_walkthrough with next
+      part. 2. If all plan_parts are complete → go to check_has_commits. Unlike implementation.yaml
+      (which routes done → audit_impl → push), remediation runs audit_impl pre-merge
+      (GO → commit_guard), so the fallthrough here goes directly to check_has_commits
+      → push (or close_issue_already_done if zero commits ahead of base).
 
-
+      '
   check_has_commits:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_commits_ahead"
-      cwd: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.smoke_utils.check_commits_ahead
+      cwd: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.has_commits }}"
+    - when: ${{ result.has_commits }}
       route: push
     - route: close_issue_already_done
     on_failure: release_issue_failure
-
   close_issue_already_done:
-    description: "Close issue as already-implemented when branch has zero commits ahead of base"
+    description: Close issue as already-implemented when branch has zero commits ahead
+      of base
     tool: run_python
     optional: true
-    skip_when_false: "inputs.issue_url"
+    skip_when_false: inputs.issue_url
     with:
-      callable: "autoskillit.smoke_utils.close_issue_already_done"
-      issue_url: "${{ inputs.issue_url }}"
+      callable: autoskillit.smoke_utils.close_issue_already_done
+      issue_url: ${{ inputs.issue_url }}
     on_success: register_clone_success
     on_failure: register_clone_success
-    note: >
-      Zero commits ahead of base means the feature is already merged.
-      Remove in-progress label, close issue with "already implemented" comment,
-      and route to clone cleanup.
+    note: 'Zero commits ahead of base means the feature is already merged. Remove
+      in-progress label, close issue with "already implemented" comment, and route
+      to clone cleanup.
 
+      '
   push:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
     on_success: prepare_pr
     on_failure: release_issue_failure
-    note: >
-      Runs once at the end.
-      Pushes merge_target branch from the clone to the upstream remote.
-      By default (open_pr=true), this pushes the feature branch; when open_pr=false, pushes base_branch.
-      Uses the pre-resolved remote_url captured at clone time, preserving clone isolation.
-      On success, routes to prepare_pr (which opens the PR by default; skipped when open_pr=false).
-      On failure, release_issue_failure registers the clone and escalates.
+    note: 'Runs once at the end. Pushes merge_target branch from the clone to the
+      upstream remote. By default (open_pr=true), this pushes the feature branch;
+      when open_pr=false, pushes base_branch. Uses the pre-resolved remote_url captured
+      at clone time, preserving clone isolation. On success, routes to prepare_pr
+      (which opens the PR by default; skipped when open_pr=false). On failure, release_issue_failure
+      registers the clone and escalates.
 
+      '
   prepare_pr:
     tool: run_skill
-    model: ""
+    model: ''
     retries: 1
     with:
-      skill_command: "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "prepare_pr"
+      skill_command: /autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name
+        }} ${{ inputs.base_branch }} ${{ context.issue_number }}
+      cwd: ${{ context.work_dir }}
+      step_name: prepare_pr
     capture:
-      prep_path: "${{ result.prep_path }}"
-      selected_lenses: "${{ result.selected_lenses }}"
-      lens_context_paths: "${{ result.lens_context_paths }}"
+      prep_path: ${{ result.prep_path }}
+      selected_lenses: ${{ result.selected_lenses }}
+      lens_context_paths: ${{ result.lens_context_paths }}
     on_result:
-    - when: "${{ result.prep_path }} and ${{ inputs.arch_lenses }} == 'true'"
+    - when: ${{ result.prep_path }} and ${{ inputs.arch_lenses }} == 'true'
       route: run_arch_lenses
-    - when: "${{ result.prep_path }}"
+    - when: ${{ result.prep_path }}
       route: compose_pr
     - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: prepare_pr
     on_exhausted: release_issue_failure
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Reads plan, runs git diff, classifies changed files, selects 1–3 arch-lens slugs,
-      writes one PR context file per lens, and writes a PR prep file. Does NOT invoke
-      arch-lens skills.
+    skip_when_false: inputs.open_pr
+    note: 'Reads plan, runs git diff, classifies changed files, selects 1–3 arch-lens
+      slugs, writes one PR context file per lens, and writes a PR prep file. Does
+      NOT invoke arch-lens skills.
 
+      '
   run_arch_lenses:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:arch-lens-{slug} {context_path}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "run_arch_lenses"
+      skill_command: /autoskillit:arch-lens-{slug} {context_path}
+      cwd: ${{ context.work_dir }}
+      step_name: run_arch_lenses
     capture_list:
-      all_diagram_paths: "${{ result.diagram_path }}"
+      all_diagram_paths: ${{ result.diagram_path }}
     retries: 0
     on_success: compose_pr
     on_failure: compose_pr
     on_context_limit: compose_pr
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      LENS ITERATION: context.selected_lenses contains comma-separated arch-lens slugs
-      (e.g. "module-dependency,process-flow"). context.lens_context_paths contains the
-      corresponding comma-separated context file paths (same order as slugs). For each
-      lens slug, run:
-        /autoskillit:arch-lens-{slug} {matching_context_path}
-      Run all selected lenses in parallel (all run_skill calls in a single message).
-      Accumulate each diagram_path value into context.all_diagram_paths via capture_list.
-      If a lens fails, continue with remaining lenses — compose_pr handles empty lists
-      gracefully by omitting the Architecture Impact section.
-
+    skip_when_false: inputs.open_pr
+    note: "LENS ITERATION: context.selected_lenses contains comma-separated arch-lens\
+      \ slugs (e.g. \"module-dependency,process-flow\"). context.lens_context_paths\
+      \ contains the corresponding comma-separated context file paths (same order\
+      \ as slugs). For each lens slug, run:\n  /autoskillit:arch-lens-{slug} {matching_context_path}\n\
+      Run all selected lenses in parallel (all run_skill calls in a single message).\
+      \ Accumulate each diagram_path value into context.all_diagram_paths via capture_list.\
+      \ If a lens fails, continue with remaining lenses — compose_pr handles empty\
+      \ lists gracefully by omitting the Architecture Impact section.\n"
   compose_pr:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "compose_pr"
+      skill_command: /autoskillit:compose-pr ${{ context.prep_path }} "${{ context.all_diagram_paths
+        }}" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: compose_pr
     capture:
-      pr_url: "${{ result.pr_url }}"
+      pr_url: ${{ result.pr_url }}
     on_result:
-    - when: "${{ result.pr_url }}"
+    - when: ${{ result.pr_url }}
       route: guard_pr_url
     - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●),
-      composes the PR body, and runs gh pr create. Degrades gracefully if gh is
+    skip_when_false: inputs.open_pr
+    note: 'Reads the PR prep file, validates arch-lens diagrams (must contain ★ or
+      ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is
       unavailable (emits pr_url=).
 
+      '
   guard_pr_url:
     action: route
     on_result:
-    - when: "${{ context.pr_url }}"
+    - when: ${{ context.pr_url }}
       route: extract_pr_number
     - route: release_issue_failure
-    note: Guard — skip PR extraction if pr_url is empty (graceful degradation from compose_pr).
-
+    note: Guard — skip PR extraction if pr_url is empty (graceful degradation from
+      compose_pr).
   extract_pr_number:
     tool: run_cmd
     with:
-      cmd: "gh pr view '${{ context.merge_target }}' --json number -q .number"
-      cwd: "${{ context.work_dir }}"
-      step_name: "extract_pr_number"
+      cmd: gh pr view '${{ context.merge_target }}' --json number -q .number
+      cwd: ${{ context.work_dir }}
+      step_name: extract_pr_number
     capture:
-      pr_number: "${{ result.stdout | trim }}"
+      pr_number: ${{ result.stdout | trim }}
     on_success: annotate_pr_diff
     on_failure: release_issue_failure
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Extracts the integer PR number from the feature branch opened by compose_pr.
+    skip_when_false: inputs.open_pr
+    note: 'Extracts the integer PR number from the feature branch opened by compose_pr.
       pr_number is required by the queue finale steps (enable_auto_merge, wait_for_queue).
 
+      '
   annotate_pr_diff:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.annotate_pr_diff"
-      pr_number: "${{ context.pr_number }}"
-      cwd: "${{ context.work_dir }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
-      base_branch: "${{ inputs.base_branch }}"
-      local_review_rounds: "${{ inputs.local_review_rounds }}"
-      current_iteration: "${{ context.review_loop_count }}"
+      callable: autoskillit.smoke_utils.annotate_pr_diff
+      pr_number: ${{ context.pr_number }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'
+      base_branch: ${{ inputs.base_branch }}
+      local_review_rounds: ${{ inputs.local_review_rounds }}
+      current_iteration: ${{ context.review_loop_count }}
     capture:
-      annotated_diff_path: "${{ result.annotated_diff_path }}"
-      hunk_ranges_path: "${{ result.hunk_ranges_path }}"
-      diff_metrics_path: "${{ result.diff_metrics_path }}"
-      review_mode: "${{ result.review_mode }}"
+      annotated_diff_path: ${{ result.annotated_diff_path }}
+      hunk_ranges_path: ${{ result.hunk_ranges_path }}
+      diff_metrics_path: ${{ result.diff_metrics_path }}
+      review_mode: ${{ result.review_mode }}
     on_success: review_pr
     on_failure: review_pr
     optional: true
-    skip_when_false: "inputs.open_pr"
+    skip_when_false: inputs.open_pr
     optional_context_refs:
     - review_loop_count
-    note: >
-      Pre-computes annotated diff with [LNNN] markers and hunk ranges JSON for
+    note: 'Pre-computes annotated diff with [LNNN] markers and hunk ranges JSON for
       review-pr. On failure, falls through to review_pr which uses empty fallback.
 
+      '
   review_pr:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "review_pr"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"
+      skill_command: /autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch
+        }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{
+        context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path
+        }} mode=${{ context.review_mode }}
+      cwd: ${{ context.work_dir }}
+      step_name: review_pr
+      output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'
     capture:
-      review_verdict: "${{ result.verdict }}"
+      review_verdict: ${{ result.verdict }}
     on_result:
-    - when: "${{ result.verdict }} == changes_requested"
+    - when: ${{ result.verdict }} == changes_requested
       route: resolve_review
-    - when: "${{ result.verdict }} == approved_with_comments"
+    - when: ${{ result.verdict }} == approved_with_comments
       route: resolve_review
-    - when: "${{ result.verdict }} == needs_human"
+    - when: ${{ result.verdict }} == needs_human
       route: check_review_loop
-    - when: "${{ result.verdict }} == approved"
+    - when: ${{ result.verdict }} == approved
       route: check_review_loop
-    - when: "true"
+    - when: 'true'
       route: check_review_loop
     on_failure: check_repo_ci_event
     on_context_limit: check_repo_ci_event
     optional: true
-    skip_when_false: "inputs.open_pr"
+    skip_when_false: inputs.open_pr
     optional_context_refs:
     - review_loop_count
     - review_mode
-    note: >
-      Runs after compose_pr creates the PR. Invokes the review-pr skill as a
+    note: 'Runs after compose_pr creates the PR. Invokes the review-pr skill as a
       headless session to leave inline review comments on the PR. The skill finds
       the open PR by feature branch name (context.merge_target). Captures verdict
       as review_verdict and routes via on_result: changes_requested/approved_with_comments
-      → resolve_review; all other verdicts (including approved, needs_human)
-      → check_review_loop (mandatory waypoint to increment review_loop_count).
-      On tool-level failure (MCP error, gh unavailable), routes to check_repo_ci_event
-      (no review to resolve). Skipped when open_pr=false.
+      → resolve_review; all other verdicts (including approved, needs_human) → check_review_loop
+      (mandatory waypoint to increment review_loop_count). On tool-level failure (MCP
+      error, gh unavailable), routes to check_repo_ci_event (no review to resolve).
+      Skipped when open_pr=false.
 
+      '
   resolve_review:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_review"
+      skill_command: /autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch
+        }} mode=${{ context.review_mode }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_review
     capture:
-      verdict: "${{ result.verdict }}"
+      verdict: ${{ result.verdict }}
     retries: 2
     on_exhausted: release_issue_failure
     on_context_limit: re_push_review
     on_result:
-    - when: "${{ result.verdict }} == 'real_fix'"
+    - when: ${{ result.verdict }} == 'real_fix'
       route: re_push_review
-    - when: "${{ result.verdict }} == 'already_green'"
+    - when: ${{ result.verdict }} == 'already_green'
       route: re_push_review
-    - when: "${{ result.verdict }} == 'flake_suspected'"
+    - when: ${{ result.verdict }} == 'flake_suspected'
       route: re_push_review
-    - when: "${{ result.verdict }} == 'ci_only_failure'"
+    - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
     on_failure: release_issue_failure
-    note: >
-      Runs when review_pr reports issues (verdict=changes_requested). The clone
+    note: 'Runs when review_pr reports issues (verdict=changes_requested). The clone
       (context.work_dir) has the feature branch (context.merge_target) checked out.
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
       commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
-      flake_suspected all route to re_push_review (retry bounded by retries: 2);
-      ci_only_failure escalates to release_issue_failure.
+      flake_suspected all route to re_push_review (retry bounded by retries: 2); ci_only_failure
+      escalates to release_issue_failure.
+
+      '
     optional_context_refs:
     - review_mode
-
   re_push_review:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
     on_success: check_review_loop
     on_failure: release_issue_failure
-    note: >
-      Pushes the review-fixed feature branch back to the remote after resolve_review
+    note: 'Pushes the review-fixed feature branch back to the remote after resolve_review
       succeeds. Routes to check_review_loop to determine if another review-resolve
       cycle is needed (bounded by review_max_retries). On push failure, escalates
       via release_issue_failure.
 
+      '
   check_review_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_review_loop"
-      pr_number: "${{ context.pr_number }}"
-      current_iteration: "${{ context.review_loop_count }}"
-      max_iterations: "${{ inputs.review_max_retries }}"
-      previous_verdict: "${{ context.review_verdict }}"
-      local_review_rounds: "${{ inputs.local_review_rounds }}"
+      callable: autoskillit.smoke_utils.check_review_loop
+      pr_number: ${{ context.pr_number }}
+      current_iteration: ${{ context.review_loop_count }}
+      max_iterations: ${{ inputs.review_max_retries }}
+      previous_verdict: ${{ context.review_verdict }}
+      local_review_rounds: ${{ inputs.local_review_rounds }}
     capture:
-      review_loop_count: "${{ result.next_iteration }}"
+      review_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false"
+    - when: ${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false
       route: annotate_pr_diff
     - route: check_repo_ci_event
     on_failure: check_repo_ci_event
     optional_context_refs:
     - review_loop_count
     - review_verdict
-    note: >
-      Compound iteration + blocking guard. Routes back to annotate_pr_diff only when
-      had_blocking=true AND max_exceeded=false. had_blocking is true when
-      previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds),
-      ensuring local review rounds are fully exhausted before exiting to CI.
+    note: 'Compound iteration + blocking guard. Routes back to annotate_pr_diff only
+      when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested
+      OR (local_review_rounds > 0 AND iteration < local_review_rounds), ensuring local
+      review rounds are fully exhausted before exiting to CI.
 
+      '
   check_repo_ci_event:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.merge_target }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "check_repo_ci_event"
+      branch: ${{ context.merge_target }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: check_repo_ci_event
     capture:
-      ci_event: "${{ result.ci_event }}"
-      ci_applicable: "${{ result.ci_applicable }}"
+      ci_event: ${{ result.ci_event }}
+      ci_applicable: ${{ result.ci_applicable }}
     on_success: route_ci_applicable
     on_failure: ci_watch
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Derives ci_event for the feature branch BEFORE ci_watch runs.
-      Uses context.merge_target (feature branch) so push.branches filter
-      is evaluated against the actual branch being pushed, not the base branch.
-      Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).
+    skip_when_false: inputs.open_pr
+    note: 'Derives ci_event for the feature branch BEFORE ci_watch runs. Uses context.merge_target
+      (feature branch) so push.branches filter is evaluated against the actual branch
+      being pushed, not the base branch. Non-blocking: on_failure routes to ci_watch
+      with ci_event=null (match-any).
 
+      '
   route_ci_applicable:
     action: route
     on_result:
-    - when: "${{ context.ci_applicable }} == false"
+    - when: ${{ context.ci_applicable }} == false
       route: check_repo_merge_state
     - route: check_pr_state
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Short-circuits CI wait when no workflow trigger matches the feature branch.
-      ci_applicable=false means neither push nor merge_group triggers apply,
-      so wait_for_ci would exhaust its timeout budget with zero CI runs.
+    skip_when_false: inputs.open_pr
+    note: 'Short-circuits CI wait when no workflow trigger matches the feature branch.
+      ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci
+      would exhaust its timeout budget with zero CI runs.
 
+      '
   check_pr_state:
     tool: check_pr_mergeable
     with:
-      pr_number: "${{ context.pr_number }}"
-      cwd: "${{ context.work_dir }}"
+      pr_number: ${{ context.pr_number }}
+      cwd: ${{ context.work_dir }}
     on_result:
-    - when: "${{ result.mergeable_status }} == 'CONFLICTING'"
+    - when: ${{ result.mergeable_status }} == 'CONFLICTING'
       route: ci_conflict_fix
     - route: ci_watch
     on_failure: ci_watch
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Pre-CI-watch gate: checks PR mergeable state before entering the CI
-      polling loop. CONFLICTING PRs cannot trigger pull_request workflows
-      (GitHub cannot create refs/pull/N/merge), so routing to ci_watch would
-      produce a guaranteed no_runs. Routes CONFLICTING directly to ci_conflict_fix
-      (resolve-merge-conflicts) — GitHub's CONFLICTING status is authoritative,
-      no stale-base exit-code discrimination needed (mirrors merge-prs.yaml
-      check_mergeability pattern). Routes MERGEABLE/UNKNOWN to ci_watch.
+    skip_when_false: inputs.open_pr
+    note: 'Pre-CI-watch gate: checks PR mergeable state before entering the CI polling
+      loop. CONFLICTING PRs cannot trigger pull_request workflows (GitHub cannot create
+      refs/pull/N/merge), so routing to ci_watch would produce a guaranteed no_runs.
+      Routes CONFLICTING directly to ci_conflict_fix (resolve-merge-conflicts) — GitHub''s
+      CONFLICTING status is authoritative, no stale-base exit-code discrimination
+      needed (mirrors merge-prs.yaml check_mergeability pattern). Routes MERGEABLE/UNKNOWN
+      to ci_watch.
 
+      '
   ci_watch:
     tool: wait_for_ci
     with:
-      branch: "${{ context.merge_target }}"
-      event: "${{ context.ci_event }}"
+      branch: ${{ context.merge_target }}
+      event: ${{ context.ci_event }}
       timeout_seconds: 600
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
     capture:
-      ci_conclusion: "${{ result.conclusion }}"
-      ci_failed_jobs: "${{ result.failed_jobs }}"
+      ci_conclusion: ${{ result.conclusion }}
+      ci_failed_jobs: ${{ result.failed_jobs }}
     on_result:
-    - when: "${{ result.conclusion }} == 'success'"
+    - when: ${{ result.conclusion }} == 'success'
       route: check_repo_merge_state
-    - when: "${{ result.conclusion }} == 'no_runs'"
+    - when: ${{ result.conclusion }} == 'no_runs'
       route: handle_no_ci_runs
-    - when: "${{ result.conclusion }} == 'timed_out'"
+    - when: ${{ result.conclusion }} == 'timed_out'
       route: check_ci_timed_out_loop
     - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Waits for the GitHub Actions CI run on context.merge_target to complete
+    skip_when_false: inputs.open_pr
+    note: 'Waits for the GitHub Actions CI run on context.merge_target to complete
       using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output
-      (conclusion + failed job names) for downstream resolve_ci.
-      Skipped when open_pr=false — no remote feature branch is opened in that mode.
-      Routes on result.conclusion: success → check_repo_merge_state,
-      no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push +
-      re-poll; handle_no_ci_runs reached only when push fails),
-      timed_out → check_ci_timed_out_loop (iteration guard), failure → detect_ci_conflict.
+      (conclusion + failed job names) for downstream resolve_ci. Skipped when open_pr=false
+      — no remote feature branch is opened in that mode. Routes on result.conclusion:
+      success → check_repo_merge_state, no_runs → handle_no_ci_runs (auto_trigger
+      fires first: empty commit + force-push + re-poll; handle_no_ci_runs reached
+      only when push fails), timed_out → check_ci_timed_out_loop (iteration guard),
+      failure → detect_ci_conflict.
 
+      '
   check_ci_timed_out_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_timed_out_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_timed_out_loop_count }}
+      max_iterations: '2'
     capture:
-      ci_timed_out_loop_count: "${{ result.next_iteration }}"
+      ci_timed_out_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: detect_ci_conflict
     - route: ci_watch
     on_failure: detect_ci_conflict
     optional_context_refs:
     - ci_timed_out_loop_count
-    note: >
-      Caps the ci_watch re-poll loop at 2 iterations.
-      After 2 timed_out results (1200s total), routes to detect_ci_conflict
-      instead of spinning indefinitely.
+    note: 'Caps the ci_watch re-poll loop at 2 iterations. After 2 timed_out results
+      (1200s total), routes to detect_ci_conflict instead of spinning indefinitely.
 
+      '
   handle_no_ci_runs:
     tool: check_repo_merge_state
     with:
-      branch: "${{ context.merge_target }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "handle_no_ci_runs"
+      branch: ${{ context.merge_target }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: handle_no_ci_runs
     capture:
-      ci_event: "${{ result.ci_event }}"
-      ci_applicable: "${{ result.ci_applicable }}"
+      ci_event: ${{ result.ci_event }}
+      ci_applicable: ${{ result.ci_applicable }}
     on_success: check_ci_loop
     on_failure: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    note: >
-      Intercepts no_runs conclusion from wait_for_ci. Re-derives ci_event using
-      check_repo_merge_state (the original event may have been wrong for this
-      branch's workflow configuration) and routes to check_ci_loop for iteration
-      guard before retrying ci_watch. retries: 1 bounds the tool-call retry;
-      check_ci_loop bounds the outer loop at 2 iterations.
+    note: 'Intercepts no_runs conclusion from wait_for_ci. Re-derives ci_event using
+      check_repo_merge_state (the original event may have been wrong for this branch''s
+      workflow configuration) and routes to check_ci_loop for iteration guard before
+      retrying ci_watch. retries: 1 bounds the tool-call retry; check_ci_loop bounds
+      the outer loop at 2 iterations.
 
+      '
   check_ci_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_loop_count }}
+      max_iterations: '2'
     capture:
-      ci_loop_count: "${{ result.next_iteration }}"
+      ci_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: check_active_trigger_loop
     - route: ci_watch
     on_failure: check_ci_already_passed
     optional_context_refs:
     - ci_loop_count
-    note: >
-      Iteration guard for the ci_watch / handle_no_ci_runs cycle. Caps the
-      loop at 2 iterations (initial + 1 retry after re-deriving ci_event).
-      On budget exhaustion, routes to check_active_trigger_loop which caps
-      the active trigger to a single attempt before escalating.
+    note: 'Iteration guard for the ci_watch / handle_no_ci_runs cycle. Caps the loop
+      at 2 iterations (initial + 1 retry after re-deriving ci_event). On budget exhaustion,
+      routes to check_active_trigger_loop which caps the active trigger to a single
+      attempt before escalating.
 
+      '
   check_active_trigger_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.active_trigger_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.active_trigger_count }}
+      max_iterations: '2'
     capture:
-      active_trigger_count: "${{ result.next_iteration }}"
+      active_trigger_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: check_ci_already_passed
     - route: trigger_ci_actively
     on_failure: check_ci_already_passed
     optional_context_refs:
     - active_trigger_count
-    note: >
-      Bounds the trigger_ci_actively remediation to a single attempt. If
-      ci_watch still returns no_runs after the active trigger, escalates
-      to escalate_stop_no_ci rather than re-triggering indefinitely.
+    note: 'Bounds the trigger_ci_actively remediation to a single attempt. If ci_watch
+      still returns no_runs after the active trigger, escalates to escalate_stop_no_ci
+      rather than re-triggering indefinitely.
 
+      '
   trigger_ci_actively:
     tool: run_cmd
     with:
-      cmd: "gh pr close ${{ context.pr_number }} && sleep 2 && gh pr reopen ${{ context.pr_number }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "trigger_ci_actively"
+      cmd: gh pr close ${{ context.pr_number }} && sleep 2 && gh pr reopen ${{ context.pr_number
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: trigger_ci_actively
     on_success: ci_watch
     on_failure: check_ci_already_passed
     retries: 1
     on_exhausted: check_ci_already_passed
-    note: >
-      Active CI trigger remediation: closes and reopens the PR to force GitHub
-      webhook re-delivery. This re-creates the pull_request event and the
-      refs/pull/N/merge ref (if the PR is mergeable). Routes back to ci_watch
-      for one final attempt. If the close/reopen fails or the subsequent
-      ci_watch still returns no_runs, escalates to escalate_stop_no_ci.
+    note: 'Active CI trigger remediation: closes and reopens the PR to force GitHub
+      webhook re-delivery. This re-creates the pull_request event and the refs/pull/N/merge
+      ref (if the PR is mergeable). Routes back to ci_watch for one final attempt.
+      If the close/reopen fails or the subsequent ci_watch still returns no_runs,
+      escalates to escalate_stop_no_ci.
 
+      '
   check_ci_already_passed:
     tool: wait_for_ci
     with:
-      branch: "${{ context.merge_target }}"
-      event: "${{ context.ci_event }}"
+      branch: ${{ context.merge_target }}
+      event: ${{ context.ci_event }}
       timeout_seconds: 30
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
-    skip_when_false: "inputs.open_pr"
+    skip_when_false: inputs.open_pr
     on_result:
-    - when: "${{ result.conclusion }} == success"
+    - when: ${{ result.conclusion }} == success
       route: check_repo_merge_state
-    - when: "${{ result.conclusion }} == failure"
+    - when: ${{ result.conclusion }} == failure
       route: detect_ci_conflict
-    - when: "${{ result.conclusion }} == timed_out"
+    - when: ${{ result.conclusion }} == timed_out
       route: ci_watch
     - route: mark_issue_failed_no_ci
     on_failure: mark_issue_failed_no_ci
-    note: >
-      Safety net before terminal escalation: re-polls CI with a short timeout
-      to detect if CI has already passed or failed despite the watcher failing
-      to observe it. Uses wait_for_ci as the authoritative signal (30s timeout
-      for immediate state detection). success → merge gate, failure → conflict
-      remediation, timed_out (still pending) → ci_watch for re-poll,
-      no_runs → terminal escalation path.
+    note: 'Safety net before terminal escalation: re-polls CI with a short timeout
+      to detect if CI has already passed or failed despite the watcher failing to
+      observe it. Uses wait_for_ci as the authoritative signal (30s timeout for immediate
+      state detection). success → merge gate, failure → conflict remediation, timed_out
+      (still pending) → ci_watch for re-poll, no_runs → terminal escalation path.
 
+      '
   mark_issue_failed_no_ci:
-    description: "Swap in-progress → fail label before CI failure escalation"
+    description: Swap in-progress → fail label before CI failure escalation
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
-      fail_label: "fail"
+      fail_label: fail
     on_success: register_clone_no_ci
     on_failure: register_clone_no_ci
-
   register_clone_no_ci:
-    description: "Register clone as preserved (no-CI error pipeline)"
+    description: Register clone as preserved (no-CI error pipeline)
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "error"
+      clone_path: ${{ context.work_dir }}
+      status: error
       step_name: register_clone_no_ci
     on_success: run_diagnostic_no_ci
     on_failure: run_diagnostic_no_ci
-
   run_diagnostic_no_ci:
-    description: "Run post-pipeline diagnostic analysis on session logs (no-CI path)"
+    description: Run post-pipeline diagnostic analysis on session logs (no-CI path)
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: escalate_stop_no_ci
     on_failure: escalate_stop_no_ci
     on_context_limit: escalate_stop_no_ci
-    note: >
-      Diagnostic failure never blocks pipeline completion.
+    note: 'Diagnostic failure never blocks pipeline completion.
 
+      '
   escalate_stop_no_ci:
     action: stop
-    message: >-
-      CI safety net: statusCheckRollup returned no checks for PR
-      ${{ context.pr_number }}. This typically means no workflow is
-      configured to trigger on this branch pattern. Check .github/workflows/
-      trigger configuration. This is NOT a test failure — CI never started.
-      Emit the L3 result sentinel JSON block now with success=false.
-      Example sentinel: {"success": false, "reason": "no CI checks configured"}
-
+    message: 'CI safety net: statusCheckRollup returned no checks for PR ${{ context.pr_number
+      }}. This typically means no workflow is configured to trigger on this branch
+      pattern. Check .github/workflows/ trigger configuration. This is NOT a test
+      failure — CI never started. Emit the L3 result sentinel JSON block now with
+      success=false. Example sentinel: {"success": false, "reason": "no CI checks
+      configured"}'
   check_repo_merge_state:
     tool: check_repo_merge_state
     block: pre_queue_gate
     with:
-      branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      step_name: "check_repo_merge_state"
+      branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      step_name: check_repo_merge_state
     capture:
-      queue_available: "${{ result.queue_available }}"
-      merge_group_trigger: "${{ result.merge_group_trigger }}"
-      auto_merge_available: "${{ result.auto_merge_available }}"
-      ci_event: "${{ result.ci_event }}"
-      ci_applicable: "${{ result.ci_applicable }}"
+      queue_available: ${{ result.queue_available }}
+      merge_group_trigger: ${{ result.merge_group_trigger }}
+      auto_merge_available: ${{ result.auto_merge_available }}
+      ci_event: ${{ result.ci_event }}
+      ci_applicable: ${{ result.ci_applicable }}
     on_success: route_queue_mode
     on_failure: immediate_merge
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Single GraphQL round-trip that captures queue_available, merge_group_trigger,
-      auto_merge_available, and ci_event for the target branch. Consolidates the former three
-      sequential run_cmd steps (check_merge_queue, check_merge_group_trigger,
+    skip_when_false: inputs.open_pr
+    note: 'Single GraphQL round-trip that captures queue_available, merge_group_trigger,
+      auto_merge_available, and ci_event for the target branch. Consolidates the former
+      three sequential run_cmd steps (check_merge_queue, check_merge_group_trigger,
       check_auto_merge) into one MCP tool call. On failure (network error, auth failure),
-      falls through to immediate_merge (non-queue direct merge path).
-      Skipped when open_pr=false — no PR was opened.
+      falls through to immediate_merge (non-queue direct merge path). Skipped when
+      open_pr=false — no PR was opened.
 
+      '
   route_queue_mode:
     block: pre_queue_gate
     action: route
     on_result:
-    - when: "${{ inputs.auto_merge }} != 'true'"
+    - when: ${{ inputs.auto_merge }} != 'true'
       route: patch_token_summary
-    - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true"
+    - when: ${{ context.queue_available }} == true and ${{ context.merge_group_trigger
+        }} == true
       route: enqueue_to_queue
-    - when: "${{ context.auto_merge_available }} == true"
+    - when: ${{ context.auto_merge_available }} == true
       route: direct_merge
     - route: immediate_merge
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   enqueue_to_queue:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: wait_for_queue
     on_failure: verify_queue_enrollment
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Submits the PR to the merge queue via the unified enqueue_pr tool.
-      The tool resolves the enrollment strategy internally based on
-      auto_merge_available. On failure, probes the queue via
-      verify_queue_enrollment to distinguish a transient enqueue error from a
-      PR that is already merged or still in queue.
+    skip_when_false: inputs.open_pr
+    note: 'Submits the PR to the merge queue via the unified enqueue_pr tool. The
+      tool resolves the enrollment strategy internally based on auto_merge_available.
+      On failure, probes the queue via verify_queue_enrollment to distinguish a transient
+      enqueue error from a PR that is already merged or still in queue.
 
+      '
   verify_queue_enrollment:
-    description: "Probe merge queue after enqueue command failure to determine actual state"
+    description: Probe merge queue after enqueue command failure to determine actual
+      state
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       timeout_seconds: 60
       poll_interval: 10
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: release_issue_success
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: diagnose_ci
-    - when: "${{ result.pr_state }} == not_enrolled"
+    - when: ${{ result.pr_state }} == not_enrolled
       route: release_issue_failure
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: wait_for_queue
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: diagnose_ci
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: wait_for_queue
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: wait_for_queue
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_unconfirmed
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    note: >
-      Short probe (60s) after enqueue_to_queue failure. If the PR is already
-      merged, route to release_issue_success. If the queue already confirms CI
-      failure (ejected_ci_failure or dropped_merge_group_ci), route directly to
-      diagnose_ci. If enrollment was attempted but the PR never appeared in the
-      queue (not_enrolled), route to release_issue_failure — this is a repo
-      configuration error. For other active queue states (dropped_healthy, ejected,
-      stalled), route to wait_for_queue for full 900s authoritative watch. If the
-      probe timed out or returned an unexpected state, escalate via
-      register_clone_unconfirmed.
+    note: 'Short probe (60s) after enqueue_to_queue failure. If the PR is already
+      merged, route to release_issue_success. If the queue already confirms CI failure
+      (ejected_ci_failure or dropped_merge_group_ci), route directly to diagnose_ci.
+      If enrollment was attempted but the PR never appeared in the queue (not_enrolled),
+      route to release_issue_failure — this is a repo configuration error. For other
+      active queue states (dropped_healthy, ejected, stalled), route to wait_for_queue
+      for full 900s authoritative watch. If the probe timed out or returned an unexpected
+      state, escalate via register_clone_unconfirmed.
 
+      '
   wait_for_queue:
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
       timeout_seconds: 900
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
     capture:
-      queue_pr_state: "${{ result.pr_state }}"
+      queue_pr_state: ${{ result.pr_state }}
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: release_issue_success
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: diagnose_ci
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: diagnose_ci
-    - when: "${{ result.pr_state }} == not_enrolled"
+    - when: ${{ result.pr_state }} == not_enrolled
       route: release_issue_failure
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: check_dropped_healthy_loop
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: check_eject_limit
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: reenroll_stalled_pr
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_unconfirmed
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Waits up to 15 minutes for the PR to merge through the queue.
-      merged → release_issue_success to apply staged label, then register_clone_success.
-      release_issue_success is optional with skip_when_false: inputs.issue_url — when
-      issue_url is absent the step is silently skipped and pipeline continues to register_clone_success.
-      ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
-      not_enrolled → release_issue_failure (enrollment failed; repo configuration error).
-      ejected → conflict fix cycle then re-enter.
-      stalled → lightweight re-enrollment via enqueue_pr.
-      timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).
+    skip_when_false: inputs.open_pr
+    note: 'Waits up to 15 minutes for the PR to merge through the queue. merged →
+      release_issue_success to apply staged label, then register_clone_success. release_issue_success
+      is optional with skip_when_false: inputs.issue_url — when issue_url is absent
+      the step is silently skipped and pipeline continues to register_clone_success.
+      ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix
+      this). not_enrolled → release_issue_failure (enrollment failed; repo configuration
+      error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment
+      via enqueue_pr. timeout → register_clone_unconfirmed (release claim without
+      staged label; merge unconfirmed).
 
+      '
   reenroll_stalled_pr:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: check_stall_loop
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   check_stall_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.stall_loop_count }}"
-      max_iterations: "3"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.stall_loop_count }}
+      max_iterations: '3'
     capture:
-      stall_loop_count: "${{ result.next_iteration }}"
+      stall_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: register_clone_unconfirmed
     - route: wait_for_queue
     on_failure: register_clone_unconfirmed
     optional_context_refs:
     - stall_loop_count
-    note: >
-      Iteration guard for the wait_for_queue / reenroll_stalled_pr cycle.
-      Caps stall re-enrollment at 3 attempts. On budget exhaustion, routes
-      to register_clone_unconfirmed (merge outcome unconfirmed).
+    note: 'Iteration guard for the wait_for_queue / reenroll_stalled_pr cycle. Caps
+      stall re-enrollment at 3 attempts. On budget exhaustion, routes to register_clone_unconfirmed
+      (merge outcome unconfirmed).
 
+      '
   check_eject_limit:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.check_eject_limit"
-      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count"
-      max_ejects: "3"
+      callable: autoskillit.recipe._cmd_rpc.check_eject_limit
+      counter_file: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count
+      max_ejects: '3'
     on_result:
-    - when: "${{ result.status }} == EJECT_LIMIT_EXCEEDED"
+    - when: ${{ result.status }} == EJECT_LIMIT_EXCEEDED
       route: release_issue_failure
     - route: queue_ejected_fix
     on_failure: release_issue_failure
-    note: >
-      Circuit breaker for the queue ejection loop. Tracks ejection count in a
-      file-based counter under {{AUTOSKILLIT_TEMP}}/. After 3 ejections, routes
-      to release_issue_failure to prevent infinite re-enqueue cycles.
+    note: 'Circuit breaker for the queue ejection loop. Tracks ejection count in a
+      file-based counter under {{AUTOSKILLIT_TEMP}}/. After 3 ejections, routes to
+      release_issue_failure to prevent infinite re-enqueue cycles.
 
+      '
   check_dropped_healthy_loop:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop"
-      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count"
-      max_drops: "2"
+      callable: autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop
+      counter_file: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count
+      max_drops: '2'
     on_result:
-    - when: "${{ result.status }} == DROPPED_LIMIT_EXCEEDED"
+    - when: ${{ result.status }} == DROPPED_LIMIT_EXCEEDED
       route: release_issue_failure
     - route: reenter_merge_queue_cheap
     on_failure: release_issue_failure
-    note: >
-      Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive
+    note: 'Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive
       unexplained drops with healthy PR-branch CI, escalates to release_issue_failure
       instead of looping. Matches the check_eject_limit pattern used for the ejected
-      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed
-      directly to diagnose_ci and never reaches this step.
+      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed directly
+      to diagnose_ci and never reaches this step.
 
+      '
   queue_ejected_fix:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.queue_ejected_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.queue_ejected_fix
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.status }} == clean"
+    - when: ${{ result.status }} == clean
       route: re_push_queue_fix
     - route: resolve_queue_merge_conflicts
     on_failure: resolve_queue_merge_conflicts
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Attempts a cheap rebase before invoking the full conflict-resolution skill.
+    skip_when_false: inputs.open_pr
+    note: 'Attempts a cheap rebase before invoking the full conflict-resolution skill.
       On a clean rebase (stdout "clean"), skips the skill and proceeds directly to
-      re_push_queue_fix. On conflict, aborts the rebase and routes to
-      resolve_queue_merge_conflicts for goal-aware resolution.
+      re_push_queue_fix. On conflict, aborts the rebase and routes to resolve_queue_merge_conflicts
+      for goal-aware resolution.
 
+      '
   resolve_queue_merge_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_queue_merge_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_queue_merge_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: re_push_queue_fix
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Resolves rebase conflicts on the feature branch after queue ejection.
-      Only reached when the cheap rebase in queue_ejected_fix encountered conflicts.
-      escalation_required=true → release_issue_failure for human review.
+    skip_when_false: inputs.open_pr
+    note: 'Resolves rebase conflicts on the feature branch after queue ejection. Only
+      reached when the cheap rebase in queue_ejected_fix encountered conflicts. escalation_required=true
+      → release_issue_failure for human review.
 
+      '
   re_push_queue_fix:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
     capture:
-      push_error_type: "${{ result.error_type }}"
+      push_error_type: ${{ result.error_type }}
     retries: 2
     on_exhausted: register_clone_unconfirmed
     on_success: ci_watch_post_queue_fix
     on_failure: classify_push_failure
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   classify_push_failure:
     action: route
     on_result:
-    - when: "${{ context.push_error_type }} == queued_branch"
+    - when: ${{ context.push_error_type }} == queued_branch
       route: wait_dequeue_retry
     - route: release_issue_failure
-
   wait_dequeue_retry:
     tool: wait_for_merge_queue
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      timeout_seconds: "60"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      timeout_seconds: '60'
     on_result:
-    - when: "${{ result.pr_state }} == merged"
+    - when: ${{ result.pr_state }} == merged
       route: release_issue_success
-    - when: "${{ result.pr_state }} == ejected_ci_failure"
+    - when: ${{ result.pr_state }} == ejected_ci_failure
       route: register_clone_unconfirmed
-    - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+    - when: ${{ result.pr_state }} == dropped_merge_group_ci
       route: register_clone_unconfirmed
-    - when: "${{ result.pr_state }} == dropped_healthy"
+    - when: ${{ result.pr_state }} == dropped_healthy
       route: register_clone_unconfirmed
-    - when: "${{ result.pr_state }} == ejected"
+    - when: ${{ result.pr_state }} == ejected
       route: re_push_queue_fix
-    - when: "${{ result.pr_state }} == stalled"
+    - when: ${{ result.pr_state }} == stalled
       route: register_clone_unconfirmed
-    - when: "${{ result.pr_state }} == timeout"
+    - when: ${{ result.pr_state }} == timeout
       route: register_clone_unconfirmed
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
     optional_context_refs:
     - push_error_type
-
   ci_watch_post_queue_fix:
     tool: wait_for_ci
     with:
-      branch: "${{ context.merge_target }}"
-      event: "${{ context.ci_event }}"
+      branch: ${{ context.merge_target }}
+      event: ${{ context.ci_event }}
       timeout_seconds: 600
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      cwd: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
       auto_trigger: true
     capture:
-      ci_conclusion: "${{ result.conclusion }}"
-      ci_failed_jobs: "${{ result.failed_jobs }}"
+      ci_conclusion: ${{ result.conclusion }}
+      ci_failed_jobs: ${{ result.failed_jobs }}
     on_result:
-    - when: "${{ result.conclusion }} == 'success'"
+    - when: ${{ result.conclusion }} == 'success'
       route: reenter_merge_queue
-    - when: "${{ result.conclusion }} == 'no_runs'"
+    - when: ${{ result.conclusion }} == 'no_runs'
       route: release_issue_failure
-    - when: "${{ result.conclusion }} == 'timed_out'"
+    - when: ${{ result.conclusion }} == 'timed_out'
       route: check_ci_post_queue_loop
     - route: detect_ci_conflict
     on_failure: detect_ci_conflict
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Validates CI on the rebased feature branch after queue ejection fix and re-push.
-      Routes on result.conclusion: success → reenter_merge_queue,
-      no_runs → release_issue_failure (auto_trigger fires first: empty commit +
-      force-push + re-poll; no_runs reached only when trigger recovery fails),
-      timed_out → check_ci_post_queue_loop, failure → detect_ci_conflict.
+    skip_when_false: inputs.open_pr
+    note: 'Validates CI on the rebased feature branch after queue ejection fix and
+      re-push. Routes on result.conclusion: success → reenter_merge_queue, no_runs
+      → release_issue_failure (auto_trigger fires first: empty commit + force-push
+      + re-poll; no_runs reached only when trigger recovery fails), timed_out → check_ci_post_queue_loop,
+      failure → detect_ci_conflict.
 
+      '
   check_ci_post_queue_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_post_queue_loop_count }}"
-      max_iterations: "2"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_post_queue_loop_count }}
+      max_iterations: '2'
     capture:
-      ci_post_queue_loop_count: "${{ result.next_iteration }}"
+      ci_post_queue_loop_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
     - route: ci_watch_post_queue_fix
     on_failure: release_issue_failure
     optional_context_refs:
     - ci_post_queue_loop_count
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Iteration guard for the ci_watch_post_queue_fix timed_out self-loop.
-      Caps at 2 iterations (initial + 1 retry). On budget exhaustion,
-      routes to release_issue_failure — this is already a post-ejection
-      retry path so further escalation is not warranted.
+    skip_when_false: inputs.open_pr
+    note: 'Iteration guard for the ci_watch_post_queue_fix timed_out self-loop. Caps
+      at 2 iterations (initial + 1 retry). On budget exhaustion, routes to release_issue_failure
+      — this is already a post-ejection retry path so further escalation is not warranted.
 
+      '
   reenter_merge_queue:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: wait_for_queue
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Re-submits the PR after conflict resolution. Routes back to wait_for_queue.
+    skip_when_false: inputs.open_pr
+    note: 'Re-submits the PR after conflict resolution. Routes back to wait_for_queue.
       If re-entry fails, release_issue_failure preserves the clone for debugging.
 
+      '
   reenter_merge_queue_cheap:
     tool: enqueue_pr
     with:
-      pr_number: "${{ context.pr_number }}"
-      target_branch: "${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      auto_merge_available: "${{ context.auto_merge_available }}"
+      pr_number: ${{ context.pr_number }}
+      target_branch: ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
     on_success: wait_for_queue
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Re-submits a healthy PR into the merge queue after auto_merge was cleared
-      externally (DROPPED_HEALTHY state). No conflict-resolution CI wait needed.
-      Routes back to wait_for_queue on success.
+    skip_when_false: inputs.open_pr
+    note: 'Re-submits a healthy PR into the merge queue after auto_merge was cleared
+      externally (DROPPED_HEALTHY state). No conflict-resolution CI wait needed. Routes
+      back to wait_for_queue on success.
 
+      '
   direct_merge:
     tool: run_cmd
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
-      cwd: "${{ context.work_dir }}"
-      step_name: "direct_merge"
+      cmd: gh pr merge '${{ context.pr_number }}' --squash --auto
+      cwd: ${{ context.work_dir }}
+      step_name: direct_merge
     on_success: wait_for_direct_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Enables GitHub native auto-merge for direct merge (no merge queue). GitHub
-      merges automatically once all required checks pass. On failure, escalates
-      via release_issue_failure so the issue claim is released and the pipeline
-      reports an error rather than silently succeeding.
+    skip_when_false: inputs.open_pr
+    note: 'Enables GitHub native auto-merge for direct merge (no merge queue). GitHub
+      merges automatically once all required checks pass. On failure, escalates via
+      release_issue_failure so the issue claim is released and the pipeline reports
+      an error rather than silently succeeding.
 
+      '
   wait_for_direct_merge:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.wait_for_direct_merge"
-      pr_number: "${{ context.pr_number }}"
-      max_polls: "90"
-      poll_interval: "10"
+      callable: autoskillit.recipe._cmd_rpc.wait_for_direct_merge
+      pr_number: ${{ context.pr_number }}
+      max_polls: '90'
+      poll_interval: '10'
     on_result:
-    - when: "${{ result.state }} == merged"
+    - when: ${{ result.state }} == merged
       route: release_issue_success
-    - when: "${{ result.state }} == closed"
+    - when: ${{ result.state }} == closed
       route: direct_merge_conflict_fix
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Polls GitHub PR state every 10 s for up to 15 minutes.
-      merged → release_issue_success.
-      closed → conflict fix cycle.
-      timeout → register_clone_unconfirmed (releases claim; merge unconfirmed).
+    skip_when_false: inputs.open_pr
+    note: 'Polls GitHub PR state every 10 s for up to 15 minutes. merged → release_issue_success.
+      closed → conflict fix cycle. timeout → register_clone_unconfirmed (releases
+      claim; merge unconfirmed).
 
+      '
   direct_merge_conflict_fix:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.status }} == clean"
+    - when: ${{ result.status }} == clean
       route: re_push_direct_fix
     - route: resolve_direct_merge_conflicts
     on_failure: resolve_direct_merge_conflicts
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Attempts a cheap rebase before invoking the full conflict-resolution skill.
-      On clean rebase, proceeds to re_push_direct_fix. On conflict, routes to
-      resolve_direct_merge_conflicts for goal-aware resolution.
+    skip_when_false: inputs.open_pr
+    note: 'Attempts a cheap rebase before invoking the full conflict-resolution skill.
+      On clean rebase, proceeds to re_push_direct_fix. On conflict, routes to resolve_direct_merge_conflicts
+      for goal-aware resolution.
 
+      '
   resolve_direct_merge_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_direct_merge_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_direct_merge_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: re_push_direct_fix
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Resolves rebase conflicts after direct-merge rejection.
-      Only reached when the cheap rebase in direct_merge_conflict_fix encountered conflicts.
-      escalation_required=true → release_issue_failure for human review.
+    skip_when_false: inputs.open_pr
+    note: 'Resolves rebase conflicts after direct-merge rejection. Only reached when
+      the cheap rebase in direct_merge_conflict_fix encountered conflicts. escalation_required=true
+      → release_issue_failure for human review.
 
+      '
   re_push_direct_fix:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
     on_success: redirect_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   redirect_merge:
     tool: run_cmd
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
-      cwd: "${{ context.work_dir }}"
-      step_name: "redirect_merge"
+      cmd: gh pr merge '${{ context.pr_number }}' --squash --auto
+      cwd: ${{ context.work_dir }}
+      step_name: redirect_merge
     on_success: wait_for_direct_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Re-enables auto-merge after conflict resolution and re-push.
-      Routes back to wait_for_direct_merge to poll for completion.
-      On failure, release_issue_failure preserves the clone for debugging.
+    skip_when_false: inputs.open_pr
+    note: 'Re-enables auto-merge after conflict resolution and re-push. Routes back
+      to wait_for_direct_merge to poll for completion. On failure, release_issue_failure
+      preserves the clone for debugging.
 
+      '
   immediate_merge:
     tool: run_cmd
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
-      cwd: "${{ context.work_dir }}"
-      step_name: "immediate_merge"
+      cmd: gh pr merge '${{ context.pr_number }}' --squash
+      cwd: ${{ context.work_dir }}
+      step_name: immediate_merge
     on_success: wait_for_immediate_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Merges the PR immediately using plain --squash when autoMergeAllowed=false.
-      Unlike direct_merge, no --auto flag is used — GitHub executes the merge
-      synchronously rather than queueing it for when checks pass. On failure,
-      escalates via release_issue_failure so the issue claim is released and the
-      pipeline reports an error rather than silently succeeding.
+    skip_when_false: inputs.open_pr
+    note: 'Merges the PR immediately using plain --squash when autoMergeAllowed=false.
+      Unlike direct_merge, no --auto flag is used — GitHub executes the merge synchronously
+      rather than queueing it for when checks pass. On failure, escalates via release_issue_failure
+      so the issue claim is released and the pipeline reports an error rather than
+      silently succeeding.
 
+      '
   wait_for_immediate_merge:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.wait_for_immediate_merge"
-      pr_number: "${{ context.pr_number }}"
-      max_polls: "30"
-      poll_interval: "10"
+      callable: autoskillit.recipe._cmd_rpc.wait_for_immediate_merge
+      pr_number: ${{ context.pr_number }}
+      max_polls: '30'
+      poll_interval: '10'
     on_result:
-    - when: "${{ result.state }} == merged"
+    - when: ${{ result.state }} == merged
       route: release_issue_success
-    - when: "${{ result.state }} == closed"
+    - when: ${{ result.state }} == closed
       route: immediate_merge_conflict_fix
     - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Polls GitHub PR state every 10s for up to 5 minutes (30 iterations).
-      Since immediate_merge uses --squash without --auto, the merge completes
-      synchronously — this poll is a confirmation window.
-      merged → release_issue_success.
-      closed → PR was rejected (stale base or conflict) — route to conflict fix.
-      timeout → register_clone_unconfirmed.
+    skip_when_false: inputs.open_pr
+    note: 'Polls GitHub PR state every 10s for up to 5 minutes (30 iterations). Since
+      immediate_merge uses --squash without --auto, the merge completes synchronously
+      — this poll is a confirmation window. merged → release_issue_success. closed
+      → PR was rejected (stale base or conflict) — route to conflict fix. timeout
+      → register_clone_unconfirmed.
 
+      '
   immediate_merge_conflict_fix:
     tool: run_python
     with:
-      callable: "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      callable: autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
     on_result:
-    - when: "${{ result.status }} == clean"
+    - when: ${{ result.status }} == clean
       route: re_push_immediate_fix
     - route: resolve_immediate_merge_conflicts
     on_failure: resolve_immediate_merge_conflicts
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Attempts a cheap rebase before invoking the full conflict-resolution skill.
-      On clean rebase, proceeds to re_push_immediate_fix. On conflict, routes to
-      resolve_immediate_merge_conflicts for goal-aware resolution.
+    skip_when_false: inputs.open_pr
+    note: 'Attempts a cheap rebase before invoking the full conflict-resolution skill.
+      On clean rebase, proceeds to re_push_immediate_fix. On conflict, routes to resolve_immediate_merge_conflicts
+      for goal-aware resolution.
 
+      '
   resolve_immediate_merge_conflicts:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_immediate_merge_conflicts"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_immediate_merge_conflicts
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: re_push_immediate_fix
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Resolves rebase conflicts after immediate-merge rejection.
-      Only reached when the cheap rebase in immediate_merge_conflict_fix encountered conflicts.
+    skip_when_false: inputs.open_pr
+    note: 'Resolves rebase conflicts after immediate-merge rejection. Only reached
+      when the cheap rebase in immediate_merge_conflict_fix encountered conflicts.
       escalation_required=true → release_issue_failure for human review.
 
+      '
   re_push_immediate_fix:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
     on_success: remerge_immediate
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-
+    skip_when_false: inputs.open_pr
   remerge_immediate:
     tool: run_cmd
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
-      cwd: "${{ context.work_dir }}"
-      step_name: "remerge_immediate"
+      cmd: gh pr merge '${{ context.pr_number }}' --squash
+      cwd: ${{ context.work_dir }}
+      step_name: remerge_immediate
     on_success: wait_for_immediate_merge
     on_failure: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Re-attempts plain squash merge after conflict resolution and re-push.
-      Routes back to wait_for_immediate_merge to confirm completion.
-      On failure, release_issue_failure preserves the clone for debugging.
+    skip_when_false: inputs.open_pr
+    note: 'Re-attempts plain squash merge after conflict resolution and re-push. Routes
+      back to wait_for_immediate_merge to confirm completion. On failure, release_issue_failure
+      preserves the clone for debugging.
 
+      '
   diagnose_ci:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:diagnose-ci ${{ context.merge_target }} - - - ${{ context.ci_event }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "diagnose_ci"
-      ci_failed_jobs: "${{ context.ci_failed_jobs }}"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-ci"
+      skill_command: /autoskillit:diagnose-ci ${{ context.merge_target }} - - - ${{
+        context.ci_event }}
+      cwd: ${{ context.work_dir }}
+      step_name: diagnose_ci
+      ci_failed_jobs: ${{ context.ci_failed_jobs }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-ci'
     capture:
-      diagnosis_path: "${{ result.diagnosis_path }}"
+      diagnosis_path: ${{ result.diagnosis_path }}
     on_success: resolve_ci
     on_failure: resolve_ci
     on_context_limit: resolve_ci
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Runs when ci_watch reports a CI failure. Fetches CI logs via gh API and writes
-      a structured diagnosis to {{AUTOSKILLIT_TEMP}}/diagnose-ci/. Routes to resolve_ci on success
-      OR failure (best-effort: resolve-failures proceeds even without a diagnosis).
-      diagnosis_path is passed to resolve_ci for targeted remediation context.
+    skip_when_false: inputs.open_pr
+    note: 'Runs when ci_watch reports a CI failure. Fetches CI logs via gh API and
+      writes a structured diagnosis to {{AUTOSKILLIT_TEMP}}/diagnose-ci/. Routes to
+      resolve_ci on success OR failure (best-effort: resolve-failures proceeds even
+      without a diagnosis). diagnosis_path is passed to resolve_ci for targeted remediation
+      context.
 
+      '
   resolve_ci:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "resolve_ci"
+      skill_command: /autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path
+        }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs
+        }} ${{ context.diagnosis_path }}
+      cwd: ${{ context.work_dir }}
+      step_name: resolve_ci
     capture:
-      verdict: "${{ result.verdict }}"
+      verdict: ${{ result.verdict }}
     retries: 2
     on_exhausted: release_issue_failure
     on_context_limit: re_push
     on_result:
-    - when: "${{ result.verdict }} == 'real_fix'"
+    - when: ${{ result.verdict }} == 'real_fix'
       route: re_push
-    - when: "${{ result.verdict }} == 'already_green'"
+    - when: ${{ result.verdict }} == 'already_green'
       route: pre_resolve_rebase
-    - when: "${{ result.verdict }} == 'flake_suspected'"
+    - when: ${{ result.verdict }} == 'flake_suspected'
       route: re_push
-    - when: "${{ result.verdict }} == 'ci_only_failure'"
+    - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
-    - when: "${{ result.verdict }} == 'no_test_infrastructure'"
+    - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     - route: release_issue_failure
     on_failure: release_issue_failure
-    note: >
-      Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci
+    note: 'Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci
       structured output to avoid redundant CI failure re-investigation. Routes via
       on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses
-      (sibling fix may have landed), flake_suspected retries via re_push (bounded by
-      retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates to human.
-      Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
+      (sibling fix may have landed), flake_suspected retries via re_push (bounded
+      by retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates
+      to human. Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
+      '
   pre_resolve_rebase:
     tool: run_cmd
     with:
-      cmd: |
-        REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
+        | grep -qv "^file://" && echo upstream || echo origin) &&
+
         git -C ${{ context.work_dir }} fetch "$REMOTE" &&
+
         git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-      step_name: "pre_resolve_rebase"
+
+        '
+      step_name: pre_resolve_rebase
     retries: 1
     on_success: check_ci_rebase_loop
     on_failure: release_issue_failure
-    note: >
-      Rebases the feature branch against integration head when resolve_ci emits
-      already_green — the worktree was already clean because a sibling pipeline's
+    note: 'Rebases the feature branch against integration head when resolve_ci emits
+      already_green — the worktree was already clean because a sibling pipeline''s
       fix already landed on integration. Pulling it in before re-running diagnose_ci
       gives the pipeline a real chance at emitting real_fix and reaching re_push.
 
+      '
   check_ci_rebase_loop:
     tool: run_python
     with:
-      callable: "autoskillit.smoke_utils.check_loop_iteration"
-      current_iteration: "${{ context.ci_rebase_count }}"
-      max_iterations: "3"
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ci_rebase_count }}
+      max_iterations: '3'
     capture:
-      ci_rebase_count: "${{ result.next_iteration }}"
+      ci_rebase_count: ${{ result.next_iteration }}
     on_result:
-    - when: "${{ result.max_exceeded }} == true"
+    - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
     - route: diagnose_ci
     on_failure: release_issue_failure
     optional_context_refs:
     - ci_rebase_count
-    note: >
-      Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci cycle.
-      Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green
+    note: 'Guards the resolve_ci(already_green) → pre_resolve_rebase → diagnose_ci
+      cycle. Caps at 3 rebase-rediagnose iterations. If CI keeps reporting already_green
       after 3 rebases, a structural issue requires human intervention.
 
+      '
   re_push:
     tool: push_to_remote
     with:
-      clone_path: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
-      branch: "${{ context.merge_target }}"
-      force: "true"
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
     on_success: check_repo_ci_event
     on_failure: release_issue_failure
-    note: >
-      Pushes the CI-fixed feature branch back to the remote after resolve_ci succeeds.
-      Routes to check_repo_ci_event to derive ci_event before ci_watch verifies the fix.
-      On push failure, escalates via release_issue_failure.
+    note: 'Pushes the CI-fixed feature branch back to the remote after resolve_ci
+      succeeds. Routes to check_repo_ci_event to derive ci_event before ci_watch verifies
+      the fix. On push failure, escalates via release_issue_failure.
 
+      '
   detect_ci_conflict:
     tool: run_cmd
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://"
+        && echo upstream || echo origin) &&
+
         git fetch "$REMOTE" ${{ inputs.base_branch }} &&
+
         ! git merge-base --is-ancestor "$REMOTE"/${{ inputs.base_branch }} HEAD
-      cwd: "${{ context.work_dir }}"
-      step_name: "detect_ci_conflict"
+
+        '
+      cwd: ${{ context.work_dir }}
+      step_name: detect_ci_conflict
     on_success: ci_conflict_fix
     on_failure: diagnose_ci
     optional: true
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Stale-base triage gate for CI FAILURE paths only. Do NOT route
-      check_pr_mergeable CONFLICTING here — GitHub's CONFLICTING status is
-      authoritative and should route directly to ci_conflict_fix.
-      Valid callers: ci_watch, check_ci_timed_out_loop, check_ci_already_passed,
-      ci_watch_post_queue_fix. Exit 0 (base NOT ancestor) → ci_conflict_fix.
-      Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.
+    skip_when_false: inputs.open_pr
+    note: 'Stale-base triage gate for CI FAILURE paths only. Do NOT route check_pr_mergeable
+      CONFLICTING here — GitHub''s CONFLICTING status is authoritative and should
+      route directly to ci_conflict_fix. Valid callers: ci_watch, check_ci_timed_out_loop,
+      check_ci_already_passed, ci_watch_post_queue_fix. Exit 0 (base NOT ancestor)
+      → ci_conflict_fix. Exit 1 (base IS ancestor or fetch failed) → diagnose_ci.
 
+      '
   ci_conflict_fix:
     tool: run_skill
-    model: ""
+    model: ''
     with:
-      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "ci_conflict_fix"
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      step_name: ci_conflict_fix
     capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
+      conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
-    - when: "${{ result.escalation_required }} == true"
+    - when: ${{ result.escalation_required }} == true
       route: release_issue_failure
     - route: re_push
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Resolves a stale-base CI failure by rebasing the feature branch onto the latest
-      integration HEAD. Mirrors queue_ejected_fix: on clean rebase or goal-aware conflict
-      resolution, routes to re_push to re-trigger CI on the rebased branch. On escalation
-      (LOW confidence conflicts) or tool failure, routes to release_issue_failure.
+    skip_when_false: inputs.open_pr
+    note: 'Resolves a stale-base CI failure by rebasing the feature branch onto the
+      latest integration HEAD. Mirrors queue_ejected_fix: on clean rebase or goal-aware
+      conflict resolution, routes to re_push to re-trigger CI on the rebased branch.
+      On escalation (LOW confidence conflicts) or tool failure, routes to release_issue_failure.
       retries: 1 bounds the loop; after 2 total attempts, escalates.
 
+      '
   register_clone_unconfirmed:
-    description: "Register clone as preserved — merge unconfirmed, in-progress label retained"
+    description: Register clone as preserved — merge unconfirmed, in-progress label
+      retained
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "unconfirmed"
+      clone_path: ${{ context.work_dir }}
+      status: unconfirmed
       step_name: register_clone_unconfirmed
     on_success: run_diagnostic_unconfirmed
     on_failure: run_diagnostic_unconfirmed
-    note: >
-      Called when a merge-wait step times out before merge is confirmed.
-      Does NOT call release_issue — the in-progress label stays on the issue
-      so operators can see the PR is still actively queued. The clone is
-      preserved (status: unconfirmed) for human inspection.
+    note: 'Called when a merge-wait step times out before merge is confirmed. Does
+      NOT call release_issue — the in-progress label stays on the issue so operators
+      can see the PR is still actively queued. The clone is preserved (status: unconfirmed)
+      for human inspection.
 
+      '
   run_diagnostic_unconfirmed:
-    description: "Run post-pipeline diagnostic analysis on session logs (unconfirmed path)"
+    description: Run post-pipeline diagnostic analysis on session logs (unconfirmed
+      path)
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: done_unconfirmed
     on_failure: done_unconfirmed
     on_context_limit: done_unconfirmed
-    note: >
-      Diagnostic failure never blocks pipeline completion.
+    note: 'Diagnostic failure never blocks pipeline completion.
 
+      '
   done_unconfirmed:
     action: stop
-    message: >-
-      Implementation pipeline finished but merge was not confirmed within the timeout
-      window. The PR is still open and the clone has been preserved for inspection.
-      The in-progress label remains on the issue. Human operator should verify merge
-      status.
-      Emit the L3 result sentinel JSON block now with success=true and
-      reason="merge_unconfirmed".
-      Example sentinel:
-      {"success": true, "reason": "merge_unconfirmed"}
-
+    message: 'Implementation pipeline finished but merge was not confirmed within
+      the timeout window. The PR is still open and the clone has been preserved for
+      inspection. The in-progress label remains on the issue. Human operator should
+      verify merge status. Emit the L3 result sentinel JSON block now with success=true
+      and reason="merge_unconfirmed". Example sentinel: {"success": true, "reason":
+      "merge_unconfirmed"}'
   release_issue_success:
-    description: "Transition issue from in-progress to staged after successful pipeline completion"
+    description: Transition issue from in-progress to staged after successful pipeline
+      completion
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
@@ -1795,100 +1828,99 @@ steps:
       target_branch: ${{ inputs.base_branch }}
     on_success: patch_token_summary
     on_failure: patch_token_summary
-    note: >
-      Applies staged label after successful PR merge; skipped when no issue_url.
+    note: 'Applies staged label after successful PR merge; skipped when no issue_url.
       optional=true so registration proceeds even if this step errors.
 
+      '
   patch_token_summary:
-    description: "Collect all pipeline token data and patch the PR body with complete summary"
+    description: Collect all pipeline token data and patch the PR body with complete
+      summary
     tool: run_python
     optional: true
-    skip_when_false: "inputs.open_pr"
+    skip_when_false: inputs.open_pr
     with:
-      callable: "autoskillit.smoke_utils.patch_pr_token_summary"
+      callable: autoskillit.smoke_utils.patch_pr_token_summary
       timeout: 60
-      pr_url: "${{ context.pr_url }}"
-      cwd: "${{ context.work_dir }}"
+      pr_url: ${{ context.pr_url }}
+      cwd: ${{ context.work_dir }}
     on_success: register_clone_success
     on_failure: register_clone_success
-    note: >
-      Patches PR body with complete token summary; failure never blocks pipeline completion.
+    note: 'Patches PR body with complete token summary; failure never blocks pipeline
+      completion.
 
+      '
   release_issue_failure:
-    description: "Release the in-progress claim after pipeline failure"
+    description: Release the in-progress claim after pipeline failure
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
-      fail_label: "fail"
+      fail_label: fail
     on_success: register_clone_failure
     on_failure: register_clone_failure
-
   register_clone_success:
-    description: "Register clone as cleanup candidate for batch deletion"
+    description: Register clone as cleanup candidate for batch deletion
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "success"
+      clone_path: ${{ context.work_dir }}
+      status: success
       step_name: register_clone_success
     on_success: run_diagnostic
     on_failure: run_diagnostic
-
   register_clone_failure:
-    description: "Register clone as preserved (error pipeline)"
+    description: Register clone as preserved (error pipeline)
     tool: register_clone_status
     with:
-      clone_path: "${{ context.work_dir }}"
-      status: "error"
+      clone_path: ${{ context.work_dir }}
+      status: error
       step_name: register_clone_failure
     on_success: run_diagnostic_error
     on_failure: run_diagnostic_error
-
   run_diagnostic:
-    description: "Run post-pipeline diagnostic analysis on session logs"
+    description: Run post-pipeline diagnostic analysis on session logs
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: done
     on_failure: done
     on_context_limit: done
-    note: >
-      Diagnostic failure never blocks pipeline completion. Both on_failure and
+    note: 'Diagnostic failure never blocks pipeline completion. Both on_failure and
       on_context_limit route to the same terminal as on_success.
 
+      '
   run_diagnostic_error:
-    description: "Run post-pipeline diagnostic analysis on session logs (error path)"
+    description: Run post-pipeline diagnostic analysis on session logs (error path)
     tool: run_skill
-    model: ""
+    model: ''
     optional: true
-    skip_when_false: "inputs.post_run_diagnostics"
+    skip_when_false: inputs.post_run_diagnostics
     with:
-      skill_command: "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}"
-      cwd: "${{ context.work_dir }}"
-      step_name: "post_run_diagnostics"
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir
+        }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: escalate_stop
     on_failure: escalate_stop
     on_context_limit: escalate_stop
-    note: >
-      Diagnostic failure never blocks pipeline completion.
+    note: 'Diagnostic failure never blocks pipeline completion.
 
+      '
   done:
     action: stop
-    message: >-
-      Investigation complete. Fix implemented and PR opened.
-      Emit the L3 result sentinel JSON block now with success=true.
-      Example sentinel: {"success": true, "reason": "remediation complete"}
-
+    message: 'Investigation complete. Fix implemented and PR opened. Emit the L3 result
+      sentinel JSON block now with success=true. Example sentinel: {"success": true,
+      "reason": "remediation complete"}'
   escalate_stop:
     action: stop
-    message: >-
-      Human intervention needed. Review the latest output for details.
-      Emit the L3 result sentinel JSON block now with success=false.
-      Example sentinel: {"success": false, "reason": "remediation pipeline failed"}
-
+    message: 'Human intervention needed. Review the latest output for details. Emit
+      the L3 result sentinel JSON block now with success=false. Example sentinel:
+      {"success": false, "reason": "remediation pipeline failed"}'

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -36,6 +36,7 @@ from autoskillit.server._misc import (
     _hook_config_path,
     _prime_quota_cache,
     _quota_refresh_loop,
+    resolve_log_dir,
     resolve_provider,
 )
 from autoskillit.server._notify import track_response_size
@@ -402,6 +403,9 @@ async def open_kitchen(
             _auto_overrides: dict[str, str] = {
                 "kitchen_id": tool_ctx.kitchen_id,
                 "post_run_diagnostics": _defaults.get("post_run_diagnostics", "false"),
+                "is_fleet_dispatch": _defaults.get("is_fleet_dispatch", "false"),
+                "dispatch_id": _defaults.get("dispatch_id", ""),
+                "diagnostics_log_dir": str(resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)),
             }
             _merged_overrides = {**_auto_overrides, **(overrides or {})}
             # Runtime enum check: output_mode must be validated before recipe loading

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -14,7 +14,7 @@ from autoskillit.core import get_logger, temp_dir_display_str
 from autoskillit.pipeline import GATED_TOOLS, UNGATED_TOOLS  # noqa: F401
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
-from autoskillit.server._misc import _apply_triage_gate
+from autoskillit.server._misc import _apply_triage_gate, resolve_log_dir
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._state import _get_ctx_or_none
 
@@ -201,6 +201,9 @@ async def load_recipe(
         _auto_overrides: dict[str, str] = {
             "kitchen_id": tool_ctx.kitchen_id,
             "post_run_diagnostics": _defaults.get("post_run_diagnostics", "false"),
+            "is_fleet_dispatch": _defaults.get("is_fleet_dispatch", "false"),
+            "dispatch_id": _defaults.get("dispatch_id", ""),
+            "diagnostics_log_dir": str(resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)),
         }
         _merged_overrides = {**_auto_overrides, **(overrides or {})}
         result = tool_ctx.recipes.load_and_validate(

--- a/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
@@ -17,9 +17,11 @@ Coordinator skill that reads session logs from a pipeline run, groups them by st
 
 ## Arguments
 
-`/autoskillit:analyze-pipeline-health <kitchen_id>`
+`/autoskillit:analyze-pipeline-health <kitchen_id> [--dispatch-id=<id>] [--diagnostics-log-dir=<path>]`
 
 - **kitchen_id** (required) — The kitchen session identifier to scope log queries.
+- **--dispatch-id** (optional) — Fleet dispatch identifier. When non-empty, write a structured JSON report file in addition to text output.
+- **--diagnostics-log-dir** (optional) — Resolved path to the diagnostics log directory. Defaults to ~/.local/share/autoskillit/logs/ if not provided.
 
 ## Critical Constraints
 
@@ -27,35 +29,31 @@ Coordinator skill that reads session logs from a pipeline run, groups them by st
 - Fabricate, embellish, or invent findings not supported by evidence in session data
 - Modify any source code files
 - Create issues or PRs (findings are reported to the calling session only)
-- Run subagents in the background (`run_in_background: true` is prohibited)
+- Run subagents in the background (run_in_background: true is prohibited)
 
 **ALWAYS:**
 - Filter sessions.jsonl by kitchen_id to scope to this pipeline run
 - Spawn scanner subagents in parallel (one per step group)
-- Use `model: "haiku"` for scanner subagents
+- Use model: "haiku" for scanner subagents
 - Report "no issues found" clearly when the pipeline is clean
 
 ## Workflow
 
 ### Step 1: Read sessions.jsonl
 
-Read `~/.local/share/autoskillit/logs/sessions.jsonl` and filter entries where `kitchen_id` matches the provided argument.
-
-```bash
-jq -c 'select(.kitchen_id == "<kitchen_id>")' ~/.local/share/autoskillit/logs/sessions.jsonl
-```
+Read ~/.local/share/autoskillit/logs/sessions.jsonl and filter entries where kitchen_id matches the provided argument.
 
 ### Step 2: Group by step_name
 
-Group the filtered entries by `step_name`. Each group represents one phase of the pipeline (e.g., plan, implement, test, merge).
+Group the filtered entries by step_name. Each group represents one phase of the pipeline (e.g., plan, implement, test, merge).
 
 ### Step 3: Spawn scanner subagents
 
-For each step group, spawn a scanner subagent via the Agent tool with `subagent_type: "autoskillit:pipeline-health-scanner"`.
+For each step group, spawn a scanner subagent via the Agent tool with subagent_type: "autoskillit:pipeline-health-scanner".
 
 Each scanner receives in its prompt:
-- The `sessions.jsonl` entries for its batch (JSON array)
-- The session directory paths: `~/.local/share/autoskillit/logs/sessions/<dir_name>/`
+- The sessions.jsonl entries for its batch (JSON array)
+- The session directory paths: ~/.local/share/autoskillit/logs/sessions/<dir_name>/
 - Context about what the step does (derive from step_name)
 
 Issue ALL Agent calls in a single message for parallel execution.
@@ -67,6 +65,26 @@ Collect results from all scanners. Produce a consolidated report:
 - Include the scanner's evidence and adversarial validation status for each finding
 - If no scanners found issues, report "Pipeline health check: no issues found"
 
-### Step 5: Output
+### Step 5: Write report file (fleet dispatches only)
 
-Present the consolidated report as your final output text. The calling orchestrator session will receive this as the `run_skill` result.
+If --dispatch-id was provided and is non-empty:
+
+1. Build a JSON report object with these fields:
+   - kitchen_id: the kitchen_id argument value
+   - dispatch_id: the --dispatch-id value
+   - timestamp: current UTC ISO 8601 timestamp
+   - findings: array of finding objects from Step 4, each with severity, step_group, summary, evidence
+   - summary: the human-readable consolidated report text from Step 4
+
+2. Determine the report directory:
+   - If --diagnostics-log-dir was provided and non-empty, use {diagnostics-log-dir}/health-reports/
+   - Otherwise use ~/.local/share/autoskillit/logs/health-reports/
+
+3. Write the JSON to {report_dir}/{dispatch_id}_health_report.json using the Write tool.
+   Create the health-reports/ directory first if it doesn't exist (use Bash: mkdir -p {report_dir}).
+
+If --dispatch-id was not provided or is empty, skip this step entirely.
+
+### Step 6: Output
+
+Present the consolidated report as your final output text. The calling orchestrator session will receive this as the run_skill result.

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -1063,3 +1063,58 @@ def close_issue_already_done(issue_url: str) -> dict[str, str]:
         timeout=60,
     )
     return {"closed": "true"}
+
+
+def consolidate_health_reports(*, diagnostics_log_dir: str, kitchen_id: str) -> dict:
+    """Consolidate per-dispatch health reports filtered by kitchen_id.
+
+    Writes a JSON report file to {diagnostics_log_dir}/health-reports/ when running
+    inside a food truck dispatch, persisting the report outside the clone filesystem.
+    """
+    reports_dir = Path(diagnostics_log_dir) / "health-reports"
+    if not reports_dir.is_dir():
+        return {"summary": "No health reports directory found. No diagnostics to consolidate."}
+
+    reports = []
+    for path in sorted(reports_dir.glob("*_health_report.json")):
+        try:
+            data = json.loads(path.read_text())
+            if data.get("kitchen_id") == kitchen_id:
+                reports.append(data)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    if not reports:
+        return {"summary": "No health reports found for this campaign."}
+
+    all_findings = []
+    for report in reports:
+        dispatch_id = report.get("dispatch_id", "unknown")
+        for finding in report.get("findings", []):
+            all_findings.append({**finding, "dispatch_id": dispatch_id})
+
+    if not all_findings:
+        return {
+            "summary": (
+                f"Pipeline health check: {len(reports)} dispatches analyzed, no issues found."
+            )
+        }
+
+    severity_order = {"confirmed_bug": 0, "regression": 1, "anomaly": 2, "informational": 3}
+    all_findings.sort(key=lambda f: severity_order.get(f.get("severity", ""), 99))
+
+    lines = [
+        "## Consolidated Pipeline Health Report",
+        "",
+        f"**Dispatches analyzed:** {len(reports)}",
+        f"**Total findings:** {len(all_findings)}",
+        "",
+    ]
+    for finding in all_findings:
+        sev = finding.get("severity", "unknown").upper()
+        lines.append(
+            f"- [{sev}] (dispatch {finding.get('dispatch_id', '?')}): "
+            f"{finding.get('summary', 'No summary')}"
+        )
+
+    return {"summary": "\n".join(lines)}

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -936,7 +936,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         1200,
         "REQ-CNST-010-E7: agent-eval + skill-eval smoke functions + consolidate_health_reports — "
         "parse_agent_eval_manifests and build_agent_eval_context parallel "
-        "parse_eval_manifests/build_eval_context; consolidate_health_reports added for L3 "
+        "parse_eval_manifests/build_eval_context; consolidate_health_reports added for campaign "
         "diagnostic aggregation; shared helpers extracted but residual size from three domains",
     ),
 }

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -933,10 +933,11 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "smoke_utils.py": (
-        1100,
-        "REQ-CNST-010-E7: agent-eval + skill-eval smoke functions — parse_agent_eval_manifests "
-        "and build_agent_eval_context parallel parse_eval_manifests/build_eval_context; "
-        "shared helpers extracted but residual size from two eval domains",
+        1200,
+        "REQ-CNST-010-E7: agent-eval + skill-eval smoke functions + consolidate_health_reports — "
+        "parse_agent_eval_manifests and build_agent_eval_context parallel "
+        "parse_eval_manifests/build_eval_context; consolidate_health_reports added for L3 "
+        "diagnostic aggregation; shared helpers extracted but residual size from three domains",
     ),
 }
 

--- a/tests/config/test_helpers.py
+++ b/tests/config/test_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
@@ -90,3 +91,76 @@ def test_resolve_ingredient_defaults_includes_post_run_diagnostics(tmp_path):
 
     defaults = resolve_ingredient_defaults(repo)
     assert defaults.get("post_run_diagnostics") == "false"
+
+
+def test_resolve_ingredient_defaults_includes_is_fleet_dispatch_false(tmp_path):
+    """T1.1: resolve_ingredient_defaults includes is_fleet_dispatch=false when no DISPATCH_ID env var."""
+    from autoskillit.config import resolve_ingredient_defaults
+
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", str(repo)], check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/org/repo"],
+        cwd=str(repo),
+        check=True,
+    )
+
+    defaults = resolve_ingredient_defaults(repo)
+    assert defaults.get("is_fleet_dispatch") == "false"
+
+
+def test_resolve_ingredient_defaults_includes_is_fleet_dispatch_true(tmp_path, monkeypatch):
+    """T1.2: resolve_ingredient_defaults includes is_fleet_dispatch=true when DISPATCH_ID env var is set."""
+    from autoskillit.config import resolve_ingredient_defaults
+
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", str(repo)], check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/org/repo"],
+        cwd=str(repo),
+        check=True,
+    )
+    monkeypatch.setenv("AUTOSKILLIT_DISPATCH_ID", "test-dispatch-123")
+
+    defaults = resolve_ingredient_defaults(repo)
+    assert defaults.get("is_fleet_dispatch") == "true"
+    assert defaults.get("dispatch_id") == "test-dispatch-123"
+
+
+def test_resolve_ingredient_defaults_includes_dispatch_id_empty_when_absent(tmp_path):
+    """T1.3: resolve_ingredient_defaults includes dispatch_id empty string when no DISPATCH_ID env var."""
+    from autoskillit.config import resolve_ingredient_defaults
+
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", str(repo)], check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/org/repo"],
+        cwd=str(repo),
+        check=True,
+    )
+
+    defaults = resolve_ingredient_defaults(repo)
+    assert defaults.get("dispatch_id") == ""
+
+
+def test_resolve_ingredient_defaults_fleet_keys_survive_config_failure(tmp_path, monkeypatch):
+    """T1.4: Fleet env-var keys resolve even when load_config() fails."""
+    from autoskillit.config import resolve_ingredient_defaults
+
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", str(repo)], check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/org/repo"],
+        cwd=str(repo),
+        check=True,
+    )
+    monkeypatch.setenv("AUTOSKILLIT_DISPATCH_ID", "dispatch-456")
+
+    with patch(
+        "autoskillit.config.settings.load_config",
+        side_effect=RuntimeError("config error"),
+    ):
+        defaults = resolve_ingredient_defaults(repo)
+
+    assert defaults.get("is_fleet_dispatch") == "true"
+    assert defaults.get("dispatch_id") == "dispatch-456"

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -245,10 +245,11 @@ def test_doctor_check_count_is_31() -> None:
     assert count == 37, f"Expected 37 doctor checks; found {count}"
 
 
-def test_bundled_recipe_count_is_14() -> None:
+def test_bundled_recipe_count_is_15() -> None:
     recipes = _bundled_recipes()
     expected = [
         "bem-wrapper",
+        "consolidate-health-reports",
         "full-audit",
         "implement-findings",
         "implementation",

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -241,9 +241,11 @@ class TestChannelBDrainWait:
         natural_exit_grace_seconds=0.1: script never exits naturally (time.sleep(3600)),
         so shorten grace window to reduce total test time and avoid asyncio-waitpid
         thread contention under CI load (default 3.0s grace + 3.0s kill = 6s total).
-        _session_id_timeout=3.0: 0.5s was too tight under heavy xdist load — the
-        event loop may not schedule the monitor coroutine before the timeout expires,
-        preventing Phase 1 from starting and causing a spurious timed_out result.
+        _session_id_timeout=30.0: increased from 0.5s → 3.0s → 30.0s — under
+        heavy xdist load the event loop may not schedule the monitor coroutine
+        before the timeout expires, preventing Phase 1 from starting and causing
+        a spurious timed_out result; 30.0s gives adequate headroom within the
+        pytest.mark.timeout(150) outer guard.
         """
         session_dir = tmp_path / "session"
         session_dir.mkdir()
@@ -260,7 +262,7 @@ class TestChannelBDrainWait:
             natural_exit_grace_seconds=0.1,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
-            _session_id_timeout=3.0,
+            _session_id_timeout=30.0,
             _phase1_timeout=250,
         )
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -117,9 +117,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 64),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools/tools_kitchen.py", 119),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 138),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 613),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 120),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 139),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 617),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 486),
     # tools_github.py — bug report dict

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -283,7 +283,14 @@ def test_promote_to_main_campaign_dispatch_chain():
     path = pkg_root() / "recipes" / "campaigns" / "promote-to-main.yaml"
     recipe = load_recipe(path)
     names = [d.name for d in recipe.dispatches]
-    assert names == ["full-audit", "review-gate", "build-map", "implement-findings", "promote"]
+    assert names == [
+        "full-audit",
+        "review-gate",
+        "build-map",
+        "implement-findings",
+        "promote",
+        "consolidate-diagnostics",
+    ]
     gate_dispatches = [d for d in recipe.dispatches if d.gate]
     assert len(gate_dispatches) == 1
     gd = gate_dispatches[0]

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -283,12 +283,16 @@ async def test_open_kitchen_injects_hidden_ingredient_overrides(tmp_path, monkey
                     ):
                         from autoskillit.server.tools.tools_kitchen import open_kitchen
 
+                        mock_ctx.config.linux_tracing.log_dir = ""
                         await open_kitchen(name="demo", ctx=mock_ctx)
 
     call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
     overrides = call_kwargs["ingredient_overrides"]
     assert overrides["kitchen_id"] == "test-kitchen-abc"
     assert overrides["post_run_diagnostics"] == "false"
+    assert overrides["is_fleet_dispatch"] == "false"
+    assert overrides["dispatch_id"] == ""
+    assert overrides["diagnostics_log_dir"]  # non-empty string
 
 
 @pytest.mark.anyio

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -16,6 +16,7 @@ from autoskillit.smoke_utils import (
     check_loop_with_progress,
     check_review_loop,
     compile_eval_scorecard,
+    consolidate_health_reports,
     enrich_diff_context,
     parse_agent_eval_manifests,
     parse_eval_manifests,
@@ -1890,3 +1891,86 @@ def test_build_agent_eval_context_default_reference_type_is_patch(tmp_path: Path
     assert result["success"] == "true"
     ctx = json.loads(Path(result["eval_context_path"]).read_text())
     assert ctx["reference"]["artifact_type"] == "patch"
+
+
+# T3.1
+def test_consolidate_health_reports_filters_by_campaign_id(tmp_path):
+    """T3.1: consolidate_health_reports filters by kitchen_id and aggregates findings."""
+
+    reports_dir = tmp_path / "health-reports"
+    reports_dir.mkdir()
+
+    # Create two dispatch reports for different campaigns
+    dispatch_a = {
+        "kitchen_id": "campaign-1",
+        "dispatch_id": "dispatch-a",
+        "findings": [
+            {"severity": "confirmed_bug", "step_group": "implement", "summary": "Bug in foo"},
+        ],
+    }
+    dispatch_b = {
+        "kitchen_id": "campaign-2",
+        "dispatch_id": "dispatch-b",
+        "findings": [
+            {"severity": "regression", "step_group": "test", "summary": "Test regression in bar"},
+        ],
+    }
+
+    (reports_dir / "dispatch-a_health_report.json").write_text(json.dumps(dispatch_a))
+    (reports_dir / "dispatch-b_health_report.json").write_text(json.dumps(dispatch_b))
+
+    result = consolidate_health_reports(diagnostics_log_dir=str(tmp_path), kitchen_id="campaign-1")
+
+    assert "dispatch-a" in result["summary"]
+    assert "Bug in foo" in result["summary"]
+    assert "dispatch-b" not in result["summary"]
+    assert "Test regression" not in result["summary"]
+
+
+# T3.2
+def test_consolidate_health_reports_empty_dir(tmp_path):
+    """T3.2: consolidate_health_reports returns 'no reports found' for empty directory."""
+
+    reports_dir = tmp_path / "health-reports"
+    reports_dir.mkdir()
+
+    result = consolidate_health_reports(diagnostics_log_dir=str(tmp_path), kitchen_id="campaign-1")
+
+    assert "no health reports found" in result["summary"].lower()
+
+
+# T3.3
+def test_consolidate_health_reports_no_dir(tmp_path):
+    """T3.3: consolidate_health_reports returns 'no directory' when health-reports does not exist."""
+
+    result = consolidate_health_reports(diagnostics_log_dir=str(tmp_path), kitchen_id="campaign-1")
+
+    assert "no health reports directory found" in result["summary"].lower()
+
+
+# T3.4
+def test_consolidate_health_reports_does_not_mutate_source_dicts(tmp_path):
+    """T3.4: consolidate_health_reports does not mutate source finding dicts."""
+
+    reports_dir = tmp_path / "health-reports"
+    reports_dir.mkdir()
+
+    original_finding = {
+        "severity": "confirmed_bug",
+        "step_group": "implement",
+        "summary": "Bug in foo",
+    }
+    dispatch_a = {
+        "kitchen_id": "campaign-1",
+        "dispatch_id": "dispatch-a",
+        "findings": [original_finding],
+    }
+
+    (reports_dir / "dispatch-a_health_report.json").write_text(json.dumps(dispatch_a))
+
+    result = consolidate_health_reports(diagnostics_log_dir=str(tmp_path), kitchen_id="campaign-1")
+
+    # Verify the original finding dict was not mutated (no dispatch_id key added)
+    assert "dispatch_id" not in original_finding
+    # Verify the result has the dispatch_id in findings
+    assert "dispatch-a" in result["summary"]


### PR DESCRIPTION
## Summary

Pipeline health diagnostics run as terminal recipe steps in L2 food trucks but their output is trapped inside `run_skill` return values — never surfacing to the L3 campaign dispatcher or the human operator. This plan adds three capabilities:

1. **Ingredient injection** — Three new hidden ingredients (`is_fleet_dispatch`, `dispatch_id`, `diagnostics_log_dir`) auto-injected into recipe sessions, enabling the diagnostic skill to know whether it's in a fleet context and where to write files.
2. **File-based report persistence** — The `analyze-pipeline-health` skill writes a structured JSON report to `{diagnostics_log_dir}/health-reports/{dispatch_id}_health_report.json` when running inside a food truck, persisting the report outside the clone filesystem.
3. **L3 consolidation dispatch** — A new `consolidate-health-reports` food truck recipe reads all per-dispatch reports for the campaign, aggregates them, and emits the summary via L3 sentinel so it surfaces to the human session.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

| File | Resolution |
|------|------------|
| — | No conflicts resolved |

Closes #3029

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-094356-968014/.autoskillit/temp/make-plan/propagate_health_diagnostics_plan_2026-05-26_100600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.4k | 31.2k | 1.7M | 138.0k | 270 | 110.0k | 18m 9s |
| verify | claude-sonnet-4-6 | 1 | 76 | 10.5k | 317.9k | 102.3k | 112 | 39.5k | 5m 48s |
| implement* | MiniMax-M2.7-highspeed | 1 | 8.6M | 38.6k | 3.9M | 30.7k | 269 | 15.9k | 26m 56s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 107.7k | 4.7k | 215.1k | 30.7k | 21 | 43.2k | 1m 30s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 61.6k | 2.4k | 242.9k | 30.7k | 18 | 15.2k | 1m 0s |
| review_pr | claude-sonnet-4-6 | 2 | 268 | 43.8k | 1.1M | 169.5k | 307 | 109.4k | 18m 16s |
| resolve_review | claude-sonnet-4-6 | 2 | 682 | 50.4k | 5.5M | 94.7k | 272 | 164.2k | 26m 16s |
| **Total** | | | 8.8M | 181.4k | 13.1M | 169.5k | | 497.4k | 1h 37m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 6267 | 627.2 | 2.5 | 6.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **6267** | 2096.6 | 79.4 | 28.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 2.5k | 135.8k | 8.8M | 423.1k | 1h 8m |
| MiniMax-M2.7-highspeed | 3 | 8.8M | 45.6k | 4.4M | 74.3k | 29m 27s |