### PR TITLE
[FEATURE] Refactor AutoskillitConfig construction block

### DIFF
--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -181,7 +181,9 @@ def _coerce_value(value: Any, target_type: type, context: str) -> Any:
             inner = non_none[0]
             if inner is bool:
                 return bool(value) if value is not None else None
-            if value is None:
+            if inner in (int, float):
+                return _coerce_value(value, inner, context) if value is not None else None
+            if not value:
                 return None
             return _coerce_value(value, inner, context)
         return value

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -236,7 +236,7 @@ _YAML_KEY_ALIASES: dict[tuple[str, str], str] = {
 # Custom field builders that bypass _coerce_value.
 # Signature: (section_dict, defaults_dict) -> coerced_value
 # The override is responsible for its own key lookup from section_dict.
-_FIELD_OVERRIDES: dict[tuple[str, str], Any] = {
+_FIELD_OVERRIDES: dict[tuple[str, str], Callable[[dict[str, Any], dict[str, Any]], Any]] = {
     # YAML key "default" with None-means-unset semantic
     ("model", "default_model"): lambda sec, defs: (
         str(sec["default"]) if sec.get("default") is not None else defs["default_model"]

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -15,7 +15,7 @@ import types
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, TypeVar, Union, get_args, get_origin, get_type_hints
 
 from autoskillit.config._config_dataclasses import (
     _COMMAND_UNSET,
@@ -175,13 +175,13 @@ def _coerce_value(value: Any, target_type: type, context: str) -> Any:
     origin = get_origin(target_type)
     args = get_args(target_type)
 
-    if origin is types.UnionType:
+    if origin is types.UnionType or origin is Union:
         non_none = [a for a in args if a is not type(None)]
         if type(None) in args and len(non_none) == 1:
             inner = non_none[0]
             if inner is bool:
                 return bool(value) if value is not None else None
-            if not value:
+            if value is None:
                 return None
             return _coerce_value(value, inner, context)
         return value
@@ -201,9 +201,15 @@ def _coerce_value(value: Any, target_type: type, context: str) -> Any:
     if target_type is str:
         return str(value)
     if origin is list:
-        return list(value)
+        try:
+            return list(value)
+        except TypeError as exc:
+            raise ConfigSchemaError(f"{context} must be iterable for list, got {value!r}") from exc
     if origin is set:
-        return set(value)
+        try:
+            return set(value)
+        except TypeError as exc:
+            raise ConfigSchemaError(f"{context} must be iterable for set, got {value!r}") from exc
     if origin is dict:
         return value
     return value

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -11,10 +11,11 @@ Resolution order (low → high priority):
 from __future__ import annotations
 
 import dataclasses
+import types
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar, get_args, get_origin, get_type_hints
 
 from autoskillit.config._config_dataclasses import (
     _COMMAND_UNSET,
@@ -56,7 +57,6 @@ from autoskillit.config._config_loader import (
     _build_packs_config,
     _build_subsets_config,
     _to_optional_commands,
-    _to_optional_list,
     load_config,
 )
 from autoskillit.core import (
@@ -153,14 +153,6 @@ __all__ = [
 ]
 
 
-def _parse_int_field(val: Any, config_key: str) -> int:
-    """Convert a config value to int, raising a descriptive ConfigSchemaError on failure."""
-    try:
-        return int(val)
-    except (TypeError, ValueError) as exc:
-        raise ConfigSchemaError(f"{config_key} must be an integer, got {val!r}") from exc
-
-
 def _field_defaults(cls: type) -> dict[str, Any]:
     """Extract default values from dataclass fields into a dict keyed by field name."""
     defaults: dict[str, Any] = {}
@@ -170,6 +162,125 @@ def _field_defaults(cls: type) -> dict[str, Any]:
         elif f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
             defaults[f.name] = f.default_factory()  # type: ignore[call-arg]
     return defaults
+
+
+_T = TypeVar("_T")
+
+
+def _coerce_value(value: Any, target_type: type, context: str) -> Any:
+    """Coerce a raw config value to target_type based on its type annotation.
+
+    Raises ConfigSchemaError for int/float conversion failures, including context.
+    """
+    origin = get_origin(target_type)
+    args = get_args(target_type)
+
+    if origin is types.UnionType:
+        non_none = [a for a in args if a is not type(None)]
+        if type(None) in args and len(non_none) == 1:
+            inner = non_none[0]
+            if inner is bool:
+                return bool(value) if value is not None else None
+            if not value:
+                return None
+            return _coerce_value(value, inner, context)
+        return value
+
+    if target_type is int:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ConfigSchemaError(f"{context} must be an integer, got {value!r}") from exc
+    if target_type is float:
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise ConfigSchemaError(f"{context} must be a number, got {value!r}") from exc
+    if target_type is bool:
+        return bool(value)
+    if target_type is str:
+        return str(value)
+    if origin is list:
+        return list(value)
+    if origin is set:
+        return set(value)
+    if origin is dict:
+        return value
+    return value
+
+
+# YAML key name differs from Python field name.
+# Key: (section_name, field_name), Value: yaml_key_name
+_YAML_KEY_ALIASES: dict[tuple[str, str], str] = {
+    ("model", "default_model"): "default",
+    ("model", "model_override"): "override",
+}
+
+# Custom field builders that bypass _coerce_value.
+# Signature: (section_dict, defaults_dict) -> coerced_value
+# The override is responsible for its own key lookup from section_dict.
+_FIELD_OVERRIDES: dict[tuple[str, str], Any] = {
+    # YAML key "default" with None-means-unset semantic
+    ("model", "default_model"): lambda sec, defs: (
+        str(sec["default"]) if sec.get("default") is not None else defs["default_model"]
+    ),
+    # Sentinel for __post_init__ mutual-exclusion check with commands
+    ("test_check", "command"): lambda sec, defs: (
+        list(sec["command"]) if sec.get("command") is not None else _COMMAND_UNSET
+    ),
+    # Structural validation for nested list shape
+    ("test_check", "commands"): lambda sec, defs: _to_optional_commands(
+        sec.get("commands", defs.get("commands"))
+    ),
+    # Uppercase transform
+    ("logging", "level"): lambda sec, defs: str(sec.get("level", defs["level"])).upper(),
+}
+
+
+def _preprocess_agent_backend(raw: Any) -> dict[str, Any]:
+    """Normalize agent_backend section: string shorthand or lowercased dict."""
+    if isinstance(raw, str):
+        return {"backend": raw}
+    if isinstance(raw, dict):
+        return {k.lower(): v for k, v in raw.items()}
+    raise ConfigSchemaError(
+        f"agent_backend must be a string or mapping, got {type(raw).__name__!r}: {raw!r}"
+    )
+
+
+# Section-level pre-processors applied before _build_subconfig.
+_SECTION_PREPROCESSORS: dict[str, Any] = {
+    "agent_backend": _preprocess_agent_backend,
+}
+
+# Sections with fully custom builders (bypass _build_subconfig entirely).
+_SECTION_BUILDERS: dict[str, Any] = {
+    "subsets": _build_subsets_config,
+    "packs": _build_packs_config,
+}
+
+
+def _build_subconfig(cls: type[_T], section: dict[str, Any], section_name: str) -> _T:
+    """Build a sub-config dataclass from a raw Dynaconf section dict.
+
+    Uses dataclass field introspection and type annotations to auto-coerce
+    values. Fields listed in _FIELD_OVERRIDES use custom builders. Fields
+    listed in _YAML_KEY_ALIASES read from an alternate YAML key name.
+    """
+    defaults = _field_defaults(cls)
+    hints = get_type_hints(cls)
+    kwargs: dict[str, Any] = {}
+
+    for f in dataclasses.fields(cls):  # type: ignore[arg-type]
+        override_key = (section_name, f.name)
+        if override_key in _FIELD_OVERRIDES:
+            kwargs[f.name] = _FIELD_OVERRIDES[override_key](section, defaults)
+            continue
+        yaml_key = _YAML_KEY_ALIASES.get(override_key, f.name)
+        raw = section.get(yaml_key, defaults.get(f.name))
+        kwargs[f.name] = _coerce_value(raw, hints[f.name], f"{section_name}.{yaml_key}")
+
+    return cls(**kwargs)  # type: ignore[return-value]
 
 
 @dataclass
@@ -281,308 +392,48 @@ class AutomationConfig:
 
     @classmethod
     def from_dynaconf(cls, d: Dynaconf) -> AutomationConfig:
-        """Build a typed AutomationConfig from a loaded Dynaconf instance.
-
-        d.as_dict() returns UPPERCASE keys — map them explicitly.
-        Lists are converted to set where the dataclass field is set[str].
-        """
+        """Build a typed AutomationConfig from a loaded Dynaconf instance."""
         raw = d.as_dict()
 
         def sec(name: str) -> dict[str, Any]:
             return raw.get(name.upper(), {})
 
-        def val(section: dict[str, Any], key: str, default: Any) -> Any:
-            return section.get(key, default)
-
-        def _parse_int_config(value: Any, field_name: str) -> int:
-            try:
-                return int(value)
-            except (ValueError, TypeError) as exc:
-                raise ConfigSchemaError(
-                    f"Config field '{field_name}' must be an integer, got {value!r}"
-                ) from exc
-
-        tc = sec("test_check")
-        cf = sec("classify_fix")
-        rw = sec("reset_workspace")
-        ig = sec("implement_gate")
-        sf = sec("safety")
-        rd = sec("read_db")
-        rs = sec("run_skill")
-        mc = sec("model")
-        ws = sec("worktree_setup")
-        mi = sec("migration")
-        tu = sec("token_usage")
-        qg = sec("quota_guard")
-        gh = sec("github")
-        rb = sec("report_bug")
-        lg = sec("logging")
-        dg = sec("diagnostics")
-        lt = sec("linux_tracing")
-        mr = sec("mcp_response")
-        br = sec("branching")
-        ci = sec("ci")
-        rv = sec("review")
-        pn = sec("plan")
-        sk = sec("skills")
-        _sub = sec("subsets")
-        pk = sec("packs")
-        ws_raw = sec("workspace")
-        fr = sec("fleet")
-        pvd = sec("providers")
-        ab = sec("agent_backend")
-        if isinstance(ab, str):
-            ab = {"backend": ab}
-        elif isinstance(ab, dict):
-            ab = {k.lower(): v for k, v in ab.items()}
         feat = sec("features")
-
-        _tc = _field_defaults(TestCheckConfig)
-        _cf = _field_defaults(ClassifyFixConfig)
-        _rw = _field_defaults(ResetWorkspaceConfig)
-        _ig = _field_defaults(ImplementGateConfig)
-        _sf = _field_defaults(SafetyConfig)
-        _rd = _field_defaults(ReadDbConfig)
-        _rs = _field_defaults(RunSkillConfig)
-        _mc = _field_defaults(CoreRunConfig)
-        _ws = _field_defaults(WorktreeSetupConfig)
-        _mi = _field_defaults(MigrationConfig)
-        _tu = _field_defaults(TokenUsageConfig)
-        _qg = _field_defaults(QuotaGuardConfig)
-        _gh = _field_defaults(GitHubConfig)
-        _rb = _field_defaults(ReportBugConfig)
-        _lg = _field_defaults(LoggingConfig)
-        _dg = _field_defaults(DiagnosticsConfig)
-        _lt = _field_defaults(LinuxTracingConfig)
-        _mr = _field_defaults(McpResponseConfig)
-        _br = _field_defaults(BranchingConfig)
-        _ci = _field_defaults(CIConfig)
-        _rv = _field_defaults(ReviewConfig)
-        _pn = _field_defaults(PlanConfig)
-        _sk = _field_defaults(SkillsConfig)
-        _wsc = _field_defaults(WorkspaceConfig)
-        _fr = _field_defaults(FleetConfig)
-        _pvd = _field_defaults(ProvidersConfig)
-        _ab = _field_defaults(AgentBackendConfig)
-
-        _features_dict, _exp_enabled = AutomationConfig._build_features_dict(
+        features_dict, exp_enabled = AutomationConfig._build_features_dict(
             dict(feat) if isinstance(feat, dict) else {}
         )
 
-        _raw_command = val(tc, "command", None)
-        result = cls(
-            test_check=TestCheckConfig(
-                command=list(_raw_command) if _raw_command is not None else _COMMAND_UNSET,
-                timeout=int(val(tc, "timeout", _tc["timeout"])),
-                filter_mode=val(tc, "filter_mode", _tc["filter_mode"]) or None,
-                base_ref=val(tc, "base_ref", _tc["base_ref"]) or None,
-                commands=_to_optional_commands(val(tc, "commands", _tc["commands"])),
-            ),
-            classify_fix=ClassifyFixConfig(
-                path_prefixes=list(val(cf, "path_prefixes", _cf["path_prefixes"])),
-            ),
-            reset_workspace=ResetWorkspaceConfig(
-                command=_to_optional_list(val(rw, "command", _rw["command"])),
-                preserve_dirs=set(val(rw, "preserve_dirs", _rw["preserve_dirs"])),
-            ),
-            implement_gate=ImplementGateConfig(
-                marker=str(val(ig, "marker", _ig["marker"])),
-                skill_names=set(val(ig, "skill_names", _ig["skill_names"])),
-                allowed_plan_dirs=set(val(ig, "allowed_plan_dirs", _ig["allowed_plan_dirs"])),
-            ),
-            safety=SafetyConfig(
-                reset_guard_marker=str(val(sf, "reset_guard_marker", _sf["reset_guard_marker"])),
-                require_dry_walkthrough=bool(
-                    val(sf, "require_dry_walkthrough", _sf["require_dry_walkthrough"])
-                ),
-                test_gate_on_merge=bool(val(sf, "test_gate_on_merge", _sf["test_gate_on_merge"])),
-                protected_branches=list(val(sf, "protected_branches", _sf["protected_branches"])),
-            ),
-            read_db=ReadDbConfig(
-                timeout=int(val(rd, "timeout", _rd["timeout"])),
-                max_rows=int(val(rd, "max_rows", _rd["max_rows"])),
-            ),
-            run_skill=RunSkillConfig(
-                timeout=int(val(rs, "timeout", _rs["timeout"])),
-                stale_threshold=int(val(rs, "stale_threshold", _rs["stale_threshold"])),
-                completion_marker=str(val(rs, "completion_marker", _rs["completion_marker"])),
-                completion_drain_timeout=float(
-                    val(rs, "completion_drain_timeout", _rs["completion_drain_timeout"])
-                ),
-                exit_after_stop_delay_ms=int(
-                    val(rs, "exit_after_stop_delay_ms", _rs["exit_after_stop_delay_ms"])
-                ),
-                natural_exit_grace_seconds=float(
-                    val(rs, "natural_exit_grace_seconds", _rs["natural_exit_grace_seconds"])
-                ),
-                idle_output_timeout=int(
-                    val(rs, "idle_output_timeout", _rs["idle_output_timeout"])
-                ),
-                max_suppression_seconds=int(
-                    val(rs, "max_suppression_seconds", _rs["max_suppression_seconds"])
-                ),
-                stream_idle_timeout_ms=int(
-                    val(rs, "stream_idle_timeout_ms", _rs["stream_idle_timeout_ms"])
-                ),
-            ),
-            model=CoreRunConfig(
-                default_model=_d
-                if (_d := val(mc, "default", None)) is not None
-                else _mc["default_model"],
-                model_override=val(mc, "override", _mc["model_override"]) or None,
-                provider=str(val(mc, "provider", _mc["provider"])),
-                step_overrides=val(mc, "step_overrides", _mc["step_overrides"]),
-                recipe_overrides=val(mc, "recipe_overrides", _mc["recipe_overrides"]),
-            ),
-            worktree_setup=WorktreeSetupConfig(
-                command=_to_optional_list(val(ws, "command", _ws["command"])),
-            ),
-            migration=MigrationConfig(
-                suppressed=list(val(mi, "suppressed", _mi["suppressed"])),
-            ),
-            token_usage=TokenUsageConfig(
-                verbosity=str(val(tu, "verbosity", _tu["verbosity"])),
-            ),
-            quota_guard=QuotaGuardConfig(
-                enabled=bool(val(qg, "enabled", _qg["enabled"])),
-                short_window_enabled=bool(
-                    val(qg, "short_window_enabled", _qg["short_window_enabled"])
-                ),
-                long_window_enabled=bool(
-                    val(qg, "long_window_enabled", _qg["long_window_enabled"])
-                ),
-                short_window_threshold=float(
-                    val(qg, "short_window_threshold", _qg["short_window_threshold"])
-                ),
-                long_window_threshold=float(
-                    val(qg, "long_window_threshold", _qg["long_window_threshold"])
-                ),
-                long_window_patterns=list(
-                    val(qg, "long_window_patterns", _qg["long_window_patterns"])
-                ),
-                buffer_seconds=int(val(qg, "buffer_seconds", _qg["buffer_seconds"])),
-                cache_max_age=int(val(qg, "cache_max_age", _qg["cache_max_age"])),
-                cache_refresh_interval=int(
-                    val(qg, "cache_refresh_interval", _qg["cache_refresh_interval"])
-                ),
-                credentials_path=str(val(qg, "credentials_path", _qg["credentials_path"])),
-                cache_path=str(val(qg, "cache_path", _qg["cache_path"])),
-            ),
-            github=GitHubConfig(
-                token=val(gh, "token", _gh["token"]) or None,
-                default_repo=val(gh, "default_repo", _gh["default_repo"]) or None,
-                in_progress_label=str(val(gh, "in_progress_label", _gh["in_progress_label"])),
-                staged_label=str(val(gh, "staged_label", _gh["staged_label"])),
-                fail_label=str(val(gh, "fail_label", _gh["fail_label"])),
-                queued_label=str(val(gh, "queued_label", _gh["queued_label"])),
-                allowed_labels=list(val(gh, "allowed_labels", _gh["allowed_labels"])),
-            ),
-            report_bug=ReportBugConfig(
-                timeout=int(val(rb, "timeout", _rb["timeout"])),
-                model=val(rb, "model", _rb["model"]) or None,
-                report_dir=val(rb, "report_dir", _rb["report_dir"]) or None,
-                github_filing=bool(val(rb, "github_filing", _rb["github_filing"])),
-                github_labels=list(val(rb, "github_labels", _rb["github_labels"])),
-            ),
-            logging=LoggingConfig(
-                level=str(val(lg, "level", _lg["level"])).upper(),
-                json_output=(
-                    bool(_jo)
-                    if (_jo := val(lg, "json_output", _lg["json_output"])) is not None
-                    else None
-                ),
-            ),
-            diagnostics=DiagnosticsConfig(
-                post_run_analysis=bool(val(dg, "post_run_analysis", _dg["post_run_analysis"])),
-            ),
-            linux_tracing=LinuxTracingConfig(
-                enabled=bool(val(lt, "enabled", _lt["enabled"])),
-                proc_interval=float(val(lt, "proc_interval", _lt["proc_interval"])),
-                log_dir=str(val(lt, "log_dir", _lt["log_dir"])),
-                tmpfs_path=str(val(lt, "tmpfs_path", _lt["tmpfs_path"])),
-                max_sessions=int(val(lt, "max_sessions", _lt["max_sessions"])),
-            ),
-            mcp_response=McpResponseConfig(
-                alert_threshold_tokens=int(
-                    val(mr, "alert_threshold_tokens", _mr["alert_threshold_tokens"])
-                ),
-            ),
-            branching=BranchingConfig(
-                default_base_branch=str(
-                    val(br, "default_base_branch", _br["default_base_branch"])
-                ),
-                promotion_target=str(val(br, "promotion_target", _br["promotion_target"])),
-            ),
-            ci=CIConfig(
-                workflow=val(ci, "workflow", _ci["workflow"]) or None,
-                event=val(ci, "event", _ci["event"]) or None,
-            ),
-            review=ReviewConfig(
-                local_review_rounds=_parse_int_config(
-                    val(rv, "local_review_rounds", _rv["local_review_rounds"]),
-                    "review.local_review_rounds",
-                ),
-            ),
-            plan=PlanConfig(
-                adversarial_review_level=val(
-                    pn, "adversarial_review_level", _pn["adversarial_review_level"]
-                ),
-            ),
-            skills=SkillsConfig(
-                tier1=list(val(sk, "tier1", _sk["tier1"])),
-                tier2=list(val(sk, "tier2", _sk["tier2"])),
-                tier3=list(val(sk, "tier3", _sk["tier3"])),
-            ),
-            subsets=_build_subsets_config(_sub),
-            packs=_build_packs_config(pk),
-            workspace=WorkspaceConfig(
-                worktree_root=val(ws_raw, "worktree_root", _wsc["worktree_root"]) or None,
-                runs_root=val(ws_raw, "runs_root", _wsc["runs_root"]) or None,
-                temp_dir=val(ws_raw, "temp_dir", _wsc["temp_dir"]) or None,
-            ),
-            fleet=FleetConfig(
-                default_timeout_sec=int(
-                    val(fr, "default_timeout_sec", _fr["default_timeout_sec"])
-                ),
-                max_concurrent_dispatches=int(
-                    val(fr, "max_concurrent_dispatches", _fr["max_concurrent_dispatches"])
-                ),
-                max_total_issues=int(val(fr, "max_total_issues", _fr["max_total_issues"])),
-                enable_deadline_extension=bool(
-                    val(fr, "enable_deadline_extension", _fr["enable_deadline_extension"])
-                ),
-                max_extension_seconds=float(
-                    val(fr, "max_extension_seconds", _fr["max_extension_seconds"])
-                ),
-                idle_output_timeout=float(
-                    val(fr, "idle_output_timeout", _fr["idle_output_timeout"])
-                ),
-                acquire_timeout_sec=float(
-                    val(fr, "acquire_timeout_sec", _fr["acquire_timeout_sec"])
-                ),
-                max_issues_per_food_truck=int(
-                    val(fr, "max_issues_per_food_truck", _fr["max_issues_per_food_truck"])
-                ),
-            ),
-            providers=ProvidersConfig(
-                default_provider=val(pvd, "default_provider", _pvd["default_provider"]),
-                profiles=val(pvd, "profiles", _pvd["profiles"]),
-                step_overrides=val(pvd, "step_overrides", _pvd["step_overrides"]),
-                recipe_overrides=val(pvd, "recipe_overrides", _pvd["recipe_overrides"]),
-                model_overrides=val(pvd, "model_overrides", _pvd["model_overrides"]),
-                provider_retry_limit=_parse_int_field(
-                    val(pvd, "provider_retry_limit", _pvd["provider_retry_limit"]),
-                    "providers.provider_retry_limit",
-                ),
-            ),
-            agent_backend=AgentBackendConfig(
-                backend=str(
-                    ab if isinstance(ab, str) and ab else val(ab, "backend", _ab["backend"])
-                ),
-            ),
-            features=_features_dict,
-            experimental_enabled=_exp_enabled,
-        )
+        kwargs: dict[str, Any] = {}
+        for f in dataclasses.fields(cls):
+            if f.name in ("features", "experimental_enabled"):
+                continue
+
+            section_name = f.name
+            section_raw = sec(section_name)
+
+            preprocess = _SECTION_PREPROCESSORS.get(section_name)
+            if preprocess is not None:
+                section_raw = preprocess(section_raw)
+
+            builder = _SECTION_BUILDERS.get(section_name)
+            if builder is not None:
+                kwargs[section_name] = builder(section_raw)
+            else:
+                if f.default_factory is dataclasses.MISSING or not dataclasses.is_dataclass(
+                    f.default_factory
+                ):
+                    raise ConfigSchemaError(
+                        f"AutomationConfig field {f.name!r} has no dataclass factory; "
+                        f"add it to _SECTION_BUILDERS or handle it explicitly."
+                    )
+                kwargs[section_name] = _build_subconfig(
+                    f.default_factory, section_raw, section_name
+                )
+
+        kwargs["features"] = features_dict
+        kwargs["experimental_enabled"] = exp_enabled
+
+        result = cls(**kwargs)
         try:
             result.fleet.validate(
                 is_feature_enabled(
@@ -599,20 +450,11 @@ def _build_config_schema() -> dict[str, frozenset[str]]:
     """Derive a two-level schema map {section: {valid_field_names}} from AutomationConfig."""
     schema: dict[str, frozenset[str]] = {}
     for f in dataclasses.fields(AutomationConfig):
-        # Special case: features is a dict[str, bool]; valid sub-keys come from FEATURE_REGISTRY
         if f.name == "features":
             schema["features"] = frozenset(FEATURE_REGISTRY.keys()) | frozenset(
                 {"experimental_enabled"}
             )
             continue
-        # YAML uses short keys ('default', 'override') to keep user config concise;
-        # the Python fields use explicit names to avoid shadowing builtins.
-        if f.name == "model":
-            schema["model"] = frozenset(
-                {"default", "override", "provider", "step_overrides", "recipe_overrides"}
-            )
-            continue
-        # Skip the scalar experimental_enabled field — it is handled under the features section
         if f.name == "experimental_enabled":
             continue
         sub_type: type | None = None
@@ -622,11 +464,20 @@ def _build_config_schema() -> dict[str, frozenset[str]]:
                 sub_type = factory
         elif f.default is not dataclasses.MISSING and dataclasses.is_dataclass(f.default):
             sub_type = type(f.default)
-        schema[f.name] = (
-            frozenset(sf.name for sf in dataclasses.fields(sub_type))
-            if sub_type is not None
-            else frozenset()
-        )
+        if sub_type is not None:
+            yaml_keys: set[str] = set()
+            for sf in dataclasses.fields(sub_type):
+                alias = _YAML_KEY_ALIASES.get((f.name, sf.name))
+                yaml_keys.add(alias if alias is not None else sf.name)
+            # Also include YAML keys from field overrides that use different key names
+            for (sec_name, _field_name), _override in _FIELD_OVERRIDES.items():
+                if sec_name == f.name:
+                    alias = _YAML_KEY_ALIASES.get((sec_name, _field_name))
+                    if alias is not None:
+                        yaml_keys.add(alias)
+            schema[f.name] = frozenset(yaml_keys)
+        else:
+            schema[f.name] = frozenset()
     return schema
 
 

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -13,9 +13,18 @@ from __future__ import annotations
 import dataclasses
 import types
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar, Union, get_args, get_origin, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from autoskillit.config._config_dataclasses import (
     _COMMAND_UNSET,
@@ -257,12 +266,12 @@ def _preprocess_agent_backend(raw: Any) -> dict[str, Any]:
 
 
 # Section-level pre-processors applied before _build_subconfig.
-_SECTION_PREPROCESSORS: dict[str, Any] = {
+_SECTION_PREPROCESSORS: dict[str, Callable[[Any], dict[str, Any]]] = {
     "agent_backend": _preprocess_agent_backend,
 }
 
 # Sections with fully custom builders (bypass _build_subconfig entirely).
-_SECTION_BUILDERS: dict[str, Any] = {
+_SECTION_BUILDERS: dict[str, Callable[[dict[str, Any]], Any]] = {
     "subsets": _build_subsets_config,
     "packs": _build_packs_config,
 }
@@ -286,6 +295,10 @@ def _build_subconfig(cls: type[_T], section: dict[str, Any], section_name: str) 
             continue
         yaml_key = _YAML_KEY_ALIASES.get(override_key, f.name)
         raw = section.get(yaml_key, defaults.get(f.name))
+        if raw is None and f.name not in defaults:
+            raise ConfigSchemaError(
+                f"{section_name}.{f.name} is required but absent from config and has no default."
+            )
         kwargs[f.name] = _coerce_value(raw, hints[f.name], f"{section_name}.{yaml_key}")
 
     return cls(**kwargs)  # type: ignore[return-value]
@@ -293,6 +306,16 @@ def _build_subconfig(cls: type[_T], section: dict[str, Any], section_name: str) 
 
 @dataclass
 class AutomationConfig:
+    """Root configuration dataclass for AutoSkillit.
+
+    Schema contract: all direct fields (except ``features`` and
+    ``experimental_enabled``) must use ``field(default_factory=<DataclassType>)``
+    where the factory is a dataclass, or be registered in ``_SECTION_BUILDERS``
+    for custom build logic. Any scalar or non-dataclass field not in
+    ``_SECTION_BUILDERS`` will raise ``ConfigSchemaError`` at load time in
+    ``from_dynaconf``.
+    """
+
     test_check: TestCheckConfig = field(default_factory=TestCheckConfig)
     classify_fix: ClassifyFixConfig = field(default_factory=ClassifyFixConfig)
     reset_workspace: ResetWorkspaceConfig = field(default_factory=ResetWorkspaceConfig)

--- a/tests/config/CLAUDE.md
+++ b/tests/config/CLAUDE.md
@@ -28,4 +28,5 @@ Configuration loading, defaults, and schema tests.
 | `test_timeout_coherence.py` | Tests for idle_output_timeout config coherence validation gate |
 | `test_subsets_config.py` | Tests for SubsetsConfig loading and validation |
 | `test_workspace_temp_dir_config.py` | Tests for workspace.temp_dir layered config resolution |
+| `test_subconfig_builder.py` | Tests for _coerce_value, _build_subconfig, YAML key aliases, and field overrides |
 | `test_write_config_layer.py` | Tests for write_config_layer atomic write and validation |

--- a/tests/config/test_subconfig_builder.py
+++ b/tests/config/test_subconfig_builder.py
@@ -15,20 +15,10 @@ from autoskillit.config.settings import (
 pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
 
-# ---------------------------------------------------------------------------
-# Helper test dataclass
-# ---------------------------------------------------------------------------
-
-
 @dataclasses.dataclass
 class SimpleConfig:
     x: int = 1
     y: str = "a"
-
-
-# ---------------------------------------------------------------------------
-# T1: test_coerce_value_int
-# ---------------------------------------------------------------------------
 
 
 def test_coerce_value_int() -> None:
@@ -39,11 +29,6 @@ def test_coerce_value_int() -> None:
     assert "x.y" in str(exc_info.value)
 
 
-# ---------------------------------------------------------------------------
-# T2: test_coerce_value_float
-# ---------------------------------------------------------------------------
-
-
 def test_coerce_value_float() -> None:
     assert _coerce_value(1.5, float, "x.y") == 1.5
     assert _coerce_value("2.5", float, "x.y") == 2.5
@@ -52,19 +37,9 @@ def test_coerce_value_float() -> None:
     assert "x.y" in str(exc_info.value)
 
 
-# ---------------------------------------------------------------------------
-# T3: test_coerce_value_bool
-# ---------------------------------------------------------------------------
-
-
 def test_coerce_value_bool() -> None:
     assert _coerce_value(True, bool, "x.y") is True
     assert _coerce_value(0, bool, "x.y") is False
-
-
-# ---------------------------------------------------------------------------
-# T4: test_coerce_value_str
-# ---------------------------------------------------------------------------
 
 
 def test_coerce_value_str() -> None:
@@ -72,38 +47,18 @@ def test_coerce_value_str() -> None:
     assert _coerce_value(42, str, "x.y") == "42"
 
 
-# ---------------------------------------------------------------------------
-# T5: test_coerce_value_list
-# ---------------------------------------------------------------------------
-
-
 def test_coerce_value_list() -> None:
     assert _coerce_value(["a", "b"], list[str], "x.y") == ["a", "b"]
     assert _coerce_value(("a",), list[str], "x.y") == ["a"]
-
-
-# ---------------------------------------------------------------------------
-# T6: test_coerce_value_set
-# ---------------------------------------------------------------------------
 
 
 def test_coerce_value_set() -> None:
     assert _coerce_value(["a", "b"], set[str], "x.y") == {"a", "b"}
 
 
-# ---------------------------------------------------------------------------
-# T7: test_coerce_value_dict_passthrough
-# ---------------------------------------------------------------------------
-
-
 def test_coerce_value_dict_passthrough() -> None:
     d = {"k": "v"}
     assert _coerce_value(d, dict[str, str], "x.y") is d
-
-
-# ---------------------------------------------------------------------------
-# T8: test_coerce_value_str_or_none
-# ---------------------------------------------------------------------------
 
 
 def test_coerce_value_str_or_none() -> None:
@@ -112,20 +67,10 @@ def test_coerce_value_str_or_none() -> None:
     assert _coerce_value(None, str | None, "x.y") is None
 
 
-# ---------------------------------------------------------------------------
-# T9: test_coerce_value_list_or_none
-# ---------------------------------------------------------------------------
-
-
 def test_coerce_value_list_or_none() -> None:
     assert _coerce_value(["a"], list[str] | None, "x.y") == ["a"]
     assert _coerce_value([], list[str] | None, "x.y") is None
     assert _coerce_value(None, list[str] | None, "x.y") is None
-
-
-# ---------------------------------------------------------------------------
-# T10: test_coerce_value_bool_or_none_preserves_false
-# ---------------------------------------------------------------------------
 
 
 def test_coerce_value_bool_or_none_preserves_false() -> None:
@@ -134,20 +79,10 @@ def test_coerce_value_bool_or_none_preserves_false() -> None:
     assert _coerce_value(None, bool | None, "x.y") is None
 
 
-# ---------------------------------------------------------------------------
-# T11: test_build_subconfig_simple
-# ---------------------------------------------------------------------------
-
-
 def test_build_subconfig_simple() -> None:
     result = _build_subconfig(SimpleConfig, {"x": 5, "y": "b"}, "simple")
     assert result.x == 5
     assert result.y == "b"
-
-
-# ---------------------------------------------------------------------------
-# T12: test_build_subconfig_missing_key_uses_default
-# ---------------------------------------------------------------------------
 
 
 def test_build_subconfig_missing_key_uses_default() -> None:
@@ -156,21 +91,11 @@ def test_build_subconfig_missing_key_uses_default() -> None:
     assert result.y == "a"
 
 
-# ---------------------------------------------------------------------------
-# T13: test_build_subconfig_yaml_key_alias
-# ---------------------------------------------------------------------------
-
-
 def test_build_subconfig_yaml_key_alias(monkeypatch: pytest.MonkeyPatch) -> None:
     # Temporarily add an alias for "simple.x" -> "aliased_x"
     monkeypatch.setitem(_YAML_KEY_ALIASES, ("simple", "x"), "aliased_x")
     result = _build_subconfig(SimpleConfig, {"aliased_x": 99}, "simple")
     assert result.x == 99
-
-
-# ---------------------------------------------------------------------------
-# T14: test_build_subconfig_field_override
-# ---------------------------------------------------------------------------
 
 
 def test_build_subconfig_field_override(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/config/test_subconfig_builder.py
+++ b/tests/config/test_subconfig_builder.py
@@ -1,0 +1,220 @@
+"""Tests for _coerce_value, _build_subconfig, and related helpers."""
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from autoskillit.config.settings import (
+    _FIELD_OVERRIDES,
+    _YAML_KEY_ALIASES,
+    _build_subconfig,
+    _coerce_value,
+    _field_defaults,
+)
+
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# Helper test dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SimpleConfig:
+    x: int = 1
+    y: str = "a"
+
+
+# ---------------------------------------------------------------------------
+# T1: test_coerce_value_int
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_int() -> None:
+    assert _coerce_value(42, int, "x.y") == 42
+    assert _coerce_value("42", int, "x.y") == 42
+    with pytest.raises(Exception) as exc_info:
+        _coerce_value("abc", int, "x.y")
+    assert "x.y" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# T2: test_coerce_value_float
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_float() -> None:
+    assert _coerce_value(1.5, float, "x.y") == 1.5
+    assert _coerce_value("2.5", float, "x.y") == 2.5
+    with pytest.raises(Exception) as exc_info:
+        _coerce_value("abc", float, "x.y")
+    assert "x.y" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# T3: test_coerce_value_bool
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_bool() -> None:
+    assert _coerce_value(True, bool, "x.y") is True
+    assert _coerce_value(0, bool, "x.y") is False
+
+
+# ---------------------------------------------------------------------------
+# T4: test_coerce_value_str
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_str() -> None:
+    assert _coerce_value("hello", str, "x.y") == "hello"
+    assert _coerce_value(42, str, "x.y") == "42"
+
+
+# ---------------------------------------------------------------------------
+# T5: test_coerce_value_list
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_list() -> None:
+    assert _coerce_value(["a", "b"], list[str], "x.y") == ["a", "b"]
+    assert _coerce_value(("a",), list[str], "x.y") == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# T6: test_coerce_value_set
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_set() -> None:
+    assert _coerce_value(["a", "b"], set[str], "x.y") == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# T7: test_coerce_value_dict_passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_dict_passthrough() -> None:
+    d = {"k": "v"}
+    assert _coerce_value(d, dict[str, str], "x.y") is d
+
+
+# ---------------------------------------------------------------------------
+# T8: test_coerce_value_str_or_none
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_str_or_none() -> None:
+    assert _coerce_value("hello", str | None, "x.y") == "hello"
+    assert _coerce_value("", str | None, "x.y") is None
+    assert _coerce_value(None, str | None, "x.y") is None
+
+
+# ---------------------------------------------------------------------------
+# T9: test_coerce_value_list_or_none
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_list_or_none() -> None:
+    assert _coerce_value(["a"], list[str] | None, "x.y") == ["a"]
+    assert _coerce_value([], list[str] | None, "x.y") is None
+    assert _coerce_value(None, list[str] | None, "x.y") is None
+
+
+# ---------------------------------------------------------------------------
+# T10: test_coerce_value_bool_or_none_preserves_false
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_value_bool_or_none_preserves_false() -> None:
+    assert _coerce_value(False, bool | None, "x.y") is False
+    assert _coerce_value(True, bool | None, "x.y") is True
+    assert _coerce_value(None, bool | None, "x.y") is None
+
+
+# ---------------------------------------------------------------------------
+# T11: test_build_subconfig_simple
+# ---------------------------------------------------------------------------
+
+
+def test_build_subconfig_simple() -> None:
+    result = _build_subconfig(SimpleConfig, {"x": 5, "y": "b"}, "simple")
+    assert result.x == 5
+    assert result.y == "b"
+
+
+# ---------------------------------------------------------------------------
+# T12: test_build_subconfig_missing_key_uses_default
+# ---------------------------------------------------------------------------
+
+
+def test_build_subconfig_missing_key_uses_default() -> None:
+    result = _build_subconfig(SimpleConfig, {}, "simple")
+    assert result.x == 1
+    assert result.y == "a"
+
+
+# ---------------------------------------------------------------------------
+# T13: test_build_subconfig_yaml_key_alias
+# ---------------------------------------------------------------------------
+
+
+def test_build_subconfig_yaml_key_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Temporarily add an alias for "simple.x" -> "aliased_x"
+    monkeypatch.setitem(_YAML_KEY_ALIASES, ("simple", "x"), "aliased_x")
+    result = _build_subconfig(SimpleConfig, {"aliased_x": 99}, "simple")
+    assert result.x == 99
+
+
+# ---------------------------------------------------------------------------
+# T14: test_build_subconfig_field_override
+# ---------------------------------------------------------------------------
+
+
+def test_build_subconfig_field_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    override_called: list[Any] = []
+
+    def my_override(sec: dict[str, Any], defs: dict[str, Any]) -> Any:
+        override_called.append((sec, defs))
+        return 999
+
+    monkeypatch.setitem(_FIELD_OVERRIDES, ("simple", "x"), my_override)
+    result = _build_subconfig(SimpleConfig, {"x": 5}, "simple")
+    assert result.x == 999
+    assert override_called
+
+
+# ---------------------------------------------------------------------------
+# T15: test_build_subconfig_discovers_all_production_fields
+# ---------------------------------------------------------------------------
+
+
+def test_build_subconfig_discovers_all_production_fields() -> None:
+    """Regression gate: every production sub-config dataclass must be handled."""
+    from autoskillit.config.settings import (
+        _SECTION_BUILDERS,
+        AutomationConfig,
+    )
+
+    for f in dataclasses.fields(AutomationConfig):
+        if f.name in ("features", "experimental_enabled"):
+            continue
+        if f.name in _SECTION_BUILDERS:
+            continue
+        if f.default_factory is dataclasses.MISSING or not dataclasses.is_dataclass(
+            f.default_factory
+        ):
+            continue
+
+        cls = f.default_factory
+        defaults = _field_defaults(cls)
+        section_name = f.name
+        result = _build_subconfig(cls, dict(defaults), section_name)
+
+        for sf in dataclasses.fields(cls):
+            assert hasattr(result, sf.name), (
+                f"{cls.__name__}.{sf.name} not populated by _build_subconfig"
+            )

--- a/tests/config/test_subconfig_builder.py
+++ b/tests/config/test_subconfig_builder.py
@@ -10,7 +10,6 @@ from autoskillit.config.settings import (
     _YAML_KEY_ALIASES,
     _build_subconfig,
     _coerce_value,
-    _field_defaults,
 )
 
 pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
@@ -185,36 +184,3 @@ def test_build_subconfig_field_override(monkeypatch: pytest.MonkeyPatch) -> None
     result = _build_subconfig(SimpleConfig, {"x": 5}, "simple")
     assert result.x == 999
     assert override_called
-
-
-# ---------------------------------------------------------------------------
-# T15: test_build_subconfig_discovers_all_production_fields
-# ---------------------------------------------------------------------------
-
-
-def test_build_subconfig_discovers_all_production_fields() -> None:
-    """Regression gate: every production sub-config dataclass must be handled."""
-    from autoskillit.config.settings import (
-        _SECTION_BUILDERS,
-        AutomationConfig,
-    )
-
-    for f in dataclasses.fields(AutomationConfig):
-        if f.name in ("features", "experimental_enabled"):
-            continue
-        if f.name in _SECTION_BUILDERS:
-            continue
-        if f.default_factory is dataclasses.MISSING or not dataclasses.is_dataclass(
-            f.default_factory
-        ):
-            continue
-
-        cls = f.default_factory
-        defaults = _field_defaults(cls)
-        section_name = f.name
-        result = _build_subconfig(cls, dict(defaults), section_name)
-
-        for sf in dataclasses.fields(cls):
-            assert hasattr(result, sf.name), (
-                f"{cls.__name__}.{sf.name} not populated by _build_subconfig"
-            )

--- a/tests/contracts/test_config_field_coverage.py
+++ b/tests/contracts/test_config_field_coverage.py
@@ -1,13 +1,10 @@
 """REQ-CONFIG-001: every sub-config dataclass field must be referenced in from_dynaconf.
 
 Finding 9.1 — gate that prevents silent omissions when new fields are added to any
-*Config dataclass in settings.py without a corresponding val(...) line in
-AutomationConfig.from_dynaconf (or in a _build_* helper directly called from it).
+*Config dataclass in settings.py without being handled by _build_subconfig.
 """
 
-import ast
 import dataclasses
-from pathlib import Path
 
 import pytest
 
@@ -24,81 +21,33 @@ _SUBCONFIG_DATACLASSES = [
 ]
 
 
-def _collect_referenced_names(tree: ast.Module) -> set[str]:
-    """Collect all string constants and keyword argument names from from_dynaconf
-    and any _build_* module-level helper functions it calls directly.
-
-    Rationale: some sub-configs (e.g. SubsetsConfig, PacksConfig) are built by
-    dedicated _build_* helpers that contain the actual val(...) / .get(...) calls.
-    These helpers are called directly from from_dynaconf and are part of the same
-    construction pipeline — their field references are equally authoritative.
-    After the config split, _build_* helpers may reside in _config_loader.py
-    rather than settings.py; both modules are scanned.
-    """
-    # Collect all module-level function definitions from settings.py
-    top_level_fns: dict[str, ast.FunctionDef] = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef):
-            top_level_fns[node.name] = node
-
-    # Also collect from _config_loader.py (split destination for _build_* helpers)
-    loader_path = Path(settings_mod.__file__).parent / "_config_loader.py"
-    if loader_path.exists():
-        loader_tree = ast.parse(loader_path.read_text())
-        for node in ast.walk(loader_tree):
-            if isinstance(node, ast.FunctionDef) and node.name not in top_level_fns:
-                top_level_fns[node.name] = node
-
-    fn: ast.FunctionDef | None = top_level_fns.get("from_dynaconf")
-    assert fn is not None, "from_dynaconf must exist"
-
-    # Collect _build_* function names called from from_dynaconf
-    helper_names: set[str] = set()
-    for node in ast.walk(fn):
-        if isinstance(node, ast.Call):
-            func = node.func
-            name = (
-                func.id
-                if isinstance(func, ast.Name)
-                else func.attr
-                if isinstance(func, ast.Attribute)
-                else None
-            )
-            if name and name.startswith("_build_"):
-                helper_names.add(name)
-
-    # Walk from_dynaconf + all called _build_* helpers
-    nodes_to_walk: list[ast.AST] = [fn]
-    for helper_name in helper_names:
-        helper_fn = top_level_fns.get(helper_name)
-        if helper_fn is not None:
-            nodes_to_walk.append(helper_fn)
-
-    referenced: set[str] = set()
-    for root in nodes_to_walk:
-        for node in ast.walk(root):
-            if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                referenced.add(node.value)
-            if isinstance(node, ast.keyword) and node.arg:
-                referenced.add(node.arg)
-    return referenced
-
-
 @pytest.mark.parametrize("dc", _SUBCONFIG_DATACLASSES, ids=lambda c: c.__name__)
 def test_every_subconfig_field_referenced_in_from_dynaconf(dc: type) -> None:
     """REQ-CONFIG-001: every dataclass field declared in any *Config
-    dataclass in settings.py must appear at least once as a string
-    constant or kwarg name inside AutomationConfig.from_dynaconf (or in
-    a _build_* helper function directly called from it).
-    Catches silent omissions when a new field is added without a
-    corresponding val(...) line."""
-    src = Path(settings_mod.__file__).read_text()
-    tree = ast.parse(src)
+    dataclass must be handled by _build_subconfig.
 
-    referenced = _collect_referenced_names(tree)
+    Calls _build_subconfig with a section dict containing all default values
+    and verifies every field is populated on the result.
+    """
+    from autoskillit.config.settings import (
+        _SECTION_BUILDERS,
+        _build_subconfig,
+        _field_defaults,
+    )
 
-    missing = [f.name for f in dataclasses.fields(dc) if f.name not in referenced]
+    section_name = None
+    for f in dataclasses.fields(AutomationConfig):
+        if f.default_factory is not dataclasses.MISSING and f.default_factory is dc:
+            section_name = f.name
+            break
+    if section_name is None or section_name in _SECTION_BUILDERS:
+        pytest.skip(f"{dc.__name__} uses a custom builder")
+
+    defaults = _field_defaults(dc)
+    result = _build_subconfig(dc, dict(defaults), section_name)
+
+    missing = [f.name for f in dataclasses.fields(dc) if not hasattr(result, f.name)]
     assert not missing, (
-        f"{dc.__name__} fields missing from from_dynaconf/_build_* helpers: {missing}. "
-        f"Add an explicit val(...) line for each."
+        f"{dc.__name__} fields not populated by _build_subconfig: {missing}. "
+        f"Check _coerce_value handles the field's type annotation."
     )


### PR DESCRIPTION
## Summary

Replace the 200-line manual field-by-field `AutomationConfig` construction in `from_dynaconf()` (`settings.py:373–585`) with an introspection-driven loop. A new `_build_subconfig(cls, section, section_name)` function uses `dataclasses.fields()` and `typing.get_type_hints()` to auto-discover fields and apply type-appropriate coercion. A small override registry handles the ~5 fields with non-standard logic (YAML key aliases, sentinel values, transforms). This eliminates the silent-omission risk: new fields added to any sub-config dataclass are automatically populated from YAML/env-var config without requiring a manual addition to `from_dynaconf`.

## Changed Files

### New (★):
- `tests/config/test_subconfig_builder.py`

### Modified (●):
- `src/autoskillit/config/settings.py`
- `tests/contracts/test_config_field_coverage.py`

Closes #2835

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-171432-246229/.autoskillit/temp/make-plan/refactor_autoskillitconfig_construction_plan_2026-05-26_172500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 57 | 40.5k | 1.2M | 125.6k | 142 | 186.8k | 20m 24s |
| verify | claude-sonnet-4-6 | 1 | 1.8k | 12.2k | 378.0k | 57.3k | 93 | 41.4k | 6m 41s |
| implement* | MiniMax-M2.7-highspeed | 1 | 4.4M | 24.8k | 2.6M | 36.2k | 191 | 32.5k | 15m 33s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 89.0k | 2.8k | 249.5k | 36.3k | 21 | 27.5k | 1m 15s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.5k | 1.5k | 182.4k | 30.9k | 14 | 15.4k | 39s |
| review_pr | claude-sonnet-4-6 | 3 | 464 | 104.4k | 3.1M | 102.8k | 186 | 306.0k | 26m 32s |
| resolve_review | claude-sonnet-4-6 | 3 | 1.0k | 65.4k | 6.9M | 76.1k | 283 | 180.6k | 41m 2s |
| **Total** | | | 4.5M | 251.6k | 14.6M | 125.6k | | 790.2k | 1h 52m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 804 | 3228.6 | 40.4 | 30.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 157 | 43818.7 | 1150.3 | 416.3 |
| **Total** | **961** | 15215.4 | 822.2 | 261.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 3.4k | 222.5k | 11.6M | 714.7k | 1h 34m |
| MiniMax-M2.7-highspeed | 3 | 4.5M | 29.2k | 3.0M | 75.4k | 17m 28s |