### PR TITLE
Rectify: ci_applicable False-Positive from merge_group Trigger — PART A ONLY

### DIFF
--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -46,6 +46,7 @@ from autoskillit.execution.merge_queue._merge_queue_repo_state import (
     _RATE_LIMIT_SECONDARY_MARKER,  # noqa: F401 — re-export for callers
     _REPO_STATE_QUERY,  # noqa: F401 — re-export for callers
     _has_merge_group_trigger,  # noqa: F401 — re-export for callers
+    _has_pull_request_trigger_for_base,  # noqa: F401 — re-export for callers
     _is_secondary_rate_limit,  # noqa: F401 — re-export for callers
     _push_trigger_applies_to_branch,  # noqa: F401 — re-export for callers
     _retry_after_seconds,  # noqa: F401 — re-export for callers

--- a/src/autoskillit/execution/merge_queue/_merge_queue_repo_state.py
+++ b/src/autoskillit/execution/merge_queue/_merge_queue_repo_state.py
@@ -134,6 +134,45 @@ def _has_merge_group_trigger(text: str) -> bool:
     return False
 
 
+def _has_pull_request_trigger_for_base(text: str, base_branch: str) -> bool:
+    """Return True if the workflow pull_request trigger fires for PRs targeting base_branch.
+
+    Parses YAML to inspect pull_request.branches / pull_request.branches-ignore filters.
+    Falls back to presence-only heuristic on YAML parse failure.
+    """
+    try:
+        parsed = load_yaml(text)
+    except YAMLError:
+        return "pull_request" in text
+
+    if not isinstance(parsed, dict):
+        return False
+
+    # PyYAML (YAML 1.1) parses the bare key `on` as boolean True.
+    # Accept both to be safe.
+    on_value = parsed.get(True, parsed.get("on"))
+    if on_value == "pull_request":
+        return True
+    if isinstance(on_value, list):
+        return "pull_request" in on_value
+    if not isinstance(on_value, dict) or "pull_request" not in on_value:
+        return False
+
+    pr_cfg = on_value["pull_request"]
+    if not isinstance(pr_cfg, dict) or not pr_cfg:
+        # pull_request: null or pull_request: {} — no branch filter, fires for all PRs
+        return True
+
+    branches = pr_cfg.get("branches")
+    branches_ignore = pr_cfg.get("branches-ignore")
+
+    if branches is not None:
+        return any(fnmatch.fnmatch(base_branch, pat) for pat in branches)
+    if branches_ignore is not None:
+        return not any(fnmatch.fnmatch(base_branch, pat) for pat in branches_ignore)
+    return True
+
+
 def _is_secondary_rate_limit(resp: httpx.Response) -> bool:
     """Return True when a 403 response is a GitHub secondary rate limit.
 
@@ -171,6 +210,7 @@ async def fetch_repo_merge_state(
     repo: str,
     branch: str,
     token: str | None,
+    base_branch: str | None = None,
 ) -> dict[str, bool | str | None]:
     """Fetch repository merge-state in a single GraphQL round-trip.
 
@@ -182,6 +222,10 @@ async def fetch_repo_merge_state(
     - ``ci_event``: ``"push"`` when any workflow declares a push trigger
       that fires for the given branch, or ``None`` otherwise (match-any —
       ci.py scope.event=None lets head_sha provide correctness).
+    - ``ci_applicable``: ``True`` when a push trigger matches the branch or a
+      pull_request trigger targets ``base_branch`` (when provided). ``False``
+      when ``base_branch`` is ``None`` and no push trigger fires — conservative
+      default preserves backward compatibility for callers that omit it.
 
     Null-handling:
     - ``mergeQueue is null`` → ``queue_available: False``  (no queue)
@@ -244,10 +288,11 @@ async def fetch_repo_merge_state(
         False if auto_merge_field_missing else bool(repo_data.get("autoMergeAllowed", False))
     )
 
-    # Scan workflow files for push and merge_group trigger declarations.
-    # Both flags are derived from the same Blob.text scan — no extra round-trips.
+    # Scan workflow files for push, pull_request, and merge_group trigger declarations.
+    # All flags are derived from the same Blob.text scan — no extra round-trips.
     merge_group_trigger = False
     has_push_trigger = False
+    has_pr_trigger = False
     workflows_tree = repo_data.get("object")
     if workflows_tree is not None:
         for entry in workflows_tree.get("entries", []):
@@ -259,9 +304,11 @@ async def fetch_repo_merge_state(
                 merge_group_trigger = True
             if _push_trigger_applies_to_branch(text, branch):
                 has_push_trigger = True
+            if base_branch is not None and _has_pull_request_trigger_for_base(text, base_branch):
+                has_pr_trigger = True
 
     ci_event: Literal["push"] | None = "push" if has_push_trigger else None
-    ci_applicable: bool = has_push_trigger or merge_group_trigger
+    ci_applicable: bool = has_push_trigger or has_pr_trigger
 
     return {
         "queue_available": queue_available,

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -133,6 +133,15 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
             "cwd",
         }
     ),
+    "check_repo_merge_state": frozenset(
+        {
+            "branch",
+            "cwd",
+            "remote_url",
+            "step_name",
+            "base_branch",
+        }
+    ),
     # --- Git tools ---
     "create_unique_branch": frozenset(
         {

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -750,7 +750,8 @@
         "branch": "${{ context.merge_target }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "check_repo_ci_event"
+        "step_name": "check_repo_ci_event",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "ci_event": "${{ result.ci_event }}",
@@ -773,7 +774,7 @@
         }
       ],
       "skip_when_false": "inputs.open_pr",
-      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
+      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor pull_request triggers apply to this branch/base combination, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
     },
     "check_pr_state": {
       "tool": "check_pr_mergeable",
@@ -861,7 +862,8 @@
         "branch": "${{ context.merge_target }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "handle_no_ci_runs"
+        "step_name": "handle_no_ci_runs",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "ci_event": "${{ result.ci_event }}",
@@ -1111,7 +1113,8 @@
         "branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "check_repo_merge_state"
+        "step_name": "check_repo_merge_state",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "queue_available": "${{ result.queue_available }}",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -699,6 +699,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
       step_name: "check_repo_ci_event"
+      base_branch: "${{ inputs.base_branch }}"
     capture:
       ci_event: "${{ result.ci_event }}"
       ci_applicable: "${{ result.ci_applicable }}"
@@ -720,8 +721,8 @@ steps:
     skip_when_false: "inputs.open_pr"
     note: >
       Short-circuits CI wait when no workflow trigger matches the feature branch.
-      ci_applicable=false means neither push nor merge_group triggers apply,
-      so wait_for_ci would exhaust its timeout budget with zero CI runs.
+      ci_applicable=false means neither push nor pull_request triggers apply to this
+      branch/base combination, so wait_for_ci would exhaust its timeout budget with zero CI runs.
 
   check_pr_state:
     tool: check_pr_mergeable
@@ -803,6 +804,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
       step_name: "handle_no_ci_runs"
+      base_branch: "${{ inputs.base_branch }}"
     capture:
       ci_event: "${{ result.ci_event }}"
       ci_applicable: "${{ result.ci_applicable }}"
@@ -1047,6 +1049,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
       step_name: "check_repo_merge_state"
+      base_branch: "${{ inputs.base_branch }}"
     capture:
       queue_available: "${{ result.queue_available }}"
       merge_group_trigger: "${{ result.merge_group_trigger }}"

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -843,7 +843,8 @@
         "branch": "${{ context.merge_target }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "check_repo_ci_event"
+        "step_name": "check_repo_ci_event",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "ci_event": "${{ result.ci_event }}",
@@ -866,7 +867,7 @@
         }
       ],
       "skip_when_false": "inputs.open_pr",
-      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
+      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor pull_request triggers apply to this branch/base combination, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
     },
     "check_pr_state": {
       "tool": "check_pr_mergeable",
@@ -954,7 +955,8 @@
         "branch": "${{ context.merge_target }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "handle_no_ci_runs"
+        "step_name": "handle_no_ci_runs",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "ci_event": "${{ result.ci_event }}",
@@ -1110,7 +1112,8 @@
         "branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "check_repo_merge_state"
+        "step_name": "check_repo_merge_state",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "queue_available": "${{ result.queue_available }}",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -799,6 +799,7 @@ steps:
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       step_name: check_repo_ci_event
+      base_branch: ${{ inputs.base_branch }}
     capture:
       ci_event: ${{ result.ci_event }}
       ci_applicable: ${{ result.ci_applicable }}
@@ -819,8 +820,9 @@ steps:
     - route: check_pr_state
     skip_when_false: inputs.open_pr
     note: 'Short-circuits CI wait when no workflow trigger matches the feature branch.
-      ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci
-      would exhaust its timeout budget with zero CI runs.
+      ci_applicable=false means neither push nor pull_request triggers apply to this
+      branch/base combination, so wait_for_ci would exhaust its timeout budget with zero
+      CI runs.
 
       '
   check_pr_state:
@@ -902,6 +904,7 @@ steps:
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       step_name: handle_no_ci_runs
+      base_branch: ${{ inputs.base_branch }}
     capture:
       ci_event: ${{ result.ci_event }}
       ci_applicable: ${{ result.ci_applicable }}
@@ -1054,6 +1057,7 @@ steps:
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       step_name: check_repo_merge_state
+      base_branch: ${{ inputs.base_branch }}
     capture:
       queue_available: ${{ result.queue_available }}
       merge_group_trigger: ${{ result.merge_group_trigger }}

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -983,7 +983,8 @@
         "branch": "${{ context.worktree_branch_name }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "derive_conflict_ci_event"
+        "step_name": "derive_conflict_ci_event",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "conflict_ci_event": "${{ result.ci_event }}",
@@ -1004,7 +1005,7 @@
           "route": "wait_for_conflict_ci"
         }
       ],
-      "note": "Short-circuits CI wait when no workflow trigger matches the conflict resolution branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
+      "note": "Short-circuits CI wait when no workflow trigger matches the conflict resolution branch. ci_applicable=false means neither push nor pull_request triggers apply to this branch/base combination, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
     },
     "guard_ci_skip_conflict": {
       "tool": "run_python",
@@ -1092,7 +1093,8 @@
         "branch": "${{ context.worktree_branch_name }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "handle_conflict_no_runs"
+        "step_name": "handle_conflict_no_runs",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "conflict_ci_event": "${{ result.ci_event }}",

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -971,6 +971,7 @@ steps:
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       step_name: derive_conflict_ci_event
+      base_branch: ${{ inputs.base_branch }}
     capture:
       conflict_ci_event: ${{ result.ci_event }}
       conflict_ci_applicable: ${{ result.ci_applicable }}
@@ -990,8 +991,8 @@ steps:
       route: guard_ci_skip_conflict
     - route: wait_for_conflict_ci
     note: 'Short-circuits CI wait when no workflow trigger matches the conflict resolution
-      branch. ci_applicable=false means neither push nor merge_group triggers apply,
-      so wait_for_ci would exhaust its timeout budget with zero CI runs.
+      branch. ci_applicable=false means neither push nor pull_request triggers apply to this
+      branch/base combination, so wait_for_ci would exhaust its timeout budget with zero CI runs.
 
       '
   guard_ci_skip_conflict:
@@ -1069,6 +1070,7 @@ steps:
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       step_name: handle_conflict_no_runs
+      base_branch: ${{ inputs.base_branch }}
     capture:
       conflict_ci_event: ${{ result.ci_event }}
       conflict_ci_applicable: ${{ result.ci_applicable }}

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -869,7 +869,8 @@
         "branch": "${{ context.merge_target }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "check_repo_ci_event"
+        "step_name": "check_repo_ci_event",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "ci_event": "${{ result.ci_event }}",
@@ -892,7 +893,7 @@
         }
       ],
       "skip_when_false": "inputs.open_pr",
-      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
+      "note": "Short-circuits CI wait when no workflow trigger matches the feature branch. ci_applicable=false means neither push nor pull_request triggers apply to this branch/base combination, so wait_for_ci would exhaust its timeout budget with zero CI runs.\n"
     },
     "check_pr_state": {
       "tool": "check_pr_mergeable",
@@ -980,7 +981,8 @@
         "branch": "${{ context.merge_target }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "handle_no_ci_runs"
+        "step_name": "handle_no_ci_runs",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "ci_event": "${{ result.ci_event }}",
@@ -1136,7 +1138,8 @@
         "branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
-        "step_name": "check_repo_merge_state"
+        "step_name": "check_repo_merge_state",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "capture": {
         "queue_available": "${{ result.queue_available }}",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -794,6 +794,7 @@ steps:
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       step_name: check_repo_ci_event
+      base_branch: ${{ inputs.base_branch }}
     capture:
       ci_event: ${{ result.ci_event }}
       ci_applicable: ${{ result.ci_applicable }}
@@ -814,8 +815,9 @@ steps:
     - route: check_pr_state
     skip_when_false: inputs.open_pr
     note: 'Short-circuits CI wait when no workflow trigger matches the feature branch.
-      ci_applicable=false means neither push nor merge_group triggers apply, so wait_for_ci
-      would exhaust its timeout budget with zero CI runs.
+      ci_applicable=false means neither push nor pull_request triggers apply to this
+      branch/base combination, so wait_for_ci would exhaust its timeout budget with zero
+      CI runs.
 
       '
   check_pr_state:
@@ -897,6 +899,7 @@ steps:
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       step_name: handle_no_ci_runs
+      base_branch: ${{ inputs.base_branch }}
     capture:
       ci_event: ${{ result.ci_event }}
       ci_applicable: ${{ result.ci_applicable }}
@@ -1049,6 +1052,7 @@ steps:
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
       step_name: check_repo_merge_state
+      base_branch: ${{ inputs.base_branch }}
     capture:
       queue_available: ${{ result.queue_available }}
       merge_group_trigger: ${{ result.merge_group_trigger }}

--- a/src/autoskillit/server/tools/tools_ci.py
+++ b/src/autoskillit/server/tools/tools_ci.py
@@ -118,6 +118,7 @@ async def check_repo_merge_state(
     cwd: str = ".",
     remote_url: str = "",
     step_name: str = "",
+    base_branch: str = "",
     ctx: Context = CurrentContext(),
 ) -> str:
     """Single GraphQL round-trip returning queue_available, merge_group_trigger,
@@ -132,14 +133,17 @@ async def check_repo_merge_state(
         cwd: Working directory for git remote resolution.
         remote_url: Full GitHub remote URL; parsed to owner/repo if provided.
         step_name: Step name for timing telemetry.
+        base_branch: PR target branch; enables pull_request trigger detection.
+            When empty, pull_request triggers are not evaluated (conservative).
 
     Returns a JSON object with keys:
     - ``queue_available``: branch has an active GitHub merge queue.
     - ``merge_group_trigger``: a CI workflow declares the merge_group event.
     - ``auto_merge_available``: repository has auto-merge enabled.
-    - ``ci_event``: ``"push"`` | ``"merge_group"`` | ``null`` — recommended
-      event to use when polling CI via wait_for_ci.
-    On any error, returns an error field alongside the four boolean/null defaults.
+    - ``ci_event``: ``"push"`` | ``null`` — recommended event for wait_for_ci.
+    - ``ci_applicable``: True when push or pull_request triggers apply to this
+      branch/base combination; False otherwise.
+    On any error, returns an error field alongside boolean/null defaults.
 
     Never raises.
     """
@@ -160,6 +164,7 @@ async def check_repo_merge_state(
                         "merge_group_trigger": False,
                         "auto_merge_available": False,
                         "ci_event": None,
+                        "ci_applicable": False,
                     }
                 )
             owner, repo = resolved_repo.split("/", 1)
@@ -173,6 +178,7 @@ async def check_repo_merge_state(
                 repo=repo,
                 branch=branch,
                 token=resolved_token,
+                base_branch=base_branch or None,
             )
             return json.dumps(state)
         except Exception as exc:
@@ -183,6 +189,7 @@ async def check_repo_merge_state(
                 "merge_group_trigger": False,
                 "auto_merge_available": False,
                 "ci_event": None,
+                "ci_applicable": False,
             }
             if isinstance(exc, httpx.HTTPStatusError):
                 envelope["http_status"] = exc.response.status_code
@@ -199,5 +206,6 @@ async def check_repo_merge_state(
                 "merge_group_trigger": False,
                 "auto_merge_available": False,
                 "ci_event": None,
+                "ci_applicable": False,
             }
         )

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -108,7 +108,7 @@ SESSION_FSM_SIZE_BUDGETS = {
 MQ_SIZE_BUDGETS = {
     "merge_queue/__init__.py": 500,
     "merge_queue/_merge_queue_classifier.py": 175,
-    "merge_queue/_merge_queue_repo_state.py": 280,
+    "merge_queue/_merge_queue_repo_state.py": 320,
 }
 
 
@@ -202,5 +202,6 @@ def test_merge_queue_facade_does_not_define_repo_state():
         "async def fetch_repo_merge_state",
         "def _text_has_push_trigger",
         "def _has_merge_group_trigger",
+        "def _has_pull_request_trigger_for_base",
     ):
         assert sym not in src, f"{sym} must live in _merge_queue_repo_state.py"

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -7,6 +7,7 @@ must come from a single HTTP round-trip to the GitHub GraphQL endpoint.
 
 from __future__ import annotations
 
+import inspect
 import textwrap
 
 import pytest
@@ -502,3 +503,21 @@ async def test_ci_applicable_matches_trigger_type(
     )
     result = await fetch_repo_merge_state(owner="o", repo="r", branch=branch, token=None)
     assert result["ci_applicable"] is expected_ci_applicable
+
+
+def test_ci_applicable_does_not_use_merge_group_trigger():
+    """Guard: ci_applicable must not be inflated by merge_group_trigger.
+
+    merge_group events only fire for gh-readonly-queue branches, not feature branches.
+    This test prevents future regressions where merge_group_trigger is re-added to
+    the ci_applicable formula.
+    """
+    source = inspect.getsource(fetch_repo_merge_state)
+    for line in source.splitlines():
+        stripped = line.split("#")[0]  # ignore comments
+        if "ci_applicable" in stripped and "=" in stripped:
+            assert "merge_group_trigger" not in stripped, (
+                "ci_applicable formula must not include merge_group_trigger — "
+                "merge_group events only fire for gh-readonly-queue branches, "
+                "not feature branches"
+            )

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -384,15 +384,18 @@ async def test_ci_applicable_true_when_push_trigger(httpx_mock):
 
 
 @pytest.mark.anyio
-async def test_ci_applicable_true_when_merge_group_only(httpx_mock):
-    """ci_applicable=True when merge_group trigger exists but push doesn't match."""
+async def test_ci_applicable_false_when_merge_group_only(httpx_mock):
+    """ci_applicable=False when only merge_group trigger exists.
+
+    merge_group events only fire for gh-readonly-queue branches, not feature branches.
+    """
     workflow_text = "on:\n  merge_group:\n"
     httpx_mock.add_response(
         url="https://api.github.com/graphql",
         json=_make_repo_state_response([("tests.yml", workflow_text)]),
     )
     result = await fetch_repo_merge_state(owner="o", repo="r", branch="feature/x", token=None)
-    assert result["ci_applicable"] is True
+    assert result["ci_applicable"] is False
     assert result["ci_event"] is None
 
 
@@ -407,3 +410,95 @@ async def test_ci_applicable_false_when_no_triggers(httpx_mock):
     result = await fetch_repo_merge_state(owner="o", repo="r", branch="main", token=None)
     assert result["ci_applicable"] is False
     assert result["ci_event"] is None
+
+
+@pytest.mark.anyio
+async def test_ci_applicable_true_when_pull_request_only(httpx_mock):
+    """ci_applicable=True when pull_request trigger targets the base branch."""
+    workflow_text = "on:\n  pull_request:\n    branches: [develop]\n"
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(
+        owner="o", repo="r", branch="feature/x", token=None, base_branch="develop"
+    )
+    assert result["ci_applicable"] is True
+    assert result["ci_event"] is None
+
+
+@pytest.mark.anyio
+async def test_ci_applicable_true_when_pr_plus_merge_group(httpx_mock):
+    """ci_applicable=True from pull_request trigger, not merge_group."""
+    workflow_text = textwrap.dedent("""        on:
+          push:
+            branches: [main, stable]
+          pull_request:
+            branches: [main, develop, stable]
+          merge_group:
+    """)
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(
+        owner="o", repo="r", branch="impl/20250527", token=None, base_branch="develop"
+    )
+    assert result["ci_applicable"] is True
+    assert result["ci_event"] is None
+    assert result["merge_group_trigger"] is True
+
+
+@pytest.mark.anyio
+async def test_ci_applicable_false_when_base_branch_not_provided_pull_request_only(httpx_mock):
+    """ci_applicable=False when pull_request-only repo called without base_branch.
+
+    Conservative behavior: if base branch is unknown, pull_request triggers cannot
+    be evaluated against branch filters, so ci_applicable=False.
+    """
+    workflow_text = "on:\n  pull_request:\n    branches: [develop]\n"
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(owner="o", repo="r", branch="feature/x", token=None)
+    assert result["ci_applicable"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "workflow_text, branch, expected_ci_applicable",
+    [
+        ("on: [push, merge_group]", "main", True),
+        ("on:\n  push:\n    branches: [main]\n  merge_group:", "main", True),
+        ("on:\n  push:\n    branches: [main]\n  merge_group:", "feature/x", False),
+        ("on: [merge_group]", "feature/x", False),
+        ("on: [pull_request]", "feature/x", False),
+        ("on:\n  schedule:\n    - cron: '0 0 * * *'", "main", False),
+        ("on: push", "any-branch", True),
+    ],
+    ids=[
+        "push_and_mg_push_applies",
+        "push_branches_match_with_mg",
+        "push_excluded_mg_present",
+        "mg_only",
+        "pr_only_no_base_branch",
+        "schedule_only",
+        "push_no_filter",
+    ],
+)
+async def test_ci_applicable_matches_trigger_type(
+    httpx_mock, workflow_text, branch, expected_ci_applicable
+):
+    """ci_applicable must reflect only branch-applicable triggers (push/pull_request).
+
+    merge_group_trigger must not inflate ci_applicable — merge_group events only
+    fire for gh-readonly-queue branches, not feature branches.
+    Calls without base_branch treat pull_request triggers as inapplicable (conservative).
+    """
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(owner="o", repo="r", branch=branch, token=None)
+    assert result["ci_applicable"] is expected_ci_applicable

--- a/tests/execution/test_push_trigger_applies.py
+++ b/tests/execution/test_push_trigger_applies.py
@@ -4,6 +4,7 @@ import pytest
 
 from autoskillit.execution.merge_queue import (
     _has_merge_group_trigger,
+    _has_pull_request_trigger_for_base,
     _push_trigger_applies_to_branch,
 )
 
@@ -112,3 +113,49 @@ def test_merge_group_in_shell_string():
 
 def test_yaml_parse_failure_falls_back_to_heuristic():
     assert _has_merge_group_trigger("{invalid yaml merge_group") is True
+
+
+# ---------------------------------------------------------------------------
+# _has_pull_request_trigger_for_base tests
+# ---------------------------------------------------------------------------
+
+
+def test_pr_trigger_branches_matches_base():
+    text = "on:\n  pull_request:\n    branches: [develop]\n"
+    assert _has_pull_request_trigger_for_base(text, "develop") is True
+
+
+def test_pr_trigger_branches_excludes_other_base():
+    text = "on:\n  pull_request:\n    branches: [main]\n"
+    assert _has_pull_request_trigger_for_base(text, "develop") is False
+
+
+def test_pr_trigger_branches_ignore_allows_base():
+    text = "on:\n  pull_request:\n    branches-ignore: [release-*]\n"
+    assert _has_pull_request_trigger_for_base(text, "develop") is True
+
+
+def test_pr_trigger_no_branches_filter_matches_all():
+    text = "on:\n  pull_request:\n"
+    assert _has_pull_request_trigger_for_base(text, "develop") is True
+
+
+def test_pr_trigger_list_form_matches_all():
+    assert _has_pull_request_trigger_for_base("on: [pull_request]", "main") is True
+
+
+def test_pr_trigger_scalar_form_matches_all():
+    assert _has_pull_request_trigger_for_base("on: pull_request", "main") is True
+
+
+def test_no_pr_trigger_returns_false():
+    text = "on:\n  push:\n    branches: [main]\n"
+    assert _has_pull_request_trigger_for_base(text, "main") is False
+
+
+def test_pr_trigger_yaml_parse_failure_falls_back_to_substring():
+    assert _has_pull_request_trigger_for_base("{invalid yaml pull_request", "main") is True
+
+
+def test_pr_trigger_yaml_parse_failure_no_substring_returns_false():
+    assert _has_pull_request_trigger_for_base("{invalid yaml on: push", "main") is False

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -170,3 +170,31 @@ def test_ci_event_capture_has_ci_applicable_guard(recipe_data) -> None:
     assert not violations, f"{recipe_name}: ci_event capture without ci_applicable:\n" + "\n".join(
         f"  - {v}" for v in violations
     )
+
+
+def test_check_repo_merge_state_with_ci_applicable_passes_base_branch(recipe_data) -> None:
+    """Every check_repo_merge_state step that captures ci_applicable must also pass base_branch.
+
+    ci_applicable requires base_branch to detect pull_request triggers. Steps that
+    capture ci_applicable without passing base_branch will silently get ci_applicable=False
+    for pull_request-only repos, causing false ci_watch skips.
+    """
+    recipe_name, data = recipe_data
+    steps = data.get("steps") or {}
+
+    violations = []
+    for step_name, step in steps.items():
+        tool = step.get("tool", "")
+        if "check_repo_merge_state" not in tool:
+            continue
+        capture = step.get("capture") or {}
+        if not any("ci_applicable" in k for k in capture):
+            continue
+        with_args = step.get("with") or {}
+        if "base_branch" not in with_args:
+            violations.append(step_name)
+
+    assert not violations, (
+        f"{recipe_name}: check_repo_merge_state steps capture ci_applicable "
+        f"but omit base_branch: {violations}"
+    )

--- a/tests/server/test_tools_ci_merge_state.py
+++ b/tests/server/test_tools_ci_merge_state.py
@@ -32,13 +32,14 @@ async def test_check_repo_merge_state_uses_token_factory(tool_ctx_kitchen_open, 
 
     captured_tokens = []
 
-    async def fake_fetch(owner, repo, branch, token):
+    async def fake_fetch(owner, repo, branch, token, base_branch=None):
         captured_tokens.append(token)
         return {
             "queue_available": False,
             "merge_group_trigger": False,
             "auto_merge_available": False,
             "ci_event": None,
+            "ci_applicable": False,
         }
 
     monkeypatch.setattr("autoskillit.server.tools.tools_ci.fetch_repo_merge_state", fake_fetch)
@@ -62,13 +63,14 @@ async def test_check_repo_merge_state_falls_back_to_config_token_when_no_factory
 
     captured_tokens = []
 
-    async def fake_fetch(owner, repo, branch, token):
+    async def fake_fetch(owner, repo, branch, token, base_branch=None):
         captured_tokens.append(token)
         return {
             "queue_available": False,
             "merge_group_trigger": False,
             "auto_merge_available": False,
             "ci_event": None,
+            "ci_applicable": False,
         }
 
     monkeypatch.setattr("autoskillit.server.tools.tools_ci.fetch_repo_merge_state", fake_fetch)
@@ -87,7 +89,7 @@ async def test_check_repo_merge_state_error_includes_http_status(
 ):
     """HTTP error response envelope contains http_status field."""
 
-    async def fake_fetch(owner, repo, branch, token):
+    async def fake_fetch(owner, repo, branch, token, base_branch=None):
         response = httpx.Response(
             403,
             request=httpx.Request("POST", "https://api.github.com/graphql"),


### PR DESCRIPTION
## Summary

The `ci_applicable` formula in `_merge_queue_repo_state.py:264` conflates repo-level trigger presence with branch-level trigger applicability. `merge_group_trigger=True` inflates `ci_applicable=True` for all branches, even though `merge_group` events only fire for synthetic `gh-readonly-queue/...` branches created by GitHub's merge queue. This causes the recipe to enter `ci_watch` for feature branches where only `pull_request`-event CI exists, leading to `no_runs` → `auto_trigger` empty commits → `escalate_stop_no_ci` halt.

The architectural weakness: the formula has no concept of `pull_request` triggers — the most common CI mechanism for feature branches. The formula was designed to answer "will CI trigger for this branch?" but only checks `push` and `merge_group`, missing the dominant trigger type.

**Part A** fixes the `ci_applicable` formula and its tests to correctly model the three CI trigger types (`push`, `pull_request`, `merge_group`) at the branch/base-branch level. Part B will address the `auto_trigger` tail-chasing problem and the `head_sha` scope mismatch.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260527-140810-291696/.autoskillit/temp/rectify/rectify_ci_applicable_false_positive_2026-05-27_150000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 5.0k | 24.1k | 2.7M | 120.7k | 206 | 209.4k | 20m 8s |
| dry_walkthrough | claude-sonnet-4-6 | 3 | 668 | 37.6k | 4.9M | 122.1k | 384 | 212.1k | 21m 10s |
| review | claude-sonnet-4-6 | 1 | 50 | 5.6k | 184.5k | 81.8k | 40 | 28.2k | 4m 17s |
| implement | claude-sonnet-4-6 | 2 | 1.3k | 39.4k | 2.8M | 118.5k | 265 | 127.0k | 23m 1s |
| audit_impl | claude-sonnet-4-6 | 2 | 1.0k | 22.6k | 1.2M | 66.3k | 145 | 78.1k | 13m 48s |
| make_plan | claude-sonnet-4-6 | 1 | 2.9k | 17.4k | 748.5k | 64.0k | 148 | 46.3k | 10m 14s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 164.6k | 4.0k | 277.9k | 30.9k | 25 | 43.7k | 1m 26s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 132.9k | 2.7k | 398.5k | 30.9k | 27 | 15.3k | 1m 13s |
| review_pr | claude-sonnet-4-6 | 1 | 158 | 24.4k | 981.2k | 84.0k | 53 | 68.9k | 6m 3s |
| resolve_review | claude-sonnet-4-6 | 1 | 181 | 14.4k | 1.0M | 61.7k | 51 | 92.5k | 8m 16s |
| **Total** | | | 308.7k | 192.4k | 15.2M | 122.1k | | 921.7k | 1h 49m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| review | 0 | — | — | — |
| implement | 665 | 4155.4 | 191.1 | 59.3 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **665** | 22815.4 | 1386.0 | 289.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 8 | 11.2k | 185.6k | 14.5M | 862.7k | 1h 47m |
| MiniMax-M2.7-highspeed | 2 | 297.5k | 6.8k | 676.4k | 59.0k | 2m 39s |