### PR TITLE
Rectify: Headless PTY Allocation Immunity — Dispatch-Context-Aware Process Configuration

### DIFF
--- a/src/autoskillit/_llm_triage.py
+++ b/src/autoskillit/_llm_triage.py
@@ -139,7 +139,7 @@ async def _triage_batch(
             cwd=Path.cwd(),
             timeout=30.0,
             env=_triage_env,
-            pty_mode=True,
+            pty_mode=False,
         )
         if result.termination == TerminationReason.TIMED_OUT:
             raise TimeoutError("triage_staleness batch timed out")

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -435,6 +435,7 @@ class DefaultHeadlessExecutor:
             prior_completion_markers=prior_completion_markers,
             on_spawn=on_spawn,
             skip_clone_guard=True,
+            pty_override=False,
             provider_name=provider_name,
             provider_fallback_env=provider_fallback_env,
             provider_fallback_name=provider_fallback_name,

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -222,9 +222,7 @@ async def _execute_claude_headless(
                 pty_mode=(
                     pty_override if pty_override is not None else _resolve_pty_mode(_step_backend)
                 ),
-                session_log_dir=_resolve_session_log_dir(
-                    cwd, cast(CodingAgentBackend, ctx.backend)
-                ),
+                session_log_dir=_resolve_session_log_dir(cwd, _step_backend),
                 completion_marker=completion_marker,
                 stale_threshold=stale_threshold,
                 completion_drain_timeout=cfg.completion_drain_timeout,

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -92,6 +92,7 @@ async def _execute_claude_headless(
     recipe_version: str = "",
     on_spawn: Callable[[int, int], None] | None = None,
     skip_clone_guard: bool = False,
+    pty_override: bool | None = None,
     readonly_skill: bool = False,
     write_watch_dirs: Sequence[Path] = (),
     provider_name: str = "",
@@ -218,7 +219,9 @@ async def _execute_claude_headless(
                 cwd=Path(cwd),
                 timeout=timeout,
                 env=spec.env,
-                pty_mode=_resolve_pty_mode(cast(CodingAgentBackend, ctx.backend)),
+                pty_mode=(
+                    pty_override if pty_override is not None else _resolve_pty_mode(_step_backend)
+                ),
                 session_log_dir=_resolve_session_log_dir(
                     cwd, cast(CodingAgentBackend, ctx.backend)
                 ),
@@ -394,6 +397,7 @@ async def _execute_claude_headless(
                 result_parser=_step_backend.result_parser(),
                 provider_extras=provider_extras,
                 retry_reason=skill_result.retry_reason,
+                pty_override=pty_override,
             )
             if nudge_success is not None:
                 skill_result = nudge_success

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -216,6 +216,7 @@ async def _attempt_contract_nudge(
     result_parser: ResultParser | None = None,
     provider_extras: Mapping[str, str] | None = None,
     retry_reason: RetryReason = RetryReason.CONTRACT_RECOVERY,
+    pty_override: bool | None = None,
 ) -> SkillResult | None:
     """Attempt a lightweight resume nudge to recover missing structured output tokens.
 
@@ -273,7 +274,7 @@ async def _attempt_contract_nudge(
             cwd=Path(cwd),
             timeout=_NUDGE_TIMEOUT,
             env=spec.env,
-            pty_mode=_resolve_pty_mode(backend),
+            pty_mode=(pty_override if pty_override is not None else _resolve_pty_mode(backend)),
         )
     except OSError:
         logger.debug("nudge_runner_failed", exc_info=True)

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -533,6 +533,9 @@ async def _run_dispatch(
 
     started_at = time.time()
     _dispatched_pid: list[int] = []
+    _dispatched_ticks: list[int] = []
+    _dispatched_create_time: list[float] = []
+    _dispatched_boot_id: list[str] = []
 
     # Collect prior dispatch_ids from attempt_history for defense-in-depth parsing
     prior_ids: list[str] = []
@@ -557,11 +560,17 @@ async def _run_dispatch(
     )
 
     def _on_spawn(pid: int, ticks: int) -> None:
+        from autoskillit.core import read_boot_id
+
         _dispatched_pid.append(pid)
         try:
             create_time = psutil.Process(pid).create_time()
         except psutil.NoSuchProcess:
             create_time = 0.0
+        boot_id = read_boot_id() or ""
+        _dispatched_ticks.append(ticks)
+        _dispatched_create_time.append(create_time)
+        _dispatched_boot_id.append(boot_id)
         _write_pid(
             state_path,
             effective_name,
@@ -762,6 +771,9 @@ async def _run_dispatch(
         session_chain=extended_chain,
         dispatched_session_log_dir=project_log_dir,
         dispatched_pid=_dispatched_pid[0] if _dispatched_pid else 0,
+        dispatched_starttime_ticks=_dispatched_ticks[0] if _dispatched_ticks else 0,
+        dispatched_boot_id=_dispatched_boot_id[0] if _dispatched_boot_id else "",
+        dispatched_create_time=_dispatched_create_time[0] if _dispatched_create_time else 0.0,
         reason=reason,
         kill_reason=skill_result.retry_reason or "",
         infra_exit_category=skill_result.infra.exit_category or "",

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -49,6 +49,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_no_inline_jsonl_request_id_dedup.py` | AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py |
 | `test_protocol_names.py` | T5-T6: Protocol naming and DefaultSkillResolver export smoke tests |
 | `test_provider_profile_contract.py` | Tier 3 contract: _resolve_provider_profile must never return step_name as profile |
+| `test_pty_coherence.py` | Dispatch-type-aware PTY allocation guards: AST enforcement that dispatch_food_truck passes pty_override=False and _attempt_contract_nudge accepts pty_override |
 | `test_python_no_hardcoded_temp.py` | Architectural invariant: no literal `.autoskillit/temp` outside the whitelist |
 | `test_recipe_rule_registration.py` | REQ-RECIPE-001: every recipe/rules_*.py file must be imported by recipe/__init__.py |
 | `test_regex_guards.py` | Arch guard: keyword regexes in cmd-scanning rules must use path-safe lookbehind guards |

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -19,7 +19,7 @@ HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 460,
     "headless/_headless_helpers.py": 175,
     "headless/_headless_execute.py": 562,
-    "headless/_headless_recovery.py": 365,
+    "headless/_headless_recovery.py": 366,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,
 }

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -18,7 +18,7 @@ NEW_HEADLESS_MODULES = [
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 460,
     "headless/_headless_helpers.py": 175,
-    "headless/_headless_execute.py": 560,
+    "headless/_headless_execute.py": 562,
     "headless/_headless_recovery.py": 365,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,

--- a/tests/arch/test_pty_coherence.py
+++ b/tests/arch/test_pty_coherence.py
@@ -105,7 +105,7 @@ class TestBoundaryPtyDispatchPaths:
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(
-            "You are an L3 orchestrator",
+            "You are a fleet orchestrator",
             str(tmp_path),
             completion_marker="%%FT_DONE%%",
         )

--- a/tests/arch/test_pty_coherence.py
+++ b/tests/arch/test_pty_coherence.py
@@ -1,0 +1,165 @@
+"""Architectural guards for dispatch-type-aware PTY allocation."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.execution.conftest import _mock_backend
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def _find_function(tree: ast.AST, func_name: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            return node
+    return None
+
+
+def _find_call(func_node: ast.AST, callee_name: str) -> ast.Call | None:
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == callee_name:
+                return node
+            if isinstance(node.func, ast.Attribute) and node.func.attr == callee_name:
+                return node
+    return None
+
+
+class TestDispatchFoodTruckPtyOverrideGuard:
+    def test_dispatch_food_truck_passes_pty_override_false(self) -> None:
+        """dispatch_food_truck must call _execute_claude_headless with pty_override=False."""
+        src = Path(__file__).parents[2] / "src/autoskillit/execution/headless/__init__.py"
+        tree = ast.parse(src.read_text())
+
+        dispatch_func = _find_function(tree, "dispatch_food_truck")
+        assert dispatch_func is not None, "dispatch_food_truck not found"
+
+        call = _find_call(dispatch_func, "_execute_claude_headless")
+        assert call is not None, "_execute_claude_headless call not found in dispatch_food_truck"
+
+        kw_names_values = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
+        assert "pty_override" in kw_names_values, (
+            "dispatch_food_truck must pass pty_override= to _execute_claude_headless. "
+            "Removing this guard causes food truck dispatches to use PTY (SIGTERM exit 143)."
+        )
+        val = kw_names_values["pty_override"]
+        assert isinstance(val, ast.Constant) and val.value is False, (
+            f"dispatch_food_truck must pass pty_override=False, got {ast.unparse(val)!r}"
+        )
+
+
+class TestAttemptContractNudgePtyOverrideGuard:
+    def test_attempt_contract_nudge_accepts_pty_override(self) -> None:
+        """_attempt_contract_nudge must have pty_override in its parameter list."""
+        src = (
+            Path(__file__).parents[2] / "src/autoskillit/execution/headless/_headless_recovery.py"
+        )
+        tree = ast.parse(src.read_text())
+
+        func = _find_function(tree, "_attempt_contract_nudge")
+        assert func is not None, "_attempt_contract_nudge not found"
+
+        param_names = [arg.arg for arg in func.args.kwonlyargs]
+        assert "pty_override" in param_names, (
+            "_attempt_contract_nudge must accept pty_override= parameter. "
+            "Without it, nudge paths in food truck dispatches reintroduce PTY allocation."
+        )
+
+
+class TestBoundaryPtyDispatchPaths:
+    @pytest.mark.anyio
+    async def test_food_truck_dispatch_uses_pty_false(self, minimal_ctx, tmp_path: Path) -> None:
+        """dispatch_food_truck passes pty_mode=False to the subprocess runner."""
+        from autoskillit.core.types import SubprocessResult, TerminationReason
+        from autoskillit.core.types._type_plugin_source import DirectInstall
+        from autoskillit.execution.backends.claude import ClaudeCodeBackend
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+        from tests.fakes import MockSubprocessRunner
+
+        runner = MockSubprocessRunner()
+        runner.set_default(
+            SubprocessResult(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "result": "done %%FT_DONE%%",
+                        "session_id": "ft-session",
+                        "is_error": False,
+                    }
+                ),
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=55555,
+            )
+        )
+        minimal_ctx.runner = runner
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        minimal_ctx.backend = ClaudeCodeBackend()
+
+        executor = DefaultHeadlessExecutor(minimal_ctx)
+        await executor.dispatch_food_truck(
+            "You are an L3 orchestrator",
+            str(tmp_path),
+            completion_marker="%%FT_DONE%%",
+        )
+
+        assert runner.last_pty_mode is False, (
+            f"Food truck dispatch must use pty_mode=False (Claude Code has TUI mode), "
+            f"got {runner.last_pty_mode!r}"
+        )
+
+    @pytest.mark.anyio
+    async def test_run_headless_core_claude_code_uses_pty_true(
+        self, minimal_ctx, tmp_path: Path
+    ) -> None:
+        """run_headless_core with Claude Code backend (no override) uses pty_mode=True."""
+        import json
+
+        from autoskillit.core import CmdSpec
+        from autoskillit.core.types import SubprocessResult, TerminationReason
+        from autoskillit.execution.headless._headless_execute import _execute_claude_headless
+        from tests.fakes import MockSubprocessRunner
+
+        runner = MockSubprocessRunner()
+        runner.set_default(
+            SubprocessResult(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "result": "done",
+                        "session_id": "s1",
+                        "is_error": False,
+                    }
+                ),
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=1,
+            )
+        )
+        minimal_ctx.runner = runner
+        backend = _mock_backend(pty_required=True)
+        minimal_ctx.backend = backend
+
+        spec = CmdSpec(cmd=("claude", "--print", "do something"), env={})
+        await _execute_claude_headless(
+            spec,
+            cwd=str(tmp_path),
+            ctx=minimal_ctx,
+            timeout=10.0,
+            stale_threshold=60.0,
+            step_backend=backend,
+        )
+
+        assert runner.last_pty_mode is True, (
+            f"run_headless_core with Claude Code backend (pty_required=True) must use "
+            f"pty_mode=True, got {runner.last_pty_mode!r}"
+        )

--- a/tests/execution/headless/test_headless_recovery.py
+++ b/tests/execution/headless/test_headless_recovery.py
@@ -85,3 +85,71 @@ class TestNudgePtyMode:
             f"Expected last_pty_mode=True for ClaudeCode backend (pty_required=True), "
             f"got {mock_runner.last_pty_mode!r}"
         )
+
+    @pytest.mark.anyio
+    async def test_nudge_respects_pty_override_false(self, tmp_path: Path) -> None:
+        """_attempt_contract_nudge with pty_override=False uses pty_mode=False."""
+        from autoskillit.execution.headless._headless_recovery import _attempt_contract_nudge
+        from tests.execution.conftest import _mock_backend
+        from tests.fakes import MockSubprocessRunner
+
+        marker = "%%NUDGE_DONE%%"
+
+        mock_runner = MockSubprocessRunner()
+        mock_runner.set_default(
+            SubprocessResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=0,
+            )
+        )
+
+        backend = _mock_backend(pty_required=True, session_resume_capable=True)
+
+        result_parser = Mock()
+        parsed_session = Mock()
+        parsed_session.output = marker
+        parsed_session.raw = {}
+        result_parser.parse_stdout.return_value = parsed_session
+
+        skill_result = SkillResult(
+            success=False,
+            result="",
+            session_id="test-session",
+            subtype="empty_output",
+            is_error=False,
+            exit_code=0,
+            needs_retry=True,
+            retry_reason=RetryReason.CONTRACT_RECOVERY,
+            stderr="",
+            kill_reason=KillReason.NATURAL_EXIT,
+            evidence=WriteEvidence.none_observed(),
+        )
+
+        subprocess_result = SubprocessResult(
+            returncode=0,
+            stdout="",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=0,
+        )
+
+        await _attempt_contract_nudge(
+            skill_result=skill_result,
+            subprocess_result=subprocess_result,
+            expected_output_patterns=[],
+            completion_marker=marker,
+            cwd=str(tmp_path),
+            runner=mock_runner,
+            backend=backend,
+            result_parser=result_parser,
+            retry_reason=RetryReason.EARLY_STOP,
+            pty_override=False,
+        )
+
+        assert mock_runner.last_pty_mode is False, (
+            f"Expected last_pty_mode=False when pty_override=False, "
+            f"got {mock_runner.last_pty_mode!r}"
+        )

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -60,7 +60,7 @@ class TestStepBackendPtyOverride:
     ) -> None:
         """_execute_claude_headless uses _step_backend.pty_required, not ctx.backend."""
         import json
-        from unittest.mock import patch
+        from unittest.mock import Mock, patch
 
         from autoskillit.core import CmdSpec
         from autoskillit.core.types import SubprocessResult, TerminationReason
@@ -90,6 +90,11 @@ class TestStepBackendPtyOverride:
 
         codex_step = _mock_backend(pty_required=False, channel_b_capable=False)
         codex_step.name = "codex"
+        _mock_parsed = Mock()
+        _mock_parsed.raw = {}
+        _mock_parser = Mock()
+        _mock_parser.parse_stdout.return_value = _mock_parsed
+        codex_step.result_parser.return_value = _mock_parser
 
         spec = CmdSpec(cmd=("codex", "--print", "do something"), env={})
         with patch("autoskillit.execution.headless._headless_execute.assert_headless_cmd"):

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -50,7 +50,6 @@ class TestResolveSessionLogDir:
         minimal_ctx.backend = _mock_backend(channel_b_capable=False)
         result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx.backend)
         assert result is None
-        assert result is None
 
 
 class TestStepBackendPtyOverride:

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -91,7 +91,11 @@ class TestStepBackendPtyOverride:
         codex_step = _mock_backend(pty_required=False, channel_b_capable=False)
         codex_step.name = "codex"
         _mock_parsed = Mock()
-        _mock_parsed.raw = {}
+        _mock_parsed.raw = {"subtype": "success"}
+        _mock_parsed.error = None
+        _mock_parsed.session_id = "s1"
+        _mock_parsed.success = True
+        _mock_parsed.output = "done"
         _mock_parser = Mock()
         _mock_parser.parse_stdout.return_value = _mock_parsed
         codex_step.result_parser.return_value = _mock_parser

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -50,3 +50,59 @@ class TestResolveSessionLogDir:
         minimal_ctx.backend = _mock_backend(channel_b_capable=False)
         result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx.backend)
         assert result is None
+        assert result is None
+
+
+class TestStepBackendPtyOverride:
+    @pytest.mark.anyio
+    async def test_execute_claude_headless_uses_step_backend_pty_mode(
+        self, minimal_ctx, tmp_path: Path
+    ) -> None:
+        """_execute_claude_headless uses _step_backend.pty_required, not ctx.backend."""
+        import json
+        from unittest.mock import patch
+
+        from autoskillit.core import CmdSpec
+        from autoskillit.core.types import SubprocessResult, TerminationReason
+        from autoskillit.execution.headless._headless_execute import _execute_claude_headless
+        from tests.fakes import MockSubprocessRunner
+
+        runner = MockSubprocessRunner()
+        runner.set_default(
+            SubprocessResult(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "result": "done",
+                        "session_id": "s1",
+                        "is_error": False,
+                    }
+                ),
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=1,
+            )
+        )
+        minimal_ctx.runner = runner
+        minimal_ctx.backend = _mock_backend(pty_required=True)
+
+        codex_step = _mock_backend(pty_required=False, channel_b_capable=False)
+        codex_step.name = "codex"
+
+        spec = CmdSpec(cmd=("codex", "--print", "do something"), env={})
+        with patch("autoskillit.execution.headless._headless_execute.assert_headless_cmd"):
+            await _execute_claude_headless(
+                spec,
+                cwd=str(tmp_path),
+                ctx=minimal_ctx,
+                timeout=10.0,
+                stale_threshold=60.0,
+                step_backend=codex_step,
+            )
+
+        assert runner.last_pty_mode is False, (
+            f"step_backend has pty_required=False; expected pty_mode=False, "
+            f"got {runner.last_pty_mode!r}"
+        )

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -61,7 +61,7 @@ class TestDispatchFoodTruck:
         assert env["AUTOSKILLIT_HEADLESS"] == "1"
         assert env["TERM"] == "dumb"
         assert env["NO_COLOR"] == "1"
-        assert runner.last_pty_mode is True
+        assert runner.last_pty_mode is False
         assert "--tools" in cmd
         assert "AskUserQuestion" in cmd
 

--- a/tests/fleet/test_dispatch_state_handle.py
+++ b/tests/fleet/test_dispatch_state_handle.py
@@ -432,3 +432,151 @@ class TestDispatchedSessionLogDirPopulated:
         assert len(state.dispatches) == 1
         disp = state.dispatches[0]
         assert disp.dispatched_session_log_dir != ""
+
+
+class TestProcessIdentityPreservation:
+    @pytest.mark.anyio
+    async def test_final_dispatch_record_carries_identity_from_on_spawn(
+        self, tool_ctx, monkeypatch, tmp_path
+    ):
+        """Final DispatchRecord carries starttime_ticks/boot_id/create_time from _on_spawn."""
+        from collections.abc import Callable
+
+        from autoskillit.core import RetryReason, SkillResult
+        from autoskillit.fleet import FleetSemaphore
+        from autoskillit.fleet._api import _run_dispatch
+        from autoskillit.fleet.state import read_state
+        from autoskillit.fleet.state_types import DispatchRejected
+        from autoskillit.recipe.schema import Recipe, RecipeKind
+        from tests.fleet._helpers import (
+            _make_recipe_info,
+            _no_sleep_quota_checker,
+            _noop_quota_refresher,
+        )
+
+        _KNOWN_TICKS = 42
+        _KNOWN_CREATE_TIME = 1716900000.0
+        _KNOWN_BOOT_ID = "abc123-test-boot"
+        _KNOWN_PID = 99999
+
+        class _SpawnCallingExecutor:
+            """Executor fake that calls on_spawn with known values."""
+
+            async def run(self, *a, **kw) -> SkillResult:
+                return SkillResult(
+                    success=True,
+                    result="ok",
+                    session_id="s1",
+                    subtype="success",
+                    is_error=False,
+                    exit_code=0,
+                    needs_retry=False,
+                    retry_reason=RetryReason.NONE,
+                    stderr="",
+                )
+
+            async def dispatch_food_truck(
+                self,
+                orchestrator_prompt: str,
+                cwd: str,
+                *,
+                completion_marker: str,
+                on_spawn: Callable[[int, int], None] | None = None,
+                **kwargs,
+            ) -> SkillResult:
+                if on_spawn is not None:
+                    on_spawn(_KNOWN_PID, _KNOWN_TICKS)
+                return SkillResult(
+                    success=True,
+                    result="ok",
+                    session_id="s1",
+                    subtype="success",
+                    is_error=False,
+                    exit_code=0,
+                    needs_retry=False,
+                    retry_reason=RetryReason.NONE,
+                    stderr="",
+                )
+
+        tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
+        recipe_name = "id-test-recipe"
+        from tests.fakes import InMemoryRecipeRepository
+
+        repo = InMemoryRecipeRepository()
+        recipe_info = _make_recipe_info(recipe_name)
+        repo.add_recipe(recipe_name, recipe_info)
+        repo.add_full_recipe(
+            recipe_info.path,
+            Recipe(
+                name=recipe_name,
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={},
+                requires_packs=[],
+            ),
+        )
+        tool_ctx.recipes = repo
+        tool_ctx.executor = _SpawnCallingExecutor()
+
+        dispatches_dir = tool_ctx.temp_dir / "dispatches"
+        dispatches_dir.mkdir(parents=True, exist_ok=True)
+
+        from autoskillit.fleet.result_parser import L3ParseResult
+
+        def _fake_parse(*args, **kwargs):
+            return L3ParseResult(
+                outcome="completed_clean",
+                payload={"success": True},
+                raw_body=None,
+                parse_error=None,
+                source="stdout",
+            )
+
+        def _fake_classify(*args, **kwargs):
+            from autoskillit.fleet.state import DispatchStatus
+
+            return (DispatchStatus.SUCCESS, None)
+
+        monkeypatch.setattr("autoskillit.fleet._api.parse_l3_result_block", _fake_parse)
+        monkeypatch.setattr("autoskillit.fleet.classify_dispatch_outcome", _fake_classify)
+
+        monkeypatch.setattr(
+            "psutil.Process",
+            lambda pid: type("P", (), {"create_time": lambda self: _KNOWN_CREATE_TIME})(),
+        )
+        monkeypatch.setattr(
+            "autoskillit.core.read_boot_id",
+            lambda: _KNOWN_BOOT_ID,
+        )
+
+        result = await _run_dispatch(
+            tool_ctx=tool_ctx,
+            recipe=recipe_name,
+            task="do something",
+            ingredients=None,
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=lambda **_: "prompt",
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+
+        assert not isinstance(result.outcome, DispatchRejected), (
+            f"Expected successful dispatch, got: {result.outcome}"
+        )
+
+        state_files = list(dispatches_dir.glob("*.json"))
+        assert len(state_files) == 1
+        state = read_state(state_files[0])
+        assert state is not None
+        disp = state.dispatches[0]
+
+        assert disp.dispatched_starttime_ticks == _KNOWN_TICKS, (
+            f"Expected starttime_ticks={_KNOWN_TICKS}, got {disp.dispatched_starttime_ticks}"
+        )
+        assert disp.dispatched_boot_id == _KNOWN_BOOT_ID, (
+            f"Expected boot_id={_KNOWN_BOOT_ID!r}, got {disp.dispatched_boot_id!r}"
+        )
+        assert abs(disp.dispatched_create_time - _KNOWN_CREATE_TIME) < 1.0, (
+            f"Expected create_time≈{_KNOWN_CREATE_TIME}, got {disp.dispatched_create_time}"
+        )

--- a/tests/test_llm_triage.py
+++ b/tests/test_llm_triage.py
@@ -604,3 +604,57 @@ async def test_triage_command_uses_backend_binary_name(
     assert cmd[0] == expected_binary, (
         f"triage_cmd[0] must equal get_backend().binary_name(), got {cmd[0]!r}"
     )
+
+
+@pytest.mark.anyio
+async def test_triage_staleness_does_not_use_pty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """triage_staleness calls run_managed_async with pty_mode=False."""
+    from unittest.mock import AsyncMock
+
+    from autoskillit._llm_triage import triage_staleness
+    from autoskillit.core.types import SubprocessResult, TerminationReason
+    from autoskillit.recipe.contracts import StaleItem
+
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# test skill")
+    monkeypatch.setattr("autoskillit._llm_triage.bundled_skills_dir", lambda: tmp_path)
+
+    ndjson = (
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": json.dumps(
+                    [
+                        {
+                            "index": 1,
+                            "skill": "test-skill",
+                            "meaningful_change": False,
+                            "summary": "ok",
+                        }
+                    ]
+                ),
+                "session_id": "s1",
+            }
+        )
+        + "\n"
+    )
+    mock_run = AsyncMock(
+        return_value=SubprocessResult(0, ndjson, "", TerminationReason.NATURAL_EXIT, pid=1)
+    )
+    monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
+
+    item = StaleItem(
+        skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
+    )
+    await triage_staleness([item], agent_backend="claude-code")
+
+    assert mock_run.called
+    pty_mode = mock_run.call_args.kwargs.get("pty_mode")
+    assert pty_mode is False, (
+        f"triage_staleness must call run_managed_async with pty_mode=False, got {pty_mode!r}"
+    )


### PR DESCRIPTION
## Summary

Food truck dispatches fail (exit 143 / SIGTERM) because `_resolve_pty_mode()` unconditionally returns `True` for the Claude Code backend, wrapping every headless subprocess in `script(1)`. This allocates a real PTY where `process.stdout.isTTY=true`, activating Claude Code's React Ink TUI despite the `-p` (headless) flag. The TUI then receives SIGTERM and exits with code 143.

The fix adds a `pty_override` parameter to `_execute_claude_headless` and threads it through `_attempt_contract_nudge`, following the same pattern as `skip_clone_guard`. Food truck dispatches pass `pty_override=False`, disabling PTY allocation for headless sessions while preserving interactive session functionality.

The secondary fix preserves process-identity fields (`dispatched_starttime_ticks`, `dispatched_boot_id`, `dispatched_create_time`) through the final `DispatchRecord` construction, preventing identity fields from being overwritten with default zeros.

## Requirements

Food truck dispatch sessions consistently fail with `fleet_l3_no_result_block`. Sessions receive SIGTERM (exit 143) at varying times before producing the L3 result sentinel. The root cause is unconditional PTY allocation via `script(1)` for food truck sessions, causing Claude Code to activate its React Ink TUI despite the `-p` (headless) flag.

Primary fix: Disable PTY for food truck dispatches via `pty_override=False` parameter threaded through `_execute_claude_headless` and `_attempt_contract_nudge`.

Secondary fix: Carry process-identity fields through post-dispatch state write to prevent `identity_confirmed=False`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-173130-060925/.autoskillit/temp/rectify/rectify_headless_pty_allocation_immunity_2026-05-28_173600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 97 | 25.4k | 2.4M | 141.8k | 293 | 108.7k | 21m 48s |
| review_approach* | sonnet | 1 | 1.9k | 6.7k | 185.3k | 43.7k | 42 | 33.1k | 3m 12s |
| dry_walkthrough* | opus | 1 | 49 | 12.0k | 618.4k | 62.9k | 134 | 48.7k | 7m 9s |
| implement* | sonnet | 1 | 428 | 33.7k | 5.9M | 151.2k | 151 | 250.5k | 12m 9s |
| audit_impl* | sonnet | 1 | 60 | 6.2k | 218.5k | 39.8k | 19 | 33.1k | 1m 45s |
| prepare_pr* | sonnet | 1 | 221.0k | 5.4k | 401.6k | 30.9k | 31 | 43.6k | 1m 59s |
| compose_pr* | sonnet | 1 | 48.4k | 1.5k | 213.4k | 30.9k | 14 | 15.5k | 45s |
| review_pr* | sonnet | 1 | 486 | 33.6k | 1.1M | 96.8k | 76 | 81.7k | 7m 53s |
| resolve_review* | sonnet | 1 | 279 | 21.2k | 1.9M | 75.0k | 88 | 60.1k | 9m 41s |
| **Total** | | | 272.7k | 145.8k | 12.9M | 151.2k | | 675.1k | 1h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 518 | 11430.6 | 483.6 | 65.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 374810.8 | 12029.2 | 4249.6 |
| **Total** | **523** | 24754.7 | 1290.9 | 278.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 97 | 25.4k | 2.4M | 108.7k | 21m 48s |
| sonnet | 7 | 272.6k | 108.3k | 9.9M | 517.7k | 37m 26s |
| opus | 1 | 49 | 12.0k | 618.4k | 48.7k | 7m 9s |