### PR TITLE
Add phoropter_family Field to RecipeStep

### DIFF
--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -348,6 +348,7 @@ _PARSE_STEP_HANDLED_FIELDS: frozenset[str] = frozenset(
         "idle_output_timeout",
         "block",  # Named block anchor; maps to step's block: key in YAML
         "pass_through",  # Captured outputs used for informational propagation only
+        "phoropter_family",
     }
 )
 if _PARSE_STEP_HANDLED_FIELDS != frozenset(RecipeStep.__dataclass_fields__):
@@ -631,6 +632,7 @@ def _parse_step(data: dict[str, Any]) -> RecipeStep:
         idle_output_timeout=data.get("idle_output_timeout"),
         block=data.get("block"),
         pass_through=_ensure_list(data.get("pass_through", [])),
+        phoropter_family=data.get("phoropter_family"),
     )
 
 

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -120,6 +120,7 @@ class RecipeStep:
     pass_through: list[str] = field(
         default_factory=list
     )  # Captured output names used for informational propagation, not flow control
+    phoropter_family: str | None = None
 
     def __post_init__(self) -> None:
         if self.capture_list and self.retries > 0:

--- a/tests/recipe/test_io_parsing.py
+++ b/tests/recipe/test_io_parsing.py
@@ -472,6 +472,16 @@ class TestRecipeParser:
         step = _parse_step(data)
         assert step.idle_output_timeout == 0
 
+    def test_parse_step_reads_phoropter_family(self) -> None:
+        data = {"tool": "run_skill", "phoropter_family": "lens-a", "on_success": "done"}
+        step = _parse_step(data)
+        assert step.phoropter_family == "lens-a"
+
+    def test_parse_step_phoropter_family_defaults_to_none(self) -> None:
+        data = {"tool": "run_skill", "on_success": "done"}
+        step = _parse_step(data)
+        assert step.phoropter_family is None
+
     # MOD4
     def test_bundled_resolve_failures_steps_use_config_default(self) -> None:
         bd = builtin_recipes_dir()


### PR DESCRIPTION
## Summary

Add `phoropter_family: str | None = None` to the `RecipeStep` dataclass in `schema.py` and atomically update `io.py` so the import-time frozenset assertion and `test_parse_step_handles_all_recipe_step_fields` both pass. This is a two-file atomic change within the `recipe/` package.

Closes #3073

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-234330-974855/.autoskillit/temp/make-plan/add-phoropter-family-field-to-recipestep_plan_2026-05-26_234500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 59 | 4.5k | 549.8k | 78.7k | 105 | 35.0k | 6m 22s |
| verify | claude-sonnet-4-6 | 1 | 108 | 4.4k | 509.3k | 48.9k | 32 | 32.9k | 1m 36s |
| implement* | MiniMax-M2.7-highspeed | 1 | 499.1k | 5.2k | 831.4k | 30.9k | 57 | 16.2k | 6m 45s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 89.8k | 2.6k | 306.1k | 30.9k | 20 | 15.8k | 1m 5s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 65.9k | 1.4k | 275.2k | 30.9k | 20 | 15.5k | 47s |
| review_pr | claude-sonnet-4-6 | 2 | 298 | 35.4k | 1.5M | 58.6k | 112 | 80.7k | 8m 50s |
| resolve_review | claude-sonnet-4-6 | 1 | 213 | 10.2k | 1.4M | 66.8k | 66 | 51.4k | 4m 59s |
| **Total** | | | 655.5k | 63.7k | 5.3M | 78.7k | | 247.4k | 30m 26s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 3 | 277139.0 | 5395.0 | 1740.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 135381.0 | 5137.4 | 1017.4 |
| **Total** | **13** | 406311.2 | 19031.7 | 4897.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 678 | 54.4k | 3.9M | 200.0k | 21m 49s |
| MiniMax-M2.7-highspeed | 3 | 654.8k | 9.2k | 1.4M | 47.4k | 8m 37s |