### PR TITLE
Delete ghost `franchise/` directory artifact

### DIFF
--- a/tests/fleet/test_fleet_rename_integrity.py
+++ b/tests/fleet/test_fleet_rename_integrity.py
@@ -110,7 +110,6 @@ def test_tool_context_fleet_lock_field() -> None:
 
 
 def test_franchise_source_directory_gone() -> None:
-    """src/autoskillit/franchise/ must not contain any Python source files."""
     from autoskillit.core.paths import pkg_root
 
     franchise_dir = pkg_root() / "franchise"

--- a/tests/fleet/test_fleet_rename_integrity.py
+++ b/tests/fleet/test_fleet_rename_integrity.py
@@ -107,3 +107,17 @@ def test_tool_context_fleet_lock_field() -> None:
     field_names = {f.name for f in fields(ToolContext)}
     assert "fleet_lock" in field_names
     assert "franchise_lock" not in field_names
+
+
+def test_franchise_source_directory_gone() -> None:
+    """src/autoskillit/franchise/ must not contain any Python source files."""
+    from autoskillit.core.paths import pkg_root
+
+    franchise_dir = pkg_root() / "franchise"
+    if not franchise_dir.exists():
+        return
+    py_files = list(franchise_dir.rglob("*.py"))
+    assert not py_files, (
+        f"Ghost franchise/ directory contains Python files: "
+        f"{[str(p.relative_to(franchise_dir)) for p in py_files]}"
+    )


### PR DESCRIPTION
## Summary

The `src/autoskillit/franchise/` directory is a filesystem ghost — source files were removed in commit `805418358` (franchise → fleet rename) but `__pycache__/` with stale `.pyc` files can persist on machines that checked out the old code. Git already has no tracked files under this path (confirmed via `git ls-tree`), and `.gitignore` already excludes `__pycache__/` and `*.pyc`. The fix adds a structural guard test that prevents the directory from ever being re-introduced with tracked content, completing the rename integrity contract alongside the existing tests in `test_fleet_rename_integrity.py`.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Architecture Impact

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-2826-20260527-073239-449930/.autoskillit/temp/make-plan/delete_ghost_franchise_directory_plan_2026-05-27_073600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 71 | 7.5k | 1.1M | 58.1k | 56 | 60.3k | 3m 2s |
| verify | claude-sonnet-4-6 | 1 | 108 | 6.5k | 476.9k | 46.7k | 36 | 46.8k | 2m 4s |
| implement* | MiniMax-M2.7-highspeed | 1 | 308.4k | 3.7k | 679.0k | 30.9k | 48 | 44.1k | 5m 51s |
| audit_impl | claude-sonnet-4-6 | 1 | 68 | 3.5k | 235.0k | 34.5k | 21 | 25.9k | 1m 13s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 69.0k | 2.4k | 280.3k | 36.3k | 22 | 21.4k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 44.0k | 1.1k | 213.2k | 30.9k | 15 | 15.4k | 40s |
| review_pr | claude-sonnet-4-6 | 1 | 140 | 17.9k | 665.2k | 52.0k | 48 | 40.2k | 4m 57s |
| resolve_review | claude-sonnet-4-6 | 1 | 175 | 10.3k | 964.4k | 57.1k | 45 | 41.6k | 4m 23s |
| **Total** | | | 422.0k | 53.0k | 4.6M | 58.1k | | 295.7k | 23m 24s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 14 | 48502.1 | 3151.7 | 261.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 964408.0 | 41566.0 | 10329.0 |
| **Total** | **15** | 305653.7 | 19713.1 | 3533.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 71 | 7.5k | 1.1M | 60.3k | 3m 2s |
| claude-sonnet-4-6 | 4 | 491 | 38.3k | 2.3M | 154.5k | 12m 39s |
| MiniMax-M2.7-highspeed | 3 | 421.4k | 7.1k | 1.2M | 80.9k | 7m 41s |