### PR TITLE
Implementation Plan: P1-A1-WP1 — Extend BackendCapabilities with 18 New Declarative Fields

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -36,6 +36,24 @@ class BackendCapabilities:
     food_truck_capable: bool
     completion_record_types: frozenset[str]
     session_record_types: frozenset[str]
+    triage_capable: bool = field(default=False)
+    record_capable: bool = field(default=False)
+    replay_capable: bool = field(default=False)
+    plugin_install_capable: bool = field(default=False)
+    anthropic_provider_capable: bool = field(default=False)
+    session_log_compressed: bool = field(default=False)
+    supports_context_exhaustion_detection: bool = field(default=False)
+    supports_api_retry_events: bool = field(default=False)
+    project_local_skills_capable: bool = field(default=False)
+    required_skill_fields: frozenset[str] = field(default_factory=frozenset)
+    required_session_files: frozenset[str] = field(default_factory=frozenset)
+    session_dir_symlinks: frozenset[str] = field(default_factory=frozenset)
+    applicable_guards: frozenset[str] = field(default_factory=frozenset)
+    env_denylist_prefixes: tuple[str, ...] = field(default=())
+    min_version: str = ""
+    version_check_command: str = ""
+    process_name: str = ""
+    skills_subdir: str = ""
 
 
 CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
@@ -50,6 +68,24 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     food_truck_capable=True,
     completion_record_types=frozenset({"result"}),
     session_record_types=frozenset({"assistant"}),
+    triage_capable=True,
+    record_capable=True,
+    replay_capable=True,
+    plugin_install_capable=True,
+    anthropic_provider_capable=True,
+    session_log_compressed=False,
+    supports_context_exhaustion_detection=True,
+    supports_api_retry_events=False,
+    project_local_skills_capable=True,
+    required_skill_fields=frozenset({"name", "description"}),
+    required_session_files=frozenset(),
+    session_dir_symlinks=frozenset(),
+    applicable_guards=frozenset({"skill_load_guard"}),
+    env_denylist_prefixes=(),
+    min_version="",
+    version_check_command="claude --version",
+    process_name="claude",
+    skills_subdir=".claude/skills",
 )
 
 

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -50,13 +50,15 @@ def test_backend_capabilities_slots():
 
 
 def test_backend_capabilities_field_count():
-    """11 fields: 9 bool + 2 frozenset[str]."""
+    """29 fields: 18 bool + 6 frozenset[str] + 4 str + 1 tuple."""
     from autoskillit.core import BackendCapabilities
 
     fields = dataclasses.fields(BackendCapabilities)
     hints = typing.get_type_hints(BackendCapabilities)
     bool_fields = {f.name for f in fields if hints[f.name] is bool}
     frozenset_fields = {f.name for f in fields if hints[f.name] == frozenset[str]}
+    str_fields = {f.name for f in fields if hints[f.name] is str}
+    tuple_fields = {f.name for f in fields if hints[f.name] == tuple[str, ...]}
     assert bool_fields == {
         "channel_b_capable",
         "pty_required",
@@ -67,12 +69,30 @@ def test_backend_capabilities_field_count():
         "exit_code_is_terminal",
         "mcp_config_capable",
         "food_truck_capable",
+        "triage_capable",
+        "record_capable",
+        "replay_capable",
+        "plugin_install_capable",
+        "anthropic_provider_capable",
+        "session_log_compressed",
+        "supports_context_exhaustion_detection",
+        "supports_api_retry_events",
+        "project_local_skills_capable",
     }
-    assert frozenset_fields == {"completion_record_types", "session_record_types"}
+    assert frozenset_fields == {
+        "completion_record_types",
+        "session_record_types",
+        "required_skill_fields",
+        "required_session_files",
+        "session_dir_symlinks",
+        "applicable_guards",
+    }
+    assert str_fields == {"min_version", "version_check_command", "process_name", "skills_subdir"}
+    assert tuple_fields == {"env_denylist_prefixes"}
 
 
 def test_backend_capabilities_field_names_locked():
-    """Field names match the design specification."""
+    """Field names match the 29-field design specification."""
     from autoskillit.core import BackendCapabilities
 
     expected = {
@@ -87,6 +107,24 @@ def test_backend_capabilities_field_names_locked():
         "food_truck_capable",
         "completion_record_types",
         "session_record_types",
+        "triage_capable",
+        "record_capable",
+        "replay_capable",
+        "plugin_install_capable",
+        "anthropic_provider_capable",
+        "session_log_compressed",
+        "supports_context_exhaustion_detection",
+        "supports_api_retry_events",
+        "project_local_skills_capable",
+        "required_skill_fields",
+        "required_session_files",
+        "session_dir_symlinks",
+        "applicable_guards",
+        "env_denylist_prefixes",
+        "min_version",
+        "version_check_command",
+        "process_name",
+        "skills_subdir",
     }
     actual = {f.name for f in dataclasses.fields(BackendCapabilities)}
     assert actual == expected
@@ -107,6 +145,55 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.food_truck_capable is True
     assert CLAUDE_CODE_CAPABILITIES.completion_record_types == frozenset({"result"})
     assert CLAUDE_CODE_CAPABILITIES.session_record_types == frozenset({"assistant"})
+    assert CLAUDE_CODE_CAPABILITIES.triage_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.record_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.replay_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.plugin_install_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.anthropic_provider_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.session_log_compressed is False
+    assert CLAUDE_CODE_CAPABILITIES.supports_context_exhaustion_detection is True
+    assert CLAUDE_CODE_CAPABILITIES.supports_api_retry_events is False
+    assert CLAUDE_CODE_CAPABILITIES.project_local_skills_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.required_skill_fields == frozenset({"name", "description"})
+    assert CLAUDE_CODE_CAPABILITIES.required_session_files == frozenset()
+    assert CLAUDE_CODE_CAPABILITIES.session_dir_symlinks == frozenset()
+    assert CLAUDE_CODE_CAPABILITIES.applicable_guards == frozenset({"skill_load_guard"})
+    assert CLAUDE_CODE_CAPABILITIES.env_denylist_prefixes == ()
+    assert CLAUDE_CODE_CAPABILITIES.min_version == ""
+    assert CLAUDE_CODE_CAPABILITIES.version_check_command == "claude --version"
+    assert CLAUDE_CODE_CAPABILITIES.process_name == "claude"
+    assert CLAUDE_CODE_CAPABILITIES.skills_subdir == ".claude/skills"
+
+
+def test_backend_capabilities_frozenset_defaults():
+    """Four new frozenset[str] fields default to frozenset()."""
+    from autoskillit.core import BackendCapabilities
+
+    instance = BackendCapabilities(
+        channel_b_capable=True,
+        pty_required=True,
+        session_resume_capable=True,
+        skill_injection_capable=True,
+        supports_thinking_blocks=True,
+        supports_claude_format_stdout=True,
+        exit_code_is_terminal=False,
+        mcp_config_capable=False,
+        food_truck_capable=True,
+        completion_record_types=frozenset(),
+        session_record_types=frozenset(),
+    )
+    new_frozenset_fields = {
+        "required_skill_fields",
+        "required_session_files",
+        "session_dir_symlinks",
+        "applicable_guards",
+    }
+    field_names = {f.name for f in dataclasses.fields(instance)}
+    hints = typing.get_type_hints(BackendCapabilities)
+    for name in new_frozenset_fields:
+        assert name in field_names
+        assert hints[name] == frozenset[str]
+        assert getattr(instance, name) == frozenset()
 
 
 def test_no_autoskillit_imports():


### PR DESCRIPTION
## Summary

Extend the `BackendCapabilities` frozen dataclass in `src/autoskillit/core/types/_type_backend.py` with 18 new fields (9 bool, 4 frozenset[str], 1 tuple[str, ...], 4 str) — all with safe defaults so existing call sites remain unbroken. Update `CLAUDE_CODE_CAPABILITIES` with Claude Code-specific values for all 18 new fields. Update all locked tests in `tests/core/test_backend_capabilities.py` to cover the expanded 29-field surface.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 75, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph IL0_siblings ["IL-0 ▸ core/types — Sibling Imports (consumed by _type_backend)"]
        direction LR
        TCHK["_type_checkpoint<br/>━━━━━━━━━━<br/>SessionCheckpoint"]
        TENM["_type_enums<br/>━━━━━━━━━━<br/>BackendEventKind<br/>OutputFormat"]
        TPLG["_type_plugin_source<br/>━━━━━━━━━━<br/>PluginSource"]
        TRES["_type_results<br/>━━━━━━━━━━<br/>ValidatedAddDir"]
    end

    subgraph IL0_core ["IL-0 ▸ core/types — Backend Type Hub"]
        direction TB
        TBCK["● _type_backend.py<br/>━━━━━━━━━━<br/>BackendCapabilities (+18 fields)<br/>CLAUDE_CODE_CAPABILITIES<br/>CmdSpec · SkillSessionConfig<br/>ClaudeEventData · CodexEventData<br/>SessionEvent · AgentSessionResult<br/>━━ fan-in: 17 prod files ━━"]
        TPROT["_type_protocols_backend<br/>━━━━━━━━━━<br/>CodingAgentBackend Protocol<br/>StreamParser · ResultParser<br/>EnvPolicy · SessionLocator"]
    end

    subgraph IL0_pub ["IL-0 ▸ core — Public API (re-export chain)"]
        direction LR
        TINIT["core/types/__init__.py<br/>━━━━━━━━━━<br/>star-import hub<br/>26 _type_* modules → __all__"]
        CINIT["core/__init__.py<br/>━━━━━━━━━━<br/>lazy_loader stub<br/>189 type symbols re-exported<br/>+ 107 runtime symbols"]
    end

    subgraph IL1_exec ["IL-1 ▸ execution/ — Primary Consumer (11 production files)"]
        direction LR
        EBCK["backends/<br/>━━━━━━━━━━<br/>claude.py · codex.py<br/>_codex_parse.py<br/>__init__.py"]
        EHLS["headless/<br/>━━━━━━━━━━<br/>_headless_execute<br/>_headless_helpers<br/>_headless_evidence<br/>_headless_recovery<br/>__init__.py"]
        ECMD["commands.py<br/>━━━━━━━━━━<br/>SkillSessionConfig<br/>consumer"]
    end

    subgraph IL1_cli ["IL-1 ▸ cli/ (3 production files)"]
        direction LR
        CSES["session/<br/>━━━━━━━━━━<br/>_session_launch<br/>_cook"]
        CINH["_init_helpers.py"]
    end

    subgraph IL1_wsp ["IL-1 ▸ workspace/"]
        WSKL["session_skills.py<br/>━━━━━━━━━━<br/>BackendCapabilities<br/>consumer"]
    end

    subgraph TESTS ["Tests"]
        direction LR
        TCAP["● tests/core/test_backend_capabilities.py<br/>━━━━━━━━━━<br/>BackendCapabilities field coverage"]
        TOTH["tests/core/ (3 more files)<br/>tests/execution/ (25 files)<br/>tests/cli/ (5 files)<br/>tests/contracts/ (2 files)"]
    end

    %% Sibling imports flowing INTO _type_backend
    TCHK -->|"SessionCheckpoint"| TBCK
    TENM -->|"BackendEventKind, OutputFormat"| TBCK
    TPLG -->|"PluginSource"| TBCK
    TRES -->|"ValidatedAddDir"| TBCK

    %% _type_backend exports to sibling protocol module
    TBCK -->|"BackendCapabilities, CmdSpec,<br/>SessionEvent, AgentSessionResult,<br/>SkillSessionConfig"| TPROT

    %% Re-export chain
    TBCK -->|"star import (*)"| TINIT
    TINIT -->|"189 type symbols"| CINIT

    %% IL-1 consumers via core public API
    CINIT -->|"4 files"| EBCK
    CINIT -->|"5 files"| EHLS
    CINIT -->|"1 file"| ECMD
    CINIT -->|"2 files"| CSES
    CINIT -->|"1 file"| CINH
    CINIT -->|"1 file"| WSKL

    %% Test dependencies
    TBCK -.->|"direct import"| TCAP
    CINIT -.->|"via core public API"| TOTH

    %% CLASS ASSIGNMENTS %%
    class TBCK stateNode;
    class TPROT phase;
    class TCHK,TENM,TPLG,TRES handler;
    class TINIT,CINIT output;
    class EBCK,EHLS,ECMD cli;
    class CSES,CINH cli;
    class WSKL cli;
    class TCAP,TOTH detector;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% CONSTRUCTION PATHS %%
    subgraph Construction ["CONSTRUCTION PATHS (two sites, no others)"]
        direction LR
        CONST["CLAUDE_CODE_CAPABILITIES<br/>━━━━━━━━━━<br/>Module-level constant<br/>All 29 fields explicit<br/><i>_type_backend.py:59</i>"]
        CODEX["CodexBackend.capabilities<br/>━━━━━━━━━━<br/>Per-call construction<br/>11 required fields only<br/>Optional fields → defaults<br/><i>execution/backends/codex.py:247</i>"]
    end

    %% FIELD LIFECYCLE CATEGORIES %%
    subgraph Lifecycles ["FIELD LIFECYCLE — ALL INIT_ONLY (frozen=True + slots=True)"]
        direction TB
        REQUIRED["INIT_ONLY · Required (11 fields)<br/>━━━━━━━━━━<br/>channel_b_capable · pty_required<br/>session_resume_capable · skill_injection_capable<br/>supports_thinking_blocks · supports_claude_format_stdout<br/>exit_code_is_terminal · mcp_config_capable<br/>food_truck_capable<br/>completion_record_types · session_record_types<br/><b>No default — callers must supply</b>"]
        OPTIONAL["● INIT_ONLY · Optional (★18 new fields)<br/>━━━━━━━━━━<br/>9 bool (default=False): triage_capable · record_capable<br/>replay_capable · plugin_install_capable<br/>anthropic_provider_capable · session_log_compressed<br/>supports_context_exhaustion_detection<br/>supports_api_retry_events · project_local_skills_capable<br/>4 frozenset[str] (default=frozenset()): required_skill_fields<br/>required_session_files · session_dir_symlinks · applicable_guards<br/>1 tuple (default=()): env_denylist_prefixes<br/>4 str (default=''): min_version · version_check_command<br/>process_name · skills_subdir<br/><b>Safe defaults → CodexBackend unaffected</b>"]
    end

    %% MUTATION BARRIER %%
    subgraph Barrier ["MUTATION BARRIER (enforced at class level)"]
        direction LR
        FROZEN["frozen=True<br/>━━━━━━━━━━<br/>FrozenInstanceError<br/>on any field write<br/><i>dataclasses.frozen</i>"]
        SLOTS["slots=True<br/>━━━━━━━━━━<br/>No __dict__<br/>Blocks attribute injection<br/><i>__slots__ only</i>"]
    end

    %% PROTOCOL BOUNDARY %%
    PROTOCOL["● CodingAgentBackend.capabilities<br/>━━━━━━━━━━<br/>Protocol property (read-only)<br/>Sole access interface for callers<br/><i>_type_protocols_backend.py:83</i>"]

    %% CALL-SITE GUARDS %%
    subgraph Guards ["CALL-SITE GUARDS (read-then-act pattern)"]
        direction TB
        G1["session_resume_capable guard<br/>━━━━━━━━━━<br/>Returns None early if False<br/><i>_headless_recovery.py:232</i>"]
        G2["food_truck_capable guard<br/>━━━━━━━━━━<br/>Raises RuntimeError if False<br/><i>headless/__init__.py:341</i>"]
        G3["Direct field reads (no guard)<br/>━━━━━━━━━━<br/>pty_required · channel_b_capable<br/>exit_code_is_terminal<br/>supports_claude_format_stdout<br/>skill_injection_capable<br/><i>various headless/cli modules</i>"]
    end

    %% TEST INVARIANT GATES %%
    subgraph TestGates ["TEST INVARIANT GATES (● test_backend_capabilities.py)"]
        direction TB
        T1["Field count locked<br/>━━━━━━━━━━<br/>29 fields: 18 bool + 6 frozenset<br/>+ 4 str + 1 tuple<br/><i>test_backend_capabilities_field_count</i>"]
        T2["Field names locked<br/>━━━━━━━━━━<br/>Exact set of 29 names asserted<br/><i>test_backend_capabilities_field_names_locked</i>"]
        T3["Frozen invariant<br/>━━━━━━━━━━<br/>FrozenInstanceError on write<br/><i>test_backend_capabilities_is_frozen_dataclass</i>"]
        T4["IL-0 constraint<br/>━━━━━━━━━━<br/>Zero autoskillit.* imports<br/><i>test_no_autoskillit_imports</i>"]
        T5["Frozenset defaults<br/>━━━━━━━━━━<br/>4 new frozenset fields → frozenset()<br/><i>test_backend_capabilities_frozenset_defaults</i>"]
    end

    %% CONNECTIONS %%
    CONST --> Lifecycles
    CODEX --> Lifecycles

    REQUIRED --> Barrier
    OPTIONAL --> Barrier

    Barrier --> PROTOCOL
    PROTOCOL --> Guards
    PROTOCOL --> TestGates

    %% CLASS ASSIGNMENTS %%
    class CONST stateNode;
    class CODEX handler;
    class REQUIRED detector;
    class OPTIONAL newComponent;
    class FROZEN,SLOTS phase;
    class PROTOCOL output;
    class G1,G2 detector;
    class G3 handler;
    class T1,T2,T3,T4,T5 cli;
```

Closes #3103

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-234237-761811/.autoskillit/temp/make-plan/p1_a1_wp1_extend_backend_capabilities_plan_2026-05-26_234700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 71 | 18.8k | 943.6k | 95.9k | 127 | 73.8k | 10m 53s |
| review | claude-sonnet-4-6 | 1 | 7.8k | 5.4k | 216.7k | 45.9k | 76 | 32.4k | 4m 37s |
| verify | claude-sonnet-4-6 | 1 | 108 | 13.9k | 624.1k | 66.2k | 34 | 83.3k | 4m 33s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.1M | 16.0k | 1.2M | 30.9k | 88 | 16.2k | 9m 46s |
| audit_impl | claude-sonnet-4-6 | 1 | 134 | 6.0k | 234.7k | 36.5k | 26 | 25.7k | 2m 31s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 154.7k | 3.4k | 370.7k | 30.9k | 26 | 43.7k | 1m 32s |
| run_arch_lenses | claude-sonnet-4-6 | 2 | 578 | 14.4k | 493.4k | 49.0k | 80 | 64.6k | 7m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 78.1k | 4.1k | 213.3k | 30.9k | 17 | 15.8k | 1m 3s |
| review_pr | claude-sonnet-4-6 | 1 | 118 | 30.9k | 573.9k | 71.8k | 42 | 58.5k | 6m 5s |
| resolve_review | claude-sonnet-4-6 | 1 | 167 | 9.5k | 840.1k | 53.6k | 45 | 38.1k | 5m 14s |
| **Total** | | | 1.3M | 122.4k | 5.7M | 95.9k | | 452.2k | 53m 30s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 129 | 9079.2 | 125.4 | 123.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| run_arch_lenses | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **129** | 44044.6 | 3505.8 | 949.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 7 | 9.0k | 98.9k | 3.9M | 376.5k | 41m 7s |
| MiniMax-M2.7-highspeed | 3 | 1.3M | 23.5k | 1.8M | 75.7k | 12m 22s |