### PR TITLE
Rectify: Hidden Ingredient `skip_when_false` Evaluation Has No LLM Delivery Channel

### DIFF
--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -55,7 +55,7 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
         "- NEVER skip a step because the PR is small, the diff is trivial, the change\n"
         "  looks simple, or you judge the step unnecessary.\n"
         "- skip_when_false ingredient references are resolved server-side; you may see\n"
-        '  literal "false" (evaluate and skip) or no skip_when_false field (mandatory).\n'
+        '  literal "false" (skip) or no skip_when_false field (mandatory).\n'
         "- Consequence: skipping PR review steps results in unreviewed code, missing diff\n"
         "  annotations, and no architectural lens analysis — code reaches main without\n"
         "  quality gates.\n\n"

--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -47,14 +47,15 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
         "to receive the full recipe content and orchestration rules.\n\n"
         "OPTIONAL STEP SEMANTICS:\n"
         "- optional: true means the step is SKIPPED when its skip_when_false ingredient\n"
-        "  is false. When skip_when_false evaluates to true (or is absent), the step is\n"
-        "  MANDATORY. The ONLY reason to skip an optional step is skip_when_false being false.\n"
+        "  resolves to false. skip_when_false ingredient references are resolved\n"
+        '  server-side; you may see literal "false" (skip) or no field (mandatory).\n'
         "- A running optional step that returns success: false MUST follow on_failure.\n\n"
         "STEP EXECUTION IS NOT DISCRETIONARY:\n"
         "- You MUST execute every step the pipeline routes you to.\n"
         "- NEVER skip a step because the PR is small, the diff is trivial, the change\n"
         "  looks simple, or you judge the step unnecessary.\n"
-        "- The ONLY mechanism for skipping a step is skip_when_false evaluating to false.\n"
+        "- skip_when_false ingredient references are resolved server-side; you may see\n"
+        '  literal "false" (evaluate and skip) or no skip_when_false field (mandatory).\n'
         "- Consequence: skipping PR review steps results in unreviewed code, missing diff\n"
         "  annotations, and no architectural lens analysis — code reaches main without\n"
         "  quality gates.\n\n"

--- a/src/autoskillit/cli/_prompts_orchestrator.py
+++ b/src/autoskillit/cli/_prompts_orchestrator.py
@@ -91,7 +91,6 @@ def _build_orchestrator_prompt(
             f"{ingredients_table}\n\n"
             "The ingredient names above are authoritative. Use them verbatim when:\n"
             "- Collecting values from the user\n"
-            "- Evaluating skip_when_false conditions\n"
             "- Passing ingredients to pipeline steps via `with:` arguments\n\n"
         )
 
@@ -271,10 +270,10 @@ TWO FAILURE TIERS FOR PREDICATE-FORMAT STEPS:
 
 OPTIONAL STEP SEMANTICS:
 - optional: true means the step is SKIPPED (treated as bypassed) when its
-  skip_when_false ingredient is false. It does NOT mean failures are tolerated.
-- When skip_when_false evaluates to true (or is absent), the step is MANDATORY
-  and MUST execute. The ONLY reason to skip an optional step is skip_when_false
-  being false — no other reason is valid.
+  skip_when_false ingredient resolves to false. It does NOT mean failures are tolerated.
+- skip_when_false ingredient references are resolved server-side before the recipe
+  is served. You may see literal "false" values (skip the step) or no skip_when_false
+  field at all (step is mandatory). Never evaluate inputs.* references yourself.
 - A running optional step that returns success: false MUST follow on_failure.
   Never route a running optional step's failure to done.
 
@@ -282,8 +281,9 @@ STEP EXECUTION IS NOT DISCRETIONARY:
 - You MUST execute every step the pipeline routes you to.
 - NEVER skip a step because the PR is small, the diff is trivial, the change
   looks simple, or you judge the step unnecessary.
-- The ONLY mechanism for skipping a step is skip_when_false evaluating to false.
-  When skip_when_false evaluates to true (or is absent), the step is MANDATORY.
+- skip_when_false ingredient references are resolved server-side before the recipe
+  is served. You may see literal "false" values (evaluate and skip) or no
+  skip_when_false field at all (step is mandatory). The LLM never evaluates inputs.*.
 - Consequence: skipping PR review steps results in unreviewed code, missing diff
   annotations, and no architectural lens analysis — code reaches main without
   quality gates.

--- a/src/autoskillit/cli/_prompts_orchestrator.py
+++ b/src/autoskillit/cli/_prompts_orchestrator.py
@@ -282,7 +282,7 @@ STEP EXECUTION IS NOT DISCRETIONARY:
 - NEVER skip a step because the PR is small, the diff is trivial, the change
   looks simple, or you judge the step unnecessary.
 - skip_when_false ingredient references are resolved server-side before the recipe
-  is served. You may see literal "false" values (evaluate and skip) or no
+  is served. You may see literal "false" values (skip the step) or no
   skip_when_false field at all (step is mandatory). The LLM never evaluates inputs.*.
 - Consequence: skipping PR review steps results in unreviewed code, missing diff
   annotations, and no architectural lens analysis — code reaches main without

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -215,7 +215,7 @@ STEP EXECUTION IS NOT DISCRETIONARY:
 - NEVER skip a step because the PR is small, the diff is trivial, the change
   looks simple, or you judge the step unnecessary.
 - skip_when_false ingredient references are resolved server-side before the recipe
-  is served. You may see literal "false" values (evaluate and skip) or no
+  is served. You may see literal "false" values (skip the step) or no
   skip_when_false field at all (step is mandatory). The LLM never evaluates inputs.*.
 
 {ROUTING_AUTHORITY_CLAUSE}

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -203,10 +203,10 @@ TWO FAILURE TIERS FOR PREDICATE-FORMAT STEPS:
 
 OPTIONAL STEP SEMANTICS:
 - optional: true means the step is SKIPPED (treated as bypassed) when its
-  skip_when_false ingredient is false. It does NOT mean failures are tolerated.
-- When skip_when_false evaluates to true (or is absent), the step is MANDATORY
-  and MUST execute. The ONLY reason to skip an optional step is skip_when_false
-  being false — no other reason is valid.
+  skip_when_false ingredient resolves to false. It does NOT mean failures are tolerated.
+- skip_when_false ingredient references are resolved server-side before the recipe
+  is served. You may see literal "false" values (skip the step) or no skip_when_false
+  field at all (step is mandatory). Never evaluate inputs.* references yourself.
 - A running optional step that returns success: false MUST follow on_failure.
   Never route a running optional step's failure to done.
 
@@ -214,8 +214,9 @@ STEP EXECUTION IS NOT DISCRETIONARY:
 - You MUST execute every step the pipeline routes you to.
 - NEVER skip a step because the PR is small, the diff is trivial, the change
   looks simple, or you judge the step unnecessary.
-- The ONLY mechanism for skipping a step is skip_when_false evaluating to false.
-  When skip_when_false evaluates to true (or is absent), the step is MANDATORY.
+- skip_when_false ingredient references are resolved server-side before the recipe
+  is served. You may see literal "false" values (evaluate and skip) or no
+  skip_when_false field at all (step is mandatory). The LLM never evaluates inputs.*.
 
 {ROUTING_AUTHORITY_CLAUSE}
 

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -42,6 +42,8 @@ from autoskillit.recipe._api_listing import (  # noqa: F401
 )
 from autoskillit.recipe._recipe_composition import (
     _build_active_recipe,
+    _prune_skipped_steps,
+    _resolve_skip_guards_in_content,
 )
 from autoskillit.recipe._recipe_ingredients import (
     ListRecipesResult,  # noqa: F401
@@ -147,8 +149,9 @@ def _build_orchestration_rules(
     parts = [
         "STEP EXECUTION IS NOT DISCRETIONARY:\n"
         "You MUST execute every step the pipeline routes you to. "
-        "The ONLY mechanism for skipping a step is skip_when_false evaluating to false. "
-        "When skip_when_false evaluates to true (or is absent), the step is MANDATORY. "
+        "skip_when_false ingredient references are resolved server-side before the recipe "
+        'is served. You may see literal "false" values (evaluate normally and skip) '
+        "or no skip_when_false field at all (step is mandatory). "
         "NEVER skip a step because the PR is small, the diff is trivial, or you judge "
         "the step unnecessary. NEVER replace recipe steps with manual tool calls. "
         "Consequence: skipping PR review steps results in unreviewed code, missing "
@@ -368,6 +371,15 @@ def load_and_validate(
             if name in _suppressed:
                 semantic_suggestions = filter_version_rule(semantic_suggestions)
             suggestions.extend(semantic_suggestions)
+
+            # Stage: skip_when_false pruning (Python-side evaluation)
+            _pre_prune_steps = dict(active_recipe.steps)
+            active_recipe, _skip_resolutions = _prune_skipped_steps(
+                active_recipe, ingredient_overrides
+            )
+            if _skip_resolutions:
+                raw = _resolve_skip_guards_in_content(raw, _skip_resolutions, _pre_prune_steps)
+            t0 = _t("prune_skipped_steps", t0, name)
 
             # Stage: contract card
             contract = load_recipe_card(name, recipes_dir)

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -150,7 +150,7 @@ def _build_orchestration_rules(
         "STEP EXECUTION IS NOT DISCRETIONARY:\n"
         "You MUST execute every step the pipeline routes you to. "
         "skip_when_false ingredient references are resolved server-side before the recipe "
-        'is served. You may see literal "false" values (evaluate normally and skip) '
+        'is served. You may see literal "false" values (skip the step) '
         "or no skip_when_false field at all (step is mandatory). "
         "NEVER skip a step because the PR is small, the diff is trivial, or you judge "
         "the step unnecessary. NEVER replace recipe steps with manual tool calls. "

--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -196,3 +196,108 @@ def _build_active_recipe(
             working = _drop_sub_recipe_step(working, step_name)
 
     return working, combined
+
+
+def _prune_skipped_steps(
+    recipe: Any,
+    ingredient_overrides: dict[str, str] | None = None,
+) -> tuple[Any, dict[str, bool]]:
+    """Evaluate skip_when_false guards and prune steps Python-side.
+
+    Iterates all steps with a skip_when_false field. For each:
+    - Truthy value: clears skip_when_false on the step (step becomes mandatory).
+    - Falsy value: removes the step and repairs upstream routes.
+
+    Returns a tuple of (pruned_recipe, resolutions) where resolutions maps
+    step_name -> bool (True = kept, False = pruned).
+    """
+    overrides = ingredient_overrides or {}
+    resolutions: dict[str, bool] = {}
+    working = recipe
+
+    # Collect guarded steps from the original recipe (stable iteration order)
+    steps_to_check = [
+        name for name, step in recipe.steps.items() if step.skip_when_false is not None
+    ]
+
+    for step_name in steps_to_check:
+        step = working.steps.get(step_name)
+        if step is None or not step.skip_when_false:
+            continue
+        ref = step.skip_when_false
+        if not ref.startswith("inputs."):
+            continue
+        ingredient_name = ref[len("inputs.") :]
+
+        # Resolve value: explicit override > recipe default > absent (falsy)
+        if ingredient_name in overrides:
+            value = overrides[ingredient_name]
+        else:
+            ing = working.ingredients.get(ingredient_name)
+            value = (ing.default or "false") if ing is not None else "false"
+
+        is_truthy = value.lower() in ("true", "1", "yes")
+        resolutions[step_name] = is_truthy
+
+        if is_truthy:
+            new_steps = dict(working.steps)
+            new_steps[step_name] = dataclasses.replace(step, skip_when_false=None)
+            working = dataclasses.replace(working, steps=new_steps)
+        else:
+            # Redirect all routes pointing to the pruned step
+            redirect = step.on_success
+            new_steps = {}
+            for name, s in working.steps.items():
+                if name == step_name:
+                    continue
+                fixes: dict[str, Any] = {}
+                if s.on_success == step_name:
+                    fixes["on_success"] = redirect
+                if s.on_failure == step_name:
+                    fixes["on_failure"] = redirect
+                if s.on_context_limit == step_name:
+                    fixes["on_context_limit"] = redirect
+                if s.on_exhausted == step_name:
+                    fixes["on_exhausted"] = redirect
+                new_steps[name] = dataclasses.replace(s, **fixes) if fixes else s
+            working = dataclasses.replace(working, steps=new_steps)
+
+    return working, resolutions
+
+
+def _resolve_skip_guards_in_content(
+    raw: str,
+    resolutions: dict[str, bool],
+    original_steps: dict[str, Any],
+) -> str:
+    """Apply skip_when_false resolution decisions to the raw YAML content string.
+
+    For each resolved step:
+    - Truthy (step kept): strip the skip_when_false line so the step appears mandatory.
+    - Falsy (step pruned): replace the ingredient reference with literal "false" so
+      the LLM evaluates the literal and skips the step without needing ingredient visibility.
+    """
+    if not resolutions:
+        return raw
+
+    for step_name, is_truthy in resolutions.items():
+        step = original_steps.get(step_name)
+        if step is None or not step.skip_when_false:
+            continue
+        ref = step.skip_when_false
+        if not ref.startswith("inputs."):
+            continue
+        ingredient_name = re.escape(ref[len("inputs.") :])
+        if is_truthy:
+            raw = re.sub(
+                rf"(?m)^([ \t]+)skip_when_false:[ \t]+inputs\.{ingredient_name}[ \t]*\n",
+                "",
+                raw,
+            )
+        else:
+            raw = re.sub(
+                rf"(?m)^([ \t]+skip_when_false:[ \t]+)inputs\.{ingredient_name}[ \t]*$",
+                r'\1"false"',
+                raw,
+            )
+    return raw

--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -225,16 +225,20 @@ def _prune_skipped_steps(
         if step is None or not step.skip_when_false:
             continue
         ref = step.skip_when_false
-        if not ref.startswith("inputs."):
-            continue
-        ingredient_name = ref[len("inputs.") :]
 
-        # Resolve value: explicit override > recipe default > absent (falsy)
-        if ingredient_name in overrides:
-            value = overrides[ingredient_name]
+        if ref.startswith("inputs."):
+            ingredient_name = ref[len("inputs.") :]
+            # Resolve value: explicit override > recipe default > absent (falsy)
+            if ingredient_name in overrides:
+                value = str(overrides[ingredient_name])
+            else:
+                ing = working.ingredients.get(ingredient_name)
+                value = (
+                    str(ing.default) if ing is not None and ing.default is not None else "false"
+                )
         else:
-            ing = working.ingredients.get(ingredient_name)
-            value = (ing.default or "false") if ing is not None else "false"
+            # Literal value already resolved — evaluate directly without ingredient lookup
+            value = ref
 
         is_truthy = value.lower() in ("true", "1", "yes")
         resolutions[step_name] = is_truthy
@@ -244,23 +248,26 @@ def _prune_skipped_steps(
             new_steps[step_name] = dataclasses.replace(step, skip_when_false=None)
             working = dataclasses.replace(working, steps=new_steps)
         else:
-            # Redirect all routes pointing to the pruned step
+            # Redirect all routes pointing to the pruned step; guard against None redirect
             redirect = step.on_success
             new_steps = {}
             for name, s in working.steps.items():
                 if name == step_name:
                     continue
                 fixes: dict[str, Any] = {}
-                if s.on_success == step_name:
+                if s.on_success == step_name and redirect is not None:
                     fixes["on_success"] = redirect
-                if s.on_failure == step_name:
+                if s.on_failure == step_name and redirect is not None:
                     fixes["on_failure"] = redirect
-                if s.on_context_limit == step_name:
+                if s.on_context_limit == step_name and redirect is not None:
                     fixes["on_context_limit"] = redirect
-                if s.on_exhausted == step_name:
+                if s.on_exhausted == step_name and redirect is not None:
                     fixes["on_exhausted"] = redirect
                 new_steps[name] = dataclasses.replace(s, **fixes) if fixes else s
-            working = dataclasses.replace(working, steps=new_steps)
+            recipe_kwargs: dict[str, Any] = {"steps": new_steps}
+            if getattr(working, "entry", None) == step_name:
+                recipe_kwargs["entry"] = redirect
+            working = dataclasses.replace(working, **recipe_kwargs)
 
     return working, resolutions
 

--- a/src/autoskillit/recipe/rules/rules_bypass.py
+++ b/src/autoskillit/recipe/rules/rules_bypass.py
@@ -113,3 +113,41 @@ def _advisory_step_missing_context_limit(ctx: ValidationContext) -> list[RuleFin
             )
         )
     return findings
+
+
+@semantic_rule(
+    name="skip-when-false-on-hidden",
+    description=(
+        "A step uses skip_when_false referencing a hidden ingredient. "
+        "Hidden ingredients are invisible to the LLM. This works because "
+        "skip_when_false is evaluated server-side, but the pattern is fragile — "
+        "prefer gate: on a sub_recipe step for hidden ingredient gating."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_skip_when_false_on_hidden(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if not step.skip_when_false:
+            continue
+        ref = step.skip_when_false
+        if not ref.startswith("inputs."):
+            continue
+        ingredient_name = ref[len("inputs.") :]
+        ing = ctx.recipe.ingredients.get(ingredient_name)
+        if ing is not None and ing.hidden:
+            findings.append(
+                RuleFinding(
+                    rule="skip-when-false-on-hidden",
+                    severity=Severity.WARNING,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}': skip_when_false references hidden ingredient "
+                        f"'{ingredient_name}'. Hidden ingredients are invisible to the LLM. "
+                        "This works because skip_when_false is evaluated server-side, but the "
+                        "pattern is fragile — prefer gate: on a sub_recipe step for hidden "
+                        "ingredient gating."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -166,7 +166,8 @@ async def load_recipe(
 
     OPTIONAL STEP SEMANTICS:
     - optional: true means the step is SKIPPED when its skip_when_false ingredient
-      is false. When the ingredient is true (or absent), the step is MANDATORY.
+      resolves to false. skip_when_false references are resolved server-side before
+      the recipe is served — the LLM sees literal "false" (skip) or no field (mandatory).
     - NEVER skip a step for any other reason (PR size, diff triviality, etc.).
     - A running optional step that returns success: false MUST follow on_failure.
 

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -667,8 +667,9 @@ every step at full fidelity regardless of session length.
 - NEVER skip a step because the PR is small, the diff is trivial, the change looks
   simple, or you judge the step unnecessary.
 - NEVER skip a step because you believe it has already been done or is redundant.
-- The ONLY mechanism for skipping a step is `skip_when_false` evaluating to false.
-  When `skip_when_false` evaluates to true (or is absent), the step MUST execute.
+- `skip_when_false` ingredient references are resolved server-side before the recipe
+  is served. The LLM sees literal `"false"` (evaluate and skip) or no `skip_when_false`
+  field at all (step is mandatory). Never evaluate `inputs.*` references yourself.
 - Consequence: skipping PR review steps results in unreviewed code, missing diff
   annotations, and no architectural lens analysis — code reaches main without
   quality gates. Skipping issue lifecycle steps breaks traceability.
@@ -685,7 +686,9 @@ every step at full fidelity regardless of session length.
 ### 3. The word "optional" in YAML
 
 `optional: true` on a recipe step does NOT mean the step is discretionary. It means:
-- The step is SKIPPED when its `skip_when_false` ingredient evaluates to false.
+- The step is SKIPPED when its `skip_when_false` ingredient resolves to false.
+  `skip_when_false` references are resolved server-side — the LLM sees literal
+  `"false"` or no field at all. Never evaluate `inputs.*` references yourself.
 - When the ingredient evaluates to true, the step is MANDATORY.
 - A running optional step that returns `success: false` MUST follow `on_failure`.
 

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -42,7 +42,8 @@ issues upfront, load recipe, execute session, collect result, report.
 - After loading a recipe via `load_recipe`, execute every step in the recipe's step
   graph in sequence. Never skip, replace, or improvise steps.
 - `optional: true` means the step is skipped ONLY when its `skip_when_false` ingredient
-  evaluates to false. When the ingredient is true, the step is mandatory.
+  resolves to false. `skip_when_false` references are resolved server-side — the LLM
+  sees literal `"false"` (skip) or no field at all (mandatory). Never evaluate `inputs.*`.
 - Follow `on_success`, `on_failure`, `on_result`, and `on_context_limit` routing exactly
   as declared in the recipe YAML.
 - NEVER replace recipe PR steps (`prepare_pr`, `run_arch_lenses`, `compose_pr`,

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -510,13 +510,14 @@ def test_open_kitchen_prompt_contains_anti_skip_rule():
 
 
 def test_orchestrator_prompt_closes_optional_semantics():
-    """OPTIONAL STEP SEMANTICS must state that skip_when_false=false is the ONLY skip reason."""
+    """OPTIONAL STEP SEMANTICS must instruct the LLM to never evaluate inputs.*
+    references itself — skip_when_false is resolved server-side."""
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
     prompt = _build_orchestrator_prompt("test", mcp_prefix=DIRECT_PREFIX)
     idx = prompt.index("OPTIONAL STEP SEMANTICS")
     section = prompt[idx : idx + 500]
-    assert "ONLY" in section
+    assert "Never evaluate" in section
 
 
 # ING-1

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -55,28 +55,27 @@ def test_upfront_claimed_is_hidden_in_recipe(recipe_name: str) -> None:
 
 
 @pytest.mark.parametrize("recipe_name", BUNDLED_RECIPE_NAMES)
-def test_no_bundled_recipe_has_skip_when_false_on_hidden_ingredient(recipe_name: str) -> None:
-    """No bundled recipe step may use skip_when_false referencing a hidden ingredient.
+def test_bundled_recipe_content_has_no_unresolved_hidden_skip_guards(recipe_name: str) -> None:
+    """load_and_validate must not deliver unresolved hidden ingredient refs to the LLM.
 
-    This regression test catches any future recipe that introduces the pattern of
-    skip_when_false pointing at a hidden: true ingredient, which would have been
-    silently broken before server-side evaluation was added.
+    Regression guard: if server-side skip_when_false evaluation is accidentally
+    removed or bypassed, this test will catch it by finding inputs.* references
+    in skip_when_false fields of the served content.
     """
-    recipe_path = pkg_root() / "recipes" / f"{recipe_name}.yaml"
-    recipe = load_recipe(recipe_path)
-    violations = []
-    for step_name, step in recipe.steps.items():
-        if not step.skip_when_false:
-            continue
-        ref = step.skip_when_false
-        if not ref.startswith("inputs."):
-            continue
-        ingredient_name = ref[len("inputs.") :]
-        ing = recipe.ingredients.get(ingredient_name)
-        if ing is not None and ing.hidden:
-            msg = f"Step '{step_name}': skip_when_false refs hidden '{ingredient_name}'"
-            violations.append(msg)
-    assert violations == [], (
-        f"Recipe '{recipe_name}' has skip_when_false on hidden ingredients:\n"
-        + "\n".join(f"  - {v}" for v in violations)
+    from autoskillit.recipe import load_and_validate
+
+    result = load_and_validate(recipe_name)
+    recipe_content = result["content"]
+    # Parse the raw recipe to find hidden ingredients referenced by skip_when_false
+    recipe_obj = load_recipe(pkg_root() / "recipes" / f"{recipe_name}.yaml")
+    hidden_ing_names = {name for name, ing in recipe_obj.ingredients.items() if ing.hidden}
+    unresolved = []
+    for ing_name in hidden_ing_names:
+        ref = f"skip_when_false: inputs.{ing_name}"
+        if ref in recipe_content:
+            unresolved.append(ref)
+    assert unresolved == [], (
+        f"Recipe '{recipe_name}' content still has unresolved hidden ingredient refs "
+        f"in skip_when_false after load_and_validate: {unresolved}. "
+        f"Server-side evaluation may be broken."
     )

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -52,3 +52,31 @@ def test_upfront_claimed_is_hidden_in_recipe(recipe_name: str) -> None:
         f"upfront_claimed.hidden must be True in {recipe_name} "
         f"(it is set by process-issues, not by users)"
     )
+
+
+@pytest.mark.parametrize("recipe_name", BUNDLED_RECIPE_NAMES)
+def test_no_bundled_recipe_has_skip_when_false_on_hidden_ingredient(recipe_name: str) -> None:
+    """No bundled recipe step may use skip_when_false referencing a hidden ingredient.
+
+    This regression test catches any future recipe that introduces the pattern of
+    skip_when_false pointing at a hidden: true ingredient, which would have been
+    silently broken before server-side evaluation was added.
+    """
+    recipe_path = pkg_root() / "recipes" / f"{recipe_name}.yaml"
+    recipe = load_recipe(recipe_path)
+    violations = []
+    for step_name, step in recipe.steps.items():
+        if not step.skip_when_false:
+            continue
+        ref = step.skip_when_false
+        if not ref.startswith("inputs."):
+            continue
+        ingredient_name = ref[len("inputs.") :]
+        ing = recipe.ingredients.get(ingredient_name)
+        if ing is not None and ing.hidden:
+            msg = f"Step '{step_name}': skip_when_false refs hidden '{ingredient_name}'"
+            violations.append(msg)
+    assert violations == [], (
+        f"Recipe '{recipe_name}' has skip_when_false on hidden ingredients:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+    )

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from autoskillit.recipe._api import format_ingredients_table
@@ -116,3 +118,148 @@ def test_all_hidden_ingredients_returns_none() -> None:
     )
     table = format_ingredients_table(recipe)
     assert table is None
+
+
+def test_prune_skipped_steps_truthy_clears_field() -> None:
+    """_prune_skipped_steps keeps step and clears skip_when_false when override is true."""
+    from autoskillit.recipe._recipe_composition import _prune_skipped_steps
+
+    recipe = Recipe(
+        name="test",
+        description="test",
+        ingredients={
+            "post_run_diagnostics": RecipeIngredient(
+                description="Enable post-run diagnostics",
+                default="false",
+                hidden=True,
+            )
+        },
+        steps={
+            "main_step": RecipeStep(
+                tool="run_cmd", with_args={"cmd": "echo hi"}, on_success="diag"
+            ),
+            "diag": RecipeStep(
+                tool="run_skill",
+                optional=True,
+                skip_when_false="inputs.post_run_diagnostics",
+                on_success="done",
+                on_failure="done",
+                with_args={"skill_command": "/autoskillit:diagnose /tmp/x.md", "cwd": "/tmp"},
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+        kitchen_rules=["test"],
+    )
+
+    pruned, resolutions = _prune_skipped_steps(
+        recipe, ingredient_overrides={"post_run_diagnostics": "true"}
+    )
+    assert "diag" in pruned.steps
+    assert pruned.steps["diag"].skip_when_false is None
+    assert resolutions["diag"] is True
+
+    pruned2, resolutions2 = _prune_skipped_steps(
+        recipe, ingredient_overrides={"post_run_diagnostics": "false"}
+    )
+    assert "diag" not in pruned2.steps
+    assert resolutions2["diag"] is False
+
+
+def test_prune_skipped_steps_removes_step_and_cleans_routes() -> None:
+    """_prune_skipped_steps removes the step and repairs upstream routes when falsy."""
+    from autoskillit.recipe._recipe_composition import _prune_skipped_steps
+
+    recipe = Recipe(
+        name="test",
+        description="test",
+        ingredients={
+            "post_run_diagnostics": RecipeIngredient(
+                description="Enable diagnostics",
+                default="false",
+                hidden=True,
+            )
+        },
+        steps={
+            "upstream": RecipeStep(
+                tool="run_cmd", with_args={"cmd": "echo hi"}, on_success="diag"
+            ),
+            "diag": RecipeStep(
+                tool="run_skill",
+                optional=True,
+                skip_when_false="inputs.post_run_diagnostics",
+                on_success="done",
+                on_failure="done",
+                with_args={"skill_command": "/autoskillit:diagnose /tmp/x.md", "cwd": "/tmp"},
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+        kitchen_rules=["test"],
+    )
+
+    pruned, _ = _prune_skipped_steps(
+        recipe, ingredient_overrides={"post_run_diagnostics": "false"}
+    )
+    assert "diag" not in pruned.steps
+    # Route repaired: upstream.on_success now points to diag's on_success (done)
+    assert pruned.steps["upstream"].on_success == "done"
+    # Pruned step name does not appear as any route target
+    for step in pruned.steps.values():
+        assert step.on_success != "diag"
+        assert step.on_failure != "diag"
+
+
+def test_load_and_validate_resolves_skip_guards_in_content(tmp_path: Path) -> None:
+    """load_and_validate strips/resolves skip_when_false lines in content."""
+    from autoskillit.recipe import load_and_validate
+
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    yaml_text = """
+name: test-skip-guards
+description: Test skip guards
+recipe_version: "0.0.1"
+kitchen_rules:
+  - no native tools
+ingredients:
+  post_run_diagnostics:
+    description: Enable diagnostics
+    default: "false"
+    hidden: true
+steps:
+  main_step:
+    tool: run_cmd
+    with:
+      cmd: echo hi
+    on_success: diag
+  diag:
+    tool: run_skill
+    optional: true
+    skip_when_false: inputs.post_run_diagnostics
+    with:
+      skill_command: /autoskillit:diagnose /tmp/x.md
+      cwd: /tmp
+    on_success: done
+    on_failure: done
+    on_context_limit: done
+  done:
+    action: stop
+    message: done
+"""
+    (recipe_dir / "test-skip-guards.yaml").write_text(yaml_text)
+
+    # When true: skip_when_false line should be stripped from content
+    result = load_and_validate(
+        "test-skip-guards",
+        project_dir=tmp_path,
+        ingredient_overrides={"post_run_diagnostics": "true"},
+    )
+    assert "inputs.post_run_diagnostics" not in result["content"]
+
+    # When false: skip_when_false should be resolved to literal "false"
+    result2 = load_and_validate(
+        "test-skip-guards",
+        project_dir=tmp_path,
+        ingredient_overrides={"post_run_diagnostics": "false"},
+    )
+    assert "inputs.post_run_diagnostics" not in result2["content"]
+    assert 'skip_when_false: "false"' in result2["content"]

--- a/tests/recipe/test_rule_decomposition.py
+++ b/tests/recipe/test_rule_decomposition.py
@@ -28,7 +28,7 @@ def test_no_deferred_validator_imports_in_rule_modules() -> None:
 
 
 def test_all_rules_registered_across_submodules() -> None:
-    """T2: All 28 rules registered, distributed across sub-modules."""
+    """T2: All 29 rules registered, distributed across sub-modules."""
     import autoskillit.recipe  # noqa: F401 -- triggers rule registration
     from autoskillit.recipe.registry import _RULE_REGISTRY
 
@@ -62,6 +62,7 @@ def test_all_rules_registered_across_submodules() -> None:
         "missing-output-patterns",
         "ci-failure-missing-conflict-gate",
         "unknown-required-pack",
+        "skip-when-false-on-hidden",
     }
     assert expected <= rule_names
 

--- a/tests/recipe/test_rules_bypass.py
+++ b/tests/recipe/test_rules_bypass.py
@@ -94,3 +94,60 @@ def test_skip_when_false_referencing_undeclared_ingredient_fires() -> None:
     violations = run_semantic_rules(recipe)
     rule_findings = [v for v in violations if v.rule == "skip-when-false-undeclared"]
     assert len(rule_findings) == 1
+
+
+def test_skip_when_false_on_hidden_ingredient_fires_warning() -> None:
+    """skip-when-false-on-hidden rule fires WARNING when ingredient is hidden: true."""
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={
+            "entry": RecipeStep(tool="run_cmd", on_success="guarded"),
+            "guarded": RecipeStep(
+                tool="run_skill",
+                optional=True,
+                skip_when_false="inputs.bar",
+                on_success="done",
+                on_failure="done",
+                with_args={"skill_command": "/autoskillit:foo /tmp/x.md", "cwd": "/tmp"},
+                on_context_limit="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+        ingredients={
+            "bar": RecipeIngredient(description="Hidden flag", default="false", hidden=True)
+        },
+        kitchen_rules=["test"],
+    )
+    violations = run_semantic_rules(recipe)
+    findings = [v for v in violations if v.rule == "skip-when-false-on-hidden"]
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.WARNING
+
+
+def test_skip_when_false_on_visible_ingredient_no_warning() -> None:
+    """skip-when-false-on-hidden rule does NOT fire when ingredient is visible."""
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={
+            "entry": RecipeStep(tool="run_cmd", on_success="guarded"),
+            "guarded": RecipeStep(
+                tool="run_skill",
+                optional=True,
+                skip_when_false="inputs.bar",
+                on_success="done",
+                on_failure="done",
+                with_args={"skill_command": "/autoskillit:foo /tmp/x.md", "cwd": "/tmp"},
+                on_context_limit="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+        ingredients={
+            "bar": RecipeIngredient(description="Visible flag", default="false", hidden=False)
+        },
+        kitchen_rules=["test"],
+    )
+    violations = run_semantic_rules(recipe)
+    findings = [v for v in violations if v.rule == "skip-when-false-on-hidden"]
+    assert findings == []


### PR DESCRIPTION
## Summary

Recipe steps guarded by `skip_when_false: inputs.<name>` are evaluated entirely by the LLM. When the referenced ingredient is `hidden: true`, both LLM delivery channels (GFM ingredients table and raw YAML content) filter it out. The LLM has zero information about the ingredient's value and treats it as unset, unconditionally skipping the step — even when the config resolves the ingredient to `"true"`.

The architectural fix has two layers: (1) move `skip_when_false` evaluation to Python-side in `load_and_validate()`, eliminating the LLM from boolean guard decisions entirely; (2) add a semantic rule that prevents future `skip_when_false` references to hidden ingredients from passing validation. Seven LLM instruction delivery channels must be updated to reflect the new architecture.

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_hidden_ingredient_skip_when_false_2026-05-26_195700.md`

## Changed Files

- src/autoskillit/cli/_prompts_kitchen.py
- src/autoskillit/cli/_prompts_orchestrator.py
- src/autoskillit/fleet/_prompts.py
- src/autoskillit/recipe/_api.py
- src/autoskillit/recipe/_recipe_composition.py
- src/autoskillit/recipe/rules/rules_bypass.py
- src/autoskillit/server/tools/tools_recipe.py
- src/autoskillit/skills/sous-chef/SKILL.md
- src/autoskillit/skills_extended/process-issues/SKILL.md
- tests/cli/test_cli_prompts.py
- tests/recipe/test_bundled_recipe_hidden_policy.py
- tests/recipe/test_hidden_ingredients.py
- tests/recipe/test_rule_decomposition.py
- tests/recipe/test_rules_bypass.py

Closes #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 6.0k | 27.1k | 2.0M | 141.9k | 303 | 122.3k | 23m 57s |
| review | claude-sonnet-4-6 | 1 | 4.5k | 7.4k | 231.7k | 49.8k | 121 | 38.4k | 7m 55s |
| dry_walkthrough | claude-opus-4-6 | 1 | 1.1k | 48.9k | 3.4M | 119.3k | 160 | 103.1k | 21m 18s |
| implement | claude-sonnet-4-6 | 1 | 3.4k | 66.9k | 13.0M | 176.4k | 245 | 317.5k | 24m 10s |
| audit_impl | claude-sonnet-4-6 | 1 | 110 | 16.7k | 434.9k | 52.3k | 90 | 43.2k | 11m 5s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 92.0k | 3.4k | 185.4k | 30.9k | 18 | 43.7k | 1m 9s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 42.0k | 1.5k | 182.5k | 30.9k | 15 | 15.4k | 36s |
| review_pr | claude-sonnet-4-6 | 1 | 132 | 32.7k | 579.3k | 72.8k | 40 | 69.0k | 7m 55s |
| resolve_review | claude-sonnet-4-6 | 1 | 165 | 24.5k | 1.3M | 92.3k | 85 | 83.0k | 11m 3s |
| **Total** | | | 149.3k | 229.2k | 21.3M | 176.4k | | 835.7k | 1h 49m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 442 | 29445.4 | 718.4 | 151.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 43 | 30076.9 | 1931.2 | 569.7 |
| **Total** | **485** | 43952.4 | 1723.2 | 472.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 6 | 14.2k | 175.3k | 17.5M | 673.6k | 1h 26m |
| claude-opus-4-6 | 1 | 1.1k | 48.9k | 3.4M | 103.1k | 21m 18s |
| MiniMax-M2.7-highspeed | 2 | 134.0k | 4.9k | 367.8k | 59.1k | 1m 44s |