### PR TITLE
fix: model-independent worktree detection in clone guard

### DIFF
--- a/src/autoskillit/core/claude_conventions.py
+++ b/src/autoskillit/core/claude_conventions.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from .paths import is_git_worktree
 from .types import AGENT_BACKEND_CODEX, CodingAgentBackend, ValidatedAddDir, ValidatedWorktreePath
 
 
@@ -74,9 +75,15 @@ def validate_project_local_skill_dir(
         return None
 
 
-def validate_worktree_path(path: Path | str) -> ValidatedWorktreePath | None:
+def validate_worktree_path(
+    path: Path | str,
+    *,
+    verify_git: bool = False,
+) -> ValidatedWorktreePath | None:
     """Validate a worktree path is absolute and exists. Returns None on failure."""
     p = Path(path) if isinstance(path, str) else path
     if not p.is_absolute() or not p.is_dir():
+        return None
+    if verify_git and not is_git_worktree(p):
         return None
     return ValidatedWorktreePath(path=str(p))

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -193,7 +193,7 @@ async def _detect_new_worktrees(
 
 def _recover_worktree_path(new_worktrees: list[str]) -> str | None:
     for path in new_worktrees:
-        validated = validate_worktree_path(path)
+        validated = validate_worktree_path(path, verify_git=True)
         if validated is not None:
             return validated.path
     return None

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -410,7 +410,7 @@ async def check_and_revert_clone_contamination(
                 logger.info(
                     "worktree_path_recovered_from_git",
                     recovered_path=recovered,
-                    token_extraction="failed",
+                    extraction_status="failed",
                 )
                 skill_result = dataclasses.replace(skill_result, worktree_path=recovered)
 

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -27,6 +27,7 @@ from autoskillit.core import (
     RetryReason,
     SkillResult,
     get_logger,
+    validate_worktree_path,
 )
 
 if TYPE_CHECKING:
@@ -96,6 +97,7 @@ class CloneSnapshot:
     """Pre-session state of the clone directory."""
 
     head_sha: str
+    worktree_set: frozenset[str] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,8 +159,48 @@ def is_clone_commit_skill(skill_command: str) -> bool:
     return any(name in skill_command for name in CLONE_COMMIT_SKILLS)
 
 
+def _parse_worktree_list(stdout: str) -> list[str]:
+    """Parse ``git worktree list --porcelain`` output into linked worktree paths.
+
+    Skips the first entry (main worktree) — only returns linked worktrees.
+    """
+    paths: list[str] = []
+    first = True
+    for line in stdout.splitlines():
+        if line.startswith("worktree "):
+            if first:
+                first = False
+                continue
+            paths.append(line.split(" ", 1)[1].strip())
+    return paths
+
+
+async def _detect_new_worktrees(
+    pre_worktree_set: frozenset[str],
+    cwd: str,
+    runner: SubprocessRunner,
+) -> list[str]:
+    result = await runner(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    if result.returncode != 0:
+        return []
+    current = _parse_worktree_list(result.stdout)
+    return [p for p in current if p not in pre_worktree_set]
+
+
+def _recover_worktree_path(new_worktrees: list[str]) -> str | None:
+    for path in new_worktrees:
+        validated = validate_worktree_path(path)
+        if validated is not None:
+            return validated.path
+    return None
+
+
 async def snapshot_clone_state(cwd: str, runner: SubprocessRunner) -> CloneSnapshot | None:
-    """Capture the clone's HEAD SHA before a worktree-skill session.
+    """Capture the clone's HEAD SHA and worktree set before a session.
 
     Returns None on failure (graceful degradation — guard simply won't activate).
     """
@@ -174,8 +216,22 @@ async def snapshot_clone_state(cwd: str, runner: SubprocessRunner) -> CloneSnaps
     if not head_sha:
         logger.debug("snapshot_clone_state_empty_sha")
         return None
-    logger.debug("snapshot_clone_state_captured", head_sha=head_sha)
-    return CloneSnapshot(head_sha=head_sha)
+
+    wt_result = await runner(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    wt_set: frozenset[str] | None = None
+    if wt_result.returncode == 0:
+        wt_set = frozenset(_parse_worktree_list(wt_result.stdout))
+
+    logger.debug(
+        "snapshot_clone_state_captured",
+        head_sha=head_sha,
+        worktree_count=len(wt_set) if wt_set is not None else -1,
+    )
+    return CloneSnapshot(head_sha=head_sha, worktree_set=wt_set)
 
 
 def _status_path_under_prefix(status_line: str, prefix: str) -> bool:
@@ -341,6 +397,23 @@ async def check_and_revert_clone_contamination(
     """
     if snapshot is None:
         return skill_result, False
+
+    if (
+        skill_result.worktree_path is None
+        and is_worktree_skill(skill_command)
+        and snapshot.worktree_set is not None
+    ):
+        new_worktrees = await _detect_new_worktrees(snapshot.worktree_set, cwd, runner)
+        if new_worktrees:
+            recovered = _recover_worktree_path(new_worktrees)
+            if recovered:
+                logger.info(
+                    "worktree_path_recovered_from_git",
+                    recovered_path=recovered,
+                    token_extraction="failed",
+                )
+                skill_result = dataclasses.replace(skill_result, worktree_path=recovered)
+
     if not policy.should_fire(skill_result.success):
         return skill_result, False
     if skill_result.worktree_path is not None:

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -1087,3 +1087,15 @@ async def test_worktree_recovery_on_success_path(tmp_path):
     )
     assert not reverted
     assert result.worktree_path == str(wt_dir)
+
+
+# ---------------------------------------------------------------------------
+# T28: validate_worktree_path rejects non-worktree dir with verify_git
+# ---------------------------------------------------------------------------
+def test_validate_worktree_path_rejects_non_worktree_dir(tmp_path):
+    regular_dir = tmp_path / "not-a-worktree"
+    regular_dir.mkdir()
+    from autoskillit.core import validate_worktree_path
+
+    assert validate_worktree_path(regular_dir) is not None
+    assert validate_worktree_path(regular_dir, verify_git=True) is None

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -905,6 +905,7 @@ async def test_guard_fires_when_worktree_path_none_despite_real_worktree(tmp_pat
     runner = MockSubprocessRunner()
     wt_dir = tmp_path / "worktrees" / "impl-fix"
     wt_dir.mkdir(parents=True)
+    (wt_dir / ".git").write_text("gitdir: /tmp/fake/.git/worktrees/impl-fix\n")
 
     porcelain_post = f"worktree {tmp_path}\n\nworktree {wt_dir}\n"
 
@@ -997,6 +998,7 @@ async def test_recovered_worktree_path_is_validated(tmp_path):
     runner = MockSubprocessRunner()
     wt_dir = tmp_path / "worktrees" / "impl-fix"
     wt_dir.mkdir(parents=True)
+    (wt_dir / ".git").write_text("gitdir: /tmp/fake/.git/worktrees/impl-fix\n")
 
     porcelain_post = f"worktree {tmp_path}\n\nworktree {wt_dir}\n"
     snapshot = CloneSnapshot(head_sha="abc123", worktree_set=frozenset())
@@ -1018,9 +1020,10 @@ async def test_recovered_worktree_path_is_validated(tmp_path):
             is_worktree=True,
         ),
     )
-    assert result.worktree_path == str(wt_dir)
     from autoskillit.core import validate_worktree_path
 
+    assert result.worktree_path is not None
+    assert result.worktree_path == str(wt_dir)
     assert validate_worktree_path(result.worktree_path) is not None
 
 
@@ -1064,6 +1067,7 @@ async def test_worktree_recovery_on_success_path(tmp_path):
     runner = MockSubprocessRunner()
     wt_dir = tmp_path / "worktrees" / "impl-fix"
     wt_dir.mkdir(parents=True)
+    (wt_dir / ".git").write_text("gitdir: /tmp/fake/.git/worktrees/impl-fix\n")
 
     porcelain_post = f"worktree {tmp_path}\n\nworktree {wt_dir}\n"
     snapshot = CloneSnapshot(head_sha="abc123", worktree_set=frozenset())
@@ -1090,12 +1094,13 @@ async def test_worktree_recovery_on_success_path(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# T28: validate_worktree_path rejects non-worktree dir with verify_git
+# T28: validate_worktree_path accepts dir without verify_git, rejects with it
 # ---------------------------------------------------------------------------
-def test_validate_worktree_path_rejects_non_worktree_dir(tmp_path):
+def test_validate_worktree_path_verify_git_rejects_non_worktree_dir(tmp_path):
+    from autoskillit.core import validate_worktree_path
+
     regular_dir = tmp_path / "not-a-worktree"
     regular_dir.mkdir()
-    from autoskillit.core import validate_worktree_path
 
     assert validate_worktree_path(regular_dir) is not None
     assert validate_worktree_path(regular_dir, verify_git=True) is None

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -117,9 +117,23 @@ class TestIsWorktreeSkillNegative:
 async def test_snapshot_clone_state_captures_sha(tmp_path):
     runner = MockSubprocessRunner()
     runner.push(_git_result(stdout="abc123\n"))
+    porcelain = f"worktree {tmp_path}\nHEAD abc123\nbranch refs/heads/main\n"
+    runner.push(_git_result(stdout=porcelain))
     snapshot = await snapshot_clone_state(str(tmp_path), runner)
     assert snapshot is not None
     assert snapshot.head_sha == "abc123"
+    assert snapshot.worktree_set == frozenset()
+
+
+@pytest.mark.anyio
+async def test_snapshot_clone_state_worktree_list_failure(tmp_path):
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="abc123\n"))
+    runner.push(_git_result(returncode=128))
+    snapshot = await snapshot_clone_state(str(tmp_path), runner)
+    assert snapshot is not None
+    assert snapshot.head_sha == "abc123"
+    assert snapshot.worktree_set is None
 
 
 # ---------------------------------------------------------------------------
@@ -881,3 +895,195 @@ class TestDeriveExcludePrefix:
 
     def test_uses_first_dir(self, tmp_path):
         assert derive_exclude_prefix([tmp_path / "a", tmp_path / "b"], tmp_path) == "a/"
+
+
+# ---------------------------------------------------------------------------
+# T22: guard fires when worktree_path is None despite real worktree created
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_guard_fires_when_worktree_path_none_despite_real_worktree(tmp_path):
+    runner = MockSubprocessRunner()
+    wt_dir = tmp_path / "worktrees" / "impl-fix"
+    wt_dir.mkdir(parents=True)
+
+    porcelain_post = f"worktree {tmp_path}\n\nworktree {wt_dir}\n"
+
+    snapshot = CloneSnapshot(head_sha="abc123", worktree_set=frozenset())
+    skill_result = _make_skill_result(success=False, worktree_path=None)
+
+    runner.push(_git_result(stdout=porcelain_post))
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        str(tmp_path),
+        runner,
+        None,
+        skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+        policy=build_clone_guard_policy(
+            readonly_skill=False,
+            has_write_scope=False,
+            is_clone_commit=False,
+            is_worktree=True,
+        ),
+    )
+    assert not reverted
+    assert result.worktree_path == str(wt_dir)
+
+
+# ---------------------------------------------------------------------------
+# T23: snapshot captures worktree set
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_snapshot_captures_worktree_set(tmp_path):
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="abc123\n"))
+    porcelain = (
+        f"worktree {tmp_path}\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+        f"worktree {tmp_path}/worktrees/impl-a\n"
+        "HEAD def456\n"
+        "branch refs/heads/impl-a\n"
+    )
+    runner.push(_git_result(stdout=porcelain))
+
+    snapshot = await snapshot_clone_state(str(tmp_path), runner)
+    assert snapshot is not None
+    assert snapshot.head_sha == "abc123"
+    assert snapshot.worktree_set == frozenset({f"{tmp_path}/worktrees/impl-a"})
+
+
+# ---------------------------------------------------------------------------
+# T24: worktree recovery requires worktree skill
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_worktree_recovery_requires_worktree_skill(tmp_path):
+    runner = MockSubprocessRunner()
+    wt_dir = tmp_path / "worktrees" / "impl-fix"
+    wt_dir.mkdir(parents=True)
+
+    porcelain_post = f"worktree {tmp_path}\n\nworktree {wt_dir}\n"
+    snapshot = CloneSnapshot(head_sha="abc123", worktree_set=frozenset())
+    skill_result = _make_skill_result(success=True, worktree_path=None)
+
+    runner.push(_git_result(stdout=porcelain_post))
+    runner.push(_git_result(stdout="abc123\n"))
+    runner.push(_git_result(stdout=""))
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        str(tmp_path),
+        runner,
+        None,
+        skill_command="/autoskillit:investigate foo",
+        policy=build_clone_guard_policy(
+            readonly_skill=True,
+            has_write_scope=False,
+            is_clone_commit=False,
+            is_worktree=False,
+        ),
+    )
+    assert result.worktree_path is None
+
+
+# ---------------------------------------------------------------------------
+# T25: recovered worktree path is validated
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_recovered_worktree_path_is_validated(tmp_path):
+    runner = MockSubprocessRunner()
+    wt_dir = tmp_path / "worktrees" / "impl-fix"
+    wt_dir.mkdir(parents=True)
+
+    porcelain_post = f"worktree {tmp_path}\n\nworktree {wt_dir}\n"
+    snapshot = CloneSnapshot(head_sha="abc123", worktree_set=frozenset())
+    skill_result = _make_skill_result(success=False, worktree_path=None)
+
+    runner.push(_git_result(stdout=porcelain_post))
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        str(tmp_path),
+        runner,
+        None,
+        skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+        policy=build_clone_guard_policy(
+            readonly_skill=False,
+            has_write_scope=False,
+            is_clone_commit=False,
+            is_worktree=True,
+        ),
+    )
+    assert result.worktree_path == str(wt_dir)
+    from autoskillit.core import validate_worktree_path
+
+    assert validate_worktree_path(result.worktree_path) is not None
+
+
+# ---------------------------------------------------------------------------
+# T26: recovery skipped when snapshot worktree_set is None
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_worktree_recovery_skipped_when_snapshot_worktree_set_none(tmp_path):
+    runner = MockSubprocessRunner()
+    snapshot = CloneSnapshot(head_sha="abc123", worktree_set=None)
+    skill_result = _make_skill_result(success=False, worktree_path=None)
+
+    runner.push(_git_result(stdout="def456\n"))
+    runner.push(_git_result(stdout=" M file.py\n"))
+    runner.push(_git_result())
+    runner.push(_git_result())
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        str(tmp_path),
+        runner,
+        None,
+        skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+        policy=build_clone_guard_policy(
+            readonly_skill=False,
+            has_write_scope=False,
+            is_clone_commit=False,
+            is_worktree=True,
+        ),
+    )
+    assert reverted
+    assert result.worktree_path is None
+
+
+# ---------------------------------------------------------------------------
+# T27: worktree recovery on success path with missing token
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_worktree_recovery_on_success_path(tmp_path):
+    runner = MockSubprocessRunner()
+    wt_dir = tmp_path / "worktrees" / "impl-fix"
+    wt_dir.mkdir(parents=True)
+
+    porcelain_post = f"worktree {tmp_path}\n\nworktree {wt_dir}\n"
+    snapshot = CloneSnapshot(head_sha="abc123", worktree_set=frozenset())
+    skill_result = _make_skill_result(success=True, worktree_path=None, exit_code=0)
+
+    runner.push(_git_result(stdout=porcelain_post))
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        str(tmp_path),
+        runner,
+        None,
+        skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+        policy=build_clone_guard_policy(
+            readonly_skill=False,
+            has_write_scope=False,
+            is_clone_commit=False,
+            is_worktree=True,
+        ),
+    )
+    assert not reverted
+    assert result.worktree_path == str(wt_dir)

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -1457,6 +1457,19 @@ class TestExtractWorktreePath:
         )
         assert result == "/abs/worktrees/impl-first"
 
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "**worktree_path:** /path/to/wt",
+            "worktree_path: /path/to/wt",
+            "WORKTREE_PATH = /path/to/wt",
+            "`worktree_path` = /path/to/wt",
+        ],
+        ids=["markdown-bold", "colon-separator", "uppercase", "backtick-wrapped"],
+    )
+    def test_extract_worktree_path_format_variants_return_none(self, token: str):
+        assert _extract_worktree_path([token]) is None
+
 
 class TestBuildSkillResultWorktreePath:
     """_build_skill_result extracts worktree_path on context exhaustion."""


### PR DESCRIPTION
## Summary

The clone guard's worktree bypass was entirely dependent on `SkillResult.worktree_path` being populated by model-emitted tokens. Non-Claude models that fail to emit the exact required token format (`worktree_path = /path/...`) caused the guard to detect legitimate worktree-creation git operations as contamination and revert the clone.

The fix replaces token-dependent detection with an independent `git worktree list` comparison: capture the pre-session worktree set in `CloneSnapshot`, compare post-session worktree list, and recover `worktree_path` from observed system state when extraction fails. This makes the guard model-independent while preserving the fast path for Claude models.

Key changes:
- Extend `CloneSnapshot` with `worktree_set: frozenset[str] | None`
- Capture `git worktree list --porcelain` in `snapshot_clone_state()`
- Add `_detect_new_worktrees()` and `_recover_worktree_path()` helpers
- Add worktree-delta recovery block in `check_and_revert_clone_contamination()` before the policy gate
- Add `verify_git` parameter to `validate_worktree_path` for defense-in-depth

## Problem

The clone guard's worktree bypass (`clone_guard.py:346`) depends entirely on `SkillResult.worktree_path` being non-`None` to suppress contamination detection for worktree-creating skills. This value is populated by `_extract_worktree_path()` which regex-matches `^worktree_path\s*=\s*(.+)$` against the worker's assistant messages. When a non-Claude model (e.g., MiniMax-M2.7-highspeed) fails to emit the structured token in the exact required format, `worktree_path` resolves to `None`, and the guard proceeds to detect and revert the legitimate worktree-creation git operations as contamination.

## Observed Failure (Session `856785f0`)

- **Model:** MiniMax-M2.7-highspeed
- **Skill:** `/implement-worktree-no-merge`
- **What happened:** The model completed implementation (wrote files, ran 428 tests passing, committed to worktree branch), but emitted `**Worktree path:** \`/path/...\`` (bold markdown) instead of `worktree_path = /path/...` (plain text token). The extraction regex returned `None`, the clone guard fired, and the clone was reverted. The pipeline marked the session as `retry_reason: clone_contamination` and routed to `on_failure`.

Closes #3191

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-074319-277652/.autoskillit/temp/rectify/rectify_clone_guard_worktree_bypass_2026-05-28_074500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 66 | 24.5k | 2.7M | 123.9k | 236 | 133.2k | 25m 0s |
| review | claude-opus-4-6 | 1 | 21 | 5.8k | 555.3k | 63.0k | 31 | 49.6k | 4m 2s |
| dry_walkthrough | claude-opus-4-6 | 1 | 558 | 9.0k | 1.3M | 67.5k | 108 | 51.2k | 6m 53s |
| implement | claude-opus-4-6 | 1 | 2.1k | 18.2k | 3.3M | 102.0k | 104 | 85.9k | 7m 21s |
| audit_impl | claude-sonnet-4-6 | 1 | 999 | 7.2k | 254.2k | 75.7k | 88 | 32.1k | 4m 48s |
| prepare_pr* | MiniMax-M2.7 | 1 | 50.9k | 3.3k | 313.3k | 0 | 20 | 0 | 55s |
| compose_pr* | MiniMax-M2.7 | 1 | 37.3k | 1.4k | 230.0k | 0 | 16 | 0 | 29s |
| review_pr | claude-opus-4-6 | 1 | 54 | 27.2k | 899.5k | 81.5k | 53 | 68.7k | 6m 17s |
| resolve_review | claude-opus-4-6 | 1 | 59 | 13.4k | 2.0M | 76.1k | 66 | 60.5k | 8m 20s |
| **Total** | | | 92.1k | 110.0k | 11.6M | 123.9k | | 481.4k | 1h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 319 | 10492.6 | 269.3 | 57.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 15 | 135964.0 | 4036.4 | 895.1 |
| **Total** | **334** | 34854.8 | 1441.2 | 329.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 1.1k | 31.7k | 2.9M | 165.4k | 29m 48s |
| claude-opus-4-6 | 5 | 2.8k | 73.6k | 8.2M | 316.0k | 32m 56s |
| MiniMax-M2.7 | 2 | 88.2k | 4.7k | 543.3k | 0 | 1m 23s |