### PR TITLE
[FIX] Fix clone guard false-positive when session writes are under .autoskillit/

### DIFF
--- a/src/autoskillit/cli/_prompts_orchestrator.py
+++ b/src/autoskillit/cli/_prompts_orchestrator.py
@@ -189,6 +189,10 @@ CONTEXT LIMIT ROUTING — run_skill only (check BEFORE on_failure):
   - The session wrote files outside its working directory. This is a CWD boundary violation,
     not a context limit. No partial worktree progress should be resumed.
   - Fall through to on_failure regardless of whether on_context_limit is defined.
+- When run_skill returns "needs_retry: true" AND "retry_reason: clone_contamination":
+  - The clone guard detected modifications to the clone's git state (HEAD advanced or
+    uncommitted tracked files appeared). This is a clone integrity violation.
+  - Fall through to on_failure regardless of whether on_context_limit is defined.
 - When run_skill returns "needs_retry: true" AND "retry_reason: thinking_stall":
   - The model consumed tokens (thinking blocks were present) but produced no text or tool output.
     If lifespan_started is true (model made tool calls before the thinking-only final turn),

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -90,10 +90,14 @@ def build_clone_guard_policy(
     has_write_scope: bool,
     is_clone_commit: bool,
     is_worktree: bool,
+    writes_under_exclude: bool = False,
 ) -> CloneGuardPolicy:
     """Build a CloneGuardPolicy from session properties."""
     fire_on_success = (
-        not is_clone_commit and not is_worktree and (readonly_skill or has_write_scope)
+        not is_clone_commit
+        and not is_worktree
+        and not writes_under_exclude
+        and (readonly_skill or has_write_scope)
     )
     selective_revert = readonly_skill or has_write_scope
     should_snapshot = is_worktree or readonly_skill or has_write_scope
@@ -135,8 +139,20 @@ async def snapshot_clone_state(cwd: str, runner: SubprocessRunner) -> CloneSnaps
     return CloneSnapshot(head_sha=head_sha)
 
 
+def _status_path_under_prefix(status_line: str, prefix: str) -> bool:
+    """Return True if the file path in a git status --porcelain line is under prefix."""
+    path_part = status_line[3:]  # Skip "XY " status chars
+    if " -> " in path_part:
+        path_part = path_part.split(" -> ")[-1]
+    return path_part.startswith(prefix)
+
+
 async def detect_contamination(
-    snapshot: CloneSnapshot, cwd: str, runner: SubprocessRunner
+    snapshot: CloneSnapshot,
+    cwd: str,
+    runner: SubprocessRunner,
+    *,
+    exclude_prefix: str = "",
 ) -> ContaminationReport | None:
     """Check whether the clone directory was contaminated during the session.
 
@@ -161,6 +177,11 @@ async def detect_contamination(
         logger.debug("detect_contamination_status_failed", returncode=status_result.returncode)
         return None
     status_lines = [line for line in status_result.stdout.splitlines() if line.strip()]
+
+    if exclude_prefix:
+        status_lines = [
+            line for line in status_lines if not _status_path_under_prefix(line, exclude_prefix)
+        ]
 
     direct_commits = bool(post_sha and post_sha != snapshot.head_sha)
     uncommitted = len(status_lines) > 0
@@ -286,7 +307,7 @@ async def check_and_revert_clone_contamination(
     if skill_result.worktree_path is not None:
         return skill_result, False
 
-    report = await detect_contamination(snapshot, cwd, runner)
+    report = await detect_contamination(snapshot, cwd, runner, exclude_prefix=exclude_prefix)
     if report is None:
         return skill_result, False
 

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -49,7 +49,19 @@ CLONE_COMMIT_SKILLS: frozenset[str] = frozenset(
     }
 )
 
+GUARD_EXCLUDE_PREFIX = ".autoskillit/"
+
 _GIT_TIMEOUT: float = 10.0
+
+
+def is_path_under_exclude(path: Path, cwd: Path, prefix: str) -> bool:
+    try:
+        rel = path.relative_to(cwd)
+        if not rel.parts:
+            return False
+        return str(rel.parts[0]) + "/" == prefix
+    except ValueError:
+        return False
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -32,9 +32,11 @@ from autoskillit.core import (
 )
 from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
 from autoskillit.execution.clone_guard import (
+    GUARD_EXCLUDE_PREFIX,
     build_clone_guard_policy,
     check_and_revert_clone_contamination,
     is_clone_commit_skill,
+    is_path_under_exclude,
     is_worktree_skill,
     snapshot_clone_state,
 )
@@ -61,20 +63,6 @@ if TYPE_CHECKING:
     from autoskillit.pipeline.context import ToolContext
 
 logger = get_logger(__name__)
-
-
-_GUARD_EXCLUDE_PREFIX = ".autoskillit/"
-
-
-def _is_path_under_exclude(path: Path, cwd: Path, prefix: str) -> bool:
-    """Return True if path is under cwd/prefix."""
-    try:
-        rel = path.relative_to(cwd)
-        if not rel.parts:
-            return False
-        return str(rel.parts[0]) + "/" == prefix
-    except ValueError:
-        return False
 
 
 async def _execute_claude_headless(
@@ -178,7 +166,7 @@ async def _execute_claude_headless(
     _writes_under_exclude = bool(
         write_watch_dirs
         and all(
-            _is_path_under_exclude(d, Path(cwd), _GUARD_EXCLUDE_PREFIX) for d in write_watch_dirs
+            is_path_under_exclude(d, Path(cwd), GUARD_EXCLUDE_PREFIX) for d in write_watch_dirs
         )
     )
     _clone_guard_policy = build_clone_guard_policy(

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -63,6 +63,20 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+_GUARD_EXCLUDE_PREFIX = ".autoskillit/"
+
+
+def _is_path_under_exclude(path: Path, cwd: Path, prefix: str) -> bool:
+    """Return True if path is under cwd/prefix."""
+    try:
+        rel = path.relative_to(cwd)
+        if not rel.parts:
+            return False
+        return str(rel.parts[0]) + "/" == prefix
+    except ValueError:
+        return False
+
+
 async def _execute_claude_headless(
     spec: CmdSpec,
     cwd: str,
@@ -161,11 +175,18 @@ async def _execute_claude_headless(
 
     _readonly_skill = readonly_skill
     _has_write_scope = bool(write_watch_dirs)
+    _writes_under_exclude = bool(
+        write_watch_dirs
+        and all(
+            _is_path_under_exclude(d, Path(cwd), _GUARD_EXCLUDE_PREFIX) for d in write_watch_dirs
+        )
+    )
     _clone_guard_policy = build_clone_guard_policy(
         readonly_skill=_readonly_skill,
         has_write_scope=_has_write_scope,
         is_clone_commit=is_clone_commit_skill(skill_command),
         is_worktree=is_worktree_skill(skill_command),
+        writes_under_exclude=_writes_under_exclude,
     )
     _clone_snapshot = None
     if (

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -136,6 +136,7 @@ Summary: `needs_retry=true` + `retry_reason=resume` + `subtype=stale` → re-exe
          `needs_retry=true` + `retry_reason=completed_no_flush` + no `on_context_limit` → `on_failure`.
          `needs_retry=true` + `retry_reason=empty_output` → `on_failure`.
          `needs_retry=true` + `retry_reason=path_contamination` → `on_failure`.
+         `needs_retry=true` + `retry_reason=clone_contamination` → `on_failure`.
          `needs_retry=true` + `retry_reason=contract_recovery` + `has_progress_evidence=true` + step has `on_context_limit` → follow `on_context_limit`.
          `needs_retry=true` + `retry_reason=contract_recovery` + `has_progress_evidence=false` → `on_failure`.
          `needs_retry=true` + `retry_reason=thinking_stall` + `lifespan_started=true` + step has `on_context_limit` → follow `on_context_limit`.

--- a/tests/arch/test_clone_guard_policy_enforcement.py
+++ b/tests/arch/test_clone_guard_policy_enforcement.py
@@ -44,3 +44,18 @@ def test_check_and_revert_has_no_readonly_skill_param():
     assert "policy" in sig.parameters, (
         "check_and_revert_clone_contamination missing policy parameter"
     )
+
+
+def test_clone_guard_detection_revert_exclude_coherence():
+    """detect_contamination must accept exclude_prefix if revert_contamination does."""
+    import inspect
+
+    from autoskillit.execution.clone_guard import detect_contamination, revert_contamination
+
+    detect_sig = inspect.signature(detect_contamination)
+    revert_sig = inspect.signature(revert_contamination)
+    assert "exclude_prefix" in revert_sig.parameters
+    assert "exclude_prefix" in detect_sig.parameters, (
+        "Detection-revert coherence gap: revert_contamination accepts exclude_prefix "
+        "but detect_contamination does not. Detection must filter excluded files."
+    )

--- a/tests/cli/test_routing_completeness.py
+++ b/tests/cli/test_routing_completeness.py
@@ -16,11 +16,9 @@ pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 # Reasons excluded from orchestrator-prompt routing check:
 # - NONE: not a retry scenario, no routing needed
 # - BUDGET_EXHAUSTED: caps other reasons; orchestrator never sees it directly
-# - CLONE_CONTAMINATION: handled by clone_guard infrastructure
 _ROUTING_EXCLUDED = {
     RetryReason.NONE,
     RetryReason.BUDGET_EXHAUSTED,
-    RetryReason.CLONE_CONTAMINATION,
 }
 
 # Routing contract: RetryReason → (expected_route_keyword, evidence_condition_keyword_or_None)
@@ -31,6 +29,7 @@ _EXPECTED_ROUTES: dict[RetryReason, tuple[str, str | None]] = {
     RetryReason.COMPLETED_NO_FLUSH: ("on_context_limit", None),
     RetryReason.EMPTY_OUTPUT: ("on_failure", None),
     RetryReason.PATH_CONTAMINATION: ("on_failure", None),
+    RetryReason.CLONE_CONTAMINATION: ("on_failure", None),
     RetryReason.THINKING_STALL: ("on_context_limit", "lifespan_started"),
     RetryReason.IDLE_STALL: ("on_context_limit", "lifespan_started"),
     RetryReason.EARLY_STOP: ("on_context_limit", "has_progress_evidence"),

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -726,3 +726,36 @@ async def test_result_needs_retry_set_on_revert(tmp_path):
     assert reverted
     assert result.needs_retry is True
     assert result.retry_reason == RetryReason.CLONE_CONTAMINATION
+
+
+# ---------------------------------------------------------------------------
+# Exclude-prefix filtering in detect_contamination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_detect_contamination_ignores_excluded_files(tmp_path):
+    """Files under exclude_prefix should not count as contamination."""
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="abc123\n"))  # rev-parse HEAD (same as snapshot)
+    runner.push(_git_result(stdout="?? .autoskillit/temp/planner/output.json\n"))  # status
+    snapshot = CloneSnapshot(head_sha="abc123")
+    report = await detect_contamination(
+        snapshot, str(tmp_path), runner, exclude_prefix=".autoskillit/"
+    )
+    assert report is None
+
+
+@pytest.mark.anyio
+async def test_detect_contamination_external_head_with_excluded_files(tmp_path):
+    """External HEAD advance with only excluded dirty files should report HEAD change only."""
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="def456\n"))  # rev-parse HEAD (different from snapshot)
+    runner.push(_git_result(stdout="?? .autoskillit/temp/planner/output.json\n"))  # status
+    snapshot = CloneSnapshot(head_sha="abc123")
+    report = await detect_contamination(
+        snapshot, str(tmp_path), runner, exclude_prefix=".autoskillit/"
+    )
+    assert report is not None
+    assert report.direct_commits is True
+    assert report.uncommitted_files == []

--- a/tests/execution/test_clone_guard_policy.py
+++ b/tests/execution/test_clone_guard_policy.py
@@ -141,3 +141,18 @@ def test_policy_selective_revert():
     ]:
         policy = build_clone_guard_policy(**kwargs)
         assert policy.selective_revert is expected, f"Failed for {kwargs}"
+
+
+def test_policy_for_write_scope_under_exclude():
+    """When write scope is entirely under exclude_prefix, guard must not fire on success."""
+    policy = build_clone_guard_policy(
+        readonly_skill=True,
+        has_write_scope=True,
+        is_clone_commit=False,
+        is_worktree=False,
+        writes_under_exclude=True,
+    )
+    assert policy.should_fire(success=True) is False
+    assert policy.should_fire(success=False) is True
+    assert policy.selective_revert is True
+    assert policy.should_snapshot is True

--- a/tests/execution/test_headless_clone_guard_integration.py
+++ b/tests/execution/test_headless_clone_guard_integration.py
@@ -141,3 +141,47 @@ async def test_planner_commits_reverted_on_success(git_repo: Path) -> None:
         text=True,
     )
     assert status.stdout.strip() == ""
+
+
+@pytest.mark.anyio
+async def test_planner_excluded_write_scope_not_reverted_on_external_head_advance(
+    git_repo: Path,
+) -> None:
+    """Planner session: writes under .autoskillit/ + external HEAD advance = no revert."""
+    runner = RealGitRunner()
+    cwd = str(git_repo)
+
+    policy = build_clone_guard_policy(
+        readonly_skill=True,
+        has_write_scope=True,
+        is_clone_commit=False,
+        is_worktree=False,
+        writes_under_exclude=True,
+    )
+    assert policy.should_fire(success=True) is False
+
+    snapshot = await snapshot_clone_state(cwd, runner)  # type: ignore[arg-type]
+    assert snapshot is not None
+
+    # External HEAD advance (simulates Cursor editor sync)
+    (git_repo / "src" / "main.rs").write_text("fn main() { /* external edit */ }")
+    _git(git_repo, "add", ".")
+    _git(git_repo, "commit", "-m", "external: cursor sync")
+
+    # Session writes under .autoskillit/ only
+    temp_dir = git_repo / ".autoskillit" / "temp" / "planner"
+    temp_dir.mkdir(parents=True)
+    (temp_dir / "output.json").write_text("{}")
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        _make_skill_result(success=True),
+        cwd,
+        runner,  # type: ignore[arg-type]
+        DefaultAuditLog(),
+        skill_command="/autoskillit:planner-elaborate-wps",
+        policy=policy,
+        exclude_prefix=".autoskillit/",
+    )
+    assert result.success is True
+    assert not reverted, "Guard should not fire when writes_under_exclude=True"

--- a/tests/execution/test_planner_write_isolation.py
+++ b/tests/execution/test_planner_write_isolation.py
@@ -103,8 +103,8 @@ async def test_planner_session_source_write_detected_and_reverted(git_repo: Path
     audit = DefaultAuditLog()
     skill_result = _make_skill_result(success=True, exit_code=0)
 
-    # _effective_readonly=True mirrors what headless/__init__.py computes when
-    # _has_write_scope=True (write_watch_dirs is non-empty for planner sessions).
+    # Planner session that writes OUTSIDE .autoskillit/ (source tree contamination).
+    # This is the legacy scenario — writes_under_exclude defaults to False.
     _, reverted = await check_and_revert_clone_contamination(
         snapshot,
         skill_result,
@@ -134,3 +134,65 @@ async def test_planner_session_source_write_detected_and_reverted(git_repo: Path
     records = audit.get_report_as_dicts()
     assert len(records) == 1
     assert records[0].get("subtype") == "clone_contamination"
+
+
+@pytest.mark.anyio
+async def test_planner_session_excluded_writes_not_reverted(git_repo: Path) -> None:
+    """Planner session writing only under .autoskillit/ should not trigger revert."""
+
+    class RealGitRunner:
+        async def __call__(
+            self,
+            cmd: list[str],
+            *,
+            cwd: Path,
+            timeout: float,
+            **_kwargs: object,
+        ) -> SubprocessResult:
+            result = subprocess.run(
+                cmd,
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return SubprocessResult(
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=0,
+            )
+
+    runner = RealGitRunner()
+    cwd = str(git_repo)
+
+    snapshot = await snapshot_clone_state(cwd, runner)  # type: ignore[arg-type]
+    assert snapshot is not None
+
+    # Write only under .autoskillit/
+    temp_dir = git_repo / ".autoskillit" / "temp" / "planner"
+    temp_dir.mkdir(parents=True)
+    (temp_dir / "output.json").write_text("{}")
+
+    audit = DefaultAuditLog()
+    skill_result = _make_skill_result(success=True, exit_code=0)
+
+    _, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        cwd,
+        runner,  # type: ignore[arg-type]
+        audit,
+        skill_command="/autoskillit:planner-elaborate-wps",
+        policy=build_clone_guard_policy(
+            readonly_skill=True,
+            has_write_scope=True,
+            is_clone_commit=False,
+            is_worktree=False,
+            writes_under_exclude=True,
+        ),
+        exclude_prefix=".autoskillit/",
+    )
+
+    assert not reverted, "Guard should not fire when writes_under_exclude=True"


### PR DESCRIPTION
## Summary

The clone guard fires a false-positive `clone_contamination` on sessions whose entire write scope is under the guard's own `exclude_prefix` (`.autoskillit/`). This happens because `build_clone_guard_policy()` uses a coarse `has_write_scope: bool` that collapses WHERE writes go into a binary, while `detect_contamination()` reports ANY dirty files or HEAD changes without filtering for the exclude prefix. The revert step correctly excludes `.autoskillit/` via `git clean --exclude=`, but by then the damage is done: `SkillResult` is already mutated to `success=False, retry_reason=CLONE_CONTAMINATION`.

The fix adds `writes_under_exclude: bool` to `build_clone_guard_policy()` to suppress `fire_on_success` when the session's write scope is entirely under `.autoskillit/`, adds `exclude_prefix` filtering to `detect_contamination()`, adds `clone_contamination` to routing tables, and covers the behavior with new and updated tests.


## Requirements

### Root Cause

`build_clone_guard_policy()` at `clone_guard.py:87-104` computes `fire_on_success=True` for any session with `has_write_scope=True`, even when the session's entire write scope is under the guard's own `exclude_prefix`.

### Recommended Fix

**Primary:** Add `writes_under_exclude_prefix` parameter to `build_clone_guard_policy()`. When the session's declared `output_dir` is entirely under the guard's `exclude_prefix` (`.autoskillit/`), set `fire_on_success=False`.

**Secondary:** Add `clone_contamination` to orchestrator and sous-chef routing tables explicitly.

## Changed Files

### Modified (●):
- `src/autoskillit/cli/_prompts_orchestrator.py`
- `src/autoskillit/execution/clone_guard.py`
- `src/autoskillit/execution/headless/_headless_execute.py`
- `src/autoskillit/skills/sous-chef/SKILL.md`
- `tests/arch/test_clone_guard_policy_enforcement.py`
- `tests/cli/test_routing_completeness.py`
- `tests/execution/test_clone_guard.py`
- `tests/execution/test_clone_guard_policy.py`
- `tests/execution/test_headless_clone_guard_integration.py`
- `tests/execution/test_headless_dispatch.py`
- `tests/execution/test_planner_write_isolation.py`

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_clone_guard_false_positive_2026-05-26_204328.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 13.3k | 22.3k | 1.7M | 130.2k | 290 | 114.1k | 15m 54s |
| dry_walkthrough | claude-opus-4-6 | 1 | 77 | 17.0k | 2.7M | 87.1k | 133 | 70.8k | 7m 10s |
| implement | claude-opus-4-6 | 1 | 79 | 13.9k | 2.7M | 108.1k | 81 | 91.9k | 5m 45s |
| prepare_pr* | MiniMax-M2.7 | 1 | 48.8k | 3.7k | 353.8k | 0 | 23 | 0 | 1m 17s |
| compose_pr* | MiniMax-M2.7 | 1 | 63.5k | 2.5k | 391.3k | 0 | 29 | 0 | 1m 8s |
| review_pr | claude-opus-4-6 | 1 | 48 | 24.7k | 552.4k | 78.1k | 34 | 63.6k | 16m 27s |
| resolve_review | claude-opus-4-6 | 1 | 49 | 7.2k | 1.2M | 65.1k | 47 | 49.9k | 6m 55s |
| ci_conflict_fix | claude-opus-4-6 | 1 | 42 | 7.9k | 1.1M | 61.0k | 48 | 45.1k | 3m 5s |
| **Total** | | | 125.9k | 99.2k | 10.8M | 130.2k | | 435.4k | 57m 44s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 229 | 11648.5 | 401.5 | 60.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 4292 | 266.0 | 10.5 | 1.8 |
| **Total** | **4521** | 2380.3 | 96.3 | 22.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 13.3k | 22.3k | 1.7M | 114.1k | 15m 54s |
| claude-opus-4-6 | 5 | 295 | 70.7k | 8.3M | 321.3k | 39m 24s |
| MiniMax-M2.7 | 2 | 112.3k | 6.2k | 745.0k | 0 | 2m 26s |