### PR TITLE
Add IssueSidecarEntry.from_dict factory

### DIFF
--- a/src/autoskillit/fleet/sidecar.py
+++ b/src/autoskillit/fleet/sidecar.py
@@ -26,6 +26,16 @@ class IssueSidecarEntry:
     pr_url: str | None = None
     reason: str | None = None
 
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> IssueSidecarEntry:
+        return cls(
+            issue_url=data["issue_url"],  # type: ignore[arg-type]
+            status=data["status"],  # type: ignore[arg-type]
+            ts=data.get("ts", ""),  # type: ignore[arg-type]
+            pr_url=data.get("pr_url"),  # type: ignore[arg-type]
+            reason=data.get("reason"),  # type: ignore[arg-type]
+        )
+
 
 class SidecarReadResult(NamedTuple):
     entries: list[IssueSidecarEntry]
@@ -55,15 +65,7 @@ def read_sidecar(dispatch_id: str, project_dir: Path) -> list[IssueSidecarEntry]
             continue
         try:
             data = json.loads(line)
-            entries.append(
-                IssueSidecarEntry(
-                    issue_url=data["issue_url"],
-                    status=data["status"],
-                    ts=data.get("ts", ""),
-                    pr_url=data.get("pr_url"),
-                    reason=data.get("reason"),
-                )
-            )
+            entries.append(IssueSidecarEntry.from_dict(data))
         except (json.JSONDecodeError, KeyError) as exc:
             logger.debug("sidecar: skipping corrupt JSONL line", path=str(path), error=str(exc))
             continue
@@ -91,15 +93,7 @@ def read_sidecar_from_path(path: Path) -> SidecarReadResult:
             continue
         try:
             data = json.loads(line)
-            entries.append(
-                IssueSidecarEntry(
-                    issue_url=data["issue_url"],
-                    status=data["status"],
-                    ts=data.get("ts", ""),
-                    pr_url=data.get("pr_url"),
-                    reason=data.get("reason"),
-                )
-            )
+            entries.append(IssueSidecarEntry.from_dict(data))
         except (json.JSONDecodeError, KeyError) as exc:
             logger.debug("sidecar: skipping corrupt JSONL line", path=str(path), error=str(exc))
             continue

--- a/src/autoskillit/fleet/sidecar.py
+++ b/src/autoskillit/fleet/sidecar.py
@@ -28,12 +28,21 @@ class IssueSidecarEntry:
 
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> IssueSidecarEntry:
+        issue_url = data["issue_url"]
+        if not isinstance(issue_url, str):
+            raise TypeError(f"issue_url must be str, got {type(issue_url).__name__!r}")
+        status = data["status"]
+        if not isinstance(status, str):
+            raise TypeError(f"status must be str, got {type(status).__name__!r}")
+        ts_raw = data.get("ts")
+        pr_url_raw = data.get("pr_url")
+        reason_raw = data.get("reason")
         return cls(
-            issue_url=data["issue_url"],  # type: ignore[arg-type]
-            status=data["status"],  # type: ignore[arg-type]
-            ts=data.get("ts", ""),  # type: ignore[arg-type]
-            pr_url=data.get("pr_url"),  # type: ignore[arg-type]
-            reason=data.get("reason"),  # type: ignore[arg-type]
+            issue_url=issue_url,
+            status=status,  # type: ignore[arg-type]
+            ts=str(ts_raw) if ts_raw is not None else "",
+            pr_url=str(pr_url_raw) if pr_url_raw is not None else None,
+            reason=str(reason_raw) if reason_raw is not None else None,
         )
 
 

--- a/tests/fleet/test_sidecar.py
+++ b/tests/fleet/test_sidecar.py
@@ -74,6 +74,14 @@ class TestIssueSidecarEntryFromDict:
         entry = IssueSidecarEntry.from_dict(data)
         assert entry.issue_url == URL1
 
+    def test_from_dict_non_string_issue_url_raises(self) -> None:
+        with pytest.raises(TypeError, match="issue_url must be str"):
+            IssueSidecarEntry.from_dict({"issue_url": 123, "status": "completed", "ts": TS})
+
+    def test_from_dict_non_string_status_raises(self) -> None:
+        with pytest.raises(TypeError, match="status must be str"):
+            IssueSidecarEntry.from_dict({"issue_url": URL1, "status": 42, "ts": TS})
+
 
 class TestAppendSidecarEntry:
     def test_creates_file_on_first_append(self, tmp_path: Path) -> None:

--- a/tests/fleet/test_sidecar.py
+++ b/tests/fleet/test_sidecar.py
@@ -35,6 +35,46 @@ class TestSidecarPath:
         assert p.parent.name == "dispatches"
 
 
+class TestIssueSidecarEntryFromDict:
+    def test_from_dict_required_fields(self) -> None:
+        data = {"issue_url": URL1, "status": "completed", "ts": TS}
+        entry = IssueSidecarEntry.from_dict(data)
+        assert entry.issue_url == URL1
+        assert entry.status == "completed"
+        assert entry.ts == TS
+        assert entry.pr_url is None
+        assert entry.reason is None
+
+    def test_from_dict_all_fields(self) -> None:
+        data = {
+            "issue_url": URL1,
+            "status": "failed",
+            "ts": TS,
+            "pr_url": "https://github.com/org/repo/pull/200",
+            "reason": "tests failed",
+        }
+        entry = IssueSidecarEntry.from_dict(data)
+        assert entry.issue_url == URL1
+        assert entry.status == "failed"
+        assert entry.ts == TS
+        assert entry.pr_url == "https://github.com/org/repo/pull/200"
+        assert entry.reason == "tests failed"
+
+    def test_from_dict_missing_ts_defaults_empty(self) -> None:
+        data = {"issue_url": URL1, "status": "completed"}
+        entry = IssueSidecarEntry.from_dict(data)
+        assert entry.ts == ""
+
+    def test_from_dict_missing_required_raises(self) -> None:
+        with pytest.raises(KeyError):
+            IssueSidecarEntry.from_dict({"status": "completed", "ts": TS})
+
+    def test_from_dict_ignores_extra_keys(self) -> None:
+        data = {"issue_url": URL1, "status": "completed", "ts": TS, "extra": "ignored"}
+        entry = IssueSidecarEntry.from_dict(data)
+        assert entry.issue_url == URL1
+
+
 class TestAppendSidecarEntry:
     def test_creates_file_on_first_append(self, tmp_path: Path) -> None:
         entry = IssueSidecarEntry(issue_url=URL1, status="completed", ts=TS)


### PR DESCRIPTION
## Summary

Add a `from_dict` classmethod to `IssueSidecarEntry` that encapsulates the dict-to-dataclass construction logic currently duplicated in `read_sidecar` (lines 58–65) and `read_sidecar_from_path` (lines 94–101). Both call sites will be replaced with a single `IssueSidecarEntry.from_dict(data)` call, eliminating the duplication identified in P9-F6.

Closes #2834

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260526-233714-771714/.autoskillit/temp/make-plan/add_issuesidecarentry_from_dict_factory_plan_2026-05-26_234600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 58 | 4.9k | 542.0k | 55.9k | 38 | 42.3k | 2m 45s |
| verify | claude-sonnet-4-6 | 1 | 100 | 8.3k | 508.6k | 53.1k | 31 | 37.2k | 2m 25s |
| implement* | MiniMax-M2.7-highspeed | 1 | 467.2k | 6.5k | 738.6k | 30.9k | 62 | 16.2k | 3m 5s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 71.7k | 3.2k | 244.2k | 30.9k | 21 | 15.6k | 1m 16s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 55.4k | 1.4k | 244.2k | 30.9k | 16 | 15.4k | 47s |
| review_pr | claude-sonnet-4-6 | 1 | 148 | 29.0k | 756.5k | 68.7k | 53 | 53.2k | 6m 17s |
| resolve_review | claude-sonnet-4-6 | 1 | 165 | 13.9k | 1.0M | 74.9k | 76 | 59.6k | 6m 57s |
| **Total** | | | 594.8k | 67.2k | 4.1M | 74.9k | | 239.5k | 23m 34s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 70 | 10550.8 | 231.1 | 93.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 27 | 37862.9 | 2208.4 | 515.8 |
| **Total** | **97** | 41818.1 | 2469.1 | 693.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 58 | 4.9k | 542.0k | 42.3k | 2m 45s |
| claude-sonnet-4-6 | 3 | 413 | 51.2k | 2.3M | 150.0k | 15m 41s |
| MiniMax-M2.7-highspeed | 3 | 594.3k | 11.1k | 1.2M | 47.2k | 5m 8s |