### PR TITLE
[FEATURE] Create select-vis-lenses/SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 136 bundled skills.
+tools and 137 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 55 MCP tools and 136 bundled skills.
+→ tests → PR → merge pipelines using 55 MCP tools and 137 bundled skills.
 
 ## Start here
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 136 bundled skills. Any new skill with an unguarded
+test that scans all 137 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 55 MCP tools and 136 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 55 MCP tools and 137 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
 The complete list of bundled skills (137 total: 3 in `src/autoskillit/skills/`,
-133 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+134 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -19,7 +19,7 @@ Located under `src/autoskillit/skills_extended/`. Grouped by purpose:
 ### Plan and implementation
 `investigate`, `make-plan`, `dry-walkthrough`, `review-approach`,
 `implement-worktree`, `rectify`, `make-groups`, `mermaid`, `make-arch-diag`,
-`make-experiment-diag`, `build-execution-map`, `plan-visualization`
+`make-experiment-diag`, `build-execution-map`, `plan-visualization`, `select-vis-lenses`
 
 ### Audit suite
 `audit-arch`, `audit-cohesion`, `audit-tests`, `audit-defense-standards`,
@@ -139,8 +139,8 @@ symptom, and the audit suite is updated so the same class of bug cannot
 recur. Commit messages prefix with `Rectify:` for traceability; the count of
 `Rectify:` commits is reported in `docs/developer/contributing.md`.
 
-## Total: 133
+## Total: 137
 
-3 (Tier 1) + 130 (`skills_extended/`) = 133 bundled skills. The total is
+3 (Tier 1) + 134 (`skills_extended/`) = 137 bundled skills. The total is
 verified by `tests/docs/test_doc_counts.py` against a filesystem walk so any
 addition or removal is caught immediately.

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,6 +1,6 @@
 # Skill catalog
 
-The complete list of bundled skills (136 total: 3 in `src/autoskillit/skills/`,
+The complete list of bundled skills (137 total: 3 in `src/autoskillit/skills/`,
 133 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 136 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 137 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -220,6 +220,7 @@ skills:
     - process-issues
     - scope
     - select-directions
+    - select-vis-lenses
     - plan-experiment
     - implement-experiment
     - run-experiment

--- a/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
+++ b/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
@@ -53,11 +53,11 @@ Extract `source_dir`, `experiment_plan_path`, and `scope_report_path` from argum
 Read the experiment plan at `experiment_plan_path`.
 
 Extract the following fields (use sensible defaults if absent):
-- `experiment_type` — string (e.g., "benchmark", "ablation", "correlation")
+- `experiment_type` — string (e.g., "benchmark", "causal_inference", "exploratory")
 - `training_curves` — boolean (default: false)
 - `num_DVs` — integer count of dependent variables (default: 1)
-- `comparative` — boolean (true if multiple conditions compared head-to-head)
-- `DV_types` — list of DV type strings (e.g., ["accuracy", "temporal", "latency"])
+- `comparative` — boolean (true if multiple conditions compared head-to-head; default: false)
+- `DV_types` — list of DV type strings (e.g., ["accuracy", "temporal", "latency"]; default: [])
 - `num_conditions` — integer count of experimental conditions (default: 1)
 - `target_domain` — string (e.g., "nlp", "cv", "rl", "general")
 
@@ -115,7 +115,7 @@ methodology is identifiable from the 12 bundled methodology traditions.
 
 **Stage 2 — LLM arbitration (only when ≥ 2 candidates):**
 1. If any registered `UnionRuleDef` covers the candidate set, apply it:
-   select `resolved_tradition`, record rule name in `applied_union_rules`,
+   select `primary_tradition`, record rule name in `applied_union_rules`,
    set `precedence_trace = "stage2_tiebreak_by_rule_{rule_name}"`
 2. Otherwise, select among candidates by analyzing the plan's primary research
    question and methodology at temperature 0. Prefer the tradition whose
@@ -178,12 +178,12 @@ section to the template above:
 
 ```
 ## Methodology Tradition
-tradition_slug: {primary_tradition from Tier-C routing triple}
-routing_triple:
-  primary_tradition: {slug}
-  applied_union_rules: [{rules}]
-  precedence_trace: {trace}
-  candidate_set: [{candidates}]
+~~~yaml
+primary_tradition: {slug}
+applied_union_rules: [{rules}]
+precedence_trace: {trace}
+candidate_set: [{candidates}]
+~~~
 ```
 
 ### Step 3 — Emit Structured Tokens
@@ -193,7 +193,7 @@ Emit exactly five tokens as your final output:
 ```
 selected_lenses = {comma-separated list of vis-lens skill slugs}
 lens_context_paths = {comma-separated list of absolute paths to context files}
-disambiguation_rule_applied = {rule_name or null}
+disambiguation_rule_applied = {first rule_name from applied_union_rules if list is non-empty, else null}
 tier_c_lens = {vis-lens-methodology-norms or null}
 methodology_tradition = {primary_tradition slug or null}
 ```

--- a/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
+++ b/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: select-vis-lenses
+categories: [research, vis-lens]
+phoropter_family: vis-lens
+description: >
+  Dial step of the vis-lens phoropter: parses experiment plan fields, applies
+  three-tier lens selection (Tier A mandatory, Tier B experiment-type, Tier C
+  methodology tradition), writes per-lens context files, and emits five
+  structured tokens for downstream vis-lens invocation.
+---
+
+# Select Vis-Lenses Skill
+
+Reads the finalized experiment plan, selects 2–4 vis-lens skills via three-tier
+logic, writes per-lens context files, and emits structured tokens for downstream
+consumption. Does NOT invoke the vis-lens skills — that is handled by the
+`run_vis_lenses` recipe step.
+
+## When to Use
+
+- As the `dial` step of the vis-lens phoropter in `research-design.yaml` and
+  `research.yaml`, after `review_design` GO and before `run_vis_lenses`
+
+## Arguments
+
+```
+/autoskillit:select-vis-lenses {source_dir} {experiment_plan_path} {scope_report_path}
+```
+
+- `{source_dir}` — Absolute path to the source repo (the CWD before worktree creation)
+- `{experiment_plan_path}` — Absolute path to the finalized experiment plan markdown
+- `{scope_report_path}` — Absolute path to the scope report (may be empty string if absent)
+
+## Critical Constraints
+
+**NEVER:**
+- Select fewer than 2 or more than 4 lenses
+- Skip vis-lens-always-on (it is always Tier A)
+- Write outputs outside `{{AUTOSKILLIT_TEMP}}/select-vis-lenses/`
+- Fabricate lens recommendations or validation conclusions not supported by the data — report what the experiment plan and scope show, not what you assume they should show
+- Run subagents in the background (`run_in_background: true` is prohibited)
+- Invoke vis-lens skills — that belongs to the `run_vis_lenses` recipe step
+
+**ALWAYS:**
+- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Write a vis-lens context file for each selected lens before emitting tokens
+
+## Workflow
+
+### Step 0 — Parse Arguments
+
+Extract `source_dir`, `experiment_plan_path`, and `scope_report_path` from arguments.
+Read the experiment plan at `experiment_plan_path`.
+
+Extract the following fields (use sensible defaults if absent):
+- `experiment_type` — string (e.g., "benchmark", "ablation", "correlation")
+- `training_curves` — boolean (default: false)
+- `num_DVs` — integer count of dependent variables (default: 1)
+- `comparative` — boolean (true if multiple conditions compared head-to-head)
+- `DV_types` — list of DV type strings (e.g., ["accuracy", "temporal", "latency"])
+- `num_conditions` — integer count of experimental conditions (default: 1)
+- `target_domain` — string (e.g., "nlp", "cv", "rl", "general")
+
+### Step 1 — Three-Tier Lens Selection
+
+Build `selected_lenses` (list of 2–4 vis-lens skill slugs):
+
+**Tier A (always selected, mandatory):**
+- `vis-lens-always-on`
+
+**Tier B (select 1–2 based on experiment_type and override rules):**
+
+Override rules (checked first, in priority order):
+1. If `training_curves == true` → include `vis-lens-temporal`
+2. If `num_DVs >= 6 AND comparative == true` → include `vis-lens-multi-compare`
+3. If `DV_types` contains `"temporal"` → include `vis-lens-temporal` (if not already)
+4. If `num_conditions >= 8` → include `vis-lens-multi-compare` (if not already)
+
+Experiment-type table (use when no override fires or to fill second Tier-B slot):
+| experiment_type | Primary lens | Secondary lens (optional) |
+|---|---|---|
+| benchmark | vis-lens-chart-select | vis-lens-uncertainty |
+| causal_inference | vis-lens-chart-select | vis-lens-figure-table |
+| configuration_study | vis-lens-chart-select | vis-lens-uncertainty |
+| evidence_synthesis | vis-lens-chart-select | vis-lens-figure-table |
+| exploratory | vis-lens-chart-select | vis-lens-uncertainty |
+| factorial_design | vis-lens-multi-compare | vis-lens-chart-select |
+| instrument_validation | vis-lens-multi-compare | vis-lens-uncertainty |
+| observational_correlational | vis-lens-chart-select | vis-lens-figure-table |
+| qualitative_interpretive | vis-lens-chart-select | vis-lens-uncertainty |
+| robustness_audit | vis-lens-chart-select | vis-lens-uncertainty |
+| simulation_modeling | vis-lens-temporal | vis-lens-chart-select |
+| single_subject | vis-lens-chart-select | vis-lens-uncertainty |
+| (default) | vis-lens-chart-select | — |
+
+Cap Tier B at 2 lenses total (overrides count toward this cap).
+
+**Tier C (0–1 based on methodology tradition detection):**
+
+Tier C selects `vis-lens-methodology-norms` when the experiment plan's research
+methodology is identifiable from the 12 bundled methodology traditions.
+
+**Stage 1 — Deterministic keyword match:**
+1. Load all methodology traditions from `recipes/methodology-traditions/*.yaml`
+2. For each tradition, count how many of its `detection_keywords` appear in the
+   experiment plan text (case-insensitive, word-boundary matching)
+3. Build `candidate_set` = traditions with ≥ 2 keyword matches
+4. Branch on `len(candidate_set)`:
+
+| Candidates | Action | `precedence_trace` |
+|---|---|---|
+| 0 | Skip Tier C entirely | `stage1_no_match_fallback` |
+| 1 | Use that tradition as `primary_tradition` | `stage1_single_match` |
+| ≥ 2 | Proceed to Stage 2 | — |
+
+**Stage 2 — LLM arbitration (only when ≥ 2 candidates):**
+1. If any registered `UnionRuleDef` covers the candidate set, apply it:
+   select `resolved_tradition`, record rule name in `applied_union_rules`,
+   set `precedence_trace = "stage2_tiebreak_by_rule_{rule_name}"`
+2. Otherwise, select among candidates by analyzing the plan's primary research
+   question and methodology at temperature 0. Prefer the tradition whose
+   mandatory figures are most relevant to the stated research design.
+   Set `precedence_trace = "stage2_tiebreak_by_methodology_fit"`
+
+**Emit routing triple** (include as a fenced yaml block in the vis-lens context file):
+```yaml
+primary_tradition: <tradition_slug>
+applied_union_rules: [<rule_name>, ...]
+precedence_trace: "<trace_value>"
+candidate_set: [<tradition_slugs>]
+```
+
+When `primary_tradition` is set, add `vis-lens-methodology-norms` to `selected_lenses`
+and write the `tradition_slug` and routing triple into its context file (Step 2).
+
+Only add Tier C lens if it is not already in Tier A or Tier B.
+
+**Enforcement:** Total must be 2–4. If total < 2, add `vis-lens-chart-select`. If total
+> 4, drop the last Tier C lens, then last Tier B secondary.
+
+### Step 2 — Write Vis-Lens Context Files
+
+For each lens in `selected_lenses`, write a context file:
+
+Path: `{{AUTOSKILLIT_TEMP}}/select-vis-lenses/vis_ctx_{slug}_{YYYY-MM-DD_HHMMSS}.md`
+
+Template for each context file:
+```
+# Vis-Lens Context: {slug}
+
+## Experiment Summary
+{1–3 sentence description of the experiment from the plan}
+
+## Data Shape
+- Dependent Variables ({num_DVs} total): {DV names and types}
+- Independent Variables: {IV names, levels, and ranges}
+- Conditions: {num_conditions} conditions
+- Replication: {n_seeds or n_trials if available}
+
+## DV Specification
+{For each DV: name, type (continuous/discrete/temporal), unit, expected range}
+
+## IV Specification
+{For each IV: name, type, levels (for categorical) or range (for continuous)}
+
+## Comparison Structure
+- Comparative: {true/false}
+- Head-to-head pairs: {list if applicable}
+- Factorial interactions: {list if applicable}
+
+## Expected Data Outputs
+{List the files or data structures the experiment will produce, from the plan's
+data_manifest or results/ section if available}
+```
+
+When the context file is for `vis-lens-methodology-norms`, append the following
+section to the template above:
+
+```
+## Methodology Tradition
+tradition_slug: {primary_tradition from Tier-C routing triple}
+routing_triple:
+  primary_tradition: {slug}
+  applied_union_rules: [{rules}]
+  precedence_trace: {trace}
+  candidate_set: [{candidates}]
+```
+
+### Step 3 — Emit Structured Tokens
+
+Emit exactly five tokens as your final output:
+
+```
+selected_lenses = {comma-separated list of vis-lens skill slugs}
+lens_context_paths = {comma-separated list of absolute paths to context files}
+disambiguation_rule_applied = {rule_name or null}
+tier_c_lens = {vis-lens-methodology-norms or null}
+methodology_tradition = {primary_tradition slug or null}
+```
+
+Do NOT emit `visualization_plan_path`, `report_plan_path`, `visualization_plan_trace_path`,
+or `classification_timestamp` — those belong to `synthesize-vis-plan` or other downstream steps.

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -255,7 +255,7 @@ file-audit-issues, implement-experiment, implement-worktree, implement-worktree-
 make-campaign, make-experiment-diag, make-groups, make-plan, make-req, merge-pr, mermaid, migrate-recipes, open-integration-pr,
 open-kitchen, pipeline-summary, plan-experiment, plan-visualization, planner-analyze, planner-assess-review-approach, planner-consolidate-wps, planner-elaborate-assignments, planner-elaborate-phase, planner-elaborate-wps, planner-extract-domain, planner-generate-phases, planner-reconcile-deps, planner-refine, planner-refine-assignments, planner-refine-phases, planner-refine-wps, planner-validate-task-alignment, prepare-issue, prepare-pr, prepare-research-pr, process-issues, promote-to-main, rectify, reload-session, report-bug,
 resolve-claims-review, resolve-design-review, resolve-failures, resolve-merge-conflicts, resolve-research-review, resolve-review, retry-worktree, review-approach, review-design, review-pr, review-research-pr, run-experiment,
-scope, select-directions, setup-environment, setup-project, smoke-task, stage-data, triage-issues, troubleshoot-experiment,
+scope, select-directions, select-vis-lenses, setup-environment, setup-project, smoke-task, stage-data, triage-issues, troubleshoot-experiment,
 validate-audit, validate-review-decisions, validate-test-audit, verify-diag,
 vis-lens-always-on, vis-lens-antipattern, vis-lens-caption-annot, vis-lens-chart-select,
 vis-lens-color-access, vis-lens-methodology-norms, vis-lens-figure-table, vis-lens-multi-compare,

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -45,6 +45,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_package_gateways.py` | Tests for Package Gateway API (groupC) — REQ-GWAY-001 through REQ-GWAY-008 |
 | `test_plan_experiment_contracts.py` | Contract tests for plan-experiment SKILL.md — data provenance lifecycle |
 | `test_plan_visualization_contracts.py` | Contract tests: plan-visualization SKILL.md experiment type vocabulary |
+| `test_select_vis_lenses_contracts.py` | Contract tests: select-vis-lenses SKILL.md experiment type vocabulary and token emission |
 | `test_pr_traceability_contracts.py` | Cross-skill contract tests for requirement traceability across PR lifecycle skills |
 | `test_prepare_compose_pr_contracts.py` | Contract tests for prepare-pr and compose-pr skills |
 | `test_prepare_research_pr_contracts.py` | Contract tests: prepare-research-pr SKILL.md experiment type vocabulary |

--- a/tests/contracts/test_select_vis_lenses_contracts.py
+++ b/tests/contracts/test_select_vis_lenses_contracts.py
@@ -1,0 +1,114 @@
+"""Contract tests: select-vis-lenses SKILL.md experiment type vocabulary and token emission."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.small]
+
+SKILL_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "select-vis-lenses"
+    / "SKILL.md"
+)
+EXPERIMENT_TYPES_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "recipes"
+    / "experiment-types"
+)
+
+
+def _read_skill() -> str:
+    return SKILL_PATH.read_text()
+
+
+def _extract_lens_table_section(text: str) -> str:
+    """Extract the Tier B lens selection table section from SKILL.md."""
+    m = re.search(
+        r"Experiment-type table[^\n]*\n(\|[^\n]*\n)+",
+        text,
+        re.IGNORECASE,
+    )
+    assert m, "Tier B experiment-type table not found in select-vis-lenses SKILL.md"
+    return m.group(0).lower()
+
+
+class TestSelectVisLensesExperimentTypes:
+    def test_experiment_types_use_canonical_names(self) -> None:
+        """Tier B lens selection table must reference all 12 canonical experiment types."""
+        registry_types = {p.stem for p in EXPERIMENT_TYPES_DIR.glob("*.yaml")}
+        assert len(registry_types) > 0, "experiment-types registry is empty"
+
+        table_section = _extract_lens_table_section(_read_skill())
+        for rtype in registry_types:
+            assert rtype in table_section, (
+                f"select-vis-lenses Tier B lens selection table does not reference "
+                f"canonical experiment type '{rtype}' from the registry"
+            )
+
+    def test_experiment_type_table_has_default_row(self) -> None:
+        """Tier B table must include a (default) fallback row."""
+        table_section = _extract_lens_table_section(_read_skill())
+        assert "(default)" in table_section, "select-vis-lenses Tier B table missing (default) row"
+
+
+class TestSelectVisLensesTokenEmission:
+    _EXPECTED_TOKENS = {
+        "selected_lenses",
+        "lens_context_paths",
+        "disambiguation_rule_applied",
+        "tier_c_lens",
+        "methodology_tradition",
+    }
+    _PROHIBITED_TOKENS = {
+        "visualization_plan_path",
+        "report_plan_path",
+        "visualization_plan_trace_path",
+        "classification_timestamp",
+    }
+
+    def test_emits_exactly_five_tokens(self) -> None:
+        """Step 3 must emit exactly the five specified tokens — no more, no fewer."""
+        content = _read_skill()
+        step3_match = re.search(r"### Step 3.*?(?=### Step \d|$)", content, re.DOTALL)
+        assert step3_match, "Step 3 section not found in select-vis-lenses SKILL.md"
+        step3_text = step3_match.group(0)
+        for token in self._EXPECTED_TOKENS:
+            assert token in step3_text, (
+                f"select-vis-lenses Step 3 missing required token '{token}'"
+            )
+        token_lines = re.findall(r"^\w[\w_]* =", step3_text, re.MULTILINE)
+        assert len(token_lines) == len(self._EXPECTED_TOKENS), (
+            f"Step 3 must emit exactly {len(self._EXPECTED_TOKENS)} tokens, "
+            f"found {len(token_lines)}: {token_lines}"
+        )
+
+    def test_does_not_emit_prohibited_tokens(self) -> None:
+        """Step 3 must not emit tokens belonging to downstream skills."""
+        content = _read_skill()
+        step3_match = re.search(r"### Step 3.*?(?=### Step \d|$)", content, re.DOTALL)
+        assert step3_match, "Step 3 section not found"
+        step3_text = step3_match.group(0)
+        for token in self._PROHIBITED_TOKENS:
+            assert f"{token} =" not in step3_text, (
+                f"select-vis-lenses Step 3 must not emit '{token}' (belongs to downstream skill)"
+            )
+
+
+class TestSelectVisLensesOutputDirectory:
+    def test_output_dir_uses_select_vis_lenses(self) -> None:
+        """All output paths must reference select-vis-lenses/, not plan-visualization/."""
+        content = _read_skill()
+        assert "select-vis-lenses/" in content
+        temp_refs = re.findall(r"\{\{AUTOSKILLIT_TEMP\}\}/([a-z0-9-]+)/", content)
+        for ref in temp_refs:
+            assert ref == "select-vis-lenses", (
+                f"SKILL.md references '{{{{AUTOSKILLIT_TEMP}}}}/{ref}/' "
+                f"but should only reference select-vis-lenses/"
+            )

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -309,9 +309,9 @@ def test_docs_state_38_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 38)
 
 
-def test_skill_visibility_states_136_skills() -> None:
-    # 136 total = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 132 extended.
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 136)
+def test_skill_visibility_states_137_skills() -> None:
+    # 137 total = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 133 extended.
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 137)
 
 
 def test_safety_hooks_states_21_hooks() -> None:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -310,7 +310,7 @@ def test_docs_state_38_kitchen_tools(doc_path: Path) -> None:
 
 
 def test_skill_visibility_states_137_skills() -> None:
-    # 137 total = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 133 extended.
+    # 137 total = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 134 extended.
     _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 137)
 
 


### PR DESCRIPTION
## Summary

Create `src/autoskillit/skills_extended/select-vis-lenses/SKILL.md` — a new phoropter dial-step skill that extracts Steps 0–2 (argument parsing, three-tier lens selection, context file writing) from `plan-visualization/SKILL.md` and emits exactly five structured tokens: `selected_lenses`, `lens_context_paths`, `disambiguation_rule_applied`, `tier_c_lens`, `methodology_tradition`. This is a pure markdown skill definition with no Python code — the only code change is a new contract test mirroring the existing `test_plan_visualization_contracts.py` pattern.

## Requirements

(No ## Requirements section found in issue #3079)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

(None provided)

Closes #3079

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/p2-a1-wp1-20260528-153149-920431/.autoskillit/temp/make-plan/create_select_vis_lenses_skill_md_plan_2026-05-28_153500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 257 | 15.8k | 1.7M | 95.4k | 199 | 79.3k | 14m 8s |
| review_approach | claude-sonnet-4-6 | 1 | 3.2k | 5.5k | 180.8k | 41.2k | 35 | 28.5k | 3m 9s |
| verify | claude-sonnet-4-6 | 1 | 140 | 13.7k | 916.3k | 69.4k | 56 | 53.5k | 4m 17s |
| implement* | MiniMax-M2.7-highspeed | 1 | 1.9M | 16.0k | 1.9M | 30.9k | 126 | 44.3k | 7m 11s |
| fix | claude-sonnet-4-6 | 1 | 206 | 10.9k | 1.3M | 65.9k | 62 | 49.9k | 5m 54s |
| audit_impl | claude-sonnet-4-6 | 1 | 1.3k | 7.1k | 263.1k | 42.4k | 28 | 29.3k | 2m 39s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 119.8k | 3.0k | 247.1k | 30.9k | 26 | 43.8k | 1m 15s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 94.0k | 2.4k | 336.9k | 30.9k | 25 | 15.5k | 1m 3s |
| review_pr | claude-sonnet-4-6 | 1 | 182 | 38.5k | 1.2M | 94.2k | 85 | 79.2k | 10m 53s |
| resolve_review | claude-sonnet-4-6 | 1 | 231 | 22.1k | 1.7M | 81.5k | 74 | 104.9k | 8m 53s |
| diagnose_ci* | MiniMax-M2.7-highspeed | 1 | 539.5k | 4.3k | 494.4k | 30.9k | 44 | 43.4k | 1m 44s |
| resolve_ci | claude-sonnet-4-6 | 1 | 118 | 4.9k | 543.0k | 46.9k | 42 | 33.2k | 5m 17s |
| **Total** | | | 2.6M | 144.2k | 10.7M | 95.4k | | 604.7k | 1h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 329 | 5635.6 | 134.6 | 48.6 |
| fix | 14 | 89446.0 | 3566.9 | 775.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 24 | 72305.1 | 4369.5 | 919.2 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 3 | 180987.3 | 11066.3 | 1636.0 |
| **Total** | **370** | 28888.1 | 1634.3 | 389.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 8 | 5.6k | 118.5k | 7.8M | 457.8k | 55m 14s |
| MiniMax-M2.7-highspeed | 4 | 2.6M | 25.7k | 2.9M | 146.9k | 11m 15s |