### PR TITLE
P1-A5-WP1 — Add Null-Synthesis Note Annotations

### DIFF
--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -745,7 +745,7 @@
       "on_context_limit": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is unavailable (emits pr_url=).\n"
+      "note": "Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is unavailable (emits pr_url=).\nsynthesis_algorithm: null — arch-lens readings forwarded to compose_pr without aggregation. Dial (prepare_pr) -> Apply (run_arch_lenses) -> Output (compose_pr). Explicit null-synthesis is a deliberate choice, not an omission.\n"
     },
     "guard_pr_url": {
       "action": "route",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -745,7 +745,7 @@
       "on_context_limit": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is unavailable (emits pr_url=).\nsynthesis_algorithm: null — arch-lens readings forwarded to compose_pr without aggregation. Dial (prepare_pr) -> Apply (run_arch_lenses) -> Output (compose_pr). Explicit null-synthesis is a deliberate choice, not an omission.\n"
+      "note": "Reads the PR prep file, validates arch-lens diagrams (must contain ★ or ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is unavailable (emits pr_url=).\nsynthesis_algorithm: null — arch-lens readings forwarded to compose_pr without aggregation. Dial (prepare_pr) -> Apply (run_arch_lenses) -> Output (compose_pr).\n"
     },
     "guard_pr_url": {
       "action": "route",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -696,11 +696,14 @@ steps:
     on_context_limit: release_issue_failure
     optional: true
     skip_when_false: inputs.open_pr
-    note: 'Reads the PR prep file, validates arch-lens diagrams (must contain ★ or
+    note: >
+      Reads the PR prep file, validates arch-lens diagrams (must contain ★ or
       ●), composes the PR body, and runs gh pr create. Degrades gracefully if gh is
       unavailable (emits pr_url=).
 
-      '
+      synthesis_algorithm: null — arch-lens readings forwarded to compose_pr without
+      aggregation. Dial (prepare_pr) -> Apply (run_arch_lenses) -> Output (compose_pr).
+      Explicit null-synthesis is a deliberate choice, not an omission.
   guard_pr_url:
     action: route
     on_result:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -703,7 +703,6 @@ steps:
 
       synthesis_algorithm: null — arch-lens readings forwarded to compose_pr without
       aggregation. Dial (prepare_pr) -> Apply (run_arch_lenses) -> Output (compose_pr).
-      Explicit null-synthesis is a deliberate choice, not an omission.
   guard_pr_url:
     action: route
     on_result:

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -149,7 +149,7 @@
       },
       "on_success": "route_pr_or_local",
       "on_failure": "route_pr_or_local",
-      "note": "Idempotent file staging step. Copies phase-group, phase-plan, and exp-lens diagram artifacts from the worktree temp directory into research/{slug}/artifacts/. Creates images/ and scripts/ subdirectories. No compression, no rename, no commit. Safe to run multiple times — cp overwrites are idempotent. Runs after run_experiment_lenses to capture all exp-lens diagrams written to AUTOSKILLIT_TEMP/exp-lens-*/.\n"
+      "note": "Idempotent file staging step. Copies phase-group, phase-plan, and exp-lens diagram artifacts from the worktree temp directory into research/{slug}/artifacts/. Creates images/ and scripts/ subdirectories. No compression, no rename, no commit. Safe to run multiple times — cp overwrites are idempotent. Runs after run_experiment_lenses to capture all exp-lens diagrams written to AUTOSKILLIT_TEMP/exp-lens-*/.\nsynthesis_algorithm: null — exp-lens readings forwarded to stage_bundle without aggregation. Dial (prepare_research_pr) -> Apply (run_experiment_lenses) -> Output (stage_bundle -> compose_research_pr). Explicit null-synthesis is a deliberate choice, not an omission.\n"
     },
     "route_pr_or_local": {
       "action": "route",

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -149,7 +149,7 @@
       },
       "on_success": "route_pr_or_local",
       "on_failure": "route_pr_or_local",
-      "note": "Idempotent file staging step. Copies phase-group, phase-plan, and exp-lens diagram artifacts from the worktree temp directory into research/{slug}/artifacts/. Creates images/ and scripts/ subdirectories. No compression, no rename, no commit. Safe to run multiple times — cp overwrites are idempotent. Runs after run_experiment_lenses to capture all exp-lens diagrams written to AUTOSKILLIT_TEMP/exp-lens-*/.\nsynthesis_algorithm: null — exp-lens readings forwarded to stage_bundle without aggregation. Dial (prepare_research_pr) -> Apply (run_experiment_lenses) -> Output (stage_bundle -> compose_research_pr). Explicit null-synthesis is a deliberate choice, not an omission.\n"
+      "note": "Idempotent file staging step. Copies phase-group, phase-plan, and exp-lens diagram artifacts from the worktree temp directory into research/{slug}/artifacts/. Creates images/ and scripts/ subdirectories. No compression, no rename, no commit. Safe to run multiple times — cp overwrites are idempotent. Runs after run_experiment_lenses to capture all exp-lens diagrams written to AUTOSKILLIT_TEMP/exp-lens-*/.\nsynthesis_algorithm: null — exp-lens readings forwarded to stage_bundle without aggregation. Dial (prepare_research_pr) -> Apply (run_experiment_lenses) -> Output (stage_bundle -> compose_research_pr).\n"
     },
     "route_pr_or_local": {
       "action": "route",

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -143,6 +143,11 @@ steps:
       run multiple times — cp overwrites are idempotent. Runs after run_experiment_lenses
       to capture all exp-lens diagrams written to AUTOSKILLIT_TEMP/exp-lens-*/.
 
+      synthesis_algorithm: null — exp-lens readings forwarded to stage_bundle without
+      aggregation. Dial (prepare_research_pr) -> Apply (run_experiment_lenses) -> Output
+      (stage_bundle -> compose_research_pr). Explicit null-synthesis is a deliberate
+      choice, not an omission.
+
   route_pr_or_local:
     action: route
     on_result:

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -145,8 +145,7 @@ steps:
 
       synthesis_algorithm: null — exp-lens readings forwarded to stage_bundle without
       aggregation. Dial (prepare_research_pr) -> Apply (run_experiment_lenses) -> Output
-      (stage_bundle -> compose_research_pr). Explicit null-synthesis is a deliberate
-      choice, not an omission.
+      (stage_bundle -> compose_research_pr).
 
   route_pr_or_local:
     action: route


### PR DESCRIPTION
## Summary

Append null-synthesis annotation paragraphs to two recipe step `note:` fields:
1. `compose_pr` step in `implementation.yaml` — documents the Dial (prepare_pr) -> Apply (run_arch_lenses) -> Output (compose_pr) null-synthesis pattern
2. `stage_bundle` step in `research-review.yaml` — documents the Dial (prepare_research_pr) -> Apply (run_experiment_lenses) -> Output (stage_bundle -> compose_research_pr) null-synthesis pattern

Then regenerate contract cards and compile recipes to keep `recipe_source_hash` values in sync.

## Changed Files

● src/autoskillit/recipes/implementation.yaml
● src/autoskillit/recipes/implementation.json
● src/autoskillit/recipes/research-review.yaml
● src/autoskillit/recipes/research-review.json

Closes #3077

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260528-130041-103131/.autoskillit/temp/make-plan/p1-a5-wp1-null-synthesis-notes_plan_2026-05-28_130500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 78 | 9.9k | 1.2M | 63.3k | 85 | 52.3k | 5m 7s |
| review_approach | claude-sonnet-4-6 | 1 | 52 | 4.2k | 167.0k | 34.8k | 40 | 21.1k | 2m 39s |
| verify | claude-sonnet-4-6 | 1 | 84 | 6.7k | 383.0k | 48.9k | 49 | 32.9k | 5m 15s |
| implement* | MiniMax-M2.7-highspeed | 1 | 362.7k | 5.1k | 679.8k | 30.9k | 50 | 44.2k | 2m 30s |
| audit_impl | claude-sonnet-4-6 | 1 | 188 | 10.3k | 935.1k | 55.5k | 59 | 39.5k | 3m 24s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 80.7k | 3.1k | 244.3k | 30.9k | 21 | 15.8k | 1m 13s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 37.5k | 1.3k | 182.5k | 30.9k | 14 | 15.4k | 35s |
| review_pr | claude-sonnet-4-6 | 2 | 292 | 42.5k | 1.5M | 61.9k | 105 | 92.1k | 9m 22s |
| resolve_review | claude-sonnet-4-6 | 1 | 149 | 9.0k | 684.0k | 47.9k | 46 | 79.4k | 3m 41s |
| **Total** | | | 481.8k | 92.1k | 5.9M | 63.3k | | 392.7k | 33m 49s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 16 | 42487.5 | 2763.4 | 320.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 85499.5 | 9930.2 | 1123.8 |
| **Total** | **24** | 247690.6 | 16364.2 | 3836.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 1 | 78 | 9.9k | 1.2M | 52.3k | 5m 7s |
| claude-sonnet-4-6 | 5 | 765 | 72.6k | 3.7M | 265.1k | 24m 23s |
| MiniMax-M2.7-highspeed | 3 | 481.0k | 9.6k | 1.1M | 75.4k | 4m 18s |