### PR TITLE
Enforce CaptureEntrySpec.value_type as required field

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -177,6 +177,7 @@ from .types import BareResume as BareResume
 from .types import CampaignProtector as CampaignProtector
 from .types import CanonicalTokenUsage as CanonicalTokenUsage
 from .types import CaptureEntrySpec as CaptureEntrySpec
+from .types import CaptureValueType as CaptureValueType
 from .types import CaptureValueTypeError as CaptureValueTypeError
 from .types import ChannelBStatus as ChannelBStatus
 from .types import ChannelConfirmation as ChannelConfirmation

--- a/src/autoskillit/core/types/_type_capture.py
+++ b/src/autoskillit/core/types/_type_capture.py
@@ -44,11 +44,10 @@ class CaptureEntrySpec:
         from_: The ``${{ result.<field_name> }}`` template string — what was previously
             the plain string value in the ``dict[str, str]`` capture spec.
         value_type: One of ``path``, ``url``, ``string``, ``optional_string``.
-            Defaults to ``string`` for backward compatibility during migration.
     """
 
     from_: str
-    value_type: str = "string"
+    value_type: str
 
     def __post_init__(self) -> None:
         if not self.from_ or not self.from_.strip():

--- a/src/autoskillit/core/types/_type_capture.py
+++ b/src/autoskillit/core/types/_type_capture.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import Literal
 
 __all__ = [
     "CAPTURE_VALID_VALUE_TYPES",
     "CaptureEntrySpec",
+    "CaptureValueType",
     "CaptureValueTypeError",
     "resolve_payload_field",
 ]
@@ -35,6 +37,8 @@ def resolve_payload_field(entry: CaptureEntrySpec) -> str | None:
 
 CAPTURE_VALID_VALUE_TYPES = frozenset({"path", "url", "string", "optional_string"})
 
+CaptureValueType = Literal["path", "url", "string", "optional_string"]
+
 
 @dataclass(frozen=True, slots=True)
 class CaptureEntrySpec:
@@ -47,7 +51,7 @@ class CaptureEntrySpec:
     """
 
     from_: str
-    value_type: str
+    value_type: Literal["path", "url", "string", "optional_string"]
 
     def __post_init__(self) -> None:
         if not self.from_ or not self.from_.strip():

--- a/src/autoskillit/fleet/_capture.py
+++ b/src/autoskillit/fleet/_capture.py
@@ -129,6 +129,8 @@ def _normalize_capture_spec(
     if capture is None:
         return None
     return {
-        key: val if isinstance(val, CaptureEntrySpec) else CaptureEntrySpec(from_=val)
+        key: val
+        if isinstance(val, CaptureEntrySpec)
+        else CaptureEntrySpec(from_=val, value_type="string")
         for key, val in capture.items()
     }

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import json as _json
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from autoskillit.core import (
     CAPTURE_VALID_VALUE_TYPES,
     CORE_PACKS,
     CaptureEntrySpec,
+    CaptureValueType,
     DispatchGateType,
     LoadReport,
     LoadResult,
@@ -433,7 +434,9 @@ def _parse_capture_spec(capture_raw: Any) -> dict[str, CaptureEntrySpec]:
                         fallback="string",
                     )
                     effective_type = "string"
-                result[key] = CaptureEntrySpec(from_=from_, value_type=effective_type)
+                result[key] = CaptureEntrySpec(
+                    from_=from_, value_type=cast(CaptureValueType, effective_type)
+                )
             else:
                 logger.warning(
                     "capture_spec_malformed_longform",

--- a/tests/cli/test_food_truck_prompt.py
+++ b/tests/cli/test_food_truck_prompt.py
@@ -235,11 +235,15 @@ class TestSentinelFormat:
         "capture_arg",
         [
             {
-                "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
+                "worktree_path": CaptureEntrySpec(
+                    from_="${{ result.worktree_path }}", value_type="string"
+                ),
             },
             {
-                "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
-                "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
+                "worktree_path": CaptureEntrySpec(
+                    from_="${{ result.worktree_path }}", value_type="string"
+                ),
+                "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
             },
         ],
         ids=["1-key", "2-key"],

--- a/tests/core/test_capture.py
+++ b/tests/core/test_capture.py
@@ -45,7 +45,7 @@ class TestResolvePayloadField:
         entry = CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="path")
         assert resolve_payload_field(entry) == "worktree_path"
 
+
 def test_value_type_is_required() -> None:
     with pytest.raises(TypeError, match="value_type"):
         CaptureEntrySpec(from_="${{ result.x }}")
-

--- a/tests/core/test_capture.py
+++ b/tests/core/test_capture.py
@@ -19,15 +19,15 @@ class TestResolvePayloadField:
         ],
     )
     def test_basic_field_extraction(self, template: str, expected: str) -> None:
-        entry = CaptureEntrySpec(from_=template)
+        entry = CaptureEntrySpec(from_=template, value_type="string")
         assert resolve_payload_field(entry) == expected
 
     def test_hyphenated_field_name(self) -> None:
-        entry = CaptureEntrySpec(from_="${{ result.worktree-path }}")
+        entry = CaptureEntrySpec(from_="${{ result.worktree-path }}", value_type="string")
         assert resolve_payload_field(entry) == "worktree-path"
 
     def test_non_result_template_returns_none(self) -> None:
-        entry = CaptureEntrySpec(from_="not a template")
+        entry = CaptureEntrySpec(from_="not a template", value_type="string")
         assert resolve_payload_field(entry) is None
 
     @pytest.mark.parametrize(
@@ -38,9 +38,14 @@ class TestResolvePayloadField:
         ],
     )
     def test_whitespace_variations(self, template: str) -> None:
-        entry = CaptureEntrySpec(from_=template)
+        entry = CaptureEntrySpec(from_=template, value_type="string")
         assert resolve_payload_field(entry) == "worktree_path"
 
     def test_with_value_type(self) -> None:
         entry = CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="path")
         assert resolve_payload_field(entry) == "worktree_path"
+
+def test_value_type_is_required() -> None:
+    with pytest.raises(TypeError, match="value_type"):
+        CaptureEntrySpec(from_="${{ result.x }}")
+

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -14,7 +14,7 @@ pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature
 
 def _ce(from_: str, value_type: str = "string") -> CaptureEntrySpec:
     """Shorthand to build a CaptureEntrySpec in tests."""
-    return CaptureEntrySpec(from_=from_, value_type=value_type, value_type="string")
+    return CaptureEntrySpec(from_=from_, value_type=value_type)
 
 
 # ---------------------------------------------------------------------------
@@ -628,7 +628,9 @@ class TestCaptureFieldNameRoundTrip:
         from autoskillit.fleet._prompts import _build_food_truck_prompt
 
         capture_spec = {
-            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+            "worktree_path": CaptureEntrySpec(
+                from_="${{ result.worktree_path }}", value_type="string"
+            ),
             "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
         }
 
@@ -659,7 +661,9 @@ class TestCaptureFieldNameRoundTrip:
         from autoskillit.fleet._capture import _extract_captures
 
         capture_spec = {
-            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+            "worktree_path": CaptureEntrySpec(
+                from_="${{ result.worktree_path }}", value_type="string"
+            ),
             "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
         }
 
@@ -682,7 +686,9 @@ class TestCaptureFieldNameRoundTrip:
         from autoskillit.fleet._prompts import _build_food_truck_prompt
 
         capture_spec = {
-            "worktree-path": CaptureEntrySpec(from_="${{ result.worktree-path }}", value_type="string"),
+            "worktree-path": CaptureEntrySpec(
+                from_="${{ result.worktree-path }}", value_type="string"
+            ),
         }
 
         prompt = _build_food_truck_prompt(
@@ -721,7 +727,7 @@ def test_extract_path_type_rejects_empty_string():
     from autoskillit.fleet._capture import _extract_captures
 
     capture_spec = {
-        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path", value_type="string"),
+        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
     }
     payload = {"p": ""}
 
@@ -737,7 +743,7 @@ def test_extract_url_type_rejects_empty_string():
     from autoskillit.fleet._capture import _extract_captures
 
     capture_spec = {
-        "u": CaptureEntrySpec(from_="${{ result.u }}", value_type="url", value_type="string"),
+        "u": CaptureEntrySpec(from_="${{ result.u }}", value_type="url"),
     }
     payload = {"u": ""}
 
@@ -752,7 +758,7 @@ def test_extract_optional_string_type_accepts_empty():
     from autoskillit.fleet._capture import _extract_captures
 
     capture_spec = {
-        "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="optional_string", value_type="string"),
+        "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="optional_string"),
     }
     payload = {"pr_url": ""}
 
@@ -766,7 +772,7 @@ def test_extract_path_type_rejects_nonexistent_path(tmp_path: Path):
     from autoskillit.fleet._capture import _extract_captures
 
     capture_spec = {
-        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path", value_type="string"),
+        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
     }
     payload = {"p": str(tmp_path / "nonexistent")}
 

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -14,7 +14,7 @@ pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature
 
 def _ce(from_: str, value_type: str = "string") -> CaptureEntrySpec:
     """Shorthand to build a CaptureEntrySpec in tests."""
-    return CaptureEntrySpec(from_=from_, value_type=value_type)
+    return CaptureEntrySpec(from_=from_, value_type=value_type, value_type="string")
 
 
 # ---------------------------------------------------------------------------
@@ -628,8 +628,8 @@ class TestCaptureFieldNameRoundTrip:
         from autoskillit.fleet._prompts import _build_food_truck_prompt
 
         capture_spec = {
-            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
-            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
+            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
         }
 
         prompt = _build_food_truck_prompt(
@@ -659,8 +659,8 @@ class TestCaptureFieldNameRoundTrip:
         from autoskillit.fleet._capture import _extract_captures
 
         capture_spec = {
-            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
-            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
+            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
         }
 
         synthetic_payload = {
@@ -682,7 +682,7 @@ class TestCaptureFieldNameRoundTrip:
         from autoskillit.fleet._prompts import _build_food_truck_prompt
 
         capture_spec = {
-            "worktree-path": CaptureEntrySpec(from_="${{ result.worktree-path }}"),
+            "worktree-path": CaptureEntrySpec(from_="${{ result.worktree-path }}", value_type="string"),
         }
 
         prompt = _build_food_truck_prompt(
@@ -721,7 +721,7 @@ def test_extract_path_type_rejects_empty_string():
     from autoskillit.fleet._capture import _extract_captures
 
     capture_spec = {
-        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
+        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path", value_type="string"),
     }
     payload = {"p": ""}
 
@@ -737,7 +737,7 @@ def test_extract_url_type_rejects_empty_string():
     from autoskillit.fleet._capture import _extract_captures
 
     capture_spec = {
-        "u": CaptureEntrySpec(from_="${{ result.u }}", value_type="url"),
+        "u": CaptureEntrySpec(from_="${{ result.u }}", value_type="url", value_type="string"),
     }
     payload = {"u": ""}
 
@@ -752,7 +752,7 @@ def test_extract_optional_string_type_accepts_empty():
     from autoskillit.fleet._capture import _extract_captures
 
     capture_spec = {
-        "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="optional_string"),
+        "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="optional_string", value_type="string"),
     }
     payload = {"pr_url": ""}
 
@@ -766,7 +766,7 @@ def test_extract_path_type_rejects_nonexistent_path(tmp_path: Path):
     from autoskillit.fleet._capture import _extract_captures
 
     capture_spec = {
-        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path"),
+        "p": CaptureEntrySpec(from_="${{ result.p }}", value_type="path", value_type="string"),
     }
     payload = {"p": str(tmp_path / "nonexistent")}
 

--- a/tests/fleet/test_capture_roundtrip.py
+++ b/tests/fleet/test_capture_roundtrip.py
@@ -54,8 +54,8 @@ def test_prompt_capture_fields_match_extractor_expectations():
     from autoskillit.fleet._prompts import _build_food_truck_prompt
 
     capture_arg = {
-        "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
-        "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
+        "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+        "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
     }
 
     prompt = _build_food_truck_prompt(
@@ -90,7 +90,7 @@ def test_prompt_capture_fields_do_not_use_capture_prefix():
     from autoskillit.fleet._prompts import _build_food_truck_prompt
 
     capture_arg = {
-        "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
+        "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
     }
 
     prompt = _build_food_truck_prompt(
@@ -130,24 +130,24 @@ def _build_prompt(capture_spec: dict[str, CaptureEntrySpec]) -> str:
     "capture_spec",
     [
         # Single field, underscore name
-        {"worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}")},
+        {"worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string")},
         # Two fields, mixed names
         {
-            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
-            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
+            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
         },
         # Hyphenated field name
-        {"worktree-path": CaptureEntrySpec(from_="${{ result.worktree-path }}")},
+        {"worktree-path": CaptureEntrySpec(from_="${{ result.worktree-path }}", value_type="string")},
         # Five fields (large campaign like research recipe)
         {
-            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}"),
-            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}"),
-            "report_path": CaptureEntrySpec(from_="${{ result.report_path }}"),
-            "branch_name": CaptureEntrySpec(from_="${{ result.branch_name }}"),
-            "summary": CaptureEntrySpec(from_="${{ result.summary }}"),
+            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+            "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
+            "report_path": CaptureEntrySpec(from_="${{ result.report_path }}", value_type="string"),
+            "branch_name": CaptureEntrySpec(from_="${{ result.branch_name }}", value_type="string"),
+            "summary": CaptureEntrySpec(from_="${{ result.summary }}", value_type="string"),
         },
         # Single-char field name
-        {"x": CaptureEntrySpec(from_="${{ result.x }}")},
+        {"x": CaptureEntrySpec(from_="${{ result.x }}", value_type="string")},
     ],
     ids=["single", "two-fields", "hyphenated", "five-fields", "single-char"],
 )
@@ -213,7 +213,7 @@ def test_typed_capture_round_trip_contract(value_type, test_value, tmp_path):
     resolved_value = str(tmp_path / "test_file") if test_value is None else test_value
 
     capture_spec = {
-        "result_field": CaptureEntrySpec(from_="${{ result.result_field }}", value_type=value_type)
+        "result_field": CaptureEntrySpec(from_="${{ result.result_field }}", value_type=value_type, value_type="string")
     }
     prompt = _build_prompt(capture_spec)
 
@@ -244,7 +244,7 @@ def test_non_result_template_fallback_asymmetry():
     # Build a capture spec with a non-result.* template
     # CaptureEntrySpec.__post_init__ only checks from_ is non-empty string,
     # so ${{ campaign.x }} is accepted (passes __post_init__, fails _RESULT_REF_RE)
-    capture_spec = {"campaign_x": CaptureEntrySpec(from_="${{ campaign.x }}")}
+    capture_spec = {"campaign_x": CaptureEntrySpec(from_="${{ campaign.x }}", value_type="string")}
     prompt = _build_prompt(capture_spec)
 
     # The prompt builder falls back to key name when resolve_payload_field returns None

--- a/tests/fleet/test_capture_roundtrip.py
+++ b/tests/fleet/test_capture_roundtrip.py
@@ -54,7 +54,9 @@ def test_prompt_capture_fields_match_extractor_expectations():
     from autoskillit.fleet._prompts import _build_food_truck_prompt
 
     capture_arg = {
-        "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+        "worktree_path": CaptureEntrySpec(
+            from_="${{ result.worktree_path }}", value_type="string"
+        ),
         "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
     }
 
@@ -90,7 +92,9 @@ def test_prompt_capture_fields_do_not_use_capture_prefix():
     from autoskillit.fleet._prompts import _build_food_truck_prompt
 
     capture_arg = {
-        "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+        "worktree_path": CaptureEntrySpec(
+            from_="${{ result.worktree_path }}", value_type="string"
+        ),
     }
 
     prompt = _build_food_truck_prompt(
@@ -130,20 +134,36 @@ def _build_prompt(capture_spec: dict[str, CaptureEntrySpec]) -> str:
     "capture_spec",
     [
         # Single field, underscore name
-        {"worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string")},
+        {
+            "worktree_path": CaptureEntrySpec(
+                from_="${{ result.worktree_path }}", value_type="string"
+            )
+        },
         # Two fields, mixed names
         {
-            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+            "worktree_path": CaptureEntrySpec(
+                from_="${{ result.worktree_path }}", value_type="string"
+            ),
             "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
         },
         # Hyphenated field name
-        {"worktree-path": CaptureEntrySpec(from_="${{ result.worktree-path }}", value_type="string")},
+        {
+            "worktree-path": CaptureEntrySpec(
+                from_="${{ result.worktree-path }}", value_type="string"
+            )
+        },
         # Five fields (large campaign like research recipe)
         {
-            "worktree_path": CaptureEntrySpec(from_="${{ result.worktree_path }}", value_type="string"),
+            "worktree_path": CaptureEntrySpec(
+                from_="${{ result.worktree_path }}", value_type="string"
+            ),
             "pr_url": CaptureEntrySpec(from_="${{ result.pr_url }}", value_type="string"),
-            "report_path": CaptureEntrySpec(from_="${{ result.report_path }}", value_type="string"),
-            "branch_name": CaptureEntrySpec(from_="${{ result.branch_name }}", value_type="string"),
+            "report_path": CaptureEntrySpec(
+                from_="${{ result.report_path }}", value_type="string"
+            ),
+            "branch_name": CaptureEntrySpec(
+                from_="${{ result.branch_name }}", value_type="string"
+            ),
             "summary": CaptureEntrySpec(from_="${{ result.summary }}", value_type="string"),
         },
         # Single-char field name
@@ -213,7 +233,7 @@ def test_typed_capture_round_trip_contract(value_type, test_value, tmp_path):
     resolved_value = str(tmp_path / "test_file") if test_value is None else test_value
 
     capture_spec = {
-        "result_field": CaptureEntrySpec(from_="${{ result.result_field }}", value_type=value_type, value_type="string")
+        "result_field": CaptureEntrySpec(from_="${{ result.result_field }}", value_type=value_type)
     }
     prompt = _build_prompt(capture_spec)
 

--- a/tests/fleet/test_dispatch_state_handle.py
+++ b/tests/fleet/test_dispatch_state_handle.py
@@ -104,7 +104,9 @@ class TestResumeWithoutPriorDispatchId:
             quota_refresher=_noop_quota_refresher,
             resume_session_id="sess-123",
             prior_dispatch_id=None,
-            capture={"plan_path": CaptureEntrySpec(from_="${{ result.plan_path }}")},
+            capture={
+                "plan_path": CaptureEntrySpec(from_="${{ result.plan_path }}", value_type="string")
+            },
         )
 
         dispatches_dir = tool_ctx.temp_dir / "dispatches"


### PR DESCRIPTION
## Summary

Remove the backward-compatibility default `"string"` from `CaptureEntrySpec.value_type`, making it a required positional argument. Update all call sites (1 production, ~23 test) to pass `value_type` explicitly. Add a test verifying that omitting `value_type` raises `TypeError`.

Closes #2839

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-171431-248816/.autoskillit/temp/make-plan/enforce_captureentryspec_value_type_plan_2026-05-26_172200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 75 | 11.3k | 1.2M | 89.2k | 113 | 73.0k | 6m 56s |
| verify | claude-sonnet-4-6 | 1 | 84 | 9.0k | 456.3k | 66.2k | 33 | 50.2k | 2m 38s |
| implement* | MiniMax-M2.7-highspeed | 1 | 816.5k | 7.8k | 799.8k | 30.9k | 62 | 18.9k | 2m 52s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 100.2k | 3.3k | 305.9k | 30.9k | 26 | 15.7k | 1m 25s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 54.4k | 1.3k | 244.1k | 30.9k | 16 | 15.4k | 41s |
| review_pr | claude-sonnet-4-6 | 1 | 182 | 20.1k | 903.4k | 65.1k | 59 | 89.9k | 5m 4s |
| resolve_review | claude-sonnet-4-6 | 1 | 309 | 13.7k | 1.8M | 60.1k | 80 | 44.9k | 6m 16s |
| **Total** | | | 971.7k | 66.4k | 5.7M | 89.2k | | 308.0k | 25m 54s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 84 | 9521.3 | 224.9 | 92.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 14 | 129326.4 | 3205.6 | 980.9 |
| **Total** | **98** | 58434.7 | 3143.3 | 678.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 75 | 11.3k | 1.2M | 73.0k | 6m 56s |
| claude-sonnet-4-6 | 3 | 575 | 42.8k | 3.2M | 185.0k | 13m 59s |
| MiniMax-M2.7-highspeed | 3 | 971.1k | 12.3k | 1.3M | 50.0k | 4m 58s |