### PR TITLE
Fix hidden ingredient ${{ inputs.* }} interpolation in served recipe content (#3209)

### DIFF
--- a/docs/recipes/authoring.md
+++ b/docs/recipes/authoring.md
@@ -53,7 +53,7 @@ The rule families live in `src/autoskillit/recipe/rules_*.py` (28 files):
 |------|-----------------|
 | `rules_actions.py` | Action-type semantic rules: `stop-step-has-no-routing`, `recipe-has-terminal-step`, `route-step-requires-on-result` |
 | `rules_blocks.py` | Block-level budget rules: per-block `run_cmd` and `run_skill` call-count budgets |
-| `rules_bypass.py` | `skip_when_false` routes that have no fallthrough — a step that gets bypassed must also have a downstream consumer that handles the bypass |
+| `rules_bypass.py` | `skip_when_false` bypass routing contracts; `hidden-input-ref-in-template` detection — warns when a step template field references a hidden ingredient via `${{ inputs.X }}` (safe because load_and_validate resolves these server-side) |
 | `rules_campaign_capture.py` | Campaign capture validation: identifier keys, result refs, sentinel cross-checks |
 | `rules_campaign_deps.py` | Campaign dependency graph rules: valid refs, acyclic, sequential |
 | `rules_campaign_dispatch.py` | Campaign dispatch structure: kind, names, recipe refs, packs, task |

--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -24,7 +24,7 @@ Sub-package: rules/ (see rules/CLAUDE.md).
 | `_cmd_rpc_merge.py` | Rebase, PR polling, branch management |
 | `_cmd_rpc_issues.py` | Issue creation, bundles, audit run dirs |
 | `_recipe_ingredients.py` | `format_ingredients_table` + `LoadRecipeResult` TypedDicts |
-| `_recipe_composition.py` | Sub-recipe composition, `_prune_skipped_steps`, `_is_ingredient_truthy` + `FALSY_STRINGS` truthiness evaluation |
+| `_recipe_composition.py` | Sub-recipe composition, `_prune_skipped_steps`, `_resolve_hidden_inputs_in_content`, `_is_ingredient_truthy` + `FALSY_STRINGS` truthiness evaluation |
 | `_rule_helpers.py` | Shared helper utilities for recipe semantic rules |
 | `diagrams.py` | Flow diagram generation + staleness detection |
 | `_registry_utils.py` | `dir_mtime`, `parse_int_field` — shared helpers for registry loaders |

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -44,6 +44,7 @@ from autoskillit.recipe._recipe_composition import (
     _assert_content_integrity,
     _build_active_recipe,
     _prune_skipped_steps,
+    _resolve_hidden_inputs_in_content,
     _resolve_skip_guards_in_content,
     _validate_no_dangling_routes,
 )
@@ -395,6 +396,10 @@ def load_and_validate(
                 raw = ""
             t0 = _t("prune_skipped_steps", t0, name)
 
+            # Stage: hidden ingredient interpolation
+            raw = _resolve_hidden_inputs_in_content(raw, active_recipe, ingredient_overrides)
+            t0 = _t("resolve_hidden_inputs", t0, name)
+
             # Stage: contract card
             contract = load_recipe_card(name, recipes_dir)
             contract_findings: list[dict[str, Any]] = []
@@ -467,7 +472,16 @@ def load_and_validate(
         else None
     )
 
-    _assert_no_raw_placeholders(raw, context=name)
+    _hidden_names = (
+        frozenset(
+            n
+            for n, ing in (active_recipe.ingredients or {}).items()
+            if getattr(ing, "hidden", False)
+        )
+        if active_recipe is not None
+        else None
+    )
+    _assert_no_raw_placeholders(raw, context=name, hidden_ingredient_names=_hidden_names)
     result: LoadRecipeResult = {
         "content": raw,
         "diagram": diagram,

--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -464,7 +464,8 @@ def _resolve_hidden_inputs_in_content(
         value = overrides.get(name)
         if value is None:
             ing = hidden_ingredients[name]
-            value = str(ing.default) if ing.default is not None else ""
+            default = getattr(ing, "default", None)
+            value = str(default) if default is not None else ""
         return val_a if value == cond else val_b
 
     raw = _MODEL_COND_RE.sub(_resolve_model_cond, raw)
@@ -477,7 +478,8 @@ def _resolve_hidden_inputs_in_content(
         value = overrides.get(name)
         if value is None:
             ing = hidden_ingredients[name]
-            value = str(ing.default) if ing.default is not None else ""
+            default = getattr(ing, "default", None)
+            value = str(default) if default is not None else ""
         return value
 
     return INPUT_REF_RE.sub(_resolve_ref, raw)

--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -429,6 +429,60 @@ def _resolve_skip_guards_in_content(
     return raw
 
 
+_MODEL_COND_RE = re.compile(
+    r"""\$\{\{\s*'([^']+)'\s+if\s+inputs\.(\w+)\s*==\s*'([^']+)'\s+else\s+'([^']+)'\s*\}\}"""
+)
+
+
+def _resolve_hidden_inputs_in_content(
+    raw: str,
+    recipe: Any,
+    ingredient_overrides: dict[str, str] | None,
+) -> str:
+    """Substitute hidden ingredient ${{ inputs.<name> }} templates in raw YAML content.
+
+    Only hidden ingredients are resolved — visible ingredient refs remain as literals
+    for the LLM to substitute using the ingredients table values.
+    """
+    from autoskillit.recipe._contracts_types import INPUT_REF_RE  # noqa: PLC0415
+
+    overrides = ingredient_overrides or {}
+    hidden_ingredients = {
+        name: ing
+        for name, ing in (recipe.ingredients or {}).items()
+        if getattr(ing, "hidden", False)
+    }
+    if not hidden_ingredients:
+        return raw
+
+    # First pass: resolve conditional expressions in model: fields
+    # Pattern: ${{ 'val_a' if inputs.name == 'cond' else 'val_b' }}
+    def _resolve_model_cond(m: re.Match[str]) -> str:
+        val_a, name, cond, val_b = m.group(1), m.group(2), m.group(3), m.group(4)
+        if name not in hidden_ingredients:
+            return m.group(0)
+        value = overrides.get(name)
+        if value is None:
+            ing = hidden_ingredients[name]
+            value = str(ing.default) if ing.default is not None else ""
+        return val_a if value == cond else val_b
+
+    raw = _MODEL_COND_RE.sub(_resolve_model_cond, raw)
+
+    # Second pass: resolve simple ${{ inputs.name }} references for hidden ingredients
+    def _resolve_ref(m: re.Match[str]) -> str:
+        name = m.group(1)
+        if name not in hidden_ingredients:
+            return m.group(0)
+        value = overrides.get(name)
+        if value is None:
+            ing = hidden_ingredients[name]
+            value = str(ing.default) if ing.default is not None else ""
+        return value
+
+    return INPUT_REF_RE.sub(_resolve_ref, raw)
+
+
 def _assert_content_integrity(
     raw: str,
     resolutions: dict[str, bool | None],

--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -10,6 +10,7 @@ from typing import Any
 import regex as re
 
 from autoskillit.core import YAMLError, load_yaml
+from autoskillit.recipe._contracts_types import INPUT_REF_RE
 from autoskillit.recipe.io import find_sub_recipe_by_name
 from autoskillit.recipe.io import load_recipe as _load_recipe_from_path
 from autoskillit.recipe.schema import (
@@ -444,7 +445,6 @@ def _resolve_hidden_inputs_in_content(
     Only hidden ingredients are resolved — visible ingredient refs remain as literals
     for the LLM to substitute using the ingredients table values.
     """
-    from autoskillit.recipe._contracts_types import INPUT_REF_RE  # noqa: PLC0415
 
     overrides = ingredient_overrides or {}
     hidden_ingredients = {

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -78,7 +78,12 @@ def substitute_scripts_placeholder(text: str) -> str:
     return text.replace(_SCRIPTS_PLACEHOLDER, str(builtin_scripts_dir()))
 
 
-def _assert_no_raw_placeholders(text: str, *, context: str = "") -> None:
+def _assert_no_raw_placeholders(
+    text: str,
+    *,
+    context: str = "",
+    hidden_ingredient_names: frozenset[str] | None = None,
+) -> None:
     # Content-delivery boundary guard: raises if placeholder substitution was skipped.
     for placeholder in (_TEMP_PLACEHOLDER, _SCRIPTS_PLACEHOLDER):
         if placeholder in text:
@@ -86,6 +91,17 @@ def _assert_no_raw_placeholders(text: str, *, context: str = "") -> None:
                 f"Unresolved {placeholder} in recipe content"
                 + (f" ({context})" if context else "")
             )
+    if hidden_ingredient_names:
+        import regex as _re  # noqa: PLC0415
+
+        _hidden_ref_re = _re.compile(r"\$\{\{\s*inputs\.(\w+)\s*\}\}")
+        for _m in _hidden_ref_re.finditer(text):
+            _name = _m.group(1)
+            if _name in hidden_ingredient_names:
+                raise ValueError(
+                    f"Unresolved hidden ingredient template ${{{{ inputs.{_name} }}}} "
+                    "in recipe content" + (f" ({context})" if context else "")
+                )
 
 
 def _load_recipe_dict(

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -21,6 +21,7 @@ from autoskillit.core import (
     pkg_root,
 )
 from autoskillit.core import fast_loads as _fast_loads
+from autoskillit.recipe._contracts_types import INPUT_REF_RE
 from autoskillit.recipe.order import BUNDLED_RECIPE_ORDER
 from autoskillit.recipe.schema import (
     AUTOSKILLIT_VERSION_KEY,
@@ -92,10 +93,7 @@ def _assert_no_raw_placeholders(
                 + (f" ({context})" if context else "")
             )
     if hidden_ingredient_names:
-        import regex as _re  # noqa: PLC0415
-
-        _hidden_ref_re = _re.compile(r"\$\{\{\s*inputs\.(\w+)\s*\}\}")
-        for _m in _hidden_ref_re.finditer(text):
+        for _m in INPUT_REF_RE.finditer(text):
             _name = _m.group(1)
             if _name in hidden_ingredient_names:
                 raise ValueError(

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -9,7 +9,7 @@ Semantic validation rule modules for recipe analysis (48 rule files).
 | `__init__.py` | Docstring-only — rules register via `@semantic_rule` decorator on import |
 | `rules_actions.py` | Semantic rules for `stop`/`route`/`confirm` action-type steps |
 | `rules_blocks.py` | Block-level budget rules; loads `block_budgets.yaml` at import |
-| `rules_bypass.py` | Rules for `skip_when_false` bypass routing contracts |
+| `rules_bypass.py` | Rules for `skip_when_false` bypass routing contracts and `hidden-input-ref-in-template` detection (hidden ingredient `${{ inputs.X }}` in step template fields) |
 | `rules_callable_scope.py` | Enforces scoped directory args for file-discovering callables (e.g. `batch_create_issues` → `audit_run_dir`) |
 | `rules_campaign_capture.py` | Campaign capture validation: identifier keys, result refs, sentinel cross-checks |
 | `rules_campaign_deps.py` | Campaign dependency graph rules: valid refs, acyclic, sequential |

--- a/src/autoskillit/recipe/rules/rules_bypass.py
+++ b/src/autoskillit/recipe/rules/rules_bypass.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from autoskillit.core import SKILL_TOOLS, Severity
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._contracts_types import INPUT_REF_RE
 from autoskillit.recipe._recipe_composition import _is_ingredient_truthy
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
@@ -227,4 +228,54 @@ def _check_skip_guard_falsy_default(ctx: ValidationContext) -> list[RuleFinding]
                     ),
                 )
             )
+    return findings
+
+
+@semantic_rule(
+    name="hidden-input-ref-in-template",
+    description=(
+        "A step template field (${{ inputs.X }}) or kitchen_rules entry references a hidden "
+        "ingredient. Hidden ingredients are invisible to the LLM. This is safe because "
+        "load_and_validate resolves hidden input templates server-side."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_hidden_input_ref_in_template(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    recipe = ctx.recipe
+
+    def _check_text(text: str, location: str) -> None:
+        for m in INPUT_REF_RE.finditer(text):
+            name = m.group(1)
+            ing = recipe.ingredients.get(name)
+            if ing is not None and ing.hidden:
+                findings.append(
+                    RuleFinding(
+                        rule="hidden-input-ref-in-template",
+                        severity=Severity.WARNING,
+                        step_name=location,
+                        message=(
+                            f"{location}: template ${{{{ inputs.{name} }}}} references hidden "
+                            f"ingredient '{name}'. Hidden ingredients are invisible to the LLM. "
+                            "This is safe only because load_and_validate resolves hidden input "
+                            "templates server-side."
+                        ),
+                    )
+                )
+
+    for step_name, step in recipe.steps.items():
+        for val in (step.with_args or {}).values():
+            _check_text(str(val), f"Step '{step_name}'")
+        if step.model:
+            _check_text(step.model, f"Step '{step_name}'")
+        if step.note:
+            _check_text(step.note, f"Step '{step_name}'")
+        if step.on_result and step.on_result.conditions:
+            for cond in step.on_result.conditions:
+                if cond.when:
+                    _check_text(cond.when, f"Step '{step_name}'")
+
+    for rule_text in recipe.kitchen_rules or []:
+        _check_text(str(rule_text), "kitchen_rules")
+
     return findings

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -121,3 +121,37 @@ def test_bundled_recipe_content_has_no_residual_skip_signals(recipe_name: str) -
             f"Recipe '{recipe_name}': steps {residual_skip} retain "
             f"'skip_when_false: inputs.{ing_name}' after truthy resolution."
         )
+
+
+@pytest.mark.parametrize("recipe_name", BUNDLED_RECIPE_NAMES)
+def test_bundled_recipe_content_has_no_residual_hidden_input_templates(
+    recipe_name: str,
+) -> None:
+    """load_and_validate must not deliver unresolved ${{ inputs.X }} for hidden ingredients.
+
+    Regression guard: any bundled recipe that uses a hidden ingredient in a template field
+    must have that template resolved server-side before the content is delivered to the LLM.
+    Hidden ingredients are excluded from the ingredients table, so the LLM cannot resolve them.
+    """
+    import re
+
+    from autoskillit.recipe import load_and_validate
+
+    recipe_obj = load_recipe(pkg_root() / "recipes" / f"{recipe_name}.yaml")
+    hidden_ing_names = {name for name, ing in recipe_obj.ingredients.items() if ing.hidden}
+    if not hidden_ing_names:
+        return
+
+    result = load_and_validate(recipe_name)
+    recipe_content = result["content"]
+
+    unresolved = []
+    for name in hidden_ing_names:
+        pattern = re.compile(r"\$\{\{\s*inputs\." + re.escape(name) + r"\s*\}\}")
+        if pattern.search(recipe_content):
+            unresolved.append(f"${{{{ inputs.{name} }}}}")
+    assert unresolved == [], (
+        f"Recipe '{recipe_name}' content has unresolved hidden ingredient templates "
+        f"after load_and_validate: {unresolved}. "
+        f"Server-side hidden input interpolation may be broken."
+    )

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -140,7 +140,7 @@ def test_bundled_recipe_content_has_no_residual_hidden_input_templates(
     recipe_obj = load_recipe(pkg_root() / "recipes" / f"{recipe_name}.yaml")
     hidden_ing_names = {name for name, ing in recipe_obj.ingredients.items() if ing.hidden}
     if not hidden_ing_names:
-        return
+        pytest.skip(f"Recipe '{recipe_name}' has no hidden ingredients — not applicable")
 
     result = load_and_validate(recipe_name)
     recipe_content = result["content"]

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -1139,6 +1139,7 @@ def test_hidden_ingredient_uses_default_when_no_override(tmp_path: Path) -> None
 
     result = load_and_validate("test-hidden-interp", project_dir=tmp_path)
     assert "${{ inputs.kitchen_id }}" not in result["content"]
+    assert "skill_command: /autoskillit:run-diagnostic" in result["content"]
 
 
 def test_visible_ingredient_not_resolved_by_hidden_interpolation(tmp_path: Path) -> None:

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -995,3 +995,185 @@ def test_assert_content_integrity_allows_literal_skip_when_false() -> None:
     }
     resolutions = {"guarded": True}
     _assert_content_integrity(raw, resolutions, original_steps)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Hidden ingredient ${{ inputs.* }} interpolation tests
+# ---------------------------------------------------------------------------
+
+_RECIPE_HIDDEN_SKILL_COMMAND = """\
+name: test-hidden-interp
+description: Test hidden ingredient interpolation
+recipe_version: "0.0.1"
+kitchen_rules:
+  - no native tools
+ingredients:
+  kitchen_id:
+    description: Kitchen ID
+    default: ""
+    hidden: true
+steps:
+  run_diag:
+    tool: run_skill
+    with:
+      skill_command: /autoskillit:run-diagnostic ${{ inputs.kitchen_id }}
+      cwd: /tmp
+    on_success: done
+    on_failure: done
+  done:
+    action: stop
+    message: done
+"""
+
+
+def test_hidden_ingredient_in_skill_command_resolved_in_content(tmp_path: Path) -> None:
+    """load_and_validate resolves ${{ inputs.X }} in skill_command for hidden ingredients."""
+    from autoskillit.recipe import load_and_validate
+
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / "test-hidden-interp.yaml").write_text(_RECIPE_HIDDEN_SKILL_COMMAND)
+
+    result = load_and_validate(
+        "test-hidden-interp",
+        project_dir=tmp_path,
+        ingredient_overrides={"kitchen_id": "test-abc-123"},
+    )
+    assert "test-abc-123" in result["content"]
+    assert "${{ inputs.kitchen_id }}" not in result["content"]
+
+
+_RECIPE_HIDDEN_WITH_BLOCK = """\
+name: test-hidden-with
+description: Test hidden ingredient in with block
+recipe_version: "0.0.1"
+kitchen_rules:
+  - no native tools
+ingredients:
+  diagnostics_log_dir:
+    description: Log directory
+    default: ""
+    hidden: true
+steps:
+  consolidate:
+    tool: run_skill
+    with:
+      skill_command: /autoskillit:consolidate-health-reports
+      log_dir: ${{ inputs.diagnostics_log_dir }}
+      cwd: /tmp
+    on_success: done
+    on_failure: done
+  done:
+    action: stop
+    message: done
+"""
+
+
+def test_hidden_ingredient_in_with_block_resolved_in_content(tmp_path: Path) -> None:
+    """load_and_validate resolves ${{ inputs.X }} in with: block for hidden ingredients."""
+    from autoskillit.recipe import load_and_validate
+
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / "test-hidden-with.yaml").write_text(_RECIPE_HIDDEN_WITH_BLOCK)
+
+    result = load_and_validate(
+        "test-hidden-with",
+        project_dir=tmp_path,
+        ingredient_overrides={"diagnostics_log_dir": "/var/log/autoskillit"},
+    )
+    assert "/var/log/autoskillit" in result["content"]
+    assert "${{ inputs.diagnostics_log_dir }}" not in result["content"]
+
+
+_RECIPE_HIDDEN_DISPATCH_ID = """\
+name: test-dispatch-id
+description: Test dispatch_id hidden ingredient resolution
+recipe_version: "0.0.1"
+kitchen_rules:
+  - no native tools
+ingredients:
+  dispatch_id:
+    description: Dispatch ID
+    default: ""
+    hidden: true
+    authority: config
+steps:
+  run_diag:
+    tool: run_skill
+    with:
+      skill_command: /autoskillit:run-diagnostic ${{ inputs.dispatch_id }}
+      cwd: /tmp
+    on_success: done
+    on_failure: done
+  done:
+    action: stop
+    message: done
+"""
+
+
+def test_dispatch_id_hidden_ingredient_resolved_in_content(tmp_path: Path) -> None:
+    """load_and_validate resolves dispatch_id hidden ingredient via ingredient_overrides."""
+    from autoskillit.recipe import load_and_validate
+
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / "test-dispatch-id.yaml").write_text(_RECIPE_HIDDEN_DISPATCH_ID)
+
+    result = load_and_validate(
+        "test-dispatch-id",
+        project_dir=tmp_path,
+        ingredient_overrides={"dispatch_id": "d-999"},
+    )
+    assert "d-999" in result["content"]
+    assert "${{ inputs.dispatch_id }}" not in result["content"]
+
+
+def test_hidden_ingredient_uses_default_when_no_override(tmp_path: Path) -> None:
+    """load_and_validate uses ingredient default when no override is provided."""
+    from autoskillit.recipe import load_and_validate
+
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / "test-hidden-interp.yaml").write_text(_RECIPE_HIDDEN_SKILL_COMMAND)
+
+    result = load_and_validate("test-hidden-interp", project_dir=tmp_path)
+    assert "${{ inputs.kitchen_id }}" not in result["content"]
+
+
+def test_visible_ingredient_not_resolved_by_hidden_interpolation(tmp_path: Path) -> None:
+    """Visible ingredient ${{ inputs.X }} references are NOT resolved server-side."""
+    from autoskillit.recipe import load_and_validate
+
+    yaml_text = """\
+name: test-visible-interp
+description: Test visible ingredient stays as template
+recipe_version: "0.0.1"
+kitchen_rules:
+  - no native tools
+ingredients:
+  task:
+    description: The task
+    required: true
+steps:
+  do_work:
+    tool: run_skill
+    with:
+      skill_command: /autoskillit:implement ${{ inputs.task }}
+      cwd: /tmp
+    on_success: done
+    on_failure: done
+  done:
+    action: stop
+    message: done
+"""
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / "test-visible-interp.yaml").write_text(yaml_text)
+
+    result = load_and_validate(
+        "test-visible-interp",
+        project_dir=tmp_path,
+        ingredient_overrides={"task": "some task"},
+    )
+    assert "${{ inputs.task }}" in result["content"]

--- a/tests/recipe/test_recipe_temp_substitution.py
+++ b/tests/recipe/test_recipe_temp_substitution.py
@@ -191,3 +191,39 @@ def test_all_bundled_recipes_content_no_raw_placeholders(
         f"The following recipes have unsubstituted {{{{AUTOSKILLIT_TEMP}}}} in "
         f"result['content']: {offenders}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for hidden ingredient residual check in _assert_no_raw_placeholders
+# ---------------------------------------------------------------------------
+
+
+def test_assert_no_raw_placeholders_rejects_hidden_input_template() -> None:
+    """_assert_no_raw_placeholders raises ValueError for residual hidden ${{ inputs.X }}."""
+    from autoskillit.recipe.io import _assert_no_raw_placeholders
+
+    with pytest.raises(ValueError, match="kitchen_id"):
+        _assert_no_raw_placeholders(
+            "skill_command: /autoskillit:diag ${{ inputs.kitchen_id }}",
+            hidden_ingredient_names=frozenset({"kitchen_id"}),
+        )
+
+
+def test_assert_no_raw_placeholders_allows_visible_ingredient_template() -> None:
+    """_assert_no_raw_placeholders does NOT raise for visible ingredient ${{ inputs.X }}."""
+    from autoskillit.recipe.io import _assert_no_raw_placeholders
+
+    _assert_no_raw_placeholders(
+        "skill_command: /autoskillit:implement ${{ inputs.task }}",
+        hidden_ingredient_names=frozenset({"kitchen_id"}),
+    )
+
+
+def test_assert_no_raw_placeholders_no_hidden_names_passes() -> None:
+    """_assert_no_raw_placeholders skips hidden check when hidden_ingredient_names is None."""
+    from autoskillit.recipe.io import _assert_no_raw_placeholders
+
+    _assert_no_raw_placeholders(
+        "skill_command: /autoskillit:diag ${{ inputs.kitchen_id }}",
+        hidden_ingredient_names=None,
+    )

--- a/tests/recipe/test_rules_bypass.py
+++ b/tests/recipe/test_rules_bypass.py
@@ -244,3 +244,64 @@ def test_skip_when_false_on_required_no_default_no_warning() -> None:
     violations = run_semantic_rules(recipe)
     findings = [v for v in violations if v.rule == "skip-when-false-on-non-boolean"]
     assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# hidden-input-ref-in-template rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_input_ref_in_template_fires_warning() -> None:
+    """hidden-input-ref-in-template fires WARNING for hidden ${{ inputs.X }} templates."""
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={
+            "entry": RecipeStep(tool="run_cmd", on_success="run_diag"),
+            "run_diag": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": "/autoskillit:run-diagnostic ${{ inputs.kitchen_id }}",
+                    "cwd": "/tmp",
+                },
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+        ingredients={
+            "kitchen_id": RecipeIngredient(description="Kitchen ID", default="", hidden=True)
+        },
+        kitchen_rules=["test"],
+    )
+    violations = run_semantic_rules(recipe)
+    findings = [v for v in violations if v.rule == "hidden-input-ref-in-template"]
+    assert len(findings) >= 1
+    assert findings[0].severity == Severity.WARNING
+    assert "kitchen_id" in findings[0].message
+
+
+def test_hidden_input_ref_in_template_visible_ingredient_no_warning() -> None:
+    """hidden-input-ref-in-template does NOT fire for visible ingredient references."""
+    recipe = Recipe(
+        name="test",
+        description="test",
+        steps={
+            "entry": RecipeStep(tool="run_cmd", on_success="do_work"),
+            "do_work": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": "/autoskillit:implement ${{ inputs.task }}",
+                    "cwd": "/tmp",
+                },
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+        ingredients={"task": RecipeIngredient(description="Task to implement", required=True)},
+        kitchen_rules=["test"],
+    )
+    violations = run_semantic_rules(recipe)
+    findings = [v for v in violations if v.rule == "hidden-input-ref-in-template"]
+    assert findings == []


### PR DESCRIPTION
Recovers the implementation from PR #3215 (which merged empty due to an auto-commit revert).

## Changes
- Add `_resolve_hidden_inputs_in_content()` to `_recipe_composition.py` — resolves `${{ inputs.X }}` for hidden ingredients server-side before serving to the LLM
- Wire interpolation into `load_and_validate()` pipeline after skip pruning
- Extend `_assert_no_raw_placeholders()` with `hidden_ingredient_names` fail-safe guard
- Add `hidden-input-ref-in-template` semantic rule (WARNING) to `rules_bypass.py`
- Add tests: skill_command interpolation, with: block interpolation, dispatch_id resolution, bundled recipe regression, semantic rule, raw-placeholder guard
- Update recipe/CLAUDE.md, rules/CLAUDE.md, docs/recipes/authoring.md

Closes #3209

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 3.5k | 8.8k | 640.9k | 156.6k | 318 | 62.9k | 9m 17s |
| rectify | claude-sonnet-4-6 | 1 | 11.4k | 27.9k | 4.1M | 133.0k | 257 | 121.1k | 22m 16s |
| review_approach | claude-sonnet-4-6 | 1 | 9.1k | 8.0k | 200.1k | 71.0k | 129 | 43.1k | 7m 46s |
| dry_walkthrough | claude-opus-4-6 | 1 | 1.1k | 13.3k | 1.6M | 73.5k | 165 | 57.2k | 9m 17s |
| implement | claude-sonnet-4-6 | 1 | 690 | 47.9k | 9.9M | 173.1k | 230 | 157.6k | 15m 9s |
| audit_impl | claude-sonnet-4-6 | 1 | 70 | 13.6k | 248.7k | 47.2k | 45 | 39.9k | 7m 22s |
| prepare_pr* | MiniMax-M2.7-highspeed | 1 | 66.4k | 1.4k | 154.4k | 30.9k | 14 | 43.6k | 42s |
| compose_pr* | MiniMax-M2.7-highspeed | 1 | 283.5k | 4.6k | 676.3k | 30.9k | 45 | 15.5k | 1m 58s |
| review_pr | claude-sonnet-4-6 | 6 | 1.1k | 165.4k | 7.1M | 145.1k | 437 | 499.7k | 44m 39s |
| post_run_diagnostics | claude-sonnet-4-6 | 1 | 62 | 9.6k | 184.0k | 70.4k | 179 | 32.3k | 7m 26s |
| resolve_review | claude-sonnet-4-6 | 3 | 841 | 55.6k | 6.3M | 83.8k | 251 | 209.5k | 37m 59s |
| **Total** | | | 377.7k | 356.2k | 31.0M | 173.1k | | 1.3M | 2h 43m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| post_run_diagnostics | 0 | — | — | — |
| resolve_review | 17 | 372632.0 | 12325.4 | 3268.8 |
| **Total** | **17** | 1825826.4 | 75436.0 | 20950.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 8 | 26.8k | 336.9k | 28.6M | 1.2M | 2h 31m |
| claude-opus-4-6 | 1 | 1.1k | 13.3k | 1.6M | 57.2k | 9m 17s |
| MiniMax-M2.7-highspeed | 2 | 349.9k | 6.0k | 830.7k | 59.1k | 2m 40s |