### PR TITLE
[FEATURE] Introduce git/gh subprocess abstraction layer for recipe/_cmd_rpc.py

### DIFF
--- a/src/autoskillit/core/CLAUDE.md
+++ b/src/autoskillit/core/CLAUDE.md
@@ -9,6 +9,7 @@ Sub-packages: types/ (see types/CLAUDE.md) and runtime/ (see runtime/CLAUDE.md).
 |------|---------|
 | `__init__.py` | Re-exports public surface |
 | `io.py` | `atomic_write`, `ensure_project_temp`, YAML helpers |
+| `_cmd_runner.py` | `CmdRunner` protocol, `default_cmd_runner`, `run_git`, `run_gh` — sync subprocess for git/gh CLI |
 | `_json.py` | Fast JSON via orjson (with stdlib fallback) — `fast_loads`, `fast_dumps` |
 | `logging.py` | Logging configuration |
 | `paths.py` | `pkg_root()`, `is_git_worktree()` |

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -1,5 +1,9 @@
 from ._claude_env import build_agent_env as build_agent_env
 from ._claude_env import build_claude_env as build_claude_env
+from ._cmd_runner import CmdRunner as CmdRunner
+from ._cmd_runner import default_cmd_runner as default_cmd_runner
+from ._cmd_runner import run_gh as run_gh
+from ._cmd_runner import run_git as run_git
 from ._install_detect import DirectUrlInfo as DirectUrlInfo
 from ._install_detect import _is_release_tag as _is_release_tag
 from ._install_detect import _is_stable_track as _is_stable_track

--- a/src/autoskillit/core/_cmd_runner.py
+++ b/src/autoskillit/core/_cmd_runner.py
@@ -1,0 +1,80 @@
+"""Sync subprocess runner for short-lived git/gh CLI commands.
+
+Lighter than SubprocessRunner (which targets managed agent sessions).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "CmdRunner",
+    "default_cmd_runner",
+    "run_gh",
+    "run_git",
+]
+
+
+@runtime_checkable
+class CmdRunner(Protocol):
+    """Sync callable for short-lived subprocess execution."""
+
+    def __call__(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | Path | None = None,
+        timeout: float | None = None,
+        check: bool = False,
+        input_data: str | None = None,
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+def default_cmd_runner(
+    cmd: list[str],
+    *,
+    cwd: str | Path | None = None,
+    timeout: float | None = None,
+    check: bool = False,
+    input_data: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+        input=input_data,
+    )
+
+
+def run_git(
+    args: list[str],
+    *,
+    cwd: str | Path,
+    timeout: float | None = None,
+    check: bool = False,
+    runner: CmdRunner = default_cmd_runner,
+) -> subprocess.CompletedProcess[str]:
+    return runner(["git", *args], cwd=cwd, timeout=timeout, check=check)
+
+
+def run_gh(
+    args: list[str],
+    *,
+    cwd: str | Path | None = None,
+    timeout: float | None = None,
+    check: bool = False,
+    input_data: str | None = None,
+    runner: CmdRunner = default_cmd_runner,
+) -> subprocess.CompletedProcess[str]:
+    return runner(
+        ["gh", *args],
+        cwd=cwd,
+        timeout=timeout,
+        check=check,
+        input_data=input_data,
+    )

--- a/src/autoskillit/recipe/_cmd_rpc_guards.py
+++ b/src/autoskillit/recipe/_cmd_rpc_guards.py
@@ -7,7 +7,7 @@ import subprocess
 from datetime import date
 from pathlib import Path
 
-from autoskillit.core import atomic_write, get_logger, is_generated_path
+from autoskillit.core import atomic_write, get_logger, is_generated_path, run_git
 
 logger = get_logger(__name__)
 
@@ -62,12 +62,7 @@ def check_dropped_healthy_loop(
 
 def main_repo_guard(clone_path: str) -> dict[str, str]:
     """Stash dirty state from the main repo before merge."""
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
-        cwd=clone_path,
-        capture_output=True,
-        text=True,
-    )
+    result = run_git(["status", "--porcelain"], cwd=clone_path)
     if result.returncode != 0:
         raise subprocess.CalledProcessError(
             result.returncode, result.args, result.stdout, result.stderr
@@ -78,13 +73,7 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
 
     # Detect and remove linked worktrees nested inside the clone.
     clone_resolved = Path(clone_path).resolve()
-    wt_list = subprocess.run(
-        ["git", "worktree", "list", "--porcelain"],
-        cwd=clone_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    wt_list = run_git(["worktree", "list", "--porcelain"], cwd=clone_path)
     if wt_list.returncode == 0:
         first = True
         for line in wt_list.stdout.splitlines():
@@ -95,27 +84,15 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
                 continue  # main worktree is always first in porcelain output
             wt_path = Path(line.split(" ", 1)[1].strip())
             if wt_path.resolve().is_relative_to(clone_resolved):
-                rm_result = subprocess.run(
-                    ["git", "worktree", "remove", "--force", str(wt_path)],
-                    cwd=clone_path,
-                    capture_output=True,
-                    text=True,
-                    check=False,
+                rm_result = run_git(
+                    ["worktree", "remove", "--force", str(wt_path)], cwd=clone_path
                 )
                 if rm_result.returncode != 0 and wt_path.exists():
                     shutil.rmtree(wt_path, ignore_errors=True)
 
-    stash_result = subprocess.run(
-        [
-            "git",
-            "stash",
-            "--include-untracked",
-            "-m",
-            "autoskillit: main_repo_guard pre-merge stash",
-        ],
+    stash_result = run_git(
+        ["stash", "--include-untracked", "-m", "autoskillit: main_repo_guard pre-merge stash"],
         cwd=clone_path,
-        capture_output=True,
-        text=True,
     )
     if stash_result.returncode != 0:
         logger.warning(
@@ -123,26 +100,14 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
             stash_result.returncode,
             stash_result.stderr.strip(),
         )
-        co = subprocess.run(
-            ["git", "checkout", "--", "."],
-            cwd=clone_path,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        co = run_git(["checkout", "--", "."], cwd=clone_path)
         if co.returncode != 0:
             logger.warning(
                 "git checkout force-clean failed (rc=%d): %s",
                 co.returncode,
                 co.stderr.strip(),
             )
-        cl = subprocess.run(
-            ["git", "clean", "-fd"],
-            cwd=clone_path,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        cl = run_git(["clean", "-fd"], cwd=clone_path)
         if cl.returncode != 0:
             logger.warning(
                 "git clean force-clean failed (rc=%d): %s",
@@ -151,13 +116,7 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
             )
         if co.returncode != 0 and cl.returncode != 0:
             return {"cleaned": "failed"}
-        verify = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=clone_path,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        verify = run_git(["status", "--porcelain"], cwd=clone_path)
         if verify.returncode == 0 and verify.stdout.strip():
             remaining = ", ".join(ln.strip() for ln in verify.stdout.splitlines() if ln.strip())[
                 :200
@@ -165,13 +124,7 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
             return {"cleaned": "failed", "remaining": remaining}
         return {"cleaned": "force"}
 
-    verify = subprocess.run(
-        ["git", "status", "--porcelain"],
-        cwd=clone_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    verify = run_git(["status", "--porcelain"], cwd=clone_path)
     if verify.returncode == 0 and verify.stdout.strip():
         remaining = ", ".join(ln.strip() for ln in verify.stdout.splitlines() if ln.strip())[:200]
         return {"cleaned": "failed", "remaining": remaining}
@@ -208,10 +161,8 @@ def commit_guard(worktree_path: str) -> dict[str, str]:
     if not files_to_add:
         return {"committed": "false"}
 
-    subprocess.run(["git", "add", "--", *files_to_add], cwd=worktree_path, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "chore: commit pending session changes"],
-        cwd=worktree_path,
-        check=True,
+    run_git(["add", "--", *files_to_add], cwd=worktree_path, check=True)
+    run_git(
+        ["commit", "-m", "chore: commit pending session changes"], cwd=worktree_path, check=True
     )
     return {"committed": "true"}

--- a/src/autoskillit/recipe/_cmd_rpc_issues.py
+++ b/src/autoskillit/recipe/_cmd_rpc_issues.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import json
 import secrets
 import shutil
-import subprocess
 import time
 from datetime import UTC, datetime
 from pathlib import Path
 
 import regex as re
 
-from autoskillit.core import atomic_write, get_logger
+from autoskillit.core import atomic_write, get_logger, run_gh
 
 logger = get_logger(__name__)
 
@@ -35,21 +34,16 @@ def refetch_issues(issue_urls: str) -> dict[str, str]:
     if not parts:
         return {"issue_numbers": ""}
     query = "{" + " ".join(parts) + "}"
-    result = subprocess.run(
+    result = run_gh(
         [
-            "gh",
             "api",
             "graphql",
             "-f",
             f"query={query}",
             "--jq",
-            (
-                '[.data[] | select(.issue != null and .issue.state == "OPEN")'
-                ' | .issue.number | tostring] | join(" ")'
-            ),
-        ],
-        capture_output=True,
-        text=True,
+            '[.data[] | select(.issue != null and .issue.state == "OPEN") '
+            '| .issue.number | tostring] | join(" ")',
+        ]
     )
     if result.returncode != 0:
         msg = f"gh graphql failed: {result.stderr}"
@@ -160,11 +154,8 @@ def _strip_ticket_body(raw: str) -> str:
 
 def _resolve_repo_identity(cwd: str) -> tuple[str, str, str]:
     """Return (owner, repo_name, repo_node_id) for the given workspace."""
-    result = subprocess.run(
-        ["gh", "repo", "view", "--json", "owner,name", "-q", '.owner.login + " " + .name'],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
+    result = run_gh(
+        ["repo", "view", "--json", "owner,name", "-q", '.owner.login + " " + .name'], cwd=cwd
     )
     if result.returncode != 0:
         msg = f"gh repo view failed: {result.stderr}"
@@ -177,12 +168,7 @@ def _resolve_repo_identity(cwd: str) -> tuple[str, str, str]:
     safe_owner = json.dumps(owner)[1:-1]
     safe_repo = json.dumps(repo_name)[1:-1]
     query = f'{{ repository(owner: "{safe_owner}", name: "{safe_repo}") {{ id }} }}'
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={query}"],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    )
+    result = run_gh(["api", "graphql", "-f", f"query={query}"], cwd=cwd)
     if result.returncode != 0:
         msg = f"gh graphql repo ID query failed: {result.stderr}"
         raise RuntimeError(msg)
@@ -204,11 +190,7 @@ def _ensure_and_resolve_labels(cwd: str, owner: str, repo_name: str) -> list[str
         ("enhancement", "a2eeef"),
     ]
     for name, color in label_defs:
-        subprocess.run(
-            ["gh", "label", "create", name, "--force", "--color", color],
-            cwd=cwd,
-            capture_output=True,
-        )
+        run_gh(["label", "create", name, "--force", "--color", color], cwd=cwd)
         time.sleep(1)
     safe_owner = json.dumps(owner)[1:-1]
     safe_repo = json.dumps(repo_name)[1:-1]
@@ -217,12 +199,7 @@ def _ensure_and_resolve_labels(cwd: str, owner: str, repo_name: str) -> list[str
         f' impl: label(name: "recipe:implementation") {{ id }}'
         f' enh: label(name: "enhancement") {{ id }} }} }}'
     )
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={query}"],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    )
+    result = run_gh(["api", "graphql", "-f", f"query={query}"], cwd=cwd)
     if result.returncode != 0:
         msg = f"gh graphql label query failed: {result.stderr}"
         raise RuntimeError(msg)
@@ -329,13 +306,7 @@ def batch_create_issues(
             + "}"
         )
         payload = json.dumps({"query": mutation, "variables": variables})
-        result = subprocess.run(
-            ["gh", "api", "graphql", "--input", "-"],
-            input=payload,
-            cwd=workspace,
-            capture_output=True,
-            text=True,
-        )
+        result = run_gh(["api", "graphql", "--input", "-"], cwd=workspace, input_data=payload)
         if result.returncode != 0:
             msg = f"gh graphql createIssue failed: {result.stderr}"
             raise RuntimeError(msg)

--- a/src/autoskillit/recipe/_cmd_rpc_merge.py
+++ b/src/autoskillit/recipe/_cmd_rpc_merge.py
@@ -3,22 +3,16 @@
 from __future__ import annotations
 
 import json
-import subprocess
 import time
 
-from autoskillit.core import get_logger
+from autoskillit.core import get_logger, run_gh, run_git
 
 logger = get_logger(__name__)
 
 
 def _detect_remote(cwd: str) -> str:
     """Detect preferred remote: upstream (non-file) or origin."""
-    result = subprocess.run(
-        ["git", "remote", "get-url", "upstream"],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    )
+    result = run_git(["remote", "get-url", "upstream"], cwd=cwd)
     if result.returncode == 0 and not result.stdout.strip().startswith("file://"):
         return "upstream"
     return "origin"
@@ -30,27 +24,13 @@ def queue_ejected_fix(
 ) -> dict[str, str]:
     """Fetch and rebase onto base branch; return clean or conflicts."""
     remote = _detect_remote(work_dir)
-    fetch = subprocess.run(
-        ["git", "fetch", remote, base_branch],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-    )
+    fetch = run_git(["fetch", remote, base_branch], cwd=work_dir)
     if fetch.returncode != 0:
         return {"status": "conflicts"}
-    rebase = subprocess.run(
-        ["git", "rebase", f"{remote}/{base_branch}"],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-    )
+    rebase = run_git(["rebase", f"{remote}/{base_branch}"], cwd=work_dir)
     if rebase.returncode == 0:
         return {"status": "clean"}
-    subprocess.run(
-        ["git", "rebase", "--abort"],
-        cwd=work_dir,
-        capture_output=True,
-    )
+    run_git(["rebase", "--abort"], cwd=work_dir)
     return {"status": "conflicts"}
 
 
@@ -80,11 +60,7 @@ def wait_for_direct_merge(
     max_polls = max_polls or "90"
     poll_interval = poll_interval or "10"
     for _ in range(int(max_polls)):
-        result = subprocess.run(
-            ["gh", "pr", "view", str(pr_number), "--json", "state", "--jq", ".state"],
-            capture_output=True,
-            text=True,
-        )
+        result = run_gh(["pr", "view", str(pr_number), "--json", "state", "--jq", ".state"])
         if result.returncode != 0:
             time.sleep(int(poll_interval))
             continue
@@ -115,31 +91,12 @@ def attempt_cheap_rebase(
 ) -> dict[str, str]:
     """Checkout ejected branch and attempt rebase."""
     remote = _detect_remote(work_dir)
-    subprocess.run(
-        ["git", "fetch", remote, ejected_pr_branch],
-        cwd=work_dir,
-        capture_output=True,
-        check=True,
-    )
-    subprocess.run(
-        ["git", "checkout", ejected_pr_branch],
-        cwd=work_dir,
-        capture_output=True,
-        check=True,
-    )
-    rebase = subprocess.run(
-        ["git", "rebase", f"{remote}/{base_branch}"],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-    )
+    run_git(["fetch", remote, ejected_pr_branch], cwd=work_dir, check=True)
+    run_git(["checkout", ejected_pr_branch], cwd=work_dir, check=True)
+    rebase = run_git(["rebase", f"{remote}/{base_branch}"], cwd=work_dir)
     if rebase.returncode == 0:
         return {"status": "clean"}
-    subprocess.run(
-        ["git", "rebase", "--abort"],
-        cwd=work_dir,
-        capture_output=True,
-    )
+    run_git(["rebase", "--abort"], cwd=work_dir)
     return {"status": "conflicts"}
 
 
@@ -152,21 +109,13 @@ def wait_for_review_pr_mergeability(
 
     max_polls = max_polls or "12"
     poll_interval = poll_interval or "15"
-    result = subprocess.run(
-        ["gh", "pr", "view", pr_url, "--json", "number", "-q", ".number"],
-        capture_output=True,
-        text=True,
-    )
+    result = run_gh(["pr", "view", pr_url, "--json", "number", "-q", ".number"])
     if result.returncode != 0:
         msg = f"failed to resolve PR number: {result.stderr}"
         raise RuntimeError(msg)
     pr_number = result.stdout.strip()
     for _ in range(int(max_polls)):
-        r = subprocess.run(
-            ["gh", "pr", "view", pr_number, "--json", "mergeable", "-q", ".mergeable"],
-            capture_output=True,
-            text=True,
-        )
+        r = run_gh(["pr", "view", pr_number, "--json", "mergeable", "-q", ".mergeable"])
         if r.returncode != 0:
             time.sleep(int(poll_interval))
             continue
@@ -184,29 +133,15 @@ def create_persistent_integration(
 ) -> dict[str, str]:
     """Create and push persistent integration branch from default branch."""
     remote = _detect_remote(work_dir)
-    result = subprocess.run(
-        ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-    )
+    result = run_git(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd=work_dir)
     default_branch = "main"
     if result.returncode == 0:
         ref = result.stdout.strip()
         default_branch = ref.replace("refs/remotes/origin/", "")
-    subprocess.run(
-        ["git", "checkout", default_branch], cwd=work_dir, check=True, capture_output=True
-    )
-    subprocess.run(["git", "pull"], cwd=work_dir, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "checkout", "-b", base_branch], cwd=work_dir, check=True, capture_output=True
-    )
-    push = subprocess.run(
-        ["git", "push", remote, base_branch],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-    )
+    run_git(["checkout", default_branch], cwd=work_dir, check=True)
+    run_git(["pull"], cwd=work_dir, check=True)
+    run_git(["checkout", "-b", base_branch], cwd=work_dir, check=True)
+    push = run_git(["push", remote, base_branch], cwd=work_dir)
     if push.returncode != 0:
         msg = f"push failed: {push.stderr}"
         raise RuntimeError(msg)
@@ -225,20 +160,13 @@ def force_push_and_wait_mergeability(
     max_polls = max_polls or "12"
     poll_interval = poll_interval or "15"
     remote = _detect_remote(work_dir)
-    push = subprocess.run(
-        ["git", "push", remote, batch_branch, "--force-with-lease"],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-    )
+    push = run_git(["push", remote, batch_branch, "--force-with-lease"], cwd=work_dir)
     if push.returncode != 0:
         msg = f"force-push failed: {push.stderr}"
         raise RuntimeError(msg)
     for _ in range(int(max_polls)):
-        r = subprocess.run(
-            ["gh", "pr", "view", str(review_pr_number), "--json", "mergeable", "-q", ".mergeable"],
-            capture_output=True,
-            text=True,
+        r = run_gh(
+            ["pr", "view", str(review_pr_number), "--json", "mergeable", "-q", ".mergeable"]
         )
         if r.returncode != 0:
             time.sleep(int(poll_interval))
@@ -283,29 +211,12 @@ def proactive_rebase_next_pr(
 ) -> dict[str, str]:
     """Fetch, checkout, and rebase next PR branch."""
     remote = _detect_remote(work_dir)
-    subprocess.run(
-        ["git", "fetch", remote, next_pr_branch],
-        cwd=work_dir,
-        capture_output=True,
-        check=True,
+    run_git(["fetch", remote, next_pr_branch], cwd=work_dir, check=True)
+    run_git(
+        ["checkout", "-B", next_pr_branch, f"{remote}/{next_pr_branch}"], cwd=work_dir, check=True
     )
-    subprocess.run(
-        ["git", "checkout", "-B", next_pr_branch, f"{remote}/{next_pr_branch}"],
-        cwd=work_dir,
-        capture_output=True,
-        check=True,
-    )
-    rebase = subprocess.run(
-        ["git", "rebase", f"{remote}/{base_branch}"],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-    )
+    rebase = run_git(["rebase", f"{remote}/{base_branch}"], cwd=work_dir)
     if rebase.returncode == 0:
         return {"status": "clean"}
-    subprocess.run(
-        ["git", "rebase", "--abort"],
-        cwd=work_dir,
-        capture_output=True,
-    )
+    run_git(["rebase", "--abort"], cwd=work_dir)
     return {"status": "conflicts"}

--- a/src/autoskillit/recipe/_cmd_rpc_merge.py
+++ b/src/autoskillit/recipe/_cmd_rpc_merge.py
@@ -166,7 +166,8 @@ def force_push_and_wait_mergeability(
         raise RuntimeError(msg)
     for _ in range(int(max_polls)):
         r = run_gh(
-            ["pr", "view", str(review_pr_number), "--json", "mergeable", "-q", ".mergeable"]
+            ["pr", "view", str(review_pr_number), "--json", "mergeable", "-q", ".mergeable"],
+            cwd=work_dir,
         )
         if r.returncode != 0:
             time.sleep(int(poll_interval))

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -164,6 +164,7 @@ _CORE_UNIVERSAL_EXCLUSIONS: dict[str, frozenset[str]] = {
 }
 
 MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
+    "_cmd_runner": frozenset({"core", "recipe"}),
     "_json": frozenset({"core", "execution", "pipeline", "recipe"}),
     "feature_flags": frozenset(
         {"core", "cli", "config", "execution", "recipe", "server", "workspace"}

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -13,6 +13,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_branch_guard.py` | Tests for core.branch_guard — protected-branch validation |
 | `test_claude_env.py` | Unit tests for build_agent_env() — IDE env scrubbing at the subprocess launch boundary |
 | `test_build_agent_env.py` | Alias contract tests for build_agent_env / build_claude_env |
+| `test_cmd_runner.py` | Tests for core/_cmd_runner.py — CmdRunner protocol, default_cmd_runner, run_git, run_gh |
 | `test_core.py` | Tests for the core/ sub-package foundation layer |
 | `test_core_terminal_table.py` | Tests for core/_terminal_table.py — the L0 shared table primitive |
 | `test_ensure_project_temp_with_config.py` | Tests for ensure_project_temp with configurable override |

--- a/tests/core/test_cmd_runner.py
+++ b/tests/core/test_cmd_runner.py
@@ -1,0 +1,127 @@
+"""Tests for core/_cmd_runner.py — CmdRunner protocol, default_cmd_runner, run_git, run_gh."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autoskillit.core import CmdRunner, default_cmd_runner, run_gh, run_git
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.medium]
+
+
+class TestDefaultCmdRunner:
+    def test_default_cmd_runner_captures_output(self) -> None:
+        result = default_cmd_runner(["echo", "hello"])
+        assert isinstance(result, subprocess.CompletedProcess)
+        assert result.returncode == 0
+        assert result.stdout == "hello\n"
+
+    def test_default_cmd_runner_check_raises(self) -> None:
+        with pytest.raises(subprocess.CalledProcessError):
+            default_cmd_runner(["false"], check=True)
+
+    def test_default_cmd_runner_timeout_passed(self) -> None:
+        with patch("autoskillit.core._cmd_runner.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+            default_cmd_runner(["echo", "test"], timeout=30.0)
+            call_kwargs = mock_run.call_args[1]
+            assert call_kwargs["timeout"] == 30.0
+
+    def test_default_cmd_runner_input_data(self) -> None:
+        result = default_cmd_runner(["cat"], input_data="hello")
+        assert result.stdout == "hello"
+
+    def test_cmd_runner_protocol_compliance(self) -> None:
+        assert isinstance(default_cmd_runner, CmdRunner)
+
+
+class TestRunGit:
+    def test_run_git_prepends_git(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        run_git(["status"], cwd="/tmp", runner=mock_runner)
+        mock_runner.assert_called_once()
+        call_args = mock_runner.call_args[0][0]
+        assert call_args == ["git", "status"]
+
+    def test_run_git_requires_cwd(self) -> None:
+        with pytest.raises(TypeError):
+            run_git(["status"])  # type: ignore[call-arg]
+
+    def test_run_git_passes_cwd(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        run_git(["status"], cwd="/tmp", runner=mock_runner)
+        assert mock_runner.call_args[1]["cwd"] == "/tmp"
+
+    def test_run_git_passes_check(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        run_git(["status"], cwd="/tmp", check=True, runner=mock_runner)
+        assert mock_runner.call_args[1]["check"] is True
+
+    def test_run_git_passes_timeout(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        run_git(["status"], cwd="/tmp", timeout=60.0, runner=mock_runner)
+        assert mock_runner.call_args[1]["timeout"] == 60.0
+
+
+class TestRunGh:
+    def test_run_gh_prepends_gh(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        run_gh(["pr", "list"], runner=mock_runner)
+        mock_runner.assert_called_once()
+        call_args = mock_runner.call_args[0][0]
+        assert call_args == ["gh", "pr", "list"]
+
+    def test_run_gh_allows_no_cwd(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        # Should not raise — cwd is optional
+        run_gh(["pr", "list"], runner=mock_runner)
+        assert mock_runner.call_args[1]["cwd"] is None
+
+    def test_run_gh_passes_cwd(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        run_gh(["pr", "list"], cwd="/tmp", runner=mock_runner)
+        assert mock_runner.call_args[1]["cwd"] == "/tmp"
+
+    def test_run_gh_passes_input_data(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        run_gh(
+            ["api", "graphql", "--input", "-"],
+            input_data="payload",
+            runner=mock_runner,
+        )
+        assert mock_runner.call_args[1]["input_data"] == "payload"
+
+    def test_run_gh_passes_check(self) -> None:
+        mock_runner = MagicMock(spec=CmdRunner)
+        mock_runner.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        run_gh(["pr", "list"], check=True, runner=mock_runner)
+        assert mock_runner.call_args[1]["check"] is True
+
+
+class TestCustomRunnerInjection:
+    def test_custom_runner_injection(self) -> None:
+        custom_runner = MagicMock(spec=CmdRunner)
+        custom_runner.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="custom"
+        )
+        result = run_git(["status"], cwd="/tmp", runner=custom_runner)
+        custom_runner.assert_called_once()
+        assert result.stdout == "custom"
+
+    def test_custom_runner_not_default(self) -> None:
+        with patch("autoskillit.core._cmd_runner.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+            # Using default runner should call subprocess.run
+            default_cmd_runner(["echo", "test"])
+            mock_run.assert_called_once()

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -166,7 +166,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 293),
     # _cmd_rpc_issues.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc_issues.py", 83),
+    ("src/autoskillit/recipe/_cmd_rpc_issues.py", 77),
 }
 
 

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -752,8 +752,9 @@ def test_wait_for_direct_merge_int_pr_number(mock_sleep, mock_run_gh):
     )
     result = wait_for_direct_merge(pr_number=42, max_polls="1", poll_interval="1")  # type: ignore[arg-type]
     assert result["state"] == "merged"
-    # Verify the gh call was made with the PR number (coerced to str by str() guard)
     assert mock_run_gh.call_count >= 1
+    call_cmd = mock_run_gh.call_args[0][0]
+    assert "42" in call_cmd
 
 
 # ─── Multi-run accumulation tests for batch_create_issues ────────────────────
@@ -934,5 +935,6 @@ def test_force_push_int_review_pr_number(mock_sleep, mock_run_git, mock_run_gh, 
             poll_interval="1",
         )
     assert result["ok"] == "true"
-    # Verify gh pr view was called (coerced to str by str() guard)
     assert mock_run_gh.call_count >= 1
+    call_cmd = mock_run_gh.call_args[0][0]
+    assert "1958" in call_cmd

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -393,16 +393,15 @@ def test_export_local_bundle(tmp_path):
 
 
 def test_refetch_issues_builds_query():
-    with patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run:
-        mock_run.return_value = subprocess.CompletedProcess(
+    with patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh:
+        mock_run_gh.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="1 2", stderr=""
         )
         result = refetch_issues(
             issue_urls="https://github.com/org/repo/issues/1,https://github.com/org/repo/issues/2"
         )
     assert result["issue_numbers"] == "1 2"
-    call_args = mock_run.call_args[0][0]
-    assert "gh" in call_args
+    call_args = mock_run_gh.call_args[0][0]
     assert "graphql" in call_args
     query_arg = next(a for a in call_args if a.startswith("query="))
     assert "org" in query_arg
@@ -464,10 +463,10 @@ def test_batch_create_issues_discovers_ticket_bodies(tmp_path):
             f"validated: true\n\n# Title {n}\n\n| col1 | col2 |\n"
         )
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect(
+        mock_run_gh.side_effect = _make_side_effect(
             issue_data=[
                 {"number": 1, "url": "https://github.com/org/repo/issues/1"},
                 {"number": 2, "url": "https://github.com/org/repo/issues/2"},
@@ -492,19 +491,19 @@ def test_batch_create_issues_strips_body_content(tmp_path):
         "**Exception note:** this is an exception.\n"
     )
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect()
+        mock_run_gh.side_effect = _make_side_effect()
         batch_create_issues(workspace=str(tmp_path))
     # Find the createIssue mutation call
     mutation_call: dict[str, object] = {}
-    for call in mock_run.call_args_list:
+    for call in mock_run_gh.call_args_list:
         args = call[0][0]
         if "--input" in args:
-            mutation_call = json.loads(call[1].get("input", "{}"))
+            mutation_call = json.loads(call[1].get("input_data", "{}"))
             break
-    assert mutation_call, "no createIssue mutation call found in mock_run calls"
+    assert mutation_call, "no createIssue mutation call found in mock_run_gh calls"
     body = mutation_call["variables"]["i0"]["body"]
     assert ".autoskillit/" not in body
     assert "| CONTESTED |" not in body
@@ -521,20 +520,20 @@ def test_batch_create_issues_extracts_h1_title(tmp_path):
         "validated: true\n\n# Audit: Missing test coverage\n\nBody content."
     )
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect()
+        mock_run_gh.side_effect = _make_side_effect()
         batch_create_issues(workspace=str(tmp_path))
     found = False
-    for call in mock_run.call_args_list:
+    for call in mock_run_gh.call_args_list:
         kwargs = call[1]
-        if kwargs.get("input"):
-            mutation_call = json.loads(kwargs["input"])
+        if kwargs.get("input_data"):
+            mutation_call = json.loads(kwargs["input_data"])
             assert mutation_call["variables"]["i0"]["title"] == "Audit: Missing test coverage"
             found = True
             break
-    assert found, "no createIssue mutation call found in mock_run calls"
+    assert found, "no createIssue mutation call found in mock_run_gh calls"
 
 
 def test_batch_create_issues_constructs_graphql_mutation(tmp_path):
@@ -543,10 +542,10 @@ def test_batch_create_issues_constructs_graphql_mutation(tmp_path):
     (va_dir / "ticket_body_tests_1_2026-01-01_120000.md").write_text("# Issue One\n\nBody one.")
     (va_dir / "ticket_body_tests_2_2026-01-01_120000.md").write_text("# Issue Two\n\nBody two.")
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect(
+        mock_run_gh.side_effect = _make_side_effect(
             issue_data=[
                 {"number": 1, "url": "https://github.com/org/repo/issues/1"},
                 {"number": 2, "url": "https://github.com/org/repo/issues/2"},
@@ -554,10 +553,10 @@ def test_batch_create_issues_constructs_graphql_mutation(tmp_path):
         )
         batch_create_issues(workspace=str(tmp_path))
     found = False
-    for call in mock_run.call_args_list:
+    for call in mock_run_gh.call_args_list:
         kwargs = call[1]
-        if kwargs.get("input"):
-            mutation_call = json.loads(kwargs["input"])
+        if kwargs.get("input_data"):
+            mutation_call = json.loads(kwargs["input_data"])
             query = mutation_call["query"]
             variables = mutation_call["variables"]
             assert "issue0: createIssue" in query
@@ -568,7 +567,7 @@ def test_batch_create_issues_constructs_graphql_mutation(tmp_path):
             assert variables["i1"]["labelIds"] == ["L_1", "L_2"]
             found = True
             break
-    assert found, "no createIssue mutation call found in mock_run calls"
+    assert found, "no createIssue mutation call found in mock_run_gh calls"
 
 
 def test_batch_create_issues_chunks_large_batches(tmp_path):
@@ -579,7 +578,7 @@ def test_batch_create_issues_chunks_large_batches(tmp_path):
             f"# Issue {n + 1}\n\nBody {n + 1}."
         )
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
 
@@ -654,12 +653,12 @@ def test_batch_create_issues_chunks_large_batches(tmp_path):
 
             return side_effect
 
-        mock_run.side_effect = side_effect_factory()
+        mock_run_gh.side_effect = side_effect_factory()
         result = batch_create_issues(workspace=str(tmp_path), chunk_size="10")
     mutation_calls = sum(
         1
-        for call in mock_run.call_args_list
-        if call[1].get("input") and "createIssue" in call[1]["input"]
+        for call in mock_run_gh.call_args_list
+        if call[1].get("input_data") and "createIssue" in call[1]["input_data"]
     )
     assert mutation_calls == 3
     assert result["issue_count"] == "25"
@@ -680,15 +679,15 @@ def test_batch_create_issues_ignores_validation_summary_file(tmp_path):
         "## Validation Summary\nAll clear."
     )
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect()
+        mock_run_gh.side_effect = _make_side_effect()
         batch_create_issues(workspace=str(tmp_path))
-    for call in mock_run.call_args_list:
+    for call in mock_run_gh.call_args_list:
         kwargs = call[1]
-        if kwargs.get("input"):
-            mutation_call = json.loads(kwargs["input"])
+        if kwargs.get("input_data"):
+            mutation_call = json.loads(kwargs["input_data"])
             body = mutation_call["variables"]["i0"]["body"]
             assert "## Validation Summary" not in body, (
                 "validation_summary content must not be appended to issue bodies"
@@ -697,7 +696,7 @@ def test_batch_create_issues_ignores_validation_summary_file(tmp_path):
                 "validation_summary content must not be appended to issue bodies"
             )
             return
-    pytest.fail("no createIssue mutation call found in mock_run calls")
+    pytest.fail("no createIssue mutation call found in mock_run_gh calls")
 
 
 def test_batch_create_issues_handles_no_tickets(tmp_path):
@@ -733,10 +732,10 @@ def test_batch_create_issues_handles_graphql_error(tmp_path):
         subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="rate limited"),
     ]
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = error_side_effect
+        mock_run_gh.side_effect = error_side_effect
         with pytest.raises(RuntimeError, match="rate limited"):
             batch_create_issues(workspace=str(tmp_path))
 
@@ -744,17 +743,17 @@ def test_batch_create_issues_handles_graphql_error(tmp_path):
 # ─── Type coercion: int pr_number for _cmd_rpc callables (Step 1c) ───────────
 
 
-@patch("autoskillit.recipe._cmd_rpc_merge.subprocess.run")
+@patch("autoskillit.recipe._cmd_rpc_merge.run_gh")
 @patch("autoskillit.recipe._cmd_rpc_merge.time.sleep")
-def test_wait_for_direct_merge_int_pr_number(mock_sleep, mock_run):
+def test_wait_for_direct_merge_int_pr_number(mock_sleep, mock_run_gh):
     """wait_for_direct_merge handles int pr_number from LLM JSON boundary."""
-    mock_run.return_value = subprocess.CompletedProcess(
+    mock_run_gh.return_value = subprocess.CompletedProcess(
         args=[], returncode=0, stdout="MERGED\n", stderr=""
     )
     result = wait_for_direct_merge(pr_number=42, max_polls="1", poll_interval="1")  # type: ignore[arg-type]
     assert result["state"] == "merged"
     # Verify the gh call was made with the PR number (coerced to str by str() guard)
-    assert mock_run.call_count >= 1
+    assert mock_run_gh.call_count >= 1
 
 
 # ─── Multi-run accumulation tests for batch_create_issues ────────────────────
@@ -779,10 +778,10 @@ def test_batch_create_issues_ignores_prior_run_files(tmp_path):
 
     # Call batch_create_issues — should return 3 issues
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect(
+        mock_run_gh.side_effect = _make_side_effect(
             issue_data=[
                 {"number": 1, "url": "https://github.com/org/repo/issues/1"},
                 {"number": 2, "url": "https://github.com/org/repo/issues/2"},
@@ -801,10 +800,10 @@ def test_batch_create_issues_ignores_prior_run_files(tmp_path):
 
     # Call batch_create_issues WITHOUT audit_run_dir — globs all 5 files
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect(
+        mock_run_gh.side_effect = _make_side_effect(
             issue_data=[
                 {"number": i, "url": f"https://github.com/org/repo/issues/{i}"}
                 for i in range(1, 6)
@@ -847,10 +846,10 @@ def test_batch_create_issues_scoped_to_audit_run_dir(tmp_path):
 
     # Call batch_create_issues scoped to run2_dir only
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect(
+        mock_run_gh.side_effect = _make_side_effect(
             issue_data=[
                 {"number": 4, "url": "https://github.com/org/repo/issues/4"},
                 {"number": 5, "url": "https://github.com/org/repo/issues/5"},
@@ -884,10 +883,10 @@ def test_batch_create_issues_audit_run_dir_only(tmp_path):
     (scoped_dir / "ticket_body_tests_1_2026-05-06_130000.md").write_text("# Active Issue\n\nBody.")
 
     with (
-        patch("autoskillit.recipe._cmd_rpc_issues.subprocess.run") as mock_run,
+        patch("autoskillit.recipe._cmd_rpc_issues.run_gh") as mock_run_gh,
         patch("autoskillit.recipe._cmd_rpc_issues.time.sleep"),
     ):
-        mock_run.side_effect = _make_side_effect(
+        mock_run_gh.side_effect = _make_side_effect(
             issue_data=[{"number": 99, "url": "https://github.com/org/repo/issues/99"}]
         )
         result = batch_create_issues(workspace=str(tmp_path), audit_run_dir=str(scoped_dir))
@@ -915,15 +914,18 @@ def _raise_os_error(*_args, **_kwargs):
     raise OSError("Permission denied")
 
 
-@patch("autoskillit.recipe._cmd_rpc_merge.subprocess.run")
+@patch("autoskillit.recipe._cmd_rpc_merge.run_gh")
+@patch("autoskillit.recipe._cmd_rpc_merge.run_git")
 @patch("autoskillit.recipe._cmd_rpc_merge.time.sleep")
-def test_force_push_int_review_pr_number(mock_sleep, mock_run, tmp_path):
+def test_force_push_int_review_pr_number(mock_sleep, mock_run_git, mock_run_gh, tmp_path):
     """force_push_and_wait_mergeability handles int review_pr_number."""
     with patch("autoskillit.recipe._cmd_rpc_merge._detect_remote", return_value="origin"):
-        mock_run.side_effect = [
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="TRUE\n", stderr=""),
-        ]
+        mock_run_git.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        mock_run_gh.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="TRUE\n", stderr=""
+        )
         result = force_push_and_wait_mergeability(
             work_dir=str(tmp_path),
             batch_branch="feat-x/42",
@@ -933,4 +935,4 @@ def test_force_push_int_review_pr_number(mock_sleep, mock_run, tmp_path):
         )
     assert result["ok"] == "true"
     # Verify gh pr view was called (coerced to str by str() guard)
-    assert mock_run.call_count >= 2
+    assert mock_run_gh.call_count >= 1

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -77,6 +77,7 @@ class TestModuleCascadeCore:
             "github_url",
             "paths",
             "_claude_env",
+            "_cmd_runner",
             "_version_snapshot",
             "claude_conventions",
             "_type_resume",


### PR DESCRIPTION
## Summary

Introduce a lightweight sync subprocess abstraction at IL-0 (`core/_cmd_runner.py`) providing `CmdRunner` protocol, `default_cmd_runner` implementation, `run_git`, and `run_gh` helper functions. Refactor all 38 direct `subprocess.run` calls across `_cmd_rpc_guards.py`, `_cmd_rpc_merge.py`, and `_cmd_rpc_issues.py` to use these helpers. One call in `commit_guard` (raw bytes mode with `surrogateescape` decoding) remains as direct `subprocess.run` since it requires `text=False`.

This addresses issue #2833 (P7-F1) and unblocks ticket group 7 (monolithic file splits).

## Requirements

(Issue #2833 had no ## Requirements section)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None

Closes #2833

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/introduce_git_gh_subprocess_abstraction_plan_2026-05-26_234500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.0k | 28.9k | 2.0M | 149.0k | 206 | 134.1k | 16m 52s |
| review | claude-sonnet-4-6 | 1 | 52 | 5.2k | 184.0k | 46.0k | 57 | 30.0k | 3m 43s |
| verify | claude-sonnet-4-6 | 1 | 118 | 17.2k | 799.0k | 77.7k | 77 | 87.9k | 6m 48s |
| implement* | MiniMax-M2.7-highspeed | 1 | 4.1M | 27.5k | 2.0M | 30.9k | 167 | 16.2k | 10m 23s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 92.6k | 3.3k | 213.4k | 30.9k | 19 | 15.7k | 1m 13s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 38.0k | 1.4k | 182.5k | 30.9k | 13 | 15.4k | 45s |
| review_pr | claude-sonnet-4-6 | 1 | 1.1k | 39.5k | 1.2M | 102.8k | 70 | 88.2k | 9m 45s |
| resolve_review | claude-sonnet-4-6 | 1 | 225 | 19.2k | 1.7M | 83.6k | 82 | 68.6k | 10m 39s |
| **Total** | | | 4.2M | 142.2k | 8.3M | 149.0k | | 456.1k | 1h 0m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 592 | 3387.5 | 27.4 | 46.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 188619.0 | 7625.2 | 2130.9 |
| **Total** | **601** | 13828.0 | 758.9 | 236.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 5 | 5.5k | 109.9k | 5.9M | 408.8k | 47m 49s |
| MiniMax-M2.7-highspeed | 3 | 4.2M | 32.2k | 2.4M | 47.3k | 12m 20s |