### PR TITLE
Create eval-agent Wrapper Skill for Isolated Subagent Evaluation

### DIFF
--- a/.autoskillit/recipes/eval/agent-eval.yaml
+++ b/.autoskillit/recipes/eval/agent-eval.yaml
@@ -115,7 +115,7 @@ steps:
             run_cmd cp {agent_file} {inputs.source_dir}/src/autoskillit/agents/{agent_name}-eval-{variant_id}.md
 
          d. Run the eval-agent wrapper:
-            run_skill /autoskillit:eval-agent --agent-name {agent_name}-eval-{variant_id} --prompt-file {eval_run_dir}/{canary_id}/resolved_prompt.txt
+            run_skill /eval-agent --agent-name {agent_name}-eval-{variant_id} --prompt-file {eval_run_dir}/{canary_id}/resolved_prompt.txt
             cwd = inputs.source_dir
 
          e. On SUCCESS:

--- a/.autoskillit/skills/eval-agent/SKILL.md
+++ b/.autoskillit/skills/eval-agent/SKILL.md
@@ -35,7 +35,7 @@ Example invocation:
 **NEVER:**
 - Fabricate, invent, or embellish information not supported by the available evidence or code.
 - Modify any source code files
-- Use MCP tools (open_kitchen, run_skill, run_cmd, run_python) — this skill uses only native Claude Code tools
+- Use any MCP tools — this skill uses only native Claude Code tools
 - Create files outside `{{AUTOSKILLIT_TEMP}}/eval-agent/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Skip writing the output file on agent failure — always write a result

--- a/.autoskillit/skills/eval-agent/SKILL.md
+++ b/.autoskillit/skills/eval-agent/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: eval-agent
+categories: [eval]
+description: >
+  Invoke a named agent definition against a provided prompt and capture its output.
+  Execution primitive for the agent-eval recipe — isolates a single agent invocation.
+---
+
+# Eval Agent Wrapper
+
+Invokes a named agent definition against a provided prompt, captures the full response,
+and writes it to a JSON output file. Stateless — does not know about canaries, variants,
+or evaluation. Runs one agent against one prompt and captures output.
+
+## When to Use
+
+- Called by the `agent-eval` recipe for each canary x variant evaluation
+- Testing individual agent definitions in isolation
+
+## Arguments
+
+The skill receives its arguments as a single string. Parse these arguments:
+
+- `--agent-name {name}` — The agent definition name (without `autoskillit:` prefix).
+  The skill prepends `autoskillit:` when calling the Agent tool.
+- `--prompt-file {path}` — Absolute path to a file containing the prompt text.
+
+Example invocation:
+```
+/eval-agent --agent-name wp-elaborator --prompt-file /tmp/test-prompt.txt
+```
+
+## Critical Constraints
+
+**NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+- Modify any source code files
+- Use MCP tools (open_kitchen, run_skill, run_cmd, run_python) — this skill uses only native Claude Code tools
+- Create files outside `{{AUTOSKILLIT_TEMP}}/eval-agent/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
+- Skip writing the output file on agent failure — always write a result
+- Use output files as a notepad — do not add useless comments, extraneous fields, or AI-generated boilerplate to the JSON output
+
+**ALWAYS:**
+- Parse `--agent-name` and `--prompt-file` from the ARGUMENTS string
+- Read the prompt file using the Read tool
+- Invoke the agent via `Agent(subagent_type="autoskillit:{agent_name}", prompt=<file contents>)`
+- Write output JSON to `{{AUTOSKILLIT_TEMP}}/eval-agent/{agent_name}_output.json` (relative to the current working directory) using the Write tool
+- Emit `agent_output_path = <absolute_path>` as a structured output token (plain text, no markdown formatting on the token name)
+- The absolute path in the structured output token must be constructed by prepending the current working directory to the relative output path
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Extract `--agent-name` and `--prompt-file` values from the ARGUMENTS string.
+
+If either argument is missing, proceed to Step 4 (error handling) with an error message
+describing the missing argument.
+
+### Step 2: Read Prompt File
+
+Use the `Read` tool to read the contents of the file at the `--prompt-file` path.
+
+If the file cannot be read, proceed to Step 4 (error handling).
+
+### Step 3: Invoke Agent and Capture Output
+
+Invoke the agent using the native Agent tool:
+
+```
+Agent(subagent_type="autoskillit:{agent_name}", prompt=<prompt file contents>)
+```
+
+Capture the agent's full response text.
+
+On success, write the output JSON:
+
+```json
+{
+  "agent_name": "{agent_name}",
+  "success": true,
+  "output": "<agent response text>"
+}
+```
+
+On agent failure, proceed to Step 4.
+
+### Step 4: Handle Errors
+
+If any step fails, write an error output JSON:
+
+```json
+{
+  "agent_name": "{agent_name}",
+  "success": false,
+  "error": "<description of what failed>",
+  "output": null
+}
+```
+
+### Step 5: Write Output and Emit Token
+
+Write the JSON (success or error) to:
+`{{AUTOSKILLIT_TEMP}}/eval-agent/{agent_name}_output.json`
+
+Use the native `Write` tool. Construct the absolute path by joining the current working
+directory with the relative path.
+
+Emit the structured output token as the final output:
+
+```
+agent_output_path = /absolute/path/to/.autoskillit/temp/eval-agent/{agent_name}_output.json
+```
+
+## Output
+
+Output file: `{{AUTOSKILLIT_TEMP}}/eval-agent/{agent_name}_output.json` (relative to the current working directory)
+
+Structured output token: `agent_output_path = <absolute_path>`

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -18,6 +18,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_backend_command_path.py` | AST tests enforcing ctx.backend usage for command construction in headless path |
 | `test_backend_protocol_completeness.py` | Protocol completeness tests for CodingAgentBackend command builders |
 | `test_audit_feature_gates_skill.py` | Structural integrity tests for the audit-feature-gates skill |
+| `test_eval_agent_skill.py` | Structural integrity tests for the eval-agent skill |
 | `test_boot_step_symmetry.py` | AST guard: both boot functions (_fleet_auto_gate_boot, _food_truck_auto_gate_boot) must call sweep_stale_dispatch_labels |
 | `test_bundled_recipes_split.py` | Enforcement: test_bundled_recipes.py split structure guard |
 | `test_cascade_map_guard.py` | REQ-GUARD-001..003, 005: CI guard validating cascade maps against AST-derived reverse import graph |

--- a/tests/arch/test_eval_agent_skill.py
+++ b/tests/arch/test_eval_agent_skill.py
@@ -1,0 +1,96 @@
+"""Structural integrity tests for the eval-agent skill."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SKILL_DIR = _PROJECT_ROOT / ".autoskillit" / "skills" / "eval-agent"
+_SKILL_FILE = _SKILL_DIR / "SKILL.md"
+_RECIPE_FILE = _PROJECT_ROOT / ".autoskillit" / "recipes" / "eval" / "agent-eval.yaml"
+
+
+def test_eval_agent_skill_exists():
+    """eval-agent SKILL.md exists at .autoskillit/skills/eval-agent/SKILL.md."""
+    assert _SKILL_FILE.is_file(), ".autoskillit/skills/eval-agent/SKILL.md must exist"
+
+
+def test_eval_agent_frontmatter_name():
+    """Frontmatter name field matches directory name."""
+    source = _SKILL_FILE.read_text()
+    parts = source.split("---", 2)
+    assert len(parts) >= 3, "SKILL.md must have YAML frontmatter"
+    fm = yaml.safe_load(parts[1])
+    assert isinstance(fm, dict), "frontmatter must parse to dict"
+    assert fm.get("name") == "eval-agent"
+
+
+def test_eval_agent_categories_include_eval():
+    """Frontmatter categories includes eval."""
+    source = _SKILL_FILE.read_text()
+    parts = source.split("---", 2)
+    fm = yaml.safe_load(parts[1])
+    assert "eval" in fm.get("categories", [])
+
+
+def test_eval_agent_has_critical_constraints():
+    """SKILL.md has Critical Constraints with NEVER and ALWAYS blocks."""
+    source = _SKILL_FILE.read_text()
+    assert "## Critical Constraints" in source
+    assert "**NEVER:**" in source
+    assert "**ALWAYS:**" in source
+
+
+def test_eval_agent_uses_agent_tool():
+    """SKILL.md instructs use of native Agent tool with autoskillit: subagent_type."""
+    source = _SKILL_FILE.read_text()
+    assert 'Agent(subagent_type=' in source
+    assert 'autoskillit:' in source
+
+
+def test_eval_agent_uses_write_tool():
+    """SKILL.md instructs use of native Write tool for output capture."""
+    source = _SKILL_FILE.read_text()
+    assert "Write" in source and "tool" in source.lower()
+
+
+def test_eval_agent_emits_output_token():
+    """SKILL.md emits agent_output_path structured output token."""
+    source = _SKILL_FILE.read_text()
+    assert "agent_output_path =" in source
+
+
+def test_eval_agent_no_source_modification():
+    """SKILL.md prohibits source code modification."""
+    source = _SKILL_FILE.read_text()
+    never_section = source.split("**NEVER:**")[1].split("**ALWAYS:**")[0] if "**NEVER:**" in source and "**ALWAYS:**" in source else ""
+    assert "source code" in never_section.lower() or "Modify any source" in never_section
+
+
+def test_eval_agent_no_kitchen_tools():
+    """SKILL.md does not reference MCP kitchen tools."""
+    source = _SKILL_FILE.read_text()
+    assert "open_kitchen" not in source
+    assert "run_skill" not in source
+    assert "run_cmd" not in source
+
+
+def test_agent_eval_recipe_uses_bare_invocation():
+    """agent-eval.yaml invokes eval-agent as bare /eval-agent (project-local convention)."""
+    content = _RECIPE_FILE.read_text()
+    assert "/eval-agent " in content
+    assert "/autoskillit:eval-agent" not in content
+
+
+def test_eval_agent_references_temp_variable():
+    """SKILL.md uses {{AUTOSKILLIT_TEMP}} not literal paths."""
+    source = _SKILL_FILE.read_text()
+    assert "{{AUTOSKILLIT_TEMP}}" in source
+
+
+def test_eval_agent_error_handling_writes_json():
+    """SKILL.md documents error handling that writes JSON and emits token on failure."""
+    source = _SKILL_FILE.read_text()
+    assert '"success": false' in source or '"success":false' in source
+    assert "error" in source.lower()

--- a/tests/arch/test_eval_agent_skill.py
+++ b/tests/arch/test_eval_agent_skill.py
@@ -1,6 +1,5 @@
 """Structural integrity tests for the eval-agent skill."""
 
-import re
 from pathlib import Path
 
 import yaml
@@ -45,8 +44,8 @@ def test_eval_agent_has_critical_constraints():
 def test_eval_agent_uses_agent_tool():
     """SKILL.md instructs use of native Agent tool with autoskillit: subagent_type."""
     source = _SKILL_FILE.read_text()
-    assert 'Agent(subagent_type=' in source
-    assert 'autoskillit:' in source
+    assert "Agent(subagent_type=" in source
+    assert "autoskillit:" in source
 
 
 def test_eval_agent_uses_write_tool():
@@ -64,7 +63,11 @@ def test_eval_agent_emits_output_token():
 def test_eval_agent_no_source_modification():
     """SKILL.md prohibits source code modification."""
     source = _SKILL_FILE.read_text()
-    never_section = source.split("**NEVER:**")[1].split("**ALWAYS:**")[0] if "**NEVER:**" in source and "**ALWAYS:**" in source else ""
+    never_section = (
+        source.split("**NEVER:**")[1].split("**ALWAYS:**")[0]
+        if "**NEVER:**" in source and "**ALWAYS:**" in source
+        else ""
+    )
     assert "source code" in never_section.lower() or "Modify any source" in never_section
 
 

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -1978,6 +1978,8 @@ def test_consolidate_health_reports_does_not_mutate_source_dicts(tmp_path):
     assert "dispatch_id" not in original_finding
     # Verify the result has the dispatch_id in findings
     assert "dispatch-a" in result["summary"]
+
+
 # ---------------------------------------------------------------------------
 # T_FACADE_1–T_FACADE_2: smoke_utils package facade verification
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Create a project-local skill at `.autoskillit/skills/eval-agent/SKILL.md` that invokes a named agent definition against a provided prompt and captures its output. The skill is stateless — it reads a prompt file, spawns one agent via the native `Agent` tool, captures the response, writes it to a JSON file, and emits a structured output token. This is the execution primitive for the `agent-eval` recipe.

Key discovery during planning: The `agent-eval.yaml` recipe (line 118) references this skill as `/autoskillit:eval-agent` (plugin-namespaced), but project-local skills under `.autoskillit/skills/` are discovered via `--add-dir` and invoked with bare names (no `autoskillit:` prefix). The existing `judge-eval` skill is invoked as bare `/judge-eval`. The recipe line 118 must be corrected to `/eval-agent` for consistency.

## Requirements

The skill must:

1. Accept arguments: `--agent-name {name}` and `--prompt-file {path}`
2. Read the prompt text from the specified file
3. Invoke `Agent(subagent_type="autoskillit:{agent_name}", prompt=<file contents>)`
4. Capture the agent's full response (JSON or text)
5. Write it to `{{AUTOSKILLIT_TEMP}}/eval-agent/{agent_name}_output.json` via native `Write` tool
6. Emit `agent_output_path=<path>` as structured output token

Closes #2954

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-134541-818087/.autoskillit/temp/make-plan/eval_agent_wrapper_skill_plan_2026-05-26_140200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.0k | 15.7k | 2.5M | 101.0k | 203 | 85.5k | 12m 59s |
| verify | claude-sonnet-4-6 | 1 | 132 | 10.8k | 612.3k | 51.8k | 45 | 41.8k | 3m 20s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.2M | 11.2k | 1.3M | 30.7k | 122 | 43.9k | 11m 26s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 166.6k | 3.7k | 427.2k | 30.7k | 29 | 15.4k | 1m 27s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 78.1k | 1.8k | 242.9k | 30.7k | 17 | 15.2k | 52s |
| review_pr | claude-sonnet-4-6 | 1 | 166 | 31.0k | 783.7k | 64.4k | 48 | 58.7k | 7m 16s |
| resolve_review | claude-sonnet-4-6 | 1 | 125 | 11.3k | 634.6k | 56.7k | 43 | 42.2k | 4m 33s |
| **Total** | | | 1.4M | 85.5k | 6.5M | 101.0k | | 302.8k | 41m 55s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 224 | 5764.7 | 196.1 | 50.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **224** | 28879.6 | 1351.9 | 381.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.4k | 68.8k | 4.5M | 228.3k | 28m 9s |
| MiniMax-M2.7-highspeed | 3 | 1.4M | 16.7k | 2.0M | 74.5k | 13m 46s |