### PR TITLE
Consolidate duplicated quota-hook helpers into `_hook_settings.py`

### DIFF
--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -16,7 +16,9 @@ Claude Code hook subprocesses.
 
 import json
 import os
+import sys
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
 # Keep in sync with _HOOK_CONFIG_PATH_COMPONENTS in hooks/_fmt_primitives.py
@@ -183,3 +185,62 @@ def resolve_quota_settings(*, cache_path_override: str | None = None) -> QuotaHo
         buffer_seconds=buffer_seconds,
         disabled=disabled,
     )
+
+
+_AUTOSKILLIT_LOG_DIR_ENV = "AUTOSKILLIT_LOG_DIR"
+
+
+def read_quota_cache(cache_path_str: str, max_age: int) -> dict | None:
+    """Read quota cache file. Returns parsed data or None if missing/stale/corrupt."""
+    cache_path = Path(cache_path_str).expanduser()
+    if not cache_path.is_file():
+        return None
+    try:
+        data = json.loads(cache_path.read_text())
+        fetched = datetime.fromisoformat(data["fetched_at"])
+        age = (datetime.now(UTC) - fetched).total_seconds()
+        if age > max_age:
+            return None
+        return data
+    except (json.JSONDecodeError, KeyError, ValueError, OSError, TypeError):
+        return None
+
+
+def resolve_quota_log_dir(*, caller: str = "") -> Path | None:
+    """Resolve the autoskillit log root directory. Returns None on any error.
+
+    Priority: AUTOSKILLIT_LOG_DIR env var > platform default.
+    Mirrors the logic in execution/session_log.py:resolve_log_dir().
+    """
+    try:
+        override = os.environ.get(_AUTOSKILLIT_LOG_DIR_ENV)
+        if override:
+            return Path(override)
+        if sys.platform == "darwin":
+            return Path.home() / "Library" / "Application Support" / "autoskillit" / "logs"
+        xdg = os.environ.get("XDG_DATA_HOME")
+        if xdg:
+            return Path(xdg) / "autoskillit" / "logs"
+        return Path.home() / ".local" / "share" / "autoskillit" / "logs"
+    except Exception as exc:
+        if caller:
+            print(f"{caller}: failed to resolve log directory: {exc}", file=sys.stderr)
+        return None
+
+
+def write_quota_log_event(event: dict, log_dir: Path | None, *, caller: str = "") -> None:
+    """Append a quota event to quota_events.jsonl at the log root.
+
+    No-ops when ``log_dir`` is None. On write failure, prints to stderr when
+    ``caller`` is provided; otherwise silently returns.
+    """
+    if log_dir is None:
+        return
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event) + "\n"
+        with open(log_dir / "quota_events.jsonl", "a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception as exc:
+        if caller:
+            print(f"{caller}: failed to write quota log event: {exc}", file=sys.stderr)

--- a/src/autoskillit/hooks/guards/quota_guard.py
+++ b/src/autoskillit/hooks/guards/quota_guard.py
@@ -62,7 +62,7 @@ def main(*, cache_path_override: str | None = None) -> None:
         sys.exit(0)  # quota guard disabled for this session
     cache_path_str = settings.cache_path
     cache_max_age = settings.cache_max_age
-    log_dir = resolve_quota_log_dir()
+    log_dir = resolve_quota_log_dir(caller="quota_guard")
     ts = datetime.now(UTC).isoformat()
 
     profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE", "").strip()
@@ -75,6 +75,7 @@ def main(*, cache_path_override: str | None = None) -> None:
                 "cache_path": cache_path_str,
             },
             log_dir,
+            caller="quota_guard",
         )
         sys.exit(0)
 
@@ -87,6 +88,7 @@ def main(*, cache_path_override: str | None = None) -> None:
                 "cache_path": cache_path_str,
             },
             log_dir,
+            caller="quota_guard",
         )
         sys.exit(0)  # no fresh cache — fail open
 
@@ -106,6 +108,7 @@ def main(*, cache_path_override: str | None = None) -> None:
                 "cache_path": cache_path_str,
             },
             log_dir,
+            caller="quota_guard",
         )
         sys.exit(0)  # malformed cache — fail open
 
@@ -147,6 +150,7 @@ def main(*, cache_path_override: str | None = None) -> None:
                 "budget_exceeded": budget_exceeded,
             },
             log_dir,
+            caller="quota_guard",
         )
 
         if budget_exceeded:
@@ -204,6 +208,7 @@ def main(*, cache_path_override: str | None = None) -> None:
                 "utilization": utilization,
             },
             log_dir,
+            caller="quota_guard",
         )
     sys.exit(0)  # exit 0 so Claude Code parses the JSON decision
 

--- a/src/autoskillit/hooks/guards/quota_guard.py
+++ b/src/autoskillit/hooks/guards/quota_guard.py
@@ -28,9 +28,12 @@ _HOOKS_DIR = str(Path(__file__).resolve().parent.parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
-from _hook_settings import resolve_quota_settings  # type: ignore[import-not-found]  # noqa: E402
-
-_AUTOSKILLIT_LOG_DIR_ENV = "AUTOSKILLIT_LOG_DIR"
+from _hook_settings import (  # noqa: E402
+    read_quota_cache,
+    resolve_quota_log_dir,
+    resolve_quota_settings,
+    write_quota_log_event,
+)  # type: ignore[import-not-found]
 
 # Emitted in deny messages; also referenced by orchestrator prompt QUOTA DENIAL ROUTING.
 # Changing this value requires updating _prompts.py and sous-chef/SKILL.md in the same commit.
@@ -39,60 +42,6 @@ QUOTA_GUARD_DENY_TRIGGER: str = "QUOTA WAIT REQUIRED"
 # Emitted when required sleep exceeds remaining session wall-clock budget.
 # Instructs the session to emit a clean sentinel and exit, rather than sleep-and-retry.
 QUOTA_BUDGET_EXCEEDED_TRIGGER: str = "QUOTA BUDGET EXCEEDED"
-
-
-def _read_quota_cache(cache_path_str: str, max_age: int) -> dict | None:
-    """Read quota cache file. Returns parsed data or None if missing/stale/corrupt."""
-    cache_path = Path(cache_path_str).expanduser()
-    if not cache_path.is_file():
-        return None
-    try:
-        data = json.loads(cache_path.read_text())
-        fetched = datetime.fromisoformat(data["fetched_at"])
-        age = (datetime.now(UTC) - fetched).total_seconds()
-        if age > max_age:
-            return None  # stale
-        return data
-    except (json.JSONDecodeError, KeyError, ValueError, OSError):
-        return None
-
-
-def _resolve_quota_log_dir() -> Path | None:
-    """Resolve the autoskillit log root directory. Returns None on any error.
-
-    Priority: AUTOSKILLIT_LOG_DIR env var > platform default.
-    Mirrors the logic in execution/session_log.py:resolve_log_dir().
-    """
-    try:
-        override = os.environ.get(_AUTOSKILLIT_LOG_DIR_ENV)
-        if override:
-            return Path(override)
-        if sys.platform == "darwin":
-            return Path.home() / "Library" / "Application Support" / "autoskillit" / "logs"
-        xdg = os.environ.get("XDG_DATA_HOME")
-        if xdg:
-            return Path(xdg) / "autoskillit" / "logs"
-        return Path.home() / ".local" / "share" / "autoskillit" / "logs"
-    except Exception:
-        return None
-
-
-def _write_quota_log_event(event: dict, log_dir: Path | None) -> None:
-    """Append a quota guard event to quota_events.jsonl at the log root.
-
-    Silently no-ops on any error — hook observability must never block run_skill.
-    Event schema: {ts, event, effective_threshold?, window_name?, utilization?,
-    sleep_seconds?, resets_at?, cache_path?}
-    """
-    if log_dir is None:
-        return
-    try:
-        log_dir.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(event) + "\n"
-        with open(log_dir / "quota_events.jsonl", "a", encoding="utf-8") as f:
-            f.write(line)
-    except Exception:
-        pass  # Never block the hook on logging failure
 
 
 def main(*, cache_path_override: str | None = None) -> None:
@@ -113,12 +62,12 @@ def main(*, cache_path_override: str | None = None) -> None:
         sys.exit(0)  # quota guard disabled for this session
     cache_path_str = settings.cache_path
     cache_max_age = settings.cache_max_age
-    log_dir = _resolve_quota_log_dir()
+    log_dir = resolve_quota_log_dir()
     ts = datetime.now(UTC).isoformat()
 
     profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE", "").strip()
     if profile and profile.casefold() != "anthropic":
-        _write_quota_log_event(
+        write_quota_log_event(
             {
                 "ts": ts,
                 "event": "provider_bypass",
@@ -129,9 +78,9 @@ def main(*, cache_path_override: str | None = None) -> None:
         )
         sys.exit(0)
 
-    cache = _read_quota_cache(cache_path_str, cache_max_age)
+    cache = read_quota_cache(cache_path_str, cache_max_age)
     if cache is None:
-        _write_quota_log_event(
+        write_quota_log_event(
             {
                 "ts": ts,
                 "event": "cache_miss",
@@ -150,7 +99,7 @@ def main(*, cache_path_override: str | None = None) -> None:
         effective_threshold = float(binding.get("effective_threshold", 0.0))
         window_name = str(binding.get("window_name", "unknown"))
     except (KeyError, ValueError, TypeError):
-        _write_quota_log_event(
+        write_quota_log_event(
             {
                 "ts": ts,
                 "event": "parse_error",
@@ -186,7 +135,7 @@ def main(*, cache_path_override: str | None = None) -> None:
             except (ValueError, TypeError):
                 pass  # malformed deadline — fall through to normal deny
 
-        _write_quota_log_event(
+        write_quota_log_event(
             {
                 "ts": ts,
                 "event": "blocked_budget_exceeded" if budget_exceeded else "blocked",
@@ -246,7 +195,7 @@ def main(*, cache_path_override: str | None = None) -> None:
                 )
             )
     else:
-        _write_quota_log_event(
+        write_quota_log_event(
             {
                 "ts": ts,
                 "event": "approved",

--- a/src/autoskillit/hooks/quota_post_hook.py
+++ b/src/autoskillit/hooks/quota_post_hook.py
@@ -25,59 +25,16 @@ _HOOKS_DIR = str(Path(__file__).resolve().parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
-from _hook_settings import resolve_quota_settings  # type: ignore[import-not-found]  # noqa: E402
-
-_AUTOSKILLIT_LOG_DIR_ENV = "AUTOSKILLIT_LOG_DIR"
+from _hook_settings import (  # noqa: E402
+    read_quota_cache,
+    resolve_quota_log_dir,
+    resolve_quota_settings,
+    write_quota_log_event,
+)  # type: ignore[import-not-found]
 
 # Emitted in post-tool output; referenced by orchestrator prompt and sous-chef SKILL.md.
 QUOTA_POST_WARNING_TRIGGER: str = "--- QUOTA WARNING ---"
 QUOTA_POST_BUDGET_EXCEEDED_TRIGGER: str = "QUOTA BUDGET EXCEEDED"
-
-
-def _read_quota_cache(cache_path_str: str, max_age: int) -> dict | None:
-    """Read quota cache file. Returns parsed data or None if missing/stale/corrupt."""
-    cache_path = Path(cache_path_str).expanduser()
-    if not cache_path.is_file():
-        return None
-    try:
-        data = json.loads(cache_path.read_text())
-        fetched = datetime.fromisoformat(data["fetched_at"])
-        age = (datetime.now(UTC) - fetched).total_seconds()
-        if age > max_age:
-            return None  # stale
-        return data
-    except (json.JSONDecodeError, KeyError, ValueError, OSError, TypeError):
-        return None
-
-
-def _resolve_quota_log_dir() -> Path | None:
-    """Resolve the autoskillit log root directory. Returns None on any error."""
-    try:
-        override = os.environ.get(_AUTOSKILLIT_LOG_DIR_ENV)
-        if override:
-            return Path(override)
-        if sys.platform == "darwin":
-            return Path.home() / "Library" / "Application Support" / "autoskillit" / "logs"
-        xdg = os.environ.get("XDG_DATA_HOME")
-        if xdg:
-            return Path(xdg) / "autoskillit" / "logs"
-        return Path.home() / ".local" / "share" / "autoskillit" / "logs"
-    except Exception as exc:
-        print(f"quota_post_hook: failed to resolve log directory: {exc}", file=sys.stderr)
-        return None
-
-
-def _write_quota_log_event(event: dict, log_dir: Path | None) -> None:
-    """Append a quota guard event to quota_events.jsonl at the log root."""
-    if log_dir is None:
-        return
-    try:
-        log_dir.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(event) + "\n"
-        with open(log_dir / "quota_events.jsonl", "a", encoding="utf-8") as f:
-            f.write(line)
-    except Exception as exc:
-        print(f"quota_post_hook: failed to write quota log event: {exc}", file=sys.stderr)
 
 
 def _extract_run_skill_result(tool_response: str | dict) -> str:
@@ -121,12 +78,12 @@ def main(*, cache_path_override: str | None = None) -> None:
         sys.exit(0)  # quota guard disabled for this session
     cache_path_str = settings.cache_path
     cache_max_age = settings.cache_max_age
-    log_dir = _resolve_quota_log_dir()
+    log_dir = resolve_quota_log_dir(caller="quota_post_hook")
     ts = datetime.now(UTC).isoformat()
 
     profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE", "").strip()
     if profile and profile.casefold() != "anthropic":
-        _write_quota_log_event(
+        write_quota_log_event(
             {
                 "ts": ts,
                 "event": "post_provider_bypass",
@@ -135,10 +92,11 @@ def main(*, cache_path_override: str | None = None) -> None:
                 "cache_path": cache_path_str,
             },
             log_dir,
+            caller="quota_post_hook",
         )
         sys.exit(0)
 
-    cache = _read_quota_cache(cache_path_str, cache_max_age)
+    cache = read_quota_cache(cache_path_str, cache_max_age)
     if cache is None:
         sys.exit(0)
 
@@ -154,7 +112,7 @@ def main(*, cache_path_override: str | None = None) -> None:
         sys.exit(0)
 
     if not should_block:
-        _write_quota_log_event(
+        write_quota_log_event(
             {
                 "ts": ts,
                 "event": "post_check_pass",
@@ -164,6 +122,7 @@ def main(*, cache_path_override: str | None = None) -> None:
                 "tool_name": tool_name,
             },
             log_dir,
+            caller="quota_post_hook",
         )
         sys.exit(0)
 
@@ -224,7 +183,7 @@ def main(*, cache_path_override: str | None = None) -> None:
             f"'Quota at {utilization:.0f}%. Sleeping {n}s before next step.'"
         )
 
-    _write_quota_log_event(
+    write_quota_log_event(
         {
             "ts": ts,
             "event": "post_check_budget_exceeded" if budget_exceeded else "post_check_warning",
@@ -238,6 +197,7 @@ def main(*, cache_path_override: str | None = None) -> None:
             "remaining_budget": remaining_budget if remaining_budget != float("inf") else None,
         },
         log_dir,
+        caller="quota_post_hook",
     )
     print(
         json.dumps(

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -82,6 +82,7 @@ _PRINT_EXEMPT = frozenset(
         "_validate.py",
         "_workspace.py",
         "branch_protection_guard.py",
+        "_hook_settings.py",
         "lint_after_edit_hook.py",
         "open_kitchen_guard.py",
         "pretty_output_hook.py",
@@ -100,6 +101,7 @@ _PRINT_EXEMPT = frozenset(
 # _onboarding.py: CLI helper with user-facing graceful degradation (fail-open UX, not a hook)
 _BROAD_EXCEPT_EXEMPT = frozenset(
     {
+        "_hook_settings.py",
         "_onboarding.py",
         "open_kitchen_guard.py",
         "pretty_output_hook.py",

--- a/tests/execution/test_quota_sleep.py
+++ b/tests/execution/test_quota_sleep.py
@@ -487,7 +487,7 @@ class TestIntegration:
         """Cache written by _write_cache must be readable and actionable by quota_guard.main().
 
         T-INT-1: Catches format drift between _write_cache (execution layer) and
-        _read_quota_cache (hook subprocess layer).
+        read_quota_cache (hook subprocess layer, _hook_settings.py).
         """
         import io
         from contextlib import redirect_stdout

--- a/tests/hooks/test_hook_settings.py
+++ b/tests/hooks/test_hook_settings.py
@@ -14,6 +14,9 @@ These tests use ``tmp_path`` and ``monkeypatch`` for isolation — no global sta
 from __future__ import annotations
 
 import json
+import pathlib
+from datetime import UTC, datetime
+from unittest.mock import patch
 
 _ENV_VARS = (
     "AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH",
@@ -212,3 +215,159 @@ def test_merged_hook_config_overlay_wins():
     assert merged["quota_guard"]["disabled"] is True
     assert merged["quota_guard"]["cache_max_age"] == 60
     assert merged["kitchen_id"] == "k1"
+
+
+
+# T-HS-10
+def test_read_quota_cache_returns_data_for_fresh_cache(tmp_path):
+    """Call read_quota_cache with a fresh cache file and assert it returns the parsed dict."""
+    from autoskillit.hooks._hook_settings import read_quota_cache
+
+    cache_file = tmp_path / "cache.json"
+    cache_file.write_text(json.dumps({"fetched_at": datetime.now(UTC).isoformat(), "binding": {}}))
+    result = read_quota_cache(str(cache_file), 300)
+    assert result is not None
+    assert "binding" in result
+
+
+# T-HS-11
+def test_read_quota_cache_returns_none_for_missing_file():
+    """Call read_quota_cache with a nonexistent path and assert it returns None."""
+    from autoskillit.hooks._hook_settings import read_quota_cache
+
+    result = read_quota_cache("/nonexistent/path.json", 300)
+    assert result is None
+
+
+# T-HS-12
+def test_read_quota_cache_returns_none_for_stale_cache(tmp_path):
+    """Cache 10 min old; read_quota_cache returns None for max_age=300."""
+    from autoskillit.hooks._hook_settings import read_quota_cache
+
+    cache_file = tmp_path / "cache.json"
+    old_time = datetime.now(UTC).timestamp() - 600  # 10 minutes ago
+    cache_file.write_text(
+        json.dumps(
+            {"fetched_at": datetime.fromtimestamp(old_time, tz=UTC).isoformat(), "binding": {}}
+        )
+    )
+    result = read_quota_cache(str(cache_file), 300)
+    assert result is None
+
+
+# T-HS-13
+def test_read_quota_cache_returns_none_for_corrupt_json(tmp_path):
+    """Write "not json" to a cache file and assert read_quota_cache returns None."""
+    from autoskillit.hooks._hook_settings import read_quota_cache
+
+    cache_file = tmp_path / "cache.json"
+    cache_file.write_text("not json")
+    result = read_quota_cache(str(cache_file), 300)
+    assert result is None
+
+
+# T-HS-14
+def test_read_quota_cache_returns_none_on_type_error(tmp_path):
+    """fetched_at: null triggers TypeError; read_quota_cache returns None."""
+    from autoskillit.hooks._hook_settings import read_quota_cache
+
+    cache_file = tmp_path / "cache.json"
+    cache_file.write_text(json.dumps({"fetched_at": None, "binding": {}}))
+    result = read_quota_cache(str(cache_file), 300)
+    assert result is None
+
+
+# T-HS-15
+def test_resolve_quota_log_dir_returns_platform_default(monkeypatch):
+    """Unset env vars; resolve_quota_log_dir returns a Path ending with autoskillit/logs."""
+    from autoskillit.hooks._hook_settings import resolve_quota_log_dir
+
+    monkeypatch.delenv("AUTOSKILLIT_LOG_DIR", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    result = resolve_quota_log_dir()
+    assert result is not None
+    assert str(result).endswith("autoskillit/logs")
+
+
+# T-HS-16
+def test_resolve_quota_log_dir_respects_env_override(monkeypatch):
+    """AUTOSKILLIT_LOG_DIR=/tmp/custom; resolve_quota_log_dir returns Path("/tmp/custom")."""
+    from autoskillit.hooks._hook_settings import resolve_quota_log_dir
+
+    monkeypatch.setenv("AUTOSKILLIT_LOG_DIR", "/tmp/custom")
+    result = resolve_quota_log_dir()
+    assert result == pathlib.Path("/tmp/custom")
+
+
+# T-HS-17
+def test_resolve_quota_log_dir_silent_when_no_caller(monkeypatch, capsys):
+    """Path.home raises; resolve_quota_log_dir() returns None, stderr empty (no caller)."""
+    from autoskillit.hooks._hook_settings import resolve_quota_log_dir
+
+    def raise_():
+        raise OSError("boom")
+
+    monkeypatch.setattr(pathlib.Path, "home", staticmethod(raise_))
+    result = resolve_quota_log_dir()
+    assert result is None
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+# T-HS-18
+def test_resolve_quota_log_dir_prints_stderr_with_caller(monkeypatch, capsys):
+    """Path.home raises; resolve_quota_log_dir(caller="test_hook") prints to stderr."""
+    from autoskillit.hooks._hook_settings import resolve_quota_log_dir
+
+    def raise_():
+        raise OSError("boom")
+
+    monkeypatch.setattr(pathlib.Path, "home", staticmethod(raise_))
+    result = resolve_quota_log_dir(caller="test_hook")
+    assert result is None
+    captured = capsys.readouterr()
+    assert "test_hook" in captured.err
+
+
+# T-HS-19
+def test_write_quota_log_event_writes_jsonl(tmp_path):
+    """write_quota_log_event writes JSON line to quota_events.jsonl."""
+    from autoskillit.hooks._hook_settings import write_quota_log_event
+
+    write_quota_log_event({"event": "test"}, tmp_path)
+    log_file = tmp_path / "quota_events.jsonl"
+    assert log_file.exists()
+    lines = log_file.read_text().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["event"] == "test"
+
+
+# T-HS-20
+def test_write_quota_log_event_noop_when_log_dir_none():
+    """Call write_quota_log_event with log_dir=None; assert no error and no output."""
+    from autoskillit.hooks._hook_settings import write_quota_log_event
+
+    # Should not raise
+    write_quota_log_event({"event": "test"}, None)
+
+
+# T-HS-21
+def test_write_quota_log_event_silent_when_no_caller(tmp_path, capsys):
+    """open raises; write_quota_log_event({}, tmp_path) stderr empty (no caller)."""
+    from autoskillit.hooks._hook_settings import write_quota_log_event
+
+    with patch("builtins.open", side_effect=OSError("disk full")):
+        write_quota_log_event({}, tmp_path)
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+# T-HS-22
+def test_write_quota_log_event_prints_stderr_with_caller(tmp_path, capsys):
+    """open raises; write_quota_log_event(..., caller="test_hook") prints to stderr."""
+    from autoskillit.hooks._hook_settings import write_quota_log_event
+
+    with patch("builtins.open", side_effect=OSError("disk full")):
+        write_quota_log_event({}, tmp_path, caller="test_hook")
+    captured = capsys.readouterr()
+    assert "test_hook" in captured.err

--- a/tests/hooks/test_hook_settings.py
+++ b/tests/hooks/test_hook_settings.py
@@ -217,7 +217,6 @@ def test_merged_hook_config_overlay_wins():
     assert merged["kitchen_id"] == "k1"
 
 
-
 # T-HS-10
 def test_read_quota_cache_returns_data_for_fresh_cache(tmp_path):
     """Call read_quota_cache with a fresh cache file and assert it returns the parsed dict."""

--- a/tests/hooks/test_quota_check.py
+++ b/tests/hooks/test_quota_check.py
@@ -578,14 +578,14 @@ def test_hook_respects_should_block_false_when_class_disabled(tmp_path):
 
 
 def test_resolve_quota_log_dir_and_resolve_log_dir_in_sync(monkeypatch):
-    """_resolve_quota_log_dir() must produce the same path as resolve_log_dir('') for
+    """resolve_quota_log_dir() must produce the same path as resolve_log_dir('') for
     identical env inputs. Guards against independent evolution of the two implementations.
 
-    Constraint: these functions MUST NOT be merged — quota_guard.py is stdlib-only
-    and self-contained. This test is the canonical drift guard.
+    Constraint: this function MUST NOT be merged with execution/session_log.resolve_log_dir —
+    _hook_settings.py is stdlib-only and self-contained. This test is the canonical drift guard.
     """
     from autoskillit.execution.session_log import resolve_log_dir
-    from autoskillit.hooks.guards.quota_guard import _resolve_quota_log_dir
+    from autoskillit.hooks._hook_settings import resolve_quota_log_dir as _resolve_quota_log_dir
 
     # Case 1: platform default (no env overrides)
     monkeypatch.delenv("AUTOSKILLIT_LOG_DIR", raising=False)
@@ -594,10 +594,10 @@ def test_resolve_quota_log_dir_and_resolve_log_dir_in_sync(monkeypatch):
     quota_path = _resolve_quota_log_dir()
     session_path = resolve_log_dir("")
 
-    assert quota_path is not None, "_resolve_quota_log_dir() must not return None"
+    assert quota_path is not None, "resolve_quota_log_dir() must not return None"
     assert quota_path == session_path, (
         f"Log dir mismatch (no env overrides):\n"
-        f"  quota_check._resolve_quota_log_dir(): {quota_path}\n"
+        f"  _hook_settings.resolve_quota_log_dir(): {quota_path}\n"
         f"  session_log.resolve_log_dir(''): {session_path}"
     )
 

--- a/tests/hooks/test_quota_post_check.py
+++ b/tests/hooks/test_quota_post_check.py
@@ -437,8 +437,8 @@ def test_qpc_cache_max_age_env_var_override(tmp_path, monkeypatch):
 def test_resolve_quota_log_dir_prints_to_stderr_on_exception(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """_resolve_quota_log_dir() bare except must print warning to stderr, not silently swallow."""
-    from autoskillit.hooks.quota_post_hook import _resolve_quota_log_dir
+    """resolve_quota_log_dir() must print to stderr when caller= is provided."""
+    from autoskillit.hooks._hook_settings import resolve_quota_log_dir
 
     def _raise() -> None:
         raise OSError("boom")
@@ -447,7 +447,7 @@ def test_resolve_quota_log_dir_prints_to_stderr_on_exception(
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     monkeypatch.setattr(pathlib.Path, "home", staticmethod(_raise))
 
-    result = _resolve_quota_log_dir()
+    result = resolve_quota_log_dir(caller="quota_post_hook")
 
     assert result is None
     captured = capsys.readouterr()
@@ -457,11 +457,11 @@ def test_resolve_quota_log_dir_prints_to_stderr_on_exception(
 def test_write_quota_log_event_prints_to_stderr_on_write_failure(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """_write_quota_log_event() bare except must print warning to stderr, not silently swallow."""
-    from autoskillit.hooks.quota_post_hook import _write_quota_log_event
+    """write_quota_log_event() must print to stderr when caller= is provided."""
+    from autoskillit.hooks._hook_settings import write_quota_log_event
 
     with patch("builtins.open", side_effect=OSError("disk full")):
-        _write_quota_log_event({}, tmp_path)
+        write_quota_log_event({}, tmp_path, caller="quota_post_hook")
 
     captured = capsys.readouterr()
     assert "quota_post_hook" in captured.err


### PR DESCRIPTION
## Summary

Move three duplicated stdlib-only functions (`_read_quota_cache`, `_resolve_quota_log_dir`, `_write_quota_log_event`) and one duplicated constant (`_AUTOSKILLIT_LOG_DIR_ENV`) from `hooks/guards/quota_guard.py` and `hooks/quota_post_hook.py` into the shared `hooks/_hook_settings.py` module. The consolidated versions adopt the defensive superset behavior: `TypeError` in the except tuple for cache reads, and a `caller` keyword parameter for stderr error reporting (preserving both the guard's silent default and the post-hook's verbose behavior). Both hook scripts become thin consumers that import from `_hook_settings` instead of defining their own copies.

Closes #2827

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-234006-464355/.autoskillit/temp/make-plan/consolidate_quota_hook_helpers_plan_2026-05-26_234500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 2.6k | 20.9k | 2.2M | 110.7k | 149 | 94.7k | 10m 23s |
| verify | claude-sonnet-4-6 | 1 | 124 | 12.3k | 848.9k | 74.2k | 42 | 58.3k | 3m 35s |
| implement* | MiniMax-M2.7-highspeed | 1 | 3.1M | 21.9k | 2.2M | 30.9k | 161 | 16.2k | 8m 46s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 77.0k | 3.3k | 185.3k | 30.9k | 20 | 43.7k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 47.1k | 1.3k | 213.2k | 30.9k | 14 | 15.4k | 42s |
| review_pr | claude-sonnet-4-6 | 1 | 190 | 26.4k | 1.1M | 85.2k | 68 | 70.0k | 6m 9s |
| resolve_review | claude-sonnet-4-6 | 1 | 159 | 9.5k | 837.0k | 56.1k | 53 | 40.7k | 6m 51s |
| **Total** | | | 3.2M | 95.5k | 7.6M | 110.7k | | 338.9k | 37m 40s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 391 | 5681.1 | 41.3 | 56.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 7 | 119570.9 | 5809.1 | 1352.4 |
| **Total** | **398** | 19174.0 | 851.4 | 240.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 2.6k | 20.9k | 2.2M | 94.7k | 10m 23s |
| claude-sonnet-4-6 | 3 | 473 | 48.2k | 2.8M | 168.9k | 16m 36s |
| MiniMax-M2.7-highspeed | 3 | 3.2M | 26.5k | 2.6M | 75.3k | 10m 39s |