### PR TITLE
Rectify: Pre-Review Rebase Conflict Immunity

### DIFF
--- a/src/autoskillit/hooks/guards/review_loop_gate.py
+++ b/src/autoskillit/hooks/guards/review_loop_gate.py
@@ -16,8 +16,9 @@ _DENY_REASON = (
     "pr_number, cwd, current_iteration, max_iterations, and "
     "previous_verdict parameters BEFORE proceeding to "
     "wait_for_ci/enqueue_pr. "
-    "Recipe routing: resolve_review → pre_review_rebase → "
-    "re_push_review → on_success: check_review_loop."
+    "Recipe routing: resolve_review → pre_review_rebase (run_python) → "
+    "[clean → re_push_review | conflicts → resolve_pre_review_conflicts → "
+    "re_push_review] → check_review_loop."
 )
 
 _STATE_FILE_RELPATH = (".autoskillit", "temp", "review_gate_state.json")

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -27,6 +27,7 @@ from autoskillit.recipe._cmd_rpc_merge import (  # noqa: F401
     immediate_merge_conflict_fix,
     proactive_rebase_next_pr,
     queue_ejected_fix,
+    review_path_rebase,
     wait_for_direct_merge,
     wait_for_immediate_merge,
     wait_for_review_pr_mergeability,

--- a/src/autoskillit/recipe/_cmd_rpc_merge.py
+++ b/src/autoskillit/recipe/_cmd_rpc_merge.py
@@ -205,6 +205,14 @@ def advance_queue_pr(
     return {"current_pr_number": "done"}
 
 
+def review_path_rebase(
+    work_dir: str,
+    base_branch: str,
+) -> dict[str, str]:
+    """Fetch and rebase for review/resolve paths; return clean or conflicts."""
+    return queue_ejected_fix(work_dir=work_dir, base_branch=base_branch)
+
+
 def proactive_rebase_next_pr(
     work_dir: str,
     next_pr_branch: str,

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -21,7 +21,7 @@ Semantic validation rule modules for recipe analysis (46 rule files).
 | `rules_ci_guards.py` | CI applicability guards, self-loop, enqueue gate, cwd/branch mismatch |
 | `rules_ci_merge_queue.py` | Merge queue PR state routing completeness and conformance |
 | `rules_clone.py` | Clone/push dataflow rules: missing remote URL, local-strategy capture |
-| `rules_cmd.py` | `run_cmd` echo-capture alignment; git remote command detection |
+| `rules_cmd.py` | `run_cmd` echo-capture alignment; git remote command detection; bare git rebase without conflict routing detection |
 | `rules_contracts.py` | Skill contract completeness rules |
 | `rules_dataflow.py` | Capture key validation, dead output, weak constraint |
 | `rules_dataflow_callable.py` | Callable contract validation, signature mismatch, context gap |

--- a/src/autoskillit/recipe/rules/rules_cmd.py
+++ b/src/autoskillit/recipe/rules/rules_cmd.py
@@ -199,3 +199,86 @@ def _check_run_cmd_script_exists(ctx: ValidationContext) -> list[RuleFinding]:
                 )
             )
     return findings
+
+
+_BARE_REBASE_RE = re.compile(r"\bgit\b[^\n]*\brebase\b(?!\s+--abort)")
+
+_CONFLICT_SKILL = "resolve-merge-conflicts"
+
+
+def _has_conflict_routing(step, recipe) -> bool:
+    """Check if a step routes to conflict resolution via on_failure or on_result."""
+    from collections import deque
+
+    targets: list[str] = []
+    if step.on_failure:
+        targets.append(step.on_failure)
+    if step.on_result:
+        for cond in step.on_result.conditions or []:
+            if cond.route:
+                targets.append(cond.route)
+
+    for target_name in targets:
+        visited: set[str] = set()
+        queue: deque[tuple[str, int]] = deque([(target_name, 0)])
+        while queue:
+            name, hops = queue.popleft()
+            if name in visited or hops > 6:
+                continue
+            visited.add(name)
+            target_step = recipe.steps.get(name)
+            if target_step is None:
+                continue
+            if target_step.tool == "run_skill":
+                cmd = (target_step.with_args or {}).get("skill_command", "")
+                if _CONFLICT_SKILL in cmd:
+                    return True
+            if target_step.tool == "run_python":
+                callable_str = (target_step.with_args or {}).get("callable", "")
+                if "rebase" in callable_str:
+                    return True
+            if target_step.on_success:
+                queue.append((target_step.on_success, hops + 1))
+            if target_step.on_failure:
+                queue.append((target_step.on_failure, hops + 1))
+            if target_step.on_result:
+                for cond in target_step.on_result.conditions or []:
+                    if cond.route:
+                        queue.append((cond.route, hops + 1))
+    return False
+
+
+@semantic_rule(
+    name="run-cmd-bare-rebase-without-conflict-routing",
+    description=(
+        "run_cmd step performs git rebase but routes on_failure to a terminal "
+        "without conflict resolution. Use run_python with a rebase callable instead."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_run_cmd_bare_rebase(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "run_cmd":
+            continue
+        cmd = (step.with_args or {}).get("cmd", "")
+        if not isinstance(cmd, str):
+            continue
+        if not _BARE_REBASE_RE.search(cmd):
+            continue
+        if _has_conflict_routing(step, ctx.recipe):
+            continue
+        findings.append(
+            RuleFinding(
+                rule="run-cmd-bare-rebase-without-conflict-routing",
+                severity=Severity.ERROR,
+                step_name=name,
+                message=(
+                    f"Step '{name}' performs a bare git rebase via run_cmd but does not "
+                    "route failures to conflict resolution (resolve-merge-conflicts). "
+                    "Use run_python with a rebase callable that aborts on conflict and "
+                    "route the result to a resolve-merge-conflicts skill step."
+                ),
+            )
+        )
+    return findings

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2610,6 +2610,17 @@ callable_contracts:
     outputs:
     - name: committed
       type: str
+  autoskillit.recipe._cmd_rpc.review_path_rebase:
+    inputs:
+    - name: work_dir
+      type: str
+      required: true
+    - name: base_branch
+      type: str
+      required: true
+    outputs:
+    - name: status
+      type: str
   autoskillit.recipe._cmd_rpc.queue_ejected_fix:
     inputs:
     - name: work_dir

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -714,13 +714,48 @@
       "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n"
     },
     "pre_review_rebase": {
-      "tool": "run_cmd",
+      "tool": "run_python",
       "with": {
-        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
-        "step_name": "pre_review_rebase"
+        "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
+        "work_dir": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
-      "on_success": "re_push_review",
-      "on_failure": "release_issue_failure"
+      "on_result": [
+        {
+          "when": "${{ result.status }} == clean",
+          "route": "re_push_review"
+        },
+        {
+          "route": "resolve_pre_review_conflicts"
+        }
+      ],
+      "on_failure": "resolve_pre_review_conflicts"
+    },
+    "resolve_pre_review_conflicts": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "output_dir": ".",
+        "step_name": "resolve_pre_review_conflicts"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "re_push_review"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "re_push_review": {
       "tool": "push_to_remote",
@@ -1079,15 +1114,49 @@
       "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected retries via re_push (bounded by retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates to human. Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
     },
     "pre_resolve_rebase": {
-      "tool": "run_cmd",
+      "tool": "run_python",
       "with": {
-        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
-        "step_name": "pre_resolve_rebase"
+        "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
+        "work_dir": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
-      "retries": 1,
-      "on_success": "check_ci_rebase_loop",
-      "on_failure": "release_issue_failure",
+      "on_result": [
+        {
+          "when": "${{ result.status }} == clean",
+          "route": "check_ci_rebase_loop"
+        },
+        {
+          "route": "resolve_pre_resolve_conflicts"
+        }
+      ],
+      "on_failure": "resolve_pre_resolve_conflicts",
       "note": "Rebases the feature branch against integration head when resolve_ci emits already_green — the worktree was already clean because a sibling pipeline's fix already landed on integration. Pulling it in before re-running diagnose_ci gives the pipeline a real chance at emitting real_fix and reaching re_push.\n"
+    },
+    "resolve_pre_resolve_conflicts": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "output_dir": ".",
+        "step_name": "resolve_pre_resolve_conflicts"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "check_ci_rebase_loop"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "check_ci_rebase_loop": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -1147,16 +1147,16 @@
       "on_result": [
         {
           "when": "${{ result.escalation_required }} == true",
-          "route": "release_issue_failure"
+          "route": "diagnose_ci"
         },
         {
           "route": "check_ci_rebase_loop"
         }
       ],
-      "on_failure": "release_issue_failure",
-      "on_context_limit": "release_issue_failure",
+      "on_failure": "diagnose_ci",
+      "on_context_limit": "diagnose_ci",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "diagnose_ci"
     },
     "check_ci_rebase_loop": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1062,12 +1062,12 @@ steps:
       conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
     - when: ${{ result.escalation_required }} == true
-      route: release_issue_failure
+      route: diagnose_ci
     - route: check_ci_rebase_loop
-    on_failure: release_issue_failure
-    on_context_limit: release_issue_failure
+    on_failure: diagnose_ci
+    on_context_limit: diagnose_ci
     retries: 1
-    on_exhausted: release_issue_failure
+    on_exhausted: diagnose_ci
   check_ci_rebase_loop:
     tool: run_python
     with:

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -664,19 +664,35 @@ steps:
       ci_only_failure escalates to release_issue_failure.
 
   pre_review_rebase:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
-        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
-
-        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
-
-        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-
-        '
-      step_name: pre_review_rebase
-    on_success: re_push_review
+      callable: autoskillit.recipe._cmd_rpc.review_path_rebase
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
+    on_result:
+    - when: ${{ result.status }} == clean
+      route: re_push_review
+    - route: resolve_pre_review_conflicts
+    on_failure: resolve_pre_review_conflicts
+  resolve_pre_review_conflicts:
+    tool: run_skill
+    model: ''
+    with:
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '.'
+      step_name: resolve_pre_review_conflicts
+    capture:
+      conflict_escalation_required: ${{ result.escalation_required }}
+    on_result:
+    - when: ${{ result.escalation_required }} == true
+      route: release_issue_failure
+    - route: re_push_review
     on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
   re_push_review:
     tool: push_to_remote
     with:
@@ -1017,22 +1033,41 @@ steps:
       Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
   pre_resolve_rebase:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
-        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-      step_name: "pre_resolve_rebase"
-    retries: 1
-    on_success: check_ci_rebase_loop
-    on_failure: release_issue_failure
+      callable: autoskillit.recipe._cmd_rpc.review_path_rebase
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
+    on_result:
+    - when: ${{ result.status }} == clean
+      route: check_ci_rebase_loop
+    - route: resolve_pre_resolve_conflicts
+    on_failure: resolve_pre_resolve_conflicts
     note: >
       Rebases the feature branch against integration head when resolve_ci emits
       already_green — the worktree was already clean because a sibling pipeline's
       fix already landed on integration. Pulling it in before re-running diagnose_ci
       gives the pipeline a real chance at emitting real_fix and reaching re_push.
 
+  resolve_pre_resolve_conflicts:
+    tool: run_skill
+    model: ''
+    with:
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '.'
+      step_name: resolve_pre_resolve_conflicts
+    capture:
+      conflict_escalation_required: ${{ result.escalation_required }}
+    on_result:
+    - when: ${{ result.escalation_required }} == true
+      route: release_issue_failure
+    - route: check_ci_rebase_loop
+    on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
   check_ci_rebase_loop:
     tool: run_python
     with:

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1926,16 +1926,16 @@
       "on_result": [
         {
           "when": "${{ result.escalation_required }} == true",
-          "route": "release_issue_failure"
+          "route": "diagnose_ci"
         },
         {
           "route": "check_ci_rebase_loop"
         }
       ],
-      "on_failure": "release_issue_failure",
-      "on_context_limit": "release_issue_failure",
+      "on_failure": "diagnose_ci",
+      "on_context_limit": "diagnose_ci",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "diagnose_ci"
     },
     "check_ci_rebase_loop": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -813,13 +813,48 @@
       "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n"
     },
     "pre_review_rebase": {
-      "tool": "run_cmd",
+      "tool": "run_python",
       "with": {
-        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
-        "step_name": "pre_review_rebase"
+        "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
+        "work_dir": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
-      "on_success": "re_push_review",
-      "on_failure": "release_issue_failure"
+      "on_result": [
+        {
+          "when": "${{ result.status }} == clean",
+          "route": "re_push_review"
+        },
+        {
+          "route": "resolve_pre_review_conflicts"
+        }
+      ],
+      "on_failure": "resolve_pre_review_conflicts"
+    },
+    "resolve_pre_review_conflicts": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "output_dir": ".",
+        "step_name": "resolve_pre_review_conflicts"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "re_push_review"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "re_push_review": {
       "tool": "push_to_remote",
@@ -1858,15 +1893,49 @@
       "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected retries via re_push (bounded by retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates to human. Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
     },
     "pre_resolve_rebase": {
-      "tool": "run_cmd",
+      "tool": "run_python",
       "with": {
-        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
-        "step_name": "pre_resolve_rebase"
+        "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
+        "work_dir": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
-      "retries": 1,
-      "on_success": "check_ci_rebase_loop",
-      "on_failure": "release_issue_failure",
+      "on_result": [
+        {
+          "when": "${{ result.status }} == clean",
+          "route": "check_ci_rebase_loop"
+        },
+        {
+          "route": "resolve_pre_resolve_conflicts"
+        }
+      ],
+      "on_failure": "resolve_pre_resolve_conflicts",
       "note": "Rebases the feature branch against integration head when resolve_ci emits already_green — the worktree was already clean because a sibling pipeline's fix already landed on integration. Pulling it in before re-running diagnose_ci gives the pipeline a real chance at emitting real_fix and reaching re_push.\n"
+    },
+    "resolve_pre_resolve_conflicts": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "output_dir": ".",
+        "step_name": "resolve_pre_resolve_conflicts"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "check_ci_rebase_loop"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "check_ci_rebase_loop": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1763,12 +1763,12 @@ steps:
       conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
     - when: ${{ result.escalation_required }} == true
-      route: release_issue_failure
+      route: diagnose_ci
     - route: check_ci_rebase_loop
-    on_failure: release_issue_failure
-    on_context_limit: release_issue_failure
+    on_failure: diagnose_ci
+    on_context_limit: diagnose_ci
     retries: 1
-    on_exhausted: release_issue_failure
+    on_exhausted: diagnose_ci
   check_ci_rebase_loop:
     tool: run_python
     with:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -774,19 +774,35 @@ steps:
 
       '
   pre_review_rebase:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
-        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
-
-        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
-
-        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-
-        '
-      step_name: pre_review_rebase
-    on_success: re_push_review
+      callable: autoskillit.recipe._cmd_rpc.review_path_rebase
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
+    on_result:
+    - when: ${{ result.status }} == clean
+      route: re_push_review
+    - route: resolve_pre_review_conflicts
+    on_failure: resolve_pre_review_conflicts
+  resolve_pre_review_conflicts:
+    tool: run_skill
+    model: ''
+    with:
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '.'
+      step_name: resolve_pre_review_conflicts
+    capture:
+      conflict_escalation_required: ${{ result.escalation_required }}
+    on_result:
+    - when: ${{ result.escalation_required }} == true
+      route: release_issue_failure
+    - route: re_push_review
     on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
   re_push_review:
     tool: push_to_remote
     with:
@@ -1718,26 +1734,41 @@ steps:
 
       '
   pre_resolve_rebase:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
-        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
-
-        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
-
-        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-
-        '
-      step_name: pre_resolve_rebase
-    retries: 1
-    on_success: check_ci_rebase_loop
-    on_failure: release_issue_failure
+      callable: autoskillit.recipe._cmd_rpc.review_path_rebase
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
+    on_result:
+    - when: ${{ result.status }} == clean
+      route: check_ci_rebase_loop
+    - route: resolve_pre_resolve_conflicts
+    on_failure: resolve_pre_resolve_conflicts
     note: 'Rebases the feature branch against integration head when resolve_ci emits
       already_green — the worktree was already clean because a sibling pipeline''s
       fix already landed on integration. Pulling it in before re-running diagnose_ci
       gives the pipeline a real chance at emitting real_fix and reaching re_push.
 
       '
+  resolve_pre_resolve_conflicts:
+    tool: run_skill
+    model: ''
+    with:
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '.'
+      step_name: resolve_pre_resolve_conflicts
+    capture:
+      conflict_escalation_required: ${{ result.escalation_required }}
+    on_result:
+    - when: ${{ result.escalation_required }} == true
+      route: release_issue_failure
+    - route: check_ci_rebase_loop
+    on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
   check_ci_rebase_loop:
     tool: run_python
     with:

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -1539,7 +1539,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:resolve-merge-conflicts '${{ context.work_dir }}' '${{ inputs.base_branch }}'",
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "output_dir": ".",
         "step_name": "resolve_pre_review_integration_conflicts"

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -1518,13 +1518,47 @@
       "note": "Resolves review findings on the integration PR (REQ-REVIEW-002). Fetches inline and summary review comments from GitHub and applies fixes. Retries up to 2 times (3 total attempts) before escalating to register_clone_failure (REQ-REVIEW-005). Routes via on_result: verdict dispatch — real_fix/already_green route through pre_review_rebase_integration (fetch+rebase before push); flake_suspected/ ci_only_failure escalate to register_clone_failure.\n"
     },
     "pre_review_rebase_integration": {
-      "tool": "run_cmd",
+      "tool": "run_python",
       "with": {
-        "cmd": "REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null | grep -qv \"^file://\" && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
-        "step_name": "pre_review_rebase_integration"
+        "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
+        "work_dir": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
-      "on_success": "re_push_review_integration",
-      "on_failure": "register_clone_failure"
+      "on_result": [
+        {
+          "when": "${{ result.status }} == clean",
+          "route": "re_push_review_integration"
+        },
+        {
+          "route": "resolve_pre_review_integration_conflicts"
+        }
+      ],
+      "on_failure": "resolve_pre_review_integration_conflicts"
+    },
+    "resolve_pre_review_integration_conflicts": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts '${{ context.work_dir }}' '${{ inputs.base_branch }}'",
+        "cwd": "${{ context.work_dir }}",
+        "output_dir": ".",
+        "step_name": "resolve_pre_review_integration_conflicts"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "register_clone_failure"
+        },
+        {
+          "route": "re_push_review_integration"
+        }
+      ],
+      "on_failure": "register_clone_failure",
+      "retries": 0,
+      "on_exhausted": "register_clone_failure"
     },
     "re_push_review_integration": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1494,19 +1494,33 @@ steps:
 
       '
   pre_review_rebase_integration:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: 'REMOTE=$(git -C ${{ context.work_dir }} remote get-url upstream 2>/dev/null
-        | grep -qv "^file://" && echo upstream || echo origin) &&
-
-        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
-
-        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-
-        '
-      step_name: pre_review_rebase_integration
-    on_success: re_push_review_integration
+      callable: autoskillit.recipe._cmd_rpc.review_path_rebase
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
+    on_result:
+    - when: ${{ result.status }} == clean
+      route: re_push_review_integration
+    - route: resolve_pre_review_integration_conflicts
+    on_failure: resolve_pre_review_integration_conflicts
+  resolve_pre_review_integration_conflicts:
+    tool: run_skill
+    model: ''
+    with:
+      skill_command: /autoskillit:resolve-merge-conflicts '${{ context.work_dir }}' '${{ inputs.base_branch }}'
+      cwd: ${{ context.work_dir }}
+      output_dir: '.'
+      step_name: resolve_pre_review_integration_conflicts
+    capture:
+      conflict_escalation_required: ${{ result.escalation_required }}
+    on_result:
+    - when: ${{ result.escalation_required }} == true
+      route: register_clone_failure
+    - route: re_push_review_integration
     on_failure: register_clone_failure
+    retries: 0
+    on_exhausted: register_clone_failure
   re_push_review_integration:
     tool: push_to_remote
     with:

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1508,7 +1508,8 @@ steps:
     tool: run_skill
     model: ''
     with:
-      skill_command: /autoskillit:resolve-merge-conflicts '${{ context.work_dir }}' '${{ inputs.base_branch }}'
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       output_dir: '.'
       step_name: resolve_pre_review_integration_conflicts

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -859,13 +859,48 @@
       ]
     },
     "pre_review_rebase": {
-      "tool": "run_cmd",
+      "tool": "run_python",
       "with": {
-        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
-        "step_name": "pre_review_rebase"
+        "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
+        "work_dir": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
-      "on_success": "re_push_review",
-      "on_failure": "release_issue_failure"
+      "on_result": [
+        {
+          "when": "${{ result.status }} == clean",
+          "route": "re_push_review"
+        },
+        {
+          "route": "resolve_pre_review_conflicts"
+        }
+      ],
+      "on_failure": "resolve_pre_review_conflicts"
+    },
+    "resolve_pre_review_conflicts": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "output_dir": ".",
+        "step_name": "resolve_pre_review_conflicts"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "re_push_review"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "re_push_review": {
       "tool": "push_to_remote",
@@ -1904,15 +1939,49 @@
       "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected retries via re_push (bounded by retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates to human. Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
     },
     "pre_resolve_rebase": {
-      "tool": "run_cmd",
+      "tool": "run_python",
       "with": {
-        "cmd": "REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream | grep -qv \"^file://\") 2>/dev/null && echo upstream || echo origin) &&\ngit -C ${{ context.work_dir }} fetch \"$REMOTE\" &&\ngit -C ${{ context.work_dir }} rebase \"$REMOTE\"/${{ inputs.base_branch }}\n",
-        "step_name": "pre_resolve_rebase"
+        "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
+        "work_dir": "${{ context.work_dir }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
-      "retries": 1,
-      "on_success": "check_ci_rebase_loop",
-      "on_failure": "release_issue_failure",
+      "on_result": [
+        {
+          "when": "${{ result.status }} == clean",
+          "route": "check_ci_rebase_loop"
+        },
+        {
+          "route": "resolve_pre_resolve_conflicts"
+        }
+      ],
+      "on_failure": "resolve_pre_resolve_conflicts",
       "note": "Rebases the feature branch against integration head when resolve_ci emits already_green — the worktree was already clean because a sibling pipeline's fix already landed on integration. Pulling it in before re-running diagnose_ci gives the pipeline a real chance at emitting real_fix and reaching re_push.\n"
+    },
+    "resolve_pre_resolve_conflicts": {
+      "tool": "run_skill",
+      "model": "",
+      "with": {
+        "skill_command": "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "cwd": "${{ context.work_dir }}",
+        "output_dir": ".",
+        "step_name": "resolve_pre_resolve_conflicts"
+      },
+      "capture": {
+        "conflict_escalation_required": "${{ result.escalation_required }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.escalation_required }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "check_ci_rebase_loop"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "on_context_limit": "release_issue_failure",
+      "retries": 1,
+      "on_exhausted": "release_issue_failure"
     },
     "check_ci_rebase_loop": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1972,16 +1972,16 @@
       "on_result": [
         {
           "when": "${{ result.escalation_required }} == true",
-          "route": "release_issue_failure"
+          "route": "diagnose_ci"
         },
         {
           "route": "check_ci_rebase_loop"
         }
       ],
-      "on_failure": "release_issue_failure",
-      "on_context_limit": "release_issue_failure",
+      "on_failure": "diagnose_ci",
+      "on_context_limit": "diagnose_ci",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "diagnose_ci"
     },
     "check_ci_rebase_loop": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1792,12 +1792,12 @@ steps:
       conflict_escalation_required: ${{ result.escalation_required }}
     on_result:
     - when: ${{ result.escalation_required }} == true
-      route: release_issue_failure
+      route: diagnose_ci
     - route: check_ci_rebase_loop
-    on_failure: release_issue_failure
-    on_context_limit: release_issue_failure
+    on_failure: diagnose_ci
+    on_context_limit: diagnose_ci
     retries: 1
-    on_exhausted: release_issue_failure
+    on_exhausted: diagnose_ci
   check_ci_rebase_loop:
     tool: run_python
     with:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -802,19 +802,35 @@ steps:
     optional_context_refs:
     - review_mode
   pre_review_rebase:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
-        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
-
-        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
-
-        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-
-        '
-      step_name: pre_review_rebase
-    on_success: re_push_review
+      callable: autoskillit.recipe._cmd_rpc.review_path_rebase
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
+    on_result:
+    - when: ${{ result.status }} == clean
+      route: re_push_review
+    - route: resolve_pre_review_conflicts
+    on_failure: resolve_pre_review_conflicts
+  resolve_pre_review_conflicts:
+    tool: run_skill
+    model: ''
+    with:
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '.'
+      step_name: resolve_pre_review_conflicts
+    capture:
+      conflict_escalation_required: ${{ result.escalation_required }}
+    on_result:
+    - when: ${{ result.escalation_required }} == true
+      route: release_issue_failure
+    - route: re_push_review
     on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
   re_push_review:
     tool: push_to_remote
     with:
@@ -1747,26 +1763,41 @@ steps:
 
       '
   pre_resolve_rebase:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: 'REMOTE=$((git -C ${{ context.work_dir }} remote get-url upstream
-        | grep -qv "^file://") 2>/dev/null && echo upstream || echo origin) &&
-
-        git -C ${{ context.work_dir }} fetch "$REMOTE" &&
-
-        git -C ${{ context.work_dir }} rebase "$REMOTE"/${{ inputs.base_branch }}
-
-        '
-      step_name: pre_resolve_rebase
-    retries: 1
-    on_success: check_ci_rebase_loop
-    on_failure: release_issue_failure
+      callable: autoskillit.recipe._cmd_rpc.review_path_rebase
+      work_dir: ${{ context.work_dir }}
+      base_branch: ${{ inputs.base_branch }}
+    on_result:
+    - when: ${{ result.status }} == clean
+      route: check_ci_rebase_loop
+    - route: resolve_pre_resolve_conflicts
+    on_failure: resolve_pre_resolve_conflicts
     note: 'Rebases the feature branch against integration head when resolve_ci emits
       already_green — the worktree was already clean because a sibling pipeline''s
       fix already landed on integration. Pulling it in before re-running diagnose_ci
       gives the pipeline a real chance at emitting real_fix and reaching re_push.
 
       '
+  resolve_pre_resolve_conflicts:
+    tool: run_skill
+    model: ''
+    with:
+      skill_command: /autoskillit:resolve-merge-conflicts ${{ context.work_dir }}
+        ${{ context.plan_path }} ${{ inputs.base_branch }}
+      cwd: ${{ context.work_dir }}
+      output_dir: '.'
+      step_name: resolve_pre_resolve_conflicts
+    capture:
+      conflict_escalation_required: ${{ result.escalation_required }}
+    on_result:
+    - when: ${{ result.escalation_required }} == true
+      route: release_issue_failure
+    - route: check_ci_rebase_loop
+    on_failure: release_issue_failure
+    on_context_limit: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
   check_ci_rebase_loop:
     tool: run_python
     with:

--- a/tests/recipe/test_bundled_recipes_review_pr.py
+++ b/tests/recipe/test_bundled_recipes_review_pr.py
@@ -215,6 +215,37 @@ def test_merge_prs_annotate_step_captures_diff_metrics_path() -> None:
     assert "diff_metrics_path" in step.capture
 
 
+def test_merge_prs_pre_review_rebase_integration_uses_run_python() -> None:
+    """merge-prs pre_review_rebase_integration must use run_python (not run_cmd)."""
+    recipe = load_recipe(builtin_recipes_dir() / "merge-prs.yaml")
+    step = recipe.steps["pre_review_rebase_integration"]
+    assert step.tool == "run_python", (
+        f"pre_review_rebase_integration must use run_python, got {step.tool!r}"
+    )
+
+
+def test_merge_prs_pre_review_rebase_integration_routes_to_conflict_resolution() -> None:
+    """merge-prs pre_review_rebase_integration on_result must route to conflict resolution."""
+    recipe = load_recipe(builtin_recipes_dir() / "merge-prs.yaml")
+    step = recipe.steps["pre_review_rebase_integration"]
+    assert step.on_result is not None
+    routes = [c.route for c in step.on_result.conditions]
+    assert "resolve_pre_review_integration_conflicts" in routes, (
+        f"pre_review_rebase_integration on_result must include "
+        f"resolve_pre_review_integration_conflicts, got {routes}"
+    )
+
+
+def test_merge_prs_resolve_pre_review_integration_conflicts_uses_merge_skill() -> None:
+    """merge-prs resolve_pre_review_integration_conflicts must invoke resolve-merge-conflicts."""
+    recipe = load_recipe(builtin_recipes_dir() / "merge-prs.yaml")
+    assert "resolve_pre_review_integration_conflicts" in recipe.steps
+    step = recipe.steps["resolve_pre_review_integration_conflicts"]
+    assert step.tool == "run_skill"
+    cmd = step.with_args.get("skill_command", "")
+    assert "resolve-merge-conflicts" in cmd
+
+
 # ---------------------------------------------------------------------------
 # T4.1–T4.7: local_review_rounds wiring tests
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_bundled_recipes_review_pr.py
+++ b/tests/recipe/test_bundled_recipes_review_pr.py
@@ -409,7 +409,10 @@ class TestLocalReviewRoundsAndMaxRetriesAlignment:
 
 
 class TestPreReviewRebaseConflictResolution:
-    """Verify pre_review_rebase uses run_python with conflict routing in all 4 recipes."""
+    """Verify pre_review_rebase uses run_python with conflict routing in 3 recipes.
+
+    merge-prs uses different step names; covered by standalone tests.
+    """
 
     @pytest.fixture(
         scope="class",

--- a/tests/recipe/test_bundled_recipes_review_pr.py
+++ b/tests/recipe/test_bundled_recipes_review_pr.py
@@ -143,12 +143,15 @@ class TestReviewPrRecipeIntegration:
         )
 
     def test_pre_review_rebase_routes_to_re_push_review(self, recipe: object) -> None:
-        """T_RP7b: pre_review_rebase on_success must route to re_push_review."""
+        """T_RP7b: pre_review_rebase uses run_python and routes clean to re_push_review."""
         assert "pre_review_rebase" in recipe.steps  # type: ignore[operator]
         step = recipe.steps["pre_review_rebase"]  # type: ignore[attr-defined]
-        assert step.on_success == "re_push_review", (
-            "pre_review_rebase must route on_success to re_push_review"
-        )
+        assert step.tool == "run_python"
+        assert step.on_success is None, "routing is via on_result, not on_success"
+        assert step.on_result is not None
+        clean_routes = [c.route for c in step.on_result.conditions if c.when and "clean" in c.when]
+        assert "re_push_review" in clean_routes
+        assert step.on_failure == "resolve_pre_review_conflicts"
 
     def test_re_push_review_routes_to_check_review_loop(self, recipe: object) -> None:
         """T_RP8: re_push_review routes to check_review_loop (bounded retry gate)."""
@@ -372,3 +375,41 @@ class TestLocalReviewRoundsAndMaxRetriesAlignment:
             f"[{recipe.name}] local_review_rounds ({local_rounds}) >= review_max_retries "
             f"({max_retries}). Mode will never transition to github with default config."
         )
+
+
+class TestPreReviewRebaseConflictResolution:
+    """Verify pre_review_rebase uses run_python with conflict routing in all 4 recipes."""
+
+    @pytest.fixture(
+        scope="class",
+        params=[
+            "implementation.yaml",
+            "implementation-groups.yaml",
+            "remediation.yaml",
+        ],
+    )
+    def recipe(self, request: pytest.FixtureRequest) -> object:
+        return load_recipe(builtin_recipes_dir() / request.param)
+
+    def test_pre_review_rebase_uses_run_python(self, recipe: object) -> None:
+        step = recipe.steps["pre_review_rebase"]
+        assert step.tool == "run_python", (
+            f"{recipe.name}: pre_review_rebase must use run_python, got {step.tool!r}"
+        )
+
+    def test_pre_review_rebase_on_result_routes_to_conflict_resolution(
+        self, recipe: object
+    ) -> None:
+        step = recipe.steps["pre_review_rebase"]
+        assert step.on_result is not None
+        routes = [c.route for c in step.on_result.conditions]
+        assert "resolve_pre_review_conflicts" in routes, (
+            f"{recipe.name}: pre_review_rebase on_result must include resolve_pre_review_conflicts"
+        )
+
+    def test_resolve_pre_review_conflicts_uses_merge_conflicts_skill(self, recipe: object) -> None:
+        assert "resolve_pre_review_conflicts" in recipe.steps
+        step = recipe.steps["resolve_pre_review_conflicts"]
+        assert step.tool == "run_skill"
+        cmd = step.with_args.get("skill_command", "")
+        assert "resolve-merge-conflicts" in cmd

--- a/tests/recipe/test_callable_contracts.py
+++ b/tests/recipe/test_callable_contracts.py
@@ -33,3 +33,19 @@ def test_all_callable_contracts_declare_inputs():
                 f"{dotted_path}: required parameter '{param}' not declared in "
                 f"callable_contracts inputs"
             )
+
+
+def test_review_path_rebase_contract_inputs_and_outputs():
+    """review_path_rebase callable contract must declare correct inputs and outputs."""
+    from autoskillit.recipe.contracts import get_callable_contract
+
+    contract = get_callable_contract("autoskillit.recipe._cmd_rpc.review_path_rebase")
+    assert contract is not None, "review_path_rebase must be declared in callable_contracts"
+    input_names = {inp.name for inp in contract.inputs}
+    assert "work_dir" in input_names
+    assert "base_branch" in input_names
+    for inp in contract.inputs:
+        if inp.name in ("work_dir", "base_branch"):
+            assert inp.required is True, f"{inp.name} must be required"
+    output_names = {out.name for out in contract.outputs}
+    assert "status" in output_names

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -938,3 +938,35 @@ def test_force_push_int_review_pr_number(mock_sleep, mock_run_git, mock_run_gh, 
     assert mock_run_gh.call_count >= 1
     call_cmd = mock_run_gh.call_args[0][0]
     assert "1958" in call_cmd
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# review_path_rebase
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestReviewPathRebase:
+    """Unit tests for the review_path_rebase callable."""
+
+    def test_delegates_to_queue_ejected_fix(self) -> None:
+        """review_path_rebase must delegate to queue_ejected_fix."""
+        from unittest.mock import patch
+
+        from autoskillit.recipe._cmd_rpc import review_path_rebase
+
+        with patch("autoskillit.recipe._cmd_rpc_merge.queue_ejected_fix") as mock:
+            mock.return_value = {"status": "clean"}
+            result = review_path_rebase(work_dir="/tmp/work", base_branch="main")
+            assert result == {"status": "clean"}
+            mock.assert_called_once_with(work_dir="/tmp/work", base_branch="main")
+
+    def test_returns_conflicts_on_conflict(self) -> None:
+        """review_path_rebase returns conflicts when delegate does."""
+        from unittest.mock import patch
+
+        from autoskillit.recipe._cmd_rpc import review_path_rebase
+
+        with patch("autoskillit.recipe._cmd_rpc_merge.queue_ejected_fix") as mock:
+            mock.return_value = {"status": "conflicts"}
+            result = review_path_rebase(work_dir="/tmp/work", base_branch="main")
+            assert result == {"status": "conflicts"}

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -106,10 +106,15 @@ def test_check_review_loop_has_on_failure(recipe) -> None:
 
 # T_IP_LOOP7
 def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
-    """pre_review_rebase on_success must route to re_push_review in implementation recipe."""
+    """pre_review_rebase uses run_python and routes clean to re_push_review."""
     assert "pre_review_rebase" in recipe.steps
     step = recipe.steps["pre_review_rebase"]
-    assert step.on_success == "re_push_review"
+    assert step.tool == "run_python"
+    assert step.on_success is None, "routing is via on_result, not on_success"
+    assert step.on_result is not None
+    clean_routes = [c.route for c in step.on_result.conditions if c.when and "clean" in c.when]
+    assert "re_push_review" in clean_routes
+    assert step.on_failure == "resolve_pre_review_conflicts"
 
 
 def test_re_push_review_routes_to_check_review_loop(recipe) -> None:

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -25,10 +25,15 @@ def test_check_review_loop_step_exists(recipe) -> None:
 
 # T_IG_LOOP2
 def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
-    """pre_review_rebase on_success must route to re_push_review in implementation-groups."""
+    """pre_review_rebase uses run_python and routes clean to re_push_review."""
     assert "pre_review_rebase" in recipe.steps
     step = recipe.steps["pre_review_rebase"]
-    assert step.on_success == "re_push_review"
+    assert step.tool == "run_python"
+    assert step.on_success is None, "routing is via on_result, not on_success"
+    assert step.on_result is not None
+    clean_routes = [c.route for c in step.on_result.conditions if c.when and "clean" in c.when]
+    assert "re_push_review" in clean_routes
+    assert step.on_failure == "resolve_pre_review_conflicts"
 
 
 def test_re_push_review_routes_to_check_review_loop(recipe) -> None:

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -42,10 +42,15 @@ def test_check_review_loop_step_exists(recipe) -> None:
 
 # T_REM_LOOP2
 def test_pre_review_rebase_routes_to_re_push_review(recipe) -> None:
-    """pre_review_rebase on_success must route to re_push_review in remediation recipe."""
+    """pre_review_rebase uses run_python and routes clean to re_push_review."""
     assert "pre_review_rebase" in recipe.steps
     step = recipe.steps["pre_review_rebase"]
-    assert step.on_success == "re_push_review"
+    assert step.tool == "run_python"
+    assert step.on_success is None, "routing is via on_result, not on_success"
+    assert step.on_result is not None
+    clean_routes = [c.route for c in step.on_result.conditions if c.when and "clean" in c.when]
+    assert "re_push_review" in clean_routes
+    assert step.on_failure == "resolve_pre_review_conflicts"
 
 
 def test_re_push_review_routes_to_check_review_loop(recipe) -> None:

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -233,10 +233,27 @@ def test_flake_suspected_routes_consistently_across_fix_and_resolve_ci(
 
 @pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)
 def test_pre_resolve_rebase_step_exists(recipe_name: str) -> None:
-    """pre_resolve_rebase step must exist for already_green re-entry path."""
+    """pre_resolve_rebase must use run_python and route conflicts to resolution."""
     recipe_path = _RECIPES_DIR / recipe_name
     recipe = load_recipe(recipe_path)
     assert "pre_resolve_rebase" in recipe.steps, (
         f"{recipe_name}: missing 'pre_resolve_rebase' step. "
         "This step is required for the already_green verdict re-entry path."
+    )
+    step = recipe.steps["pre_resolve_rebase"]
+    assert step.tool == "run_python", (
+        f"{recipe_name}: pre_resolve_rebase must use run_python, got {step.tool!r}"
+    )
+    assert step.on_failure == "resolve_pre_resolve_conflicts", (
+        f"{recipe_name}: pre_resolve_rebase.on_failure must route to "
+        "resolve_pre_resolve_conflicts for conflict resolution"
+    )
+    assert step.on_result is not None
+    conflict_routes = [
+        c.route
+        for c in step.on_result.conditions
+        if c.when is None or (c.when and "clean" not in c.when)
+    ]
+    assert "resolve_pre_resolve_conflicts" in conflict_routes, (
+        f"{recipe_name}: pre_resolve_rebase must route conflicts to resolve_pre_resolve_conflicts"
     )

--- a/tests/recipe/test_rules_cmd.py
+++ b/tests/recipe/test_rules_cmd.py
@@ -396,3 +396,130 @@ def test_emit_alignment_non_bash_capture_still_flagged():
     findings = run_semantic_rules(recipe)
     codes = [f.rule for f in findings]
     assert "run-cmd-emit-alignment" in codes
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# run-cmd-bare-rebase-without-conflict-routing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_bare_rebase_fires_on_terminal_on_failure():
+    """run_cmd git rebase with on_failure → terminal step → ERROR."""
+    recipe = _make_recipe(
+        {
+            "rebase_step": {
+                "tool": "run_cmd",
+                "with": {"cmd": "git fetch origin && git rebase origin/main"},
+                "on_success": "END",
+                "on_failure": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "run-cmd-bare-rebase-without-conflict-routing" in codes
+    finding = next(f for f in findings if f.rule == "run-cmd-bare-rebase-without-conflict-routing")
+    assert "rebase_step" in finding.step_name
+
+
+def test_bare_rebase_clean_when_run_python():
+    """run_python step (not run_cmd) does NOT trigger the rule."""
+    recipe = _make_recipe(
+        {
+            "rebase_step": {
+                "tool": "run_python",
+                "with": {
+                    "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
+                    "work_dir": "/tmp",
+                    "base_branch": "main",
+                },
+                "on_result": [
+                    {"when": "${{ result.status }} == clean", "route": "END"},
+                    {"route": "END"},
+                ],
+                "on_failure": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-bare-rebase-without-conflict-routing" for f in findings)
+
+
+def test_bare_rebase_clean_when_on_failure_routes_to_conflict_resolution():
+    """run_cmd git rebase with on_failure → resolve-merge-conflicts → no finding."""
+    recipe = _make_recipe(
+        {
+            "rebase_step": {
+                "tool": "run_cmd",
+                "with": {"cmd": "git fetch origin && git rebase origin/main"},
+                "on_success": "END",
+                "on_failure": "resolve_conflicts",
+            },
+            "resolve_conflicts": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:resolve-merge-conflicts /work main"},
+                "on_success": "END",
+                "on_failure": "END",
+            },
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-bare-rebase-without-conflict-routing" for f in findings)
+
+
+def test_bare_rebase_clean_when_on_result_routes_to_conflict_resolution():
+    """run_cmd git rebase with on_result routing to resolve-merge-conflicts → no finding."""
+    recipe = _make_recipe(
+        {
+            "rebase_step": {
+                "tool": "run_cmd",
+                "with": {"cmd": "git fetch origin && git rebase origin/main"},
+                "on_result": [
+                    {"when": "${{ result.status }} == clean", "route": "END"},
+                    {"route": "resolve_conflicts"},
+                ],
+                "on_failure": "resolve_conflicts",
+            },
+            "resolve_conflicts": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:resolve-merge-conflicts /work main"},
+                "on_success": "END",
+                "on_failure": "END",
+            },
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-bare-rebase-without-conflict-routing" for f in findings)
+
+
+def test_bare_rebase_does_not_match_rebase_abort():
+    """run_cmd with git rebase --abort does NOT trigger the rule."""
+    recipe = _make_recipe(
+        {
+            "cleanup_step": {
+                "tool": "run_cmd",
+                "with": {"cmd": "git rebase --abort"},
+                "on_success": "END",
+                "on_failure": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-bare-rebase-without-conflict-routing" for f in findings)
+
+
+def test_bundled_recipes_have_no_bare_rebase_findings():
+    """All bundled recipes must have zero run-cmd-bare-rebase-without-conflict-routing findings."""
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    recipes_dir = builtin_recipes_dir()
+    for yaml_path in sorted(recipes_dir.glob("*.yaml")):
+        recipe = load_recipe(yaml_path)
+        findings = run_semantic_rules(recipe)
+        bare_rebase = [
+            f for f in findings if f.rule == "run-cmd-bare-rebase-without-conflict-routing"
+        ]
+        assert not bare_rebase, (
+            f"{yaml_path.name}: found bare rebase findings: "
+            f"{[(f.step_name, f.message) for f in bare_rebase]}"
+        )


### PR DESCRIPTION
## Summary

Seven `run_cmd` steps across four recipes perform bare `git rebase` with `on_failure` routing directly to terminal steps, bypassing the established two-step conflict resolution pattern (cheap rebase callable + `resolve-merge-conflicts` skill). The semantic rule `merge-failure-skill-domain-mismatch` only validates `merge_worktree` steps, so these `run_cmd` rebases escape validation entirely. The fix creates architectural immunity through: (1) a new `run_python` callable for review-path rebases, (2) a new semantic rule that makes bare `run_cmd` rebases without conflict routing structurally unrepresentable at validation time, and (3) tests that assert conflict routing on all rebase steps.

Closes #3193

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-081540-453227/.autoskillit/temp/rectify/rectify_pre_review_rebase_conflict_immunity_2026-05-28_091500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 3.7k | 18.4k | 2.5M | 131.7k | 294 | 162.3k | 20m 25s |
| review | claude-sonnet-4-6 | 1 | 34 | 5.9k | 226.3k | 44.3k | 52 | 31.3k | 3m 35s |
| dry_walkthrough | claude-opus-4-6 | 2 | 105 | 40.3k | 2.4M | 83.9k | 218 | 124.8k | 17m 43s |
| implement | claude-opus-4-6 | 2 | 1.5k | 41.9k | 14.5M | 151.8k | 304 | 172.4k | 17m 27s |
| audit_impl | claude-opus-4-6 | 3 | 1.3k | 29.0k | 1.3M | 69.5k | 135 | 130.5k | 21m 19s |
| make_plan | claude-opus-4-6 | 1 | 64 | 10.2k | 1.5M | 72.4k | 101 | 60.5k | 8m 13s |
| prepare_pr* | MiniMax-M2.7 | 1 | 123.4k | 3.8k | 247.2k | 30.9k | 24 | 44.5k | 1m 43s |
| compose_pr* | MiniMax-M2.7 | 1 | 39.1k | 1.5k | 320.7k | 0 | 19 | 0 | 35s |
| review_pr | claude-opus-4-6 | 1 | 58 | 17.7k | 1.3M | 86.6k | 52 | 71.8k | 5m 25s |
| resolve_review | claude-opus-4-6 | 1 | 59 | 11.8k | 1.7M | 65.6k | 70 | 50.1k | 9m 0s |
| **Total** | | | 169.3k | 180.5k | 25.9M | 151.8k | | 848.2k | 1h 45m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 997 | 14498.4 | 172.9 | 42.0 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **997** | 25988.6 | 850.7 | 181.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 3.7k | 24.3k | 2.7M | 193.6k | 24m 1s |
| claude-opus-4-6 | 6 | 3.1k | 150.8k | 22.6M | 610.0k | 1h 19m |
| MiniMax-M2.7 | 2 | 162.5k | 5.4k | 567.9k | 44.5k | 2m 18s |