### PR TITLE
Rectify: `close_issue_no_changes` Closes Issues Unconditionally

### DIFF
--- a/src/autoskillit/recipe/rules/rules_clone.py
+++ b/src/autoskillit/recipe/rules/rules_clone.py
@@ -9,6 +9,10 @@ clone-step dataflow rules
   local transport, remote_url is always empty, so any downstream consumer of
   context.remote_url will receive "". The rule fires at recipe-validation time
   (open_kitchen / load_recipe) before any runtime call.
+- clone-terminal-requires-registration: all terminal paths reachable from a
+  clone-creating step (bootstrap_clone / clone_repo) must pass through a
+  register_clone_status step before reaching an action:stop terminal. Detects
+  clone-directory leaks where no cleanup registration is recorded.
 """
 
 from __future__ import annotations
@@ -22,6 +26,7 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._analysis_bfs import bfs_reachable
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
@@ -201,5 +206,87 @@ def _check_clone_local_remote_url_capture(ctx: ValidationContext) -> list[RuleFi
                 message=explanation,
             )
         )
+
+    return findings
+
+
+_CLONE_CREATING_TOOLS: frozenset[str] = frozenset({"bootstrap_clone", "clone_repo"})
+
+
+@semantic_rule(
+    name="clone-terminal-requires-registration",
+    description=(
+        "All terminal paths in clone-creating recipes must pass through "
+        "register_clone_status before reaching an action: stop step. "
+        "Without registration, the clone directory leaks and diagnostics "
+        "are never run."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_clone_terminal_requires_registration(ctx: ValidationContext) -> list[RuleFinding]:
+    recipe = ctx.recipe
+
+    # Find the first clone-creating step; if none, rule does not apply.
+    clone_step_name: str | None = None
+    for step_name, step in recipe.steps.items():
+        if step.tool in _CLONE_CREATING_TOOLS:
+            clone_step_name = step_name
+            break
+    if clone_step_name is None:
+        return []
+
+    # Build a full routing graph (all edge types: on_success, on_failure, on_context_limit,
+    # on_result conditions). Barrier nodes are register_clone_status steps.
+    graph: dict[str, set[str]] = {}
+    barrier_steps: set[str] = set()
+    all_step_names = set(recipe.steps)
+
+    for sn, step in recipe.steps.items():
+        targets: set[str] = set()
+        if step.on_success and step.on_success in all_step_names:
+            targets.add(step.on_success)
+        if step.on_failure and step.on_failure in all_step_names:
+            targets.add(step.on_failure)
+        if step.on_context_limit and step.on_context_limit in all_step_names:
+            targets.add(step.on_context_limit)
+        if step.on_result:
+            for cond in step.on_result.conditions:
+                if cond.route and cond.route in all_step_names:
+                    targets.add(cond.route)
+            for route in step.on_result.routes.values():
+                if route in all_step_names:
+                    targets.add(route)
+        if step.on_exhausted and step.on_exhausted in all_step_names:
+            targets.add(step.on_exhausted)
+        graph[sn] = targets
+        if step.tool == "register_clone_status":
+            barrier_steps.add(sn)
+
+    # Remove outgoing edges from barrier nodes so BFS stops there.
+    for barrier in barrier_steps:
+        graph[barrier] = set()
+
+    # Find all steps reachable from the clone step (BFS with barriers suppressed).
+    reachable = bfs_reachable(graph, clone_step_name)
+
+    # Check if any reachable step is a terminal (action == "stop").
+    findings: list[RuleFinding] = []
+    for sn in reachable:
+        step = recipe.steps[sn]
+        if step.action == "stop":
+            findings.append(
+                RuleFinding(
+                    rule="clone-terminal-requires-registration",
+                    severity=Severity.ERROR,
+                    step_name=clone_step_name,
+                    message=(
+                        f"Clone step '{clone_step_name}' has a path to terminal step '{sn}' "
+                        f"that bypasses register_clone_status. All terminal paths from a "
+                        f"clone-creating step must pass through register_clone_status to "
+                        f"register the clone for batch cleanup and diagnostics."
+                    ),
+                )
+            )
+            break  # one finding per clone step is sufficient
 
     return findings

--- a/src/autoskillit/recipe/rules/rules_clone.py
+++ b/src/autoskillit/recipe/rules/rules_clone.py
@@ -28,6 +28,7 @@ from autoskillit.core import (
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe._analysis_bfs import bfs_reachable
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
+from autoskillit.recipe.schema import _TERMINAL_TARGETS
 
 logger = get_logger(__name__)
 
@@ -256,7 +257,14 @@ def _check_clone_terminal_requires_registration(ctx: ValidationContext) -> list[
             for route in step.on_result.routes.values():
                 if route in all_step_names:
                     targets.add(route)
-        if step.on_exhausted and step.on_exhausted in all_step_names:
+        # on_exhausted defaults to the sentinel "escalate" on every RecipeStep.
+        # Skip sentinel values to avoid false edges when a step happens to share
+        # a name with a sentinel (e.g. a step literally named "escalate").
+        if (
+            step.on_exhausted
+            and step.on_exhausted in all_step_names
+            and step.on_exhausted not in _TERMINAL_TARGETS
+        ):
             targets.add(step.on_exhausted)
         graph[sn] = targets
         if step.tool == "register_clone_status":

--- a/src/autoskillit/recipe/rules/rules_clone.py
+++ b/src/autoskillit/recipe/rules/rules_clone.py
@@ -266,8 +266,16 @@ def _check_clone_terminal_requires_registration(ctx: ValidationContext) -> list[
     for barrier in barrier_steps:
         graph[barrier] = set()
 
-    # Find all steps reachable from the clone step (BFS with barriers suppressed).
-    reachable = bfs_reachable(graph, clone_step_name)
+    # Start BFS from the clone step's on_success target, not the clone step itself.
+    # If the clone fails (on_failure path), no clone was created so no registration
+    # is required on that path.
+    clone_step = recipe.steps[clone_step_name]
+    success_target = clone_step.on_success
+    if not success_target or success_target not in all_step_names:
+        return []
+
+    # Find all steps reachable after a successful clone (BFS with barriers suppressed).
+    reachable = bfs_reachable(graph, success_target)
 
     # Check if any reachable step is a terminal (action == "stop").
     findings: list[RuleFinding] = []

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -394,7 +394,10 @@ def _check_rebase_then_push_requires_force(ctx: ValidationContext) -> list[RuleF
 
 @semantic_rule(
     name="release-issue-requires-disposition",
-    description="release_issue must have fail_label or target_branch to avoid bare removal",
+    description=(
+        "release_issue must have fail_label or target_branch — close_issue alone is not a "
+        "valid disposition because it bypasses staging logic on non-default branches"
+    ),
     severity=Severity.ERROR,
 )
 def _check_release_issue_requires_disposition(ctx: ValidationContext) -> list[RuleFinding]:
@@ -404,8 +407,7 @@ def _check_release_issue_requires_disposition(ctx: ValidationContext) -> list[Ru
             continue
         has_fail_label = bool(step.with_args.get("fail_label"))
         has_target_branch = bool(step.with_args.get("target_branch"))
-        has_close_issue = bool(step.with_args.get("close_issue"))
-        if not has_fail_label and not has_target_branch and not has_close_issue:
+        if not has_fail_label and not has_target_branch:
             findings.append(
                 RuleFinding(
                     rule="release-issue-requires-disposition",
@@ -413,9 +415,10 @@ def _check_release_issue_requires_disposition(ctx: ValidationContext) -> list[Ru
                     step_name=step_name,
                     message=(
                         f"Step '{step_name}' calls release_issue without fail_label or "
-                        f"target_branch — this performs bare label removal with no "
-                        f"replacement. Add fail_label for failure paths or target_branch "
-                        f"for success/staging paths."
+                        f"target_branch. close_issue alone is not a valid disposition — "
+                        f"without target_branch, the tool cannot determine whether to stage "
+                        f"(non-default branch) or close (promotion target). Add target_branch "
+                        f"for success/staging paths or fail_label for failure paths."
                     ),
                 )
             )

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:fe042fe400b76dfd7d1d2d30fd316cfecd146227c75c5c2d6f00f5ae91d11c19 -->
+<!-- autoskillit-recipe-hash: sha256:169e575e265babf6ca6e9eebb9b33d0614759e29b68b5f613d179d82461ec2ea -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -119,11 +119,11 @@
           "route": "create_and_publish"
         },
         {
-          "route": "escalate_stop"
+          "route": "register_clone_failure"
         }
       ],
-      "on_failure": "escalate_stop",
-      "note": "Fetches issue title/slug and claims the issue in one turn. Returns issue_number, issue_title, issue_slug, and claimed boolean. When claimed=false (another session owns it), routes to escalate_stop. issue_slug and issue_number are passed to create_and_publish for branch naming.\n"
+      "on_failure": "register_clone_failure",
+      "note": "Fetches issue title/slug and claims the issue in one turn. Returns issue_number, issue_title, issue_slug, and claimed boolean. When claimed=false (another session owns it), routes to register_clone_failure before escalate_stop so the clone directory is registered for cleanup. issue_slug and issue_number are passed to create_and_publish for branch naming.\n"
     },
     "create_and_publish": {
       "tool": "create_and_publish_branch",
@@ -471,14 +471,14 @@
         },
         {
           "when": "result.error",
-          "route": "escalate_stop"
+          "route": "register_clone_failure"
         },
         {
           "route": "remediate"
         }
       ],
-      "on_failure": "escalate_stop",
-      "on_context_limit": "escalate_stop",
+      "on_failure": "register_clone_failure",
+      "on_context_limit": "register_clone_failure",
       "optional": true,
       "skip_when_false": "inputs.audit",
       "note": "Only execute if inputs.audit is 'true'. If false, skip directly to push. Captures verdict and remediation_path. Routes GO → push, NO GO → remediate which re-enters the plan step with the remediation file. All groups and parts have been merged at this point — no worktree exists. Uses context.base_sha (a stable commit SHA captured before any merge began) as implementation_ref. A SHA names a git object and survives git branch -D unconditionally. The diff git diff base_sha..base_branch (two-dot, SHA on the left) covers the full implementation across all plan groups.\n"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -104,12 +104,13 @@ steps:
     on_result:
     - when: "${{ result.claimed }} == true"
       route: create_and_publish
-    - route: escalate_stop
-    on_failure: escalate_stop
+    - route: register_clone_failure
+    on_failure: register_clone_failure
     note: >
       Fetches issue title/slug and claims the issue in one turn.
       Returns issue_number, issue_title, issue_slug, and claimed boolean.
-      When claimed=false (another session owns it), routes to escalate_stop.
+      When claimed=false (another session owns it), routes to register_clone_failure
+      before escalate_stop so the clone directory is registered for cleanup.
       issue_slug and issue_number are passed to create_and_publish for branch naming.
 
   create_and_publish:
@@ -433,10 +434,10 @@ steps:
     - when: "${{ result.verdict }} == GO"
       route: push
     - when: "result.error"
-      route: escalate_stop
+      route: register_clone_failure
     - route: remediate
-    on_failure: escalate_stop
-    on_context_limit: escalate_stop
+    on_failure: register_clone_failure
+    on_context_limit: register_clone_failure
     optional: true
     skip_when_false: "inputs.audit"
     note: >

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -158,11 +158,11 @@
           "route": "create_and_publish"
         },
         {
-          "route": "escalate_stop"
+          "route": "register_clone_failure"
         }
       ],
-      "on_failure": "escalate_stop",
-      "note": "Fetches issue title/slug and claims the issue in one turn. Returns issue_number, issue_title, issue_slug, and claimed boolean. When claimed=false (another session owns it), routes to escalate_stop. issue_slug and issue_number are passed to create_and_publish for branch naming.\n"
+      "on_failure": "register_clone_failure",
+      "note": "Fetches issue title/slug and claims the issue in one turn. Returns issue_number, issue_title, issue_slug, and claimed boolean. When claimed=false (another session owns it), routes to register_clone_failure before escalate_stop so the clone directory is registered for cleanup. issue_slug and issue_number are passed to create_and_publish for branch naming.\n"
     },
     "create_and_publish": {
       "tool": "create_and_publish_branch",
@@ -554,14 +554,14 @@
         },
         {
           "when": "result.error",
-          "route": "escalate_stop"
+          "route": "register_clone_failure"
         },
         {
           "route": "remediate"
         }
       ],
-      "on_failure": "escalate_stop",
-      "on_context_limit": "escalate_stop",
+      "on_failure": "register_clone_failure",
+      "on_context_limit": "register_clone_failure",
       "optional": true,
       "skip_when_false": "inputs.audit",
       "note": "Only execute if inputs.audit is 'true'. If false, skip directly to check_has_commits. Captures verdict and remediation_path. Routes GO → push, NO GO → remediate which re-enters the plan step with the remediation file. All parts have been merged at this point — no worktree exists. Uses context.base_sha (a stable commit SHA captured before any merge began) as implementation_ref. A SHA names a git object and survives git branch -D unconditionally. The diff git diff base_sha..base_branch (two-dot, SHA on the left) covers the full implementation.\n"

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -309,15 +309,18 @@
       "on_failure": "release_issue_failure"
     },
     "close_issue_no_changes": {
+      "description": "Release issue after zero-change detection — stages on non-default branch, closes on promotion target",
       "tool": "release_issue",
       "optional": true,
       "skip_when_false": "inputs.issue_url",
       "with": {
         "issue_url": "${{ inputs.issue_url }}",
+        "target_branch": "${{ inputs.base_branch }}",
         "close_issue": "true"
       },
-      "on_success": "done",
-      "on_failure": "done"
+      "on_success": "register_clone_success",
+      "on_failure": "register_clone_success",
+      "note": "Zero changes detected post-implement. Passes target_branch so release_issue stages on non-default branches (base_branch != promotion_target) or closes on the promotion target branch. close_issue is silently ignored by release_issue when staging applies (Branch 1 takes precedence over Branch 3). Routes to register_clone_success for clone cleanup and diagnostics."
     },
     "test": {
       "tool": "test_check",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -315,14 +315,22 @@ steps:
     - route: test
     on_failure: release_issue_failure
   close_issue_no_changes:
+    description: Release issue after zero-change detection — stages on non-default
+      branch, closes on promotion target
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
+      target_branch: ${{ inputs.base_branch }}
       close_issue: 'true'
-    on_success: done
-    on_failure: done
+    on_success: register_clone_success
+    on_failure: register_clone_success
+    note: 'Zero changes detected post-implement. Passes target_branch so release_issue
+      stages on non-default branches (base_branch != promotion_target) or closes on
+      the promotion target branch. close_issue is silently ignored by release_issue
+      when staging applies (Branch 1 takes precedence over Branch 3). Routes to
+      register_clone_success for clone cleanup and diagnostics.'
   test:
     tool: test_check
     with:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -166,11 +166,12 @@ steps:
     on_result:
     - when: ${{ result.claimed }} == true
       route: create_and_publish
-    - route: escalate_stop
-    on_failure: escalate_stop
+    - route: register_clone_failure
+    on_failure: register_clone_failure
     note: 'Fetches issue title/slug and claims the issue in one turn. Returns issue_number,
       issue_title, issue_slug, and claimed boolean. When claimed=false (another session
-      owns it), routes to escalate_stop. issue_slug and issue_number are passed to
+      owns it), routes to register_clone_failure before escalate_stop so the clone
+      directory is registered for cleanup. issue_slug and issue_number are passed to
       create_and_publish for branch naming.
 
       '
@@ -527,10 +528,10 @@ steps:
     - when: ${{ result.verdict }} == GO
       route: check_has_commits
     - when: result.error
-      route: escalate_stop
+      route: register_clone_failure
     - route: remediate
-    on_failure: escalate_stop
-    on_context_limit: escalate_stop
+    on_failure: register_clone_failure
+    on_context_limit: register_clone_failure
     optional: true
     skip_when_false: inputs.audit
     note: 'Only execute if inputs.audit is ''true''. If false, skip directly to check_has_commits.

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -326,15 +326,18 @@
       "on_failure": "release_issue_failure"
     },
     "close_issue_no_changes": {
+      "description": "Release issue after zero-change detection — stages on non-default branch, closes on promotion target",
       "tool": "release_issue",
       "optional": true,
       "skip_when_false": "inputs.issue_url",
       "with": {
         "issue_url": "${{ inputs.issue_url }}",
+        "target_branch": "${{ inputs.base_branch }}",
         "close_issue": "true"
       },
-      "on_success": "done",
-      "on_failure": "done"
+      "on_success": "register_clone_success",
+      "on_failure": "register_clone_success",
+      "note": "Zero changes detected post-implement. Passes target_branch so release_issue stages on non-default branches (base_branch != promotion_target) or closes on the promotion target branch. close_issue is silently ignored by release_issue when staging applies (Branch 1 takes precedence over Branch 3). Routes to register_clone_success for clone cleanup and diagnostics."
     },
     "test": {
       "tool": "test_check",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -157,11 +157,11 @@
           "route": "create_and_publish"
         },
         {
-          "route": "escalate_stop"
+          "route": "register_clone_failure"
         }
       ],
-      "on_failure": "escalate_stop",
-      "note": "Fetches issue title/slug and claims the issue in one turn. Returns issue_number, issue_title, issue_slug, and claimed boolean. When claimed=false (another session owns it), routes to escalate_stop. issue_slug and issue_number are passed to create_and_publish for branch naming.\n"
+      "on_failure": "register_clone_failure",
+      "note": "Fetches issue title/slug and claims the issue in one turn. Returns issue_number, issue_title, issue_slug, and claimed boolean. When claimed=false (another session owns it), routes to register_clone_failure before escalate_stop so the clone directory is registered for cleanup. issue_slug and issue_number are passed to create_and_publish for branch naming.\n"
     },
     "create_and_publish": {
       "tool": "create_and_publish_branch",
@@ -454,14 +454,14 @@
         },
         {
           "when": "result.error",
-          "route": "escalate_stop"
+          "route": "register_clone_failure"
         },
         {
           "route": "remediate"
         }
       ],
-      "on_failure": "escalate_stop",
-      "on_context_limit": "escalate_stop",
+      "on_failure": "register_clone_failure",
+      "on_context_limit": "register_clone_failure",
       "optional": true,
       "skip_when_false": "inputs.audit",
       "note": "Only run if inputs.audit = true. If inputs.audit = false, skip directly to commit_guard."

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -315,14 +315,22 @@ steps:
     - route: test
     on_failure: release_issue_failure
   close_issue_no_changes:
+    description: Release issue after zero-change detection — stages on non-default
+      branch, closes on promotion target
     tool: release_issue
     optional: true
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
+      target_branch: ${{ inputs.base_branch }}
       close_issue: 'true'
-    on_success: done
-    on_failure: done
+    on_success: register_clone_success
+    on_failure: register_clone_success
+    note: 'Zero changes detected post-implement. Passes target_branch so release_issue
+      stages on non-default branches (base_branch != promotion_target) or closes on
+      the promotion target branch. close_issue is silently ignored by release_issue
+      when staging applies (Branch 1 takes precedence over Branch 3). Routes to
+      register_clone_success for clone cleanup and diagnostics.'
   test:
     tool: test_check
     with:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -158,11 +158,12 @@ steps:
     on_result:
     - when: ${{ result.claimed }} == true
       route: create_and_publish
-    - route: escalate_stop
-    on_failure: escalate_stop
+    - route: register_clone_failure
+    on_failure: register_clone_failure
     note: 'Fetches issue title/slug and claims the issue in one turn. Returns issue_number,
       issue_title, issue_slug, and claimed boolean. When claimed=false (another session
-      owns it), routes to escalate_stop. issue_slug and issue_number are passed to
+      owns it), routes to register_clone_failure before escalate_stop so the clone
+      directory is registered for cleanup. issue_slug and issue_number are passed to
       create_and_publish for branch naming.
 
       '
@@ -415,10 +416,10 @@ steps:
     - when: ${{ result.verdict }} == GO
       route: commit_guard
     - when: result.error
-      route: escalate_stop
+      route: register_clone_failure
     - route: remediate
-    on_failure: escalate_stop
-    on_context_limit: escalate_stop
+    on_failure: register_clone_failure
+    on_context_limit: register_clone_failure
     optional: true
     skip_when_false: inputs.audit
     note: Only run if inputs.audit = true. If inputs.audit = false, skip directly

--- a/src/autoskillit/server/tools/tools_issue_labels.py
+++ b/src/autoskillit/server/tools/tools_issue_labels.py
@@ -214,12 +214,13 @@ async def release_issue(
 
             # Determine if staging is needed
             promotion_target = tool_ctx.config.branching.promotion_target
-            should_stage = target_branch is not None and target_branch != promotion_target
+            should_stage = bool(target_branch) and target_branch != promotion_target
 
             staged = False
             config_fail_label = tool_ctx.config.github.fail_label
             effective_staged_label = staged_label or tool_ctx.config.github.staged_label
 
+            # close_issue is intentionally not checked here — staging takes precedence over closing
             if should_stage:
                 if err := tool_ctx.config.github.check_label_allowed(effective_staged_label):
                     return json.dumps(

--- a/tests/contracts/test_zero_change_circuit_breaker_contracts.py
+++ b/tests/contracts/test_zero_change_circuit_breaker_contracts.py
@@ -77,3 +77,33 @@ def test_remediation_recipe_has_same_circuit_breaker() -> None:
         f"remediation retry_worktree.on_context_limit must be 'check_changes', "
         f"got {retry_step.get('on_context_limit')!r}"
     )
+
+
+def test_close_issue_no_changes_passes_target_branch() -> None:
+    """close_issue_no_changes must pass target_branch to enable branch-aware staging."""
+    for name in ("implementation", "remediation"):
+        data = _load(name)
+        step = data["steps"]["close_issue_no_changes"]
+        with_args = step.get("with", {})
+        assert "target_branch" in with_args, (
+            f"{name}: close_issue_no_changes.with must include target_branch, got: {with_args}"
+        )
+        assert with_args["target_branch"] == "${{ inputs.base_branch }}", (
+            f"{name}: close_issue_no_changes.with.target_branch must be "
+            f"'${{{{ inputs.base_branch }}}}', got: {with_args['target_branch']!r}"
+        )
+
+
+def test_close_issue_no_changes_routes_to_register_clone_success() -> None:
+    """close_issue_no_changes must route to register_clone_success, not bare done."""
+    for name in ("implementation", "remediation"):
+        data = _load(name)
+        step = data["steps"]["close_issue_no_changes"]
+        assert step.get("on_success") == "register_clone_success", (
+            f"{name}: close_issue_no_changes.on_success must be 'register_clone_success', "
+            f"got {step.get('on_success')!r}"
+        )
+        assert step.get("on_failure") == "register_clone_success", (
+            f"{name}: close_issue_no_changes.on_failure must be 'register_clone_success', "
+            f"got {step.get('on_failure')!r}"
+        )

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -138,11 +138,11 @@ def test_all_tool_steps_have_on_failure() -> None:
 
 
 def test_audit_impl_on_failure_routes_to_escalation() -> None:
-    """audit_impl.on_failure must route to an escalation step in each recipe."""
+    """audit_impl.on_failure must route through registration before escalating."""
     impl = load_recipe(builtin_recipes_dir() / "implementation.yaml")
     rem = load_recipe(builtin_recipes_dir() / "remediation.yaml")
-    assert impl.steps["audit_impl"].on_failure == "escalate_stop"
-    assert rem.steps["audit_impl"].on_failure == "escalate_stop"
+    assert impl.steps["audit_impl"].on_failure == "register_clone_failure"
+    assert rem.steps["audit_impl"].on_failure == "register_clone_failure"
 
 
 @pytest.mark.parametrize(

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -242,9 +242,10 @@ class TestPipelineVariantInvariants:
 
     def test_audit_impl_has_on_context_limit(self, recipe) -> None:
         step = recipe.steps["audit_impl"]
-        assert step.on_context_limit == "escalate_stop", (
-            "audit_impl is a merge gate; a context-exhausted audit cannot provide "
-            "a valid verdict — aborting via escalate_stop is correct"
+        assert step.on_context_limit == "register_clone_failure", (
+            "audit_impl on context limit must register the clone before escalating — "
+            "clone-terminal-requires-registration requires all terminal paths go through "
+            "register_clone_status"
         )
 
     def test_compose_pr_has_on_context_limit(self, recipe) -> None:
@@ -308,9 +309,10 @@ class TestImplementationPipelineStructure:
         """
         step = recipe.steps["audit_impl"]
         assert step.on_success is None  # on_result is used; on_success remains absent
-        assert step.on_failure == "escalate_stop", (
-            "audit_impl must declare on_failure: escalate_stop. "
-            "Tool-level failures produce no result object — on_result conditions cannot fire."
+        assert step.on_failure == "register_clone_failure", (
+            "audit_impl must declare on_failure: register_clone_failure. "
+            "Tool-level failures produce no result object — on_result conditions cannot fire. "
+            "Clone must be registered before escalating via register_clone_failure."
         )
 
     def test_ip6_plan_step_note_contains_glob_pattern(self, recipe) -> None:

--- a/tests/recipe/test_issue_url_pipeline.py
+++ b/tests/recipe/test_issue_url_pipeline.py
@@ -409,15 +409,16 @@ class TestClaimReleaseGates:
                 f"{name}: upfront_claimed.default must be 'false'"
             )
 
-    def test_claim_issue_routes_escalate_stop_when_not_claimed(self):
-        """claim_and_resolve fallthrough routes to escalate_stop."""
+    def test_claim_issue_routes_register_clone_failure_when_not_claimed(self):
+        """claim_and_resolve fallthrough routes through register_clone_failure."""
         for name in self.RECIPES:
             data = yaml.safe_load(_recipe_path(name).read_text())
             on_result = data["steps"]["claim_and_resolve"].get("on_result", [])
-            # The fallthrough route (no 'when' key) must route to escalate_stop
+            # The fallthrough route (no 'when' key) must route through register_clone_failure
+            # so the clone is registered before escalation (clone-terminal-requires-registration)
             fallthrough_routes = [r["route"] for r in on_result if "when" not in r]
-            assert "escalate_stop" in fallthrough_routes, (
-                f"{name}: claim_and_resolve must have escalate_stop as fallthrough on_result route"
+            assert "register_clone_failure" in fallthrough_routes, (
+                f"{name}: claim_and_resolve fallthrough must be register_clone_failure"
             )
 
 

--- a/tests/recipe/test_rule_decomposition.py
+++ b/tests/recipe/test_rule_decomposition.py
@@ -28,7 +28,7 @@ def test_no_deferred_validator_imports_in_rule_modules() -> None:
 
 
 def test_all_rules_registered_across_submodules() -> None:
-    """T2: All 29 rules registered, distributed across sub-modules."""
+    """T2: All 30 rules registered, distributed across sub-modules."""
     import autoskillit.recipe  # noqa: F401 -- triggers rule registration
     from autoskillit.recipe.registry import _RULE_REGISTRY
 
@@ -63,6 +63,7 @@ def test_all_rules_registered_across_submodules() -> None:
         "ci-failure-missing-conflict-gate",
         "unknown-required-pack",
         "skip-when-false-on-hidden",
+        "clone-terminal-requires-registration",
     }
     assert expected <= rule_names
 

--- a/tests/recipe/test_rules_clone.py
+++ b/tests/recipe/test_rules_clone.py
@@ -410,3 +410,70 @@ def test_bundled_recipes_pass_new_rule(recipe_path: Path) -> None:
     findings = run_semantic_rules(recipe)
     matching = [f for f in findings if f.rule == _RULE]
     assert matching == [], f"{recipe_path}: {matching}"
+
+
+# ---------------------------------------------------------------------------
+# clone-terminal-requires-registration
+# ---------------------------------------------------------------------------
+
+
+def test_clone_terminal_requires_registration_rule_is_registered() -> None:
+    """T_CTR0: clone-terminal-requires-registration is registered in _RULE_REGISTRY."""
+    from autoskillit.recipe.validator import _RULE_REGISTRY
+
+    assert "clone-terminal-requires-registration" in {r.name for r in _RULE_REGISTRY}
+
+
+def test_clone_terminal_requires_registration_fires_on_unregistered_terminal() -> None:
+    """clone_repo step that reaches action:stop without register_clone_status fires ERROR."""
+    recipe = _make_recipe(
+        {
+            "clone": RecipeStep(
+                tool="bootstrap_clone",
+                with_args={"source_dir": "/repo", "base_branch": "main"},
+                on_success="process",
+                on_failure="done",
+            ),
+            "process": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo hello", "cwd": "/tmp"},
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="Complete."),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "clone-terminal-requires-registration"]
+    assert len(rule_findings) == 1
+    assert rule_findings[0].severity == Severity.ERROR
+
+
+def test_clone_terminal_requires_registration_passes_with_registration() -> None:
+    """clone_repo step routed through register_clone_status before done passes the rule."""
+    recipe = _make_recipe(
+        {
+            "clone": RecipeStep(
+                tool="bootstrap_clone",
+                with_args={"source_dir": "/repo", "base_branch": "main"},
+                on_success="process",
+                on_failure="register",
+            ),
+            "process": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo hello", "cwd": "/tmp"},
+                on_success="register",
+                on_failure="register",
+            ),
+            "register": RecipeStep(
+                tool="register_clone_status",
+                with_args={"clone_path": "/repo", "status": "success"},
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="Complete."),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "clone-terminal-requires-registration"]
+    assert rule_findings == []

--- a/tests/recipe/test_rules_clone.py
+++ b/tests/recipe/test_rules_clone.py
@@ -477,3 +477,34 @@ def test_clone_terminal_requires_registration_passes_with_registration() -> None
     findings = run_semantic_rules(recipe)
     rule_findings = [f for f in findings if f.rule == "clone-terminal-requires-registration"]
     assert rule_findings == []
+
+
+def test_clone_terminal_requires_registration_does_not_fire_for_failure_path_only_terminal() -> (
+    None
+):
+    """Rule does not fire when the unregistered terminal is only reachable via on_failure.
+
+    BFS starts from clone.on_success, not the clone step itself. A terminal reachable
+    only through the clone's on_failure path is excluded: if the clone failed, no clone
+    directory was created so registration is not required.
+    """
+    recipe = _make_recipe(
+        {
+            "clone": RecipeStep(
+                tool="bootstrap_clone",
+                with_args={"source_dir": "/repo", "base_branch": "main"},
+                on_success="register",
+                on_failure="done",  # failure path reaches terminal without registration
+            ),
+            "register": RecipeStep(
+                tool="register_clone_status",
+                with_args={"clone_path": "/repo", "status": "success"},
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="Complete."),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "clone-terminal-requires-registration"]
+    assert rule_findings == []

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -476,6 +476,34 @@ def test_release_issue_requires_disposition_passes_with_target_branch() -> None:
     assert not hits
 
 
+def test_release_issue_requires_disposition_fires_on_close_issue_only() -> None:
+    """Rule fires when release_issue has close_issue but no target_branch or fail_label."""
+    recipe = _make_recipe_with_args(
+        "release_issue",
+        {"issue_url": "https://github.com/o/r/issues/1", "close_issue": "true"},
+    )
+    findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "release-issue-requires-disposition"]
+    assert hits
+    assert hits[0].severity == Severity.ERROR
+    assert "target_branch" in hits[0].message
+
+
+def test_release_issue_requires_disposition_passes_with_close_issue_and_target_branch() -> None:
+    """Rule does NOT fire when both close_issue and target_branch are present."""
+    recipe = _make_recipe_with_args(
+        "release_issue",
+        {
+            "issue_url": "https://github.com/o/r/issues/1",
+            "target_branch": "${{ inputs.base_branch }}",
+            "close_issue": "true",
+        },
+    )
+    findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "release-issue-requires-disposition"]
+    assert not hits
+
+
 # ---------------------------------------------------------------------------
 # push-after-edit-requires-force rule tests
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -495,6 +495,70 @@ async def test_release_issue_without_close_flag_does_not_close(tool_ctx_kitchen_
     tool_ctx_kitchen_open.github_client.close_issue.assert_not_called()
 
 
+@pytest.mark.anyio
+async def test_release_issue_close_issue_with_non_default_branch_stages_issue(
+    tool_ctx_kitchen_open,
+) -> None:
+    """close_issue + non-default target_branch → Branch 1 (staging), not close."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.ensure_label = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
+    promotion_target = tool_ctx_kitchen_open.config.branching.promotion_target
+
+    result = json.loads(
+        await release_issue(
+            "https://github.com/owner/repo/issues/42",
+            close_issue="true",
+            target_branch="develop",
+        )
+    )
+    assert result["success"] is True
+    assert result.get("staged") is True
+    tool_ctx_kitchen_open.github_client.close_issue.assert_not_called()
+    _ = promotion_target  # confirms we are targeting a non-default branch
+
+
+@pytest.mark.anyio
+async def test_release_issue_close_issue_with_promotion_target_closes_issue(
+    tool_ctx_kitchen_open,
+) -> None:
+    """close_issue + promotion_target branch → Branch 3 (bare removal + close)."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
+    tool_ctx_kitchen_open.github_client.close_issue = AsyncMock(return_value={"success": True})
+    promotion_target = tool_ctx_kitchen_open.config.branching.promotion_target
+
+    result = json.loads(
+        await release_issue(
+            "https://github.com/owner/repo/issues/42",
+            close_issue="true",
+            target_branch=promotion_target,
+        )
+    )
+    assert result["success"] is True
+    assert result.get("staged") is False
+    tool_ctx_kitchen_open.github_client.close_issue.assert_called_once_with("owner", "repo", 42)
+
+
+@pytest.mark.anyio
+async def test_release_issue_empty_string_target_branch_falls_to_bare_removal(
+    tool_ctx_kitchen_open,
+) -> None:
+    """Empty string target_branch must fall to Branch 3 (bare removal), not spurious staging."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.swap_labels = AsyncMock(return_value={"success": True})
+
+    result = json.loads(
+        await release_issue(
+            "https://github.com/owner/repo/issues/42",
+            target_branch="",
+        )
+    )
+    assert result["success"] is True
+    assert result.get("staged") is False
+    tool_ctx_kitchen_open.github_client.ensure_label.assert_not_called()
+
+
 def _make_mock_tool_ctx_for_project_dir(project_dir):
     """Build a minimal mock ToolContext for project_dir tests."""
     mock_ctx = MagicMock()

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -515,7 +515,9 @@ async def test_release_issue_close_issue_with_non_default_branch_stages_issue(
     assert result["success"] is True
     assert result.get("staged") is True
     tool_ctx_kitchen_open.github_client.close_issue.assert_not_called()
-    _ = promotion_target  # confirms we are targeting a non-default branch
+    assert (
+        promotion_target != "develop"
+    )  # invariant: fixture must use a non-develop promotion target
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

The `close_issue_no_changes` zero-change circuit breaker in the implementation recipe closes issues outright when the implement step produces 0 commits, regardless of whether the base branch is the promotion target. When a re-run occurs after a prior run already merged the work to `develop`, this closes the issue instead of applying a staged label.

Root cause: `close_issue_no_changes` calls `release_issue(close_issue='true')` with no `target_branch` parameter, landing in bare removal branch which strips lifecycle labels and closes the issue.

Fix: Add `target_branch: ${{ inputs.base_branch }}` so `release_issue` can compare against promotion_target and stage (non-default branch) or close (promotion target). Also route to `register_clone_success` instead of bare `done` to prevent clone leaks. The identical bug exists in both `implementation.yaml` and `remediation.yaml`.








## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260527-173434-111500/.autoskillit/temp/rectify/rectify_close_issue_no_changes_unconditional_close_2026-05-27_230000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 97 | 36.2k | 4.8M | 165.1k | 328 | 165.5k | 26m 58s |
| dry_walkthrough | claude-opus-4-6 | 1 | 53 | 11.9k | 1.5M | 74.9k | 101 | 58.8k | 6m 22s |
| implement | claude-sonnet-4-6 | 1 | 1.6k | 37.6k | 5.0M | 115.6k | 179 | 99.9k | 12m 51s |
| audit_impl | claude-sonnet-4-6 | 1 | 76 | 5.7k | 313.2k | 54.7k | 23 | 41.9k | 2m 2s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 81.4k | 3.5k | 221.7k | 36.3k | 22 | 55.5k | 1m 27s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 38.5k | 1.3k | 182.5k | 30.9k | 14 | 15.5k | 42s |
| review_pr | claude-sonnet-4-6 | 1 | 166 | 42.7k | 1.2M | 113.7k | 71 | 99.5k | 13m 3s |
| resolve_review | claude-sonnet-4-6 | 1 | 209 | 16.1k | 1.7M | 85.8k | 69 | 70.2k | 6m 33s |
| **Total** | | | 122.1k | 155.1k | 14.9M | 165.1k | | 606.8k | 1h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 337 | 14813.5 | 296.4 | 111.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 35 | 47571.2 | 2006.8 | 460.2 |
| **Total** | **372** | 39994.8 | 1631.1 | 417.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 5 | 2.2k | 138.4k | 13.0M | 477.0k | 1h 1m |
| claude-opus-4-6 | 1 | 53 | 11.9k | 1.5M | 58.8k | 6m 22s |
| MiniMax-M2.7-highspeed | 2 | 119.8k | 4.8k | 404.2k | 71.0k | 2m 9s |