### PR TITLE
Harden deprecated aliases and lifecycle enum hygiene

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -392,7 +392,7 @@ Features are gated by lifecycle state. The `features:` config section and
 |-----------|----------|---------------|
 | STABLE | On everywhere | Yes — opt out via `features: {name: false}` |
 | EXPERIMENTAL | On when `experimental_enabled: true` (default on develop; off on main) | Yes — per-feature entry overrides blanket |
-| DEPRECATED | Follows `default_enabled`; may be removed without warning | Yes |
+| DEPRECATED | Emits `DeprecationWarning` when enabled; must have `sunset_date`; `default_enabled` must be `False` | Yes |
 | DISABLED | Always off; cannot be enabled | No — config entry setting `true` is rejected |
 
 ### Blanket Toggle

--- a/src/autoskillit/cli/doctor/_doctor_env.py
+++ b/src/autoskillit/cli/doctor/_doctor_env.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 
 from autoskillit.core import SESSION_TYPE_ENV_VAR, Severity, get_logger
 
@@ -17,17 +16,11 @@ def _check_ambient_session_type_skill() -> DoctorResult:
     raw = os.environ.get(SESSION_TYPE_ENV_VAR, "")
     raw_lower = raw.lower()
     if raw_lower == "leaf":
-        warnings.warn(
-            "AUTOSKILLIT_SESSION_TYPE='leaf' is deprecated. Use 'skill' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return DoctorResult(
-            Severity.WARNING,
+            Severity.ERROR,
             "ambient_session_type_skill",
-            "Ambient SESSION_TYPE=leaf detected (deprecated). "
-            "Update to SESSION_TYPE=skill. Fleet sessions should set "
-            "SESSION_TYPE=skill only in launched subprocesses.",
+            "Ambient SESSION_TYPE=leaf detected — this value has been removed. "
+            "Use SESSION_TYPE=skill instead.",
         )
     if raw_lower == "skill":
         return DoctorResult(

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -78,7 +78,7 @@ def fleet_dispatch() -> None:
         print("Run this command in a regular terminal.")
         sys.exit(1)
     if os.environ.get("AUTOSKILLIT_SESSION_TYPE") in ("skill", "leaf"):
-        print("ERROR: 'fleet dispatch' cannot run inside a skill or leaf (deprecated) session.")
+        print("ERROR: 'fleet dispatch' cannot run inside a skill session.")
         sys.exit(1)
 
     from autoskillit.config import load_config
@@ -120,7 +120,7 @@ def fleet_campaign(
         print("Run this command in a regular terminal.")
         sys.exit(1)
     if os.environ.get("AUTOSKILLIT_SESSION_TYPE") in ("skill", "leaf"):
-        print("ERROR: 'fleet campaign' cannot run inside a skill or leaf (deprecated) session.")
+        print("ERROR: 'fleet campaign' cannot run inside a skill session.")
         sys.exit(1)
 
     from autoskillit.config import load_config

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -11,6 +11,7 @@ Resolution order (low → high priority):
 from __future__ import annotations
 
 import dataclasses
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -245,6 +246,14 @@ class AutomationConfig:
                     raise ConfigSchemaError(
                         f"Feature {name!r} has lifecycle DISABLED"
                         " and cannot be explicitly enabled."
+                    )
+                if FEATURE_REGISTRY[name].lifecycle == FeatureLifecycle.DEPRECATED:
+                    warnings.warn(
+                        f"Feature {name!r} has lifecycle DEPRECATED"
+                        f" (sunset: {FEATURE_REGISTRY[name].sunset_date}). "
+                        "Consider removing this override before the sunset date.",
+                        DeprecationWarning,
+                        stacklevel=2,
                     )
             result[name] = value
 

--- a/src/autoskillit/core/feature_flags.py
+++ b/src/autoskillit/core/feature_flags.py
@@ -7,6 +7,8 @@ full AutomationConfig to keep core/ free of config/ imports.
 
 from __future__ import annotations
 
+import warnings
+
 from .types._type_constants_features import FEATURE_REGISTRY
 from .types._type_enums import FeatureLifecycle
 
@@ -48,12 +50,23 @@ def is_feature_enabled(
     if defn.lifecycle == FeatureLifecycle.DISABLED:
         return False
     if name in features:
-        return features[name]
-    if experimental_enabled and defn.lifecycle == FeatureLifecycle.EXPERIMENTAL:
+        result = features[name]
+    elif experimental_enabled and defn.lifecycle == FeatureLifecycle.EXPERIMENTAL:
         if defn.requires_backend_alignment:
-            return defn.default_enabled
-        return True
-    return defn.default_enabled
+            result = defn.default_enabled
+        else:
+            result = True
+    else:
+        result = defn.default_enabled
+    if result and defn.lifecycle == FeatureLifecycle.DEPRECATED:
+        warnings.warn(
+            f"Feature {name!r} has lifecycle DEPRECATED"
+            f" (sunset: {defn.sunset_date}). "
+            "It will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    return result
 
 
 def _collect_disabled_feature_tags(

--- a/src/autoskillit/core/types/_type_constants_features.py
+++ b/src/autoskillit/core/types/_type_constants_features.py
@@ -190,3 +190,28 @@ if not all(
         "FeatureDef.tool_tags contains a tag not present in TOOL_SUBSET_TAGS values. "
         "Add the tag to the appropriate tool entry in TOOL_SUBSET_TAGS first."
     )
+
+# Guard: DEPRECATED features must have sunset_date
+_DEPRECATED_WITHOUT_SUNSET = [
+    k
+    for k, defn in FEATURE_REGISTRY.items()
+    if defn.lifecycle == FeatureLifecycle.DEPRECATED and defn.sunset_date is None
+]
+if _DEPRECATED_WITHOUT_SUNSET:
+    raise AssertionError(
+        f"DEPRECATED features must have a sunset_date. Missing: {_DEPRECATED_WITHOUT_SUNSET}"
+    )
+del _DEPRECATED_WITHOUT_SUNSET
+
+# Guard: DEPRECATED features must not be default_enabled=True
+_DEPRECATED_DEFAULT_ENABLED = [
+    k
+    for k, defn in FEATURE_REGISTRY.items()
+    if defn.lifecycle == FeatureLifecycle.DEPRECATED and defn.default_enabled
+]
+if _DEPRECATED_DEFAULT_ENABLED:
+    raise AssertionError(
+        "DEPRECATED features must not be default_enabled=True. "
+        f"Violations: {_DEPRECATED_DEFAULT_ENABLED}"
+    )
+del _DEPRECATED_DEFAULT_ENABLED

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -160,6 +160,7 @@ def fleet_error(
 def session_type() -> SessionType:
     """Resolve current session type from AUTOSKILLIT_SESSION_TYPE env var.
 
+    Raises ValueError for the removed 'leaf' alias.
     Fail-closed: returns SKILL on unset or invalid values.
     Transitional bridge: HEADLESS=1 without SESSION_TYPE emits DeprecationWarning.
     """
@@ -167,13 +168,9 @@ def session_type() -> SessionType:
     if raw:
         raw_lower = raw.lower()
         if raw_lower == "leaf":
-            warnings.warn(
-                "AUTOSKILLIT_SESSION_TYPE='leaf' is deprecated. "
-                "Use 'skill' instead. Mapped to SessionType.SKILL.",
-                DeprecationWarning,
-                stacklevel=2,
+            raise ValueError(
+                "AUTOSKILLIT_SESSION_TYPE='leaf' has been removed. Use 'skill' instead."
             )
-            return SessionType.SKILL
         try:
             return SessionType(raw_lower)
         except ValueError:

--- a/src/autoskillit/hooks/guards/skill_orchestration_guard.py
+++ b/src/autoskillit/hooks/guards/skill_orchestration_guard.py
@@ -33,8 +33,8 @@ def main() -> None:
     session_type = raw_session_type.lower()
     if session_type in ("orchestrator", "fleet"):
         sys.exit(0)  # permitted tiers — not a skill session
-    # skill, leaf, unset → deny below; unrecognized non-empty values also denied
-    _unrecognized_tier = bool(session_type) and session_type not in ("skill", "leaf")
+    # skill, unset → deny below; unrecognized non-empty values also denied
+    _unrecognized_tier = bool(session_type) and session_type != "skill"
 
     tool_name: str = data.get("tool_name", "")
     # MCP tool names are prefixed: mcp__<server>__<tool>

--- a/src/autoskillit/hooks/guards/skill_orchestration_guard.py
+++ b/src/autoskillit/hooks/guards/skill_orchestration_guard.py
@@ -33,7 +33,7 @@ def main() -> None:
     session_type = raw_session_type.lower()
     if session_type in ("orchestrator", "fleet"):
         sys.exit(0)  # permitted tiers — not a skill session
-    # skill, leaf (deprecated), unset → deny below; unrecognized non-empty values also denied
+    # skill, leaf (removed), unset → deny below; unrecognized non-empty values also denied
     _unrecognized_tier = bool(session_type) and session_type not in ("skill", "leaf")
 
     tool_name: str = data.get("tool_name", "")

--- a/src/autoskillit/hooks/guards/skill_orchestration_guard.py
+++ b/src/autoskillit/hooks/guards/skill_orchestration_guard.py
@@ -33,7 +33,7 @@ def main() -> None:
     session_type = raw_session_type.lower()
     if session_type in ("orchestrator", "fleet"):
         sys.exit(0)  # permitted tiers — not a skill session
-    # skill, leaf (removed), unset → deny below; unrecognized non-empty values also denied
+    # skill, leaf, unset → deny below; unrecognized non-empty values also denied
     _unrecognized_tier = bool(session_type) and session_type not in ("skill", "leaf")
 
     tool_name: str = data.get("tool_name", "")

--- a/src/autoskillit/migrations/0.9.388-to-0.9.389.yaml
+++ b/src/autoskillit/migrations/0.9.388-to-0.9.389.yaml
@@ -3,18 +3,17 @@ to_version: "0.9.389"
 description: >
   Rename L1 session terminology from "leaf" to "skill". SessionType.LEAF
   is replaced by SessionType.SKILL; the wire value changes from "leaf" to
-  "skill". The old "leaf" value is recognized with a DeprecationWarning for
-  one release cycle.
+  "skill". The old "leaf" value was recognized with a DeprecationWarning
+  for one release cycle; it now raises ValueError.
 changes:
   - id: session-type-leaf-to-skill
     description: >
       SessionType.LEAF renamed to SessionType.SKILL; wire value "leaf"
       deprecated in favor of "skill".
     instruction: |
-      AUTOSKILLIT_SESSION_TYPE=leaf is still accepted but emits a
-      DeprecationWarning and maps to SessionType.SKILL. Update any
-      scripts or config that sets SESSION_TYPE=leaf to use SESSION_TYPE=skill.
-      The old value will be removed in a future release.
+      AUTOSKILLIT_SESSION_TYPE=leaf is no longer accepted and raises
+      ValueError. Update any scripts or config that sets
+      SESSION_TYPE=leaf to use SESSION_TYPE=skill.
 
   - id: build-leaf-headless-cmd-renamed
     description: >

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -689,3 +689,110 @@ def test_fleet_still_promoted_by_experimental_blanket():
     from autoskillit.core.feature_flags import is_feature_enabled
 
     assert is_feature_enabled("fleet", {}, experimental_enabled=True) is True
+
+
+# -- T-DEPRECATED: lifecycle gating --
+
+
+def test_deprecated_features_must_have_sunset_date():
+    """DEPRECATED lifecycle features must carry a sunset_date."""
+    from autoskillit.core.types._type_constants_features import FEATURE_REGISTRY
+    from autoskillit.core.types._type_enums import FeatureLifecycle
+
+    violations = [
+        k
+        for k, defn in FEATURE_REGISTRY.items()
+        if defn.lifecycle == FeatureLifecycle.DEPRECATED and defn.sunset_date is None
+    ]
+    assert not violations, f"DEPRECATED features without sunset_date: {violations}"
+
+
+def test_deprecated_features_not_default_enabled():
+    """DEPRECATED lifecycle features must not be default_enabled=True."""
+    from autoskillit.core.types._type_constants_features import FEATURE_REGISTRY
+    from autoskillit.core.types._type_enums import FeatureLifecycle
+
+    violations = [
+        k
+        for k, defn in FEATURE_REGISTRY.items()
+        if defn.lifecycle == FeatureLifecycle.DEPRECATED and defn.default_enabled
+    ]
+    assert not violations, f"DEPRECATED features with default_enabled=True: {violations}"
+
+
+def test_is_feature_enabled_deprecated_emits_warning(monkeypatch):
+    """DEPRECATED feature emits DeprecationWarning when resolved as enabled."""
+    from datetime import date, timedelta
+
+    import autoskillit.core.types._type_constants_features as tc
+    from autoskillit.core.feature_flags import is_feature_enabled
+    from autoskillit.core.types._type_constants_features import FeatureDef
+    from autoskillit.core.types._type_enums import FeatureLifecycle
+
+    depr_def = FeatureDef(
+        lifecycle=FeatureLifecycle.DEPRECATED,
+        description="deprecated test feature",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        default_enabled=False,
+        sunset_date=date.today() + timedelta(days=30),
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_depr_feat", depr_def)
+    with pytest.warns(DeprecationWarning, match="test_depr_feat"):
+        result = is_feature_enabled(
+            "test_depr_feat", {"test_depr_feat": True}, experimental_enabled=False
+        )
+    assert result is True
+
+
+def test_is_feature_enabled_deprecated_disabled_no_warning(monkeypatch):
+    """DEPRECATED feature does NOT warn when resolved as disabled."""
+    import warnings
+    from datetime import date, timedelta
+
+    import autoskillit.core.types._type_constants_features as tc
+    from autoskillit.core.feature_flags import is_feature_enabled
+    from autoskillit.core.types._type_constants_features import FeatureDef
+    from autoskillit.core.types._type_enums import FeatureLifecycle
+
+    depr_def = FeatureDef(
+        lifecycle=FeatureLifecycle.DEPRECATED,
+        description="deprecated test feature",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        default_enabled=False,
+        sunset_date=date.today() + timedelta(days=30),
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_depr_feat", depr_def)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = is_feature_enabled("test_depr_feat", {}, experimental_enabled=False)
+    assert result is False
+    depr_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(depr_warnings) == 0
+
+
+def test_build_features_dict_warns_enabling_deprecated_feature(monkeypatch):
+    """_build_features_dict emits DeprecationWarning for explicitly enabling DEPRECATED."""
+    from datetime import date, timedelta
+
+    import autoskillit.core.types._type_constants_features as tc
+    from autoskillit.config.settings import AutomationConfig
+    from autoskillit.core.types._type_constants_features import FeatureDef
+    from autoskillit.core.types._type_enums import FeatureLifecycle
+
+    depr_def = FeatureDef(
+        lifecycle=FeatureLifecycle.DEPRECATED,
+        description="deprecated config test",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        default_enabled=False,
+        sunset_date=date.today() + timedelta(days=30),
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_depr_cfg", depr_def)
+    with pytest.warns(DeprecationWarning, match="test_depr_cfg"):
+        result, _ = AutomationConfig._build_features_dict({"test_depr_cfg": True})
+    assert result["test_depr_cfg"] is True

--- a/tests/cli/test_doctor_fleet_checks.py
+++ b/tests/cli/test_doctor_fleet_checks.py
@@ -41,17 +41,16 @@ class TestGroupMFranchiseDoctorChecks:
         assert result.severity == Severity.WARNING
         assert result.check == "ambient_session_type_skill"
 
-    # M2b: SESSION_TYPE=leaf (deprecated) → WARN with DeprecationWarning
-    def test_check_ambient_session_type_skill_warns_when_leaf_deprecated(
+    # M2b: SESSION_TYPE=leaf (removed) → ERROR
+    def test_check_ambient_session_type_skill_errors_when_leaf(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from autoskillit.cli.doctor import _check_ambient_session_type_skill
         from autoskillit.core import Severity
 
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaf")
-        with pytest.warns(DeprecationWarning, match="deprecated"):
-            result = _check_ambient_session_type_skill()
-        assert result.severity == Severity.WARNING
+        result = _check_ambient_session_type_skill()
+        assert result.severity == Severity.ERROR
         assert result.check == "ambient_session_type_skill"
 
     # M3: SESSION_TYPE=orchestrator → OK (not this check's concern)

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -71,7 +71,7 @@ def test_fleet_dispatch_rejects_skill_session_type(monkeypatch: pytest.MonkeyPat
 def test_fleet_dispatch_rejects_deprecated_leaf_session_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """fleet dispatch exits 1 when ambient SESSION_TYPE is deprecated 'leaf'."""
+    """fleet dispatch exits 1 when ambient SESSION_TYPE is removed 'leaf'."""
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaf")
     monkeypatch.delenv("CLAUDECODE", raising=False)
     with pytest.raises(SystemExit, match="1"):

--- a/tests/core/test_session_type.py
+++ b/tests/core/test_session_type.py
@@ -25,7 +25,6 @@ pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
         ("fleet", "FLEET", False, False),
         ("FLEET", "FLEET", False, False),
         ("fleet", "FLEET", False, True),
-        ("leaf", "SKILL", True, False),
     ],
     ids=[
         "orchestrator",
@@ -36,7 +35,6 @@ pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
         "fleet",
         "fleet-case-insensitive",
         "fleet-no-warning",
-        "leaf-deprecated-suppressed",
     ],
 )
 def test_session_type_resolver(
@@ -122,14 +120,12 @@ def test_session_type_env_var_constant():
 # ---------------------------------------------------------------------------
 
 
-def test_leaf_value_maps_to_skill_with_deprecation_warning(monkeypatch):
-    from autoskillit.core import SessionType, session_type
+def test_leaf_value_raises_value_error(monkeypatch):
+    from autoskillit.core import session_type
 
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaf")
-    with pytest.warns(DeprecationWarning, match="leaf") as warning_list:
-        result = session_type()
-    assert result is SessionType.SKILL
-    assert "SKILL" in str(warning_list[0].message)
+    with pytest.raises(ValueError, match="leaf.*removed"):
+        session_type()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/infra/test_skill_orchestration_guard.py
+++ b/tests/infra/test_skill_orchestration_guard.py
@@ -63,7 +63,7 @@ def test_guard_denies_skill_tier(tool_name):
 
 @pytest.mark.parametrize("tool_name", _ORCHESTRATION_TOOLS)
 def test_guard_denies_deprecated_leaf_tier(tool_name):
-    """Backward compat: SESSION_TYPE=leaf (old value) is also denied."""
+    """SESSION_TYPE=leaf (removed value) is also denied."""
     response = _run_guard_headless(
         {"tool_name": f"mcp__autoskillit__{tool_name}"}, session_type="leaf"
     )

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -1978,6 +1978,8 @@ def test_consolidate_health_reports_does_not_mutate_source_dicts(tmp_path):
     assert "dispatch_id" not in original_finding
     # Verify the result has the dispatch_id in findings
     assert "dispatch-a" in result["summary"]
+
+
 # ---------------------------------------------------------------------------
 # T_FACADE_1–T_FACADE_2: smoke_utils package facade verification
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two hardening changes:

1. **CC-10 — Replace `SessionType.LEAF` deprecated alias warning with rejection.** The `session_type()` resolver emits `DeprecationWarning` for `AUTOSKILLIT_SESSION_TYPE=leaf` instead of raising. The migration from `leaf` to `skill` (0.9.388->0.9.389) is long past its one-release grace period. Change the warning to a `ValueError`, update the doctor check to report ERROR severity, update the fleet CLI error message, update the hook guard comment, and update the migration document.

2. **CC-13 — Add gating and invariant enforcement for `FeatureLifecycle.DEPRECATED`.** The `DEPRECATED` lifecycle value exists in the enum but receives no special treatment anywhere — `is_feature_enabled()` treats it identically to any non-DISABLED lifecycle. Add: (a) a `DeprecationWarning` emission when a DEPRECATED feature resolves as enabled, (b) a config-layer warning when explicitly enabling a DEPRECATED feature, (c) registry invariants requiring `sunset_date` and forbidding `default_enabled=True` on DEPRECATED entries, (d) documentation update.

Closes #2840

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-135100-062373/.autoskillit/temp/make-plan/harden_deprecated_aliases_and_lifecycle_enum_hygiene_plan_2026-05-26_140600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.1k | 23.3k | 1.6M | 110.1k | 188 | 101.9k | 11m 34s |
| verify | claude-sonnet-4-6 | 1 | 180 | 11.9k | 990.0k | 67.3k | 61 | 91.1k | 3m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 9.1M | 23.0k | 3.3M | 30.7k | 213 | 16.0k | 11m 59s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 80.0k | 3.4k | 212.2k | 30.7k | 27 | 15.5k | 1m 59s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 127.8k | 2.1k | 365.9k | 30.7k | 27 | 15.2k | 57s |
| review_pr | claude-sonnet-4-6 | 1 | 150 | 35.3k | 873.8k | 89.4k | 56 | 74.8k | 8m 39s |
| resolve_review | claude-sonnet-4-6 | 1 | 245 | 22.5k | 1.7M | 71.8k | 73 | 56.3k | 10m 5s |
| **Total** | | | 9.3M | 121.4k | 9.0M | 110.1k | | 370.8k | 49m 9s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 232 | 14032.5 | 68.9 | 99.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 417246.8 | 14085.0 | 5619.8 |
| **Total** | **236** | 38033.2 | 1571.4 | 514.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 2.7k | 92.9k | 5.1M | 324.1k | 34m 13s |
| MiniMax-M2.7-highspeed | 3 | 9.3M | 28.5k | 3.8M | 46.7k | 14m 55s |