### PR TITLE
Eliminate Small In-Module and Cross-Module Duplication + Dependency Housekeeping

### DIFF
--- a/src/autoskillit/execution/backends/_claude_prompt.py
+++ b/src/autoskillit/execution/backends/_claude_prompt.py
@@ -16,13 +16,6 @@ from autoskillit.core import (
 )
 
 
-def _marker_is_standalone(text: str, marker: str) -> bool:
-    for text_line in text.splitlines():
-        if text_line.strip() == marker:
-            return True
-    return False
-
-
 def _extract_write_artifacts(tool_uses: list[dict[str, Any]]) -> list[str]:
     return [
         t.get("file_path", "")

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -51,8 +51,8 @@ from autoskillit.execution.backends._claude_prompt import (
     _inject_completion_reminder,
     _inject_cwd_anchor,
     _inject_narration_suppression,
-    _marker_is_standalone,
 )
+from autoskillit.execution.process import _marker_is_standalone
 from autoskillit.execution.session import parse_session_result
 
 __all__ = [

--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -27,7 +27,7 @@ Sub-package: rules/ (see rules/CLAUDE.md).
 | `_recipe_composition.py` | `_build_active_recipe` + sub-recipe merging |
 | `_rule_helpers.py` | Shared helper utilities for recipe semantic rules |
 | `diagrams.py` | Flow diagram generation + staleness detection |
-| `_registry_utils.py` | `dir_mtime` — shared mtime helper for registry loaders |
+| `_registry_utils.py` | `dir_mtime`, `parse_int_field` — shared helpers for registry loaders |
 | `experiment_type_registry.py` | `ExperimentTypeSpec`, `load_all_experiment_types`, `is_silent_type` |
 | `methodology_tradition_registry.py` | `MethodologyTraditionSpec`, `VenueAppendixDef`, `load_all_methodology_traditions`, `get_methodology_tradition_by_name`, `is_out_of_scope_tradition` |
 | `methodology_venue_appendix.py` | `AlternateParentDef`, `MLSubAreaFoldingDef`, `VenueAppendixMatch`, `load_ml_sub_area_folding`, `resolve_venue_appendices` — Stage B venue-appendix resolution |

--- a/src/autoskillit/recipe/_registry_utils.py
+++ b/src/autoskillit/recipe/_registry_utils.py
@@ -13,3 +13,17 @@ def dir_mtime(path: Path) -> float:
         return path.stat().st_mtime
     except OSError:
         return _MISSING_MTIME
+
+
+def parse_int_field(
+    data: dict, field_name: str, default: int, source_path: Path, kind: str
+) -> int:
+    """Parse an integer field from a registry YAML dict, with a descriptive error."""
+    val = data.get(field_name, default)
+    try:
+        return int(val)
+    except (ValueError, TypeError) as e:
+        name = data.get("name", "?")
+        raise TypeError(
+            f"{kind} '{name}' field '{field_name}' must be an integer: {source_path}"
+        ) from e

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
-from autoskillit.recipe._registry_utils import _MISSING_MTIME, dir_mtime
+from autoskillit.recipe._registry_utils import _MISSING_MTIME, dir_mtime, parse_int_field
 
 logger = get_logger(__name__)
 
@@ -28,17 +28,6 @@ class ExperimentTypeSpec:
     priority: int = 999
     is_fallback: bool = False
     dimension_weight_rationale: dict[str, str] = field(default_factory=dict)
-
-
-def _parse_int_field(data: dict, field: str, default: int, source_path: Path) -> int:
-    val = data.get(field, default)
-    try:
-        return int(val)
-    except (ValueError, TypeError) as e:
-        name = data.get("name", "?")
-        raise TypeError(
-            f"Experiment type '{name}' field '{field}' must be an integer: {source_path}"
-        ) from e
 
 
 def _parse_bool_field(data: dict, field: str, default: bool, source_path: Path) -> bool:
@@ -75,7 +64,7 @@ def _parse_experiment_type(data: dict, source_path: Path) -> ExperimentTypeSpec:
         red_team_focus=dict(data.get("red_team_focus", {})),
         l1_severity=dict(data.get("l1_severity", {})),
         schema_version=str(data.get("schema_version", "")),
-        priority=_parse_int_field(data, "priority", 999, source_path),
+        priority=parse_int_field(data, "priority", 999, source_path, "Experiment type"),
         is_fallback=_parse_bool_field(data, "is_fallback", False, source_path),
         dimension_weight_rationale=dict(data.get("dimension_weight_rationale", {})),
     )

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
-from autoskillit.recipe._registry_utils import _MISSING_MTIME, dir_mtime
+from autoskillit.recipe._registry_utils import _MISSING_MTIME, dir_mtime, parse_int_field
 
 logger = get_logger(__name__)
 
@@ -38,18 +38,6 @@ class MethodologyTraditionSpec:
     schema_version: str = ""
     priority: int = 999
     venue_specific_appendices: tuple[VenueAppendixDef, ...] = field(default_factory=tuple)
-
-
-def _parse_int_field(data: dict, field_name: str, default: int, source_path: Path) -> int:
-    val = data.get(field_name, default)
-    try:
-        return int(val)
-    except (ValueError, TypeError) as e:
-        name = data.get("name", "?")
-        raise TypeError(
-            f"Methodology tradition '{name}' field '{field_name}' must be an integer:"
-            f" {source_path}"
-        ) from e
 
 
 def _parse_methodology_tradition(data: dict, source_path: Path) -> MethodologyTraditionSpec:
@@ -100,7 +88,7 @@ def _parse_methodology_tradition(data: dict, source_path: Path) -> MethodologyTr
         ),
         anti_patterns=_coerce_dict_list("anti_patterns", data.get("anti_patterns", [])),
         schema_version=str(data.get("schema_version", "")),
-        priority=_parse_int_field(data, "priority", 999, source_path),
+        priority=parse_int_field(data, "priority", 999, source_path, "Methodology tradition"),
         venue_specific_appendices=_parse_venue_appendices(data, source_path),
     )
 

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -86,6 +86,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_remediation_depth_ingredient.py` | Tests for remediation depth ingredient configuration |
 | `test_remediation_pr_decomposition.py` | Tests for remediation PR decomposition recipe |
 | `test_remediation_recipe.py` | Tests for the remediation recipe structure |
+| `test_registry_utils.py` | Tests for `parse_int_field` shared registry utility |
 | `test_research_campaign.py` | Contract card assertions for the research-campaign recipe |
 | `test_repository.py` | Tests for DefaultRecipeRepository |
 | `test_research_archive_recipe.py` | Tests for research-archive sub-recipe structure |

--- a/tests/recipe/test_registry_utils.py
+++ b/tests/recipe/test_registry_utils.py
@@ -35,7 +35,7 @@ def test_parse_int_field_raises_on_non_numeric() -> None:
 
 
 def test_parse_int_field_raises_on_none_value() -> None:
-    with pytest.raises(TypeError, match="Widget.*priority.*must be an integer"):
+    with pytest.raises(TypeError, match=r"Widget.*'\?'.*priority.*must be an integer"):
         parse_int_field({"priority": None}, "priority", 999, Path("test.yaml"), "Widget")
 
 

--- a/tests/recipe/test_registry_utils.py
+++ b/tests/recipe/test_registry_utils.py
@@ -1,0 +1,59 @@
+"""Tests for recipe/_registry_utils shared utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.recipe._registry_utils import parse_int_field
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_parse_int_field_returns_int_from_string() -> None:
+    assert parse_int_field({"priority": "5"}, "priority", 999, Path("test.yaml"), "Widget") == 5
+
+
+def test_parse_int_field_returns_int_from_int() -> None:
+    assert parse_int_field({"priority": 3}, "priority", 999, Path("test.yaml"), "Widget") == 3
+
+
+def test_parse_int_field_returns_default_when_missing() -> None:
+    assert parse_int_field({}, "priority", 999, Path("test.yaml"), "Widget") == 999
+
+
+def test_parse_int_field_raises_on_non_numeric() -> None:
+    with pytest.raises(TypeError, match="Widget.*'abc_thing'.*priority.*must be an integer"):
+        parse_int_field(
+            {"name": "abc_thing", "priority": "not_a_number"},
+            "priority",
+            999,
+            Path("test.yaml"),
+            "Widget",
+        )
+
+
+def test_parse_int_field_raises_on_none_value() -> None:
+    with pytest.raises(TypeError, match="Widget.*priority.*must be an integer"):
+        parse_int_field({"priority": None}, "priority", 999, Path("test.yaml"), "Widget")
+
+
+def test_parse_int_field_error_includes_entity_kind() -> None:
+    with pytest.raises(TypeError, match="Experiment type"):
+        parse_int_field(
+            {"name": "bench", "priority": "bad"},
+            "priority",
+            0,
+            Path("x.yaml"),
+            "Experiment type",
+        )
+
+    with pytest.raises(TypeError, match="Methodology tradition"):
+        parse_int_field(
+            {"name": "ctrl", "priority": "bad"},
+            "priority",
+            0,
+            Path("x.yaml"),
+            "Methodology tradition",
+        )


### PR DESCRIPTION
## Summary

Consolidate three duplicated utility functions across two packages and upgrade a pinned dependency:

1. **P6-F5** — Delete the duplicate `_marker_is_standalone` from `execution/backends/_claude_prompt.py` and import the canonical version from `execution.process` into `claude.py`.
2. **P5-F5 / P6-F6** — Extract the duplicated `_parse_int_field` from both `recipe/experiment_type_registry.py` and `recipe/methodology_tradition_registry.py` into the existing `recipe/_registry_utils.py`, parameterizing the error message entity kind.
3. **P11-F3** — Upgrade the pinned `dynaconf` dependency from the floor version (3.2.13) via `uv lock --upgrade-package dynaconf`.

Note: P5-F5 in the issue references `config/settings.py` but that file contains no `_parse_int_config` or `_parse_int_field`. The actual duplication is in the recipe registries — this is the same finding as P6-F6.

Closes #2831

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/eliminate_duplication_plan_2026-05-26_235000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 85 | 13.0k | 1.3M | 97.8k | 180 | 81.7k | 8m 56s |
| verify | claude-sonnet-4-6 | 1 | 108 | 8.8k | 682.7k | 73.2k | 39 | 57.2k | 2m 54s |
| implement* | MiniMax-M2.7-highspeed | 1 | 2.3M | 14.0k | 1.8M | 30.9k | 118 | 16.2k | 5m 53s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 122.0k | 4.0k | 336.9k | 30.9k | 29 | 15.7k | 1m 37s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 74.8k | 1.6k | 306.0k | 30.9k | 20 | 15.4k | 51s |
| review_pr | claude-sonnet-4-6 | 1 | 102 | 23.6k | 466.2k | 64.8k | 41 | 53.2k | 5m 12s |
| resolve_review | claude-sonnet-4-6 | 1 | 253 | 15.6k | 1.7M | 71.0k | 85 | 55.3k | 9m 40s |
| **Total** | | | 2.5M | 80.6k | 6.6M | 97.8k | | 294.7k | 35m 5s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 116 | 15154.2 | 139.4 | 120.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 866721.0 | 27640.5 | 7805.0 |
| **Total** | **118** | 55589.8 | 2497.3 | 682.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 548 | 61.0k | 4.2M | 247.4k | 26m 43s |
| MiniMax-M2.7-highspeed | 3 | 2.5M | 19.6k | 2.4M | 47.3k | 8m 22s |