### PR TITLE
[FIX] Fix agent-eval-prep skill: MiniMax provider docs, scorecard warnings, detection canary guidance

### DIFF
--- a/.autoskillit/recipes/eval/agent-eval.yaml
+++ b/.autoskillit/recipes/eval/agent-eval.yaml
@@ -88,6 +88,7 @@ steps:
 
   run_canaries:
     tool: run_skill
+    provider: minimax
     with:
       skill_command: "placeholder — see note for orchestration logic"
     on_success: compile_scorecard
@@ -139,6 +140,7 @@ steps:
 
          b. run_skill: /judge-eval {eval_run_dir}/{canary_id}/eval_context.json
             cwd = inputs.source_dir
+            model = opus[1m]
 
 
       4. After ALL canaries complete, this step is done — proceed to


### PR DESCRIPTION
## Summary

Update the `agent-eval-prep` user-wide skill and the `agent-eval` recipe YAML to correctly document the MiniMax provider model split, add scorecard limitation warnings, distinguish precision vs detection canaries, and fix key-lessons accuracy. Two files changed, no Python source modifications.

## Requirements

### R1: Add MiniMax provider explanation to System Context and fix provider routing

Add a 2-3 line note after "How agent-eval works" — keep it extremely concise, no wasted tokens:

> MiniMax is a third-party AI provider (~$0.30/MTok), not a game theory concept. Requires `providers` feature enabled + `minimax` profile configured.

**Fix the recipe's provider routing** to use step-level `provider:` and `model:` fields (both supported on `RecipeStep` in `schema.py`):
- Agent execution steps: `provider: minimax` — directly selects the MiniMax provider profile
- Judge step: `model: "opus[1m]"` — uses Anthropic Opus 1M context for quality-critical scoring

The skill must document this split so sessions don't override it with wrong config (e.g., `"*": minimax` which would route the judge through MiniMax too).

### R2: Add scorecard limitation warning to Steps 5 and 6

**Step 5 (hand-off):** Add a note after the run instructions:
> **Known limitation:** `compile_eval_scorecard` reads only `verdict.json` files. If the judge writes `judgment.json` for some canaries (a known format inconsistency from skill-eval), those results default to FAIL in the scorecard. Check individual verdict/judgment files in `runs/<timestamp>/<canary_id>/` as the authoritative source.

**Step 6 (process results):** Instruct to read both `verdict.json` and `judgment.json` files per canary directory, not just the scorecard.

### R3: Add detection canary guidance to Step 2

The "Canary sourcing" section and Step 2 currently describe three sourcing channels but don't distinguish precision canaries (must NOT flag) from detection canaries (must flag). Add guidance:

- **Precision canaries** test false-positive suppression — the agent must NOT flag an intentional pattern. Source from `reject_patterns_*.json`.
- **Detection canaries** test recall — the agent MUST catch a real bug. Source from `audit-bugs` output or synthetic bug planting.
- A balanced canary set needs BOTH types. If the first session only produced precision canaries, the skill should prompt the user to also add detection canaries in a follow-up to avoid optimizing precision at the cost of recall.

### R4: Fix "Key lessons" accuracy

- Change "Contrastive prompting is the strongest technique" to "Contrastive prompting is highly effective" — the handoff documents reachability tables and exploit-first as the dominant R15 techniques, not contrastive prompting alone
- The lessons referencing R16/R17 data are from run directories and the tracking issue (#2609), not the handoff document — this is fine but the skill shouldn't cite round numbers that aren't in the handoff if someone tries to verify

## Conflict Resolution Decisions

(none)

Closes #3055

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-181053-129122/.autoskillit/temp/make-plan/fix_agent_eval_prep_skill_plan_2026-05-26_181500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.5k | 12.9k | 984.5k | 104.6k | 124 | 54.9k | 10m 4s |
| verify | claude-opus-4-6 | 1 | 60 | 9.5k | 1.1M | 58.0k | 85 | 58.1k | 4m 57s |
| implement* | MiniMax-M2.7 | 1 | 274.4k | 25.3k | 4.1M | 0 | 148 | 0 | 10m 43s |
| prepare_pr* | MiniMax-M2.7 | 1 | 42.1k | 3.0k | 283.2k | 0 | 20 | 0 | 44s |
| compose_pr* | MiniMax-M2.7 | 1 | 50.8k | 1.8k | 190.0k | 0 | 15 | 0 | 58s |
| review_pr | claude-opus-4-6 | 3 | 152 | 34.3k | 2.2M | 56.1k | 169 | 109.0k | 12m 31s |
| **Total** | | | 369.0k | 86.9k | 8.8M | 104.6k | | 222.1k | 39m 59s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 2 | 2035724.0 | 0.0 | 12638.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **2** | 4388850.0 | 111049.0 | 43434.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 1.5k | 12.9k | 984.5k | 54.9k | 10m 4s |
| claude-opus-4-6 | 2 | 212 | 43.9k | 3.2M | 167.2k | 17m 29s |
| MiniMax-M2.7 | 3 | 367.3k | 30.1k | 4.5M | 0 | 12m 24s |