### PR TITLE
[FIX] Rectify: Write Guard Source-Edit Blocks & Push-Without-Rebase Immunity

### DIFF
--- a/src/autoskillit/hooks/guards/review_loop_gate.py
+++ b/src/autoskillit/hooks/guards/review_loop_gate.py
@@ -16,7 +16,8 @@ _DENY_REASON = (
     "pr_number, cwd, current_iteration, max_iterations, and "
     "previous_verdict parameters BEFORE proceeding to "
     "wait_for_ci/enqueue_pr. "
-    "Recipe routing: re_push_review → on_success: check_review_loop."
+    "Recipe routing: resolve_review → pre_review_rebase → "
+    "re_push_review → on_success: check_review_loop."
 )
 
 _STATE_FILE_RELPATH = (".autoskillit", "temp", "review_gate_state.json")

--- a/src/autoskillit/recipe/_rule_helpers.py
+++ b/src/autoskillit/recipe/_rule_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -15,6 +16,9 @@ if TYPE_CHECKING:
     from autoskillit.recipe.schema import CampaignDispatch, Recipe
 
 logger = get_logger(__name__)
+
+# Maximum hops for BFS push-reachability checks.
+_MAX_HOPS = 6
 
 # Trigger regex: matches multiple sentinel-indicating phrases
 _SENTINEL_TRIGGER_RE = re.compile(
@@ -133,3 +137,30 @@ def _is_loop_guard_step(step_name: str, ctx: ValidationContext) -> bool:
         return False
     callable_str = step.with_args.get("callable", "")
     return callable_str == "autoskillit.smoke_utils.check_loop_iteration"
+
+
+def push_reachable(
+    graph: dict[str, set[str]],
+    start: str,
+    recipe: Recipe,
+    max_hops: int = _MAX_HOPS,
+) -> tuple[bool, str | None]:
+    """Return (reachable, push_step_name) if push_to_remote is reachable within max_hops.
+
+    Returns (False, None) if no push_to_remote step is reachable.
+    """
+    visited: set[str] = set()
+    queue: deque[tuple[str, int]] = deque([(start, 0)])
+    while queue:
+        name, hops = queue.popleft()
+        if name in visited:
+            continue
+        if hops > max_hops:
+            continue
+        visited.add(name)
+        step = recipe.steps.get(name)
+        if step is not None and step.tool == "push_to_remote":
+            return True, name
+        for succ in graph.get(name, set()):
+            queue.append((succ, hops + 1))
+    return False, None

--- a/src/autoskillit/recipe/rules/rules_contracts.py
+++ b/src/autoskillit/recipe/rules/rules_contracts.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import regex as re
 
-from autoskillit.core import Severity, get_logger, pkg_root
+from autoskillit.core import SKILL_TOOLS, Severity, get_logger, pkg_root
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._rule_helpers import push_reachable
 from autoskillit.recipe.contracts import (
     get_skill_contract,
     load_bundled_manifest,
@@ -595,5 +596,62 @@ def _check_path_output_recovery_coverage(ctx: ValidationContext) -> list[RuleFin
                         ),
                     )
                 )
+
+    return findings
+
+
+@semantic_rule(
+    name="write-skill-requires-source-output-dir",
+    description=(
+        "run_skill steps with write_behavior != readonly that can reach push_to_remote "
+        "must declare output_dir. Without it, the write guard defaults to a temp-dir "
+        "prefix that blocks source-file edits."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_write_skill_requires_source_output_dir(ctx: ValidationContext) -> list[RuleFinding]:
+    """Fire when a write-behavior skill step can reach push_to_remote without output_dir."""
+    try:
+        manifest = load_bundled_manifest()
+    except Exception:
+        logger.warning(
+            "write-skill-requires-source-output-dir: failed to load manifest; skipping",
+            exc_info=True,
+        )
+        return []
+
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool not in SKILL_TOOLS:
+            continue
+        skill_cmd = (step.with_args or {}).get("skill_command", "")
+        name = resolve_skill_name(skill_cmd)
+        if not name:
+            continue
+        contract = get_skill_contract(name, manifest)
+        if contract is None:
+            continue
+        if contract.write_behavior not in ("always", "conditional") or contract.read_only:
+            continue
+        reachable, push_step = push_reachable(ctx.step_graph, step_name, ctx.recipe)
+        if not reachable:
+            continue
+        if "output_dir" not in (step.with_args or {}):
+            findings.append(
+                RuleFinding(
+                    rule="write-skill-requires-source-output-dir",
+                    step_name=step_name,
+                    severity=Severity.ERROR,
+                    message=(
+                        f"Step '{step_name}' invokes skill '{name}' "
+                        f"(write_behavior={contract.write_behavior!r}) and can reach "
+                        f"push step '{push_step}', but declares no output_dir. "
+                        f"The write guard defaults to a temp-dir prefix that blocks "
+                        f"source-file edits. Add output_dir: ${{{{ context.work_dir }}}} "
+                        f"(or equivalent) to this step."
+                    ),
+                )
+            )
 
     return findings

--- a/src/autoskillit/recipe/rules/rules_fixing.py
+++ b/src/autoskillit/recipe/rules/rules_fixing.py
@@ -13,19 +13,15 @@ Modelled on the rebase-then-push-requires-force rule in rules_tools.py.
 
 from __future__ import annotations
 
-from collections import deque
-
 import regex as re
 
 from autoskillit.core import SKILL_TOOLS, Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._rule_helpers import push_reachable
 from autoskillit.recipe.contracts import load_bundled_manifest, resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
-
-# Maximum hops to walk forward from a conditional-write step when looking for push.
-_MAX_HOPS = 6
 
 # Regex to find result.<field> references in a when: expression.
 _RESULT_REF_RE = re.compile(r"result\.([\w-]+)")
@@ -62,33 +58,6 @@ def _step_gated_on_declared_output(step, declared_outputs: frozenset[str]) -> bo
             if ref in declared_outputs:
                 return True
     return False
-
-
-def _push_reachable(
-    graph: dict[str, set[str]],
-    start: str,
-    recipe,
-    max_hops: int = _MAX_HOPS,
-) -> tuple[bool, str | None]:
-    """Return (reachable, push_step_name) if push_to_remote is reachable within max_hops.
-
-    Returns (False, None) if no push_to_remote step is reachable.
-    """
-    visited: set[str] = set()
-    queue: deque[tuple[str, int]] = deque([(start, 0)])
-    while queue:
-        name, hops = queue.popleft()
-        if name in visited:
-            continue
-        if hops > max_hops:
-            continue
-        visited.add(name)
-        step = recipe.steps.get(name)
-        if step is not None and step.tool == "push_to_remote":
-            return True, name
-        for succ in graph.get(name, set()):
-            queue.append((succ, hops + 1))
-    return False, None
 
 
 @semantic_rule(
@@ -131,8 +100,8 @@ def _check_conditional_skill_ungated_push(ctx: ValidationContext) -> list[RuleFi
         # Check that push_to_remote is reachable before firing any finding.
         # Steps that don't lead to push (e.g. worktree-fix → merge_worktree)
         # are not in scope for this rule.
-        push_reachable, push_step = _push_reachable(ctx.step_graph, step_name, ctx.recipe)
-        if not push_reachable:
+        reachable, push_step = push_reachable(ctx.step_graph, step_name, ctx.recipe)
+        if not reachable:
             continue
 
         declared = _declared_output_names(skill_data)

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -14,6 +14,7 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._rule_helpers import _MAX_HOPS
 from autoskillit.recipe.contracts import (
     get_skill_contract,
     load_bundled_manifest,
@@ -481,7 +482,7 @@ def _check_push_after_edit_requires_force(ctx: ValidationContext) -> list[RuleFi
         )
         return []
 
-    max_hops = 6
+    max_hops = _MAX_HOPS
     findings: list[RuleFinding] = []
 
     for step_name, step in ctx.recipe.steps.items():

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import deque
+
 from autoskillit.core import (
     GATED_TOOLS,
     HEADLESS_TOOLS,
@@ -486,10 +488,12 @@ def _check_push_after_edit_requires_force(ctx: ValidationContext) -> list[RuleFi
         if step.tool != "push_to_remote":
             continue
         visited: set[str] = set()
-        queue: list[tuple[str, int]] = [(p, 1) for p in ctx.predecessors.get(step_name, set())]
+        queue: deque[tuple[str, int]] = deque(
+            (p, 1) for p in ctx.predecessors.get(step_name, set())
+        )
         found_write_skill: str | None = None
         while queue and found_write_skill is None:
-            pred_name, depth = queue.pop(0)
+            pred_name, depth = queue.popleft()
             if pred_name in visited or depth > max_hops:
                 continue
             visited.add(pred_name)
@@ -510,7 +514,7 @@ def _check_push_after_edit_requires_force(ctx: ValidationContext) -> list[RuleFi
                         break
             queue.extend((p, depth + 1) for p in ctx.predecessors.get(pred_name, set()))
         if found_write_skill is not None and (
-            step.with_args.get("force", "").strip().lower() != "true"
+            (step.with_args or {}).get("force", "").strip().lower() != "true"
         ):
             findings.append(
                 RuleFinding(

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -2,8 +2,20 @@
 
 from __future__ import annotations
 
-from autoskillit.core import GATED_TOOLS, HEADLESS_TOOLS, TOOL_SUBSET_TAGS, UNGATED_TOOLS, Severity
+from autoskillit.core import (
+    GATED_TOOLS,
+    HEADLESS_TOOLS,
+    SKILL_TOOLS,
+    TOOL_SUBSET_TAGS,
+    UNGATED_TOOLS,
+    Severity,
+)
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.contracts import (
+    get_skill_contract,
+    load_bundled_manifest,
+    resolve_skill_name,
+)
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 _ALL_TOOLS: frozenset[str] = GATED_TOOLS | UNGATED_TOOLS | HEADLESS_TOOLS
@@ -438,4 +450,73 @@ def _check_patch_token_summary_order_id(ctx: ValidationContext) -> list[RuleFind
                     ),
                 )
             )
+    return findings
+
+
+@semantic_rule(
+    name="push-after-edit-requires-force",
+    description=(
+        "push_to_remote steps reachable from a write-behavior skill "
+        "(always or conditional) must have force='true'."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_push_after_edit_requires_force(ctx: ValidationContext) -> list[RuleFinding]:
+    """Fire when a push_to_remote step follows a write-behavior skill without force='true'.
+
+    After a write-behavior skill applies and commits changes, the branch history has
+    diverged from the remote. A non-force push will be rejected as non-fast-forward.
+    """
+    try:
+        manifest = load_bundled_manifest()
+    except Exception:
+        return []
+
+    max_hops = 6
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "push_to_remote":
+            continue
+        visited: set[str] = set()
+        queue: list[tuple[str, int]] = [(p, 1) for p in ctx.predecessors.get(step_name, set())]
+        found_write_skill: str | None = None
+        while queue and found_write_skill is None:
+            pred_name, depth = queue.pop(0)
+            if pred_name in visited or depth > max_hops:
+                continue
+            visited.add(pred_name)
+            pred = ctx.recipe.steps.get(pred_name)
+            if pred is None:
+                continue
+            if pred.tool in SKILL_TOOLS:
+                skill_cmd = (pred.with_args or {}).get("skill_command", "")
+                skill = resolve_skill_name(skill_cmd)
+                if skill:
+                    contract = get_skill_contract(skill, manifest)
+                    if (
+                        contract
+                        and contract.write_behavior in ("always", "conditional")
+                        and not contract.read_only
+                    ):
+                        found_write_skill = pred_name
+                        break
+            queue.extend((p, depth + 1) for p in ctx.predecessors.get(pred_name, set()))
+        if found_write_skill is not None and (
+            step.with_args.get("force", "").strip().lower() != "true"
+        ):
+            findings.append(
+                RuleFinding(
+                    rule="push-after-edit-requires-force",
+                    step_name=step_name,
+                    severity=Severity.ERROR,
+                    message=(
+                        f"push_to_remote step '{step_name}' follows write-behavior skill "
+                        f"step '{found_write_skill}' but is missing force='true'. "
+                        "A write-behavior skill rewrites commit history — a force push "
+                        "(--force-with-lease) is required to update the remote."
+                    ),
+                )
+            )
+
     return findings

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -9,6 +9,7 @@ from autoskillit.core import (
     TOOL_SUBSET_TAGS,
     UNGATED_TOOLS,
     Severity,
+    get_logger,
 )
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import (
@@ -17,6 +18,8 @@ from autoskillit.recipe.contracts import (
     resolve_skill_name,
 )
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+logger = get_logger(__name__)
 
 _ALL_TOOLS: frozenset[str] = GATED_TOOLS | UNGATED_TOOLS | HEADLESS_TOOLS
 
@@ -470,6 +473,10 @@ def _check_push_after_edit_requires_force(ctx: ValidationContext) -> list[RuleFi
     try:
         manifest = load_bundled_manifest()
     except Exception:
+        logger.warning(
+            "push-after-edit-requires-force: failed to load manifest; skipping",
+            exc_info=True,
+        )
         return []
 
     max_hops = 6

--- a/src/autoskillit/recipes/bem-wrapper.json
+++ b/src/autoskillit/recipes/bem-wrapper.json
@@ -51,7 +51,8 @@
       "model": "",
       "with": {
         "skill_command": "/autoskillit:build-execution-map ${{ context.issue_numbers }} --base-ref ${{ inputs.base_branch }}",
-        "step_name": "run_bem"
+        "step_name": "run_bem",
+        "output_dir": "."
       },
       "retries": 1,
       "capture": {

--- a/src/autoskillit/recipes/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/bem-wrapper.yaml
@@ -49,6 +49,7 @@ steps:
     with:
       skill_command: "/autoskillit:build-execution-map ${{ context.issue_numbers }} --base-ref ${{ inputs.base_branch }}"
       step_name: run_bem
+      output_dir: "."
     retries: 1
     capture:
       execution_map: "${{ result.execution_map }}"

--- a/src/autoskillit/recipes/full-audit.json
+++ b/src/autoskillit/recipes/full-audit.json
@@ -66,7 +66,8 @@
       "with": {
         "skill_command": "/autoskillit:audit-tests",
         "cwd": "${{ inputs.workspace }}",
-        "step_name": "run_audits"
+        "step_name": "run_audits",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}"
       },
       "note": "PREFER-COMPLETION AUDIT DISPATCH — Dispatch audits using prefer-completion scheduling capped at ${{ inputs.max_parallel }} concurrent slots:\n1. Queue all six audits:\n   - run_skill(skill_command=\"/autoskillit:audit-tests\", cwd=\"${{ inputs.workspace }}\", step_name=\"audit_tests\", output_dir=\"${{ inputs.workspace }}/{{AUTOSKILLIT_TEMP}}/audit-tests\")\n   - run_skill(skill_command=\"/autoskillit:audit-cohesion\", cwd=\"${{ inputs.workspace }}\", step_name=\"audit_cohesion\", output_dir=\"${{ inputs.workspace }}/{{AUTOSKILLIT_TEMP}}/audit-cohesion\")\n   - run_skill(skill_command=\"/autoskillit:audit-arch\", cwd=\"${{ inputs.workspace }}\", step_name=\"audit_arch\", output_dir=\"${{ inputs.workspace }}/{{AUTOSKILLIT_TEMP}}/audit-arch\")\n   - run_skill(skill_command=\"/audit-feature-gates\", cwd=\"${{ inputs.workspace }}\", step_name=\"audit_feature_gates\", output_dir=\"${{ inputs.workspace }}/{{AUTOSKILLIT_TEMP}}/audit-feature-gates\")  # project-local skill (.autoskillit/skills/): bare /name invocation, no /autoskillit: prefix\n   - run_skill(skill_command=\"/autoskillit:audit-docs\", cwd=\"${{ inputs.workspace }}\", step_name=\"audit_docs\", output_dir=\"${{ inputs.workspace }}/{{AUTOSKILLIT_TEMP}}/audit-docs\")\n   - run_skill(skill_command=\"/autoskillit:audit-review-decisions\", cwd=\"${{ inputs.workspace }}\", step_name=\"audit_review_decisions\", output_dir=\"${{ inputs.workspace }}/{{AUTOSKILLIT_TEMP}}/audit-review-decisions\")\n\n2. Launch the first ${{ inputs.max_parallel }} audits as run_skill calls\n   in a single message.\n\n3. When any audit completes (success or failure), immediately launch\n   the next queued audit in the same message as any other pending\n   responses. Maintain ${{ inputs.max_parallel }} in-flight at all times\n   until the queue is empty.\n\nEach audit writes its report to a well-known temp directory: - {{AUTOSKILLIT_TEMP}}/audit-tests/{name}_{timestamp}.md - {{AUTOSKILLIT_TEMP}}/audit-cohesion/cohesion_audit_{timestamp}.md - {{AUTOSKILLIT_TEMP}}/audit-arch/arch_audit_{timestamp}.md - {{AUTOSKILLIT_TEMP}}/audit-feature-gates/feature_gate_audit_{timestamp}.md - {{AUTOSKILLIT_TEMP}}/audit-docs/docs_audit_{timestamp}.md - {{AUTOSKILLIT_TEMP}}/audit-review-decisions/review_decisions_audit_{timestamp}.md\nAfter all six complete, discover the most-recently-modified .md file in each temp directory from the session output. Record which audits succeeded and their report paths for the validation wave.\nIf any audit fails, note the failure but continue with the other five. Proceed to validate_audits even if only one, two, three, four, or five audits succeeded. Route to escalate_stop ONLY if all six audits fail.\n",
       "capture_list": {
@@ -102,7 +103,8 @@
       "with": {
         "skill_command": "/autoskillit:file-audit-issues ${{ context.audit_run_dir }}",
         "cwd": "${{ inputs.workspace }}",
-        "step_name": "create_issues"
+        "step_name": "create_issues",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/file-audit-issues"
       },
       "note": "Runs /autoskillit:file-audit-issues — discovers ticket_body_*.md in audit_run_dir, deduplicates, batch-creates GitHub issues via GraphQL, applies labels.",
       "capture": {

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -75,6 +75,7 @@ steps:
       skill_command: "/autoskillit:audit-tests"
       cwd: "${{ inputs.workspace }}"
       step_name: "run_audits"
+      output_dir: "{{AUTOSKILLIT_TEMP}}"
     note: >
       PREFER-COMPLETION AUDIT DISPATCH — Dispatch audits using prefer-completion
       scheduling capped at ${{ inputs.max_parallel }} concurrent slots:
@@ -168,6 +169,7 @@ steps:
       skill_command: "/autoskillit:file-audit-issues ${{ context.audit_run_dir }}"
       cwd: "${{ inputs.workspace }}"
       step_name: "create_issues"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/file-audit-issues"
     note: "Runs /autoskillit:file-audit-issues — discovers ticket_body_*.md in audit_run_dir, deduplicates, batch-creates GitHub issues via GraphQL, applies labels."
     capture:
       issue_urls: "${{ result.issue_urls }}"

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -712,7 +712,7 @@
     "pre_review_rebase": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
         "step_name": "pre_review_rebase"
       },
       "on_success": "re_push_review",

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -170,7 +170,8 @@
         "group_files": "${{ context.group_files }}",
         "issue_url": "${{ inputs.issue_url }}",
         "issue_title": "${{ context.issue_title }}",
-        "adversarial_review_level": "${{ inputs.adversarial_review_level }}"
+        "adversarial_review_level": "${{ inputs.adversarial_review_level }}",
+        "output_dir": "."
       },
       "capture": {
         "plan_path": "${{ result.plan_path }}",
@@ -224,7 +225,8 @@
       "with": {
         "skill_command": "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "implement"
+        "step_name": "implement",
+        "output_dir": "."
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}"

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -494,6 +494,7 @@
       "with": {
         "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "prepare_pr",
         "issue_number": "${{ context.issue_number }}"
       },
@@ -546,6 +547,7 @@
       "with": {
         "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "compose_pr",
         "issue_number": "${{ context.issue_number }}"
       },
@@ -672,6 +674,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_review"
       },
       "capture": {
@@ -679,19 +682,19 @@
       },
       "retries": 2,
       "on_exhausted": "release_issue_failure",
-      "on_context_limit": "re_push_review",
+      "on_context_limit": "pre_review_rebase",
       "on_result": [
         {
           "when": "${{ result.verdict }} == 'real_fix'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'already_green'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'flake_suspected'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
@@ -702,14 +705,24 @@
       "optional_context_refs": [
         "review_mode"
       ],
-      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to re_push_review (retry bounded by retries: 2); ci_only_failure escalates to release_issue_failure.\n"
+      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n"
+    },
+    "pre_review_rebase": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "step_name": "pre_review_rebase"
+      },
+      "on_success": "re_push_review",
+      "on_failure": "release_issue_failure"
     },
     "re_push_review": {
       "tool": "push_to_remote",
       "with": {
         "clone_path": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "branch": "${{ context.merge_target }}"
+        "branch": "${{ context.merge_target }}",
+        "force": "true"
       },
       "on_success": "check_review_loop",
       "on_failure": "release_issue_failure",
@@ -1023,6 +1036,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_ci"
       },
       "capture": {
@@ -1365,6 +1379,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_queue_merge_conflicts"
       },
       "capture": {
@@ -1611,6 +1626,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_direct_merge_conflicts"
       },
       "capture": {
@@ -1719,6 +1735,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_immediate_merge_conflicts"
       },
       "capture": {
@@ -1799,6 +1816,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "ci_conflict_fix"
       },
       "capture": {

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -494,7 +494,7 @@
       "with": {
         "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "prepare_pr",
         "issue_number": "${{ context.issue_number }}"
       },
@@ -547,7 +547,7 @@
       "with": {
         "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "compose_pr",
         "issue_number": "${{ context.issue_number }}"
       },
@@ -674,7 +674,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_review"
       },
       "capture": {
@@ -1036,7 +1036,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_ci"
       },
       "capture": {
@@ -1379,7 +1379,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_queue_merge_conflicts"
       },
       "capture": {
@@ -1626,7 +1626,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_direct_merge_conflicts"
       },
       "capture": {
@@ -1735,7 +1735,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_immediate_merge_conflicts"
       },
       "capture": {
@@ -1816,7 +1816,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "ci_conflict_fix"
       },
       "capture": {

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -661,8 +661,8 @@ steps:
   pre_review_rebase:
     tool: run_cmd
     with:
-      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
-        | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
+        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
 
         git -C ${{ context.work_dir }} fetch "$REMOTE" &&
 

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -459,6 +459,7 @@ steps:
     with:
       skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      output_dir: "${{ context.work_dir }}"
       step_name: "prepare_pr"
       issue_number: "${{ context.issue_number }}"
     capture:
@@ -515,6 +516,7 @@ steps:
     with:
       skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      output_dir: "${{ context.work_dir }}"
       step_name: "compose_pr"
       issue_number: "${{ context.issue_number }}"
     capture:
@@ -626,19 +628,20 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}"
       cwd: "${{ context.work_dir }}"
+      output_dir: "${{ context.work_dir }}"
       step_name: "resolve_review"
     capture:
       verdict: "${{ result.verdict }}"
     retries: 2
     on_exhausted: release_issue_failure
-    on_context_limit: re_push_review
+    on_context_limit: pre_review_rebase
     on_result:
     - when: "${{ result.verdict }} == 'real_fix'"
-      route: re_push_review
+      route: pre_review_rebase
     - when: "${{ result.verdict }} == 'already_green'"
-      route: re_push_review
+      route: pre_review_rebase
     - when: "${{ result.verdict }} == 'flake_suspected'"
-      route: re_push_review
+      route: pre_review_rebase
     - when: "${{ result.verdict }} == 'ci_only_failure'"
       route: release_issue_failure
     on_failure: release_issue_failure
@@ -650,15 +653,30 @@ steps:
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
       commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
-      flake_suspected all route to re_push_review (retry bounded by retries: 2);
+      flake_suspected all route to pre_review_rebase (fetch+rebase before push);
       ci_only_failure escalates to release_issue_failure.
 
+  pre_review_rebase:
+    tool: run_cmd
+    with:
+      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
+        | grep -qv "^file://" && echo upstream || echo origin) &&
+
+        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
+
+        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
+
+        '
+      step_name: pre_review_rebase
+    on_success: re_push_review
+    on_failure: release_issue_failure
   re_push_review:
     tool: push_to_remote
     with:
       clone_path: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
+      force: 'true'
     on_success: check_review_loop
     on_failure: release_issue_failure
     note: >
@@ -962,6 +980,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}"
       cwd: "${{ context.work_dir }}"
+      output_dir: "${{ context.work_dir }}"
       step_name: "resolve_ci"
     capture:
       verdict: "${{ result.verdict }}"
@@ -1262,6 +1281,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      output_dir: "${{ context.work_dir }}"
       step_name: "resolve_queue_merge_conflicts"
     capture:
       conflict_escalation_required: "${{ result.escalation_required }}"
@@ -1467,6 +1487,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      output_dir: "${{ context.work_dir }}"
       step_name: "resolve_direct_merge_conflicts"
     capture:
       conflict_escalation_required: "${{ result.escalation_required }}"
@@ -1571,6 +1592,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      output_dir: "${{ context.work_dir }}"
       step_name: "resolve_immediate_merge_conflicts"
     capture:
       conflict_escalation_required: "${{ result.escalation_required }}"
@@ -1667,6 +1689,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      output_dir: "${{ context.work_dir }}"
       step_name: "ci_conflict_fix"
     capture:
       conflict_escalation_required: "${{ result.escalation_required }}"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -164,6 +164,7 @@ steps:
       issue_url: "${{ inputs.issue_url }}"
       issue_title: "${{ context.issue_title }}"
       adversarial_review_level: "${{ inputs.adversarial_review_level }}"
+      output_dir: "."
     capture:
       plan_path: "${{ result.plan_path }}"
       all_plan_paths: "${{ result.plan_path }}"
@@ -231,6 +232,7 @@ steps:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "implement"
+      output_dir: "."
     capture:
       worktree_path: "${{ result.worktree_path }}"
     retries: 0

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -459,7 +459,7 @@ steps:
     with:
       skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}"
+      output_dir: '.'
       step_name: "prepare_pr"
       issue_number: "${{ context.issue_number }}"
     capture:
@@ -516,7 +516,7 @@ steps:
     with:
       skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}"
+      output_dir: '.'
       step_name: "compose_pr"
       issue_number: "${{ context.issue_number }}"
     capture:
@@ -628,7 +628,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}"
+      output_dir: '.'
       step_name: "resolve_review"
     capture:
       verdict: "${{ result.verdict }}"
@@ -980,7 +980,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}"
+      output_dir: '.'
       step_name: "resolve_ci"
     capture:
       verdict: "${{ result.verdict }}"
@@ -1281,7 +1281,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}"
+      output_dir: '.'
       step_name: "resolve_queue_merge_conflicts"
     capture:
       conflict_escalation_required: "${{ result.escalation_required }}"
@@ -1487,7 +1487,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}"
+      output_dir: '.'
       step_name: "resolve_direct_merge_conflicts"
     capture:
       conflict_escalation_required: "${{ result.escalation_required }}"
@@ -1592,7 +1592,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}"
+      output_dir: '.'
       step_name: "resolve_immediate_merge_conflicts"
     capture:
       conflict_escalation_required: "${{ result.escalation_required }}"
@@ -1689,7 +1689,7 @@ steps:
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      output_dir: "${{ context.work_dir }}"
+      output_dir: '.'
       step_name: "ci_conflict_fix"
     capture:
       conflict_escalation_required: "${{ result.escalation_required }}"

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -192,7 +192,8 @@
         "step_name": "plan",
         "issue_url": "${{ inputs.issue_url }}",
         "issue_title": "${{ context.issue_title }}",
-        "adversarial_review_level": "${{ inputs.adversarial_review_level }}"
+        "adversarial_review_level": "${{ inputs.adversarial_review_level }}",
+        "output_dir": "."
       },
       "capture": {
         "plan_path": "${{ result.plan_path }}",
@@ -247,7 +248,8 @@
       "with": {
         "skill_command": "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "implement"
+        "step_name": "implement",
+        "output_dir": "."
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}"

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -575,7 +575,7 @@
       "with": {
         "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "prepare_pr"
       },
       "capture": {
@@ -628,7 +628,7 @@
       "with": {
         "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "compose_pr"
       },
       "capture": {
@@ -767,7 +767,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_review"
       },
       "capture": {
@@ -1377,7 +1377,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_queue_merge_conflicts"
       },
       "capture": {
@@ -1624,7 +1624,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_direct_merge_conflicts"
       },
       "capture": {
@@ -1733,7 +1733,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_immediate_merge_conflicts"
       },
       "capture": {
@@ -1805,7 +1805,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_ci"
       },
       "capture": {
@@ -1909,7 +1909,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "ci_conflict_fix"
       },
       "capture": {

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -575,6 +575,7 @@
       "with": {
         "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "prepare_pr"
       },
       "capture": {
@@ -627,6 +628,7 @@
       "with": {
         "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "compose_pr"
       },
       "capture": {
@@ -765,6 +767,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_review"
       },
       "capture": {
@@ -772,19 +775,19 @@
       },
       "retries": 2,
       "on_exhausted": "release_issue_failure",
-      "on_context_limit": "re_push_review",
+      "on_context_limit": "pre_review_rebase",
       "on_result": [
         {
           "when": "${{ result.verdict }} == 'real_fix'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'already_green'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'flake_suspected'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
@@ -795,14 +798,24 @@
       "optional_context_refs": [
         "review_mode"
       ],
-      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to re_push_review (retry bounded by retries: 2); ci_only_failure escalates to release_issue_failure.\n"
+      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n"
+    },
+    "pre_review_rebase": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "step_name": "pre_review_rebase"
+      },
+      "on_success": "re_push_review",
+      "on_failure": "release_issue_failure"
     },
     "re_push_review": {
       "tool": "push_to_remote",
       "with": {
         "clone_path": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "branch": "${{ context.merge_target }}"
+        "branch": "${{ context.merge_target }}",
+        "force": "true"
       },
       "on_success": "check_review_loop",
       "on_failure": "release_issue_failure",
@@ -1364,6 +1377,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_queue_merge_conflicts"
       },
       "capture": {
@@ -1610,6 +1624,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_direct_merge_conflicts"
       },
       "capture": {
@@ -1718,6 +1733,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_immediate_merge_conflicts"
       },
       "capture": {
@@ -1789,6 +1805,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_ci"
       },
       "capture": {
@@ -1892,6 +1909,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "ci_conflict_fix"
       },
       "capture": {

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -805,7 +805,7 @@
     "pre_review_rebase": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
         "step_name": "pre_review_rebase"
       },
       "on_success": "re_push_review",
@@ -1847,7 +1847,7 @@
     "pre_resolve_rebase": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
         "step_name": "pre_resolve_rebase"
       },
       "retries": 1,

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -206,6 +206,7 @@ steps:
       issue_url: ${{ inputs.issue_url }}
       issue_title: ${{ context.issue_title }}
       adversarial_review_level: ${{ inputs.adversarial_review_level }}
+      output_dir: '.'
     capture:
       plan_path: ${{ result.plan_path }}
       all_plan_paths: ${{ result.plan_path }}
@@ -272,6 +273,7 @@ steps:
         }}
       cwd: ${{ context.work_dir }}
       step_name: implement
+      output_dir: '.'
     capture:
       worktree_path: ${{ result.worktree_path }}
     retries: 0

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -545,6 +545,7 @@ steps:
       skill_command: /autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name
         }} ${{ inputs.base_branch }} ${{ context.issue_number }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: prepare_pr
     capture:
       prep_path: ${{ result.prep_path }}
@@ -597,6 +598,7 @@ steps:
         }}" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number
         }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: compose_pr
     capture:
       pr_url: ${{ result.pr_url }}
@@ -725,19 +727,20 @@ steps:
       skill_command: /autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch
         }} mode=${{ context.review_mode }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_review
     capture:
       verdict: ${{ result.verdict }}
     retries: 2
     on_exhausted: release_issue_failure
-    on_context_limit: re_push_review
+    on_context_limit: pre_review_rebase
     on_result:
     - when: ${{ result.verdict }} == 'real_fix'
-      route: re_push_review
+      route: pre_review_rebase
     - when: ${{ result.verdict }} == 'already_green'
-      route: re_push_review
+      route: pre_review_rebase
     - when: ${{ result.verdict }} == 'flake_suspected'
-      route: re_push_review
+      route: pre_review_rebase
     - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
     on_failure: release_issue_failure
@@ -748,16 +751,31 @@ steps:
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
       commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
-      flake_suspected all route to re_push_review (retry bounded by retries: 2); ci_only_failure
+      flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure
       escalates to release_issue_failure.
 
       '
+  pre_review_rebase:
+    tool: run_cmd
+    with:
+      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
+        | grep -qv "^file://" && echo upstream || echo origin) &&
+
+        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
+
+        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
+
+        '
+      step_name: pre_review_rebase
+    on_success: re_push_review
+    on_failure: release_issue_failure
   re_push_review:
     tool: push_to_remote
     with:
       clone_path: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       branch: ${{ context.merge_target }}
+      force: 'true'
     on_success: check_review_loop
     on_failure: release_issue_failure
     note: 'Pushes the review-fixed feature branch back to the remote after resolve_review
@@ -1268,6 +1286,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_queue_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1469,6 +1488,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_direct_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1572,6 +1592,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_immediate_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1645,6 +1666,7 @@ steps:
         }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs
         }} ${{ context.diagnosis_path }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_ci
     capture:
       verdict: ${{ result.verdict }}
@@ -1758,6 +1780,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: ci_conflict_fix
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -760,8 +760,8 @@ steps:
   pre_review_rebase:
     tool: run_cmd
     with:
-      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
-        | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
+        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
 
         git -C ${{ context.work_dir }} fetch "$REMOTE" &&
 
@@ -1699,8 +1699,8 @@ steps:
   pre_resolve_rebase:
     tool: run_cmd
     with:
-      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
-        | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
+        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
 
         git -C ${{ context.work_dir }} fetch "$REMOTE" &&
 

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -545,7 +545,7 @@ steps:
       skill_command: /autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name
         }} ${{ inputs.base_branch }} ${{ context.issue_number }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: prepare_pr
     capture:
       prep_path: ${{ result.prep_path }}
@@ -598,7 +598,7 @@ steps:
         }}" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number
         }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: compose_pr
     capture:
       pr_url: ${{ result.pr_url }}
@@ -727,7 +727,7 @@ steps:
       skill_command: /autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch
         }} mode=${{ context.review_mode }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_review
     capture:
       verdict: ${{ result.verdict }}
@@ -1286,7 +1286,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_queue_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1488,7 +1488,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_direct_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1592,7 +1592,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_immediate_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1666,7 +1666,7 @@ steps:
         }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs
         }} ${{ context.diagnosis_path }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_ci
     capture:
       verdict: ${{ result.verdict }}
@@ -1780,7 +1780,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: ci_conflict_fix
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -424,6 +424,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts '${{ context.ejected_pr_branch }}' '${{ inputs.base_branch }}'",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_ejected_conflicts"
       },
       "capture": {
@@ -719,6 +720,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts '${{ context.next_pr_branch }}' '${{ inputs.base_branch }}'",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_proactive_rebase_conflicts"
       },
       "capture": {
@@ -1470,6 +1472,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-review ${{ context.batch_branch }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_review_integration"
       },
       "capture": {
@@ -1477,15 +1480,15 @@
       },
       "retries": 2,
       "on_exhausted": "register_clone_failure",
-      "on_context_limit": "re_push_review_integration",
+      "on_context_limit": "pre_review_rebase_integration",
       "on_result": [
         {
           "when": "${{ result.verdict }} == 'real_fix'",
-          "route": "re_push_review_integration"
+          "route": "pre_review_rebase_integration"
         },
         {
           "when": "${{ result.verdict }} == 'already_green'",
-          "route": "re_push_review_integration"
+          "route": "pre_review_rebase_integration"
         },
         {
           "when": "${{ result.verdict }} == 'flake_suspected'",
@@ -1497,14 +1500,24 @@
         }
       ],
       "on_failure": "register_clone_failure",
-      "note": "Resolves review findings on the integration PR (REQ-REVIEW-002). Fetches inline and summary review comments from GitHub and applies fixes. Retries up to 2 times (3 total attempts) before escalating to register_clone_failure (REQ-REVIEW-005). Routes via on_result: verdict dispatch — real_fix/already_green push fixes; flake_suspected/ ci_only_failure escalate to register_clone_failure.\n"
+      "note": "Resolves review findings on the integration PR (REQ-REVIEW-002). Fetches inline and summary review comments from GitHub and applies fixes. Retries up to 2 times (3 total attempts) before escalating to register_clone_failure (REQ-REVIEW-005). Routes via on_result: verdict dispatch — real_fix/already_green route through pre_review_rebase_integration (fetch+rebase before push); flake_suspected/ ci_only_failure escalate to register_clone_failure.\n"
+    },
+    "pre_review_rebase_integration": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "step_name": "pre_review_rebase_integration"
+      },
+      "on_success": "re_push_review_integration",
+      "on_failure": "register_clone_failure"
     },
     "re_push_review_integration": {
       "tool": "push_to_remote",
       "with": {
         "clone_path": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "branch": "${{ context.batch_branch }}"
+        "branch": "${{ context.batch_branch }}",
+        "force": "true"
       },
       "on_success": "derive_batch_ci_event",
       "on_failure": "register_clone_failure",

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -424,7 +424,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts '${{ context.ejected_pr_branch }}' '${{ inputs.base_branch }}'",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_ejected_conflicts"
       },
       "capture": {
@@ -720,7 +720,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts '${{ context.next_pr_branch }}' '${{ inputs.base_branch }}'",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_proactive_rebase_conflicts"
       },
       "capture": {
@@ -1472,7 +1472,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-review ${{ context.batch_branch }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_review_integration"
       },
       "capture": {

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -878,7 +878,8 @@
       "with": {
         "skill_command": "/autoskillit:make-plan ${{ context.task }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "plan"
+        "step_name": "plan",
+        "output_dir": "."
       },
       "capture": {
         "pr_plan_path": "${{ result.plan_path }}"
@@ -915,7 +916,8 @@
       "with": {
         "skill_command": "/autoskillit:implement-worktree-no-merge ${{ context.pr_plan_path }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "implement"
+        "step_name": "implement",
+        "output_dir": "."
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}",

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -452,7 +452,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts '${{ context.ejected_pr_branch
         }}' '${{ inputs.base_branch }}'
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_ejected_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -692,7 +692,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts '${{ context.next_pr_branch
         }}' '${{ inputs.base_branch }}'
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_proactive_rebase_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1458,7 +1458,7 @@ steps:
       skill_command: /autoskillit:resolve-review ${{ context.batch_branch }} ${{ inputs.base_branch
         }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_review_integration
     capture:
       verdict: ${{ result.verdict }}

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -452,6 +452,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts '${{ context.ejected_pr_branch
         }}' '${{ inputs.base_branch }}'
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_ejected_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -691,6 +692,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts '${{ context.next_pr_branch
         }}' '${{ inputs.base_branch }}'
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_proactive_rebase_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1456,17 +1458,18 @@ steps:
       skill_command: /autoskillit:resolve-review ${{ context.batch_branch }} ${{ inputs.base_branch
         }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_review_integration
     capture:
       verdict: ${{ result.verdict }}
     retries: 2
     on_exhausted: register_clone_failure
-    on_context_limit: re_push_review_integration
+    on_context_limit: pre_review_rebase_integration
     on_result:
     - when: ${{ result.verdict }} == 'real_fix'
-      route: re_push_review_integration
+      route: pre_review_rebase_integration
     - when: ${{ result.verdict }} == 'already_green'
-      route: re_push_review_integration
+      route: pre_review_rebase_integration
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: register_clone_failure
     - when: ${{ result.verdict }} == 'ci_only_failure'
@@ -1475,16 +1478,32 @@ steps:
     note: 'Resolves review findings on the integration PR (REQ-REVIEW-002). Fetches
       inline and summary review comments from GitHub and applies fixes. Retries up
       to 2 times (3 total attempts) before escalating to register_clone_failure (REQ-REVIEW-005).
-      Routes via on_result: verdict dispatch — real_fix/already_green push fixes;
-      flake_suspected/ ci_only_failure escalate to register_clone_failure.
+      Routes via on_result: verdict dispatch — real_fix/already_green route through
+      pre_review_rebase_integration (fetch+rebase before push); flake_suspected/
+      ci_only_failure escalate to register_clone_failure.
 
       '
+  pre_review_rebase_integration:
+    tool: run_cmd
+    with:
+      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
+        | grep -qv "^file://" && echo upstream || echo origin) &&
+
+        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
+
+        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
+
+        '
+      step_name: pre_review_rebase_integration
+    on_success: re_push_review_integration
+    on_failure: register_clone_failure
   re_push_review_integration:
     tool: push_to_remote
     with:
       clone_path: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       branch: ${{ context.batch_branch }}
+      force: 'true'
     on_success: derive_batch_ci_event
     on_failure: register_clone_failure
     note: 'Pushes the review-fixed integration branch to the remote (REQ-REVIEW-003).

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -849,6 +849,7 @@ steps:
       skill_command: /autoskillit:make-plan ${{ context.task }}
       cwd: ${{ context.work_dir }}
       step_name: plan
+      output_dir: '.'
     capture:
       pr_plan_path: ${{ result.plan_path }}
     capture_list:
@@ -891,6 +892,7 @@ steps:
         }}
       cwd: ${{ context.work_dir }}
       step_name: implement
+      output_dir: '.'
     capture:
       worktree_path: ${{ result.worktree_path }}
       worktree_branch_name: ${{ result.branch_name }}

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -831,7 +831,7 @@
     "pre_review_rebase": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
         "step_name": "pre_review_rebase"
       },
       "on_success": "re_push_review",
@@ -1873,7 +1873,7 @@
     "pre_resolve_rebase": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
         "step_name": "pre_resolve_rebase"
       },
       "retries": 1,

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -614,6 +614,7 @@
       "with": {
         "skill_command": "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "prepare_pr"
       },
       "capture": {
@@ -666,6 +667,7 @@
       "with": {
         "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "compose_pr"
       },
       "capture": {
@@ -791,6 +793,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_review"
       },
       "capture": {
@@ -798,19 +801,19 @@
       },
       "retries": 2,
       "on_exhausted": "release_issue_failure",
-      "on_context_limit": "re_push_review",
+      "on_context_limit": "pre_review_rebase",
       "on_result": [
         {
           "when": "${{ result.verdict }} == 'real_fix'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'already_green'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'flake_suspected'",
-          "route": "re_push_review"
+          "route": "pre_review_rebase"
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
@@ -818,17 +821,27 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to re_push_review (retry bounded by retries: 2); ci_only_failure escalates to release_issue_failure.\n",
+      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n",
       "optional_context_refs": [
         "review_mode"
       ]
+    },
+    "pre_review_rebase": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
+        "step_name": "pre_review_rebase"
+      },
+      "on_success": "re_push_review",
+      "on_failure": "release_issue_failure"
     },
     "re_push_review": {
       "tool": "push_to_remote",
       "with": {
         "clone_path": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "branch": "${{ context.merge_target }}"
+        "branch": "${{ context.merge_target }}",
+        "force": "true"
       },
       "on_success": "check_review_loop",
       "on_failure": "release_issue_failure",
@@ -1390,6 +1403,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_queue_merge_conflicts"
       },
       "capture": {
@@ -1636,6 +1650,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_direct_merge_conflicts"
       },
       "capture": {
@@ -1744,6 +1759,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_immediate_merge_conflicts"
       },
       "capture": {
@@ -1815,6 +1831,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "resolve_ci"
       },
       "capture": {
@@ -1918,6 +1935,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "${{ context.work_dir }}",
         "step_name": "ci_conflict_fix"
       },
       "capture": {

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -614,7 +614,7 @@
       "with": {
         "skill_command": "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "prepare_pr"
       },
       "capture": {
@@ -667,7 +667,7 @@
       "with": {
         "skill_command": "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "compose_pr"
       },
       "capture": {
@@ -793,7 +793,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }} mode=${{ context.review_mode }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_review"
       },
       "capture": {
@@ -1403,7 +1403,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_queue_merge_conflicts"
       },
       "capture": {
@@ -1650,7 +1650,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_direct_merge_conflicts"
       },
       "capture": {
@@ -1759,7 +1759,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_immediate_merge_conflicts"
       },
       "capture": {
@@ -1831,7 +1831,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "resolve_ci"
       },
       "capture": {
@@ -1935,7 +1935,7 @@
       "with": {
         "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "${{ context.work_dir }}",
+        "output_dir": ".",
         "step_name": "ci_conflict_fix"
       },
       "capture": {

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -262,7 +262,8 @@
       "with": {
         "skill_command": "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}",
         "cwd": "${{ context.work_dir }}",
-        "step_name": "implement"
+        "step_name": "implement",
+        "output_dir": "."
       },
       "capture": {
         "implementation_ref": "${{ result.worktree_path }}",
@@ -477,7 +478,8 @@
         "task": "${{ inputs.task }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "make_plan",
-        "adversarial_review_level": "${{ inputs.adversarial_review_level }}"
+        "adversarial_review_level": "${{ inputs.adversarial_review_level }}",
+        "output_dir": "."
       },
       "capture": {
         "plan_path": "${{ result.plan_path }}"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -756,8 +756,8 @@ steps:
   pre_review_rebase:
     tool: run_cmd
     with:
-      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
-        | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
+        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
 
         git -C ${{ context.work_dir }} fetch "$REMOTE" &&
 
@@ -1696,8 +1696,8 @@ steps:
   pre_resolve_rebase:
     tool: run_cmd
     with:
-      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
-        | grep -qv "^file://" && echo upstream || echo origin) &&
+      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
+        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
 
         git -C ${{ context.work_dir }} fetch "$REMOTE" &&
 

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -556,7 +556,7 @@ steps:
       skill_command: /autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name
         }} ${{ inputs.base_branch }} ${{ context.issue_number }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: prepare_pr
     capture:
       prep_path: ${{ result.prep_path }}
@@ -609,7 +609,7 @@ steps:
         }}" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number
         }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: compose_pr
     capture:
       pr_url: ${{ result.pr_url }}
@@ -723,7 +723,7 @@ steps:
       skill_command: /autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch
         }} mode=${{ context.review_mode }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_review
     capture:
       verdict: ${{ result.verdict }}
@@ -1283,7 +1283,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_queue_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1485,7 +1485,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_direct_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1589,7 +1589,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_immediate_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1663,7 +1663,7 @@ steps:
         }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs
         }} ${{ context.diagnosis_path }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: resolve_ci
     capture:
       verdict: ${{ result.verdict }}
@@ -1777,7 +1777,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
-      output_dir: ${{ context.work_dir }}
+      output_dir: '.'
       step_name: ci_conflict_fix
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -270,6 +270,7 @@ steps:
         }}
       cwd: ${{ context.work_dir }}
       step_name: implement
+      output_dir: '.'
     capture:
       implementation_ref: ${{ result.worktree_path }}
       worktree_path: ${{ result.worktree_path }}
@@ -428,6 +429,7 @@ steps:
       cwd: ${{ context.work_dir }}
       step_name: make_plan
       adversarial_review_level: ${{ inputs.adversarial_review_level }}
+      output_dir: '.'
     capture:
       plan_path: ${{ result.plan_path }}
     capture_list:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -556,6 +556,7 @@ steps:
       skill_command: /autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name
         }} ${{ inputs.base_branch }} ${{ context.issue_number }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: prepare_pr
     capture:
       prep_path: ${{ result.prep_path }}
@@ -608,6 +609,7 @@ steps:
         }}" ${{ context.work_dir }} ${{ inputs.base_branch }} ${{ context.issue_number
         }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: compose_pr
     capture:
       pr_url: ${{ result.pr_url }}
@@ -721,19 +723,20 @@ steps:
       skill_command: /autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch
         }} mode=${{ context.review_mode }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_review
     capture:
       verdict: ${{ result.verdict }}
     retries: 2
     on_exhausted: release_issue_failure
-    on_context_limit: re_push_review
+    on_context_limit: pre_review_rebase
     on_result:
     - when: ${{ result.verdict }} == 'real_fix'
-      route: re_push_review
+      route: pre_review_rebase
     - when: ${{ result.verdict }} == 'already_green'
-      route: re_push_review
+      route: pre_review_rebase
     - when: ${{ result.verdict }} == 'flake_suspected'
-      route: re_push_review
+      route: pre_review_rebase
     - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
     on_failure: release_issue_failure
@@ -742,18 +745,33 @@ steps:
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
       commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
-      flake_suspected all route to re_push_review (retry bounded by retries: 2); ci_only_failure
+      flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure
       escalates to release_issue_failure.
 
       '
     optional_context_refs:
     - review_mode
+  pre_review_rebase:
+    tool: run_cmd
+    with:
+      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
+        | grep -qv "^file://" && echo upstream || echo origin) &&
+
+        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
+
+        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
+
+        '
+      step_name: pre_review_rebase
+    on_success: re_push_review
+    on_failure: release_issue_failure
   re_push_review:
     tool: push_to_remote
     with:
       clone_path: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       branch: ${{ context.merge_target }}
+      force: 'true'
     on_success: check_review_loop
     on_failure: release_issue_failure
     note: 'Pushes the review-fixed feature branch back to the remote after resolve_review
@@ -1265,6 +1283,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_queue_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1466,6 +1485,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_direct_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1569,6 +1589,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_immediate_merge_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
@@ -1642,6 +1663,7 @@ steps:
         }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs
         }} ${{ context.diagnosis_path }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: resolve_ci
     capture:
       verdict: ${{ result.verdict }}
@@ -1755,6 +1777,7 @@ steps:
       skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
         ${{ context.plan_path }} ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      output_dir: ${{ context.work_dir }}
       step_name: ci_conflict_fix
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -65,7 +65,8 @@
       "with": {
         "skill_command": "/autoskillit:select-directions ${{ context.scope_directions }} ${{ context.scope_report }} ${{ inputs.min_breadth }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "select_directions"
+        "step_name": "select_directions",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/select-directions"
       },
       "capture": {
         "selected_directions": "${{ result.selected_directions }}"

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -75,6 +75,7 @@ steps:
       skill_command: "/autoskillit:select-directions ${{ context.scope_directions }} ${{ context.scope_report }} ${{ inputs.min_breadth }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: select_directions
+      output_dir: "{{AUTOSKILLIT_TEMP}}/select-directions"
     capture:
       selected_directions: "${{ result.selected_directions }}"
     on_success: plan_experiment

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -146,6 +146,7 @@
         "skill_command": "/autoskillit:make-plan ${{ context.group_files }}",
         "cwd": "${{ inputs.worktree_path }}",
         "step_name": "plan_phase",
+        "output_dir": ".",
         "group_files": "${{ context.group_files }}"
       },
       "capture": {
@@ -167,7 +168,8 @@
       "with": {
         "skill_command": "/autoskillit:implement-experiment ${{ context.phase_plan_path }}",
         "cwd": "${{ inputs.worktree_path }}",
-        "step_name": "implement_phase"
+        "step_name": "implement_phase",
+        "output_dir": "."
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}"
@@ -370,7 +372,8 @@
       "with": {
         "skill_command": "/autoskillit:run-experiment ${{ context.worktree_path }}",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "run_experiment"
+        "step_name": "run_experiment",
+        "output_dir": "."
       },
       "capture": {
         "experiment_results": "${{ result.results_path }}",
@@ -434,7 +437,8 @@
       "with": {
         "skill_command": "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "adjust"
+        "step_name": "adjust",
+        "output_dir": "."
       },
       "capture": {
         "experiment_results": "${{ result.results_path }}",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -163,6 +163,7 @@ steps:
       skill_command: "/autoskillit:make-plan ${{ context.group_files }}"
       cwd: "${{ inputs.worktree_path }}"
       step_name: plan_phase
+      output_dir: '.'
       group_files: "${{ context.group_files }}"
     capture:
       phase_plan_path: "${{ result.plan_path }}"
@@ -191,6 +192,7 @@ steps:
       skill_command: "/autoskillit:implement-experiment ${{ context.phase_plan_path }}"
       cwd: "${{ inputs.worktree_path }}"
       step_name: implement_phase
+      output_dir: '.'
     capture:
       worktree_path: "${{ result.worktree_path }}"
     retries: 0
@@ -369,6 +371,7 @@ steps:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"
       step_name: run_experiment
+      output_dir: '.'
     capture:
       experiment_results: "${{ result.results_path }}"
       experiment_verdict: "${{ result.verdict }}"
@@ -417,6 +420,7 @@ steps:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust"
       cwd: "${{ context.worktree_path }}"
       step_name: adjust
+      output_dir: '.'
     capture:
       experiment_results: "${{ result.results_path }}"
       experiment_verdict: "${{ result.verdict }}"

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -104,7 +104,8 @@
       "with": {
         "skill_command": "/autoskillit:prepare-research-pr ${{ context.report_path }} ${{ context.experiment_plan }} ${{ context.worktree_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "prepare_research_pr"
+        "step_name": "prepare_research_pr",
+        "output_dir": "."
       },
       "capture": {
         "prep_path": "${{ result.prep_path }}",
@@ -170,7 +171,8 @@
       "with": {
         "skill_command": "/autoskillit:compose-research-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.worktree_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "compose_research_pr"
+        "step_name": "compose_research_pr",
+        "output_dir": "."
       },
       "capture": {
         "pr_url": "${{ result.pr_url }}"
@@ -343,7 +345,8 @@
       "with": {
         "skill_command": "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "re_run_experiment"
+        "step_name": "re_run_experiment",
+        "output_dir": "."
       },
       "capture": {
         "experiment_results": "${{ result.results_path }}",

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -103,6 +103,7 @@ steps:
       skill_command: "/autoskillit:prepare-research-pr ${{ context.report_path }} ${{ context.experiment_plan }} ${{ context.worktree_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
       step_name: prepare_research_pr
+      output_dir: '.'
     capture:
       prep_path: "${{ result.prep_path }}"
       selected_lenses: "${{ result.selected_lenses }}"
@@ -161,6 +162,7 @@ steps:
       skill_command: "/autoskillit:compose-research-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.worktree_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
       step_name: compose_research_pr
+      output_dir: '.'
     capture:
       pr_url: "${{ result.pr_url }}"
     on_success: guard_pr_url
@@ -315,6 +317,7 @@ steps:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust"
       cwd: "${{ context.worktree_path }}"
       step_name: re_run_experiment
+      output_dir: '.'
     capture:
       experiment_results: "${{ result.results_path }}"
       experiment_verdict: "${{ result.verdict }}"

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -91,7 +91,8 @@
       "with": {
         "skill_command": "/autoskillit:select-directions ${{ context.scope_directions }} ${{ context.scope_report }} ${{ inputs.min_breadth }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "select_directions"
+        "step_name": "select_directions",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/select-directions"
       },
       "capture": {
         "selected_directions": "${{ result.selected_directions }}"
@@ -383,6 +384,7 @@
         "skill_command": "/autoskillit:make-plan ${{ context.group_files }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "plan_phase",
+        "output_dir": ".",
         "group_files": "${{ context.group_files }}"
       },
       "capture": {
@@ -404,7 +406,8 @@
       "with": {
         "skill_command": "/autoskillit:implement-experiment ${{ context.phase_plan_path }}",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "implement_phase"
+        "step_name": "implement_phase",
+        "output_dir": "."
       },
       "capture": {
         "worktree_path": "${{ result.worktree_path }}"
@@ -570,7 +573,8 @@
       "with": {
         "skill_command": "/autoskillit:run-experiment ${{ context.worktree_path }}",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "run_experiment"
+        "step_name": "run_experiment",
+        "output_dir": "."
       },
       "capture": {
         "experiment_results": "${{ result.results_path }}",
@@ -634,7 +638,8 @@
       "with": {
         "skill_command": "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "adjust"
+        "step_name": "adjust",
+        "output_dir": "."
       },
       "capture": {
         "experiment_results": "${{ result.results_path }}",
@@ -830,7 +835,8 @@
       "with": {
         "skill_command": "/autoskillit:prepare-research-pr ${{ context.report_path }} ${{ context.experiment_plan }} ${{ context.worktree_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "prepare_research_pr"
+        "step_name": "prepare_research_pr",
+        "output_dir": "."
       },
       "capture": {
         "prep_path": "${{ result.prep_path }}",
@@ -886,7 +892,8 @@
       "with": {
         "skill_command": "/autoskillit:compose-research-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.worktree_path }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "compose_research_pr"
+        "step_name": "compose_research_pr",
+        "output_dir": "."
       },
       "capture": {
         "pr_url": "${{ result.pr_url }}"
@@ -1044,7 +1051,8 @@
       "with": {
         "skill_command": "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust",
         "cwd": "${{ context.worktree_path }}",
-        "step_name": "re_run_experiment"
+        "step_name": "re_run_experiment",
+        "output_dir": "."
       },
       "capture": {
         "experiment_results": "${{ result.results_path }}",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -131,6 +131,7 @@ steps:
       skill_command: "/autoskillit:select-directions ${{ context.scope_directions }} ${{ context.scope_report }} ${{ inputs.min_breadth }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: select_directions
+      output_dir: "{{AUTOSKILLIT_TEMP}}/select-directions"
     capture:
       selected_directions: "${{ result.selected_directions }}"
     on_success: plan_experiment
@@ -405,6 +406,7 @@ steps:
       skill_command: "/autoskillit:make-plan ${{ context.group_files }}"
       cwd: "${{ context.worktree_path }}"
       step_name: plan_phase
+      output_dir: '.'
       group_files: "${{ context.group_files }}"
     capture:
       phase_plan_path: "${{ result.plan_path }}"
@@ -430,6 +432,7 @@ steps:
       skill_command: "/autoskillit:implement-experiment ${{ context.phase_plan_path }}"
       cwd: "${{ context.worktree_path }}"
       step_name: implement_phase
+      output_dir: '.'
     capture:
       worktree_path: "${{ result.worktree_path }}"
     retries: 0
@@ -576,6 +579,7 @@ steps:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"
       step_name: run_experiment
+      output_dir: '.'
     capture:
       experiment_results: "${{ result.results_path }}"
       experiment_verdict: "${{ result.verdict }}"
@@ -624,6 +628,7 @@ steps:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust"
       cwd: "${{ context.worktree_path }}"
       step_name: adjust
+      output_dir: '.'
     capture:
       experiment_results: "${{ result.results_path }}"
       experiment_verdict: "${{ result.verdict }}"
@@ -785,6 +790,7 @@ steps:
       skill_command: "/autoskillit:prepare-research-pr ${{ context.report_path }} ${{ context.experiment_plan }} ${{ context.worktree_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
       step_name: prepare_research_pr
+      output_dir: '.'
     capture:
       prep_path: "${{ result.prep_path }}"
       selected_lenses: "${{ result.selected_lenses }}"
@@ -848,6 +854,7 @@ steps:
       skill_command: "/autoskillit:compose-research-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.worktree_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
       step_name: compose_research_pr
+      output_dir: '.'
     capture:
       pr_url: "${{ result.pr_url }}"
     on_success: guard_pr_url
@@ -995,6 +1002,7 @@ steps:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust"
       cwd: "${{ context.worktree_path }}"
       step_name: re_run_experiment
+      output_dir: '.'
     capture:
       experiment_results: "${{ result.results_path }}"
       experiment_verdict: "${{ result.verdict }}"

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -590,27 +590,66 @@ def test_recipe_has_unconditional_register_steps(recipe_name: str) -> None:
 
 @pytest.mark.parametrize(
     "recipe_name",
-    ["implementation.yaml", "implementation-groups.yaml", "remediation.yaml"],
+    [
+        "implementation.yaml",
+        "implementation-groups.yaml",
+        "remediation.yaml",
+        "merge-prs.yaml",
+    ],
 )
 def test_re_push_steps_have_force_true(recipe_name: str) -> None:
-    """All re_push/* steps must have force='true'.
+    """All push_to_remote steps following a write-behavior skill must have force='true'.
 
-    Post-rebase push requires --force-with-lease.
+    Structural discovery: no hardcoded step name list — catches any new push step.
     """
+    from autoskillit.core import SKILL_TOOLS
+    from autoskillit.recipe.contracts import (
+        get_skill_contract,
+        load_bundled_manifest,
+        resolve_skill_name,
+    )
+    from autoskillit.recipe.validator import make_validation_context
+
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
-    for step_name in (
-        "re_push",
-        "re_push_queue_fix",
-        "re_push_direct_fix",
-        "re_push_immediate_fix",
-    ):
-        assert step_name in recipe.steps, f"Expected step {step_name!r} in {recipe_name}"
-        step = recipe.steps[step_name]
-        assert step.tool == "push_to_remote"
-        assert step.with_args.get("force") == "true", (
-            f"{step_name} in {recipe_name} must include force='true' — "
-            "post-rebase push requires --force-with-lease"
-        )
+    ctx = make_validation_context(recipe)
+    manifest = load_bundled_manifest()
+    max_hops = 6
+
+    violations: list[str] = []
+    for step_name, step in recipe.steps.items():
+        if step.tool != "push_to_remote":
+            continue
+        visited: set[str] = set()
+        queue: list[tuple[str, int]] = [(p, 1) for p in ctx.predecessors.get(step_name, set())]
+        has_write_pred = False
+        while queue and not has_write_pred:
+            pred_name, depth = queue.pop(0)
+            if pred_name in visited or depth > max_hops:
+                continue
+            visited.add(pred_name)
+            pred = recipe.steps.get(pred_name)
+            if pred is None:
+                continue
+            if pred.tool in SKILL_TOOLS:
+                skill_cmd = (pred.with_args or {}).get("skill_command", "")
+                skill = resolve_skill_name(skill_cmd)
+                if skill:
+                    contract = get_skill_contract(skill, manifest)
+                    if (
+                        contract
+                        and contract.write_behavior in ("always", "conditional")
+                        and not contract.read_only
+                    ):
+                        has_write_pred = True
+                        break
+            queue.extend((p, depth + 1) for p in ctx.predecessors.get(pred_name, set()))
+        if has_write_pred and step.with_args.get("force", "").strip().lower() != "true":
+            violations.append(f"{step_name}: follows write-behavior skill without force='true'")
+
+    assert not violations, (
+        f"{recipe_name}: push steps after write-behavior skills need force='true':\n"
+        + "\n".join(violations)
+    )
 
 
 def test_bundled_recipes_have_no_ci_hardcoded_workflow() -> None:

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -9,6 +9,7 @@ import structlog.testing
 
 from autoskillit.core import PACK_REGISTRY, SKILL_TOOLS, Severity
 from autoskillit.recipe._analysis import build_recipe_graph
+from autoskillit.recipe._rule_helpers import _MAX_HOPS
 from autoskillit.recipe._skill_helpers import _get_skill_category_map
 from autoskillit.recipe.contracts import load_bundled_manifest, resolve_skill_name
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
@@ -613,7 +614,7 @@ def test_re_push_steps_have_force_true(recipe_name: str) -> None:
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
     ctx = make_validation_context(recipe)
     manifest = load_bundled_manifest()
-    max_hops = 6
+    max_hops = _MAX_HOPS
 
     violations: list[str] = []
     for step_name, step in recipe.steps.items():

--- a/tests/recipe/test_bundled_recipes_review_pr.py
+++ b/tests/recipe/test_bundled_recipes_review_pr.py
@@ -144,6 +144,7 @@ class TestReviewPrRecipeIntegration:
 
     def test_pre_review_rebase_routes_to_re_push_review(self, recipe: object) -> None:
         """T_RP7b: pre_review_rebase on_success must route to re_push_review."""
+        assert "pre_review_rebase" in recipe.steps  # type: ignore[operator]
         step = recipe.steps["pre_review_rebase"]  # type: ignore[attr-defined]
         assert step.on_success == "re_push_review", (
             "pre_review_rebase must route on_success to re_push_review"

--- a/tests/recipe/test_bundled_recipes_review_pr.py
+++ b/tests/recipe/test_bundled_recipes_review_pr.py
@@ -126,8 +126,8 @@ class TestReviewPrRecipeIntegration:
         """T_RP6: resolve_review has retries=2 matching resolve_ci pattern."""
         assert recipe.steps["resolve_review"].retries == 2  # type: ignore[attr-defined]
 
-    def test_resolve_review_routes_to_re_push_review(self, recipe: object) -> None:
-        """T_RP7: resolve_review uses on_result: verdict dispatch routing to re_push_review."""
+    def test_resolve_review_routes_to_pre_review_rebase(self, recipe: object) -> None:
+        """T_RP7: resolve_review uses on_result: verdict dispatch routing to pre_review_rebase."""
         step = recipe.steps["resolve_review"]  # type: ignore[attr-defined]
         assert step.on_success is None, (
             "resolve_review must use on_result: verdict dispatch, not unconditional on_success"
@@ -138,8 +138,15 @@ class TestReviewPrRecipeIntegration:
         real_fix_routes = [
             c.route for c in step.on_result.conditions if c.when and "real_fix" in c.when
         ]
-        assert any("re_push_review" in r for r in real_fix_routes), (
-            "resolve_review on_result must route verdict=real_fix to re_push_review"
+        assert any("pre_review_rebase" in r for r in real_fix_routes), (
+            "resolve_review on_result must route verdict=real_fix to pre_review_rebase"
+        )
+
+    def test_pre_review_rebase_routes_to_re_push_review(self, recipe: object) -> None:
+        """T_RP7b: pre_review_rebase on_success must route to re_push_review."""
+        step = recipe.steps["pre_review_rebase"]  # type: ignore[attr-defined]
+        assert step.on_success == "re_push_review", (
+            "pre_review_rebase must route on_success to re_push_review"
         )
 
     def test_re_push_review_routes_to_check_review_loop(self, recipe: object) -> None:

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -107,6 +107,7 @@ def test_check_review_loop_has_on_failure(recipe) -> None:
 # T_IP_LOOP7
 def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
     """pre_review_rebase on_success must route to re_push_review in implementation recipe."""
+    assert "pre_review_rebase" in recipe.steps
     step = recipe.steps["pre_review_rebase"]
     assert step.on_success == "re_push_review"
 

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -105,6 +105,12 @@ def test_check_review_loop_has_on_failure(recipe) -> None:
 
 
 # T_IP_LOOP7
+def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
+    """pre_review_rebase on_success must route to re_push_review in implementation recipe."""
+    step = recipe.steps["pre_review_rebase"]
+    assert step.on_success == "re_push_review"
+
+
 def test_re_push_review_routes_to_check_review_loop(recipe) -> None:
     """re_push_review on_success must route to check_review_loop, not ci_watch directly."""
     step = recipe.steps["re_push_review"]

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -24,6 +24,12 @@ def test_check_review_loop_step_exists(recipe) -> None:
 
 
 # T_IG_LOOP2
+def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
+    """pre_review_rebase on_success must route to re_push_review in implementation-groups."""
+    step = recipe.steps["pre_review_rebase"]
+    assert step.on_success == "re_push_review"
+
+
 def test_re_push_review_routes_to_check_review_loop(recipe) -> None:
     """re_push_review on_success must route to check_review_loop in implementation-groups
     recipe."""

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -26,6 +26,7 @@ def test_check_review_loop_step_exists(recipe) -> None:
 # T_IG_LOOP2
 def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
     """pre_review_rebase on_success must route to re_push_review in implementation-groups."""
+    assert "pre_review_rebase" in recipe.steps
     step = recipe.steps["pre_review_rebase"]
     assert step.on_success == "re_push_review"
 

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -552,8 +552,11 @@ def test_pmp_resolve_review_integration_routes_to_re_push(recipe) -> None:
     )
     assert step.on_result is not None, "resolve_review_integration must have on_result: block"
     push_routes = [c.route for c in step.on_result.conditions if c.when and "real_fix" in c.when]
-    assert any("re_push_review_integration" in r for r in push_routes), (
-        "resolve_review_integration must route verdict=real_fix to re_push_review_integration"
+    assert any(
+        "re_push_review_integration" in r or "pre_review_rebase" in r for r in push_routes
+    ), (
+        "resolve_review_integration must route verdict=real_fix to re_push_review_integration "
+        "or pre_review_rebase (fetch+rebase before push)"
     )
 
 

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -553,10 +553,11 @@ def test_pmp_resolve_review_integration_routes_to_re_push(recipe) -> None:
     assert step.on_result is not None, "resolve_review_integration must have on_result: block"
     push_routes = [c.route for c in step.on_result.conditions if c.when and "real_fix" in c.when]
     assert any(
-        "re_push_review_integration" in r or "pre_review_rebase" in r for r in push_routes
+        "re_push_review_integration" in r or "pre_review_rebase_integration" in r
+        for r in push_routes
     ), (
         "resolve_review_integration must route verdict=real_fix to re_push_review_integration "
-        "or pre_review_rebase (fetch+rebase before push)"
+        "or pre_review_rebase_integration (fetch+rebase before push)"
     )
 
 

--- a/tests/recipe/test_planner_contracts.py
+++ b/tests/recipe/test_planner_contracts.py
@@ -1,23 +1,28 @@
-"""Contract-level tests for write_behavior + output_dir coherence in planner.yaml.
+"""Contract-level tests for write_behavior + output_dir coherence across bundled recipes.
 
-Enforces the invariant: every planner skill step that expects writes (write_behavior:
-always) must declare output_dir to set the allowed_write_prefix before session launch.
+Enforces two invariants for every run_skill step:
+- write_behavior=always: output_dir must be declared unconditionally.
+- write_behavior=conditional: output_dir must be declared when a push_to_remote step is
+  reachable within _MAX_HOPS (consistent with the write-skill-requires-source-output-dir
+  semantic rule).
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 import yaml
 
-pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+from autoskillit.core import SKILL_TOOLS
+from autoskillit.recipe._analysis import _build_step_graph
+from autoskillit.recipe._rule_helpers import push_reachable
+from autoskillit.recipe.contracts import load_bundled_manifest, resolve_skill_name
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 _RECIPE_DIR = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipes"
-_CONTRACTS_PATH = (
-    Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipe" / "skill_contracts.yaml"
-)
 
 
 @pytest.fixture(scope="module")
@@ -25,49 +30,50 @@ def planner_yaml() -> dict:
     return yaml.safe_load((_RECIPE_DIR / "planner.yaml").read_text())
 
 
-@pytest.fixture(scope="module")
-def contracts() -> dict:
-    return yaml.safe_load(_CONTRACTS_PATH.read_text())
+_ALL_BUNDLED_RECIPE_PATHS = sorted(builtin_recipes_dir().glob("*.yaml"))
 
 
-def _skill_name_from_command(command: str) -> str | None:
-    """Extract bare skill name from a skill_command string."""
-    m = re.search(r"/(?:autoskillit:)?([a-z][a-z0-9-]+)", command)
-    return m.group(1) if m else None
+@pytest.mark.parametrize("recipe_yaml", _ALL_BUNDLED_RECIPE_PATHS, ids=lambda p: p.stem)
+def test_write_skill_steps_have_output_dir(recipe_yaml: Path) -> None:
+    """Every run_skill step with write-capable behavior must declare output_dir.
 
-
-def test_planner_skills_with_write_behavior_always_have_output_dir(
-    planner_yaml: dict, contracts: dict
-) -> None:
-    """Every planner run_skill step whose skill has write_behavior: always must declare output_dir.
-
-    This prevents a skill that is expected to write (write_behavior: always) from running
-    without an allowed_write_prefix — which would cause zero-write detection failures and
-    leave write scope enforcement unenforced.
+    write_behavior=always: output_dir required unconditionally.
+    write_behavior=conditional: output_dir required when push_to_remote is reachable
+    within _MAX_HOPS hops from the step (BFS over the routing graph).
     """
-    skills = contracts.get("skills", {})
-    steps = planner_yaml.get("steps", {})
+    recipe = load_recipe(recipe_yaml)
+    manifest = load_bundled_manifest()
+    skills = manifest.get("skills", {})
+    step_graph = _build_step_graph(recipe)
 
     violations: list[str] = []
-    for step_name, step in steps.items():
-        if not isinstance(step, dict):
+    for step_name, step in recipe.steps.items():
+        if step.tool not in SKILL_TOOLS:
             continue
-        if step.get("tool") != "run_skill":
+        skill_cmd = str((step.with_args or {}).get("skill_command", ""))
+        skill = resolve_skill_name(skill_cmd)
+        if skill is None:
             continue
-        with_block = step.get("with", {}) or {}
-        skill_cmd = str(with_block.get("skill_command", ""))
-        skill_name = _skill_name_from_command(skill_cmd)
-        if skill_name is None:
-            continue
-        contract = skills.get(skill_name, {})
-        if contract.get("write_behavior") == "always":
-            if not with_block.get("output_dir"):
-                violations.append(f"{step_name} ({skill_name})")
+        skill_data = skills.get(skill, {})
+        write_behavior = skill_data.get("write_behavior")
+        output_dir = (step.with_args or {}).get("output_dir")
+
+        if write_behavior == "always":
+            if not output_dir:
+                violations.append(
+                    f"{step_name} ({skill}): write_behavior=always but no output_dir"
+                )
+        elif write_behavior == "conditional":
+            reachable, push_step = push_reachable(step_graph, step_name, recipe)
+            if reachable and not output_dir:
+                violations.append(
+                    f"{step_name} ({skill}): write_behavior=conditional, "
+                    f"push reachable via '{push_step}', but no output_dir"
+                )
 
     assert not violations, (
-        f"planner.yaml run_skill steps with write_behavior=always but no output_dir: "
-        f"{violations}. Add output_dir: '${{{{ context.planner_dir }}}}' (or subdirectory) "
-        "to each step's with: block."
+        f"{recipe_yaml.stem}: run_skill steps missing required output_dir:\n"
+        + "\n".join(f"  {v}" for v in violations)
     )
 
 

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -41,6 +41,12 @@ def test_check_review_loop_step_exists(recipe) -> None:
 
 
 # T_REM_LOOP2
+def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
+    """pre_review_rebase on_success must route to re_push_review in remediation recipe."""
+    step = recipe.steps["pre_review_rebase"]
+    assert step.on_success == "re_push_review"
+
+
 def test_re_push_review_routes_to_check_review_loop(recipe) -> None:
     """re_push_review on_success must route to check_review_loop in remediation recipe."""
     step = recipe.steps["re_push_review"]

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -43,6 +43,7 @@ def test_check_review_loop_step_exists(recipe) -> None:
 # T_REM_LOOP2
 def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
     """pre_review_rebase on_success must route to re_push_review in remediation recipe."""
+    assert "pre_review_rebase" in recipe.steps
     step = recipe.steps["pre_review_rebase"]
     assert step.on_success == "re_push_review"
 

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -196,9 +196,9 @@ def test_resolve_ci_routes_flake_suspected_to_re_push(recipe_name: str) -> None:
         ]
         if not routes:
             continue
-        assert any("re_push" in r for r in routes), (
+        assert any("re_push" in r or "pre_review_rebase" in r for r in routes), (
             f"{recipe_name}/{step_name}: verdict=flake_suspected must route to "
-            f"a re_push step (retry), got routes: {routes}"
+            f"a re_push step or pre_review_rebase (retry path), got routes: {routes}"
         )
 
 

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -149,9 +149,9 @@ def test_resolve_ci_on_result_routes_real_fix_to_re_push(recipe_name: str) -> No
         ]
         if not real_fix_routes:
             continue  # no explicit real_fix route yet — other tests catch this
-        assert any("re_push" in r for r in real_fix_routes), (
-            f"{recipe_name}/{step_name}: verdict=real_fix must route to a re_push step, "
-            f"got routes: {real_fix_routes}"
+        assert any("re_push" in r or "pre_review_rebase" in r for r in real_fix_routes), (
+            f"{recipe_name}/{step_name}: verdict=real_fix must route to a re_push step "
+            f"or pre_review_rebase (fetch+rebase before push), got routes: {real_fix_routes}"
         )
 
 

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -716,9 +716,7 @@ def _make_write_contract(
     )
 
 
-def test_write_skill_reaching_push_without_source_output_dir_fires_conditional(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_write_skill_reaching_push_without_source_output_dir_fires_conditional() -> None:
     """Rule fires ERROR when conditional write skill has no output_dir and reaches push."""
     recipe = _make_write_push_recipe(output_dir=None, routes_to_push=True)
     contract = _make_write_contract(write_behavior="conditional")
@@ -735,9 +733,7 @@ def test_write_skill_reaching_push_without_source_output_dir_fires_conditional(
     assert hits[0].step_name == "skill_step"
 
 
-def test_write_skill_reaching_push_without_source_output_dir_fires_always(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_write_skill_reaching_push_without_source_output_dir_fires_always() -> None:
     """Rule fires ERROR when always-write skill has no output_dir and reaches push."""
     recipe = _make_write_push_recipe(output_dir=None, routes_to_push=True)
     contract = _make_write_contract(write_behavior="always")
@@ -751,9 +747,7 @@ def test_write_skill_reaching_push_without_source_output_dir_fires_always(
     assert hits[0].severity == Severity.ERROR
 
 
-def test_write_skill_reaching_push_with_output_dir_passes(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_write_skill_reaching_push_with_output_dir_passes() -> None:
     """Rule does NOT fire when output_dir is declared."""
     recipe = _make_write_push_recipe(output_dir="${{ context.work_dir }}", routes_to_push=True)
     contract = _make_write_contract(write_behavior="conditional")
@@ -766,9 +760,7 @@ def test_write_skill_reaching_push_with_output_dir_passes(
     assert not hits, "write-skill-requires-source-output-dir must not fire when output_dir is set"
 
 
-def test_write_skill_not_reaching_push_without_output_dir_passes(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_write_skill_not_reaching_push_without_output_dir_passes() -> None:
     """Rule does NOT fire when the skill does not reach push_to_remote."""
     recipe = _make_write_push_recipe(output_dir=None, routes_to_push=False)
     contract = _make_write_contract(write_behavior="conditional")
@@ -783,9 +775,7 @@ def test_write_skill_not_reaching_push_without_output_dir_passes(
     )
 
 
-def test_read_only_skill_without_output_dir_not_flagged(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_read_only_skill_without_output_dir_not_flagged() -> None:
     """Rule does NOT fire when the skill is read_only, even with write_behavior='always'."""
     recipe = _make_write_push_recipe(output_dir=None, routes_to_push=True)
     contract = _make_write_contract(write_behavior="always", read_only=True)

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -657,3 +657,162 @@ def test_bundled_recipes_pass_all_new_contract_rules() -> None:
         "New contract immunity rules fired on bundled recipes "
         "(ensure Part A contract fixes are applied):\n" + "\n".join(violations)
     )
+
+
+# ---------------------------------------------------------------------------
+# write-skill-requires-source-output-dir rule tests
+# ---------------------------------------------------------------------------
+
+
+def _make_write_push_recipe(
+    *,
+    output_dir: str | None = None,
+    routes_to_push: bool = True,
+) -> Recipe:
+    """Minimal recipe: run_skill → push_to_remote (or stop)."""
+    with_args: dict[str, str] = {
+        "skill_command": "/autoskillit:resolve-review branch base",
+        "cwd": "/tmp",
+    }
+    if output_dir is not None:
+        with_args["output_dir"] = output_dir
+
+    push_dest = "push_step" if routes_to_push else "done"
+    skill_step = RecipeStep(
+        tool="run_skill",
+        with_args=with_args,
+        on_success=push_dest,
+        on_failure="done",
+    )
+    steps: dict[str, RecipeStep] = {"skill_step": skill_step}
+    if routes_to_push:
+        steps["push_step"] = RecipeStep(
+            tool="push_to_remote",
+            with_args={"clone_path": "/tmp", "remote_url": "r", "branch": "b"},
+            on_success="done",
+            on_failure="done",
+        )
+    steps["done"] = RecipeStep(action="stop", message="done")
+    return Recipe(
+        name="test-recipe",
+        description="Test write-skill-requires-source-output-dir rule.",
+        version="0.2.0",
+        kitchen_rules="Use run_skill only.",
+        steps=steps,
+    )
+
+
+def _make_write_contract(
+    *,
+    write_behavior: str | None,
+    read_only: bool = False,
+) -> SkillContract:
+    return SkillContract(
+        inputs=[],
+        outputs=[{"name": "verdict", "type": "string"}] if write_behavior else [],
+        write_behavior=write_behavior,
+        write_expected_when=["verdict\\s*=\\s*\\w+"] if write_behavior == "conditional" else [],
+        read_only=read_only,
+    )
+
+
+def test_write_skill_reaching_push_without_source_output_dir_fires_conditional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule fires ERROR when conditional write skill has no output_dir and reaches push."""
+    recipe = _make_write_push_recipe(output_dir=None, routes_to_push=True)
+    contract = _make_write_contract(write_behavior="conditional")
+    with patch(
+        "autoskillit.recipe.rules.rules_contracts.get_skill_contract",
+        return_value=contract,
+    ):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "write-skill-requires-source-output-dir"]
+    assert hits, (
+        "write-skill-requires-source-output-dir must fire when no output_dir and push reachable"
+    )
+    assert hits[0].severity == Severity.ERROR
+    assert hits[0].step_name == "skill_step"
+
+
+def test_write_skill_reaching_push_without_source_output_dir_fires_always(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule fires ERROR when always-write skill has no output_dir and reaches push."""
+    recipe = _make_write_push_recipe(output_dir=None, routes_to_push=True)
+    contract = _make_write_contract(write_behavior="always")
+    with patch(
+        "autoskillit.recipe.rules.rules_contracts.get_skill_contract",
+        return_value=contract,
+    ):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "write-skill-requires-source-output-dir"]
+    assert hits, "write-skill-requires-source-output-dir must fire for write_behavior='always'"
+    assert hits[0].severity == Severity.ERROR
+
+
+def test_write_skill_reaching_push_with_output_dir_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule does NOT fire when output_dir is declared."""
+    recipe = _make_write_push_recipe(output_dir="${{ context.work_dir }}", routes_to_push=True)
+    contract = _make_write_contract(write_behavior="conditional")
+    with patch(
+        "autoskillit.recipe.rules.rules_contracts.get_skill_contract",
+        return_value=contract,
+    ):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "write-skill-requires-source-output-dir"]
+    assert not hits, "write-skill-requires-source-output-dir must not fire when output_dir is set"
+
+
+def test_write_skill_not_reaching_push_without_output_dir_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule does NOT fire when the skill does not reach push_to_remote."""
+    recipe = _make_write_push_recipe(output_dir=None, routes_to_push=False)
+    contract = _make_write_contract(write_behavior="conditional")
+    with patch(
+        "autoskillit.recipe.rules.rules_contracts.get_skill_contract",
+        return_value=contract,
+    ):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "write-skill-requires-source-output-dir"]
+    assert not hits, (
+        "write-skill-requires-source-output-dir must not fire when push is unreachable"
+    )
+
+
+def test_read_only_skill_without_output_dir_not_flagged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule does NOT fire when the skill is read_only, even with write_behavior='always'."""
+    recipe = _make_write_push_recipe(output_dir=None, routes_to_push=True)
+    contract = _make_write_contract(write_behavior="always", read_only=True)
+    with patch(
+        "autoskillit.recipe.rules.rules_contracts.get_skill_contract",
+        return_value=contract,
+    ):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "write-skill-requires-source-output-dir"]
+    assert not hits, "write-skill-requires-source-output-dir must not fire for read_only skills"
+
+
+def test_all_bundled_recipes_pass_write_skill_output_dir_rule() -> None:
+    """All bundled recipes must have zero write-skill-requires-source-output-dir findings."""
+    recipes_dir = pkg_root() / "recipes"
+    recipe_files = sorted(recipes_dir.glob("*.yaml"))
+    assert recipe_files, "No bundled recipes found"
+
+    violations: list[str] = []
+    for recipe_path in recipe_files:
+        recipe = load_recipe(recipe_path)
+        findings = run_semantic_rules(recipe)
+        for f in findings:
+            if f.rule == "write-skill-requires-source-output-dir":
+                violations.append(f"{recipe_path.name}:{f.step_name}: {f.message}")
+
+    assert not violations, (
+        "write-skill-requires-source-output-dir fired on bundled recipes:\n"
+        + "\n".join(violations)
+    )

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -709,7 +709,7 @@ def _make_write_contract(
 ) -> SkillContract:
     return SkillContract(
         inputs=[],
-        outputs=[{"name": "verdict", "type": "string"}] if write_behavior else [],
+        outputs=[],
         write_behavior=write_behavior,
         write_expected_when=["verdict\\s*=\\s*\\w+"] if write_behavior == "conditional" else [],
         read_only=read_only,

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -6,6 +6,7 @@ import inspect as _inspect
 import pytest
 
 from autoskillit.core import GATED_TOOLS, UNGATED_TOOLS, Severity
+from autoskillit.recipe.contracts import SkillContract
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
@@ -514,13 +515,15 @@ def _make_edit_then_push_recipe_tools(force: str | None = None) -> Recipe:
 
 def _patch_contract_for_push_rule(write_behavior: str, read_only: bool = False):
     """Context manager that patches get_skill_contract for push-after-edit tests."""
-    from unittest.mock import MagicMock
     from unittest.mock import patch as _patch
 
-    contract = MagicMock()
-    contract.write_behavior = write_behavior
-    contract.read_only = read_only
-    contract.write_expected_when = ["pat"] if write_behavior == "conditional" else []
+    contract = SkillContract(
+        inputs=[],
+        outputs=[],
+        write_behavior=write_behavior,
+        write_expected_when=["pat"] if write_behavior == "conditional" else [],
+        read_only=read_only,
+    )
 
     return _patch(
         "autoskillit.recipe.rules.rules_tools.get_skill_contract",

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -473,3 +473,119 @@ def test_release_issue_requires_disposition_passes_with_target_branch() -> None:
     findings = run_semantic_rules(recipe)
     hits = [f for f in findings if f.rule == "release-issue-requires-disposition"]
     assert not hits
+
+
+# ---------------------------------------------------------------------------
+# push-after-edit-requires-force rule tests
+# ---------------------------------------------------------------------------
+
+
+def _make_edit_then_push_recipe_tools(force: str | None = None) -> Recipe:
+    """Minimal recipe: run_skill (write-behavior) → push_to_remote."""
+    push_args: dict[str, str] = {"clone_path": "/tmp", "remote_url": "r", "branch": "b"}
+    if force is not None:
+        push_args["force"] = force
+    return Recipe(
+        name="test-recipe",
+        description="Test push-after-edit-requires-force rule.",
+        version="0.2.0",
+        kitchen_rules="Use run_skill only.",
+        steps={
+            "skill_step": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": "/autoskillit:resolve-review branch base",
+                    "cwd": "/tmp",
+                    "output_dir": "/tmp",
+                },
+                on_success="push_step",
+                on_failure="done",
+            ),
+            "push_step": RecipeStep(
+                tool="push_to_remote",
+                with_args=push_args,
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+    )
+
+
+def _patch_contract_for_push_rule(write_behavior: str, read_only: bool = False):
+    """Context manager that patches get_skill_contract for push-after-edit tests."""
+    from unittest.mock import MagicMock
+    from unittest.mock import patch as _patch
+
+    contract = MagicMock()
+    contract.write_behavior = write_behavior
+    contract.read_only = read_only
+    contract.write_expected_when = ["pat"] if write_behavior == "conditional" else []
+
+    return _patch(
+        "autoskillit.recipe.rules.rules_tools.get_skill_contract",
+        return_value=contract,
+    )
+
+
+def test_push_after_conditional_write_skill_without_force_fires() -> None:
+    """push-after-edit-requires-force fires ERROR: conditional-write before push without force."""
+    recipe = _make_edit_then_push_recipe_tools(force=None)
+    with _patch_contract_for_push_rule("conditional"):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "push-after-edit-requires-force"]
+    assert hits, (
+        "push-after-edit-requires-force must fire when conditional-write skill "
+        "precedes a force-less push"
+    )
+    assert hits[0].severity == Severity.ERROR
+
+
+def test_push_after_always_write_skill_without_force_fires() -> None:
+    """push-after-edit-requires-force fires ERROR when always-write precedes push without force."""
+    recipe = _make_edit_then_push_recipe_tools(force=None)
+    with _patch_contract_for_push_rule("always"):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "push-after-edit-requires-force"]
+    assert hits, "push-after-edit-requires-force must fire for write_behavior='always'"
+    assert hits[0].severity == Severity.ERROR
+
+
+def test_push_after_conditional_write_skill_with_force_passes() -> None:
+    """push-after-edit-requires-force does NOT fire when push has force='true'."""
+    recipe = _make_edit_then_push_recipe_tools(force="true")
+    with _patch_contract_for_push_rule("conditional"):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "push-after-edit-requires-force"]
+    assert not hits, "push-after-edit-requires-force must not fire when force='true'"
+
+
+def test_push_after_readonly_skill_without_force_passes() -> None:
+    """push-after-edit-requires-force does NOT fire when the skill is read_only."""
+    recipe = _make_edit_then_push_recipe_tools(force=None)
+    with _patch_contract_for_push_rule("always", read_only=True):
+        findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "push-after-edit-requires-force"]
+    assert not hits, "push-after-edit-requires-force must not fire for read_only skills"
+
+
+def test_all_bundled_recipes_pass_push_after_edit_rule() -> None:
+    """All bundled recipes must have zero push-after-edit-requires-force findings."""
+    from autoskillit.core import pkg_root
+    from autoskillit.recipe.io import load_recipe as _lr
+
+    recipes_dir = pkg_root() / "recipes"
+    recipe_files = sorted(recipes_dir.glob("*.yaml"))
+    assert recipe_files, "No bundled recipes found"
+
+    violations: list[str] = []
+    for recipe_path in recipe_files:
+        recipe = _lr(recipe_path)
+        findings = run_semantic_rules(recipe)
+        for f in findings:
+            if f.rule == "push-after-edit-requires-force":
+                violations.append(f"{recipe_path.name}:{f.step_name}: {f.message}")
+
+    assert not violations, (
+        "push-after-edit-requires-force fired on bundled recipes:\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

Two bugs caused the remediation pipeline to fail: (1) the write guard blocked `resolve_review` source edits because the recipe step lacked `output_dir`, causing the fallback to a temp-dir prefix that excluded source files; (2) `re_push_review` failed because the remote branch advanced and no fetch+rebase preceded the push. Both bugs are instances of **missing recipe-level configuration that existing load-time validation did not enforce**. The fix is two new semantic rules that make these bug classes structurally impossible by catching them at recipe load time, plus broadening the existing push test from a hardcoded allowlist to structural discovery.

Closes #3161

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260527-131813-858121/.autoskillit/temp/rectify/rectify_write_guard_push_immunity_2026-05-27_131813.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 12.5k | 27.5k | 2.5M | 145.2k | 355 | 155.9k | 23m 41s |
| review | claude-sonnet-4-6 | 1 | 2.9k | 6.0k | 174.1k | 60.5k | 90 | 27.8k | 5m 51s |
| dry_walkthrough | claude-sonnet-4-6 | 2 | 2.3k | 28.8k | 3.2M | 89.8k | 339 | 123.7k | 17m 33s |
| implement | claude-sonnet-4-6 | 2 | 1.9k | 92.5k | 7.5M | 174.8k | 243 | 215.5k | 27m 2s |
| audit_impl | claude-sonnet-4-6 | 2 | 1.8k | 16.2k | 548.2k | 48.3k | 67 | 59.1k | 6m 24s |
| make_plan | claude-sonnet-4-6 | 1 | 231 | 20.4k | 1.6M | 85.2k | 105 | 71.2k | 8m 49s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 211.1k | 4.7k | 370.7k | 30.9k | 28 | 43.7k | 1m 45s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 68.1k | 1.7k | 275.1k | 30.9k | 19 | 15.4k | 51s |
| review_pr | claude-sonnet-4-6 | 2 | 444 | 86.8k | 4.4M | 162.4k | 251 | 242.7k | 25m 3s |
| resolve_review | claude-sonnet-4-6 | 2 | 804 | 53.1k | 7.5M | 104.2k | 234 | 169.1k | 24m 51s |
| **Total** | | | 302.1k | 337.9k | 28.0M | 174.8k | | 1.1M | 2h 21m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 1492 | 5011.3 | 144.4 | 62.0 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 88 | 85395.7 | 1921.9 | 603.5 |
| **Total** | **1580** | 17744.7 | 711.5 | 213.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 8 | 22.9k | 331.5k | 27.4M | 1.1M | 2h 19m |
| MiniMax-M2.7-highspeed | 2 | 279.2k | 6.4k | 645.9k | 59.1k | 2m 36s |