### PR TITLE
Add dispatch-chain integration test for ClaudeCodeCompatMiddleware

### DIFF
--- a/tests/server/test_wire_compat.py
+++ b/tests/server/test_wire_compat.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
+from fastmcp.server.middleware import MiddlewareContext
+
+from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
@@ -126,12 +131,6 @@ class TestClaudeCodeCompatMiddlewareDispatchChain:
 
     @pytest.mark.anyio
     async def test_tools_list_dispatches_through_chain(self):
-        from unittest.mock import MagicMock
-
-        from fastmcp.server.middleware import MiddlewareContext
-
-        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
-
         mw = ClaudeCodeCompatMiddleware()
 
         tool = MagicMock()
@@ -159,12 +158,6 @@ class TestClaudeCodeCompatMiddlewareDispatchChain:
 
     @pytest.mark.anyio
     async def test_non_tools_list_method_is_passthrough(self):
-        from unittest.mock import MagicMock
-
-        from fastmcp.server.middleware import MiddlewareContext
-
-        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
-
         mw = ClaudeCodeCompatMiddleware()
 
         sentinel = object()
@@ -178,12 +171,6 @@ class TestClaudeCodeCompatMiddlewareDispatchChain:
 
     @pytest.mark.anyio
     async def test_dispatch_chain_preserves_annotations(self):
-        from unittest.mock import MagicMock
-
-        from fastmcp.server.middleware import MiddlewareContext
-
-        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
-
         mw = ClaudeCodeCompatMiddleware()
 
         tool = MagicMock()

--- a/tests/server/test_wire_compat.py
+++ b/tests/server/test_wire_compat.py
@@ -113,3 +113,96 @@ class TestClaudeCodeCompatMiddlewareEdgeCases:
         assert result[0].title is None
         assert result[1].output_schema is None
         assert result[1].title is None
+
+
+class TestClaudeCodeCompatMiddlewareDispatchChain:
+    """Dispatch-chain coverage: __call__ → _dispatch_handler → on_list_tools.
+
+    Unlike TestClaudeCodeCompatMiddlewareEdgeCases (which calls on_list_tools
+    directly), these tests drive the middleware through Middleware.__call__ so
+    that _dispatch_handler routing is exercised. A FastMCP dispatch change that
+    breaks method→hook routing will be caught here.
+    """
+
+    @pytest.mark.anyio
+    async def test_tools_list_dispatches_through_chain(self):
+        from unittest.mock import MagicMock
+
+        from fastmcp.server.middleware import MiddlewareContext
+
+        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
+
+        mw = ClaudeCodeCompatMiddleware()
+
+        tool = MagicMock()
+        tool.name = "chain_tool"
+        tool.output_schema = {"type": "string"}
+        tool.title = "Chain Tool"
+        tool.model_copy.return_value = MagicMock(
+            name="chain_tool",
+            output_schema=None,
+            title=None,
+        )
+
+        ctx = MiddlewareContext(message=MagicMock(), method="tools/list", type="request")
+
+        async def call_next(context):
+            return [tool]
+
+        result = await mw(ctx, call_next)
+
+        tool.model_copy.assert_called_once_with(
+            update={"output_schema": None, "title": None},
+        )
+        assert result[0].output_schema is None
+        assert result[0].title is None
+
+    @pytest.mark.anyio
+    async def test_non_tools_list_method_is_passthrough(self):
+        from unittest.mock import MagicMock
+
+        from fastmcp.server.middleware import MiddlewareContext
+
+        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
+
+        mw = ClaudeCodeCompatMiddleware()
+
+        sentinel = object()
+        ctx = MiddlewareContext(message=MagicMock(), method="resources/list", type="request")
+
+        async def call_next(context):
+            return sentinel
+
+        result = await mw(ctx, call_next)
+        assert result is sentinel
+
+    @pytest.mark.anyio
+    async def test_dispatch_chain_preserves_annotations(self):
+        from unittest.mock import MagicMock
+
+        from fastmcp.server.middleware import MiddlewareContext
+
+        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
+
+        mw = ClaudeCodeCompatMiddleware()
+
+        tool = MagicMock()
+        tool.name = "annotated_tool"
+        tool.output_schema = {"type": "string"}
+        tool.title = "Annotated"
+        tool.annotations = MagicMock(readOnlyHint=True)
+        copy = MagicMock()
+        copy.name = "annotated_tool"
+        copy.output_schema = None
+        copy.title = None
+        copy.annotations = MagicMock(readOnlyHint=True)
+        tool.model_copy.return_value = copy
+
+        ctx = MiddlewareContext(message=MagicMock(), method="tools/list", type="request")
+
+        async def call_next(context):
+            return [tool]
+
+        result = await mw(ctx, call_next)
+        assert result[0].annotations is not None
+        assert result[0].annotations.readOnlyHint is True

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -1978,6 +1978,8 @@ def test_consolidate_health_reports_does_not_mutate_source_dicts(tmp_path):
     assert "dispatch_id" not in original_finding
     # Verify the result has the dispatch_id in findings
     assert "dispatch-a" in result["summary"]
+
+
 # ---------------------------------------------------------------------------
 # T_FACADE_1–T_FACADE_2: smoke_utils package facade verification
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a new test class `TestClaudeCodeCompatMiddlewareDispatchChain` to `tests/server/test_wire_compat.py` that exercises `ClaudeCodeCompatMiddleware` through the full FastMCP dispatch chain (`Middleware.__call__` → `_dispatch_handler` → `on_list_tools`), closing the gap identified in P10-F1. The existing 4 tests call `mw.on_list_tools(ctx, call_next)` directly, bypassing the dispatch routing entirely — a future FastMCP routing change would be invisible.

Closes #2836

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-135058-929899/.autoskillit/temp/make-plan/add_dispatch_chain_integration_test_plan_2026-05-26_140200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 74 | 11.9k | 1.0M | 76.3k | 161 | 62.0k | 8m 58s |
| verify | claude-sonnet-4-6 | 1 | 84 | 7.5k | 294.1k | 44.8k | 30 | 62.1k | 2m 20s |
| implement* | MiniMax-M2.7-highspeed | 1 | 307.2k | 4.8k | 550.5k | 30.7k | 39 | 16.1k | 6m 4s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 79.8k | 2.5k | 273.7k | 30.7k | 19 | 15.5k | 1m 1s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 66.0k | 1.5k | 273.7k | 30.7k | 20 | 15.2k | 42s |
| review_pr | claude-sonnet-4-6 | 1 | 140 | 25.2k | 669.8k | 60.7k | 48 | 50.9k | 5m 42s |
| resolve_review | claude-sonnet-4-6 | 1 | 149 | 10.2k | 863.4k | 59.2k | 43 | 44.3k | 3m 51s |
| **Total** | | | 453.5k | 63.6k | 4.0M | 76.3k | | 266.2k | 28m 40s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 95 | 5794.9 | 169.5 | 50.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 23 | 37541.1 | 1927.3 | 444.4 |
| **Total** | **118** | 33672.7 | 2256.1 | 539.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 447 | 54.8k | 2.9M | 219.3k | 20m 53s |
| MiniMax-M2.7-highspeed | 3 | 453.1k | 8.8k | 1.1M | 46.9k | 7m 47s |