### PR TITLE
Implement CodexBackend.version() with subprocess delegation

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -643,10 +643,12 @@ class CodexBackend:
                 text=True,
                 timeout=5,
             )
+            if result.returncode != 0:
+                return ""
             return result.stdout.strip() or result.stderr.strip()
         except subprocess.TimeoutExpired:
             return ""
-        except Exception:
+        except OSError:
             logger.warning("Failed to run %s --version", self.binary_name(), exc_info=True)
             return ""
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum, unique
@@ -635,7 +636,19 @@ class CodexBackend:
         )
 
     def version(self) -> str:
-        raise NotImplementedError(f"{self.__class__.__name__}.version not yet implemented")
+        try:
+            result = subprocess.run(
+                [*self.version_cmd()],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.stdout.strip() or result.stderr.strip()
+        except subprocess.TimeoutExpired:
+            return ""
+        except Exception:
+            logger.warning("Failed to run %s --version", self.binary_name(), exc_info=True)
+            return ""
 
     def list_plugins(self) -> list[dict[str, Any]]:
         raise NotImplementedError(f"{self.__class__.__name__}.list_plugins not yet implemented")

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -931,7 +931,7 @@ class TestCodexBackendVersion:
             result.stderr = ""
             return result
 
-        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
+        monkeypatch.setattr(subprocess, "run", fake_run)
         assert CodexBackend().version() == "1.2.3"
 
     def test_version_stderr_fallback_when_stdout_empty(
@@ -943,21 +943,21 @@ class TestCodexBackendVersion:
             result.stderr = "1.2.3-stderr\n"
             return result
 
-        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
+        monkeypatch.setattr(subprocess, "run", fake_run)
         assert CodexBackend().version() == "1.2.3-stderr"
 
     def test_version_returns_empty_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def fake_run(cmd, *, capture_output, text, timeout):
             raise subprocess.TimeoutExpired(cmd, timeout)
 
-        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
+        monkeypatch.setattr(subprocess, "run", fake_run)
         assert CodexBackend().version() == ""
 
     def test_version_returns_empty_on_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def fake_run(cmd, *, capture_output, text, timeout):
             raise OSError("not found")
 
-        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
+        monkeypatch.setattr(subprocess, "run", fake_run)
         assert CodexBackend().version() == ""
 
     def test_version_delegates_to_version_cmd(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -971,7 +971,7 @@ class TestCodexBackendVersion:
             result.stderr = ""
             return result
 
-        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
+        monkeypatch.setattr(subprocess, "run", fake_run)
         result = CodexBackend().version()
         assert captured_cmd == ["codex", "--version"]
         assert result == "v1"

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from enum import StrEnum
 from pathlib import Path
 
@@ -920,3 +921,56 @@ class TestCodexBuildFoodTruckCmd:
     def test_non_resume_json_present(self) -> None:
         spec = CodexBackend().build_food_truck_cmd(**self.BASE)
         assert "--json" in spec.cmd
+
+
+class TestCodexBackendVersion:
+    def test_version_returns_stripped_stdout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_run(cmd, *, capture_output, text, timeout):
+            result = subprocess.CompletedProcess(cmd, 0)
+            result.stdout = "  1.2.3\n"
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert CodexBackend().version() == "1.2.3"
+
+    def test_version_stderr_fallback_when_stdout_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, *, capture_output, text, timeout):
+            result = subprocess.CompletedProcess(cmd, 0)
+            result.stdout = ""
+            result.stderr = "1.2.3-stderr\n"
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert CodexBackend().version() == "1.2.3-stderr"
+
+    def test_version_returns_empty_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_run(cmd, *, capture_output, text, timeout):
+            raise subprocess.TimeoutExpired(cmd, timeout)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert CodexBackend().version() == ""
+
+    def test_version_returns_empty_on_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_run(cmd, *, capture_output, text, timeout):
+            raise OSError("not found")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert CodexBackend().version() == ""
+
+    def test_version_delegates_to_version_cmd(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured_cmd = None
+
+        def fake_run(cmd, *, capture_output, text, timeout):
+            nonlocal captured_cmd
+            captured_cmd = cmd
+            result = subprocess.CompletedProcess(cmd, 0)
+            result.stdout = "v1"
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        CodexBackend().version()
+        assert captured_cmd == ["codex", "--version"]

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -931,7 +931,7 @@ class TestCodexBackendVersion:
             result.stderr = ""
             return result
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
         assert CodexBackend().version() == "1.2.3"
 
     def test_version_stderr_fallback_when_stdout_empty(
@@ -943,21 +943,21 @@ class TestCodexBackendVersion:
             result.stderr = "1.2.3-stderr\n"
             return result
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
         assert CodexBackend().version() == "1.2.3-stderr"
 
     def test_version_returns_empty_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def fake_run(cmd, *, capture_output, text, timeout):
             raise subprocess.TimeoutExpired(cmd, timeout)
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
         assert CodexBackend().version() == ""
 
     def test_version_returns_empty_on_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def fake_run(cmd, *, capture_output, text, timeout):
             raise OSError("not found")
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
         assert CodexBackend().version() == ""
 
     def test_version_delegates_to_version_cmd(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -971,6 +971,7 @@ class TestCodexBackendVersion:
             result.stderr = ""
             return result
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        CodexBackend().version()
+        monkeypatch.setattr("autoskillit.execution.backends.codex.subprocess", "run", fake_run)
+        result = CodexBackend().version()
         assert captured_cmd == ["codex", "--version"]
+        assert result == "v1"


### PR DESCRIPTION
## Summary

Replace the `NotImplementedError` stub for `CodexBackend.version()` in `src/autoskillit/execution/backends/codex.py` with a working implementation that delegates to `self.version_cmd()` via `subprocess.run`, returning stripped stdout/stderr on success and `''` on timeout or any other error. Add `import subprocess` to the stdlib imports block and add 5 unit tests in `tests/execution/backends/test_codex_backend.py` covering all return-path branches.

## Requirements

## Goal

Extend CodexBackend with a version(self) -> str method that executes self.version_cmd() via subprocess.run, returning the stripped stdout/stderr on success and '' on timeout or any other error, after adding 'import subprocess' to the stdlib imports block.

## Context

- Phase: Add Protocol Methods and Implement on Both Backends (Milestone: 2-add-protocol-methods-and-implement-on-both-backends)
- Assignment: P2-A5 (Implement version() on CodexBackend: delegate to version_cmd(), subprocess.run 5s timeout, return stripped output or '')
- Depends on: P2-A1-WP1, P1-A5-WP1, P1-A1-WP1
- Depended on by: P2-A8-WP1, P3-A3-WP2, P5-A1-WP1

## Deliverables

- `src/autoskillit/execution/backends/codex.py — 'import subprocess' added to stdlib block and CodexBackend.version() method inserted after version_cmd()`
- `tests/execution/backends/test_codex_backend.py — new TestCodexBackendVersion class with 5 unit tests`

## Technical Steps

1. Open /home/talon/projects/generic_automation_mcp/src/autoskillit/execution/backends/codex.py.
2. In the stdlib imports block (lines 5-10), insert 'import subprocess' between 'import os' and 'from collections.abc ...' to maintain alphabetical order (json, os, subprocess).
3. Locate version_cmd(self) at line 284-285 (returns ('codex', '--version')).
4. Insert version(self) -> str immediately after the closing line of version_cmd(), with the following body: try: result = subprocess.run([*self.version_cmd()], capture_output=True, text=True, timeout=5); return result.stdout.strip() or result.stderr.strip(); except subprocess.TimeoutExpired: return ''; except Exception: logger.warning('Failed to run %s --version', self.binary_name(), exc_info=True); return ''.
5. The method must NOT gate on AGENT_BACKEND_ENV_VAR — it is an instance method on the backend class and is called only when CodexBackend is active.
6. Confirm logger is already available at module scope (line 59: logger = get_logger(__name__)) — no additional setup needed.
7. Verify no new helper modules or imports beyond subprocess are introduced.
8. In tests/execution/backends/test_codex_backend.py, add a new test class TestCodexBackendVersion with 5 monkeypatched unit tests.
9. Confirm pytestmark = [pytest.mark.layer('execution'), pytest.mark.small] already covers the file — no additional marker needed on the new class.
10. Confirm no real subprocess is spawned in any of the five tests (all paths use mock or monkeypatch).

## Acceptance Criteria

- codex.py stdlib imports block contains 'import subprocess' (alphabetically ordered after 'import os').
- CodexBackend.version() exists and has the signature 'def version(self) -> str'.
- The method body calls subprocess.run([*self.version_cmd()], capture_output=True, text=True, timeout=5) — no hardcoded binary string.
- On success, the method returns result.stdout.strip() or result.stderr.strip().
- On subprocess.TimeoutExpired, the method returns ''.
- On bare Exception, the method calls logger.warning with exc_info=True and returns ''.
- No AGENT_BACKEND_ENV_VAR guard is present in the method body.
- No new helper modules or non-stdlib imports are introduced in this WP.
- The method is placed immediately after version_cmd(), maintaining the existing method ordering in CodexBackend.
- TestCodexBackendVersion.test_version_returns_stripped_stdout: mocked subprocess.run returning stdout='1.2.3\n' causes version() to return '1.2.3'.
- TestCodexBackendVersion.test_version_stderr_fallback_when_stdout_empty: mocked subprocess.run returning stdout='', stderr='1.2.3-stderr\n' causes version() to return '1.2.3-stderr'.
- TestCodexBackendVersion.test_version_returns_empty_on_timeout: subprocess.TimeoutExpired raised by subprocess.run causes version() to return ''.
- TestCodexBackendVersion.test_version_returns_empty_on_oserror: OSError raised by subprocess.run causes version() to return ''.
- TestCodexBackendVersion.test_version_delegates_to_version_cmd: subprocess.run is called with the exact tuple returned by version_cmd(), confirming no hardcoded command string in version().
- All 5 tests carry the existing pytestmark (layer='execution', small) — no real subprocess spawned.
- task test-check passes with tests/execution/backends/test_codex_backend.py in scope.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260528-124509-738137/.autoskillit/temp/make-plan/extend_codex_backend_version_plan_2026-05-28_125500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 1.9k | 9.7k | 1.1M | 95.2k | 126 | 61.6k | 9m 20s |
| review_approach | claude-sonnet-4-6 | 1 | 52 | 5.1k | 173.8k | 38.3k | 51 | 24.6k | 3m 24s |
| verify | claude-sonnet-4-6 | 1 | 148 | 9.8k | 858.0k | 58.5k | 47 | 42.5k | 3m 7s |
| implement* | MiniMax-M2.7-highspeed | 1 | 387.3k | 4.9k | 772.3k | 30.9k | 74 | 44.2k | 7m 58s |
| fix | claude-sonnet-4-6 | 1 | 54 | 2.8k | 172.4k | 35.4k | 16 | 19.5k | 3m 25s |
| audit_impl | claude-sonnet-4-6 | 1 | 52 | 8.3k | 169.5k | 36.7k | 31 | 26.8k | 3m 15s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 71.3k | 3.5k | 185.3k | 30.9k | 22 | 43.6k | 1m 9s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 67.7k | 3.0k | 244.2k | 30.9k | 22 | 15.4k | 1m 5s |
| review_pr | claude-sonnet-4-6 | 1 | 182 | 47.2k | 1.1M | 88.4k | 71 | 73.6k | 10m 30s |
| resolve_review | claude-sonnet-4-6 | 1 | 215 | 18.6k | 1.4M | 74.9k | 61 | 59.8k | 10m 8s |
| **Total** | | | 528.9k | 112.9k | 6.2M | 95.2k | | 411.6k | 53m 27s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 69 | 11193.1 | 640.5 | 70.4 |
| fix | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 7 | 204829.7 | 8549.9 | 2660.1 |
| **Total** | **76** | 81371.1 | 5416.2 | 1485.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 7 | 2.6k | 101.5k | 5.0M | 308.4k | 43m 13s |
| MiniMax-M2.7-highspeed | 3 | 526.4k | 11.4k | 1.2M | 103.2k | 10m 13s |