### PR TITLE
Wire Codex session log discovery and permanent storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ generic_automation_mcp/
 **Session diagnostics logs** — per-backend log paths and session identification:
 
 - **Claude Code**: Logs live at `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Override with `linux_tracing.log_dir`. Session directories are named by the agent session ID when available (resolved from stdout or, for Claude Code backends, from the session JSONL filename via Channel B (the JSONL side-channel stream)). Fallback: `no_session_{timestamp}`. Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`.
-- **Codex**: Session log discovery is not yet wired (`CodexSessionLocator` returns `None`; `session_record_types` is empty). The `thread_id` (from the `thread.started` NDJSON event) is the canonical session identifier for Codex backends.
+- **Codex**: Session log discovery uses `CodexSessionLocator` which searches `rollout-*.jsonl` files in `default_log_dir()/codex-sessions/` (permanent storage) and `$CODEX_HOME/sessions/` (ephemeral), matching by `thread_id` from the `thread.started` NDJSON event. Session logs are preserved via a symlink from the ephemeral `$CODEX_HOME/sessions/` to permanent storage during `init_session()`.
 
 **Import layer vs. orchestration level — disambiguation table:**
 
@@ -117,4 +117,4 @@ generic_automation_mcp/
 **Per-backend session identification:**
 
 - **Claude Code**: Session directories are named by the agent session ID (resolved from stdout or from the session JSONL filename via Channel B). Fallback: `no_session_{timestamp}`.
-- **Codex**: The canonical session identifier is the `thread_id` from the `thread.started` NDJSON event. `CodexSessionLocator` returns `None`; `session_record_types` is empty (log discovery not yet wired).
+- **Codex**: The canonical session identifier is the `thread_id` from the `thread.started` NDJSON event, extracted by `CodexStreamParser`. `CodexSessionLocator` searches `rollout-*.jsonl` files in permanent storage (`codex-sessions/`) and ephemeral `$CODEX_HOME/sessions/`. Logs are registered in `sessions.jsonl` via the `codex_log` field.

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -59,6 +59,7 @@ from .paths import is_generated_path as is_generated_path
 from .paths import is_git_main_checkout as is_git_main_checkout
 from .paths import is_git_worktree as is_git_worktree
 from .paths import pkg_root as pkg_root
+from .paths import default_log_dir as default_log_dir
 from .paths import resolve_main_worktree as resolve_main_worktree
 from .runtime._linux_proc import is_session_alive as is_session_alive
 from .runtime._linux_proc import read_boot_id as read_boot_id

--- a/src/autoskillit/core/paths.py
+++ b/src/autoskillit/core/paths.py
@@ -14,8 +14,23 @@ Design rationale:
 from __future__ import annotations
 
 import importlib.resources as ir
+import os
 import subprocess
+import sys
 from pathlib import Path
+
+
+def default_log_dir() -> Path:
+    """Platform-default session diagnostics log directory (XDG-aware).
+
+    Linux: $XDG_DATA_HOME/autoskillit/logs (fallback ~/.local/share/autoskillit/logs)
+    macOS: ~/Library/Application Support/autoskillit/logs
+    """
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "autoskillit" / "logs"
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return base / "autoskillit" / "logs"
 
 
 def pkg_root() -> Path:

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -460,6 +460,7 @@ class SessionIndexEntry(TypedDict):
     campaign_id: str
     dispatch_id: str
     claude_code_log: str
+    codex_log: str | None  # path to Codex rollout NDJSON, or None for non-Codex sessions
     skill_command: str
     success: bool
     subtype: str

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -116,37 +116,113 @@ class CodexSessionLocator:
     def locate_session(self, session_id: str, codex_home: Path | None = None) -> Path | None:
         if not session_id or session_id.startswith(("no_session_", "crashed_")):
             return None
+
+        from autoskillit.core.paths import default_log_dir
+
+        candidates: list[Path] = []
+        # 1. Permanent storage (symlink target) — checked first because
+        #    ephemeral CODEX_HOME may be cleaned up by the time we search
+        candidates.append(default_log_dir() / "codex-sessions")
+        # 2. Explicit codex_home or CODEX_HOME env var
         if codex_home is not None:
-            sessions_dir = codex_home / "sessions"
+            candidates.append(codex_home / "sessions")
         else:
             env_home = os.environ.get("CODEX_HOME")
             if env_home:
-                sessions_dir = Path(env_home) / "sessions"
-            else:
-                sessions_dir = Path.home() / ".codex" / "sessions"
-        if not sessions_dir.exists():
-            return None
-        for year_dir in sessions_dir.iterdir():
-            if not year_dir.is_dir():
+                candidates.append(Path(env_home) / "sessions")
+        # 3. Default Codex home (~/.codex/sessions/)
+        candidates.append(Path.home() / ".codex" / "sessions")
+
+        seen: set[str] = set()
+        for candidate in candidates:
+            try:
+                resolved = str(candidate.resolve()) if candidate.exists() else str(candidate)
+            except OSError:
                 continue
-            for month_dir in year_dir.iterdir():
-                if not month_dir.is_dir():
-                    continue
-                for day_dir in month_dir.iterdir():
-                    if not day_dir.is_dir():
-                        continue
-                    for entry in day_dir.iterdir():
-                        if entry.is_file() and entry.name == f"{session_id}.jsonl.zst":
-                            return entry
+            if resolved in seen or not candidate.exists():
+                continue
+            seen.add(resolved)
+            result = self._search_tree(candidate, session_id)
+            if result is not None:
+                return result
         return None
 
-    def read_session(self, path: Path) -> list[dict]:
+    def _search_tree(self, sessions_dir: Path, thread_id: str) -> Path | None:
+        """Walk YYYY/MM/DD/ date tree for rollout-*.jsonl matching thread_id."""
         try:
-            raw = path.read_bytes()
-            decompressed = zstandard.ZstdDecompressor().decompress(raw)
-            text = decompressed.decode("utf-8")
+            year_dirs = sorted(sessions_dir.iterdir(), reverse=True)
+        except OSError:
+            return None
+        for year_dir in year_dirs:
+            if not year_dir.is_dir():
+                continue
+            try:
+                month_dirs = sorted(year_dir.iterdir(), reverse=True)
+            except OSError:
+                continue
+            for month_dir in month_dirs:
+                if not month_dir.is_dir():
+                    continue
+                try:
+                    day_dirs = sorted(month_dir.iterdir(), reverse=True)
+                except OSError:
+                    continue
+                for day_dir in day_dirs:
+                    if not day_dir.is_dir():
+                        continue
+                    try:
+                        entries = list(day_dir.iterdir())
+                    except OSError:
+                        continue
+                    for entry in entries:
+                        if (
+                            entry.is_file()
+                            and entry.name.startswith("rollout-")
+                            and entry.name.endswith(".jsonl")
+                        ):
+                            if self._file_matches_thread(entry, thread_id):
+                                return entry
+        return None
+
+    @staticmethod
+    def _file_matches_thread(path: Path, thread_id: str) -> bool:
+        """Check if a rollout NDJSON file's thread.started event matches thread_id.
+
+        Only reads until the first parseable NDJSON object — thread.started is
+        always the first event in a Codex rollout file.
+        """
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        return False
+                    if isinstance(obj, dict) and obj.get("type") == "thread.started":
+                        return obj.get("thread_id", "") == thread_id
+                    return False
+        except OSError:
+            return False
+        return False
+
+    def read_session(self, path: Path) -> list[dict]:
+        """Read and parse a Codex session log file.
+
+        Handles both plain .jsonl (current Codex v0.133.0+) and
+        .jsonl.zst (legacy) formats based on file extension.
+        """
+        try:
+            if path.name.endswith(".zst"):
+                raw = path.read_bytes()
+                decompressed = zstandard.ZstdDecompressor().decompress(raw)
+                text = decompressed.decode("utf-8")
+            else:
+                text = path.read_text(encoding="utf-8")
         except Exception:
-            logger.warning("read_session: failed to decompress", path=str(path), exc_info=True)
+            logger.warning("read_session: failed to read", path=str(path), exc_info=True)
             return []
         result: list[dict] = []
         for line in text.splitlines():
@@ -180,7 +256,7 @@ class CodexBackend:
             mcp_config_capable=True,
             food_truck_capable=True,
             completion_record_types=frozenset({"turn.completed", "turn.failed", "error"}),
-            session_record_types=frozenset(),
+            session_record_types=frozenset({"item.completed"}),
         )
 
     def build_cmd(self, skill_command: str, cwd: str) -> CmdSpec:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -30,6 +30,7 @@ from autoskillit.core import (
     SessionCheckpoint,
     SkillSessionConfig,
     ValidatedAddDir,
+    default_log_dir,
     extract_skill_name,
     get_logger,
 )
@@ -116,8 +117,6 @@ class CodexSessionLocator:
     def locate_session(self, session_id: str, codex_home: Path | None = None) -> Path | None:
         if not session_id or session_id.startswith(("no_session_", "crashed_")):
             return None
-
-        from autoskillit.core.paths import default_log_dir
 
         candidates: list[Path] = []
         # 1. Permanent storage (symlink target) — checked first because

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, cast
 import anyio
 
 from autoskillit.core import (
+    AGENT_BACKEND_CODEX,
     CAMPAIGN_ID_ENV_VAR,
     DISPATCH_ID_ENV_VAR,
     CmdSpec,
@@ -421,6 +422,15 @@ async def _execute_claude_headless(
     ):
         from autoskillit.execution.session_log import flush_session_log
 
+        _codex_log: Path | None = None
+        if _step_backend.name == AGENT_BACKEND_CODEX and skill_result.session_id:
+            try:
+                _codex_log = _step_backend.session_locator().locate_session(
+                    skill_result.session_id
+                )
+            except Exception:
+                logger.debug("codex_session_locate_failed", exc_info=True)
+
         try:
             flush_session_log(
                 log_dir=ctx.config.linux_tracing.log_dir,
@@ -486,6 +496,7 @@ async def _execute_claude_headless(
                 ),
                 max_sessions=ctx.config.linux_tracing.max_sessions,
                 is_resume="--resume" in spec.cmd,
+                codex_log_path=_codex_log,
             )
         except Exception:
             logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 from autoskillit.core import (
     atomic_write,
     claude_code_log_path,
+    default_log_dir,
     get_logger,
     iter_merged_assistant_turns,
     write_versioned_json,
@@ -58,8 +59,6 @@ def resolve_log_dir(log_dir: str) -> Path:
     """Resolve session log directory. Empty string = platform default."""
     if log_dir:
         return Path(log_dir).expanduser()
-    from autoskillit.core.paths import default_log_dir
-
     return default_log_dir()
 
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -9,9 +9,7 @@ provides quick scanning across all sessions.
 from __future__ import annotations
 
 import json
-import os
 import shutil
-import sys
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -60,11 +58,9 @@ def resolve_log_dir(log_dir: str) -> Path:
     """Resolve session log directory. Empty string = platform default."""
     if log_dir:
         return Path(log_dir).expanduser()
-    if sys.platform == "darwin":
-        return Path.home() / "Library" / "Application Support" / "autoskillit" / "logs"
-    xdg = os.environ.get("XDG_DATA_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
-    return base / "autoskillit" / "logs"
+    from autoskillit.core.paths import default_log_dir
+
+    return default_log_dir()
 
 
 def write_telemetry_clear_marker(log_root: Path) -> None:
@@ -154,6 +150,7 @@ def flush_session_log(
     model_identifier: str = "",
     max_sessions: int | None = None,
     is_resume: bool = False,
+    codex_log_path: Path | None = None,
     telemetry: SessionTelemetry,
 ) -> None:
     """Flush session diagnostics to disk.
@@ -183,8 +180,12 @@ def flush_session_log(
     else:
         dir_name = f"no_session_{start_ts.replace(':', '-')}"
 
-    cc_log = claude_code_log_path(cwd, session_id)
-    cc_log_str: str | None = str(cc_log) if cc_log else None
+    if codex_log_path is not None:
+        cc_log = None
+        cc_log_str = None
+    else:
+        cc_log = claude_code_log_path(cwd, session_id)
+        cc_log_str = str(cc_log) if cc_log else None
 
     if cc_log and not cc_log.exists():
         logger.warning("claude_code_log_not_found", path=cc_log_str, session_id=session_id)
@@ -471,6 +472,7 @@ def flush_session_log(
         "campaign_id": campaign_id,
         "dispatch_id": dispatch_id,
         "claude_code_log": cc_log_str,
+        "codex_log": str(codex_log_path) if codex_log_path else None,
         "skill_command": skill_command[:100],
         "success": success,
         "subtype": subtype,

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -26,6 +26,7 @@ from autoskillit.core import (
     SkillSource,
     ValidatedAddDir,
     atomic_write,
+    default_log_dir,
     get_logger,
     is_feature_enabled,
     pkg_root,
@@ -540,9 +541,7 @@ class DefaultSessionSkillManager:
             if env_source.exists():
                 shutil.copy2(env_source, session_skills_dir / ".env")
                 logger.debug("codex_env_copy", src=str(env_source))
-            sessions_target = (
-                Path.home() / ".local" / "share" / "autoskillit" / "logs" / "codex-sessions"
-            )
+            sessions_target = default_log_dir() / "codex-sessions"
             sessions_target.mkdir(parents=True, exist_ok=True)
             sessions_link = session_skills_dir / "sessions"
             try:

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -157,3 +157,28 @@ class TestPkgRoot:
         assert result.name == "autoskillit", (
             "pkg_root() must return the autoskillit package directory"
         )
+
+
+class TestDefaultLogDir:
+    def test_linux_no_xdg(self, monkeypatch):
+        monkeypatch.setattr("autoskillit.core.paths.sys.platform", "linux")
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        from autoskillit.core.paths import default_log_dir
+
+        result = default_log_dir()
+        assert result == Path.home() / ".local" / "share" / "autoskillit" / "logs"
+
+    def test_linux_xdg_override(self, monkeypatch):
+        monkeypatch.setattr("autoskillit.core.paths.sys.platform", "linux")
+        monkeypatch.setenv("XDG_DATA_HOME", "/custom/xdg")
+        from autoskillit.core.paths import default_log_dir
+
+        result = default_log_dir()
+        assert result == Path("/custom/xdg/autoskillit/logs")
+
+    def test_darwin(self, monkeypatch):
+        monkeypatch.setattr("autoskillit.core.paths.sys.platform", "darwin")
+        from autoskillit.core.paths import default_log_dir
+
+        result = default_log_dir()
+        assert result == Path.home() / "Library" / "Application Support" / "autoskillit" / "logs"

--- a/tests/core/test_session_index_schema.py
+++ b/tests/core/test_session_index_schema.py
@@ -21,6 +21,7 @@ _REQUIRED_INDEX_FIELDS = {
     "api_retry_count",
     "api_retry_exhausted",
     "codex_version",
+    "codex_log",
 }
 
 

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -99,8 +99,8 @@ class TestCodexBackend:
         expected = frozenset({"turn.completed", "turn.failed", "error"})
         assert CodexBackend().capabilities.completion_record_types == expected
 
-    def test_capabilities_session_record_types_empty(self) -> None:
-        assert CodexBackend().capabilities.session_record_types == frozenset()
+    def test_capabilities_session_record_types(self) -> None:
+        assert CodexBackend().capabilities.session_record_types == frozenset({"item.completed"})
 
     def test_capabilities_food_truck_true(self) -> None:
         assert CodexBackend().capabilities.food_truck_capable is True
@@ -285,8 +285,8 @@ class TestCodexBackendProtocol:
             {"turn.completed", "turn.failed", "error"}
         )
 
-    def test_session_record_types_empty(self) -> None:
-        assert CodexBackend().capabilities.session_record_types == frozenset()
+    def test_session_record_types(self) -> None:
+        assert CodexBackend().capabilities.session_record_types == frozenset({"item.completed"})
 
 
 class TestCodexHeadlessCmd:

--- a/tests/execution/backends/test_codex_session_locator.py
+++ b/tests/execution/backends/test_codex_session_locator.py
@@ -13,63 +13,78 @@ from autoskillit.execution.backends.codex import CodexSessionLocator
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
+def _make_rollout(
+    parent: Path, thread_id: str, name: str = "rollout-2026-05-26T07-30-33-abc.jsonl"
+) -> Path:
+    """Helper: create a rollout NDJSON file with thread.started event."""
+    f = parent / name
+    f.write_text(
+        f'{{"type":"thread.started","thread_id":"{thread_id}"}}\n{{"type":"turn.completed"}}\n'
+    )
+    return f
+
+
 class TestCodexSessionLocator:
-    def test_locate_session_finds_file_via_explicit_codex_home(self, tmp_path: Path) -> None:
-        session_dir = tmp_path / "sessions" / "2025" / "05" / "24"
+    def test_locate_session_finds_rollout_by_thread_id(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "sessions" / "2026" / "05" / "26"
         session_dir.mkdir(parents=True)
-        session_file = session_dir / "thread_abc123.jsonl.zst"
-        session_file.write_bytes(b"fake zstd content")
-
+        rollout = _make_rollout(session_dir, "tid_abc123")
         locator = CodexSessionLocator()
-        result = locator.locate_session("thread_abc123", codex_home=tmp_path)
+        result = locator.locate_session("tid_abc123", codex_home=tmp_path)
+        assert result == rollout
 
-        assert result == session_file
+    def test_locate_session_skips_non_matching_thread_id(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "sessions" / "2026" / "05" / "26"
+        session_dir.mkdir(parents=True)
+        _make_rollout(session_dir, "tid_other")
+        locator = CodexSessionLocator()
+        assert locator.locate_session("tid_wanted") is None
 
-    def test_locate_session_finds_file_via_home_fallback(
+    def test_locate_session_searches_permanent_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        perm_dir = tmp_path / "logs" / "codex-sessions" / "2026" / "05" / "26"
+        perm_dir.mkdir(parents=True)
+        rollout = _make_rollout(perm_dir, "tid_perm")
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.default_log_dir", lambda: tmp_path / "logs"
+        )
+        locator = CodexSessionLocator()
+        result = locator.locate_session("tid_perm")
+        assert result == rollout
+
+    def test_locate_via_home_fallback(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-
-        codex_sessions = tmp_path / ".codex" / "sessions" / "2025" / "05" / "24"
-        codex_sessions.mkdir(parents=True)
-        session_file = codex_sessions / "thread_xyz789.jsonl.zst"
-        session_file.write_bytes(b"fake zstd content")
-
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.default_log_dir",
+            lambda: tmp_path / "nonexistent_logs",
+        )
+        session_dir = tmp_path / ".codex" / "sessions" / "2026" / "05" / "26"
+        session_dir.mkdir(parents=True)
+        rollout = _make_rollout(session_dir, "tid_home")
         locator = CodexSessionLocator()
-        result = locator.locate_session("thread_xyz789")
+        result = locator.locate_session("tid_home")
+        assert result == rollout
 
-        assert result == session_file
-
-    def test_locate_session_finds_file_via_env_var(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_locate_via_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.default_log_dir",
+            lambda: tmp_path / "nonexistent_logs",
+        )
         monkeypatch.delenv("CODEX_HOME", raising=False)
         monkeypatch.setenv("CODEX_HOME", str(tmp_path))
-
-        sessions_dir = tmp_path / "sessions" / "2025" / "05" / "24"
-        sessions_dir.mkdir(parents=True)
-        session_file = sessions_dir / "thread_env123.jsonl.zst"
-        session_file.write_bytes(b"fake zstd content")
-
-        locator = CodexSessionLocator()
-        result = locator.locate_session("thread_env123")
-
-        assert result == session_file
-
-    def test_locate_session_returns_none_for_missing_thread_id(self, tmp_path: Path) -> None:
-        session_dir = tmp_path / "sessions" / "2025" / "05" / "24"
+        session_dir = tmp_path / "sessions" / "2026" / "05" / "26"
         session_dir.mkdir(parents=True)
-        (session_dir / "other_id.jsonl.zst").write_bytes(b"content")
-
+        rollout = _make_rollout(session_dir, "tid_env")
         locator = CodexSessionLocator()
-        result = locator.locate_session("nonexistent")
-
-        assert result is None
+        result = locator.locate_session("tid_env")
+        assert result == rollout
 
     def test_locate_session_returns_none_for_empty_id(self) -> None:
         locator = CodexSessionLocator()
         result = locator.locate_session("")
-
         assert result is None
 
     def test_locate_session_returns_none_for_fallback_prefix_ids(self) -> None:
@@ -80,8 +95,68 @@ class TestCodexSessionLocator:
     def test_locate_session_returns_none_when_sessions_dir_absent(self, tmp_path: Path) -> None:
         locator = CodexSessionLocator()
         result = locator.locate_session("any_id", codex_home=tmp_path)
-
         assert result is None
+
+    def test_codex_home_priority_over_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env_path = tmp_path / "env_sessions"
+        env_path.mkdir(parents=True)
+        env_session_dir = env_path / "sessions" / "2026" / "05" / "26"
+        env_session_dir.mkdir(parents=True)
+        _make_rollout(env_session_dir, "tid_priority", "rollout-env.jsonl")
+
+        param_path = tmp_path / "param_sessions"
+        param_path.mkdir(parents=True)
+        param_session_dir = param_path / "sessions" / "2026" / "05" / "26"
+        param_session_dir.mkdir(parents=True)
+        rollout = _make_rollout(param_session_dir, "tid_priority", "rollout-param.jsonl")
+
+        monkeypatch.setenv("CODEX_HOME", str(env_path))
+
+        locator = CodexSessionLocator()
+        result = locator.locate_session("tid_priority", codex_home=param_path)
+
+        assert result == rollout
+
+    def test_read_session_handles_plain_jsonl(self, tmp_path: Path) -> None:
+        f = tmp_path / "rollout.jsonl"
+        f.write_text('{"valid": true}\n{"also": "valid"}\n')
+        locator = CodexSessionLocator()
+        result = locator.read_session(f)
+        assert len(result) == 2
+        assert result[0] == {"valid": True}
+
+    def test_read_session_handles_zstd_fallback(self, tmp_path: Path) -> None:
+        raw = zstandard.ZstdCompressor().compress(b'{"legacy": true}\n')
+        f = tmp_path / "session.jsonl.zst"
+        f.write_bytes(raw)
+        locator = CodexSessionLocator()
+        result = locator.read_session(f)
+        assert result == [{"legacy": True}]
+
+    def test_read_session_returns_empty_list_for_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.jsonl"
+        f.write_text("")
+        locator = CodexSessionLocator()
+        result = locator.read_session(f)
+        assert result == []
+
+    def test_read_session_handles_corrupt_data_gracefully(self, tmp_path: Path) -> None:
+        f = tmp_path / "corrupt.jsonl"
+        f.write_bytes(b"not valid data")
+        locator = CodexSessionLocator()
+        result = locator.read_session(f)
+        assert result == []
+
+    def test_read_session_skips_malformed_json_lines(self, tmp_path: Path) -> None:
+        f = tmp_path / "mixed.jsonl"
+        f.write_text('{"valid": true}\nnot json at all\n{"also": "valid"}\n')
+        locator = CodexSessionLocator()
+        result = locator.read_session(f)
+        assert len(result) == 2
+        assert result[0] == {"valid": True}
+        assert result[1] == {"also": "valid"}
 
     def test_read_session_decompresses_and_parses_ndjson(self, tmp_path: Path) -> None:
         ndjson_lines = [
@@ -91,73 +166,21 @@ class TestCodexSessionLocator:
         raw_data = zstandard.ZstdCompressor().compress("\n".join(ndjson_lines).encode("utf-8"))
         session_file = tmp_path / "session.jsonl.zst"
         session_file.write_bytes(raw_data)
-
         locator = CodexSessionLocator()
         result = locator.read_session(session_file)
-
         assert len(result) == 2
         assert result[0] == {"turn": 1, "content": "hello"}
         assert result[1] == {"turn": 2, "content": "world"}
 
-    def test_read_session_returns_empty_list_for_empty_file(self, tmp_path: Path) -> None:
-        raw_data = zstandard.ZstdCompressor().compress(b"")
-        session_file = tmp_path / "empty.jsonl.zst"
-        session_file.write_bytes(raw_data)
-
-        locator = CodexSessionLocator()
-        result = locator.read_session(session_file)
-
-        assert result == []
-
-    def test_read_session_handles_corrupt_data_gracefully(self, tmp_path: Path) -> None:
-        session_file = tmp_path / "corrupt.jsonl.zst"
-        session_file.write_bytes(b"not zstandard data")
-
-        locator = CodexSessionLocator()
-        result = locator.read_session(session_file)
-
-        assert result == []
-
-    def test_read_session_skips_malformed_json_lines(self, tmp_path: Path) -> None:
-        ndjson_lines = [
-            '{"valid": true}',
-            "not json at all",
-            '{"also": "valid"}',
-        ]
-        raw_data = zstandard.ZstdCompressor().compress("\n".join(ndjson_lines).encode("utf-8"))
-        session_file = tmp_path / "mixed.jsonl.zst"
-        session_file.write_bytes(raw_data)
-
-        locator = CodexSessionLocator()
-        result = locator.read_session(session_file)
-
-        assert len(result) == 2
-        assert result[0] == {"valid": True}
-        assert result[1] == {"also": "valid"}
-
     def test_isinstance_session_locator(self) -> None:
         assert isinstance(CodexSessionLocator(), SessionLocator)
 
-    def test_codex_home_priority_over_env_var(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        env_path = tmp_path / "env_sessions"
-        env_path.mkdir(parents=True)
-        env_session = env_path / "sessions" / "2025" / "05" / "24" / "thread_priority.jsonl.zst"
-        env_session.parent.mkdir(parents=True)
-        env_session.write_bytes(b"env content")
+    def test_file_matches_thread_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.jsonl"
+        f.write_text("")
+        assert CodexSessionLocator._file_matches_thread(f, "any") is False
 
-        param_path = tmp_path / "param_sessions"
-        param_path.mkdir(parents=True)
-        param_session = (
-            param_path / "sessions" / "2025" / "05" / "24" / "thread_priority.jsonl.zst"
-        )
-        param_session.parent.mkdir(parents=True)
-        param_session.write_bytes(b"param content")
-
-        monkeypatch.setenv("CODEX_HOME", str(env_path))
-
-        locator = CodexSessionLocator()
-        result = locator.locate_session("thread_priority", codex_home=param_path)
-
-        assert result == param_session
+    def test_file_matches_thread_no_thread_started(self, tmp_path: Path) -> None:
+        f = tmp_path / "no_start.jsonl"
+        f.write_text('{"type":"turn.completed"}\n')
+        assert CodexSessionLocator._file_matches_thread(f, "any") is False

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -346,9 +346,12 @@ class TestChannelBFullPipelineAdjudication:
         - completion_drain_timeout=0.5s: the heartbeat has already seen the empty result
           and failed to confirm by the time Channel B fires (~1s after task group start),
           so 0.5s of additional drain time is more than sufficient semantically.
-        - timeout=120s: guards against the outer wall-clock expiring under xdist -n 4 load.
-          _phase1_timeout=250 must exceed outer timeout so Phase 1 never fires STALE before
+        - timeout=180s: guards against the outer wall-clock expiring under xdist -n 4 load.
+          _phase1_timeout=360 must exceed outer timeout so Phase 1 never fires STALE before
           the outer guard when subprocess startup is slow under WSL2 + xdist load.
+        - _session_id_timeout=5.0s: Python startup under WSL2 + xdist -n 4 heavy load
+          can take several seconds; generous timeout prevents session monitor from missing
+          the session ID and failing to watch the JSONL file.
         """
         from autoskillit.execution.headless import _build_skill_result
 
@@ -360,16 +363,16 @@ class TestChannelBFullPipelineAdjudication:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=120,
+            timeout=180,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=0.5,
             natural_exit_grace_seconds=0.5,
-            _phase1_timeout=250,
+            _phase1_timeout=360,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
-            _session_id_timeout=0.5,
+            _session_id_timeout=5.0,
         )
         skill_result = _build_skill_result(
             result,

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -946,3 +946,73 @@ class TestApiRetryFields:
         api_retry_anomalies = [a for a in anomalies if a["kind"] == "api_retry_exhaustion"]
         assert len(api_retry_anomalies) == 1
         assert api_retry_anomalies[0]["detail"]["api_retry_count"] == 10
+
+
+class TestCodexLogFields:
+    """T5: codex_log_path parameter stores codex_log in sessions index."""
+
+    def test_flush_stores_codex_log_in_sessions_index(self, tmp_path):
+        codex_log = tmp_path / "codex-sessions" / "2026" / "05" / "26" / "rollout.jsonl"
+        codex_log.parent.mkdir(parents=True)
+        codex_log.write_text('{"type":"thread.started","thread_id":"tid"}\n')
+        flush_session_log(
+            log_dir=str(tmp_path),
+            codex_log_path=codex_log,
+            cwd="/some/worktree",
+            session_id="codex-session-001",
+            pid=12345,
+            skill_command="/autoskillit:implement",
+            success=True,
+            subtype="completed",
+            exit_code=0,
+            start_ts="2026-05-26T08:00:00",
+            proc_snapshots=None,
+            telemetry=SessionTelemetry.empty(),
+            provider_outcome=ProviderOutcome.none_used(),
+            recipe_identity=RecipeIdentity.empty(),
+        )
+        index = (tmp_path / "sessions.jsonl").read_text().strip()
+        entry = json.loads(index)
+        assert entry["codex_log"] == str(codex_log)
+        assert entry["claude_code_log"] is None
+
+    def test_flush_codex_log_null_when_not_provided(self, tmp_path):
+        flush_session_log(
+            log_dir=str(tmp_path),
+            cwd="/some/worktree",
+            session_id="cc-session-001",
+            pid=12345,
+            skill_command="/autoskillit:implement",
+            success=True,
+            subtype="completed",
+            exit_code=0,
+            start_ts="2026-05-26T08:00:00",
+            proc_snapshots=None,
+            telemetry=SessionTelemetry.empty(),
+            provider_outcome=ProviderOutcome.none_used(),
+            recipe_identity=RecipeIdentity.empty(),
+        )
+        index = (tmp_path / "sessions.jsonl").read_text().strip()
+        entry = json.loads(index)
+        assert entry["codex_log"] is None
+
+    def test_flush_codex_log_skips_claude_code_log_not_found_warning(self, tmp_path, caplog):
+        codex_log = tmp_path / "rollout.jsonl"
+        codex_log.write_text('{"type":"thread.started","thread_id":"tid"}\n')
+        flush_session_log(
+            log_dir=str(tmp_path),
+            codex_log_path=codex_log,
+            cwd="/some/worktree",
+            session_id="codex-session-002",
+            pid=12345,
+            skill_command="/autoskillit:implement",
+            success=True,
+            subtype="completed",
+            exit_code=0,
+            start_ts="2026-05-26T08:00:00",
+            proc_snapshots=None,
+            telemetry=SessionTelemetry.empty(),
+            provider_outcome=ProviderOutcome.none_used(),
+            recipe_identity=RecipeIdentity.empty(),
+        )
+        assert "claude_code_log_not_found" not in caplog.text

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -243,7 +243,7 @@ def test_flush_session_log_retention_purges_oldest(tmp_path):
 
 def test_resolve_log_dir_default_linux(monkeypatch):
     """Empty log_dir on Linux (no XDG_DATA_HOME) uses ~/.local/share/autoskillit/logs."""
-    monkeypatch.setattr("autoskillit.execution.session_log.sys.platform", "linux")
+    monkeypatch.setattr("autoskillit.core.paths.sys.platform", "linux")
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     result = resolve_log_dir("")
     assert result == Path.home() / ".local" / "share" / "autoskillit" / "logs"
@@ -251,7 +251,7 @@ def test_resolve_log_dir_default_linux(monkeypatch):
 
 def test_resolve_log_dir_xdg_override(monkeypatch):
     """XDG_DATA_HOME override is respected."""
-    monkeypatch.setattr("autoskillit.execution.session_log.sys.platform", "linux")
+    monkeypatch.setattr("autoskillit.core.paths.sys.platform", "linux")
     monkeypatch.setenv("XDG_DATA_HOME", "/custom/xdg")
     result = resolve_log_dir("")
     assert result == Path("/custom/xdg/autoskillit/logs")

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -140,3 +140,17 @@ def test_claude_backend_still_uses_dot_claude_layout(make_session_skill_manager)
     skill_files = list((session_path / _SKILLS_SUBDIR).glob("*/SKILL.md"))
     assert len(skill_files) > 0
     assert not (session_path / CODEX_SKILLS_SUBDIR).exists()
+
+
+def test_codex_init_session_sessions_symlink_respects_xdg(
+    make_session_skill_manager, codex_env, monkeypatch, tmp_path
+):
+    xdg_dir = tmp_path / "custom_xdg"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_dir))
+    mgr = make_session_skill_manager()
+    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+    sessions_link = session_path / "sessions"
+    assert sessions_link.is_symlink()
+    target = sessions_link.resolve()
+    expected = xdg_dir / "autoskillit" / "logs" / "codex-sessions"
+    assert target == expected


### PR DESCRIPTION
## Summary

Fix three compound issues preventing Codex session log discovery and permanent storage:

1. **Filename pattern mismatch**: `CodexSessionLocator` searches for `{thread_id}.jsonl.zst` but Codex v0.133.0 writes `rollout-{timestamp}-{UUID}.jsonl` (plain, uncompressed). Rewrite the locator to search by `rollout-*.jsonl` pattern and match by scanning NDJSON for the `thread.started` event containing the target `thread_id`.

2. **XDG-compliance for symlink target**: `init_session()` already creates the `sessions → codex-sessions` symlink, but hardcodes `~/.local/share/autoskillit/logs/codex-sessions` instead of respecting `XDG_DATA_HOME`. Extract `default_log_dir()` to `core/paths.py` (IL-0) so both `workspace` and `execution` can share the resolution logic without violating import layer contracts.

3. **Missing `flush_session_log` integration**: After a Codex session completes, the rollout file path is not registered in `sessions.jsonl`. Add a `codex_log_path` parameter to `flush_session_log()` and wire the locator call in `_headless_execute.py`.

Additionally, update `session_record_types` from `frozenset()` to `frozenset({"item.completed"})` to document which Codex event types carry assistant content.

## Requirements

## Problem

Codex session log discovery is completely non-functional. Two independent issues compound:

1. **`CodexSessionLocator` searches for the wrong filename format** — It looks for `{thread_id}.jsonl.zst` but Codex v0.133.0 actually writes `rollout-{ISO-timestamp}-{UUID}.jsonl` (uncompressed). Zero sessions will ever be found.

2. **`CODEX_HOME` override causes session logs to land in ephemeral tmpfs** — When `CODEX_HOME` is set to `/dev/shm/autoskillit-sessions/<id>/` (required for skill isolation per #3035), Codex writes session logs to `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`. This data is lost when the ephemeral dir is cleaned up.

## Fix

### Part 1: Permanent session log storage via `sessions/` symlink

During `init_session()` when `_is_codex=True`, create `<session_dir>/sessions` as a symlink to a permanent location.

### Part 2: Fix `CodexSessionLocator` filename pattern

Update `locate_session()` to search for `rollout-*.jsonl` files and match by scanning NDJSON for `thread.started` event.

### Part 3: Wire `session_record_types`

Populate `session_record_types` on `CodexBackend`.

### Part 4: Integrate with `flush_session_log()`

After a Codex session completes, scan the permanent directory and register in `sessions.jsonl`.

## Conflict Resolution Table

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-121705-614125/.autoskillit/temp/make-plan/wire_codex_session_log_discovery_plan_2026-05-26_123000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 5.6k | 40.0k | 2.9M | 132.1k | 239 | 127.6k | 19m 50s |
| verify | claude-sonnet-4-6 | 1 | 108 | 15.5k | 548.9k | 58.3k | 94 | 75.4k | 9m 35s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.4M | 17.4k | 1.4M | 30.7k | 118 | 43.8k | 5m 57s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 116.3k | 4.0k | 251.2k | 36.1k | 23 | 57.4k | 1m 28s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 107.7k | 2.6k | 273.6k | 30.7k | 25 | 15.3k | 56s |
| review_pr | claude-sonnet-4-6 | 2 | 320 | 89.8k | 1.4M | 94.2k | 92 | 171.7k | 22m 0s |
| resolve_review | claude-sonnet-4-6 | 2 | 690 | 46.4k | 5.0M | 83.3k | 264 | 193.2k | 28m 43s |
| **Total** | | | 2.6M | 215.6k | 11.8M | 132.1k | | 684.5k | 1h 28m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 488 | 2771.7 | 89.7 | 35.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **488** | 24103.9 | 1402.8 | 441.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 6.8k | 191.7k | 9.9M | 568.0k | 1h 20m |
| MiniMax-M2.7-highspeed | 3 | 2.6M | 23.9k | 1.9M | 116.5k | 8m 22s |