### PR TITLE
[FIX] Food truck dispatch self-reaping immunity — skip_dispatch_ids in reaper

### DIFF
--- a/src/autoskillit/fleet/_dispatch_reaper.py
+++ b/src/autoskillit/fleet/_dispatch_reaper.py
@@ -48,7 +48,12 @@ def _mark_dead_pid(
         logger.info("reap: [MARKED]      %s  pid=%d  (process dead)", name, pid)
 
 
-def reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
+def reap_stale_dispatches(
+    state_path: Path,
+    *,
+    dry_run: bool = False,
+    skip_dispatch_ids: frozenset[str] | None = None,
+) -> None:
     """Reap stale RUNNING dispatches with PID-recycling-safe identity checks.
 
     Uses CampaignStateMutator (which holds _resume_lock + flock on .lock sidecar)
@@ -86,6 +91,13 @@ def reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
 
         for dispatch in running:
             name = dispatch.name
+            if skip_dispatch_ids and dispatch.dispatch_id in skip_dispatch_ids:
+                logger.info(
+                    "reap: [SKIPPED]     %s  dispatch_id=%s  (self-exclusion)",
+                    name,
+                    dispatch.dispatch_id,
+                )
+                continue
             pid = dispatch.dispatched_pid
 
             if pid == 0:
@@ -173,7 +185,16 @@ def reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                     )
 
 
-async def reap_stale_dispatches_async(state_paths: list[Path]) -> None:
+async def reap_stale_dispatches_async(
+    state_paths: list[Path],
+    *,
+    skip_dispatch_ids: frozenset[str] | None = None,
+) -> None:
+    import functools  # noqa: PLC0415
+
     loop = asyncio.get_running_loop()
     for sp in state_paths:
-        await loop.run_in_executor(None, reap_stale_dispatches, sp)
+        await loop.run_in_executor(
+            None,
+            functools.partial(reap_stale_dispatches, sp, skip_dispatch_ids=skip_dispatch_ids),
+        )

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -331,7 +331,16 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         try:
             from autoskillit.fleet import reap_stale_dispatches_async  # noqa: PLC0415
 
-            await reap_stale_dispatches_async(_campaign_state_paths)
+            _skip: frozenset[str] | None = None
+            try:
+                from autoskillit.core import DISPATCH_ID_ENV_VAR  # noqa: PLC0415
+
+                _own_dispatch_id = os.environ.get(DISPATCH_ID_ENV_VAR, "")
+                _skip = frozenset({_own_dispatch_id}) if _own_dispatch_id else None
+            except Exception:
+                logger.warning("food_truck_auto_gate_boot_self_exclusion_failed", exc_info=True)
+
+            await reap_stale_dispatches_async(_campaign_state_paths, skip_dispatch_ids=_skip)
         except Exception:
             logger.warning("food_truck_auto_gate_boot_reap_failed", exc_info=True)
 

--- a/tests/arch/test_boot_step_symmetry.py
+++ b/tests/arch/test_boot_step_symmetry.py
@@ -26,6 +26,7 @@ _REQUIRED_BOOT_STEPS: list[tuple[str, tuple[str, ...]]] = [
         "_prime_quota_cache",
         ("_fleet_auto_gate_boot", "_food_truck_auto_gate_boot", "_skill_auto_gate_boot"),
     ),
+    ("DISPATCH_ID_ENV_VAR", ("_food_truck_auto_gate_boot",)),
 ]
 
 _BOOT_STEP_ORDERING: list[tuple[str, str, tuple[str, ...]]] = [

--- a/tests/fleet/test_dispatch_reaper.py
+++ b/tests/fleet/test_dispatch_reaper.py
@@ -26,6 +26,7 @@ def _make_running_state(
     tmp_path: Path,
     *,
     dispatch_name: str = "d1",
+    dispatch_id: str = "did-reap",
     dispatched_pid: int = 12345,
     dispatched_starttime_ticks: int = 1000,
     dispatched_boot_id: str = BOOT_ID,
@@ -39,7 +40,7 @@ def _make_running_state(
     raw["dispatches"][0].update(
         {
             "status": "running",
-            "dispatch_id": "did-reap",
+            "dispatch_id": dispatch_id,
             "dispatched_pid": dispatched_pid,
             "dispatched_starttime_ticks": dispatched_starttime_ticks,
             "dispatched_boot_id": dispatched_boot_id,
@@ -51,10 +52,12 @@ def _make_running_state(
     return sp
 
 
-def _reap(state_path: Path, *, dry_run: bool = False) -> None:
+def _reap(
+    state_path: Path, *, dry_run: bool = False, skip_dispatch_ids: frozenset[str] | None = None
+) -> None:
     from autoskillit.fleet import reap_stale_dispatches
 
-    reap_stale_dispatches(state_path, dry_run=dry_run)
+    reap_stale_dispatches(state_path, dry_run=dry_run, skip_dispatch_ids=skip_dispatch_ids)
 
 
 class TestReap:
@@ -333,3 +336,81 @@ class TestReap:
         state = read_state(sp)
         assert state is not None
         assert state.dispatches[0].reason == "reaped_orphan"
+
+    def test_reap_skips_dispatch_in_skip_set(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatch_id="test-dispatch-id",
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+        )
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+            patch(
+                "autoskillit.fleet._dispatch_reaper.read_starttime_ticks",
+                return_value=1000,
+            ),
+            patch(
+                "autoskillit.fleet._dispatch_reaper.read_boot_id",
+                return_value=BOOT_ID,
+            ),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree") as mock_kill,
+        ):
+            _reap(sp, skip_dispatch_ids=frozenset({"test-dispatch-id"}))
+
+        mock_kill.assert_not_called()
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].status == DispatchStatus.RUNNING
+
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+            patch(
+                "autoskillit.fleet._dispatch_reaper.read_starttime_ticks",
+                return_value=1000,
+            ),
+            patch(
+                "autoskillit.fleet._dispatch_reaper.read_boot_id",
+                return_value=BOOT_ID,
+            ),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree") as mock_kill,
+        ):
+            _reap(sp)
+
+        mock_kill.assert_called_once_with(12345)
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].reason == "reaped_orphan"
+
+    def test_reap_self_referential_pid_survives_with_skip_guard(self, tmp_path: Path) -> None:
+        import os
+
+        sp = _make_running_state(
+            tmp_path,
+            dispatch_id="my-dispatch",
+            dispatched_pid=os.getpid(),
+            dispatched_starttime_ticks=1000,
+            dispatched_boot_id=BOOT_ID,
+        )
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.read_starttime_ticks", return_value=1000),
+            patch("autoskillit.fleet._dispatch_reaper.read_boot_id", return_value=BOOT_ID),
+        ):
+            _reap(sp, skip_dispatch_ids=frozenset({"my-dispatch"}))
+
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].status == DispatchStatus.RUNNING
+
+    @pytest.mark.anyio
+    async def test_reap_async_forwards_skip_dispatch_ids(self, tmp_path: Path) -> None:
+
+        sp = tmp_path / "state.json"
+        sp.write_text("{}")
+
+        with patch("autoskillit.fleet._dispatch_reaper.reap_stale_dispatches") as mock_reap:
+            from autoskillit.fleet import reap_stale_dispatches_async
+
+            await reap_stale_dispatches_async([sp], skip_dispatch_ids=frozenset({"skip-me"}))
+
+        mock_reap.assert_called_once_with(sp, skip_dispatch_ids=frozenset({"skip-me"}))

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -881,6 +881,98 @@ class TestFoodTruckAutoGateBoot:
             f"create_background_task labels: {sweep_call_labels}"
         )
 
+    @pytest.mark.anyio
+    async def test_food_truck_auto_gate_boot_passes_self_exclusion(
+        self, tool_ctx, monkeypatch, tmp_path
+    ) -> None:
+        """Boot handler reads AUTOSKILLIT_DISPATCH_ID and passes it as skip set to reaper."""
+        import json as _json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.core import DISPATCH_ID_ENV_VAR, FOOD_TRUCK_TOOL_TAGS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _food_truck_auto_gate_boot
+
+        dispatches_dir = tmp_path / ".autoskillit" / "temp" / "dispatches"
+        dispatches_dir.mkdir(parents=True)
+        (dispatches_dir / "campaign1.json").write_text(_json.dumps({}))
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+        tool_ctx.project_dir = tmp_path
+        tool_ctx.github_client = AsyncMock()
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core")
+        monkeypatch.setenv(DISPATCH_ID_ENV_VAR, "my-ft-dispatch")
+
+        mock_reap = AsyncMock()
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task", return_value=MagicMock()
+                ):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        with patch(
+                            "autoskillit.fleet.discover_campaign_state_files",
+                            return_value=[dispatches_dir / "campaign1.json"],
+                        ):
+                            with patch(
+                                "autoskillit.fleet.reap_stale_dispatches_async",
+                                mock_reap,
+                            ):
+                                await _food_truck_auto_gate_boot(tool_ctx)
+
+        mock_reap.assert_called_once_with(
+            [dispatches_dir / "campaign1.json"],
+            skip_dispatch_ids=frozenset({"my-ft-dispatch"}),
+        )
+
+    @pytest.mark.anyio
+    async def test_food_truck_auto_gate_boot_no_dispatch_id_passes_none(
+        self, tool_ctx, monkeypatch, tmp_path
+    ) -> None:
+        """When AUTOSKILLIT_DISPATCH_ID is unset, reaper is called with skip_dispatch_ids=None."""
+        import json as _json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.core import DISPATCH_ID_ENV_VAR, FOOD_TRUCK_TOOL_TAGS_ENV_VAR
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _food_truck_auto_gate_boot
+
+        dispatches_dir = tmp_path / ".autoskillit" / "temp" / "dispatches"
+        dispatches_dir.mkdir(parents=True)
+        (dispatches_dir / "campaign1.json").write_text(_json.dumps({}))
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+        tool_ctx.project_dir = tmp_path
+        tool_ctx.github_client = AsyncMock()
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core")
+        monkeypatch.delenv(DISPATCH_ID_ENV_VAR, raising=False)
+
+        mock_reap = AsyncMock()
+
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task", return_value=MagicMock()
+                ):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        with patch(
+                            "autoskillit.fleet.discover_campaign_state_files",
+                            return_value=[dispatches_dir / "campaign1.json"],
+                        ):
+                            with patch(
+                                "autoskillit.fleet.reap_stale_dispatches_async",
+                                mock_reap,
+                            ):
+                                await _food_truck_auto_gate_boot(tool_ctx)
+
+        mock_reap.assert_called_once_with(
+            [dispatches_dir / "campaign1.json"],
+            skip_dispatch_ids=None,
+        )
+
 
 @pytest.mark.feature("skill")
 class TestSkillAutoGateBoot:


### PR DESCRIPTION
## Summary

The dispatch reaper (`reap_stale_dispatches`) has no concept of caller identity — it will kill any RUNNING dispatch whose PID and identity checks match, including the process that invoked it. When `_food_truck_auto_gate_boot` calls the reaper during MCP server lifespan startup, the food truck discovers its own dispatch state file and kills itself (SIGTERM, exit 143). This is a 100% failure rate for all food truck dispatches since commit `86900fa2f`.

The architectural weakness is that `reap_stale_dispatches` is a "kill any confirmed orphan" function with no exclusion protocol. The caller cannot tell the reaper "I am dispatch X — skip me." This fix adds a `skip_dispatch_ids` parameter to the reaper API so callers can declare their identity, and wires `_food_truck_auto_gate_boot` to use it by reading `AUTOSKILLIT_DISPATCH_ID` from the environment.

## Requirements

### REQ-1: Eliminate self-reaping in food truck boot handler
The reaper in `_food_truck_auto_gate_boot` must not kill the food truck's own process. Implemented via **Option B**: pass the current dispatch's `dispatch_id` (from `AUTOSKILLIT_DISPATCH_ID` env var) as a `skip_dispatch_ids` parameter to the reaper, which skips any state file whose dispatch_id matches. Option B was chosen over Option A (remove reaper entirely) because Option A would require reaping to run from a different process, and over Option C (freshness guard) because Option B is deterministic.

### REQ-2: Complete Fix 15's production code (secondary)
Deferred to Part B.

### REQ-3: Add boot handler timeout
Deferred to Part B.

### REQ-4: Add integration test for food truck subprocess startup
Deferred to Part B.

## Changed Files

| File | Change |
|------|--------|
| `src/autoskillit/fleet/_dispatch_reaper.py` | Add `skip_dispatch_ids` parameter to `reap_stale_dispatches` and `reap_stale_dispatches_async`; add dispatch_id guard in the iteration loop |
| `src/autoskillit/server/_lifespan.py` | Wire `_food_truck_auto_gate_boot` to read `AUTOSPATCH_ID_ENV_VAR` from env and pass as `skip_dispatch_ids` to the reaper |
| `tests/arch/test_boot_step_symmetry.py` | Add `DISPATCH_ID_ENV_VAR` to boot step symmetry requirements for food truck handler |
| `tests/fleet/test_dispatch_reaper.py` | Add skip_dispatch_ids parameter to `_make_running_state` and `_reap` helper; add 4 new tests covering skip guard, async forwarding, self-referential PID canary, and graceful degradation |
| `tests/server/test_server_init_session_visibility.py` | Add 2 new tests covering env var passthrough and graceful degradation when env var is absent |

Closes #3139

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_food_truck_self_reap_immunity_2026-05-26_235603.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 59 | 22.8k | 1.7M | 111.8k | 196 | 113.6k | 19m 36s |
| dry_walkthrough | claude-opus-4-6 | 1 | 40 | 10.4k | 1.2M | 69.4k | 102 | 53.2k | 6m 23s |
| implement | claude-opus-4-6 | 1 | 1.4k | 11.1k | 1.3M | 92.7k | 88 | 54.9k | 8m 8s |
| prepare_pr* | MiniMax-M2.7 | 1 | 47.7k | 3.9k | 338.9k | 0 | 24 | 0 | 1m 2s |
| compose_pr* | MiniMax-M2.7 | 1 | 92.4k | 2.3k | 247.4k | 30.9k | 23 | 44.2k | 1m 17s |
| review_pr | claude-opus-4-6 | 1 | 52 | 24.5k | 710.8k | 74.1k | 37 | 60.7k | 5m 10s |
| resolve_review | claude-opus-4-6 | 1 | 43 | 11.5k | 874.1k | 66.8k | 37 | 51.2k | 4m 45s |
| **Total** | | | 141.6k | 86.5k | 6.5M | 111.8k | | 377.9k | 46m 22s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 218 | 6036.4 | 252.1 | 51.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **218** | 29698.4 | 1733.3 | 396.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 59 | 22.8k | 1.7M | 113.6k | 19m 36s |
| claude-opus-4-6 | 4 | 1.5k | 57.5k | 4.1M | 220.1k | 24m 27s |
| MiniMax-M2.7 | 2 | 140.1k | 6.2k | 586.2k | 44.2k | 2m 19s |