### PR TITLE
Add planner to IL-008 independence contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
+    "autoskillit.planner",
 ]
 
 # IL-004 | Lens: module-dependency | DS-001
@@ -240,6 +241,7 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
+    "autoskillit.planner",
 ]
 
 # IL-005 | Lens: module-dependency | DS-001
@@ -259,6 +261,7 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
+    "autoskillit.planner",
 ]
 
 # IL-006 | Lens: module-dependency | DS-001
@@ -277,6 +280,7 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
+    "autoskillit.planner",
 ]
 
 # IL-007 | Lens: module-dependency | DS-001
@@ -292,6 +296,7 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
+    "autoskillit.planner",
 ]
 
 # IL-008 | Lens: module-dependency | DS-001

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
+    "autoskillit.planner",
 ]
 
 # IL-002 | Lens: module-dependency | DS-001
@@ -193,6 +194,7 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
+    "autoskillit.planner",
 ]
 
 # IL-003 | Lens: module-dependency | DS-001
@@ -293,7 +295,8 @@ forbidden_modules = [
 ]
 
 # IL-008 | Lens: module-dependency | DS-001
-# Rationale: The four IL-1 peers (config, pipeline, execution, workspace) form an
+# Rationale: The six IL-1 peers (config, pipeline, execution, workspace, report,
+# planner) form an
 # independent service tier. Lateral imports between them create hidden coupling
 # that prevents each package from being tested and deployed in isolation. The
 # independence contract makes this boundary machine-verifiable and surfaces any
@@ -307,6 +310,7 @@ modules = [
     "autoskillit.execution",
     "autoskillit.workspace",
     "autoskillit.report",
+    "autoskillit.planner",
 ]
 # EXCEPTION: autoskillit.pipeline.context may import autoskillit.config.
 # pipeline.context.ToolContext owns AutomationConfig as the DI wiring point.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,12 @@ forbidden_modules = [
     "autoskillit.report",
     "autoskillit.planner",
 ]
+# EXCEPTION: rules_contracts uses a deferred function-body import of planner
+# for skill-schema validation (REQ-COMP-009). planner/ does not import recipe/,
+# so no cycle is introduced.
+ignore_imports = [
+    "autoskillit.recipe.rules.rules_contracts -> autoskillit.planner",
+]
 
 # IL-007 | Lens: module-dependency | DS-001
 # Rationale: migration/ must not import config or pipeline to stay independently
@@ -296,7 +302,6 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
-    "autoskillit.planner",
 ]
 
 # IL-008 | Lens: module-dependency | DS-001

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -392,19 +392,20 @@ def test_req_imp_010_init_helpers_no_toplevel_recipe_imports() -> None:
 
 
 def test_il008_il1_independence() -> None:
-    """IL-008: IL-1 sibling packages (config, pipeline, execution, workspace) must
-    not import from each other at runtime.
+    """IL-008: IL-1 sibling packages (config, pipeline, execution, workspace,
+    report, planner) must
+        not import from each other at runtime.
 
-    Exception: autoskillit.pipeline.context may import autoskillit.config.
-    pipeline.context.ToolContext owns AutomationConfig as the DI wiring point
-    (see pipeline/context.py and the IL-003 inline EXCEPTION comment).
-    config/ depends only on IL-0 (IL-002), so no cycle is introduced.
+        Exception: autoskillit.pipeline.context may import autoskillit.config.
+        pipeline.context.ToolContext owns AutomationConfig as the DI wiring point
+        (see pipeline/context.py and the IL-003 inline EXCEPTION comment).
+        config/ depends only on IL-0 (IL-002), so no cycle is introduced.
 
-    TYPE_CHECKING imports are excluded — pyproject.toml sets
-    exclude_type_checking_imports = true and _parse_imports() respects
-    the in_tc flag.
+        TYPE_CHECKING imports are excluded — pyproject.toml sets
+        exclude_type_checking_imports = true and _parse_imports() respects
+        the in_tc flag.
     """
-    L1_PKGS = frozenset({"config", "pipeline", "execution", "workspace"})
+    L1_PKGS = frozenset({"config", "pipeline", "execution", "workspace", "report", "planner"})
     # (importer_pkg, imported_pkg) tuples that are explicitly allowed
     ALLOWED: frozenset[tuple[str, str]] = frozenset({("pipeline", "config")})
 

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -393,17 +393,16 @@ def test_req_imp_010_init_helpers_no_toplevel_recipe_imports() -> None:
 
 def test_il008_il1_independence() -> None:
     """IL-008: IL-1 sibling packages (config, pipeline, execution, workspace,
-    report, planner) must
-        not import from each other at runtime.
+    report, planner) must not import from each other at runtime.
 
-        Exception: autoskillit.pipeline.context may import autoskillit.config.
-        pipeline.context.ToolContext owns AutomationConfig as the DI wiring point
-        (see pipeline/context.py and the IL-003 inline EXCEPTION comment).
-        config/ depends only on IL-0 (IL-002), so no cycle is introduced.
+    Exception: autoskillit.pipeline.context may import autoskillit.config.
+    pipeline.context.ToolContext owns AutomationConfig as the DI wiring point
+    (see pipeline/context.py and the IL-003 inline EXCEPTION comment).
+    config/ depends only on IL-0 (IL-002), so no cycle is introduced.
 
-        TYPE_CHECKING imports are excluded — pyproject.toml sets
-        exclude_type_checking_imports = true and _parse_imports() respects
-        the in_tc flag.
+    TYPE_CHECKING imports are excluded — pyproject.toml sets
+    exclude_type_checking_imports = true and _parse_imports() respects
+    the in_tc flag.
     """
     L1_PKGS = frozenset({"config", "pipeline", "execution", "workspace", "report", "planner"})
     # (importer_pkg, imported_pkg) tuples that are explicitly allowed


### PR DESCRIPTION
## Summary

Add `autoskillit.planner` to the IL-008 independence contract in `pyproject.toml` and update the companion AST-based test in `tests/arch/test_import_paths.py` so the machine-verifiable boundary covers all six IL-1 siblings. The planner package already satisfies the independence constraint (imports only `autoskillit.core`), so this is a contract-gap closure, not a behavior change.

## Changed Files

### Modified (●):
- `pyproject.toml`
- `tests/arch/test_import_paths.py`

Closes #2829

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-171430-317359/.autoskillit/temp/make-plan/add_planner_to_il008_plan_2026-05-26_171800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 72 | 13.4k | 789.6k | 68.0k | 48 | 70.8k | 6m 1s |
| verify | claude-sonnet-4-6 | 1 | 100 | 5.6k | 405.6k | 41.6k | 32 | 25.7k | 1m 50s |
| implement* | MiniMax-M2.7-highspeed | 1 | 141.8k | 3.1k | 339.6k | 30.9k | 49 | 44.2k | 3m 14s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 79.1k | 2.4k | 247.0k | 30.9k | 19 | 43.7k | 1m 3s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 53.6k | 1.2k | 244.1k | 30.9k | 16 | 15.4k | 39s |
| review_pr | claude-sonnet-4-6 | 1 | 118 | 22.0k | 519.6k | 63.8k | 51 | 94.0k | 4m 46s |
| resolve_review | claude-sonnet-4-6 | 1 | 429 | 26.1k | 3.2M | 81.9k | 116 | 67.8k | 11m 48s |
| **Total** | | | 275.2k | 73.9k | 5.8M | 81.9k | | 361.6k | 29m 23s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 31 | 10954.6 | 1427.4 | 100.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 27 | 119234.0 | 2511.7 | 968.0 |
| **Total** | **58** | 99391.2 | 6235.2 | 1274.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 72 | 13.4k | 789.6k | 70.8k | 6m 1s |
| claude-sonnet-4-6 | 3 | 647 | 53.8k | 4.1M | 187.5k | 18m 25s |
| MiniMax-M2.7-highspeed | 3 | 274.4k | 6.7k | 830.6k | 103.4k | 4m 56s |