### PR TITLE
Fix report/__init__.py to export symbols instead of module reference

### DIFF
--- a/src/autoskillit/report/CLAUDE.md
+++ b/src/autoskillit/report/CLAUDE.md
@@ -6,5 +6,5 @@ IL-1 subpackage — HTML report renderer for bundle-local-report.
 
 | File | Purpose |
 |------|---------|
-| `__init__.py` | Re-exports `renderer` submodule so `autoskillit.report.renderer` is always a valid attribute |
+| `__init__.py` | Re-exports public symbols from `renderer` (`HTML_TEMPLATE`, `VALIDATION_KEYWORDS`, `main`) |
 | `renderer.py` | Self-contained HTML renderer; uses `pkg_root()` for mermaid asset resolution |

--- a/src/autoskillit/report/__init__.py
+++ b/src/autoskillit/report/__init__.py
@@ -1,3 +1,3 @@
-from autoskillit.report.renderer import HTML_TEMPLATE, VALIDATION_KEYWORDS, main
+from .renderer import HTML_TEMPLATE, VALIDATION_KEYWORDS, main
 
 __all__ = ["HTML_TEMPLATE", "VALIDATION_KEYWORDS", "main"]

--- a/src/autoskillit/report/__init__.py
+++ b/src/autoskillit/report/__init__.py
@@ -1,3 +1,3 @@
-from . import renderer
+from autoskillit.report.renderer import HTML_TEMPLATE, VALIDATION_KEYWORDS, main
 
-__all__ = ["renderer"]
+__all__ = ["HTML_TEMPLATE", "VALIDATION_KEYWORDS", "main"]

--- a/tests/contracts/test_l1_packages.py
+++ b/tests/contracts/test_l1_packages.py
@@ -44,6 +44,10 @@ def test_workspace_package_exports() -> None:
     )
 
 
+def test_report_package_exports() -> None:
+    from autoskillit.report import HTML_TEMPLATE, VALIDATION_KEYWORDS, main  # noqa: F401
+
+
 def test_failure_record_in_core_types() -> None:
     from autoskillit.core.types import FailureRecord
 

--- a/tests/contracts/test_l1_packages.py
+++ b/tests/contracts/test_l1_packages.py
@@ -45,7 +45,11 @@ def test_workspace_package_exports() -> None:
 
 
 def test_report_package_exports() -> None:
-    from autoskillit.report import HTML_TEMPLATE, VALIDATION_KEYWORDS, main  # noqa: F401
+    from autoskillit.report import HTML_TEMPLATE, VALIDATION_KEYWORDS, main
+
+    assert callable(main)
+    assert isinstance(HTML_TEMPLATE, str)
+    assert isinstance(VALIDATION_KEYWORDS, (list, tuple, set))
 
 
 def test_failure_record_in_core_types() -> None:


### PR DESCRIPTION
## Summary

`src/autoskillit/report/__init__.py` currently exports the `renderer` module object via `__all__ = ["renderer"]`, making it the only IL-1 package that re-exports a module instead of individual symbols. Every other IL-1 package (config, pipeline, execution, workspace, recipe, migration, fleet, hooks, cli, server, planner) uses the established Pattern A: explicit `from .submodule import Symbol` statements with a flat `__all__` list of symbol names.

This plan changes `report/__init__.py` to export the three public symbols from `renderer.py` (`VALIDATION_KEYWORDS`, `HTML_TEMPLATE`, `main`) using explicit imports, aligning with the project-wide convention. A new test in `test_l1_packages.py` validates the exports.


## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):

- src/autoskillit/report/CLAUDE.md
- src/autoskillit/report/__init__.py
- tests/contracts/test_l1_packages.py

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-150226-576067/.autoskillit/temp/make-plan/fix_report_init_py_export_symbols_plan_2026-05-26_152600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 412 | 7.8k | 690.5k | 76.8k | 109 | 43.0k | 7m 26s |
| verify | claude-sonnet-4-6 | 1 | 92 | 7.6k | 431.0k | 51.1k | 31 | 35.3k | 2m 17s |
| implement* | MiniMax-M2.7-highspeed | 1 | 312.9k | 3.5k | 642.4k | 30.7k | 47 | 16.1k | 1m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 57.0k | 2.4k | 212.2k | 30.7k | 18 | 15.7k | 54s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 74.7k | 1.6k | 304.4k | 30.7k | 20 | 15.4k | 45s |
| review_pr | claude-sonnet-4-6 | 2 | 308 | 36.3k | 1.5M | 56.0k | 104 | 81.5k | 8m 39s |
| resolve_review | claude-sonnet-4-6 | 1 | 325 | 14.9k | 2.1M | 66.7k | 91 | 51.3k | 6m 9s |
| **Total** | | | 445.7k | 74.0k | 5.8M | 76.8k | | 258.3k | 27m 57s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 10 | 64235.8 | 1611.1 | 353.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 257022.6 | 6413.8 | 1857.2 |
| **Total** | **18** | 322838.2 | 14349.5 | 4113.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.1k | 66.5k | 4.7M | 211.1k | 24m 32s |
| MiniMax-M2.7-highspeed | 3 | 444.6k | 7.5k | 1.2M | 47.2k | 3m 25s |