### PR TITLE
Add Related Skills Section to All 12 vis-lens SKILL.md Files

### DIFF
--- a/src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
@@ -270,3 +270,13 @@ Before creating the diagram, verify:
 - [ ] All three passes completed before computing verdict
 - [ ] yaml:spec-index emitted (not yaml:figure-spec)
 - [ ] verdict is FAIL_N if critical_count > 0, WARN_N if warning_count > 0, PASS otherwise
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-antipattern` - Severity-tiered anti-pattern detection
+- `/autoskillit:vis-lens-color-access` - Colorblind safety and perceptual uniformity
+- `/autoskillit:vis-lens-caption-annot` - Caption and axis label completeness

--- a/src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
@@ -275,3 +275,13 @@ Before creating the diagram, verify:
 - [ ] All 16 anti-patterns were checked for each figure
 - [ ] Findings are sorted critical-first
 - [ ] Each yaml:figure-spec has `anti_patterns` field populated
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-always-on` - Composite triage with PASS/WARN/FAIL verdict
+- `/autoskillit:vis-lens-chart-select` - Chart type selection via Cleveland-McGill hierarchy
+- `/autoskillit:vis-lens-uncertainty` - Error bar semantics and multi-seed variance

--- a/src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
@@ -243,3 +243,13 @@ Before creating the diagram, verify:
 - [ ] Every figure with a non-declarative title is flagged as FAIL
 - [ ] Every axis missing units on a continuous quantity is flagged as WARNING
 - [ ] Every figure with undefined error bars is flagged as FAIL
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-always-on` - Composite triage with PASS/WARN/FAIL verdict
+- `/autoskillit:vis-lens-color-access` - Colorblind safety and perceptual uniformity
+- `/autoskillit:vis-lens-figure-table` - Figure-vs-table selection heuristics

--- a/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
@@ -168,7 +168,7 @@ For each figure slot identified:
 | Matrix / Grid | Relationship | heatmap, matrix |
 | High-dimensional | Relationship | scatter-matrix, parallel-coordinates |
 
-### Step 3d: Perceptual Rank
+### Step 3: Perceptual Rank
 
 For each figure slot, rank the candidate chart types by Cleveland-McGill position:
 
@@ -315,3 +315,13 @@ Before creating the diagram, verify:
 - [ ] Diagram will include a color legend table
 - [ ] All chart types are from the controlled vocabulary (no radar, no pie)
 - [ ] Each figure spec has `perceptual_justification` filled in
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-antipattern` - Severity-tiered anti-pattern detection
+- `/autoskillit:vis-lens-figure-table` - Figure-vs-table selection heuristics
+- `/autoskillit:vis-lens-uncertainty` - Error bar semantics and multi-seed variance

--- a/src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
@@ -236,3 +236,13 @@ Before creating the diagram, verify:
 - [ ] Every failing colormap (jet, rainbow) is explicitly flagged as FAIL
 - [ ] Every color-distinguished series has been checked for redundant encoding
 - [ ] Every font size below 8pt has been flagged as WARNING
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-always-on` - Composite triage with PASS/WARN/FAIL verdict
+- `/autoskillit:vis-lens-antipattern` - Severity-tiered anti-pattern detection
+- `/autoskillit:vis-lens-caption-annot` - Caption and axis label completeness

--- a/src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
@@ -231,3 +231,13 @@ Before creating the diagram, verify:
 - [ ] Every result slot has been classified and assigned a verdict
 - [ ] Every BOTH verdict has a documented placement recommendation
 - [ ] No `yaml:figure-spec` emitted for TABLE-only result slots
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-chart-select` - Chart type selection via Cleveland-McGill hierarchy
+- `/autoskillit:vis-lens-caption-annot` - Caption and axis label completeness
+- `/autoskillit:vis-lens-story-arc` - Narrative consistency and figure progression

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -420,3 +420,13 @@ Before creating the diagram, verify:
 - [ ] ML sub-area has been identified from context or experiment plan
 - [ ] All mandatory figures for the sub-area have been checked
 - [ ] Gap list is sorted absent-first, then partial
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-multi-compare` - Small-multiples, faceting, and panel layout
+- `/autoskillit:vis-lens-reproducibility` - Figure reproducibility and seed documentation
+- `/autoskillit:vis-lens-chart-select` - Chart type selection via Cleveland-McGill hierarchy

--- a/src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
@@ -245,3 +245,13 @@ Before creating the diagram, verify:
 - [ ] Diagram will include a color legend table
 - [ ] Every figure with ≥ 4 conditions has been assigned a small-multiples layout
 - [ ] Every `yaml:figure-spec` has the `facet` field filled (or explicitly empty for overlays)
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-temporal` - Training dynamics and axis scaling
+- `/autoskillit:vis-lens-story-arc` - Narrative consistency and figure progression
+- `/autoskillit:vis-lens-methodology-norms` - Domain-specific mandatory figure norms

--- a/src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
@@ -259,3 +259,13 @@ Before creating the diagram, verify:
 - [ ] Every restricted/embargoed dataset is flagged as FAIL or WARNING
 - [ ] Every histogram bin width and time-series smoothing window is audited
 - [ ] Every stochastic figure has its seeds documented or flagged
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-methodology-norms` - Domain-specific mandatory figure norms
+- `/autoskillit:vis-lens-multi-compare` - Small-multiples, faceting, and panel layout
+- `/autoskillit:vis-lens-uncertainty` - Error bar semantics and multi-seed variance

--- a/src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
@@ -227,3 +227,13 @@ Before creating the diagram, verify:
 - [ ] Global color map table is complete before creating the diagram
 - [ ] Every color inconsistency has been flagged
 - [ ] Every redundant figure pair has been identified
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-figure-table` - Figure-vs-table selection heuristics
+- `/autoskillit:vis-lens-temporal` - Training dynamics and axis scaling
+- `/autoskillit:vis-lens-multi-compare` - Small-multiples, faceting, and panel layout

--- a/src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
@@ -253,3 +253,13 @@ Before creating the diagram, verify:
 - [ ] Every CRITICAL (n_seeds == 1) training curve is flagged
 - [ ] Every smoothing call has its parameters disclosed in the figure spec
 - [ ] Early-stopping markers are noted for all curves with early stopping
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-uncertainty` - Error bar semantics and multi-seed variance
+- `/autoskillit:vis-lens-story-arc` - Narrative consistency and figure progression
+- `/autoskillit:vis-lens-multi-compare` - Small-multiples, faceting, and panel layout

--- a/src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md
@@ -264,3 +264,13 @@ Before creating the diagram, verify:
 - [ ] Diagram will include a color legend table
 - [ ] Every CRITICAL (n_seeds == 1) figure is flagged
 - [ ] Every stat_overlay has both `measure` and `n_seeds` filled in
+
+---
+
+## Related Skills
+
+- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
+- `/autoskillit:vis-lens-chart-select` - Chart type selection via Cleveland-McGill hierarchy
+- `/autoskillit:vis-lens-antipattern` - Severity-tiered anti-pattern detection
+- `/autoskillit:vis-lens-temporal` - Training dynamics and axis scaling


### PR DESCRIPTION
## Summary

Fix the "Step 3d" typo in `vis-lens-chart-select/SKILL.md` (line 171 → "Step 3") and append a standardized `## Related Skills` section to all 12 vis-lens SKILL.md files, following the established arch-lens/exp-lens convention. Each section includes the parent `plan-visualization` skill, the required `mermaid` dependency, and 3 thematic sibling vis-lens skills per the specified mapping. Run `task regen-contracts` after edits.

## Requirements

Fix the 'Step 3d' typo in vis-lens-chart-select and add the Related Skills section to all 12 vis-lens files in a single pass

## Changed Files

### Modified (●):
● src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
● src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
● src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
● src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
● src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
● src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
● src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
● src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
● src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
● src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
● src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
● src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md

Closes #3076

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3076-20260527-204507-204283/.autoskillit/temp/make-plan/p1_a4_wp1_add_related_skills_vis_lens_plan_2026-05-27_205500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 92 | 15.0k | 977.4k | 91.1k | 227 | 70.0k | 11m 52s |
| review | claude-sonnet-4-6 | 1 | 1.5k | 4.5k | 210.8k | 38.4k | 35 | 24.5k | 3m 18s |
| verify | claude-sonnet-4-6 | 1 | 148 | 8.0k | 732.9k | 49.3k | 50 | 33.4k | 2m 31s |
| implement* | MiniMax-M2.7-highspeed | 1 | 465.5k | 8.5k | 803.3k | 30.9k | 56 | 44.2k | 3m 8s |
| audit_impl | claude-sonnet-4-6 | 1 | 68 | 7.7k | 247.0k | 38.3k | 19 | 26.6k | 1m 59s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 143.9k | 3.2k | 339.9k | 30.9k | 24 | 43.8k | 1m 11s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 38.5k | 1.4k | 182.5k | 30.9k | 14 | 15.4k | 36s |
| **Total** | | | 649.8k | 48.4k | 3.5M | 91.1k | | 257.9k | 24m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 122 | 6584.2 | 362.6 | 69.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **122** | 28637.6 | 2114.1 | 396.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 4 | 1.8k | 35.2k | 2.2M | 154.4k | 19m 42s |
| MiniMax-M2.7-highspeed | 3 | 648.0k | 13.1k | 1.3M | 103.5k | 4m 55s |