### PR TITLE
Fix PTY mode and backend resolution in food truck dispatch

### DIFF
--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -436,6 +436,9 @@ async def test_two_dispatch_happy_path(fleet_runtime: FleetRuntime) -> None:
 
     result_a = await rt.dispatch("recipe-a", shim_mode="success")
     assert result_a["success"] is True
+    assert result_a.get("lifespan_started") is not True, (
+        "plain success shim must not set lifespan_started"
+    )
 
     result_b = await rt.dispatch("recipe-b", shim_mode="success")
     assert result_b["success"] is True

--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -48,6 +48,7 @@ import time
 dispatch_id = os.environ.get("AUTOSKILLIT_DISPATCH_ID", "unknown")
 mode = os.environ.get("CLAUDE_SHIM_MODE", "success")
 sleep_sec = float(os.environ.get("CLAUDE_SHIM_SLEEP_SEC", "10"))
+usage_data = {"input_tokens": 0, "output_tokens": 0}
 
 
 def _sentinel(payload: str) -> str:
@@ -78,6 +79,20 @@ elif mode == "tui_output":
     sys.stdout.buffer.flush()
     import signal
     os.kill(os.getpid(), signal.SIGTERM)
+elif mode == "success_with_lifespan":
+    assistant = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "name": "Read", "id": "toolu_test_shim"}
+            ],
+            "model": "test-model",
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+        },
+    }
+    print(json.dumps(assistant), flush=True)
+    text = _sentinel('{"success": true, "reason": ""}')
+    usage_data = {"input_tokens": 100, "output_tokens": 50}
 else:
     text = ""
 
@@ -88,7 +103,7 @@ envelope = {
     "result": text,
     "session_id": "test-session-id",
     "errors": [],
-    "usage": {"input_tokens": 0, "output_tokens": 0},
+    "usage": usage_data,
 }
 print(json.dumps(envelope), flush=True)
 """
@@ -1112,3 +1127,22 @@ async def test_tui_output_shim_classified_as_no_result(
     result = await rt.dispatch("recipe-tui", shim_mode="tui_output")
     assert result["success"] is False
     assert result["reason"] == "fleet_l3_no_result_block"
+
+
+@pytest.mark.anyio
+async def test_success_dispatch_asserts_lifespan_and_token_usage(
+    fleet_runtime: FleetRuntime,
+) -> None:
+    """Happy-path dispatch with tool_use asserts lifespan_started and token_usage."""
+    rt = fleet_runtime
+    rt.add_recipe("recipe-a")
+
+    result = await rt.dispatch("recipe-a", shim_mode="success_with_lifespan")
+    assert result["success"] is True
+    assert result.get("lifespan_started") is True
+
+    token_usage = result.get("token_usage")
+    assert token_usage is not None, (
+        f"token_usage must be present when shim emits usage in NDJSON, got: {result}"
+    )
+    assert token_usage["input"] > 0, f"input must be > 0 from shim usage data, got: {token_usage}"

--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -1146,3 +1146,6 @@ async def test_success_dispatch_asserts_lifespan_and_token_usage(
         f"token_usage must be present when shim emits usage in NDJSON, got: {result}"
     )
     assert token_usage["input"] > 0, f"input must be > 0 from shim usage data, got: {token_usage}"
+    assert token_usage["output"] > 0, (
+        f"output must be > 0 from shim usage data, got: {token_usage}"
+    )


### PR DESCRIPTION
## Summary

Every food truck dispatch fails because `pty_wrap_command` allocates a real PTY, causing Claude Code's React Ink TUI to activate (via `process.stdout.isTTY`), emitting 89 bytes of ANSI escape sequences instead of NDJSON output. The test suite mocks or shims the subprocess boundary at every layer, making this failure class structurally undetectable. The fix (disable PTY for food trucks via a new `food_truck_pty_mode` capability field) is straightforward; the architectural immunity plan ensures: (1) PTY mode for food trucks is capability-driven and structurally correct, (2) the E2E test shim emits realistic NDJSON including `tool_use` records so `lifespan_started` can be validated, (3) a contract test at the `CmdSpec` builder level prevents construction of TUI-activating commands, and (4) env hardening is centralized to prevent `_llm_triage.py`-style inline duplication.

## Requirements

### Tier 1: Immediate Fix (PTY Skip)
- Disable PTY for food truck dispatches via `food_truck_pty_mode=False` capability field
- Zero blast radius on `run_skill` (continues using PTY via `_resolve_pty_mode`)

### Tier 2: E2E Test Hardening
- Modify `test_fleet_e2e.py` shim to emit NDJSON `tool_use` entries in `success` mode
- Assert `lifespan_started=True` on the e2e happy path
- Add `tui_mode_entry` shim mode (89-byte ANSI, exit 143) with classification assertion
- Assert non-zero `token_usage` on happy path

### Tier 3: API Simulator Integration Tests
Build a deterministic replay binary and integration test that exercises the full dispatch pipeline with real implementations at every layer — only the Anthropic API call is replaced.

### Tier 4: Regression Gate
Add a CI-level smoke test that dispatches a food truck with the replay binary and asserts `lifespan_started=True` + non-zero tokens.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.


## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260526-175957-704854/.autoskillit/temp/rectify/rectify_food_truck_dispatch_tui_mode_entry_2026-05-26_180500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 3.8k | 24.3k | 2.9M | 123.8k | 310 | 110.2k | 22m 16s |
| review | claude-sonnet-4-6 | 1 | 44 | 6.4k | 254.8k | 44.7k | 48 | 31.9k | 3m 39s |
| dry_walkthrough | claude-opus-4-6 | 2 | 101 | 17.2k | 2.1M | 73.0k | 176 | 106.6k | 8m 45s |
| implement | claude-sonnet-4-6 | 2 | 154 | 21.9k | 6.3M | 165.2k | 313 | 174.4k | 28m 16s |
| audit_impl | claude-sonnet-4-6 | 2 | 76 | 18.5k | 919.3k | 64.6k | 133 | 69.0k | 12m 49s |
| make_plan | claude-opus-4-6 | 1 | 68 | 18.0k | 1.5M | 83.7k | 85 | 75.8k | 8m 27s |
| prepare_pr* | MiniMax-M2.7 | 1 | 53.5k | 3.2k | 218.1k | 0 | 18 | 0 | 1m 20s |
| compose_pr* | MiniMax-M2.7 | 1 | 42.1k | 1.9k | 361.2k | 0 | 20 | 0 | 1m 21s |
| review_pr | claude-opus-4-6 | 1 | 48 | 13.7k | 896.2k | 61.1k | 41 | 45.1k | 3m 48s |
| resolve_review | claude-opus-4-6 | 1 | 53 | 7.7k | 1.3M | 59.5k | 49 | 43.3k | 3m 38s |
| **Total** | | | 99.9k | 132.6k | 16.8M | 165.2k | | 656.3k | 1h 34m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 511 | 12351.3 | 341.2 | 42.8 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 224542.8 | 7224.3 | 1285.2 |
| **Total** | **517** | 32527.3 | 1269.5 | 256.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 4.1k | 71.0k | 10.4M | 385.5k | 1h 7m |
| claude-opus-4-6 | 4 | 270 | 56.6k | 5.9M | 270.8k | 24m 39s |
| MiniMax-M2.7 | 2 | 95.6k | 5.1k | 579.4k | 0 | 2m 41s |