### PR TITLE
Rectify: optional: true Remains in LLM-Visible Content After Truthy Skip Resolution

### DIFF
--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -43,17 +43,17 @@ def _collect_all_route_targets(step: RecipeStep) -> set[str]:
     return targets
 
 
+def _step_block_pattern(escaped_name: str) -> str:
+    """Return the regex body matching a 2-space-indented YAML step block (no flags prefix)."""
+    return rf"^  {escaped_name}:[ \t]*\n(?:(?:  [ \t][^\n]*|[ \t]*)(?:\n|$))*"
+
+
 def _strip_step_block(raw: str, step_name: str) -> str:
     """Remove the entire YAML block for step_name from raw YAML content.
 
     Matches the step header line (2-space indent) and all deeper-indented child lines.
     """
-    escaped = re.escape(step_name)
-    return re.sub(
-        rf"(?m)^  {escaped}:[ \t]*\n(?:(?:  [ \t][^\n]*|[ \t]*)(?:\n|$))*",
-        "",
-        raw,
-    )
+    return re.sub(rf"(?m){_step_block_pattern(re.escape(step_name))}", "", raw)
 
 
 def _validate_no_dangling_routes(recipe: Recipe) -> list[str]:
@@ -394,9 +394,8 @@ def _resolve_skip_guards_in_content(
         if not is_truthy:
             raw = _strip_step_block(raw, step_name)
             continue
-        escaped = re.escape(step_name)
         raw = re.sub(
-            rf"(?m)^(  {escaped}:[ \t]*\n(?:(?:  [ \t][^\n]*|[ \t]*)(?:\n|$))*)",
+            rf"(?m)({_step_block_pattern(re.escape(step_name))})",
             lambda m: re.sub(r"(?m)^[ \t]+optional:[ \t]+(?:true|True)[ \t]*\n", "", m.group(0)),
             raw,
         )

--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -379,9 +379,9 @@ def _resolve_skip_guards_in_content(
     """Apply skip_when_false resolution decisions to the raw YAML content string.
 
     For each resolved step:
-    - Truthy (step kept): strip the skip_when_false line so the step appears mandatory.
-    - Falsy (step pruned): replace the ingredient reference with literal "false" so
-      the LLM evaluates the literal and skips the step without needing ingredient visibility.
+    - Truthy (step kept): strip skip_when_false and optional: true lines so the step
+      appears mandatory.
+    - Falsy (step pruned): strip the entire step block.
     """
     if not resolutions:
         return raw
@@ -392,12 +392,14 @@ def _resolve_skip_guards_in_content(
             continue
         ref = step.skip_when_false
         if not is_truthy:
-            # Strip the entire step block — applies to all falsy resolutions regardless of
-            # whether skip_when_false uses inputs.* or a literal value.
             raw = _strip_step_block(raw, step_name)
             continue
-        # Truthy: strip only the skip_when_false line so the step becomes mandatory.
-        # Only applicable to inputs.* refs (literal values are not surfaced in content).
+        escaped = re.escape(step_name)
+        raw = re.sub(
+            rf"(?m)^(  {escaped}:[ \t]*\n(?:(?:  [ \t][^\n]*|[ \t]*)(?:\n|$))*)",
+            lambda m: re.sub(r"(?m)^[ \t]+optional:[ \t]+(?:true|True)[ \t]*\n", "", m.group(0)),
+            raw,
+        )
         if not ref.startswith("inputs."):
             continue
         ingredient_name = re.escape(ref[len("inputs.") :])

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -66,6 +66,7 @@ def test_bundled_recipe_content_has_no_unresolved_hidden_skip_guards(recipe_name
     import re
 
     from autoskillit.recipe import load_and_validate
+    from autoskillit.recipe._recipe_composition import _step_block_pattern
 
     result = load_and_validate(recipe_name)
     recipe_content = result["content"]
@@ -101,13 +102,14 @@ def test_bundled_recipe_content_has_no_unresolved_hidden_skip_guards(recipe_name
         truthy_content = truthy_result["content"]
         residual = []
         for step_name in guarded_steps:
-            escaped = re.escape(step_name)
             block_match = re.search(
-                rf"(?m)^  {escaped}:[ \t]*\n(?:(?:  [ \t][^\n]*|[ \t]*)(?:\n|$))*",
+                rf"(?m){_step_block_pattern(re.escape(step_name))}",
                 truthy_content,
             )
-            if block_match is None:
-                continue
+            assert block_match is not None, (
+                f"Recipe '{recipe_name}': step '{step_name}' not found in truthy content "
+                f"for ingredient '{ing_name}' — step was incorrectly removed on truthy resolution."
+            )
             step_block = block_match.group(0)
             if "optional: true" in step_block:
                 residual.append(step_name)

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -60,8 +60,11 @@ def test_bundled_recipe_content_has_no_unresolved_hidden_skip_guards(recipe_name
 
     Regression guard: if server-side skip_when_false evaluation is accidentally
     removed or bypassed, this test will catch it by finding inputs.* references
-    in skip_when_false fields of the served content.
+    in skip_when_false fields of the served content. Also verifies that truthy-resolved
+    steps do not retain residual optional: true signals in the served content.
     """
+    import re
+
     from autoskillit.recipe import load_and_validate
 
     result = load_and_validate(recipe_name)
@@ -79,3 +82,36 @@ def test_bundled_recipe_content_has_no_unresolved_hidden_skip_guards(recipe_name
         f"in skip_when_false after load_and_validate: {unresolved}. "
         f"Server-side evaluation may be broken."
     )
+
+    # Truthy path: verify optional: true is stripped from steps resolved as mandatory.
+    # Tests each hidden ingredient independently so that other falsy-guarded steps
+    # (stripped from content entirely) do not interfere with the assertion scope.
+    for ing_name in hidden_ing_names:
+        guarded_steps = [
+            step_name
+            for step_name, step in recipe_obj.steps.items()
+            if step.skip_when_false == f"inputs.{ing_name}"
+        ]
+        if not guarded_steps:
+            continue
+        truthy_result = load_and_validate(
+            recipe_name,
+            ingredient_overrides={ing_name: "true"},
+        )
+        truthy_content = truthy_result["content"]
+        residual = []
+        for step_name in guarded_steps:
+            escaped = re.escape(step_name)
+            block_match = re.search(
+                rf"(?m)^  {escaped}:[ \t]*\n(?:(?:  [ \t][^\n]*|[ \t]*)(?:\n|$))*",
+                truthy_content,
+            )
+            if block_match is None:
+                continue
+            step_block = block_match.group(0)
+            if "optional: true" in step_block:
+                residual.append(step_name)
+        assert residual == [], (
+            f"Recipe '{recipe_name}': steps {residual} have residual 'optional: true' "
+            f"in content after truthy resolution of ingredient '{ing_name}'."
+        )

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -385,6 +385,7 @@ steps:
         ingredient_overrides={"post_run_diagnostics": "true"},
     )
     assert "inputs.post_run_diagnostics" not in result["content"]
+    assert "optional: true" not in result["content"]
 
     # When false: entire step block is stripped from content
     result2 = load_and_validate(
@@ -818,3 +819,96 @@ def test_bundled_recipes_prune_produces_no_dangling_routes() -> None:
                 f"Bundled recipe {yaml_file.name!r}: pruning step {step_name!r} "
                 f"produced dangling routes: {errors}"
             )
+
+
+def test_resolve_skip_guards_strips_optional_true_on_truthy() -> None:
+    """_resolve_skip_guards_in_content strips optional: true from truthy-resolved step."""
+    from autoskillit.recipe._recipe_composition import _resolve_skip_guards_in_content
+
+    raw = """steps:
+  main_step:
+    tool: run_cmd
+    with:
+      cmd: echo hi
+    on_success: guarded
+  guarded:
+    tool: run_skill
+    optional: true
+    skip_when_false: inputs.flag
+    with:
+      skill_command: /autoskillit:do_thing /tmp/x.md
+    on_success: done
+    on_failure: done
+    on_context_limit: done
+  done:
+    action: stop
+    message: done
+"""
+    original_steps = {
+        "guarded": RecipeStep(
+            tool="run_skill",
+            optional=True,
+            skip_when_false="inputs.flag",
+            on_success="done",
+            on_failure="done",
+            on_context_limit="done",
+            with_args={"skill_command": "/autoskillit:do_thing /tmp/x.md"},
+        )
+    }
+    resolutions = {"guarded": True}
+
+    result = _resolve_skip_guards_in_content(raw, resolutions, original_steps)
+    assert "optional: true" not in result
+    assert "optional: True" not in result
+    assert "tool: run_skill" in result
+    assert "on_success: done" in result
+
+
+def test_resolve_skip_guards_preserves_optional_on_unresolved_steps() -> None:
+    """_resolve_skip_guards_in_content preserves optional: true on steps not being resolved."""
+    from autoskillit.recipe._recipe_composition import _resolve_skip_guards_in_content
+
+    raw = """steps:
+  guarded:
+    tool: run_skill
+    optional: true
+    skip_when_false: inputs.flag
+    with:
+      skill_command: /autoskillit:do_thing /tmp/x.md
+    on_success: other
+  other:
+    tool: run_skill
+    optional: true
+    skip_when_false: inputs.other_flag
+    with:
+      skill_command: /autoskillit:other /tmp/y.md
+    on_success: done
+  done:
+    action: stop
+    message: done
+"""
+    original_steps = {
+        "guarded": RecipeStep(
+            tool="run_skill",
+            optional=True,
+            skip_when_false="inputs.flag",
+            on_success="other",
+            with_args={"skill_command": "/autoskillit:do_thing /tmp/x.md"},
+        ),
+        "other": RecipeStep(
+            tool="run_skill",
+            optional=True,
+            skip_when_false="inputs.other_flag",
+            on_success="done",
+            with_args={"skill_command": "/autoskillit:other /tmp/y.md"},
+        ),
+    }
+    resolutions = {"guarded": True}
+
+    result = _resolve_skip_guards_in_content(raw, resolutions, original_steps)
+    guarded_end = result.index("  other:\n")
+    guarded_block = result[result.index("  guarded:\n") : guarded_end]
+    assert "optional: true" not in guarded_block
+    other_end = result.index("  done:\n")
+    other_block = result[result.index("  other:\n") : other_end]
+    assert "optional: true" in other_block

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -385,7 +385,11 @@ steps:
         ingredient_overrides={"post_run_diagnostics": "true"},
     )
     assert "inputs.post_run_diagnostics" not in result["content"]
-    assert "optional: true" not in result["content"]
+    content = result["content"]
+    diag_block_start = content.index("  diag:\n")
+    next_step_start = content.find("\n  done:\n", diag_block_start)
+    diag_block = content[diag_block_start:next_step_start]
+    assert "optional: true" not in diag_block
 
     # When false: entire step block is stripped from content
     result2 = load_and_validate(


### PR DESCRIPTION
## Summary

When a recipe step guarded by `skip_when_false` evaluates truthy (step is kept), `_resolve_skip_guards_in_content()` strips the `skip_when_false:` line from the raw YAML content but leaves `optional: true` intact. This residual signal causes the LLM orchestrator to skip the step ~99.7% of the time. The root architectural weakness is that skip-guard content resolution treats `skip_when_false:` as the only skip signal, when in fact `optional: true` is semantically coupled to it and is the dominant LLM deprioritization signal.

The fix strips `optional: true` from the raw YAML content string in the truthy path of `_resolve_skip_guards_in_content()`, using a step-scoped regex that matches only the resolved step's YAML block. A new content-contract assertion test prevents regression by verifying the full LLM-visible artifact, not just individual signal removal.

**5th recurrence** of the step-skipping vulnerability class (PRs #966, #1093, #1307, #3072, #3160/#3164). Prior fixes addressed evaluation chain correctness; this fix addresses content-delivery completeness.

Closes #3171

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260527-173557-577212/.autoskillit/temp/rectify/rectify_optional_true_remains_in_content_after_truthy_skip_2026-05-27_180000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 2.5k | 16.3k | 1.0M | 106.0k | 179 | 94.9k | 13m 27s |
| review | claude-sonnet-4-6 | 1 | 13.9k | 7.5k | 185.2k | 118.5k | 162 | 38.7k | 8m 33s |
| dry_walkthrough | claude-opus-4-6 | 1 | 63 | 10.9k | 1.5M | 69.9k | 100 | 70.0k | 5m 40s |
| implement | claude-sonnet-4-6 | 1 | 294 | 20.5k | 2.0M | 78.0k | 90 | 62.2k | 6m 52s |
| audit_impl | claude-sonnet-4-6 | 1 | 84 | 7.3k | 340.9k | 47.0k | 30 | 31.8k | 2m 42s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 118.6k | 2.9k | 278.3k | 30.9k | 31 | 43.8k | 1m 15s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 71.0k | 2.0k | 275.4k | 30.9k | 21 | 15.5k | 53s |
| review_pr | claude-sonnet-4-6 | 2 | 1.1k | 49.2k | 1.8M | 81.6k | 115 | 108.6k | 12m 38s |
| resolve_review | claude-sonnet-4-6 | 1 | 237 | 16.5k | 1.6M | 74.1k | 73 | 58.1k | 5m 53s |
| **Total** | | | 207.7k | 133.1k | 9.1M | 118.5k | | 523.5k | 57m 56s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 148 | 13654.9 | 420.1 | 138.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 31 | 52486.6 | 1875.0 | 532.9 |
| **Total** | **179** | 50807.7 | 2924.5 | 743.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 6 | 18.0k | 117.3k | 7.0M | 394.2k | 50m 7s |
| claude-opus-4-6 | 1 | 63 | 10.9k | 1.5M | 70.0k | 5m 40s |
| MiniMax-M2.7-highspeed | 2 | 189.7k | 5.0k | 553.7k | 59.3k | 2m 8s |