### PR TITLE
[FIX] Rectify: Per-Phase Context Sharding for WP Refinement — PART A ONLY

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -21,6 +21,7 @@ from autoskillit.planner.merge import (
     extract_item,
     merge_files,
     merge_refined_assignments,
+    merge_refined_wps,
     merge_tier_results,
     replace_item,
 )
@@ -68,6 +69,7 @@ __all__ = [
     "PlannerManifestItem",
     "merge_files",
     "merge_refined_assignments",
+    "merge_refined_wps",
     "merge_tier_results",
     "extract_item",
     "replace_item",

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -169,6 +169,66 @@ def _write_refine_contexts(
     return context_paths
 
 
+def _write_wp_refine_contexts(
+    planner_dir: Path,
+    work_packages: list[dict[str, Any]],
+    task_file_path: str,
+    expected_phase_ids: frozenset[str] | None = None,
+) -> list[str]:
+    phase_groups: dict[str, list[dict[str, Any]]] = {}
+    for wp in work_packages:
+        phase_id = wp.get("phase_id", "")
+        if phase_id:
+            phase_groups.setdefault(phase_id, []).append(wp)
+        else:
+            logger.warning(
+                "WP %r has no phase_id — skipped from wp refine contexts",
+                wp.get("id", "<unknown>"),
+            )
+
+    if expected_phase_ids is not None:
+        missing = expected_phase_ids - frozenset(phase_groups)
+        if missing:
+            raise ValueError(
+                f"Phases {sorted(missing)} have no merged work packages — "
+                f"expected={sorted(expected_phase_ids)}, "
+                f"found={sorted(phase_groups)}"
+            )
+
+    contexts_dir = planner_dir / "wp_refine_contexts"
+    contexts_dir.mkdir(parents=True, exist_ok=True)
+
+    _WP_PEER_STUB_KEYS = frozenset(
+        {"id", "name", "scope", "deliverables", "apis_defined", "apis_consumed"}
+    )
+
+    context_paths: list[str] = []
+    for phase_id in sorted(phase_groups):
+        if not re.fullmatch(r"[A-Za-z0-9_\-]+", phase_id):
+            raise ValueError(
+                f"phase_id {phase_id!r} contains disallowed characters — "
+                "only alphanumeric, underscore, and hyphen are permitted in context filenames"
+            )
+        own = phase_groups[phase_id]
+        peer_summaries: list[dict[str, Any]] = [
+            {k: v for k, v in wp.items() if k in _WP_PEER_STUB_KEYS}
+            for pid, peers in sorted(phase_groups.items())
+            if pid != phase_id
+            for wp in peers
+        ]
+        context: dict[str, Any] = {
+            "phase_id": phase_id,
+            "task_file_path": task_file_path,
+            "work_packages": own,
+            "peer_summaries": peer_summaries,
+        }
+        ctx_path = contexts_dir / f"context_{phase_id}.json"
+        write_versioned_json(ctx_path, context, schema_version=1)
+        context_paths.append(str(ctx_path))
+
+    return context_paths
+
+
 def extract_item(
     source_path: str,
     item_id: str,
@@ -284,6 +344,35 @@ def merge_tier_results(
             planner_dir, assignments, task_file_path, expected_phase_ids=expected_phase_ids
         )
         result["refine_context_paths"] = ",".join(context_paths)
+    if key == "work_packages":
+        merged_data = json.loads(Path(output_path).read_text(encoding="utf-8"))
+        work_packages = merged_data.get("work_packages", [])
+        if not work_packages:
+            logger.warning(
+                "merge_tier_results: no work_packages found in %s"
+                " — wp refine contexts will be empty",
+                output_path,
+            )
+        planner_dir = Path(output_path).parent
+        wp_expected_phase_ids: frozenset[str] | None = None
+        manifest_path = planner_dir / "phase_wp_manifest.json"
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Corrupted phase_wp_manifest.json at {manifest_path}: {exc}"
+                ) from exc
+            manifest_items = manifest.get("items", [])
+            if any(not item.get("id") for item in manifest_items):
+                raise ValueError(
+                    f"Manifest item has missing or empty 'id' field at {manifest_path}"
+                )
+            wp_expected_phase_ids = frozenset(item["id"] for item in manifest_items)
+        context_paths = _write_wp_refine_contexts(
+            planner_dir, work_packages, task_file_path, expected_phase_ids=wp_expected_phase_ids
+        )
+        result["wp_refine_context_paths"] = ",".join(context_paths)
     return result
 
 
@@ -364,6 +453,71 @@ def merge_refined_assignments(
     return {
         "refined_assignments_path": str(output_path),
         "item_count": str(len(all_assignments)),
+        "conflict_count": str(conflict_count),
+    }
+
+
+def merge_refined_wps(
+    planner_dir: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    contexts_dir = Path(planner_dir) / "wp_refine_contexts"
+    result_files = sorted(contexts_dir.glob("*_result.json"))
+    if not result_files:
+        raise ValueError(
+            f"No *_result.json files found in {contexts_dir}. "
+            "Run refine_wps dispatch before calling this function."
+        )
+
+    all_wps: list[dict[str, Any]] = []
+    for path in result_files:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Skipping malformed result file %s: %s", path, exc)
+            continue
+        all_wps.extend(data.get("work_packages", []))
+
+    valid_wps: list[dict[str, Any]] = []
+    for wp in all_wps:
+        if not wp.get("id"):
+            logger.warning(
+                "merge_refined_wps: skipping wp with missing id: %r",
+                wp.get("name", "<unknown>"),
+            )
+        else:
+            valid_wps.append(wp)
+    all_wps = valid_wps
+
+    def _sort_key(wp_id: str) -> tuple[int, ...]:
+        return tuple(int(n) for n in re.findall(r"\d+", wp_id))
+
+    deliverable_owner: dict[str, str] = {}
+    for wp in all_wps:
+        wid = wp.get("id", "")
+        for d in wp.get("deliverables", []):
+            if d not in deliverable_owner or _sort_key(wid) < _sort_key(deliverable_owner[d]):
+                deliverable_owner[d] = wid
+
+    deliverable_claimants: dict[str, set[str]] = {}
+    for wp in all_wps:
+        wid = wp.get("id", "")
+        for d in wp.get("deliverables", []):
+            deliverable_claimants.setdefault(d, set()).add(wid)
+    conflict_count = sum(1 for claimants in deliverable_claimants.values() if len(claimants) > 1)
+
+    for wp in all_wps:
+        wid = wp.get("id", "")
+        wp["deliverables"] = [
+            d for d in wp.get("deliverables", []) if deliverable_owner.get(d) == wid
+        ]
+
+    output_path = Path(planner_dir) / "refined_wps.json"
+    write_versioned_json(output_path, {"work_packages": all_wps}, schema_version=1)
+
+    return {
+        "refined_wps_path": str(output_path),
+        "item_count": str(len(all_wps)),
         "conflict_count": str(conflict_count),
     }
 

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -196,7 +196,12 @@ def _write_wp_refine_contexts(
             )
 
     contexts_dir = planner_dir / "wp_refine_contexts"
-    contexts_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        contexts_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise OSError(
+            f"Failed to create wp_refine_contexts directory at {contexts_dir}: {exc}"
+        ) from exc
 
     _WP_PEER_STUB_KEYS = frozenset(
         {"id", "name", "scope", "deliverables", "apis_defined", "apis_consumed"}
@@ -366,6 +371,8 @@ def merge_tier_results(
                 raise ValueError(
                     f"Corrupted phase_wp_manifest.json at {manifest_path}: {exc}"
                 ) from exc
+            except OSError as exc:
+                raise ValueError(f"Cannot read {manifest_path}: {exc}") from exc
             manifest_items = manifest.get("items", [])
             if any(not item.get("id") for item in manifest_items):
                 raise ValueError(
@@ -485,7 +492,7 @@ def merge_refined_wps(
             raise
         all_wps.extend(data.get("work_packages", []))
 
-    valid_wps: list[dict[str, Any]] = []
+    _wps: list[dict[str, Any]] = []
     for wp in all_wps:
         if not wp.get("id"):
             logger.warning(
@@ -493,8 +500,15 @@ def merge_refined_wps(
                 wp.get("name", "<unknown>"),
             )
         else:
-            valid_wps.append(wp)
-    all_wps = valid_wps
+            _wps.append(wp)
+    all_wps = _wps
+
+    if not all_wps:
+        logger.warning(
+            "merge_refined_wps: no valid WPs collected from %d result file(s) in %s",
+            len(result_files),
+            contexts_dir,
+        )
 
     def _sort_key(wp_id: str) -> tuple[int, ...]:
         return tuple(int(n) for n in re.findall(r"\d+", wp_id))

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -344,8 +344,11 @@ def merge_tier_results(
             planner_dir, assignments, task_file_path, expected_phase_ids=expected_phase_ids
         )
         result["refine_context_paths"] = ",".join(context_paths)
-    if key == "work_packages":
-        merged_data = json.loads(Path(output_path).read_text(encoding="utf-8"))
+    elif key == "work_packages":
+        try:
+            merged_data = json.loads(Path(output_path).read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise OSError(f"Failed to read merged output at {output_path}: {exc}") from exc
         work_packages = merged_data.get("work_packages", [])
         if not work_packages:
             logger.warning(
@@ -392,9 +395,11 @@ def merge_refined_assignments(
     for path in result_files:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
+        except json.JSONDecodeError as exc:
             logger.warning("Skipping malformed result file %s: %s", path, exc)
             continue
+        except OSError:
+            raise
         all_assignments.extend(data.get("assignments", []))
 
     valid_assignments: list[dict[str, Any]] = []
@@ -473,9 +478,11 @@ def merge_refined_wps(
     for path in result_files:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
+        except json.JSONDecodeError as exc:
             logger.warning("Skipping malformed result file %s: %s", path, exc)
             continue
+        except OSError:
+            raise
         all_wps.extend(data.get("work_packages", []))
 
     valid_wps: list[dict[str, Any]] = []

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2071,25 +2071,22 @@ skills:
     write_behavior: always
   planner-refine-wps:
     inputs:
-      - name: combined_wps_path
+      - name: context_file
         type: file_path
         required: true
       - name: refined_plan_path
-        type: file_path
-        required: true
-      - name: refined_assignments_path
         type: file_path
         required: true
       - name: output_dir
         type: directory_path
         required: true
     outputs:
-      - name: refined_wps_path
+      - name: phase_wp_refined_path
         type: file_path
     expected_output_patterns:
-      - "refined_wps_path[ \\t]*=[ \\t]*\\S+"
+      - "phase_wp_refined_path[ \\t]*=[ \\t]*\\S+"
     pattern_examples:
-      - "refined_wps_path = /tmp/autoskillit/planner/run-20260101-120000/refined_wps.json\n%%ORDER_UP%%"
+      - "phase_wp_refined_path = /tmp/autoskillit/planner/run-20260101-120000/wp_refine_contexts/P1_result.json\n%%ORDER_UP%%"
     write_behavior: always
   planner-consolidate-wps:
     inputs:
@@ -2490,6 +2487,21 @@ callable_contracts:
     - name: refine_context_paths
       type: str
       when: "key == 'assignments'"
+    - name: wp_refine_context_paths
+      type: str
+      when: "key == 'work_packages'"
+  autoskillit.planner.merge.merge_refined_wps:
+    inputs:
+      - name: planner_dir
+        type: directory_path
+        required: true
+    outputs:
+      - name: refined_wps_path
+        type: file_path
+      - name: item_count
+        type: str
+      - name: conflict_count
+        type: str
   autoskillit.planner.create_run_dir:
     inputs:
     - name: temp_dir

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -295,7 +295,7 @@
         "source_dir": "${{ inputs.source_dir }}"
       },
       "capture": {
-        "combined_wps_path": "${{ result.merged_path }}"
+        "wp_refine_context_paths": "${{ result.wp_refine_context_paths }}"
       },
       "on_success": "refine_wps",
       "on_failure": "escalate_stop"
@@ -304,9 +304,24 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:planner-refine-wps ${{ context.combined_wps_path }} ${{ context.refined_plan_path }} ${{ context.refined_assignments_path }} ${{ context.planner_dir }}\n",
+        "skill_command": "/autoskillit:planner-refine-wps {context_path} ${{ context.refined_plan_path }} ${{ context.planner_dir }}",
         "cwd": "${{ inputs.source_dir }}",
-        "output_dir": "${{ context.planner_dir }}"
+        "output_dir": "${{ context.planner_dir }}/wp_refine_contexts",
+        "dispatch_items": "${{ context.wp_refine_context_paths }}"
+      },
+      "capture_list": {
+        "phase_wp_refined_path": "${{ result.phase_wp_refined_path }}"
+      },
+      "retries": 0,
+      "on_success": "merge_refined_wps",
+      "on_failure": "escalate_stop",
+      "note": "PARALLEL DISPATCH: context.wp_refine_context_paths contains comma-separated paths to per-phase WP context files. For each context_path, substitute it into the {context_path} placeholder in skill_command and issue one run_skill call in parallel. Accumulate results via capture_list.\n"
+    },
+    "merge_refined_wps": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.planner.merge.merge_refined_wps",
+        "planner_dir": "${{ context.planner_dir }}"
       },
       "capture": {
         "refined_wps_path": "${{ result.refined_wps_path }}"

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -300,7 +300,7 @@ steps:
       task_file_path: "${{ context.task_file_path }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
-      combined_wps_path: "${{ result.merged_path }}"
+      wp_refine_context_paths: "${{ result.wp_refine_context_paths }}"
     on_success: refine_wps
     on_failure: escalate_stop
 
@@ -308,14 +308,26 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: >
-        /autoskillit:planner-refine-wps
-        ${{ context.combined_wps_path }}
-        ${{ context.refined_plan_path }}
-        ${{ context.refined_assignments_path }}
-        ${{ context.planner_dir }}
+      skill_command: "/autoskillit:planner-refine-wps {context_path} ${{ context.refined_plan_path }} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
-      output_dir: "${{ context.planner_dir }}"
+      output_dir: "${{ context.planner_dir }}/wp_refine_contexts"
+      dispatch_items: "${{ context.wp_refine_context_paths }}"
+    capture_list:
+      phase_wp_refined_path: "${{ result.phase_wp_refined_path }}"
+    retries: 0
+    on_success: merge_refined_wps
+    on_failure: escalate_stop
+    note: >
+      PARALLEL DISPATCH: context.wp_refine_context_paths contains comma-separated paths
+      to per-phase WP context files. For each context_path, substitute it into
+      the {context_path} placeholder in skill_command and issue one run_skill call
+      in parallel. Accumulate results via capture_list.
+
+  merge_refined_wps:
+    tool: run_python
+    with:
+      callable: "autoskillit.planner.merge.merge_refined_wps"
+      planner_dir: "${{ context.planner_dir }}"
     capture:
       refined_wps_path: "${{ result.refined_wps_path }}"
     on_success: consolidate_wps_analyze

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -13,37 +13,37 @@ hooks:
 
 # planner-refine-wps
 
-L1 session that refines a `combined_wps.json` (a `PlanDocument` with all work
-packages in `WPElaborated` form) by spawning one L0 subagent per phase in
-parallel (batched to 6). Unlike the per-WP elaboration pass, this skill spawns
-one L0 per **phase** (not per WP). Each L0 reviews ALL WPs in its assigned phase
-against the full WP set, detecting cross-phase API mismatches, duplicate
-deliverables, missing dependencies, and scope overlap. The L1 collects structured
-suggestions, resolves conflicts, and writes `refined_wps.json`.
+L1 session that refines a single phase's work packages (from a per-phase context
+file produced by `merge_wps`) by spawning one L0 subagent per phase in parallel
+(batched to 6). Unlike the per-WP elaboration pass, this skill spawns one L0 per
+**phase** (not per WP). Each L0 reviews ALL WPs in its assigned phase against peer
+WP stubs for cross-phase awareness, detecting API mismatches, duplicate deliverables,
+missing dependencies, and scope overlap. The L1 collects structured suggestions,
+resolves conflicts, and writes `{phase_id}_result.json` to the `wp_refine_contexts/`
+directory.
 
 ## When to Use
 
-- Launched by the L2 planner recipe after the parallel WP elaboration merge step
-- Accepts `combined_wps.json`, `refined_plan.json`, and `refined_assignments.json`
-- Produces `refined_wps.json` as input for downstream planner steps (e.g. reconcile_deps)
+- Launched by the L2 planner recipe once per phase after the WP merge step
+- Accepts a per-phase context file from `wp_refine_contexts/`, `refined_plan.json`, and planner_dir
+- Produces `{phase_id}_result.json` as input for `merge_refined_wps`
 
 ## Arguments
 
-- **$1** — Absolute path to `combined_wps.json` (PlanDocument with `work_packages: list[WPElaborated]`)
+- **$1** — Absolute path to per-phase context file (`wp_refine_contexts/context_{phase_id}.json`)
 - **$2** — Absolute path to `refined_plan.json` (PlanDocument with phases as PhaseElaborated)
-- **$3** — Absolute path to `refined_assignments.json` (PlanDocument with assignments as AssignmentElaborated)
-- **$4** — Absolute path to the run-scoped planner directory (e.g., `{{AUTOSKILLIT_TEMP}}/planner/run-YYYYMMDD-HHMMSS`). Output is written to `$4/refined_wps.json`.
+- **$3** — Absolute path to the run-scoped planner directory (e.g., `{{AUTOSKILLIT_TEMP}}/planner/run-YYYYMMDD-HHMMSS`). Output is written to `$3/wp_refine_contexts/{phase_id}_result.json`.
 
 ## Critical Constraints
 
 **NEVER:**
 - Fabricate, invent, or embellish information not supported by the available evidence or code.
 
-- Write any file outside `$4/`
-- Directly modify `combined_wps.json` ($1) — always write a new `refined_wps.json`
+- Write any file outside `$3/`
+- Directly modify the context file ($1) — always write a new `{phase_id}_result.json`
 - Allow an L0 subagent to write files directly (L0s return structured text only)
-- Emit `refined_wps_path` before writing `refined_wps.json`
-- Skip emitting `refined_wps_path` even if all L0s fail (write unchanged WPs, still emit)
+- Emit `phase_wp_refined_path` before writing `{phase_id}_result.json`
+- Skip emitting `phase_wp_refined_path` even if all L0s fail (write unchanged WPs, still emit)
 - Spawn more than 6 L0s in a single parallel batch
 - Spawn one L0 per WP — L0s operate per PHASE
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
@@ -57,29 +57,32 @@ suggestions, resolves conflicts, and writes `refined_wps.json`.
 - Log `WARNING` to stdout for any L0 response that fails validation (skip that phase)
 - Log `CRITICAL` to stdout for any L0 subagent that fails entirely (proceed with N-1 suggestions)
 - When two WPs claim the same deliverable file, assign ownership to the WP with the numerically earlier ID using natural sort (e.g., `P1-A1-WP1` beats `P2-A1-WP1`)
-- Emit: `refined_wps_path = <absolute path to refined_wps.json>`
+- Emit: `phase_wp_refined_path = <absolute path to $3/wp_refine_contexts/{phase_id}_result.json>`
 
 ## Workflow
 
 ### Step 1: Parse inputs and validate
 
-Read `$1` (combined_wps.json). Parse as a `PlanDocument`. Extract all WP entries
-from `work_packages[]`. Fail immediately (exit non-zero) if `work_packages` is
-empty or the file is malformed — do not proceed to spawn L0s. The failure message
-must include the file path and the parse/validation error string:
+Read `$1` (per-phase context file: `wp_refine_contexts/context_{phase_id}.json`). Extract:
+- `phase_id` — the phase this session handles
+- `work_packages` — full `WPElaborated` objects for this phase
+- `peer_summaries` — stub dicts for WPs in all other phases
+- `task_file_path` — path to the task document
+
+Fail immediately (exit non-zero) if `work_packages` is empty or the file is malformed:
 ```
 FATAL: failed to parse {path}: {error_detail}
 ```
 
 Read `$2` (refined_plan.json). Build a map `phase_id → PhaseElaborated` for phase context.
-Read `$3` (refined_assignments.json). Build a map `assignment_id → AssignmentElaborated` for assignment context.
+The `$3` argument is the planner output directory; output is written to `$3/wp_refine_contexts/{phase_id}_result.json`.
 
-Input schema (PlanDocument with WPElaborated work packages):
+Input schema (per-phase context file):
 ```json
 {
   "schema_version": 1,
-  "task": "...",
-  "source_dir": "...",
+  "phase_id": "P1",
+  "task_file_path": "/path/to/task.md",
   "work_packages": [
     {
       "id": "P1-A1-WP1",
@@ -87,9 +90,6 @@ Input schema (PlanDocument with WPElaborated work packages):
       "phase_id": "P1",
       "name": "...",
       "scope": "...",
-      "estimated_files": ["..."],
-      "goal": "...",
-      "summary": "...",
       "technical_steps": ["..."],
       "files_touched": ["..."],
       "apis_defined": ["..."],
@@ -98,26 +98,33 @@ Input schema (PlanDocument with WPElaborated work packages):
       "deliverables": ["..."],
       "acceptance_criteria": ["..."]
     }
+  ],
+  "peer_summaries": [
+    {
+      "id": "P2-A1-WP1",
+      "name": "...",
+      "scope": "...",
+      "deliverables": ["..."],
+      "apis_defined": ["..."],
+      "apis_consumed": ["..."]
+    }
   ]
 }
 ```
 
-### Step 2: Group WPs by phase and build L0 context packets
+### Step 2: Build L0 context packets per phase
 
-Read the `task` field from the combined WPs document. Each L0 subagent reviewing a phase's
-WPs must verify that every WP's deliverables and scope serve the stated task. Flag WPs
-whose deliverables address concerns not mentioned in the task as scope creep.
+Read `task_file_path` from the context file to load the task description. Each L0 subagent
+reviews this phase's WPs against peer stubs for cross-phase awareness. Flag WPs whose
+deliverables address concerns not in the task as scope creep.
 
-Group WPs by `phase_id` (always populated; read directly from the field).
-For each phase, build a context packet containing:
-- The full serialized `combined_wps.json` content (all WPs visible for cross-phase awareness)
-- The `PhaseElaborated` entry for the phase from `$2`
-- The `AssignmentElaborated` entries for all assignments in this phase from `$3`
-- The `overlap_notes` field from the `AssignmentElaborated` entries for this phase (use as a prior signal — if an assignment's overlap_notes flag a relationship with another assignment, scrutinize their WPs for subsumption)
-- The `target_phase_id`
-- The list of WP IDs assigned to this L0 (the WPs in this phase)
-- Instructions: review this phase's WPs against the full WP set; return structured suggestions only — do NOT edit files
-- Use `overlap_notes` from assignment elaboration as a prior signal — if an assignment's overlap_notes flag a relationship with another assignment, scrutinize their WPs for subsumption and report matches in `subsumption_pairs`
+For each phase (one context file = one phase), build a context packet containing:
+- The full `work_packages` list from the context file (own phase's WPs in detail)
+- The `peer_summaries` list from the context file (other phases' WPs as stubs)
+- The `PhaseElaborated` entry for this phase from `$2`
+- The `target_phase_id` (from `context.phase_id`)
+- Instructions: review this phase's WPs against peer stubs; return structured suggestions only — do NOT edit files
+- Use `overlap_notes` from the PhaseElaborated entry as a prior signal for subsumption detection
 
 ### Step 3: Spawn parallel L0 subagents
 
@@ -228,12 +235,17 @@ Valid WPElaborated fields for changes: `goal`, `summary`, `technical_steps`,
 
 ### Step 7: Write output
 
-Write the updated `PlanDocument` to `$4/refined_wps.json`. The output schema is
-identical to the input `combined_wps.json` (a `PlanDocument` with
-`work_packages: list[WPElaborated]`).
+Write the updated work packages for this phase to `$3/wp_refine_contexts/{phase_id}_result.json`.
+The output schema:
+```json
+{
+  "schema_version": 1,
+  "work_packages": [ ... refined WPElaborated objects for this phase ... ]
+}
+```
 
 ### Step 8: Emit output token
 
 ```
-refined_wps_path = <absolute path to $4/refined_wps.json>
+phase_wp_refined_path = <absolute path to $3/wp_refine_contexts/{phase_id}_result.json>
 ```

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -574,7 +574,7 @@ class TestOutputPathTokensDerivedFromContracts:
             # planner-refine-assignments output
             "phase_refined_path",
             # planner-refine-wps output
-            "refined_wps_path",
+            "phase_wp_refined_path",
             # planner-validate-task-alignment output
             "alignment_findings_path",
             # planner-assess-review-approach output

--- a/tests/planner/test_merge_refine.py
+++ b/tests/planner/test_merge_refine.py
@@ -283,7 +283,6 @@ def test_wp_refine_context_own_phase_in_full_detail(tmp_path):
     assert "technical_steps" in own
     assert "acceptance_criteria" in own
     assert "files_touched" in own
-    assert all(wp["id"] != "P2-A1-WP1" for wp in ctx["work_packages"])
 
 
 # --- Step 1c ---
@@ -300,6 +299,7 @@ def test_wp_refine_context_peer_summaries_are_stubs(tmp_path):
     assert peer["id"] == "P2-A1-WP1"
     allowed_keys = {"id", "name", "scope", "deliverables", "apis_defined", "apis_consumed"}
     assert set(peer.keys()) <= allowed_keys
+    assert allowed_keys <= set(peer.keys())
     assert "technical_steps" not in peer
     assert "acceptance_criteria" not in peer
     assert "files_touched" not in peer
@@ -324,7 +324,7 @@ def test_wp_refine_context_validates_expected_phases(tmp_path):
     manifest = {"items": [{"id": "P1"}, {"id": "P2"}, {"id": "P3"}]}
     write_json(tmp_path / "phase_wp_manifest.json", manifest)
     out = tmp_path / "combined_wps.json"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="have no merged work packages"):
         merge_tier_results(str(results_dir), str(out), "work_packages")
 
 

--- a/tests/planner/test_merge_refine.py
+++ b/tests/planner/test_merge_refine.py
@@ -10,6 +10,7 @@ import pytest
 from autoskillit.planner.merge import (
     _write_refine_contexts,
     merge_refined_assignments,
+    merge_refined_wps,
     merge_tier_results,
 )
 from tests.planner.conftest import (
@@ -226,29 +227,173 @@ def test_merge_tier_results_no_refine_contexts_for_phases_key(tmp_path):
     assert not (tmp_path / "refine_contexts").exists()
 
 
-def test_merge_tier_results_no_refine_contexts_for_work_packages_key(tmp_path):
+def _make_wp(wp_id: str, phase_id: str, deliverables: list | None = None) -> dict:
+    return {
+        "id": wp_id,
+        "phase_id": phase_id,
+        "name": f"WP {wp_id}",
+        "summary": "summary",
+        "goal": "goal",
+        "scope": f"scope of {wp_id}",
+        "technical_steps": ["step1", "step2"],
+        "files_touched": [f"src/{wp_id}.py"],
+        "apis_defined": [f"{wp_id}.api"],
+        "apis_consumed": [],
+        "depends_on": [],
+        "deliverables": deliverables if deliverables is not None else [f"src/{wp_id}.py"],
+        "acceptance_criteria": ["criterion1"],
+    }
+
+
+def _write_wp_result(dir_: Path, wp: dict) -> None:
+    write_json(dir_ / f"{wp['id']}_result.json", wp)
+
+
+# --- Step 1a ---
+def test_merge_tier_results_produces_wp_refine_contexts(tmp_path):
     results_dir = tmp_path / "work_packages"
     results_dir.mkdir()
-    write_json(
-        results_dir / "P1-A1-WP1_result.json",
-        {
-            "id": "P1-A1-WP1",
-            "name": "WP One",
-            "summary": "s",
-            "goal": "g",
-            "technical_steps": [],
-            "files_touched": [],
-            "apis_defined": [],
-            "apis_consumed": [],
-            "depends_on": [],
-            "deliverables": ["d1"],
-            "acceptance_criteria": [],
-        },
-    )
+    for phase, wp_id in [("P1", "P1-A1-WP1"), ("P2", "P2-A1-WP1"), ("P3", "P3-A1-WP1")]:
+        _write_wp_result(results_dir, _make_wp(wp_id, phase))
     out = tmp_path / "combined_wps.json"
     result = merge_tier_results(str(results_dir), str(out), "work_packages")
-    assert "refine_context_paths" not in result
-    assert not (tmp_path / "refine_contexts").exists()
+    assert "wp_refine_context_paths" in result
+    paths = [p for p in result["wp_refine_context_paths"].split(",") if p.strip()]
+    assert len(paths) == 3
+    for phase in ("P1", "P2", "P3"):
+        ctx = tmp_path / "wp_refine_contexts" / f"context_{phase}.json"
+        assert ctx.exists()
+        assert str(ctx) in paths
+    # paths must be sorted
+    assert paths == sorted(paths)
+
+
+# --- Step 1b ---
+def test_wp_refine_context_own_phase_in_full_detail(tmp_path):
+    results_dir = tmp_path / "work_packages"
+    results_dir.mkdir()
+    _write_wp_result(results_dir, _make_wp("P1-A1-WP1", "P1"))
+    _write_wp_result(results_dir, _make_wp("P2-A1-WP1", "P2"))
+    out = tmp_path / "combined_wps.json"
+    merge_tier_results(str(results_dir), str(out), "work_packages")
+    ctx = json.loads((tmp_path / "wp_refine_contexts" / "context_P1.json").read_text())
+    assert len(ctx["work_packages"]) == 1
+    own = ctx["work_packages"][0]
+    assert own["id"] == "P1-A1-WP1"
+    assert "technical_steps" in own
+    assert "acceptance_criteria" in own
+    assert "files_touched" in own
+    assert all(wp["id"] != "P2-A1-WP1" for wp in ctx["work_packages"])
+
+
+# --- Step 1c ---
+def test_wp_refine_context_peer_summaries_are_stubs(tmp_path):
+    results_dir = tmp_path / "work_packages"
+    results_dir.mkdir()
+    _write_wp_result(results_dir, _make_wp("P1-A1-WP1", "P1"))
+    _write_wp_result(results_dir, _make_wp("P2-A1-WP1", "P2"))
+    out = tmp_path / "combined_wps.json"
+    merge_tier_results(str(results_dir), str(out), "work_packages")
+    ctx = json.loads((tmp_path / "wp_refine_contexts" / "context_P1.json").read_text())
+    assert len(ctx["peer_summaries"]) == 1
+    peer = ctx["peer_summaries"][0]
+    assert peer["id"] == "P2-A1-WP1"
+    allowed_keys = {"id", "name", "scope", "deliverables", "apis_defined", "apis_consumed"}
+    assert set(peer.keys()) <= allowed_keys
+    assert "technical_steps" not in peer
+    assert "acceptance_criteria" not in peer
+    assert "files_touched" not in peer
+
+
+# --- Step 1d ---
+def test_wp_refine_context_rejects_unsafe_phase_id(tmp_path):
+    results_dir = tmp_path / "work_packages"
+    results_dir.mkdir()
+    _write_wp_result(results_dir, _make_wp("P1-A1-WP1", "../../evil"))
+    out = tmp_path / "combined_wps.json"
+    with pytest.raises(ValueError, match="disallowed characters"):
+        merge_tier_results(str(results_dir), str(out), "work_packages")
+
+
+# --- Step 1e ---
+def test_wp_refine_context_validates_expected_phases(tmp_path):
+    results_dir = tmp_path / "work_packages"
+    results_dir.mkdir()
+    _write_wp_result(results_dir, _make_wp("P1-A1-WP1", "P1"))
+    # manifest at planner_dir (= tmp_path), NOT inside results_dir
+    manifest = {"items": [{"id": "P1"}, {"id": "P2"}, {"id": "P3"}]}
+    write_json(tmp_path / "phase_wp_manifest.json", manifest)
+    out = tmp_path / "combined_wps.json"
+    with pytest.raises(ValueError):
+        merge_tier_results(str(results_dir), str(out), "work_packages")
+
+
+# --- Step 1f ---
+def test_wp_refine_context_corrupt_manifest_raises_valueerror(tmp_path):
+    results_dir = tmp_path / "work_packages"
+    results_dir.mkdir()
+    _write_wp_result(results_dir, _make_wp("P1-A1-WP1", "P1"))
+    manifest_path = tmp_path / "phase_wp_manifest.json"
+    manifest_path.write_text("{invalid json{{")
+    out = tmp_path / "combined_wps.json"
+    with pytest.raises(ValueError, match="Corrupted phase_wp_manifest.json"):
+        merge_tier_results(str(results_dir), str(out), "work_packages")
+
+
+# --- Step 2a ---
+def _write_wp_phase_result(dir_: Path, phase_id: str, wps: list[dict]) -> None:
+    write_json(dir_ / f"{phase_id}_result.json", {"work_packages": wps})
+
+
+def test_merge_refined_wps_basic(tmp_path):
+    ctx_dir = tmp_path / "wp_refine_contexts"
+    ctx_dir.mkdir()
+    _write_wp_phase_result(
+        ctx_dir, "P1", [_make_wp("P1-A1-WP1", "P1"), _make_wp("P1-A1-WP2", "P1")]
+    )
+    _write_wp_phase_result(
+        ctx_dir, "P2", [_make_wp("P2-A1-WP1", "P2"), _make_wp("P2-A1-WP2", "P2")]
+    )
+    result = merge_refined_wps(planner_dir=str(tmp_path))
+    assert "refined_wps_path" in result
+    out_path = Path(result["refined_wps_path"])
+    assert out_path.exists()
+    data = json.loads(out_path.read_text())
+    assert len(data["work_packages"]) == 4
+    assert result["item_count"] == "4"
+
+
+# --- Step 2b ---
+def test_merge_refined_wps_deliverable_conflict_earlier_wins(tmp_path):
+    ctx_dir = tmp_path / "wp_refine_contexts"
+    ctx_dir.mkdir()
+    _write_wp_phase_result(
+        ctx_dir,
+        "P1",
+        [_make_wp("P1-A1-WP1", "P1", deliverables=["src/shared.py", "src/p1.py"])],
+    )
+    _write_wp_phase_result(
+        ctx_dir,
+        "P2",
+        [_make_wp("P2-A1-WP1", "P2", deliverables=["src/shared.py", "src/p2.py"])],
+    )
+    result = merge_refined_wps(planner_dir=str(tmp_path))
+    data = json.loads(Path(result["refined_wps_path"]).read_text())
+    wps = {wp["id"]: wp for wp in data["work_packages"]}
+    assert "src/shared.py" in wps["P1-A1-WP1"]["deliverables"]
+    assert "src/shared.py" not in wps["P2-A1-WP1"]["deliverables"]
+    assert "src/p2.py" in wps["P2-A1-WP1"]["deliverables"]
+    assert result["conflict_count"] == "1"
+
+
+# --- Step 2c ---
+def test_merge_refined_wps_empty_dir_raises(tmp_path):
+    ctx_dir = tmp_path / "wp_refine_contexts"
+    ctx_dir.mkdir()
+    # only context files, no *_result.json
+    write_json(ctx_dir / "context_P1.json", {"phase_id": "P1", "work_packages": []})
+    with pytest.raises(ValueError, match="No.*_result.json"):
+        merge_refined_wps(planner_dir=str(tmp_path))
 
 
 def test_write_refine_contexts_rejects_unsafe_phase_id(tmp_path):

--- a/tests/planner/test_planner_api.py
+++ b/tests/planner/test_planner_api.py
@@ -40,6 +40,7 @@ def test_planner_all_exports() -> None:
         "replace_item",
         "build_plan_snapshot",
         "merge_refined_assignments",
+        "merge_refined_wps",
         "PlanDocument",
         "PhaseShort",
         "PhaseElaborated",

--- a/tests/planner/test_refine_wps_contract.py
+++ b/tests/planner/test_refine_wps_contract.py
@@ -44,6 +44,16 @@ def skill_md() -> str:
     return SKILL_MD_PATH.read_text()
 
 
+@pytest.fixture
+def refined_wps_path_token(skill_contract: dict) -> dict:
+    outputs = skill_contract.get("outputs", [])
+    token = next((o for o in outputs if o.get("name") == "phase_wp_refined_path"), None)
+    assert token is not None, (
+        f"phase_wp_refined_path not in outputs. Found: {[o.get('name') for o in outputs]}"
+    )
+    return token
+
+
 class TestContractRegistration:
     def test_skill_entry_exists(self, skill_contract: dict) -> None:
         """skill_contracts.yaml must have an entry for planner-refine-wps."""
@@ -58,21 +68,15 @@ class TestContractRegistration:
             "Without it, a session that never writes is marked successful."
         )
 
-    def test_refined_wps_path_output_present(self, skill_contract: dict) -> None:
+    def test_refined_wps_path_output_present(self, refined_wps_path_token: dict) -> None:
         """outputs must declare phase_wp_refined_path."""
-        outputs = skill_contract.get("outputs", [])
-        names = [o.get("name") for o in outputs]
-        assert "phase_wp_refined_path" in names, (
-            f"phase_wp_refined_path not in outputs. Found: {names}"
-        )
+        assert refined_wps_path_token.get("name") == "phase_wp_refined_path"
 
-    def test_refined_wps_path_type_is_file_path(self, skill_contract: dict) -> None:
+    def test_refined_wps_path_type_is_file_path(self, refined_wps_path_token: dict) -> None:
         """phase_wp_refined_path output must have type file_path."""
-        outputs = skill_contract.get("outputs", [])
-        token = next((o for o in outputs if o.get("name") == "phase_wp_refined_path"), None)
-        assert token is not None
-        assert token.get("type") == "file_path", (
-            f"phase_wp_refined_path type must be 'file_path', got {token.get('type')!r}. "
+        token_type = refined_wps_path_token.get("type")
+        assert token_type == "file_path", (
+            f"phase_wp_refined_path type must be 'file_path', got {token_type!r}. "
             "Path-contamination detection requires file_path type."
         )
 
@@ -86,9 +90,6 @@ class TestContractRegistration:
     def test_three_inputs_declared(self, skill_contract: dict) -> None:
         """Three inputs: context_file (per-phase context path), refined_plan_path, output_dir."""
         inputs = skill_contract.get("inputs", [])
-        assert len(inputs) == 3, (
-            f"Expected exactly 3 inputs, got {len(inputs)}: {[i.get('name') for i in inputs]}"
-        )
         input_names = {i.get("name") for i in inputs}
         assert input_names == {
             "context_file",

--- a/tests/planner/test_refine_wps_contract.py
+++ b/tests/planner/test_refine_wps_contract.py
@@ -59,39 +59,40 @@ class TestContractRegistration:
         )
 
     def test_refined_wps_path_output_present(self, skill_contract: dict) -> None:
-        """outputs must declare refined_wps_path."""
+        """outputs must declare phase_wp_refined_path."""
         outputs = skill_contract.get("outputs", [])
         names = [o.get("name") for o in outputs]
-        assert "refined_wps_path" in names, f"refined_wps_path not in outputs. Found: {names}"
+        assert "phase_wp_refined_path" in names, (
+            f"phase_wp_refined_path not in outputs. Found: {names}"
+        )
 
     def test_refined_wps_path_type_is_file_path(self, skill_contract: dict) -> None:
-        """refined_wps_path output must have type file_path."""
+        """phase_wp_refined_path output must have type file_path."""
         outputs = skill_contract.get("outputs", [])
-        token = next((o for o in outputs if o.get("name") == "refined_wps_path"), None)
+        token = next((o for o in outputs if o.get("name") == "phase_wp_refined_path"), None)
         assert token is not None
         assert token.get("type") == "file_path", (
-            f"refined_wps_path type must be 'file_path', got {token.get('type')!r}. "
+            f"phase_wp_refined_path type must be 'file_path', got {token.get('type')!r}. "
             "Path-contamination detection requires file_path type."
         )
 
     def test_expected_output_pattern_present(self, skill_contract: dict) -> None:
-        """expected_output_patterns must include a pattern matching refined_wps_path."""
+        """expected_output_patterns must include a pattern matching phase_wp_refined_path."""
         patterns = skill_contract.get("expected_output_patterns", [])
-        assert any("refined_wps_path" in p for p in patterns), (
-            f"No expected_output_pattern referencing refined_wps_path. Found: {patterns}"
+        assert any("phase_wp_refined_path" in p for p in patterns), (
+            f"No expected_output_pattern referencing phase_wp_refined_path. Found: {patterns}"
         )
 
-    def test_four_inputs_declared(self, skill_contract: dict) -> None:
-        """Four inputs: combined_wps_path, refined_plan_path, etc."""
+    def test_three_inputs_declared(self, skill_contract: dict) -> None:
+        """Three inputs: context_file (per-phase context path), refined_plan_path, output_dir."""
         inputs = skill_contract.get("inputs", [])
-        assert len(inputs) == 4, (
-            f"Expected exactly 4 inputs, got {len(inputs)}: {[i.get('name') for i in inputs]}"
+        assert len(inputs) == 3, (
+            f"Expected exactly 3 inputs, got {len(inputs)}: {[i.get('name') for i in inputs]}"
         )
         input_names = {i.get("name") for i in inputs}
         assert input_names == {
-            "combined_wps_path",
+            "context_file",
             "refined_plan_path",
-            "refined_assignments_path",
             "output_dir",
         }, f"Unexpected input names: {input_names}"
 
@@ -125,9 +126,9 @@ class TestSkillMdPresence:
         )
 
     def test_skill_md_has_output_token(self, skill_md: str) -> None:
-        """SKILL.md must document the refined_wps_path output token."""
-        assert "refined_wps_path" in skill_md, (
-            "SKILL.md must document 'refined_wps_path = <path>' output token."
+        """SKILL.md must document the phase_wp_refined_path output token."""
+        assert "phase_wp_refined_path" in skill_md, (
+            "SKILL.md must document 'phase_wp_refined_path = <path>' output token."
         )
 
     def test_skill_md_has_l0_response_fields(self, skill_md: str) -> None:

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -328,3 +328,42 @@ def test_no_step_references_inputs_task_file(planner_recipe):
         assert "inputs.task_file" not in step_str, (
             f"Step {name!r} still references inputs.task_file"
         )
+
+
+# --- WP refine sharding tests (Steps 3b-3d, 4a) ---
+
+
+def test_refine_wps_recipe_step_uses_dispatch_items(planner_recipe):
+    step = planner_recipe.steps["refine_wps"]
+    assert "dispatch_items" in step.with_args, (
+        "refine_wps must use dispatch_items for per-phase parallel dispatch"
+    )
+    assert step.capture_list is not None, (
+        "refine_wps must use capture_list instead of capture for dispatch accumulation"
+    )
+
+
+def test_merge_wps_captures_wp_refine_context_paths(planner_recipe):
+    step = planner_recipe.steps["merge_wps"]
+    assert step.capture is not None, "merge_wps must have a capture block"
+    assert "wp_refine_context_paths" in step.capture, (
+        "merge_wps must capture wp_refine_context_paths for per-phase dispatch"
+    )
+
+
+def test_merge_refined_wps_step_exists(planner_recipe):
+    assert "merge_refined_wps" in planner_recipe.steps, (
+        "planner recipe must have a merge_refined_wps step"
+    )
+    step = planner_recipe.steps["merge_refined_wps"]
+    assert step.tool == "run_python"
+    assert step.with_args.get("callable") == "autoskillit.planner.merge.merge_refined_wps"
+
+
+@pytest.mark.parametrize("step_name", ["refine_assignments", "refine_wps"])
+def test_refine_tier_steps_all_use_dispatch_items(planner_recipe, step_name):
+    step = planner_recipe.steps[step_name]
+    assert "dispatch_items" in step.with_args, (
+        f"{step_name} must use dispatch_items for per-phase parallel dispatch. "
+        "All refine_* steps at the assignment/WP tier must shard by phase."
+    )

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -260,7 +260,7 @@ def test_output_path_tokens_synchronized() -> None:
             # planner-refine-assignments output
             "phase_refined_path",
             # planner-refine-wps output
-            "refined_wps_path",
+            "phase_wp_refined_path",
             # audit-tests output (bundled full-audit recipe)
             "audit_report_path",
             # validate-audit output (bundled full-audit recipe)
@@ -336,7 +336,7 @@ PATH_CAPTURE_SKILLS: dict[str, list[str]] = {
     "planner-generate-phases": ["phase_manifest_path"],
     "planner-refine-assignments": ["phase_refined_path"],
     "planner-refine-phases": ["refined_plan_path"],
-    "planner-refine-wps": ["refined_wps_path"],
+    "planner-refine-wps": ["phase_wp_refined_path"],
     "planner-validate-task-alignment": ["alignment_findings_path"],
     "audit-tests": ["audit_report_path"],
     "validate-audit": ["validated_report_path"],


### PR DESCRIPTION
## Summary

The `planner-refine-wps` skill exhausts its 200K context window on plans with >35 WPs because the entire `combined_wps.json` corpus (~300KB / ~75K tokens) is loaded into a single L1 session and broadcast into every L0 subagent's context. The equivalent `refine_assignments` step solved this problem via per-phase context sharding (`_write_refine_contexts()` in `merge.py`), but this mechanism was never replicated for the WP tier.

The architectural weakness is that `merge_tier_results()` uses a hardcoded `if key == "assignments"` gate (line 259) to decide whether to produce per-phase context shards. This design makes the sharding capability invisible to new tiers — there is no structural mechanism that forces new tier merges to consider sharding, and existing tests actively assert the absence of WP sharding as correct behavior.

**Immunity approach:** Generalize `merge_tier_results()` to accept a tier-configurable sharding specification rather than hardcoding tier names. This makes context sharding a declared capability of any tier, enforced by a registry and tested by parametric tier-parity tests that catch asymmetries automatically.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260526-224822-367375/.autoskillit/temp/rectify/rectify_wp_refine_context_sharding_2026-05-27_055720.md`

Closes #3069

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 3.3k | 9.0k | 666.3k | 64.2k | 135 | 59.8k | 5m 28s |
| rectify | claude-sonnet-4-6 | 1 | 78 | 27.6k | 3.2M | 133.7k | 239 | 135.6k | 20m 50s |
| dry_walkthrough | claude-opus-4-6 | 1 | 55 | 17.6k | 1.0M | 71.1k | 131 | 54.8k | 9m 4s |
| implement | claude-sonnet-4-6 | 1 | 542 | 46.3k | 6.9M | 141.2k | 183 | 126.1k | 16m 15s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 141.0k | 4.4k | 247.1k | 30.9k | 23 | 43.6k | 1m 32s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 147.6k | 3.4k | 398.7k | 30.9k | 34 | 15.4k | 1m 21s |
| review_pr | claude-sonnet-4-6 | 2 | 268 | 83.9k | 1.8M | 124.5k | 127 | 268.9k | 20m 22s |
| resolve_review | claude-sonnet-4-6 | 2 | 1.8k | 50.2k | 5.9M | 91.3k | 214 | 151.2k | 23m 21s |
| **Total** | | | 294.6k | 242.4k | 20.2M | 141.2k | | 855.3k | 1h 38m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 601 | 11515.0 | 209.8 | 77.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 72 | 81606.6 | 2099.8 | 697.9 |
| **Total** | **673** | 29961.4 | 1270.9 | 360.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 5 | 6.0k | 217.0k | 18.5M | 741.5k | 1h 26m |
| claude-opus-4-6 | 1 | 55 | 17.6k | 1.0M | 54.8k | 9m 4s |
| MiniMax-M2.7-highspeed | 2 | 288.6k | 7.8k | 645.9k | 59.0k | 2m 53s |