### PR TITLE
Standardize structlog contextvars scoping to context manager form

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -30,7 +30,9 @@ from .branch_guard import is_protected_branch as is_protected_branch
 from .claude_conventions import ClaudeDirectoryConventions as ClaudeDirectoryConventions
 from .claude_conventions import LayoutError as LayoutError
 from .claude_conventions import validate_add_dir as validate_add_dir
-from .claude_conventions import validate_project_local_skill_dir as validate_project_local_skill_dir
+from .claude_conventions import (
+    validate_project_local_skill_dir as validate_project_local_skill_dir,
+)
 from .claude_conventions import validate_worktree_path as validate_worktree_path
 from .feature_flags import _collect_disabled_feature_tags as _collect_disabled_feature_tags
 from .feature_flags import is_feature_enabled as is_feature_enabled
@@ -54,12 +56,12 @@ from .logging import get_logger as get_logger
 from .paths import GENERATED_FILES as GENERATED_FILES
 from .paths import claude_code_log_path as claude_code_log_path
 from .paths import claude_code_project_dir as claude_code_project_dir
+from .paths import default_log_dir as default_log_dir
 from .paths import find_latest_session_id as find_latest_session_id
 from .paths import is_generated_path as is_generated_path
 from .paths import is_git_main_checkout as is_git_main_checkout
 from .paths import is_git_worktree as is_git_worktree
 from .paths import pkg_root as pkg_root
-from .paths import default_log_dir as default_log_dir
 from .paths import resolve_main_worktree as resolve_main_worktree
 from .runtime._linux_proc import is_session_alive as is_session_alive
 from .runtime._linux_proc import read_boot_id as read_boot_id

--- a/src/autoskillit/server/tools/tools_ci_merge_queue.py
+++ b/src/autoskillit/server/tools/tools_ci_merge_queue.py
@@ -50,17 +50,16 @@ async def toggle_auto_merge(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(
+        with structlog.contextvars.bound_contextvars(
             tool="toggle_auto_merge", pr_number=pr_number, target_branch=target_branch
-        )
-        await _notify(
-            ctx,
-            "info",
-            f"Toggling auto-merge for PR #{pr_number} on {target_branch!r}",
-            "autoskillit.toggle_auto_merge",
-            extra={"pr_number": pr_number, "target_branch": target_branch},
-        )
+        ):
+            await _notify(
+                ctx,
+                "info",
+                f"Toggling auto-merge for PR #{pr_number} on {target_branch!r}",
+                "autoskillit.toggle_auto_merge",
+                extra={"pr_number": pr_number, "target_branch": target_branch},
+            )
 
         from autoskillit.server import _get_ctx
 
@@ -123,17 +122,16 @@ async def enqueue_pr(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(
+        with structlog.contextvars.bound_contextvars(
             tool="enqueue_pr", pr_number=pr_number, target_branch=target_branch
-        )
-        await _notify(
-            ctx,
-            "info",
-            f"Enrolling PR #{pr_number} in merge queue on {target_branch!r}",
-            "autoskillit.enqueue_pr",
-            extra={"pr_number": pr_number, "target_branch": target_branch},
-        )
+        ):
+            await _notify(
+                ctx,
+                "info",
+                f"Enrolling PR #{pr_number} in merge queue on {target_branch!r}",
+                "autoskillit.enqueue_pr",
+                extra={"pr_number": pr_number, "target_branch": target_branch},
+            )
 
         from autoskillit.server import _get_ctx
 
@@ -240,17 +238,16 @@ async def wait_for_merge_queue(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(
+        with structlog.contextvars.bound_contextvars(
             tool="wait_for_merge_queue", pr_number=pr_number, target_branch=target_branch
-        )
-        await _notify(
-            ctx,
-            "info",
-            f"Waiting for PR #{pr_number} in merge queue on {target_branch!r}",
-            "autoskillit.wait_for_merge_queue",
-            extra={"pr_number": pr_number, "target_branch": target_branch},
-        )
+        ):
+            await _notify(
+                ctx,
+                "info",
+                f"Waiting for PR #{pr_number} in merge queue on {target_branch!r}",
+                "autoskillit.wait_for_merge_queue",
+                extra={"pr_number": pr_number, "target_branch": target_branch},
+            )
 
         from autoskillit.server import _get_ctx
 

--- a/src/autoskillit/server/tools/tools_ci_merge_queue.py
+++ b/src/autoskillit/server/tools/tools_ci_merge_queue.py
@@ -61,27 +61,27 @@ async def toggle_auto_merge(
                 extra={"pr_number": pr_number, "target_branch": target_branch},
             )
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
+            tool_ctx = _get_ctx()
 
-        if tool_ctx.merge_queue_watcher is None:
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
-                }
+            if tool_ctx.merge_queue_watcher is None:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
+                    }
+                )
+
+            resolved_repo = await resolve_repo_from_remote(cwd, hint=remote_url or repo or None)
+
+            result = await tool_ctx.merge_queue_watcher.toggle(
+                pr_number=pr_number,
+                target_branch=target_branch,
+                repo=resolved_repo or None,
+                cwd=cwd,
             )
-
-        resolved_repo = await resolve_repo_from_remote(cwd, hint=remote_url or repo or None)
-
-        result = await tool_ctx.merge_queue_watcher.toggle(
-            pr_number=pr_number,
-            target_branch=target_branch,
-            repo=resolved_repo or None,
-            cwd=cwd,
-        )
-        return json.dumps(result)
+            return json.dumps(result)
     except Exception as exc:
         logger.error("toggle_auto_merge unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -133,36 +133,36 @@ async def enqueue_pr(
                 extra={"pr_number": pr_number, "target_branch": target_branch},
             )
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
+            tool_ctx = _get_ctx()
 
-        if tool_ctx.merge_queue_watcher is None:
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
-                }
-            )
+            if tool_ctx.merge_queue_watcher is None:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
+                    }
+                )
 
-        resolved_repo = await resolve_repo_from_remote(cwd, hint=remote_url or repo or None)
+            resolved_repo = await resolve_repo_from_remote(cwd, hint=remote_url or repo or None)
 
-        _start = time.monotonic()
-        try:
-            result = await tool_ctx.merge_queue_watcher.enqueue(
-                pr_number=pr_number,
-                target_branch=target_branch,
-                repo=resolved_repo or None,
-                cwd=cwd,
-                auto_merge_available=auto_merge_available,
-            )
-            return json.dumps(result)
-        except Exception as exc:
-            logger.error("enqueue_pr watcher error", exc_info=True)
-            return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            _start = time.monotonic()
+            try:
+                result = await tool_ctx.merge_queue_watcher.enqueue(
+                    pr_number=pr_number,
+                    target_branch=target_branch,
+                    repo=resolved_repo or None,
+                    cwd=cwd,
+                    auto_merge_available=auto_merge_available,
+                )
+                return json.dumps(result)
+            except Exception as exc:
+                logger.error("enqueue_pr watcher error", exc_info=True)
+                return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("enqueue_pr unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -249,45 +249,45 @@ async def wait_for_merge_queue(
                 extra={"pr_number": pr_number, "target_branch": target_branch},
             )
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
+            tool_ctx = _get_ctx()
 
-        if tool_ctx.merge_queue_watcher is None:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, 0.0)
-            return json.dumps(
-                {
-                    "success": False,
-                    "pr_state": "error",
-                    "reason": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
-                }
-            )
+            if tool_ctx.merge_queue_watcher is None:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, 0.0)
+                return json.dumps(
+                    {
+                        "success": False,
+                        "pr_state": "error",
+                        "reason": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
+                    }
+                )
 
-        resolved_repo = await resolve_repo_from_remote(cwd, hint=remote_url or repo or None)
+            resolved_repo = await resolve_repo_from_remote(cwd, hint=remote_url or repo or None)
 
-        _start = time.monotonic()
-        try:
-            result = await tool_ctx.merge_queue_watcher.wait(
-                pr_number=pr_number,
-                target_branch=target_branch,
-                repo=resolved_repo or None,
-                cwd=cwd,
-                timeout_seconds=timeout_seconds,
-                poll_interval=poll_interval,
-                stall_grace_period=stall_grace_period,
-                max_stall_retries=max_stall_retries,
-                not_in_queue_confirmation_cycles=not_in_queue_confirmation_cycles,
-                max_inconclusive_retries=max_inconclusive_retries,
-                auto_merge_available=auto_merge_available,
-            )
-            return json.dumps(result)
-        except Exception as exc:
-            logger.error("wait_for_merge_queue ci_watcher error", exc_info=True)
-            return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            _start = time.monotonic()
+            try:
+                result = await tool_ctx.merge_queue_watcher.wait(
+                    pr_number=pr_number,
+                    target_branch=target_branch,
+                    repo=resolved_repo or None,
+                    cwd=cwd,
+                    timeout_seconds=timeout_seconds,
+                    poll_interval=poll_interval,
+                    stall_grace_period=stall_grace_period,
+                    max_stall_retries=max_stall_retries,
+                    not_in_queue_confirmation_cycles=not_in_queue_confirmation_cycles,
+                    max_inconclusive_retries=max_inconclusive_retries,
+                    auto_merge_available=auto_merge_available,
+                )
+                return json.dumps(result)
+            except Exception as exc:
+                logger.error("wait_for_merge_queue ci_watcher error", exc_info=True)
+                return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("wait_for_merge_queue unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -99,124 +99,124 @@ async def wait_for_ci(
         with structlog.contextvars.bound_contextvars(tool="wait_for_ci"):
             logger.info("wait_for_ci", branch=branch, repo=repo or "(infer)")
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
-        _timing_ctx = tool_ctx
-        if tool_ctx.ci_watcher is None:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
-            return json.dumps(
-                {
-                    "run_id": None,
-                    "conclusion": "error",
-                    "failed_jobs": [],
-                    "error": "CI watcher not configured",
-                }
+            tool_ctx = _get_ctx()
+            _timing_ctx = tool_ctx
+            if tool_ctx.ci_watcher is None:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+                return json.dumps(
+                    {
+                        "run_id": None,
+                        "conclusion": "error",
+                        "failed_jobs": [],
+                        "error": "CI watcher not configured",
+                    }
+                )
+
+            # Infer head_sha from cwd if not provided
+            _sha_inferred = head_sha is None
+            if _sha_inferred and cwd:
+                try:
+                    rc, stdout, _ = await _run_subprocess(
+                        ["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0
+                    )
+                    if rc == 0:
+                        head_sha = stdout.strip()
+                except Exception:
+                    logger.warning("git rev-parse HEAD failed", exc_info=True)
+
+            if _sha_inferred and head_sha and cwd:
+                try:
+                    rc_b, branch_out, _ = await _run_subprocess(
+                        ["git", "branch", "--show-current"], cwd=cwd, timeout=5.0
+                    )
+                    if rc_b == 0:
+                        cwd_branch = branch_out.strip()
+                        if cwd_branch and cwd_branch != branch:
+                            logger.warning(
+                                "wait_for_ci: cwd branch does not match watched branch — "
+                                "head_sha may be from wrong branch",
+                                cwd_branch=cwd_branch,
+                                watched_branch=branch,
+                                inferred_sha=head_sha[:12],
+                                cwd=cwd,
+                            )
+                except Exception:
+                    logger.warning("wait_for_ci: failed to check cwd branch", exc_info=True)
+
+            scope = CIRunScope(
+                workflow=workflow or tool_ctx.default_ci_scope.workflow,
+                head_sha=head_sha,
+                event=event or tool_ctx.default_ci_scope.event,
             )
 
-        # Infer head_sha from cwd if not provided
-        _sha_inferred = head_sha is None
-        if _sha_inferred and cwd:
-            try:
-                rc, stdout, _ = await _run_subprocess(
-                    ["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0
-                )
-                if rc == 0:
-                    head_sha = stdout.strip()
-            except Exception:
-                logger.warning("git rev-parse HEAD failed", exc_info=True)
+            resolved_repo = await resolve_repo_from_remote(cwd, hint=remote_url or repo or None)
 
-        if _sha_inferred and head_sha and cwd:
-            try:
-                rc_b, branch_out, _ = await _run_subprocess(
-                    ["git", "branch", "--show-current"], cwd=cwd, timeout=5.0
-                )
-                if rc_b == 0:
-                    cwd_branch = branch_out.strip()
-                    if cwd_branch and cwd_branch != branch:
-                        logger.warning(
-                            "wait_for_ci: cwd branch does not match watched branch — "
-                            "head_sha may be from wrong branch",
-                            cwd_branch=cwd_branch,
-                            watched_branch=branch,
-                            inferred_sha=head_sha[:12],
-                            cwd=cwd,
-                        )
-            except Exception:
-                logger.warning("wait_for_ci: failed to check cwd branch", exc_info=True)
-
-        scope = CIRunScope(
-            workflow=workflow or tool_ctx.default_ci_scope.workflow,
-            head_sha=head_sha,
-            event=event or tool_ctx.default_ci_scope.event,
-        )
-
-        resolved_repo = await resolve_repo_from_remote(cwd, hint=remote_url or repo or None)
-
-        await _notify(
-            ctx,
-            "info",
-            f"Watching CI for branch {branch}",
-            "autoskillit.wait_for_ci",
-            extra={
-                "repo": resolved_repo or "(infer)",
-                "head_sha": scope.head_sha or "(any)",
-                "workflow": scope.workflow or "(any)",
-            },
-        )
-
-        try:
-            result = await tool_ctx.ci_watcher.wait(
-                branch,
-                repo=resolved_repo or None,
-                scope=scope,
-                timeout_seconds=timeout_seconds,
-                lookback_seconds=lookback_seconds,
-                cwd=cwd,
-            )
-
-            # Include head_sha used for this CI check so orchestrators can verify
-            # CI results correspond to the current HEAD after a force-push.
-            if scope.head_sha:
-                result = {**result, "head_sha": scope.head_sha}
-
-            if auto_trigger and result.get("conclusion") == "no_runs":
-                result = await _auto_trigger_ci(
-                    branch=branch,
-                    cwd=cwd,
-                    result=result,
-                    scope=scope,
-                    resolved_repo=resolved_repo,
-                    tool_ctx=tool_ctx,
-                    timeout_seconds=timeout_seconds,
-                    lookback_seconds=lookback_seconds,
-                )
-
-            conclusion = result.get("conclusion", "unknown")
-            level: Literal["info", "error"] = "info" if conclusion == "success" else "error"
             await _notify(
                 ctx,
-                level,
-                f"CI result: {conclusion}",
+                "info",
+                f"Watching CI for branch {branch}",
                 "autoskillit.wait_for_ci",
-                extra={"run_id": result.get("run_id")},
+                extra={
+                    "repo": resolved_repo or "(infer)",
+                    "head_sha": scope.head_sha or "(any)",
+                    "workflow": scope.workflow or "(any)",
+                },
             )
 
-            return json.dumps(result)
-        except Exception as exc:
-            logger.error("wait_for_ci failed", exc_info=True)
-            return json.dumps(
-                {
-                    "run_id": None,
-                    "conclusion": "error",
-                    "failed_jobs": [],
-                    "error": f"{type(exc).__name__}: {exc}",
-                }
-            )
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            try:
+                result = await tool_ctx.ci_watcher.wait(
+                    branch,
+                    repo=resolved_repo or None,
+                    scope=scope,
+                    timeout_seconds=timeout_seconds,
+                    lookback_seconds=lookback_seconds,
+                    cwd=cwd,
+                )
+
+                # Include head_sha used for this CI check so orchestrators can verify
+                # CI results correspond to the current HEAD after a force-push.
+                if scope.head_sha:
+                    result = {**result, "head_sha": scope.head_sha}
+
+                if auto_trigger and result.get("conclusion") == "no_runs":
+                    result = await _auto_trigger_ci(
+                        branch=branch,
+                        cwd=cwd,
+                        result=result,
+                        scope=scope,
+                        resolved_repo=resolved_repo,
+                        tool_ctx=tool_ctx,
+                        timeout_seconds=timeout_seconds,
+                        lookback_seconds=lookback_seconds,
+                    )
+
+                conclusion = result.get("conclusion", "unknown")
+                level: Literal["info", "error"] = "info" if conclusion == "success" else "error"
+                await _notify(
+                    ctx,
+                    level,
+                    f"CI result: {conclusion}",
+                    "autoskillit.wait_for_ci",
+                    extra={"run_id": result.get("run_id")},
+                )
+
+                return json.dumps(result)
+            except Exception as exc:
+                logger.error("wait_for_ci failed", exc_info=True)
+                return json.dumps(
+                    {
+                        "run_id": None,
+                        "conclusion": "error",
+                        "failed_jobs": [],
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                )
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("wait_for_ci unhandled exception", exc_info=True)
         if step_name and _timing_ctx is not None:

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -96,9 +96,8 @@ async def wait_for_ci(
                     "error": f"Invalid event {event!r}. Valid events: {sorted(KNOWN_CI_EVENTS)}",
                 }
             )
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="wait_for_ci")
-        logger.info("wait_for_ci", branch=branch, repo=repo or "(infer)")
+        with structlog.contextvars.bound_contextvars(tool="wait_for_ci"):
+            logger.info("wait_for_ci", branch=branch, repo=repo or "(infer)")
 
         from autoskillit.server import _get_ctx
 

--- a/src/autoskillit/server/tools/tools_clone.py
+++ b/src/autoskillit/server/tools/tools_clone.py
@@ -74,45 +74,50 @@ async def clone_repo(
     try:
         with structlog.contextvars.bound_contextvars(tool="clone_repo", source_dir=source_dir):
             logger.info("clone_repo", source_dir=source_dir, run_name=run_name, branch=branch)
-        await _notify(
-            ctx,
-            "info",
-            f"clone_repo: {source_dir!r} run_name={run_name!r} branch={branch!r}",
-            "autoskillit.clone_repo",
-            extra={
-                "source_dir": source_dir,
-                "run_name": run_name,
-                "branch": branch,
-                "strategy": strategy,
-                "remote_url": remote_url,
-            },
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        if tool_ctx.clone_mgr is None:
-            return json.dumps({"error": "Clone manager not configured"})
-
-        _start = time.monotonic()
-        try:
-            result = await asyncio.to_thread(
-                tool_ctx.clone_mgr.clone_repo, source_dir, run_name, branch, strategy, remote_url
-            )
-        except (ValueError, RuntimeError) as exc:
             await _notify(
                 ctx,
-                "error",
-                "clone_repo failed",
+                "info",
+                f"clone_repo: {source_dir!r} run_name={run_name!r} branch={branch!r}",
                 "autoskillit.clone_repo",
-                extra={"reason": str(exc)},
+                extra={
+                    "source_dir": source_dir,
+                    "run_name": run_name,
+                    "branch": branch,
+                    "strategy": strategy,
+                    "remote_url": remote_url,
+                },
             )
-            return json.dumps({"error": str(exc)})
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
 
-        return json.dumps(result)
+            from autoskillit.server import _get_ctx
+
+            tool_ctx = _get_ctx()
+            if tool_ctx.clone_mgr is None:
+                return json.dumps({"error": "Clone manager not configured"})
+
+            _start = time.monotonic()
+            try:
+                result = await asyncio.to_thread(
+                    tool_ctx.clone_mgr.clone_repo,
+                    source_dir,
+                    run_name,
+                    branch,
+                    strategy,
+                    remote_url,
+                )
+            except (ValueError, RuntimeError) as exc:
+                await _notify(
+                    ctx,
+                    "error",
+                    "clone_repo failed",
+                    "autoskillit.clone_repo",
+                    extra={"reason": str(exc)},
+                )
+                return json.dumps({"error": str(exc)})
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+
+            return json.dumps(result)
     except Exception as exc:
         logger.error("clone_repo unhandled exception", exc_info=True)
         return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
@@ -145,27 +150,27 @@ async def remove_clone(
             return gate
         with structlog.contextvars.bound_contextvars(tool="remove_clone", clone_path=clone_path):
             logger.info("remove_clone", clone_path=clone_path, keep=keep)
-        await _notify(
-            ctx,
-            "info",
-            f"remove_clone: {clone_path!r} keep={keep}",
-            "autoskillit.remove_clone",
-            extra={"clone_path": clone_path, "keep": keep},
-        )
+            await _notify(
+                ctx,
+                "info",
+                f"remove_clone: {clone_path!r} keep={keep}",
+                "autoskillit.remove_clone",
+                extra={"clone_path": clone_path, "keep": keep},
+            )
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
-        if tool_ctx.clone_mgr is None:
-            return json.dumps({"removed": "false", "reason": "Clone manager not configured"})
+            tool_ctx = _get_ctx()
+            if tool_ctx.clone_mgr is None:
+                return json.dumps({"removed": "false", "reason": "Clone manager not configured"})
 
-        _start = time.monotonic()
-        try:
-            result = await asyncio.to_thread(tool_ctx.clone_mgr.remove_clone, clone_path, keep)
-            return json.dumps(result)
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            _start = time.monotonic()
+            try:
+                result = await asyncio.to_thread(tool_ctx.clone_mgr.remove_clone, clone_path, keep)
+                return json.dumps(result)
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("remove_clone unhandled exception", exc_info=True)
         return json.dumps({"removed": "false", "reason": f"unexpected error: {exc}"})
@@ -216,63 +221,63 @@ async def push_to_remote(
                 remote_url=remote_url,
                 branch=branch,
             )
-        await _notify(
-            ctx,
-            "info",
-            f"push_to_remote: {clone_path!r} → branch={branch!r}",
-            "autoskillit.push_to_remote",
-            extra={
-                "clone_path": clone_path,
-                "source_dir": source_dir,
-                "remote_url": remote_url,
-                "branch": branch,
-            },
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        clone_mgr = tool_ctx.clone_mgr
-        if clone_mgr is None:
-            return json.dumps({"error": "Clone manager not configured", "stderr": ""})
-
-        _start = time.monotonic()
-        try:
-            result = await asyncio.to_thread(
-                lambda: clone_mgr.push_to_remote(
-                    clone_path,
-                    source_dir,
-                    branch,
-                    remote_url=remote_url,
-                    protected_branches=tool_ctx.config.safety.protected_branches,
-                    force=force.strip().lower() == "true",
-                )
+            await _notify(
+                ctx,
+                "info",
+                f"push_to_remote: {clone_path!r} → branch={branch!r}",
+                "autoskillit.push_to_remote",
+                extra={
+                    "clone_path": clone_path,
+                    "source_dir": source_dir,
+                    "remote_url": remote_url,
+                    "branch": branch,
+                },
             )
 
-            if not result.get("success"):
-                await _notify(
-                    ctx,
-                    "error",
-                    "push_to_remote failed",
-                    "autoskillit.push_to_remote",
-                    extra={
-                        "stderr": result.get("stderr", ""),
-                        "error_type": result.get("error_type", ""),
-                    },
-                )
-                return json.dumps(
-                    {
-                        "success": False,
-                        "error": "push failed",
-                        "stderr": result.get("stderr", ""),
-                        "error_type": result.get("error_type", ""),
-                    }
+            from autoskillit.server import _get_ctx
+
+            tool_ctx = _get_ctx()
+            clone_mgr = tool_ctx.clone_mgr
+            if clone_mgr is None:
+                return json.dumps({"error": "Clone manager not configured", "stderr": ""})
+
+            _start = time.monotonic()
+            try:
+                result = await asyncio.to_thread(
+                    lambda: clone_mgr.push_to_remote(
+                        clone_path,
+                        source_dir,
+                        branch,
+                        remote_url=remote_url,
+                        protected_branches=tool_ctx.config.safety.protected_branches,
+                        force=force.strip().lower() == "true",
+                    )
                 )
 
-            return json.dumps(result)
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+                if not result.get("success"):
+                    await _notify(
+                        ctx,
+                        "error",
+                        "push_to_remote failed",
+                        "autoskillit.push_to_remote",
+                        extra={
+                            "stderr": result.get("stderr", ""),
+                            "error_type": result.get("error_type", ""),
+                        },
+                    )
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": "push failed",
+                            "stderr": result.get("stderr", ""),
+                            "error_type": result.get("error_type", ""),
+                        }
+                    )
+
+                return json.dumps(result)
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("push_to_remote unhandled exception", exc_info=True)
         return json.dumps(
@@ -316,51 +321,52 @@ async def register_clone_status(
         ):
             logger.info("register_clone_status", clone_path=clone_path, status=status)
 
-        if status not in ("success", "error", "unconfirmed"):
-            return json.dumps(
-                {
-                    "registered": "false",
-                    "reason": (
-                        f"Invalid status '{status}'. Must be 'success', 'error', or 'unconfirmed'."
-                    ),
-                }
-            )
+            if status not in ("success", "error", "unconfirmed"):
+                return json.dumps(
+                    {
+                        "registered": "false",
+                        "reason": (
+                            f"Invalid status '{status}'."
+                            " Must be 'success', 'error', or 'unconfirmed'."
+                        ),
+                    }
+                )
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
-        owner = os.environ.get(CAMPAIGN_ID_ENV_VAR, "") or tool_ctx.kitchen_id
-        if owner == "":
-            return json.dumps(
-                {
-                    "registered": "false",
-                    "reason": "no active kitchen (kitchen_id empty) — cannot register clone",
-                }
+            tool_ctx = _get_ctx()
+            owner = os.environ.get(CAMPAIGN_ID_ENV_VAR, "") or tool_ctx.kitchen_id
+            if owner == "":
+                return json.dumps(
+                    {
+                        "registered": "false",
+                        "reason": "no active kitchen (kitchen_id empty) — cannot register clone",
+                    }
+                )
+            _start = time.monotonic()
+            typed_status: Literal["success", "error", "unconfirmed"] = (
+                "success"
+                if status == "success"
+                else "unconfirmed"
+                if status == "unconfirmed"
+                else "error"
             )
-        _start = time.monotonic()
-        typed_status: Literal["success", "error", "unconfirmed"] = (
-            "success"
-            if status == "success"
-            else "unconfirmed"
-            if status == "unconfirmed"
-            else "error"
-        )
-        try:
-            result = await asyncio.to_thread(
-                clone_registry.register_clone,
-                clone_path,
-                typed_status,
-                owner,
-                registry_path,
-                tool_ctx.temp_dir,
-            )
-            return json.dumps(result)
-        except Exception as exc:
-            logger.warning("register_clone_status failed", exc_info=True)
-            return json.dumps({"registered": "false", "reason": str(exc)})
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            try:
+                result = await asyncio.to_thread(
+                    clone_registry.register_clone,
+                    clone_path,
+                    typed_status,
+                    owner,
+                    registry_path,
+                    tool_ctx.temp_dir,
+                )
+                return json.dumps(result)
+            except Exception as exc:
+                logger.warning("register_clone_status failed", exc_info=True)
+                return json.dumps({"registered": "false", "reason": str(exc)})
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("register_clone_status unhandled exception", exc_info=True)
         return json.dumps({"registered": "false", "reason": f"{type(exc).__name__}: {exc}"})
@@ -402,51 +408,51 @@ async def batch_cleanup_clones(
         with structlog.contextvars.bound_contextvars(tool="batch_cleanup_clones"):
             logger.info("batch_cleanup_clones", registry_path=registry_path, all_owners=all_owners)
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
-        if tool_ctx.clone_mgr is None:
-            return json.dumps(
-                {
-                    "deleted": [],
-                    "delete_failures": [],
-                    "preserved": [],
-                    "error": "Clone manager not configured",
-                }
-            )
-
-        is_escape_hatch = all_owners.strip().lower() == "true"
-        owner_filter_resolved: str | None
-        if is_escape_hatch:
-            owner_filter_resolved = None
-        elif owner_filter:
-            owner_filter_resolved = owner_filter
-        else:
-            owner_filter_resolved = tool_ctx.kitchen_id
-            if owner_filter_resolved == "":
+            tool_ctx = _get_ctx()
+            if tool_ctx.clone_mgr is None:
                 return json.dumps(
                     {
                         "deleted": [],
                         "delete_failures": [],
                         "preserved": [],
-                        "error": "no active kitchen (kitchen_id empty) — "
-                        "pass all_owners='true' or owner_filter to force-cleanup",
+                        "error": "Clone manager not configured",
                     }
                 )
 
-        _start = time.monotonic()
-        try:
-            result = await asyncio.to_thread(
-                clone_registry.batch_delete,
-                registry_path,
-                tool_ctx.clone_mgr.remove_clone,
-                tool_ctx.temp_dir,
-                owner_filter_resolved,
-            )
-            return json.dumps(result)
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            is_escape_hatch = all_owners.strip().lower() == "true"
+            owner_filter_resolved: str | None
+            if is_escape_hatch:
+                owner_filter_resolved = None
+            elif owner_filter:
+                owner_filter_resolved = owner_filter
+            else:
+                owner_filter_resolved = tool_ctx.kitchen_id
+                if owner_filter_resolved == "":
+                    return json.dumps(
+                        {
+                            "deleted": [],
+                            "delete_failures": [],
+                            "preserved": [],
+                            "error": "no active kitchen (kitchen_id empty) — "
+                            "pass all_owners='true' or owner_filter to force-cleanup",
+                        }
+                    )
+
+            _start = time.monotonic()
+            try:
+                result = await asyncio.to_thread(
+                    clone_registry.batch_delete,
+                    registry_path,
+                    tool_ctx.clone_mgr.remove_clone,
+                    tool_ctx.temp_dir,
+                    owner_filter_resolved,
+                )
+                return json.dumps(result)
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.warning("batch_cleanup_clones failed", exc_info=True)
         return json.dumps({"deleted": [], "preserved": [], "error": str(exc)})

--- a/src/autoskillit/server/tools/tools_clone.py
+++ b/src/autoskillit/server/tools/tools_clone.py
@@ -72,9 +72,8 @@ async def clone_repo(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="clone_repo", source_dir=source_dir)
-        logger.info("clone_repo", source_dir=source_dir, run_name=run_name, branch=branch)
+        with structlog.contextvars.bound_contextvars(tool="clone_repo", source_dir=source_dir):
+            logger.info("clone_repo", source_dir=source_dir, run_name=run_name, branch=branch)
         await _notify(
             ctx,
             "info",
@@ -144,9 +143,8 @@ async def remove_clone(
     try:
         if (gate := _require_enabled()) is not None:
             return gate
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="remove_clone", clone_path=clone_path)
-        logger.info("remove_clone", clone_path=clone_path, keep=keep)
+        with structlog.contextvars.bound_contextvars(tool="remove_clone", clone_path=clone_path):
+            logger.info("remove_clone", clone_path=clone_path, keep=keep)
         await _notify(
             ctx,
             "info",
@@ -210,15 +208,14 @@ async def push_to_remote(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="push_to_remote", clone_path=clone_path)
-        logger.info(
-            "push_to_remote",
-            clone_path=clone_path,
-            source_dir=source_dir,
-            remote_url=remote_url,
-            branch=branch,
-        )
+        with structlog.contextvars.bound_contextvars(tool="push_to_remote", clone_path=clone_path):
+            logger.info(
+                "push_to_remote",
+                clone_path=clone_path,
+                source_dir=source_dir,
+                remote_url=remote_url,
+                branch=branch,
+            )
         await _notify(
             ctx,
             "info",
@@ -314,9 +311,10 @@ async def register_clone_status(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="register_clone_status", clone_path=clone_path)
-        logger.info("register_clone_status", clone_path=clone_path, status=status)
+        with structlog.contextvars.bound_contextvars(
+            tool="register_clone_status", clone_path=clone_path
+        ):
+            logger.info("register_clone_status", clone_path=clone_path, status=status)
 
         if status not in ("success", "error", "unconfirmed"):
             return json.dumps(
@@ -401,9 +399,8 @@ async def batch_cleanup_clones(
     try:
         if (gate := _require_enabled()) is not None:
             return gate
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="batch_cleanup_clones")
-        logger.info("batch_cleanup_clones", registry_path=registry_path, all_owners=all_owners)
+        with structlog.contextvars.bound_contextvars(tool="batch_cleanup_clones"):
+            logger.info("batch_cleanup_clones", registry_path=registry_path, all_owners=all_owners)
 
         from autoskillit.server import _get_ctx
 
@@ -518,13 +515,15 @@ async def bootstrap_clone(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(
+        with structlog.contextvars.bound_contextvars(
             tool="bootstrap_clone", source_dir=source_dir, base_branch=base_branch
-        )
-        logger.info(
-            "bootstrap_clone", source_dir=source_dir, run_name=run_name, base_branch=base_branch
-        )
+        ):
+            logger.info(
+                "bootstrap_clone",
+                source_dir=source_dir,
+                run_name=run_name,
+                base_branch=base_branch,
+            )
         await _notify(
             ctx,
             "info",

--- a/src/autoskillit/server/tools/tools_clone.py
+++ b/src/autoskillit/server/tools/tools_clone.py
@@ -530,89 +530,95 @@ async def bootstrap_clone(
                 run_name=run_name,
                 base_branch=base_branch,
             )
-        await _notify(
-            ctx,
-            "info",
-            f"bootstrap_clone: {source_dir!r} run_name={run_name!r} base_branch={base_branch!r}",
-            "autoskillit.bootstrap_clone",
-            extra={
-                "source_dir": source_dir,
-                "run_name": run_name,
-                "base_branch": base_branch,
-                "branch": branch,
-            },
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        if tool_ctx.clone_mgr is None:
-            return json.dumps({"error": "Clone manager not configured"})
-
-        _total_start = time.monotonic()
-
-        _clone_start = time.monotonic()
-        try:
-            clone_result = await asyncio.to_thread(
-                tool_ctx.clone_mgr.clone_repo, source_dir, run_name, branch, strategy, remote_url
-            )
-        except (ValueError, RuntimeError) as exc:
             await _notify(
                 ctx,
-                "error",
-                "bootstrap_clone: clone failed",
+                "info",
+                f"bootstrap_clone: {source_dir!r}"
+                f" run_name={run_name!r} base_branch={base_branch!r}",
                 "autoskillit.bootstrap_clone",
-                extra={"reason": str(exc)},
-            )
-            return json.dumps({"error": str(exc)})
-        finally:
-            clone_ms = int((time.monotonic() - _clone_start) * 1000)
-
-        gate_error = _require_clone_success(clone_result, source_dir)
-        if gate_error is not None:
-            return gate_error
-
-        success = cast("CloneSuccessResult", clone_result)
-        clone_path: str = success["clone_path"]
-        resolved_remote_url: str = success.get("remote_url", remote_url)
-
-        _revparse_start = time.monotonic()
-        try:
-            rc, stdout, stderr = await _run_subprocess(
-                ["git", "rev-parse", base_branch],
-                cwd=clone_path,
-                timeout=30,
-            )
-        finally:
-            rev_parse_ms = int((time.monotonic() - _revparse_start) * 1000)
-
-        if rc != 0:
-            await _notify(
-                ctx,
-                "error",
-                "bootstrap_clone: rev-parse failed",
-                "autoskillit.bootstrap_clone",
-                extra={"stderr": stderr},
-            )
-            return json.dumps({"error": f"rev-parse failed: {stderr.strip()}"})
-
-        base_sha = stdout.strip()
-
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _total_start)
-
-        return json.dumps(
-            {
-                "work_dir": clone_path,
-                "remote_url": resolved_remote_url,
-                "base_sha": base_sha,
-                "merge_target": base_branch,
-                "timings": {
-                    "clone_ms": clone_ms,
-                    "rev_parse_ms": rev_parse_ms,
+                extra={
+                    "source_dir": source_dir,
+                    "run_name": run_name,
+                    "base_branch": base_branch,
+                    "branch": branch,
                 },
-            }
-        )
+            )
+
+            from autoskillit.server import _get_ctx
+
+            tool_ctx = _get_ctx()
+            if tool_ctx.clone_mgr is None:
+                return json.dumps({"error": "Clone manager not configured"})
+
+            _total_start = time.monotonic()
+
+            _clone_start = time.monotonic()
+            try:
+                clone_result = await asyncio.to_thread(
+                    tool_ctx.clone_mgr.clone_repo,
+                    source_dir,
+                    run_name,
+                    branch,
+                    strategy,
+                    remote_url,
+                )
+            except (ValueError, RuntimeError) as exc:
+                await _notify(
+                    ctx,
+                    "error",
+                    "bootstrap_clone: clone failed",
+                    "autoskillit.bootstrap_clone",
+                    extra={"reason": str(exc)},
+                )
+                return json.dumps({"error": str(exc)})
+            finally:
+                clone_ms = int((time.monotonic() - _clone_start) * 1000)
+
+            gate_error = _require_clone_success(clone_result, source_dir)
+            if gate_error is not None:
+                return gate_error
+
+            success = cast("CloneSuccessResult", clone_result)
+            clone_path: str = success["clone_path"]
+            resolved_remote_url: str = success.get("remote_url", remote_url)
+
+            _revparse_start = time.monotonic()
+            try:
+                rc, stdout, stderr = await _run_subprocess(
+                    ["git", "rev-parse", base_branch],
+                    cwd=clone_path,
+                    timeout=30,
+                )
+            finally:
+                rev_parse_ms = int((time.monotonic() - _revparse_start) * 1000)
+
+            if rc != 0:
+                await _notify(
+                    ctx,
+                    "error",
+                    "bootstrap_clone: rev-parse failed",
+                    "autoskillit.bootstrap_clone",
+                    extra={"stderr": stderr},
+                )
+                return json.dumps({"error": f"rev-parse failed: {stderr.strip()}"})
+
+            base_sha = stdout.strip()
+
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _total_start)
+
+            return json.dumps(
+                {
+                    "work_dir": clone_path,
+                    "remote_url": resolved_remote_url,
+                    "base_sha": base_sha,
+                    "merge_target": base_branch,
+                    "timings": {
+                        "clone_ms": clone_ms,
+                        "rev_parse_ms": rev_parse_ms,
+                    },
+                }
+            )
     except Exception as exc:
         logger.error("bootstrap_clone unhandled exception", exc_info=True)
         return json.dumps({"error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -72,47 +72,49 @@ async def run_cmd(
     try:
         with structlog.contextvars.bound_contextvars(tool="run_cmd", cwd=cwd):
             logger.info("run_cmd", cmd=cmd[:80], cwd=cwd)
-        await _notify(
-            ctx, "info", f"run_cmd: {cmd[:80]}", "autoskillit.run_cmd", extra={"cwd": cwd}
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        _start = time.monotonic()
-        try:
-            m = _PURE_SLEEP_RE.match(cmd.strip())
-            if m:
-                seconds = float(m.group("py_secs") or m.group("sh_secs"))
-                await asyncio.sleep(seconds)
-                return json.dumps({"success": True, "exit_code": 0, "stdout": "", "stderr": ""})
-            _env: dict[str, str] | None = (
-                {**os.environ, SCENARIO_STEP_NAME_ENV: step_name} if step_name else None
+            await _notify(
+                ctx, "info", f"run_cmd: {cmd[:80]}", "autoskillit.run_cmd", extra={"cwd": cwd}
             )
-            returncode, stdout, stderr = await _run_subprocess(
-                ["bash", "-c", cmd],
-                cwd=cwd,
-                timeout=float(timeout),
-                env=_env,
-            )
-            result = {
-                "success": returncode == 0,
-                "exit_code": returncode,
-                "stdout": truncate_text(stdout),
-                "stderr": truncate_text(stderr),
-            }
-            if not result["success"]:
-                await _notify(
-                    ctx,
-                    "error",
-                    "run_cmd failed",
-                    "autoskillit.run_cmd",
-                    extra={"exit_code": returncode},
+
+            from autoskillit.server import _get_ctx
+
+            tool_ctx = _get_ctx()
+            _start = time.monotonic()
+            try:
+                m = _PURE_SLEEP_RE.match(cmd.strip())
+                if m:
+                    seconds = float(m.group("py_secs") or m.group("sh_secs"))
+                    await asyncio.sleep(seconds)
+                    return json.dumps(
+                        {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
+                    )
+                _env: dict[str, str] | None = (
+                    {**os.environ, SCENARIO_STEP_NAME_ENV: step_name} if step_name else None
                 )
-            return json.dumps(result)
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+                returncode, stdout, stderr = await _run_subprocess(
+                    ["bash", "-c", cmd],
+                    cwd=cwd,
+                    timeout=float(timeout),
+                    env=_env,
+                )
+                result = {
+                    "success": returncode == 0,
+                    "exit_code": returncode,
+                    "stdout": truncate_text(stdout),
+                    "stderr": truncate_text(stderr),
+                }
+                if not result["success"]:
+                    await _notify(
+                        ctx,
+                        "error",
+                        "run_cmd failed",
+                        "autoskillit.run_cmd",
+                        extra={"exit_code": returncode},
+                    )
+                return json.dumps(result)
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("run_cmd unhandled exception", exc_info=True)
         return json.dumps(
@@ -157,25 +159,27 @@ async def run_python(
     try:
         with structlog.contextvars.bound_contextvars(tool="run_python"):
             logger.info("run_python", callable=callable, timeout=timeout)
-        await _notify(
-            ctx,
-            "info",
-            f"run_python: {callable}",
-            "autoskillit.run_python",
-            extra={"callable": callable},
-        )
-        from autoskillit.server.tools._execution_helpers import _import_and_call  # noqa: PLC0415
-
-        result = await _import_and_call(callable, args=args, timeout=float(timeout))
-        if not result.get("success"):
             await _notify(
                 ctx,
-                "error",
-                "run_python failed",
+                "info",
+                f"run_python: {callable}",
                 "autoskillit.run_python",
                 extra={"callable": callable},
             )
-        return json.dumps(result)
+            from autoskillit.server.tools._execution_helpers import (
+                _import_and_call,  # noqa: PLC0415
+            )
+
+            result = await _import_and_call(callable, args=args, timeout=float(timeout))
+            if not result.get("success"):
+                await _notify(
+                    ctx,
+                    "error",
+                    "run_python failed",
+                    "autoskillit.run_python",
+                    extra={"callable": callable},
+                )
+            return json.dumps(result)
     except Exception as exc:
         logger.error("run_python unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -289,322 +293,334 @@ async def run_skill(
     try:
         with structlog.contextvars.bound_contextvars(tool="run_skill", cwd=cwd):
             logger.info("run_skill", command=skill_command[:80], cwd=cwd)
-        await _notify(
-            ctx,
-            "info",
-            f"run_skill: {skill_command[:80]}",
-            "autoskillit.run_skill",
-            extra={"cwd": cwd, "model": model or "default"},
-        )
-
-        from autoskillit.server import _get_config, _get_ctx
-
-        # Auto-enrich order_id from the fleet dispatcher's env variable when the
-        # caller did not pass an explicit value. AUTOSKILLIT_DISPATCH_ID is injected
-        # by fleet/_api.py into every L2 food truck session environment and inherited by all
-        # sub-sessions, ensuring token log entries carry the correct order_id without
-        # requiring recipe authors to thread it through every run_skill call.
-        effective_order_id = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
-
-        if _get_config().safety.require_dry_walkthrough:
-            if (gate_error := _check_dry_walkthrough(skill_command, cwd)) is not None:
-                return gate_error
-
-        tool_ctx = _get_ctx()
-        if tool_ctx.executor is None:
-            return json.dumps({"success": False, "error": "Executor not configured"})
-
-        provider_extras: dict[str, str] | None = None
-        profile_name_out: str = ""
-        effective_model = model
-
-        from autoskillit.core import (
-            AGENT_BACKEND_CLAUDE_CODE,
-            AGENT_BACKEND_CODEX,
-            is_feature_enabled,
-        )
-
-        _cfg = _get_config()
-        if is_feature_enabled(
-            "providers", _cfg.features, experimental_enabled=_cfg.experimental_enabled
-        ):
-            from autoskillit.server._guards import (
-                _resolve_model_as_profile,
-                _resolve_provider_profile,
+            await _notify(
+                ctx,
+                "info",
+                f"run_skill: {skill_command[:80]}",
+                "autoskillit.run_skill",
+                extra={"cwd": cwd, "model": model or "default"},
             )
 
-            _profile, _env_dict = _resolve_provider_profile(
-                step_name or "",
-                tool_ctx.recipe_name or "",
-                _cfg.providers,
-                step_provider=step_provider or "",
+            from autoskillit.server import _get_config, _get_ctx
+
+            # Auto-enrich order_id from the fleet dispatcher's env variable when the
+            # caller did not pass an explicit value. AUTOSKILLIT_DISPATCH_ID is injected
+            # by fleet/_api.py into every L2 food truck session environment and inherited by all
+            # sub-sessions, ensuring token log entries carry the correct order_id without
+            # requiring recipe authors to thread it through every run_skill call.
+            effective_order_id = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
+
+            if _get_config().safety.require_dry_walkthrough:
+                if (gate_error := _check_dry_walkthrough(skill_command, cwd)) is not None:
+                    return gate_error
+
+            tool_ctx = _get_ctx()
+            if tool_ctx.executor is None:
+                return json.dumps({"success": False, "error": "Executor not configured"})
+
+            provider_extras: dict[str, str] | None = None
+            profile_name_out: str = ""
+            effective_model = model
+
+            from autoskillit.core import (
+                AGENT_BACKEND_CLAUDE_CODE,
+                AGENT_BACKEND_CODEX,
+                is_feature_enabled,
             )
-            if _profile != "anthropic":
-                provider_extras = _env_dict
-                profile_name_out = _profile
-            else:
-                effective_model, prof_name, prof_extras = _resolve_model_as_profile(
-                    model, _cfg.providers
+
+            _cfg = _get_config()
+            if is_feature_enabled(
+                "providers", _cfg.features, experimental_enabled=_cfg.experimental_enabled
+            ):
+                from autoskillit.server._guards import (
+                    _resolve_model_as_profile,
+                    _resolve_provider_profile,
                 )
-                if prof_extras is not None:
-                    provider_extras = prof_extras
-                    profile_name_out = prof_name
 
-        if _cfg.model.model_override:
-            effective_model = _cfg.model.model_override
-        else:
-            if tool_ctx.recipe_name:
-                _mo_recipe_map = _cfg.providers.model_overrides.get(tool_ctx.recipe_name)
-                if _mo_recipe_map:
-                    _step_mo = _mo_recipe_map.get(step_name) if step_name else None
-                    if _step_mo is None:
-                        _step_mo = _mo_recipe_map.get("*")
-                    if _step_mo:
-                        effective_model = _step_mo
+                _profile, _env_dict = _resolve_provider_profile(
+                    step_name or "",
+                    tool_ctx.recipe_name or "",
+                    _cfg.providers,
+                    step_provider=step_provider or "",
+                )
+                if _profile != "anthropic":
+                    provider_extras = _env_dict
+                    profile_name_out = _profile
+                else:
+                    effective_model, prof_name, prof_extras = _resolve_model_as_profile(
+                        model, _cfg.providers
+                    )
+                    if prof_extras is not None:
+                        provider_extras = prof_extras
+                        profile_name_out = prof_name
 
-        backend_override: str | None = (
-            AGENT_BACKEND_CLAUDE_CODE
-            if (
-                provider_extras
-                and "ANTHROPIC_BASE_URL" in provider_extras
-                and tool_ctx.backend is not None
-                and tool_ctx.backend.name == AGENT_BACKEND_CODEX
-            )
-            else None
-        )
+            if _cfg.model.model_override:
+                effective_model = _cfg.model.model_override
+            else:
+                if tool_ctx.recipe_name:
+                    _mo_recipe_map = _cfg.providers.model_overrides.get(tool_ctx.recipe_name)
+                    if _mo_recipe_map:
+                        _step_mo = _mo_recipe_map.get(step_name) if step_name else None
+                        if _step_mo is None:
+                            _step_mo = _mo_recipe_map.get("*")
+                        if _step_mo:
+                            effective_model = _step_mo
 
-        # Look up artifact validation patterns from skill contract
-        expected_output_patterns: list[str] = []
-        if tool_ctx.output_pattern_resolver:
-            expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
-
-        # Look up write-expectation metadata from skill contract
-        from autoskillit.core import WriteBehaviorSpec
-
-        write_spec: WriteBehaviorSpec | None = None
-        if tool_ctx.write_expected_resolver:
-            write_spec = tool_ctx.write_expected_resolver(skill_command)
-
-        # Build validated add_dirs via DefaultSessionSkillManager
-        from pathlib import Path
-        from uuid import uuid4
-
-        from autoskillit.core import resolve_target_skill
-
-        # Resolve correct namespace and prepare for tier2 activation
-        resolved_command = skill_command
-        target_name: str | None = None
-        if tool_ctx.skill_resolver is not None:
-            resolved_command, target_name = resolve_target_skill(
-                skill_command, tool_ctx.skill_resolver
+            backend_override: str | None = (
+                AGENT_BACKEND_CLAUDE_CODE
+                if (
+                    provider_extras
+                    and "ANTHROPIC_BASE_URL" in provider_extras
+                    and tool_ctx.backend is not None
+                    and tool_ctx.backend.name == AGENT_BACKEND_CODEX
+                )
+                else None
             )
 
-        # Server-side recipe step parameter resolution.
-        # When a step_name is provided and the recipe's step definition is cached,
-        # auto-fill parameters the LLM may have omitted.
-        if step_name and tool_ctx.active_recipe_steps is not None:
-            _recipe_step = tool_ctx.active_recipe_steps.get(step_name)
-            if _recipe_step is not None:
-                if not output_dir and "output_dir" in _recipe_step.with_args:
-                    _recipe_output_dir = _recipe_step.with_args["output_dir"]
-                    # Skip values containing unresolved template references —
-                    # load() returns raw YAML without ingredient resolution,
-                    # so ${{ context.* }} placeholders may survive.
-                    if "${{" not in _recipe_output_dir:
-                        output_dir = _recipe_output_dir
+            # Look up artifact validation patterns from skill contract
+            expected_output_patterns: list[str] = []
+            if tool_ctx.output_pattern_resolver:
+                expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
+
+            # Look up write-expectation metadata from skill contract
+            from autoskillit.core import WriteBehaviorSpec
+
+            write_spec: WriteBehaviorSpec | None = None
+            if tool_ctx.write_expected_resolver:
+                write_spec = tool_ctx.write_expected_resolver(skill_command)
+
+            # Build validated add_dirs via DefaultSessionSkillManager
+            from pathlib import Path
+            from uuid import uuid4
+
+            from autoskillit.core import resolve_target_skill
+
+            # Resolve correct namespace and prepare for tier2 activation
+            resolved_command = skill_command
+            target_name: str | None = None
+            if tool_ctx.skill_resolver is not None:
+                resolved_command, target_name = resolve_target_skill(
+                    skill_command, tool_ctx.skill_resolver
+                )
+
+            # Server-side recipe step parameter resolution.
+            # When a step_name is provided and the recipe's step definition is cached,
+            # auto-fill parameters the LLM may have omitted.
+            if step_name and tool_ctx.active_recipe_steps is not None:
+                _recipe_step = tool_ctx.active_recipe_steps.get(step_name)
+                if _recipe_step is not None:
+                    if not output_dir and "output_dir" in _recipe_step.with_args:
+                        _recipe_output_dir = _recipe_step.with_args["output_dir"]
+                        # Skip values containing unresolved template references —
+                        # load() returns raw YAML without ingredient resolution,
+                        # so ${{ context.* }} placeholders may survive.
+                        if "${{" not in _recipe_output_dir:
+                            output_dir = _recipe_output_dir
+                            logger.warning(
+                                "output_dir_resolved_from_recipe",
+                                step=step_name,
+                                output_dir=output_dir,
+                            )
+
+                    if stale_threshold is None and _recipe_step.stale_threshold is not None:
+                        stale_threshold = _recipe_step.stale_threshold
                         logger.warning(
-                            "output_dir_resolved_from_recipe",
+                            "stale_threshold_resolved_from_recipe",
                             step=step_name,
-                            output_dir=output_dir,
+                            value=stale_threshold,
                         )
 
-                if stale_threshold is None and _recipe_step.stale_threshold is not None:
-                    stale_threshold = _recipe_step.stale_threshold
-                    logger.warning(
-                        "stale_threshold_resolved_from_recipe",
-                        step=step_name,
-                        value=stale_threshold,
-                    )
-
-                if idle_output_timeout is None and _recipe_step.idle_output_timeout is not None:
-                    idle_output_timeout = _recipe_step.idle_output_timeout
-                    logger.warning(
-                        "idle_output_timeout_resolved_from_recipe",
-                        step=step_name,
-                        value=idle_output_timeout,
-                    )
-
-        write_watch_dirs: list[Path] = []
-        if output_dir:
-            resolved_dir = Path(output_dir)
-            if not resolved_dir.is_absolute():
-                resolved_dir = Path(cwd) / output_dir
-            write_watch_dirs.append(resolved_dir)
-
-        if not write_watch_dirs:
-            _default_temp = _resolve_skill_temp_dir(cwd, skill_command)
-            if _default_temp:
-                write_watch_dirs.append(_default_temp)
-
-        is_read_only = bool(
-            tool_ctx.read_only_resolver and tool_ctx.read_only_resolver(skill_command)
-        )
-        allowed_write_prefix = ""
-        if write_watch_dirs:
-            allowed_write_prefix = str(write_watch_dirs[0]) + "/"
-        elif is_read_only:
-            _skill_temp_name = target_name or ""
-            if _skill_temp_name:
-                allowed_write_prefix = os.path.join(
-                    cwd, ".autoskillit", "temp", _skill_temp_name, ""
-                )
-            else:
-                logger.warning(
-                    "read_only_skill_no_target_name",
-                    skill_command=skill_command[:100],
-                )
-
-        invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
-
-        skill_add_dirs: list[ValidatedAddDir] = []
-        replay_snapshot_used = False
-        _runner = tool_ctx.runner
-        if (
-            step_name
-            and _runner is not None
-            and getattr(_runner, "skill_snapshots", None)
-            and hasattr(_runner, "restore_skill_snapshot")
-            and tool_ctx.ephemeral_root is not None
-        ):
-            _ephemeral_root = tool_ctx.ephemeral_root
-            session_id = f"headless-{uuid4().hex[:12]}"
-            _restored = _runner.restore_skill_snapshot(  # type: ignore[attr-defined]
-                step_name, _ephemeral_root, session_id
-            )
-            if _restored is not None:
-                skill_add_dirs.append(_restored)
-                replay_snapshot_used = True
-                logger.debug(
-                    "replay_skill_snapshot_restored",
-                    step=step_name,
-                    session_id=session_id,
-                )
-
-        if not replay_snapshot_used and tool_ctx.session_skill_manager is not None:
-            allow_only: frozenset[str] | None = None
-            if target_name:
-                closure = tool_ctx.session_skill_manager.compute_skill_closure(target_name)
-                allow_only = closure if closure else None
-
-            session_id = f"headless-{uuid4().hex[:12]}"
-            session_root = tool_ctx.session_skill_manager.init_session(
-                session_id,
-                cook_session=False,
-                config=tool_ctx.config,
-                project_dir=Path(cwd),
-                recipe_packs=tool_ctx.active_recipe_packs,
-                recipe_features=tool_ctx.active_recipe_features,
-                allow_only=allow_only,
-                backend=tool_ctx.backend,
-            )
-            skill_add_dirs.append(session_root)
-
-            if target_name:
-                tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
-                _is_known_skill = (
-                    tool_ctx.skill_resolver is not None
-                    and tool_ctx.skill_resolver.resolve(target_name) is not None
-                )
-                if _is_known_skill:
-                    _skill_md = (
-                        Path(session_root.path) / ".claude" / "skills" / target_name / "SKILL.md"
-                    )
-                    if not _skill_md.exists():
-                        logger.error(
-                            "target_skill_not_in_session",
-                            target=target_name,
-                            session_id=session_id,
-                            session_root=str(session_root.path),
+                    if (
+                        idle_output_timeout is None
+                        and _recipe_step.idle_output_timeout is not None
+                    ):
+                        idle_output_timeout = _recipe_step.idle_output_timeout
+                        logger.warning(
+                            "idle_output_timeout_resolved_from_recipe",
+                            step=step_name,
+                            value=idle_output_timeout,
                         )
-                        return SkillResult.crashed(
-                            exception=RuntimeError(
-                                f"Target skill {target_name!r} not available in session "
-                                f"{session_id!r}: SKILL.md not found after init_session + "
-                                f"activate_skill_deps. Check tier/feature/pack gating."
-                            ),
-                            skill_command=resolved_command,
-                            session_id=session_id,
-                            order_id=effective_order_id,
-                        ).to_json()
-        _local_dir = validate_project_local_skill_dir(Path(cwd), tool_ctx.backend)
-        if _local_dir is not None:
-            skill_add_dirs.append(_local_dir)
 
-        _start = time.monotonic()
-        try:
-            skill_result = await tool_ctx.executor.run(
-                resolved_command,
-                cwd,
-                model=effective_model,
-                add_dirs=skill_add_dirs,
-                step_name=step_name,
-                kitchen_id=tool_ctx.kitchen_id,
-                order_id=effective_order_id,
-                expected_output_patterns=expected_output_patterns,
-                write_behavior=write_spec,
-                stale_threshold=float(stale_threshold) if stale_threshold is not None else None,
-                idle_output_timeout=float(idle_output_timeout)
-                if idle_output_timeout is not None
-                else None,
-                completion_marker=invocation_marker,
-                recipe_name=tool_ctx.recipe_name,
-                recipe_content_hash=tool_ctx.recipe_content_hash,
-                recipe_composite_hash=tool_ctx.recipe_composite_hash,
-                recipe_version=tool_ctx.recipe_version,
-                allowed_write_prefix=allowed_write_prefix,
-                readonly_skill=is_read_only,
-                write_watch_dirs=write_watch_dirs,
-                provider_extras=provider_extras,
-                profile_name=profile_name_out,
-                backend_override=backend_override,
-                resume_session_id=resume_session_id,
-            )
-            if skill_result.success:
-                tool_ctx.audit.record_success(skill_command)
-                _clear_run_skill_state(tool_ctx.project_dir)
-            else:
-                await _notify(
-                    ctx,
-                    "error",
-                    "run_skill failed",
-                    "autoskillit.run_skill",
-                    extra={"exit_code": skill_result.exit_code, "subtype": skill_result.subtype},
-                )
-                _persist_run_skill_state(skill_result, tool_ctx.project_dir)
-            if effective_order_id:
-                skill_result.order_id = effective_order_id
-            from autoskillit.server._misc import (  # noqa: PLC0415
-                _refresh_quota_cache,
-            )
+            write_watch_dirs: list[Path] = []
+            if output_dir:
+                resolved_dir = Path(output_dir)
+                if not resolved_dir.is_absolute():
+                    resolved_dir = Path(cwd) / output_dir
+                write_watch_dirs.append(resolved_dir)
 
-            if tool_ctx.background is not None:
-                tool_ctx.background.submit(
-                    _refresh_quota_cache(tool_ctx.config.quota_guard),
-                    label="quota_post_run_refresh",
+            if not write_watch_dirs:
+                _default_temp = _resolve_skill_temp_dir(cwd, skill_command)
+                if _default_temp:
+                    write_watch_dirs.append(_default_temp)
+
+            is_read_only = bool(
+                tool_ctx.read_only_resolver and tool_ctx.read_only_resolver(skill_command)
+            )
+            allowed_write_prefix = ""
+            if write_watch_dirs:
+                allowed_write_prefix = str(write_watch_dirs[0]) + "/"
+            elif is_read_only:
+                _skill_temp_name = target_name or ""
+                if _skill_temp_name:
+                    allowed_write_prefix = os.path.join(
+                        cwd, ".autoskillit", "temp", _skill_temp_name, ""
+                    )
+                else:
+                    logger.warning(
+                        "read_only_skill_no_target_name",
+                        skill_command=skill_command[:100],
+                    )
+
+            invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
+
+            skill_add_dirs: list[ValidatedAddDir] = []
+            replay_snapshot_used = False
+            _runner = tool_ctx.runner
+            if (
+                step_name
+                and _runner is not None
+                and getattr(_runner, "skill_snapshots", None)
+                and hasattr(_runner, "restore_skill_snapshot")
+                and tool_ctx.ephemeral_root is not None
+            ):
+                _ephemeral_root = tool_ctx.ephemeral_root
+                session_id = f"headless-{uuid4().hex[:12]}"
+                _restored = _runner.restore_skill_snapshot(  # type: ignore[attr-defined]
+                    step_name, _ephemeral_root, session_id
                 )
-            return skill_result.to_json()
-        except Exception as exc:
-            logger.error("run_skill executor raised unexpectedly", exc_info=True)
-            return SkillResult.crashed(
-                exception=exc,
-                skill_command=resolved_command,
-                order_id=effective_order_id,
-            ).to_json()
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(
-                    step_name, time.monotonic() - _start, order_id=effective_order_id
+                if _restored is not None:
+                    skill_add_dirs.append(_restored)
+                    replay_snapshot_used = True
+                    logger.debug(
+                        "replay_skill_snapshot_restored",
+                        step=step_name,
+                        session_id=session_id,
+                    )
+
+            if not replay_snapshot_used and tool_ctx.session_skill_manager is not None:
+                allow_only: frozenset[str] | None = None
+                if target_name:
+                    closure = tool_ctx.session_skill_manager.compute_skill_closure(target_name)
+                    allow_only = closure if closure else None
+
+                session_id = f"headless-{uuid4().hex[:12]}"
+                session_root = tool_ctx.session_skill_manager.init_session(
+                    session_id,
+                    cook_session=False,
+                    config=tool_ctx.config,
+                    project_dir=Path(cwd),
+                    recipe_packs=tool_ctx.active_recipe_packs,
+                    recipe_features=tool_ctx.active_recipe_features,
+                    allow_only=allow_only,
+                    backend=tool_ctx.backend,
                 )
+                skill_add_dirs.append(session_root)
+
+                if target_name:
+                    tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
+                    _is_known_skill = (
+                        tool_ctx.skill_resolver is not None
+                        and tool_ctx.skill_resolver.resolve(target_name) is not None
+                    )
+                    if _is_known_skill:
+                        _skill_md = (
+                            Path(session_root.path)
+                            / ".claude"
+                            / "skills"
+                            / target_name
+                            / "SKILL.md"
+                        )
+                        if not _skill_md.exists():
+                            logger.error(
+                                "target_skill_not_in_session",
+                                target=target_name,
+                                session_id=session_id,
+                                session_root=str(session_root.path),
+                            )
+                            return SkillResult.crashed(
+                                exception=RuntimeError(
+                                    f"Target skill {target_name!r} not available in session "
+                                    f"{session_id!r}: SKILL.md not found after init_session + "
+                                    f"activate_skill_deps. Check tier/feature/pack gating."
+                                ),
+                                skill_command=resolved_command,
+                                session_id=session_id,
+                                order_id=effective_order_id,
+                            ).to_json()
+            _local_dir = validate_project_local_skill_dir(Path(cwd), tool_ctx.backend)
+            if _local_dir is not None:
+                skill_add_dirs.append(_local_dir)
+
+            _start = time.monotonic()
+            try:
+                skill_result = await tool_ctx.executor.run(
+                    resolved_command,
+                    cwd,
+                    model=effective_model,
+                    add_dirs=skill_add_dirs,
+                    step_name=step_name,
+                    kitchen_id=tool_ctx.kitchen_id,
+                    order_id=effective_order_id,
+                    expected_output_patterns=expected_output_patterns,
+                    write_behavior=write_spec,
+                    stale_threshold=float(stale_threshold)
+                    if stale_threshold is not None
+                    else None,
+                    idle_output_timeout=float(idle_output_timeout)
+                    if idle_output_timeout is not None
+                    else None,
+                    completion_marker=invocation_marker,
+                    recipe_name=tool_ctx.recipe_name,
+                    recipe_content_hash=tool_ctx.recipe_content_hash,
+                    recipe_composite_hash=tool_ctx.recipe_composite_hash,
+                    recipe_version=tool_ctx.recipe_version,
+                    allowed_write_prefix=allowed_write_prefix,
+                    readonly_skill=is_read_only,
+                    write_watch_dirs=write_watch_dirs,
+                    provider_extras=provider_extras,
+                    profile_name=profile_name_out,
+                    backend_override=backend_override,
+                    resume_session_id=resume_session_id,
+                )
+                if skill_result.success:
+                    tool_ctx.audit.record_success(skill_command)
+                    _clear_run_skill_state(tool_ctx.project_dir)
+                else:
+                    await _notify(
+                        ctx,
+                        "error",
+                        "run_skill failed",
+                        "autoskillit.run_skill",
+                        extra={
+                            "exit_code": skill_result.exit_code,
+                            "subtype": skill_result.subtype,
+                        },
+                    )
+                    _persist_run_skill_state(skill_result, tool_ctx.project_dir)
+                if effective_order_id:
+                    skill_result.order_id = effective_order_id
+                from autoskillit.server._misc import (  # noqa: PLC0415
+                    _refresh_quota_cache,
+                )
+
+                if tool_ctx.background is not None:
+                    tool_ctx.background.submit(
+                        _refresh_quota_cache(tool_ctx.config.quota_guard),
+                        label="quota_post_run_refresh",
+                    )
+                return skill_result.to_json()
+            except Exception as exc:
+                logger.error("run_skill executor raised unexpectedly", exc_info=True)
+                return SkillResult.crashed(
+                    exception=exc,
+                    skill_command=resolved_command,
+                    order_id=effective_order_id,
+                ).to_json()
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(
+                        step_name, time.monotonic() - _start, order_id=effective_order_id
+                    )
     except Exception as exc:
         logger.error("run_skill unhandled exception", exc_info=True)
         return SkillResult.crashed(

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -70,9 +70,8 @@ async def run_cmd(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="run_cmd", cwd=cwd)
-        logger.info("run_cmd", cmd=cmd[:80], cwd=cwd)
+        with structlog.contextvars.bound_contextvars(tool="run_cmd", cwd=cwd):
+            logger.info("run_cmd", cmd=cmd[:80], cwd=cwd)
         await _notify(
             ctx, "info", f"run_cmd: {cmd[:80]}", "autoskillit.run_cmd", extra={"cwd": cwd}
         )
@@ -156,9 +155,8 @@ async def run_python(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="run_python")
-        logger.info("run_python", callable=callable, timeout=timeout)
+        with structlog.contextvars.bound_contextvars(tool="run_python"):
+            logger.info("run_python", callable=callable, timeout=timeout)
         await _notify(
             ctx,
             "info",
@@ -289,9 +287,8 @@ async def run_skill(
             }
         )
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="run_skill", cwd=cwd)
-        logger.info("run_skill", command=skill_command[:80], cwd=cwd)
+        with structlog.contextvars.bound_contextvars(tool="run_skill", cwd=cwd):
+            logger.info("run_skill", command=skill_command[:80], cwd=cwd)
         await _notify(
             ctx,
             "info",

--- a/src/autoskillit/server/tools/tools_git.py
+++ b/src/autoskillit/server/tools/tools_git.py
@@ -61,46 +61,46 @@ async def merge_worktree(
     try:
         with structlog.contextvars.bound_contextvars(tool="merge_worktree", cwd=worktree_path):
             logger.info("merge_worktree", path=worktree_path, base=base_branch)
-        await _notify(
-            ctx,
-            "info",
-            f"merge_worktree: {worktree_path} -> {base_branch}",
-            "autoskillit.merge_worktree",
-            extra={"worktree": worktree_path, "base": base_branch},
-        )
-
-        from autoskillit.server import _get_config, _get_ctx
-        from autoskillit.server._misc import resolve_remote_name
-        from autoskillit.server.git import perform_merge
-
-        tool_ctx = _get_ctx()
-        runner = tool_ctx.runner
-        assert runner is not None, "No subprocess runner configured"
-        _start = time.monotonic()
-        remote = await resolve_remote_name(worktree_path)
-        try:
-            result = await perform_merge(
-                worktree_path,
-                base_branch,
-                remote=remote,
-                config=_get_config(),
-                runner=runner,
-                tester=tool_ctx.tester,
+            await _notify(
+                ctx,
+                "info",
+                f"merge_worktree: {worktree_path} -> {base_branch}",
+                "autoskillit.merge_worktree",
+                extra={"worktree": worktree_path, "base": base_branch},
             )
 
-            if "error" in result:
-                await _notify(
-                    ctx,
-                    "error",
-                    "merge_worktree failed",
-                    "autoskillit.merge_worktree",
-                    extra={"reason": result["error"]},
+            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server._misc import resolve_remote_name
+            from autoskillit.server.git import perform_merge
+
+            tool_ctx = _get_ctx()
+            runner = tool_ctx.runner
+            assert runner is not None, "No subprocess runner configured"
+            _start = time.monotonic()
+            remote = await resolve_remote_name(worktree_path)
+            try:
+                result = await perform_merge(
+                    worktree_path,
+                    base_branch,
+                    remote=remote,
+                    config=_get_config(),
+                    runner=runner,
+                    tester=tool_ctx.tester,
                 )
 
-            return json.dumps(result)
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+                if "error" in result:
+                    await _notify(
+                        ctx,
+                        "error",
+                        "merge_worktree failed",
+                        "autoskillit.merge_worktree",
+                        extra={"reason": result["error"]},
+                    )
+
+                return json.dumps(result)
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("merge_worktree unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -139,108 +139,112 @@ async def classify_fix(
     try:
         with structlog.contextvars.bound_contextvars(tool="classify_fix", cwd=worktree_path):
             logger.info("classify_fix", worktree=worktree_path, base=base_branch)
-        await _notify(
-            ctx,
-            "info",
-            f"classify_fix: {worktree_path}",
-            "autoskillit.classify_fix",
-            extra={"worktree": worktree_path, "base": base_branch},
-        )
-
-        if not os.path.isdir(worktree_path):
-            return json.dumps(
-                {
-                    "restart_scope": RestartScope.FULL_RESTART,
-                    "reason": (
-                        f"worktree_path does not exist or is not a directory: {worktree_path}"
-                    ),
-                    "critical_files": [],
-                    "all_changed_files": [],
-                }
+            await _notify(
+                ctx,
+                "info",
+                f"classify_fix: {worktree_path}",
+                "autoskillit.classify_fix",
+                extra={"worktree": worktree_path, "base": base_branch},
             )
 
-        from autoskillit.server import _get_config, _get_ctx
-        from autoskillit.server._misc import resolve_remote_name
-        from autoskillit.server.git import _filter_changed_files
-
-        tool_ctx = _get_ctx()
-        _start = time.monotonic()
-        remote = await resolve_remote_name(worktree_path)
-        try:
-            fetch_rc, _, fetch_stderr = await _run_subprocess(
-                ["git", "fetch", remote, base_branch],
-                cwd=worktree_path,
-                timeout=30,
-            )
-            if fetch_rc != 0:
+            if not os.path.isdir(worktree_path):
                 return json.dumps(
                     {
                         "restart_scope": RestartScope.FULL_RESTART,
                         "reason": (
-                            f"git fetch {remote} {base_branch} failed — "
-                            "remote-tracking ref may be stale. "
-                            f"git error: {(fetch_stderr or '').strip()[:200]}"
+                            f"worktree_path does not exist or is not a directory: {worktree_path}"
                         ),
                         "critical_files": [],
                         "all_changed_files": [],
                     }
                 )
 
-            returncode, stdout, stderr = await _run_subprocess(
-                ["git", "diff", "--name-only", f"{remote}/{base_branch}...HEAD"],
-                cwd=worktree_path,
-                timeout=30,
-            )
+            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server._misc import resolve_remote_name
+            from autoskillit.server.git import _filter_changed_files
 
-            if returncode != 0:
-                await _notify(
-                    ctx,
-                    "error",
-                    "classify_fix: git diff failed (falling back to full_restart)",
-                    "autoskillit.classify_fix",
-                    extra={"worktree": worktree_path},
+            tool_ctx = _get_ctx()
+            _start = time.monotonic()
+            remote = await resolve_remote_name(worktree_path)
+            try:
+                fetch_rc, _, fetch_stderr = await _run_subprocess(
+                    ["git", "fetch", remote, base_branch],
+                    cwd=worktree_path,
+                    timeout=30,
                 )
-                # A missing origin/<base_branch> ref (rc=128, "ambiguous argument" or
-                # "unknown revision") is treated as FULL_RESTART — conservative safe default.
-                # Any other git error also falls back to FULL_RESTART for the same reason:
-                # if we can't determine what changed, assume the worst.
+                if fetch_rc != 0:
+                    return json.dumps(
+                        {
+                            "restart_scope": RestartScope.FULL_RESTART,
+                            "reason": (
+                                f"git fetch {remote} {base_branch} failed — "
+                                "remote-tracking ref may be stale. "
+                                f"git error: {(fetch_stderr or '').strip()[:200]}"
+                            ),
+                            "critical_files": [],
+                            "all_changed_files": [],
+                        }
+                    )
+
+                returncode, stdout, stderr = await _run_subprocess(
+                    ["git", "diff", "--name-only", f"{remote}/{base_branch}...HEAD"],
+                    cwd=worktree_path,
+                    timeout=30,
+                )
+
+                if returncode != 0:
+                    await _notify(
+                        ctx,
+                        "error",
+                        "classify_fix: git diff failed (falling back to full_restart)",
+                        "autoskillit.classify_fix",
+                        extra={"worktree": worktree_path},
+                    )
+                    # A missing origin/<base_branch> ref (rc=128, "ambiguous argument" or
+                    # "unknown revision") is treated as FULL_RESTART — conservative safe default.
+                    # Any other git error also falls back to FULL_RESTART for the same reason:
+                    # if we can't determine what changed, assume the worst.
+                    return json.dumps(
+                        {
+                            "restart_scope": RestartScope.FULL_RESTART,
+                            "reason": (
+                                f"Cannot diff against {remote}/{base_branch}"
+                                f" — ref may not exist locally. "
+                                f"git error: {stderr.strip()[:200]}"
+                            ),
+                            "critical_files": [],
+                            "all_changed_files": [],
+                        }
+                    )
+
+                prefixes = _get_config().classify_fix.path_prefixes
+                changed_files, critical_files = _filter_changed_files(stdout, prefixes)
+
+                if critical_files:
+                    return json.dumps(
+                        {
+                            "restart_scope": RestartScope.FULL_RESTART,
+                            "reason": (
+                                f"Fix touches critical paths: {', '.join(critical_files[:5])}"
+                            ),
+                            "critical_files": critical_files,
+                            "all_changed_files": changed_files,
+                        }
+                    )
+
                 return json.dumps(
                     {
-                        "restart_scope": RestartScope.FULL_RESTART,
+                        "restart_scope": RestartScope.PARTIAL_RESTART,
                         "reason": (
-                            f"Cannot diff against {remote}/{base_branch}"
-                            f" — ref may not exist locally. "
-                            f"git error: {stderr.strip()[:200]}"
+                            "Fix does not touch critical paths — partial restart is sufficient"
                         ),
                         "critical_files": [],
-                        "all_changed_files": [],
-                    }
-                )
-
-            prefixes = _get_config().classify_fix.path_prefixes
-            changed_files, critical_files = _filter_changed_files(stdout, prefixes)
-
-            if critical_files:
-                return json.dumps(
-                    {
-                        "restart_scope": RestartScope.FULL_RESTART,
-                        "reason": f"Fix touches critical paths: {', '.join(critical_files[:5])}",
-                        "critical_files": critical_files,
                         "all_changed_files": changed_files,
                     }
                 )
-
-            return json.dumps(
-                {
-                    "restart_scope": RestartScope.PARTIAL_RESTART,
-                    "reason": "Fix does not touch critical paths — partial restart is sufficient",
-                    "critical_files": [],
-                    "all_changed_files": changed_files,
-                }
-            )
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("classify_fix unhandled exception", exc_info=True)
         return json.dumps(
@@ -302,49 +306,49 @@ async def create_unique_branch(
     try:
         with structlog.contextvars.bound_contextvars(tool="create_unique_branch", cwd=cwd):
             _display = base_branch_name if base_branch_name else slug
-        logger.info(
-            "create_unique_branch",
-            slug=slug,
-            issue_number=issue_number,
-            remote=remote,
-            base_branch_name=base_branch_name,
-        )
-        await _notify(
-            ctx,
-            "info",
-            f"create_unique_branch: {_display}",
-            "autoskillit.create_unique_branch",
-            extra={"remote": remote},
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        _start = time.monotonic()
-
-        if not cwd or not os.path.isdir(cwd):
-            return json.dumps(
-                {"success": False, "error": f"cwd is not a valid directory: {cwd!r}"}
+            logger.info(
+                "create_unique_branch",
+                slug=slug,
+                issue_number=issue_number,
+                remote=remote,
+                base_branch_name=base_branch_name,
+            )
+            await _notify(
+                ctx,
+                "info",
+                f"create_unique_branch: {_display}",
+                "autoskillit.create_unique_branch",
+                extra={"remote": remote},
             )
 
-        if base_branch_name:
-            base_name = base_branch_name
-        elif not slug:
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": "create_unique_branch requires either base_branch_name or slug",
-                }
-            )
-        else:
-            base_name = f"{slug}-{issue_number}" if issue_number is not None else slug
+            from autoskillit.server import _get_ctx
 
-        try:
-            result = await _resolve_and_create_branch(base_name, remote, cwd)
-            return json.dumps(result)
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            tool_ctx = _get_ctx()
+            _start = time.monotonic()
+
+            if not cwd or not os.path.isdir(cwd):
+                return json.dumps(
+                    {"success": False, "error": f"cwd is not a valid directory: {cwd!r}"}
+                )
+
+            if base_branch_name:
+                base_name = base_branch_name
+            elif not slug:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "create_unique_branch requires either base_branch_name or slug",
+                    }
+                )
+            else:
+                base_name = f"{slug}-{issue_number}" if issue_number is not None else slug
+
+            try:
+                result = await _resolve_and_create_branch(base_name, remote, cwd)
+                return json.dumps(result)
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("create_unique_branch unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -381,39 +385,41 @@ async def check_pr_mergeable(
     try:
         with structlog.contextvars.bound_contextvars(tool="check_pr_mergeable", cwd=cwd):
             logger.info("check_pr_mergeable", pr_number=pr_number, repo=repo)
-        await _notify(
-            ctx,
-            "info",
-            f"check_pr_mergeable: #{pr_number}",
-            "autoskillit.check_pr_mergeable",
-            extra={"repo": repo},
-        )
-
-        if not cwd or not os.path.isdir(cwd):
-            return json.dumps(
-                {"success": False, "error": f"cwd is not a valid directory: {cwd!r}"}
+            await _notify(
+                ctx,
+                "info",
+                f"check_pr_mergeable: #{pr_number}",
+                "autoskillit.check_pr_mergeable",
+                extra={"repo": repo},
             )
 
-        cmd = ["gh", "pr", "view", str(pr_number), "--json", "mergeable,mergeStateStatus"]
-        if repo:
-            cmd.extend(["-R", repo])
+            if not cwd or not os.path.isdir(cwd):
+                return json.dumps(
+                    {"success": False, "error": f"cwd is not a valid directory: {cwd!r}"}
+                )
 
-        rc, stdout, stderr = await _run_subprocess(cmd, cwd=cwd, timeout=30)
-        if rc != 0:
-            return json.dumps({"success": False, "error": stderr.strip() or "gh command failed"})
+            cmd = ["gh", "pr", "view", str(pr_number), "--json", "mergeable,mergeStateStatus"]
+            if repo:
+                cmd.extend(["-R", repo])
 
-        try:
-            data = json.loads(stdout)
-        except json.JSONDecodeError:
-            return json.dumps({"success": False, "error": "Failed to parse gh output"})
+            rc, stdout, stderr = await _run_subprocess(cmd, cwd=cwd, timeout=30)
+            if rc != 0:
+                return json.dumps(
+                    {"success": False, "error": stderr.strip() or "gh command failed"}
+                )
 
-        return json.dumps(
-            {
-                "mergeable": data.get("mergeable") == "MERGEABLE",
-                "merge_state_status": data.get("mergeStateStatus", ""),
-                "mergeable_status": data.get("mergeable", ""),
-            }
-        )
+            try:
+                data = json.loads(stdout)
+            except json.JSONDecodeError:
+                return json.dumps({"success": False, "error": "Failed to parse gh output"})
+
+            return json.dumps(
+                {
+                    "mergeable": data.get("mergeable") == "MERGEABLE",
+                    "merge_state_status": data.get("mergeStateStatus", ""),
+                    "mergeable_status": data.get("mergeable", ""),
+                }
+            )
     except Exception as exc:
         logger.error("check_pr_mergeable unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -526,89 +532,89 @@ async def create_and_publish_branch(
                 run_name=run_name,
                 issue_number=issue_number,
             )
-        await _notify(
-            ctx,
-            "info",
-            f"create_and_publish_branch: {issue_slug or run_name}/{issue_number or 'date'}",
-            "autoskillit.create_and_publish_branch",
-            extra={"run_name": run_name, "issue_number": issue_number},
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        clone_mgr = tool_ctx.clone_mgr
-        if clone_mgr is None:
-            return json.dumps({"error": "Clone manager not configured"})
-
-        if not work_dir or not os.path.isdir(work_dir):
-            return json.dumps({"error": f"work_dir is not a valid directory: {work_dir!r}"})
-
-        _total_start = time.monotonic()
-
-        _compute_start = time.monotonic()
-        base_name = _compute_branch_name(issue_slug, run_name, issue_number)
-        compute_ms = int((time.monotonic() - _compute_start) * 1000)
-
-        _branch_start = time.monotonic()
-        branch_result = await _resolve_and_create_branch(base_name, "origin", work_dir)
-        branch_create_ms = int((time.monotonic() - _branch_start) * 1000)
-
-        if "error" in branch_result:
-            return json.dumps(
-                {
-                    "error": branch_result["error"],
-                    "merge_target": base_name,
-                    "timings": {
-                        "compute_ms": compute_ms,
-                        "branch_create_ms": branch_create_ms,
-                        "push_ms": 0,
-                    },
-                }
+            await _notify(
+                ctx,
+                "info",
+                f"create_and_publish_branch: {issue_slug or run_name}/{issue_number or 'date'}",
+                "autoskillit.create_and_publish_branch",
+                extra={"run_name": run_name, "issue_number": issue_number},
             )
 
-        branch_name: str = branch_result["branch_name"]
-        was_unique: bool = branch_result["was_unique"]
+            from autoskillit.server import _get_ctx
 
-        _push_start = time.monotonic()
-        push_result = await asyncio.to_thread(
-            lambda: clone_mgr.push_to_remote(
-                work_dir,
-                "",
-                branch_name,
-                remote_url=remote_url,
-                protected_branches=tool_ctx.config.safety.protected_branches,
-                force=False,
+            tool_ctx = _get_ctx()
+            clone_mgr = tool_ctx.clone_mgr
+            if clone_mgr is None:
+                return json.dumps({"error": "Clone manager not configured"})
+
+            if not work_dir or not os.path.isdir(work_dir):
+                return json.dumps({"error": f"work_dir is not a valid directory: {work_dir!r}"})
+
+            _total_start = time.monotonic()
+
+            _compute_start = time.monotonic()
+            base_name = _compute_branch_name(issue_slug, run_name, issue_number)
+            compute_ms = int((time.monotonic() - _compute_start) * 1000)
+
+            _branch_start = time.monotonic()
+            branch_result = await _resolve_and_create_branch(base_name, "origin", work_dir)
+            branch_create_ms = int((time.monotonic() - _branch_start) * 1000)
+
+            if "error" in branch_result:
+                return json.dumps(
+                    {
+                        "error": branch_result["error"],
+                        "merge_target": base_name,
+                        "timings": {
+                            "compute_ms": compute_ms,
+                            "branch_create_ms": branch_create_ms,
+                            "push_ms": 0,
+                        },
+                    }
+                )
+
+            branch_name: str = branch_result["branch_name"]
+            was_unique: bool = branch_result["was_unique"]
+
+            _push_start = time.monotonic()
+            push_result = await asyncio.to_thread(
+                lambda: clone_mgr.push_to_remote(
+                    work_dir,
+                    "",
+                    branch_name,
+                    remote_url=remote_url,
+                    protected_branches=tool_ctx.config.safety.protected_branches,
+                    force=False,
+                )
             )
-        )
-        push_ms = int((time.monotonic() - _push_start) * 1000)
+            push_ms = int((time.monotonic() - _push_start) * 1000)
 
-        timings = {
-            "compute_ms": compute_ms,
-            "branch_create_ms": branch_create_ms,
-            "push_ms": push_ms,
-        }
+            timings = {
+                "compute_ms": compute_ms,
+                "branch_create_ms": branch_create_ms,
+                "push_ms": push_ms,
+            }
 
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _total_start)
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _total_start)
 
-        if not push_result.get("success"):
+            if not push_result.get("success"):
+                return json.dumps(
+                    {
+                        "error": push_result.get("stderr", "push failed"),
+                        "error_type": push_result.get("error_type", ""),
+                        "merge_target": branch_name,
+                        "timings": timings,
+                    }
+                )
+
             return json.dumps(
                 {
-                    "error": push_result.get("stderr", "push failed"),
-                    "error_type": push_result.get("error_type", ""),
                     "merge_target": branch_name,
+                    "was_unique": was_unique,
                     "timings": timings,
                 }
             )
-
-        return json.dumps(
-            {
-                "merge_target": branch_name,
-                "was_unique": was_unique,
-                "timings": timings,
-            }
-        )
     except Exception as exc:
         logger.error("create_and_publish_branch unhandled exception", exc_info=True)
         return json.dumps({"error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools/tools_git.py
+++ b/src/autoskillit/server/tools/tools_git.py
@@ -59,9 +59,8 @@ async def merge_worktree(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="merge_worktree", cwd=worktree_path)
-        logger.info("merge_worktree", path=worktree_path, base=base_branch)
+        with structlog.contextvars.bound_contextvars(tool="merge_worktree", cwd=worktree_path):
+            logger.info("merge_worktree", path=worktree_path, base=base_branch)
         await _notify(
             ctx,
             "info",
@@ -138,9 +137,8 @@ async def classify_fix(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="classify_fix", cwd=worktree_path)
-        logger.info("classify_fix", worktree=worktree_path, base=base_branch)
+        with structlog.contextvars.bound_contextvars(tool="classify_fix", cwd=worktree_path):
+            logger.info("classify_fix", worktree=worktree_path, base=base_branch)
         await _notify(
             ctx,
             "info",
@@ -302,9 +300,8 @@ async def create_unique_branch(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="create_unique_branch", cwd=cwd)
-        _display = base_branch_name if base_branch_name else slug
+        with structlog.contextvars.bound_contextvars(tool="create_unique_branch", cwd=cwd):
+            _display = base_branch_name if base_branch_name else slug
         logger.info(
             "create_unique_branch",
             slug=slug,
@@ -382,9 +379,8 @@ async def check_pr_mergeable(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="check_pr_mergeable", cwd=cwd)
-        logger.info("check_pr_mergeable", pr_number=pr_number, repo=repo)
+        with structlog.contextvars.bound_contextvars(tool="check_pr_mergeable", cwd=cwd):
+            logger.info("check_pr_mergeable", pr_number=pr_number, repo=repo)
         await _notify(
             ctx,
             "info",
@@ -519,18 +515,17 @@ async def create_and_publish_branch(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(
+        with structlog.contextvars.bound_contextvars(
             tool="create_and_publish_branch",
             work_dir=work_dir,
             issue_number=issue_number,
-        )
-        logger.info(
-            "create_and_publish_branch",
-            issue_slug=issue_slug,
-            run_name=run_name,
-            issue_number=issue_number,
-        )
+        ):
+            logger.info(
+                "create_and_publish_branch",
+                issue_slug=issue_slug,
+                run_name=run_name,
+                issue_number=issue_number,
+            )
         await _notify(
             ctx,
             "info",

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -60,101 +60,149 @@ async def claim_and_resolve_issue(
         ):
             logger.info("claim_and_resolve_issue", issue_url=issue_url)
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
-        if tool_ctx.github_client is None:
-            return json.dumps(
-                {"success": False, "error": "GitHub token required for label management"}
+            tool_ctx = _get_ctx()
+            if tool_ctx.github_client is None:
+                return json.dumps(
+                    {"success": False, "error": "GitHub token required for label management"}
+                )
+
+            effective_label = label or tool_ctx.config.github.in_progress_label
+
+            try:
+                owner, repo, issue_number = _parse_issue_ref(issue_url)
+            except ValueError as exc:
+                return json.dumps({"success": False, "error": str(exc)})
+
+            if err := tool_ctx.config.github.check_label_allowed(effective_label):
+                return json.dumps({"success": False, "error": err})
+
+            _fetch_title_start = time.monotonic()
+            title_result = await tool_ctx.github_client.fetch_title(issue_url)
+            fetch_title_ms = int((time.monotonic() - _fetch_title_start) * 1000)
+
+            if not title_result.get("success"):
+                return json.dumps(
+                    {"success": False, "error": title_result.get("error", "fetch_title failed")}
+                )
+
+            issue_title = title_result.get("title", "")
+            issue_slug = title_result.get("slug", "")
+
+            _claim_start = time.monotonic()
+            fetch_result = await tool_ctx.github_client.fetch_issue(
+                issue_url, include_comments=False
+            )
+            if not fetch_result.get("success"):
+                claim_ms = int((time.monotonic() - _claim_start) * 1000)
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": fetch_result.get("error", "fetch_issue failed"),
+                        "issue_number": issue_number,
+                        "issue_title": issue_title,
+                        "issue_slug": issue_slug,
+                        "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
+                    }
+                )
+
+            issue_body = fetch_result.get("body") or ""
+            review_approach_recommended = REVIEW_APPROACH_MARKER in issue_body
+
+            issue_state = fetch_result.get("state", "open").lower()
+            if issue_state == "closed":
+                claim_ms = int((time.monotonic() - _claim_start) * 1000)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "claimed": False,
+                        "reason": "issue is closed",
+                        "issue_number": issue_number,
+                        "issue_title": issue_title,
+                        "issue_slug": issue_slug,
+                        "review_approach_recommended": review_approach_recommended,
+                        "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
+                    }
+                )
+
+            current_labels = _extract_label_names(fetch_result.get("labels", []))
+            decision = await _try_claim_with_liveness(
+                issue_url=issue_url,
+                issue_number=issue_number,
+                effective_label=effective_label,
+                current_labels=current_labels,
+                allow_reentry=allow_reentry,
+                github_client=tool_ctx.github_client,
+                campaign_state_paths=_get_campaign_state_paths(tool_ctx),
+            )
+            if not decision.claimed:
+                claim_ms = int((time.monotonic() - _claim_start) * 1000)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "claimed": False,
+                        "reason": decision.reason,
+                        "issue_number": issue_number,
+                        "issue_title": issue_title,
+                        "issue_slug": issue_slug,
+                        "review_approach_recommended": review_approach_recommended,
+                        "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
+                    }
+                )
+            if decision.reentry:
+                claim_ms = int((time.monotonic() - _claim_start) * 1000)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "claimed": True,
+                        "reentry": True,
+                        "issue_number": issue_number,
+                        "issue_title": issue_title,
+                        "issue_slug": issue_slug,
+                        "label": effective_label,
+                        "review_approach_recommended": review_approach_recommended,
+                        "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
+                    }
+                )
+
+            ensure_color, ensure_description, remove_labels = (
+                tool_ctx.config.github.resolve_label_metadata(effective_label)
             )
 
-        effective_label = label or tool_ctx.config.github.in_progress_label
-
-        try:
-            owner, repo, issue_number = _parse_issue_ref(issue_url)
-        except ValueError as exc:
-            return json.dumps({"success": False, "error": str(exc)})
-
-        if err := tool_ctx.config.github.check_label_allowed(effective_label):
-            return json.dumps({"success": False, "error": err})
-
-        _fetch_title_start = time.monotonic()
-        title_result = await tool_ctx.github_client.fetch_title(issue_url)
-        fetch_title_ms = int((time.monotonic() - _fetch_title_start) * 1000)
-
-        if not title_result.get("success"):
-            return json.dumps(
-                {"success": False, "error": title_result.get("error", "fetch_title failed")}
+            await tool_ctx.github_client.ensure_label(
+                owner,
+                repo,
+                effective_label,
+                color=ensure_color,
+                description=ensure_description,
             )
 
-        issue_title = title_result.get("title", "")
-        issue_slug = title_result.get("slug", "")
-
-        _claim_start = time.monotonic()
-        fetch_result = await tool_ctx.github_client.fetch_issue(issue_url, include_comments=False)
-        if not fetch_result.get("success"):
+            swap_result = await tool_ctx.github_client.swap_labels(
+                owner,
+                repo,
+                issue_number,
+                remove_labels=remove_labels,
+                add_labels=[effective_label],
+            )
             claim_ms = int((time.monotonic() - _claim_start) * 1000)
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": fetch_result.get("error", "fetch_issue failed"),
-                    "issue_number": issue_number,
-                    "issue_title": issue_title,
-                    "issue_slug": issue_slug,
-                    "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
-                }
-            )
 
-        issue_body = fetch_result.get("body") or ""
-        review_approach_recommended = REVIEW_APPROACH_MARKER in issue_body
+            if not swap_result.get("success"):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": swap_result.get("error", "swap_labels failed"),
+                        "issue_number": issue_number,
+                        "issue_title": issue_title,
+                        "issue_slug": issue_slug,
+                        "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
+                    }
+                )
 
-        issue_state = fetch_result.get("state", "open").lower()
-        if issue_state == "closed":
-            claim_ms = int((time.monotonic() - _claim_start) * 1000)
-            return json.dumps(
-                {
-                    "success": True,
-                    "claimed": False,
-                    "reason": "issue is closed",
-                    "issue_number": issue_number,
-                    "issue_title": issue_title,
-                    "issue_slug": issue_slug,
-                    "review_approach_recommended": review_approach_recommended,
-                    "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
-                }
-            )
-
-        current_labels = _extract_label_names(fetch_result.get("labels", []))
-        decision = await _try_claim_with_liveness(
-            issue_url=issue_url,
-            issue_number=issue_number,
-            effective_label=effective_label,
-            current_labels=current_labels,
-            allow_reentry=allow_reentry,
-            github_client=tool_ctx.github_client,
-            campaign_state_paths=_get_campaign_state_paths(tool_ctx),
-        )
-        if not decision.claimed:
-            claim_ms = int((time.monotonic() - _claim_start) * 1000)
-            return json.dumps(
-                {
-                    "success": True,
-                    "claimed": False,
-                    "reason": decision.reason,
-                    "issue_number": issue_number,
-                    "issue_title": issue_title,
-                    "issue_slug": issue_slug,
-                    "review_approach_recommended": review_approach_recommended,
-                    "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
-                }
-            )
-        if decision.reentry:
-            claim_ms = int((time.monotonic() - _claim_start) * 1000)
             return json.dumps(
                 {
                     "success": True,
                     "claimed": True,
-                    "reentry": True,
                     "issue_number": issue_number,
                     "issue_title": issue_title,
                     "issue_slug": issue_slug,
@@ -163,52 +211,6 @@ async def claim_and_resolve_issue(
                     "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
                 }
             )
-
-        ensure_color, ensure_description, remove_labels = (
-            tool_ctx.config.github.resolve_label_metadata(effective_label)
-        )
-
-        await tool_ctx.github_client.ensure_label(
-            owner,
-            repo,
-            effective_label,
-            color=ensure_color,
-            description=ensure_description,
-        )
-
-        swap_result = await tool_ctx.github_client.swap_labels(
-            owner,
-            repo,
-            issue_number,
-            remove_labels=remove_labels,
-            add_labels=[effective_label],
-        )
-        claim_ms = int((time.monotonic() - _claim_start) * 1000)
-
-        if not swap_result.get("success"):
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": swap_result.get("error", "swap_labels failed"),
-                    "issue_number": issue_number,
-                    "issue_title": issue_title,
-                    "issue_slug": issue_slug,
-                    "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
-                }
-            )
-
-        return json.dumps(
-            {
-                "success": True,
-                "claimed": True,
-                "issue_number": issue_number,
-                "issue_title": issue_title,
-                "issue_slug": issue_slug,
-                "label": effective_label,
-                "review_approach_recommended": review_approach_recommended,
-                "timings": {"fetch_title_ms": fetch_title_ms, "claim_ms": claim_ms},
-            }
-        )
     except Exception as exc:
         logger.error("claim_and_resolve_issue unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -55,9 +55,10 @@ async def claim_and_resolve_issue(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="claim_and_resolve_issue", issue_url=issue_url)
-        logger.info("claim_and_resolve_issue", issue_url=issue_url)
+        with structlog.contextvars.bound_contextvars(
+            tool="claim_and_resolve_issue", issue_url=issue_url
+        ):
+            logger.info("claim_and_resolve_issue", issue_url=issue_url)
 
         from autoskillit.server import _get_ctx
 

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -182,9 +182,8 @@ async def prepare_issue(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="prepare_issue", title=title[:60])
-        logger.info("prepare_issue", title=title[:60], dry_run=dry_run, split=split)
+        with structlog.contextvars.bound_contextvars(tool="prepare_issue", title=title[:60]):
+            logger.info("prepare_issue", title=title[:60], dry_run=dry_run, split=split)
         await _notify(
             ctx,
             "info",
@@ -288,14 +287,13 @@ async def enrich_issues(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(
+        with structlog.contextvars.bound_contextvars(
             tool="enrich_issues",
             issue_number=issue_number,
             batch=batch,
             dry_run=dry_run,
-        )
-        logger.info("enrich_issues", issue_number=issue_number, batch=batch, dry_run=dry_run)
+        ):
+            logger.info("enrich_issues", issue_number=issue_number, batch=batch, dry_run=dry_run)
         await _notify(
             ctx,
             "info",

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -184,70 +184,71 @@ async def prepare_issue(
     try:
         with structlog.contextvars.bound_contextvars(tool="prepare_issue", title=title[:60]):
             logger.info("prepare_issue", title=title[:60], dry_run=dry_run, split=split)
-        await _notify(
-            ctx,
-            "info",
-            f"prepare_issue: {title[:60]}",
-            "autoskillit.prepare_issue",
-            extra={"dry_run": dry_run, "split": split},
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        if tool_ctx.executor is None:
-            return json.dumps({"success": False, "error": "Executor not configured"})
-
-        if labels:
-            if err := tool_ctx.config.github.check_labels_allowed(labels):
-                return json.dumps({"success": False, "error": err})
-
-        skill_command = _build_prepare_skill_command(title, body, repo, labels, dry_run, split)
-
-        expected_output_patterns: list[str] = []
-        if tool_ctx.output_pattern_resolver:
-            expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
-
-        write_spec: WriteBehaviorSpec | None = None
-        if tool_ctx.write_expected_resolver:
-            write_spec = tool_ctx.write_expected_resolver(skill_command)
-
-        result = await tool_ctx.executor.run(
-            skill_command,
-            str(tool_ctx.project_dir),
-            expected_output_patterns=expected_output_patterns,
-            write_behavior=write_spec,
-        )
-
-        if not result.success:
-            return json.dumps(
-                _build_headless_error_response(result, error=_retry_reason_to_error(result))
+            await _notify(
+                ctx,
+                "info",
+                f"prepare_issue: {title[:60]}",
+                "autoskillit.prepare_issue",
+                extra={"dry_run": dry_run, "split": split},
             )
 
-        if result.result is None or not result.result.strip():
-            return json.dumps(
-                _build_headless_error_response(
-                    result,
-                    error="session completed but output was empty (drain race)",
+            from autoskillit.server import _get_ctx
+
+            tool_ctx = _get_ctx()
+            if tool_ctx.executor is None:
+                return json.dumps({"success": False, "error": "Executor not configured"})
+
+            if labels:
+                if err := tool_ctx.config.github.check_labels_allowed(labels):
+                    return json.dumps({"success": False, "error": err})
+
+            skill_command = _build_prepare_skill_command(title, body, repo, labels, dry_run, split)
+
+            expected_output_patterns: list[str] = []
+            if tool_ctx.output_pattern_resolver:
+                expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
+
+            write_spec: WriteBehaviorSpec | None = None
+            if tool_ctx.write_expected_resolver:
+                write_spec = tool_ctx.write_expected_resolver(skill_command)
+
+            result = await tool_ctx.executor.run(
+                skill_command,
+                str(tool_ctx.project_dir),
+                expected_output_patterns=expected_output_patterns,
+                write_behavior=write_spec,
+            )
+
+            if not result.success:
+                return json.dumps(
+                    _build_headless_error_response(result, error=_retry_reason_to_error(result))
                 )
+
+            if result.result is None or not result.result.strip():
+                return json.dumps(
+                    _build_headless_error_response(
+                        result,
+                        error="session completed but output was empty (drain race)",
+                    )
+                )
+
+            parsed = _parse_prepare_result(result.result)
+            # Distinguish block-parse failures (block absent or malformed JSON)
+            # from skill-level data.
+            # The sentinel errors from _parse_prepare_result signal a block-extraction failure —
+            # these are not the same as skill-internal errors embedded in a valid block.
+            if parsed.get("error") in _BLOCK_PARSE_ERRORS:
+                return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
+
+            # Block parsed successfully. result.success=True is the authoritative signal —
+            # the parsed block's "success" field (if any) must not overwrite it.
+            return json.dumps(
+                {
+                    "success": True,
+                    "status": "complete",
+                    **_without_success_key(parsed),
+                }
             )
-
-        parsed = _parse_prepare_result(result.result)
-        # Distinguish block-parse failures (block absent or malformed JSON) from skill-level data.
-        # The sentinel errors from _parse_prepare_result signal a block-extraction failure —
-        # these are not the same as skill-internal errors embedded in a valid block.
-        if parsed.get("error") in _BLOCK_PARSE_ERRORS:
-            return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
-
-        # Block parsed successfully. result.success=True is the authoritative signal —
-        # the parsed block's "success" field (if any) must not overwrite it.
-        return json.dumps(
-            {
-                "success": True,
-                "status": "complete",
-                **_without_success_key(parsed),
-            }
-        )
     except Exception as exc:
         logger.error("prepare_issue unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -294,61 +295,61 @@ async def enrich_issues(
             dry_run=dry_run,
         ):
             logger.info("enrich_issues", issue_number=issue_number, batch=batch, dry_run=dry_run)
-        await _notify(
-            ctx,
-            "info",
-            "enrich_issues: backfilling requirements on recipe:implementation issues",
-            "autoskillit.enrich_issues",
-            extra={"dry_run": dry_run},
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        if tool_ctx.executor is None:
-            return json.dumps({"success": False, "error": "Executor not configured"})
-
-        skill_command = _build_enrich_skill_command(issue_number, batch, dry_run, repo)
-
-        expected_output_patterns: list[str] = []
-        if tool_ctx.output_pattern_resolver:
-            expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
-
-        write_spec: WriteBehaviorSpec | None = None
-        if tool_ctx.write_expected_resolver:
-            write_spec = tool_ctx.write_expected_resolver(skill_command)
-
-        result = await tool_ctx.executor.run(
-            skill_command,
-            str(tool_ctx.project_dir),
-            expected_output_patterns=expected_output_patterns,
-            write_behavior=write_spec,
-        )
-
-        if not result.success:
-            return json.dumps(
-                _build_headless_error_response(result, error=_retry_reason_to_error(result))
+            await _notify(
+                ctx,
+                "info",
+                "enrich_issues: backfilling requirements on recipe:implementation issues",
+                "autoskillit.enrich_issues",
+                extra={"dry_run": dry_run},
             )
 
-        if result.result is None or not result.result.strip():
-            return json.dumps(
-                _build_headless_error_response(
-                    result,
-                    error="session completed but output was empty (drain race)",
+            from autoskillit.server import _get_ctx
+
+            tool_ctx = _get_ctx()
+            if tool_ctx.executor is None:
+                return json.dumps({"success": False, "error": "Executor not configured"})
+
+            skill_command = _build_enrich_skill_command(issue_number, batch, dry_run, repo)
+
+            expected_output_patterns: list[str] = []
+            if tool_ctx.output_pattern_resolver:
+                expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
+
+            write_spec: WriteBehaviorSpec | None = None
+            if tool_ctx.write_expected_resolver:
+                write_spec = tool_ctx.write_expected_resolver(skill_command)
+
+            result = await tool_ctx.executor.run(
+                skill_command,
+                str(tool_ctx.project_dir),
+                expected_output_patterns=expected_output_patterns,
+                write_behavior=write_spec,
+            )
+
+            if not result.success:
+                return json.dumps(
+                    _build_headless_error_response(result, error=_retry_reason_to_error(result))
                 )
+
+            if result.result is None or not result.result.strip():
+                return json.dumps(
+                    _build_headless_error_response(
+                        result,
+                        error="session completed but output was empty (drain race)",
+                    )
+                )
+
+            parsed = _parse_enrich_result(result.result)
+            if parsed.get("error") in _BLOCK_PARSE_ERRORS:
+                return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "status": "complete",
+                    **_without_success_key(parsed),
+                }
             )
-
-        parsed = _parse_enrich_result(result.result)
-        if parsed.get("error") in _BLOCK_PARSE_ERRORS:
-            return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
-
-        return json.dumps(
-            {
-                "success": True,
-                "status": "complete",
-                **_without_success_key(parsed),
-            }
-        )
     except Exception as exc:
         logger.error("enrich_issues unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools/tools_issue_labels.py
+++ b/src/autoskillit/server/tools/tools_issue_labels.py
@@ -54,106 +54,105 @@ async def claim_issue(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="claim_issue", issue_url=issue_url)
-        logger.info("claim_issue", issue_url=issue_url)
+        with structlog.contextvars.bound_contextvars(tool="claim_issue", issue_url=issue_url):
+            logger.info("claim_issue", issue_url=issue_url)
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
-        if tool_ctx.github_client is None:
-            return json.dumps(
-                {"success": False, "error": "GitHub token required for label management"}
+            tool_ctx = _get_ctx()
+            if tool_ctx.github_client is None:
+                return json.dumps(
+                    {"success": False, "error": "GitHub token required for label management"}
+                )
+
+            effective_label = label or tool_ctx.config.github.in_progress_label
+
+            try:
+                owner, repo, issue_number = _parse_issue_ref(issue_url)
+            except ValueError as exc:
+                return json.dumps({"success": False, "error": str(exc)})
+
+            if err := tool_ctx.config.github.check_label_allowed(effective_label):
+                return json.dumps({"success": False, "error": err})
+
+            result = await tool_ctx.github_client.fetch_issue(issue_url, include_comments=False)
+            if not result.get("success"):
+                return json.dumps({"success": False, "error": result.get("error", "fetch failed")})
+
+            review_approach_recommended = REVIEW_APPROACH_MARKER in (result.get("body") or "")
+            issue_state = result.get("state", "open").lower()
+            if issue_state == "closed":
+                return json.dumps(
+                    {
+                        "success": True,
+                        "claimed": False,
+                        "reason": "issue is closed",
+                    }
+                )
+
+            current_labels = _extract_label_names(result.get("labels", []))
+            decision = await _try_claim_with_liveness(
+                issue_url=issue_url,
+                issue_number=issue_number,
+                effective_label=effective_label,
+                current_labels=current_labels,
+                allow_reentry=allow_reentry,
+                github_client=tool_ctx.github_client,
+                campaign_state_paths=_get_campaign_state_paths(tool_ctx),
+            )
+            if not decision.claimed:
+                return json.dumps(
+                    {
+                        "success": True,
+                        "claimed": False,
+                        "reason": decision.reason,
+                    }
+                )
+            if decision.reentry:
+                return json.dumps(
+                    {
+                        "success": True,
+                        "claimed": True,
+                        "reentry": True,
+                        "issue_number": issue_number,
+                        "label": effective_label,
+                        "review_approach_recommended": review_approach_recommended,
+                    }
+                )
+
+            ensure_color, ensure_description, remove_labels = (
+                tool_ctx.config.github.resolve_label_metadata(effective_label)
             )
 
-        effective_label = label or tool_ctx.config.github.in_progress_label
-
-        try:
-            owner, repo, issue_number = _parse_issue_ref(issue_url)
-        except ValueError as exc:
-            return json.dumps({"success": False, "error": str(exc)})
-
-        if err := tool_ctx.config.github.check_label_allowed(effective_label):
-            return json.dumps({"success": False, "error": err})
-
-        result = await tool_ctx.github_client.fetch_issue(issue_url, include_comments=False)
-        if not result.get("success"):
-            return json.dumps({"success": False, "error": result.get("error", "fetch failed")})
-
-        review_approach_recommended = REVIEW_APPROACH_MARKER in (result.get("body") or "")
-        issue_state = result.get("state", "open").lower()
-        if issue_state == "closed":
-            return json.dumps(
-                {
-                    "success": True,
-                    "claimed": False,
-                    "reason": "issue is closed",
-                }
+            await tool_ctx.github_client.ensure_label(
+                owner,
+                repo,
+                effective_label,
+                color=ensure_color,
+                description=ensure_description,
             )
 
-        current_labels = _extract_label_names(result.get("labels", []))
-        decision = await _try_claim_with_liveness(
-            issue_url=issue_url,
-            issue_number=issue_number,
-            effective_label=effective_label,
-            current_labels=current_labels,
-            allow_reentry=allow_reentry,
-            github_client=tool_ctx.github_client,
-            campaign_state_paths=_get_campaign_state_paths(tool_ctx),
-        )
-        if not decision.claimed:
-            return json.dumps(
-                {
-                    "success": True,
-                    "claimed": False,
-                    "reason": decision.reason,
-                }
+            swap_result = await tool_ctx.github_client.swap_labels(
+                owner,
+                repo,
+                issue_number,
+                remove_labels=remove_labels,
+                add_labels=[effective_label],
             )
-        if decision.reentry:
+            if not swap_result.get("success"):
+                return json.dumps(
+                    {"success": False, "error": swap_result.get("error", "swap_labels failed")}
+                )
+
             return json.dumps(
                 {
                     "success": True,
                     "claimed": True,
-                    "reentry": True,
                     "issue_number": issue_number,
                     "label": effective_label,
                     "review_approach_recommended": review_approach_recommended,
                 }
             )
-
-        ensure_color, ensure_description, remove_labels = (
-            tool_ctx.config.github.resolve_label_metadata(effective_label)
-        )
-
-        await tool_ctx.github_client.ensure_label(
-            owner,
-            repo,
-            effective_label,
-            color=ensure_color,
-            description=ensure_description,
-        )
-
-        swap_result = await tool_ctx.github_client.swap_labels(
-            owner,
-            repo,
-            issue_number,
-            remove_labels=remove_labels,
-            add_labels=[effective_label],
-        )
-        if not swap_result.get("success"):
-            return json.dumps(
-                {"success": False, "error": swap_result.get("error", "swap_labels failed")}
-            )
-
-        return json.dumps(
-            {
-                "success": True,
-                "claimed": True,
-                "issue_number": issue_number,
-                "label": effective_label,
-                "review_approach_recommended": review_approach_recommended,
-            }
-        )
     except Exception as exc:
         logger.error("claim_issue unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -195,19 +194,18 @@ async def release_issue(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="release_issue", issue_url=issue_url)
-        logger.info("release_issue", issue_url=issue_url)
+        with structlog.contextvars.bound_contextvars(tool="release_issue", issue_url=issue_url):
+            logger.info("release_issue", issue_url=issue_url)
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
-        if tool_ctx.github_client is None:
-            return json.dumps(
-                {"success": False, "error": "GitHub token required for label management"}
-            )
+            tool_ctx = _get_ctx()
+            if tool_ctx.github_client is None:
+                return json.dumps(
+                    {"success": False, "error": "GitHub token required for label management"}
+                )
 
-        effective_label = label or tool_ctx.config.github.in_progress_label
+            effective_label = label or tool_ctx.config.github.in_progress_label
 
         try:
             owner, repo, issue_number = _parse_issue_ref(issue_url)

--- a/src/autoskillit/server/tools/tools_issue_labels.py
+++ b/src/autoskillit/server/tools/tools_issue_labels.py
@@ -207,179 +207,183 @@ async def release_issue(
 
             effective_label = label or tool_ctx.config.github.in_progress_label
 
-        try:
-            owner, repo, issue_number = _parse_issue_ref(issue_url)
-        except ValueError as exc:
-            return json.dumps({"success": False, "error": str(exc)})
+            try:
+                owner, repo, issue_number = _parse_issue_ref(issue_url)
+            except ValueError as exc:
+                return json.dumps({"success": False, "error": str(exc)})
 
-        # Determine if staging is needed
-        promotion_target = tool_ctx.config.branching.promotion_target
-        should_stage = target_branch is not None and target_branch != promotion_target
+            # Determine if staging is needed
+            promotion_target = tool_ctx.config.branching.promotion_target
+            should_stage = target_branch is not None and target_branch != promotion_target
 
-        staged = False
-        config_fail_label = tool_ctx.config.github.fail_label
-        effective_staged_label = staged_label or tool_ctx.config.github.staged_label
+            staged = False
+            config_fail_label = tool_ctx.config.github.fail_label
+            effective_staged_label = staged_label or tool_ctx.config.github.staged_label
 
-        if should_stage:
-            if err := tool_ctx.config.github.check_label_allowed(effective_staged_label):
+            if should_stage:
+                if err := tool_ctx.config.github.check_label_allowed(effective_staged_label):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "issue_number": issue_number,
+                            "label": effective_staged_label,
+                            "error": err,
+                        }
+                    )
+
+                if tool_ctx.config.github.state_for_label(effective_staged_label) is not None:
+                    staged_color, staged_description, remove_labels = (
+                        tool_ctx.config.github.resolve_label_metadata(effective_staged_label)
+                    )
+                else:
+                    staged_color = "0075ca"
+                    staged_description = (
+                        f"Implementation staged and waiting for promotion to {promotion_target}"
+                    )
+                    remove_labels = [
+                        effective_label,
+                        config_fail_label,
+                        tool_ctx.config.github.queued_label,
+                    ]
+
+                ensure_result = await tool_ctx.github_client.ensure_label(
+                    owner,
+                    repo,
+                    effective_staged_label,
+                    color=staged_color,
+                    description=staged_description,
+                )
+                if not ensure_result.get("success"):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "issue_number": issue_number,
+                            "label": effective_label,
+                            "error": (
+                                f"Failed to ensure staged label: {ensure_result.get('error', '?')}"
+                            ),
+                        }
+                    )
+
+                swap_result = await tool_ctx.github_client.swap_labels(
+                    owner,
+                    repo,
+                    issue_number,
+                    remove_labels=remove_labels,
+                    add_labels=[effective_staged_label],
+                )
+                if not swap_result.get("success"):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "issue_number": issue_number,
+                            "label": effective_label,
+                            "error": (
+                                f"Failed to apply staged label: {swap_result.get('error', '?')}"
+                            ),
+                        }
+                    )
+                staged = True
+            elif fail_label is not None:
+                if err := tool_ctx.config.github.check_label_allowed(fail_label):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "issue_number": issue_number,
+                            "label": fail_label,
+                            "error": err,
+                        }
+                    )
+
+                if tool_ctx.config.github.state_for_label(fail_label) is not None:
+                    fail_color, fail_description, remove_labels = (
+                        tool_ctx.config.github.resolve_label_metadata(fail_label)
+                    )
+                else:
+                    fail_color = "d73a4a"
+                    fail_description = "Recipe execution failed"
+                    remove_labels = [effective_label, tool_ctx.config.github.queued_label]
+
+                ensure_result = await tool_ctx.github_client.ensure_label(
+                    owner,
+                    repo,
+                    fail_label,
+                    color=fail_color,
+                    description=fail_description,
+                )
+                if not ensure_result.get("success"):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "issue_number": issue_number,
+                            "label": effective_label,
+                            "error": (
+                                f"Failed to ensure fail label: {ensure_result.get('error', '?')}"
+                            ),
+                        }
+                    )
+
+                swap_result = await tool_ctx.github_client.swap_labels(
+                    owner,
+                    repo,
+                    issue_number,
+                    remove_labels=remove_labels,
+                    add_labels=[fail_label],
+                )
+                if not swap_result.get("success"):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "issue_number": issue_number,
+                            "label": effective_label,
+                            "error": (
+                                f"Failed to apply fail label: {swap_result.get('error', '?')}"
+                            ),
+                        }
+                    )
+
                 return json.dumps(
                     {
-                        "success": False,
+                        "success": True,
                         "issue_number": issue_number,
-                        "label": effective_staged_label,
-                        "error": err,
+                        "label": effective_label,
+                        "failed": True,
+                        "fail_label": fail_label,
                     }
-                )
-
-            if tool_ctx.config.github.state_for_label(effective_staged_label) is not None:
-                staged_color, staged_description, remove_labels = (
-                    tool_ctx.config.github.resolve_label_metadata(effective_staged_label)
                 )
             else:
-                staged_color = "0075ca"
-                staged_description = (
-                    f"Implementation staged and waiting for promotion to {promotion_target}"
+                logger.warning(
+                    "release_issue bare removal (no fail_label or target_branch) for %s",
+                    issue_url,
                 )
-                remove_labels = [
-                    effective_label,
-                    config_fail_label,
-                    tool_ctx.config.github.queued_label,
-                ]
-
-            ensure_result = await tool_ctx.github_client.ensure_label(
-                owner,
-                repo,
-                effective_staged_label,
-                color=staged_color,
-                description=staged_description,
-            )
-            if not ensure_result.get("success"):
-                return json.dumps(
-                    {
-                        "success": False,
-                        "issue_number": issue_number,
-                        "label": effective_label,
-                        "error": (
-                            f"Failed to ensure staged label: {ensure_result.get('error', '?')}"
-                        ),
-                    }
+                swap_result = await tool_ctx.github_client.swap_labels(
+                    owner,
+                    repo,
+                    issue_number,
+                    remove_labels=tool_ctx.config.github.all_lifecycle_labels(),
+                    add_labels=[],
                 )
-
-            swap_result = await tool_ctx.github_client.swap_labels(
-                owner,
-                repo,
-                issue_number,
-                remove_labels=remove_labels,
-                add_labels=[effective_staged_label],
-            )
-            if not swap_result.get("success"):
-                return json.dumps(
-                    {
-                        "success": False,
-                        "issue_number": issue_number,
-                        "label": effective_label,
-                        "error": f"Failed to apply staged label: {swap_result.get('error', '?')}",
-                    }
-                )
-            staged = True
-        elif fail_label is not None:
-            if err := tool_ctx.config.github.check_label_allowed(fail_label):
-                return json.dumps(
-                    {
-                        "success": False,
-                        "issue_number": issue_number,
-                        "label": fail_label,
-                        "error": err,
-                    }
-                )
-
-            if tool_ctx.config.github.state_for_label(fail_label) is not None:
-                fail_color, fail_description, remove_labels = (
-                    tool_ctx.config.github.resolve_label_metadata(fail_label)
-                )
-            else:
-                fail_color = "d73a4a"
-                fail_description = "Recipe execution failed"
-                remove_labels = [effective_label, tool_ctx.config.github.queued_label]
-
-            ensure_result = await tool_ctx.github_client.ensure_label(
-                owner,
-                repo,
-                fail_label,
-                color=fail_color,
-                description=fail_description,
-            )
-            if not ensure_result.get("success"):
-                return json.dumps(
-                    {
-                        "success": False,
-                        "issue_number": issue_number,
-                        "label": effective_label,
-                        "error": (
-                            f"Failed to ensure fail label: {ensure_result.get('error', '?')}"
-                        ),
-                    }
-                )
-
-            swap_result = await tool_ctx.github_client.swap_labels(
-                owner,
-                repo,
-                issue_number,
-                remove_labels=remove_labels,
-                add_labels=[fail_label],
-            )
-            if not swap_result.get("success"):
-                return json.dumps(
-                    {
-                        "success": False,
-                        "issue_number": issue_number,
-                        "label": effective_label,
-                        "error": f"Failed to apply fail label: {swap_result.get('error', '?')}",
-                    }
-                )
+                if not swap_result.get("success"):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "issue_number": issue_number,
+                            "label": effective_label,
+                            "error": f"Failed to remove label: {swap_result.get('error', '?')}",
+                        }
+                    )
+                if close_issue == "true":
+                    await tool_ctx.github_client.close_issue(owner, repo, issue_number)
 
             return json.dumps(
                 {
                     "success": True,
                     "issue_number": issue_number,
                     "label": effective_label,
-                    "failed": True,
-                    "fail_label": fail_label,
+                    "staged": staged,
+                    "staged_label": effective_staged_label if staged else None,
                 }
             )
-        else:
-            logger.warning(
-                "release_issue bare removal (no fail_label or target_branch) for %s",
-                issue_url,
-            )
-            swap_result = await tool_ctx.github_client.swap_labels(
-                owner,
-                repo,
-                issue_number,
-                remove_labels=tool_ctx.config.github.all_lifecycle_labels(),
-                add_labels=[],
-            )
-            if not swap_result.get("success"):
-                return json.dumps(
-                    {
-                        "success": False,
-                        "issue_number": issue_number,
-                        "label": effective_label,
-                        "error": f"Failed to remove label: {swap_result.get('error', '?')}",
-                    }
-                )
-            if close_issue == "true":
-                await tool_ctx.github_client.close_issue(owner, repo, issue_number)
-
-        return json.dumps(
-            {
-                "success": True,
-                "issue_number": issue_number,
-                "label": effective_label,
-                "staged": staged,
-                "staged_label": effective_staged_label if staged else None,
-            }
-        )
     except Exception as exc:
         logger.error("release_issue unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -49,10 +49,12 @@ async def list_recipes() -> str:
     try:
         with structlog.contextvars.bound_contextvars(tool="list_recipes"):
             tool_ctx = _get_ctx_or_none()
-        if tool_ctx is None or tool_ctx.recipes is None:
-            return json.dumps({"error": "kitchen not open — call open_kitchen first"})
-        result = tool_ctx.recipes.list_all(tool_ctx.project_dir, features=tool_ctx.config.features)
-        return json.dumps(result)
+            if tool_ctx is None or tool_ctx.recipes is None:
+                return json.dumps({"error": "kitchen not open — call open_kitchen first"})
+            result = tool_ctx.recipes.list_all(
+                tool_ctx.project_dir, features=tool_ctx.config.features
+            )
+            return json.dumps(result)
     except Exception:
         logger.error("list_recipes unhandled exception", exc_info=True)
         return json.dumps({"error": "internal error listing recipes — see server logs"})
@@ -192,34 +194,34 @@ async def load_recipe(
     try:
         with structlog.contextvars.bound_contextvars(tool="load_recipe"):
             tool_ctx = _get_ctx_or_none()
-        if tool_ctx is None or tool_ctx.recipes is None:
-            return json.dumps({"error": "Server not initialized"})
-        suppressed = tool_ctx.config.migration.suppressed
-        _defaults = resolve_ingredient_defaults(tool_ctx.project_dir)
-        _auto_overrides: dict[str, str] = {
-            "kitchen_id": tool_ctx.kitchen_id,
-            "post_run_diagnostics": _defaults.get("post_run_diagnostics", "false"),
-            "is_fleet_dispatch": _defaults.get("is_fleet_dispatch", "false"),
-            "dispatch_id": _defaults.get("dispatch_id", ""),
-            "diagnostics_log_dir": str(resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)),
-        }
-        _merged_overrides = {**_auto_overrides, **(overrides or {})}
-        result = tool_ctx.recipes.load_and_validate(
-            name,
-            tool_ctx.project_dir,
-            suppressed=suppressed,
-            resolved_defaults=_defaults,
-            ingredient_overrides=_merged_overrides,
-            temp_dir=tool_ctx.temp_dir,
-            temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
-        )
-        recipe_info = tool_ctx.recipes.find(name, tool_ctx.project_dir)
-        result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
-        if ingredients_only:
-            result.pop("content", None)
-            result.pop("orchestration_rules", None)
-            result.pop("stop_step_semantics", None)
-        return json.dumps(result)
+            if tool_ctx is None or tool_ctx.recipes is None:
+                return json.dumps({"error": "Server not initialized"})
+            suppressed = tool_ctx.config.migration.suppressed
+            _defaults = resolve_ingredient_defaults(tool_ctx.project_dir)
+            _auto_overrides: dict[str, str] = {
+                "kitchen_id": tool_ctx.kitchen_id,
+                "post_run_diagnostics": _defaults.get("post_run_diagnostics", "false"),
+                "is_fleet_dispatch": _defaults.get("is_fleet_dispatch", "false"),
+                "dispatch_id": _defaults.get("dispatch_id", ""),
+                "diagnostics_log_dir": str(resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)),
+            }
+            _merged_overrides = {**_auto_overrides, **(overrides or {})}
+            result = tool_ctx.recipes.load_and_validate(
+                name,
+                tool_ctx.project_dir,
+                suppressed=suppressed,
+                resolved_defaults=_defaults,
+                ingredient_overrides=_merged_overrides,
+                temp_dir=tool_ctx.temp_dir,
+                temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
+            )
+            recipe_info = tool_ctx.recipes.find(name, tool_ctx.project_dir)
+            result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
+            if ingredients_only:
+                result.pop("content", None)
+                result.pop("orchestration_rules", None)
+                result.pop("stop_step_semantics", None)
+            return json.dumps(result)
     except Exception as exc:
         logger.error("load_recipe unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -256,13 +258,13 @@ async def validate_recipe(script_path: str) -> str:
     try:
         with structlog.contextvars.bound_contextvars(tool="validate_recipe"):
             tool_ctx = _get_ctx_or_none()
-        if tool_ctx is None or tool_ctx.recipes is None:
-            return json.dumps({"valid": False, "errors": ["Server not initialized"]})
-        result = tool_ctx.recipes.validate_from_path(
-            Path(script_path),
-            temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
-        )
-        return json.dumps(result)
+            if tool_ctx is None or tool_ctx.recipes is None:
+                return json.dumps({"valid": False, "errors": ["Server not initialized"]})
+            result = tool_ctx.recipes.validate_from_path(
+                Path(script_path),
+                temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
+            )
+            return json.dumps(result)
     except Exception as exc:
         logger.error("validate_recipe unhandled exception", exc_info=True)
         return json.dumps({"valid": False, "errors": [f"{type(exc).__name__}: {exc}"]})
@@ -299,32 +301,32 @@ async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
     try:
         with structlog.contextvars.bound_contextvars(tool="migrate_recipe", recipe_name=name):
             logger.info("migrate_recipe", recipe_name=name)
-        await _notify(
-            ctx,
-            "info",
-            f"migrate_recipe: {name}",
-            "autoskillit.migrate_recipe",
-            extra={"recipe_name": name},
-        )
+            await _notify(
+                ctx,
+                "info",
+                f"migrate_recipe: {name}",
+                "autoskillit.migrate_recipe",
+                extra={"recipe_name": name},
+            )
 
-        from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import _get_config, _get_ctx
 
-        tool_ctx = _get_ctx()
+            tool_ctx = _get_ctx()
 
-        # Check suppression list before attempting migration
-        if name in _get_config().migration.suppressed:
-            return json.dumps({"status": "up_to_date", "name": name})
+            # Check suppression list before attempting migration
+            if name in _get_config().migration.suppressed:
+                return json.dumps({"status": "up_to_date", "name": name})
 
-        if tool_ctx.recipes is None:
-            return json.dumps({"error": "Recipe repository not configured"})
-        recipe = tool_ctx.recipes.find(name, tool_ctx.project_dir)
-        if recipe is None:
-            return json.dumps({"error": f"No recipe named '{name}' found"})
+            if tool_ctx.recipes is None:
+                return json.dumps({"error": "Recipe repository not configured"})
+            recipe = tool_ctx.recipes.find(name, tool_ctx.project_dir)
+            if recipe is None:
+                return json.dumps({"error": f"No recipe named '{name}' found"})
 
-        if tool_ctx.migrations is None:
-            return json.dumps({"error": "Migration service not configured", "name": name})
-        result = await tool_ctx.migrations.migrate(recipe.path)
-        return json.dumps(result)
+            if tool_ctx.migrations is None:
+                return json.dumps({"error": "Migration service not configured", "name": name})
+            result = await tool_ctx.migrations.migrate(recipe.path)
+            return json.dumps(result)
     except Exception as exc:
         logger.error("migrate_recipe unhandled exception", exc_info=True)
         return json.dumps({"error": f"{type(exc).__name__}: {exc}", "name": name})

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -47,9 +47,8 @@ async def list_recipes() -> str:
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="list_recipes")
-        tool_ctx = _get_ctx_or_none()
+        with structlog.contextvars.bound_contextvars(tool="list_recipes"):
+            tool_ctx = _get_ctx_or_none()
         if tool_ctx is None or tool_ctx.recipes is None:
             return json.dumps({"error": "kitchen not open — call open_kitchen first"})
         result = tool_ctx.recipes.list_all(tool_ctx.project_dir, features=tool_ctx.config.features)
@@ -191,9 +190,8 @@ async def load_recipe(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="load_recipe")
-        tool_ctx = _get_ctx_or_none()
+        with structlog.contextvars.bound_contextvars(tool="load_recipe"):
+            tool_ctx = _get_ctx_or_none()
         if tool_ctx is None or tool_ctx.recipes is None:
             return json.dumps({"error": "Server not initialized"})
         suppressed = tool_ctx.config.migration.suppressed
@@ -256,9 +254,8 @@ async def validate_recipe(script_path: str) -> str:
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="validate_recipe")
-        tool_ctx = _get_ctx_or_none()
+        with structlog.contextvars.bound_contextvars(tool="validate_recipe"):
+            tool_ctx = _get_ctx_or_none()
         if tool_ctx is None or tool_ctx.recipes is None:
             return json.dumps({"valid": False, "errors": ["Server not initialized"]})
         result = tool_ctx.recipes.validate_from_path(
@@ -300,9 +297,8 @@ async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="migrate_recipe", recipe_name=name)
-        logger.info("migrate_recipe", recipe_name=name)
+        with structlog.contextvars.bound_contextvars(tool="migrate_recipe", recipe_name=name):
+            logger.info("migrate_recipe", recipe_name=name)
         await _notify(
             ctx,
             "info",

--- a/src/autoskillit/server/tools/tools_status.py
+++ b/src/autoskillit/server/tools/tools_status.py
@@ -44,7 +44,6 @@ async def kitchen_status() -> str:
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="kitchen_status"):
             from autoskillit.server import _get_config, _get_ctx, version_info
 
@@ -99,7 +98,6 @@ async def get_pipeline_report(clear: bool = False) -> str:
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="get_pipeline_report"):
             from autoskillit.server._state import _startup_ready
 
@@ -176,7 +174,6 @@ async def get_token_summary(clear: bool = False, format: str = "json", order_id:
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="get_token_summary"):
             from autoskillit.server import _get_ctx
 
@@ -238,7 +235,6 @@ async def get_timing_summary(clear: bool = False, format: str = "json", order_id
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="get_timing_summary"):
             from autoskillit.server import _get_ctx
 
@@ -284,7 +280,6 @@ async def analyze_tool_sequences(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="analyze_tool_sequences"):
             _valid_formats = {"table", "mermaid", "dot"}
             if format not in _valid_formats:
@@ -397,7 +392,6 @@ async def get_quota_events(n: int = 50) -> str:
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="get_quota_events"):
             from autoskillit.server import _get_ctx
 
@@ -439,7 +433,6 @@ async def write_telemetry_files(
         return gate
 
     try:
-        structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(
             tool="write_telemetry_files", output_dir=output_dir
         ):
@@ -523,7 +516,6 @@ async def read_db(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="read_db"):
             logger.info("read_db", db_path=db_path, query=query[:80])
             await _notify(

--- a/src/autoskillit/server/tools/tools_workspace.py
+++ b/src/autoskillit/server/tools/tools_workspace.py
@@ -51,9 +51,8 @@ async def test_check(
     Never raises.
     """
     try:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="test_check", cwd=worktree_path)
-        logger.info("test_check", worktree=worktree_path)
+        with structlog.contextvars.bound_contextvars(tool="test_check", cwd=worktree_path):
+            logger.info("test_check", worktree=worktree_path)
         await _notify(
             ctx,
             "info",
@@ -152,9 +151,8 @@ async def reset_test_dir(
         return gate
     try:
         resolved = os.path.realpath(test_dir)
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="reset_test_dir", cwd=resolved)
-        logger.info("reset_test_dir", resolved=str(resolved), force=force)
+        with structlog.contextvars.bound_contextvars(tool="reset_test_dir", cwd=resolved):
+            logger.info("reset_test_dir", resolved=str(resolved), force=force)
         await _notify(
             ctx,
             "info",
@@ -224,9 +222,8 @@ async def reset_workspace(test_dir: str, ctx: Context = CurrentContext()) -> str
         return gate
     try:
         resolved = os.path.realpath(test_dir)
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(tool="reset_workspace", cwd=resolved)
-        logger.info("reset_workspace", resolved=str(resolved))
+        with structlog.contextvars.bound_contextvars(tool="reset_workspace", cwd=resolved):
+            logger.info("reset_workspace", resolved=str(resolved))
         await _notify(
             ctx,
             "info",

--- a/src/autoskillit/server/tools/tools_workspace.py
+++ b/src/autoskillit/server/tools/tools_workspace.py
@@ -53,74 +53,74 @@ async def test_check(
     try:
         with structlog.contextvars.bound_contextvars(tool="test_check", cwd=worktree_path):
             logger.info("test_check", worktree=worktree_path)
-        await _notify(
-            ctx,
-            "info",
-            f"test_check: {worktree_path}",
-            "autoskillit.test_check",
-            extra={"worktree": worktree_path},
-        )
-
-        from autoskillit.server import _get_ctx
-
-        tool_ctx = _get_ctx()
-        if tool_ctx.tester is None:
-            return json.dumps({"passed": False, "error": "Test runner not configured"})
-
-        resolved = os.path.realpath(worktree_path)
-        if not os.path.isdir(resolved):
-            logger.warning("test_check path does not exist", path=resolved)
-            return json.dumps(
-                {
-                    "passed": False,
-                    "error": f"Worktree path does not exist: {resolved}",
-                    "infrastructure_missing": True,
-                }
-            )
-        infra_issue = tool_ctx.tester.check_infrastructure(Path(resolved))
-        if infra_issue is not None:
-            logger.warning("test_check infrastructure missing", detail=infra_issue)
-            return json.dumps(
-                {
-                    "passed": False,
-                    "error": f"Test infrastructure not found: {infra_issue}",
-                    "infrastructure_missing": True,
-                }
+            await _notify(
+                ctx,
+                "info",
+                f"test_check: {worktree_path}",
+                "autoskillit.test_check",
+                extra={"worktree": worktree_path},
             )
 
-        _start = time.monotonic()
-        try:
-            test_result = await tool_ctx.tester.run(Path(resolved))
+            from autoskillit.server import _get_ctx
 
-            if not test_result.passed:
-                await _notify(
-                    ctx,
-                    "error",
-                    "test_check: tests failed",
-                    "autoskillit.test_check",
-                    extra={"worktree": worktree_path},
+            tool_ctx = _get_ctx()
+            if tool_ctx.tester is None:
+                return json.dumps({"passed": False, "error": "Test runner not configured"})
+
+            resolved = os.path.realpath(worktree_path)
+            if not os.path.isdir(resolved):
+                logger.warning("test_check path does not exist", path=resolved)
+                return json.dumps(
+                    {
+                        "passed": False,
+                        "error": f"Worktree path does not exist: {resolved}",
+                        "infrastructure_missing": True,
+                    }
+                )
+            infra_issue = tool_ctx.tester.check_infrastructure(Path(resolved))
+            if infra_issue is not None:
+                logger.warning("test_check infrastructure missing", detail=infra_issue)
+                return json.dumps(
+                    {
+                        "passed": False,
+                        "error": f"Test infrastructure not found: {infra_issue}",
+                        "infrastructure_missing": True,
+                    }
                 )
 
-            condensed_stdout, condensed_stderr = condense_test_output(test_result)
-            response = {
-                "passed": test_result.passed,
-                "stdout": truncate_text(condensed_stdout),
-                "stderr": truncate_text(condensed_stderr),
-            }
-            if test_result.duration_seconds is not None:
-                response["duration_seconds"] = round(test_result.duration_seconds, 2)
-            if test_result.filter_mode is not None:
-                response["filter_mode"] = test_result.filter_mode
-            if test_result.tests_selected is not None:
-                response["tests_selected"] = test_result.tests_selected
-            if test_result.tests_deselected is not None:
-                response["tests_deselected"] = test_result.tests_deselected
-            if test_result.full_run_reason is not None:
-                response["full_run_reason"] = test_result.full_run_reason
-            return json.dumps(response)
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            _start = time.monotonic()
+            try:
+                test_result = await tool_ctx.tester.run(Path(resolved))
+
+                if not test_result.passed:
+                    await _notify(
+                        ctx,
+                        "error",
+                        "test_check: tests failed",
+                        "autoskillit.test_check",
+                        extra={"worktree": worktree_path},
+                    )
+
+                condensed_stdout, condensed_stderr = condense_test_output(test_result)
+                response = {
+                    "passed": test_result.passed,
+                    "stdout": truncate_text(condensed_stdout),
+                    "stderr": truncate_text(condensed_stderr),
+                }
+                if test_result.duration_seconds is not None:
+                    response["duration_seconds"] = round(test_result.duration_seconds, 2)
+                if test_result.filter_mode is not None:
+                    response["filter_mode"] = test_result.filter_mode
+                if test_result.tests_selected is not None:
+                    response["tests_selected"] = test_result.tests_selected
+                if test_result.tests_deselected is not None:
+                    response["tests_deselected"] = test_result.tests_deselected
+                if test_result.full_run_reason is not None:
+                    response["full_run_reason"] = test_result.full_run_reason
+                return json.dumps(response)
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("test_check unhandled exception", exc_info=True)
         return json.dumps({"passed": False, "error": f"{type(exc).__name__}: {exc}"})
@@ -153,55 +153,59 @@ async def reset_test_dir(
         resolved = os.path.realpath(test_dir)
         with structlog.contextvars.bound_contextvars(tool="reset_test_dir", cwd=resolved):
             logger.info("reset_test_dir", resolved=str(resolved), force=force)
-        await _notify(
-            ctx,
-            "info",
-            f"reset_test_dir: {resolved}",
-            "autoskillit.reset_test_dir",
-            extra={"resolved": resolved, "force": force},
-        )
+            await _notify(
+                ctx,
+                "info",
+                f"reset_test_dir: {resolved}",
+                "autoskillit.reset_test_dir",
+                extra={"resolved": resolved, "force": force},
+            )
 
-        from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import _get_config, _get_ctx
 
-        tool_ctx = _get_ctx()
-        _start = time.monotonic()
-        try:
-            if not os.path.isdir(resolved):
-                await _notify(
-                    ctx,
-                    "error",
-                    "reset_test_dir failed",
-                    "autoskillit.reset_test_dir",
-                    extra={"reason": "directory does not exist"},
-                )
-                return json.dumps({"error": f"Directory does not exist: {resolved}"})
+            tool_ctx = _get_ctx()
+            _start = time.monotonic()
+            try:
+                if not os.path.isdir(resolved):
+                    await _notify(
+                        ctx,
+                        "error",
+                        "reset_test_dir failed",
+                        "autoskillit.reset_test_dir",
+                        extra={"reason": "directory does not exist"},
+                    )
+                    return json.dumps({"error": f"Directory does not exist: {resolved}"})
 
-            marker_name = _get_config().safety.reset_guard_marker
-            marker_path = Path(resolved) / marker_name
-            if not force and not marker_path.is_file():
-                await _notify(
-                    ctx,
-                    "error",
-                    "reset_test_dir failed",
-                    "autoskillit.reset_test_dir",
-                    extra={"reason": "marker missing"},
-                )
-                return json.dumps(
-                    {
-                        "error": f"Safety: directory missing reset guard marker ({marker_name})",
-                        "hint": f"Create the marker with: autoskillit workspace init {resolved}",
-                    }
-                )
+                marker_name = _get_config().safety.reset_guard_marker
+                marker_path = Path(resolved) / marker_name
+                if not force and not marker_path.is_file():
+                    await _notify(
+                        ctx,
+                        "error",
+                        "reset_test_dir failed",
+                        "autoskillit.reset_test_dir",
+                        extra={"reason": "marker missing"},
+                    )
+                    return json.dumps(
+                        {
+                            "error": (
+                                f"Safety: directory missing reset guard marker ({marker_name})"
+                            ),
+                            "hint": (
+                                f"Create the marker with: autoskillit workspace init {resolved}"
+                            ),
+                        }
+                    )
 
-            if tool_ctx.workspace_mgr is None:
-                return json.dumps({"error": "Workspace manager not configured"})
+                if tool_ctx.workspace_mgr is None:
+                    return json.dumps({"error": "Workspace manager not configured"})
 
-            preserve = None if force else {marker_name}
-            cleanup = tool_ctx.workspace_mgr.delete_contents(Path(resolved), preserve=preserve)
-            return json.dumps({**cleanup.to_dict(), "forced": force})
-        finally:
-            if step_name:
-                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+                preserve = None if force else {marker_name}
+                cleanup = tool_ctx.workspace_mgr.delete_contents(Path(resolved), preserve=preserve)
+                return json.dumps({**cleanup.to_dict(), "forced": force})
+            finally:
+                if step_name:
+                    tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("reset_test_dir unhandled exception", exc_info=True)
         return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
@@ -224,85 +228,85 @@ async def reset_workspace(test_dir: str, ctx: Context = CurrentContext()) -> str
         resolved = os.path.realpath(test_dir)
         with structlog.contextvars.bound_contextvars(tool="reset_workspace", cwd=resolved):
             logger.info("reset_workspace", resolved=str(resolved))
-        await _notify(
-            ctx,
-            "info",
-            f"reset_workspace: {resolved}",
-            "autoskillit.reset_workspace",
-            extra={"resolved": resolved},
-        )
-
-        if not os.path.isdir(resolved):
             await _notify(
                 ctx,
-                "error",
-                "reset_workspace failed",
+                "info",
+                f"reset_workspace: {resolved}",
                 "autoskillit.reset_workspace",
-                extra={"reason": "directory does not exist"},
-            )
-            return json.dumps({"error": f"Directory does not exist: {resolved}"})
-
-        from autoskillit.server import _get_config
-
-        marker_name = _get_config().safety.reset_guard_marker
-        marker_path = Path(resolved) / marker_name
-        if not marker_path.is_file():
-            await _notify(
-                ctx,
-                "error",
-                "reset_workspace failed",
-                "autoskillit.reset_workspace",
-                extra={"reason": "marker missing"},
-            )
-            return json.dumps(
-                {
-                    "error": f"Safety: directory missing reset guard marker ({marker_name})",
-                    "hint": f"Create the marker with: autoskillit workspace init {resolved}",
-                }
+                extra={"resolved": resolved},
             )
 
-        reset_cmd = _get_config().reset_workspace.command
-        if reset_cmd is None:
-            await _notify(
-                ctx,
-                "error",
-                "reset_workspace failed",
-                "autoskillit.reset_workspace",
-                extra={"reason": "not configured"},
+            if not os.path.isdir(resolved):
+                await _notify(
+                    ctx,
+                    "error",
+                    "reset_workspace failed",
+                    "autoskillit.reset_workspace",
+                    extra={"reason": "directory does not exist"},
+                )
+                return json.dumps({"error": f"Directory does not exist: {resolved}"})
+
+            from autoskillit.server import _get_config
+
+            marker_name = _get_config().safety.reset_guard_marker
+            marker_path = Path(resolved) / marker_name
+            if not marker_path.is_file():
+                await _notify(
+                    ctx,
+                    "error",
+                    "reset_workspace failed",
+                    "autoskillit.reset_workspace",
+                    extra={"reason": "marker missing"},
+                )
+                return json.dumps(
+                    {
+                        "error": f"Safety: directory missing reset guard marker ({marker_name})",
+                        "hint": f"Create the marker with: autoskillit workspace init {resolved}",
+                    }
+                )
+
+            reset_cmd = _get_config().reset_workspace.command
+            if reset_cmd is None:
+                await _notify(
+                    ctx,
+                    "error",
+                    "reset_workspace failed",
+                    "autoskillit.reset_workspace",
+                    extra={"reason": "not configured"},
+                )
+                return json.dumps({"error": "reset_workspace not configured for this project"})
+
+            returncode, stdout, stderr = await _run_subprocess(
+                reset_cmd,
+                cwd=resolved,
+                timeout=60,
             )
-            return json.dumps({"error": "reset_workspace not configured for this project"})
 
-        returncode, stdout, stderr = await _run_subprocess(
-            reset_cmd,
-            cwd=resolved,
-            timeout=60,
-        )
+            if returncode != 0:
+                await _notify(
+                    ctx,
+                    "error",
+                    "reset_workspace failed",
+                    "autoskillit.reset_workspace",
+                    extra={"reason": "reset command failed", "exit_code": returncode},
+                )
+                return json.dumps(
+                    {
+                        "error": "reset command failed",
+                        "exit_code": returncode,
+                        "stderr": truncate_text(stderr),
+                    }
+                )
 
-        if returncode != 0:
-            await _notify(
-                ctx,
-                "error",
-                "reset_workspace failed",
-                "autoskillit.reset_workspace",
-                extra={"reason": "reset command failed", "exit_code": returncode},
-            )
-            return json.dumps(
-                {
-                    "error": "reset command failed",
-                    "exit_code": returncode,
-                    "stderr": truncate_text(stderr),
-                }
-            )
+            from autoskillit.server import _get_ctx
 
-        from autoskillit.server import _get_ctx
+            tool_ctx = _get_ctx()
+            if tool_ctx.workspace_mgr is None:
+                return json.dumps({"error": "Workspace manager not configured"})
 
-        tool_ctx = _get_ctx()
-        if tool_ctx.workspace_mgr is None:
-            return json.dumps({"error": "Workspace manager not configured"})
-
-        preserve = set(_get_config().reset_workspace.preserve_dirs) | {marker_name}
-        cleanup = tool_ctx.workspace_mgr.delete_contents(Path(resolved), preserve=preserve)
-        return json.dumps(cleanup.to_dict())
+            preserve = set(_get_config().reset_workspace.preserve_dirs) | {marker_name}
+            cleanup = tool_ctx.workspace_mgr.delete_contents(Path(resolved), preserve=preserve)
+            return json.dumps(cleanup.to_dict())
     except Exception as exc:
         logger.error("reset_workspace unhandled exception", exc_info=True)
         return json.dumps({"error": f"{type(exc).__name__}: {exc}"})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,7 @@ def _structlog_to_null():
 
     structlog.configure(cache_logger_on_first_use=False)
     _flush_structlog_proxy_caches()
+    structlog.contextvars.clear_contextvars()
     with structlog.testing.capture_logs():
         yield
     structlog.reset_defaults()

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -509,8 +509,11 @@ def test_default_executor_satisfies_protocol_with_dispatch(minimal_ctx) -> None:
     assert isinstance(executor, HeadlessExecutor)
 
 
-def test_build_interactive_cmd_no_headless_hardening() -> None:
+def test_build_interactive_cmd_no_headless_hardening(monkeypatch: pytest.MonkeyPatch) -> None:
     from autoskillit.execution.backends.claude import ClaudeCodeBackend
+
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.delenv("NO_COLOR", raising=False)
 
     spec = ClaudeCodeBackend().build_interactive_cmd()
     assert spec.env.get("TERM") != "dumb"

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -121,7 +121,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 139),
     ("src/autoskillit/server/tools/tools_kitchen.py", 617),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools/tools_status.py", 486),
+    ("src/autoskillit/server/tools/tools_status.py", 479),
     # tools_github.py — bug report dict
     ("src/autoskillit/server/tools/tools_github.py", 304),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -79,24 +79,43 @@ class TestClaimIssueTool:
     # P5F4-T1
     @pytest.mark.anyio
     async def test_claim_issue_binds_structlog_context(self, tool_ctx_kitchen_open, monkeypatch):
-        """claim_issue must bind structlog context vars via bind_contextvars."""
+        """claim_issue must scope structlog context vars via bound_contextvars."""
+        from contextlib import contextmanager
+
         import structlog
 
         captured = {}
 
-        def fake_bind_contextvars(**kwargs):
+        @contextmanager
+        def fake_bound_contextvars(**kwargs):
             captured.update(kwargs)
+            yield
 
-        monkeypatch.setattr(structlog.contextvars, "bind_contextvars", fake_bind_contextvars)
-        monkeypatch.setattr(structlog.contextvars, "clear_contextvars", lambda: None)
+        monkeypatch.setattr(structlog.contextvars, "bound_contextvars", fake_bound_contextvars)
 
-        tool_ctx_kitchen_open.github_client = None  # triggers early return after bind
+        tool_ctx_kitchen_open.github_client = None  # triggers early return inside with block
 
         await claim_issue(issue_url="https://github.com/owner/repo/issues/1")
         assert captured == {
             "tool": "claim_issue",
             "issue_url": "https://github.com/owner/repo/issues/1",
         }
+
+    @pytest.mark.anyio
+    async def test_contextvars_cleaned_after_tool_return(self, tool_ctx_kitchen_open):
+        """bound_contextvars restores context after tool returns — no leakage."""
+        import structlog
+
+        structlog.contextvars.clear_contextvars()
+        tool_ctx_kitchen_open.github_client = None  # triggers early return
+
+        await claim_issue(issue_url="https://github.com/owner/repo/issues/1")
+
+        with structlog.testing.capture_logs(
+            processors=[structlog.contextvars.merge_contextvars]
+        ) as logs:
+            structlog.get_logger().info("probe")
+        assert "tool" not in logs[0], "tool contextvar leaked past tool function boundary"
 
     @pytest.mark.anyio
     async def test_claim_issue_allow_reentry_true_returns_claimed_true_when_already_labeled(
@@ -245,18 +264,21 @@ class TestReleaseIssueTool:
     # P5F4-T2
     @pytest.mark.anyio
     async def test_release_issue_binds_structlog_context(self, tool_ctx_kitchen_open, monkeypatch):
-        """release_issue must bind structlog context vars via bind_contextvars."""
+        """release_issue must scope structlog context vars via bound_contextvars."""
+        from contextlib import contextmanager
+
         import structlog
 
         captured = {}
 
-        def fake_bind_contextvars(**kwargs):
+        @contextmanager
+        def fake_bound_contextvars(**kwargs):
             captured.update(kwargs)
+            yield
 
-        monkeypatch.setattr(structlog.contextvars, "bind_contextvars", fake_bind_contextvars)
-        monkeypatch.setattr(structlog.contextvars, "clear_contextvars", lambda: None)
+        monkeypatch.setattr(structlog.contextvars, "bound_contextvars", fake_bound_contextvars)
 
-        tool_ctx_kitchen_open.github_client = None  # triggers early return after bind
+        tool_ctx_kitchen_open.github_client = None  # triggers early return inside with block
 
         await release_issue(issue_url="https://github.com/owner/repo/issues/1")
         assert captured == {


### PR DESCRIPTION
## Summary

Convert all 30 bare `clear_contextvars()` + `bind_contextvars()` call sites across 10 tool files to use `with bound_contextvars(...)` context manager form. Remove the redundant standalone `clear_contextvars()` from 8 hybrid call sites in `tools_status.py`. Update 2 integration tests that assert on the bare pattern, add 1 new behavioral test, and add contextvars cleanup to the test fixture. The context manager form automatically restores context on function exit (return or exception), eliminating stale-var leakage between sequential tool calls in the same asyncio task.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

( None )

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-171432-565891/.autoskillit/temp/make-plan/standardize_structlog_contextvars_plan_2026-05-26_171700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| resolve_review | claude-sonnet-4-6 | 2 | 938 | 107.9k | 11.7M | 171.8k | 300 | 306.8k | 35m 47s |
| review_pr | claude-sonnet-4-6 | 2 | 1.7k | 74.2k | 1.8M | 104.0k | 248 | 165.2k | 17m 33s |
| ci_conflict_fix | claude-sonnet-4-6 | 1 | 348 | 52.3k | 3.2M | 111.2k | 102 | 101.2k | 12m 51s |
| **Total** | | | 3.0k | 234.3k | 16.7M | 171.8k | | 573.2k | 1h 6m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| resolve_review | 3353 | 3494.8 | 91.5 | 32.2 |
| review_pr | 0 | — | — | — |
| ci_conflict_fix | 1186 | 2670.0 | 85.3 | 44.1 |
| **Total** | **4539** | 3681.0 | 126.3 | 51.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 3.0k | 234.3k | 16.7M | 573.2k | 1h 6m |