### PR TITLE
[FIX] Fix Session Skill Directory Cleanup — /dev/shm Leak

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -95,7 +95,7 @@ def _post_dispatch_cleanup(
     cache_invalidator: Callable[[str], None] | None,
     quota_refresher: Callable[..., Any],
 ) -> None:
-    """Run quota cache invalidation, background quota refresh, and session skill cleanup."""
+    """Run quota cache invalidation and background quota refresh."""
     if cache_invalidator is not None:
         cache_invalidator(tool_ctx.config.quota_guard.cache_path)
 
@@ -104,17 +104,6 @@ def _post_dispatch_cleanup(
             quota_refresher(tool_ctx.config.quota_guard),
             label="quota_post_dispatch_refresh",
         )
-
-    if tool_ctx.session_skill_manager is not None and skill_result.session_id:
-        try:
-            tool_ctx.session_skill_manager.cleanup_session(skill_result.session_id)
-        except Exception as exc:
-            logger.warning(
-                "session skills cleanup failed — dispatch not affected",
-                session_id=skill_result.session_id,
-                exc_class=type(exc).__name__,
-                exc_info=True,
-            )
 
 
 async def _touch_dispatch_marker(

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -148,6 +148,34 @@ async def _run_deferred_init(ready_event: _asyncio.Event) -> None:
         ready_event.set()
 
 
+_CLEANUP_STALE_MAX_AGE = 86400
+
+
+async def _cleanup_stale_loop(interval: float = 1800.0) -> None:
+    """Periodically sweep stale session skill directories (defense-in-depth).
+
+    Runs for the server lifetime. Sleep-first: deferred_initialize already
+    ran cleanup_stale at startup. CancelledError from sleep propagates
+    uncaught, terminating the loop cleanly.
+    """
+    loop = _asyncio.get_running_loop()
+    while True:
+        await _asyncio.sleep(interval)
+        ctx = _get_ctx_or_none()
+        if ctx is not None and ctx.session_skill_manager is not None:
+            try:
+                removed = await loop.run_in_executor(
+                    None,
+                    lambda: ctx.session_skill_manager.cleanup_stale(  # type: ignore[union-attr]
+                        max_age_seconds=_CLEANUP_STALE_MAX_AGE
+                    ),
+                )
+                if removed:
+                    logger.info("cleanup_stale_sweep", removed=removed)
+            except Exception:
+                logger.warning("cleanup_stale_loop_error", exc_info=True)
+
+
 async def _fleet_auto_gate_boot(ctx: Any) -> None:
     """Auto-open the kitchen gate and prime quota/registry state for fleet sessions.
 
@@ -474,6 +502,7 @@ async def _autoskillit_lifespan(server: Any) -> Any:
             create_background_task(_run_hook_health_check_async(), label="hook_health")
         )
         bg_tasks.append(create_background_task(_run_deferred_init(event), label="deferred_init"))
+        bg_tasks.append(create_background_task(_cleanup_stale_loop(), label="cleanup_stale"))
         _boot_ctx = _get_ctx_or_none()
 
         if _boot_ctx is not None:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -581,78 +581,75 @@ async def run_skill(
 
             _start = time.monotonic()
             try:
-                try:
-                    skill_result = await tool_ctx.executor.run(
-                        resolved_command,
-                        cwd,
-                        model=effective_model,
-                        add_dirs=skill_add_dirs,
-                        step_name=step_name,
-                        kitchen_id=tool_ctx.kitchen_id,
-                        order_id=effective_order_id,
-                        expected_output_patterns=expected_output_patterns,
-                        write_behavior=write_spec,
-                        stale_threshold=float(stale_threshold)
-                        if stale_threshold is not None
-                        else None,
-                        idle_output_timeout=float(idle_output_timeout)
-                        if idle_output_timeout is not None
-                        else None,
-                        completion_marker=invocation_marker,
-                        recipe_name=tool_ctx.recipe_name,
-                        recipe_content_hash=tool_ctx.recipe_content_hash,
-                        recipe_composite_hash=tool_ctx.recipe_composite_hash,
-                        recipe_version=tool_ctx.recipe_version,
-                        allowed_write_prefix=allowed_write_prefix,
-                        allowed_write_prefixes=allowed_write_prefixes,
-                        readonly_skill=is_read_only,
-                        write_watch_dirs=write_watch_dirs,
-                        provider_extras=provider_extras,
-                        profile_name=profile_name_out,
-                        backend_override=backend_override,
-                        resume_session_id=resume_session_id,
+                skill_result = await tool_ctx.executor.run(
+                    resolved_command,
+                    cwd,
+                    model=effective_model,
+                    add_dirs=skill_add_dirs,
+                    step_name=step_name,
+                    kitchen_id=tool_ctx.kitchen_id,
+                    order_id=effective_order_id,
+                    expected_output_patterns=expected_output_patterns,
+                    write_behavior=write_spec,
+                    stale_threshold=float(stale_threshold)
+                    if stale_threshold is not None
+                    else None,
+                    idle_output_timeout=float(idle_output_timeout)
+                    if idle_output_timeout is not None
+                    else None,
+                    completion_marker=invocation_marker,
+                    recipe_name=tool_ctx.recipe_name,
+                    recipe_content_hash=tool_ctx.recipe_content_hash,
+                    recipe_composite_hash=tool_ctx.recipe_composite_hash,
+                    recipe_version=tool_ctx.recipe_version,
+                    allowed_write_prefix=allowed_write_prefix,
+                    allowed_write_prefixes=allowed_write_prefixes,
+                    readonly_skill=is_read_only,
+                    write_watch_dirs=write_watch_dirs,
+                    provider_extras=provider_extras,
+                    profile_name=profile_name_out,
+                    backend_override=backend_override,
+                    resume_session_id=resume_session_id,
+                )
+                if skill_result.success:
+                    tool_ctx.audit.record_success(skill_command)
+                    _clear_run_skill_state(tool_ctx.project_dir)
+                else:
+                    await _notify(
+                        ctx,
+                        "error",
+                        "run_skill failed",
+                        "autoskillit.run_skill",
+                        extra={
+                            "exit_code": skill_result.exit_code,
+                            "subtype": skill_result.subtype,
+                        },
                     )
-                    if skill_result.success:
-                        tool_ctx.audit.record_success(skill_command)
-                        _clear_run_skill_state(tool_ctx.project_dir)
-                    else:
-                        await _notify(
-                            ctx,
-                            "error",
-                            "run_skill failed",
-                            "autoskillit.run_skill",
-                            extra={
-                                "exit_code": skill_result.exit_code,
-                                "subtype": skill_result.subtype,
-                            },
-                        )
-                        _persist_run_skill_state(skill_result, tool_ctx.project_dir)
-                    if effective_order_id:
-                        skill_result.order_id = effective_order_id
-                    from autoskillit.server._misc import (  # noqa: PLC0415
-                        _refresh_quota_cache,
-                    )
+                    _persist_run_skill_state(skill_result, tool_ctx.project_dir)
+                if effective_order_id:
+                    skill_result.order_id = effective_order_id
+                from autoskillit.server._misc import (  # noqa: PLC0415
+                    _refresh_quota_cache,
+                )
 
-                    if tool_ctx.background is not None:
-                        tool_ctx.background.submit(
-                            _refresh_quota_cache(tool_ctx.config.quota_guard),
-                            label="quota_post_run_refresh",
-                        )
-                    return skill_result.to_json()
-                except Exception as exc:
-                    logger.error("run_skill executor raised unexpectedly", exc_info=True)
-                    return SkillResult.crashed(
-                        exception=exc,
-                        skill_command=resolved_command,
-                        order_id=effective_order_id,
-                    ).to_json()
-                finally:
-                    if step_name:
-                        tool_ctx.timing_log.record(
-                            step_name, time.monotonic() - _start, order_id=effective_order_id
-                        )
+                if tool_ctx.background is not None:
+                    tool_ctx.background.submit(
+                        _refresh_quota_cache(tool_ctx.config.quota_guard),
+                        label="quota_post_run_refresh",
+                    )
+                return skill_result.to_json()
+            except Exception as exc:
+                logger.error("run_skill executor raised unexpectedly", exc_info=True)
+                return SkillResult.crashed(
+                    exception=exc,
+                    skill_command=resolved_command,
+                    order_id=effective_order_id,
+                ).to_json()
             finally:
-                pass  # placeholder — cleanup lives at the outer try level
+                if step_name:
+                    tool_ctx.timing_log.record(
+                        step_name, time.monotonic() - _start, order_id=effective_order_id
+                    )
     except Exception as exc:
         logger.error("run_skill unhandled exception", exc_info=True)
         return SkillResult.crashed(
@@ -679,4 +676,11 @@ async def run_skill(
             elif tool_ctx.ephemeral_root is not None:  # type: ignore[possibly-undefined]
                 _cleanup_dir = tool_ctx.ephemeral_root / _sid  # type: ignore[possibly-undefined]
                 if _cleanup_dir.is_dir():
-                    shutil.rmtree(_cleanup_dir, ignore_errors=True)
+                    try:
+                        shutil.rmtree(_cleanup_dir)
+                    except Exception:
+                        logger.warning(
+                            "session_dir_rmtree_failed",
+                            path=str(_cleanup_dir),
+                            exc_info=True,
+                        )

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
 import time
 from pathlib import Path
 
@@ -496,6 +497,7 @@ async def run_skill(
             invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
 
             skill_add_dirs: list[ValidatedAddDir] = []
+            _cleanup_session_id: str | None = None
             replay_snapshot_used = False
             _runner = tool_ctx.runner
             if (
@@ -507,6 +509,7 @@ async def run_skill(
             ):
                 _ephemeral_root = tool_ctx.ephemeral_root
                 session_id = f"headless-{uuid4().hex[:12]}"
+                _cleanup_session_id = session_id
                 _restored = _runner.restore_skill_snapshot(  # type: ignore[attr-defined]
                     step_name, _ephemeral_root, session_id
                 )
@@ -526,6 +529,7 @@ async def run_skill(
                     allow_only = closure if closure else None
 
                 session_id = f"headless-{uuid4().hex[:12]}"
+                _cleanup_session_id = session_id
                 session_root = tool_ctx.session_skill_manager.init_session(
                     session_id,
                     cook_session=False,
@@ -575,75 +579,92 @@ async def run_skill(
 
             _start = time.monotonic()
             try:
-                skill_result = await tool_ctx.executor.run(
-                    resolved_command,
-                    cwd,
-                    model=effective_model,
-                    add_dirs=skill_add_dirs,
-                    step_name=step_name,
-                    kitchen_id=tool_ctx.kitchen_id,
-                    order_id=effective_order_id,
-                    expected_output_patterns=expected_output_patterns,
-                    write_behavior=write_spec,
-                    stale_threshold=float(stale_threshold)
-                    if stale_threshold is not None
-                    else None,
-                    idle_output_timeout=float(idle_output_timeout)
-                    if idle_output_timeout is not None
-                    else None,
-                    completion_marker=invocation_marker,
-                    recipe_name=tool_ctx.recipe_name,
-                    recipe_content_hash=tool_ctx.recipe_content_hash,
-                    recipe_composite_hash=tool_ctx.recipe_composite_hash,
-                    recipe_version=tool_ctx.recipe_version,
-                    allowed_write_prefix=allowed_write_prefix,
-                    allowed_write_prefixes=allowed_write_prefixes,
-                    readonly_skill=is_read_only,
-                    write_watch_dirs=write_watch_dirs,
-                    provider_extras=provider_extras,
-                    profile_name=profile_name_out,
-                    backend_override=backend_override,
-                    resume_session_id=resume_session_id,
-                )
-                if skill_result.success:
-                    tool_ctx.audit.record_success(skill_command)
-                    _clear_run_skill_state(tool_ctx.project_dir)
-                else:
-                    await _notify(
-                        ctx,
-                        "error",
-                        "run_skill failed",
-                        "autoskillit.run_skill",
-                        extra={
-                            "exit_code": skill_result.exit_code,
-                            "subtype": skill_result.subtype,
-                        },
+                try:
+                    skill_result = await tool_ctx.executor.run(
+                        resolved_command,
+                        cwd,
+                        model=effective_model,
+                        add_dirs=skill_add_dirs,
+                        step_name=step_name,
+                        kitchen_id=tool_ctx.kitchen_id,
+                        order_id=effective_order_id,
+                        expected_output_patterns=expected_output_patterns,
+                        write_behavior=write_spec,
+                        stale_threshold=float(stale_threshold)
+                        if stale_threshold is not None
+                        else None,
+                        idle_output_timeout=float(idle_output_timeout)
+                        if idle_output_timeout is not None
+                        else None,
+                        completion_marker=invocation_marker,
+                        recipe_name=tool_ctx.recipe_name,
+                        recipe_content_hash=tool_ctx.recipe_content_hash,
+                        recipe_composite_hash=tool_ctx.recipe_composite_hash,
+                        recipe_version=tool_ctx.recipe_version,
+                        allowed_write_prefix=allowed_write_prefix,
+                        allowed_write_prefixes=allowed_write_prefixes,
+                        readonly_skill=is_read_only,
+                        write_watch_dirs=write_watch_dirs,
+                        provider_extras=provider_extras,
+                        profile_name=profile_name_out,
+                        backend_override=backend_override,
+                        resume_session_id=resume_session_id,
                     )
-                    _persist_run_skill_state(skill_result, tool_ctx.project_dir)
-                if effective_order_id:
-                    skill_result.order_id = effective_order_id
-                from autoskillit.server._misc import (  # noqa: PLC0415
-                    _refresh_quota_cache,
-                )
+                    if skill_result.success:
+                        tool_ctx.audit.record_success(skill_command)
+                        _clear_run_skill_state(tool_ctx.project_dir)
+                    else:
+                        await _notify(
+                            ctx,
+                            "error",
+                            "run_skill failed",
+                            "autoskillit.run_skill",
+                            extra={
+                                "exit_code": skill_result.exit_code,
+                                "subtype": skill_result.subtype,
+                            },
+                        )
+                        _persist_run_skill_state(skill_result, tool_ctx.project_dir)
+                    if effective_order_id:
+                        skill_result.order_id = effective_order_id
+                    from autoskillit.server._misc import (  # noqa: PLC0415
+                        _refresh_quota_cache,
+                    )
 
-                if tool_ctx.background is not None:
-                    tool_ctx.background.submit(
-                        _refresh_quota_cache(tool_ctx.config.quota_guard),
-                        label="quota_post_run_refresh",
-                    )
-                return skill_result.to_json()
-            except Exception as exc:
-                logger.error("run_skill executor raised unexpectedly", exc_info=True)
-                return SkillResult.crashed(
-                    exception=exc,
-                    skill_command=resolved_command,
-                    order_id=effective_order_id,
-                ).to_json()
+                    if tool_ctx.background is not None:
+                        tool_ctx.background.submit(
+                            _refresh_quota_cache(tool_ctx.config.quota_guard),
+                            label="quota_post_run_refresh",
+                        )
+                    return skill_result.to_json()
+                except Exception as exc:
+                    logger.error("run_skill executor raised unexpectedly", exc_info=True)
+                    return SkillResult.crashed(
+                        exception=exc,
+                        skill_command=resolved_command,
+                        order_id=effective_order_id,
+                    ).to_json()
+                finally:
+                    if step_name:
+                        tool_ctx.timing_log.record(
+                            step_name, time.monotonic() - _start, order_id=effective_order_id
+                        )
             finally:
-                if step_name:
-                    tool_ctx.timing_log.record(
-                        step_name, time.monotonic() - _start, order_id=effective_order_id
-                    )
+                if _cleanup_session_id is not None:
+                    _ssm = tool_ctx.session_skill_manager
+                    if _ssm is not None:
+                        try:
+                            _ssm.cleanup_session(_cleanup_session_id)
+                        except Exception:
+                            logger.warning(
+                                "session_skill_cleanup_failed",
+                                session_id=_cleanup_session_id,
+                                exc_info=True,
+                            )
+                    elif tool_ctx.ephemeral_root is not None:
+                        _cleanup_dir = tool_ctx.ephemeral_root / _cleanup_session_id
+                        if _cleanup_dir.is_dir():
+                            shutil.rmtree(_cleanup_dir, ignore_errors=True)
     except Exception as exc:
         logger.error("run_skill unhandled exception", exc_info=True)
         return SkillResult.crashed(

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -310,11 +310,11 @@ async def run_skill(
                 "error": f"run_skill: cwd does not exist: {cwd}",
             }
         )
-    from autoskillit.server import _get_ctx
-
-    _cleanup_session_id: str | None = None
-    tool_ctx = _get_ctx()
     try:
+        from autoskillit.server import _get_ctx
+
+        _cleanup_session_id: str | None = None
+        tool_ctx = _get_ctx()
         with structlog.contextvars.bound_contextvars(tool="run_skill", cwd=cwd):
             logger.info("run_skill", command=skill_command[:80], cwd=cwd)
             await _notify(
@@ -664,18 +664,19 @@ async def run_skill(
         logger.warning("run_skill cancelled", exc_info=True)
         raise
     finally:
-        if _cleanup_session_id is not None:
-            _ssm = tool_ctx.session_skill_manager
+        _sid: str | None = locals().get("_cleanup_session_id")  # type: ignore[assignment]
+        if _sid is not None:
+            _ssm = tool_ctx.session_skill_manager  # type: ignore[possibly-undefined]
             if _ssm is not None:
                 try:
-                    _ssm.cleanup_session(_cleanup_session_id)
+                    _ssm.cleanup_session(_sid)
                 except Exception:
                     logger.warning(
                         "session_skill_cleanup_failed",
-                        session_id=_cleanup_session_id,
+                        session_id=_sid,
                         exc_info=True,
                     )
-            elif tool_ctx.ephemeral_root is not None:
-                _cleanup_dir = tool_ctx.ephemeral_root / _cleanup_session_id
+            elif tool_ctx.ephemeral_root is not None:  # type: ignore[possibly-undefined]
+                _cleanup_dir = tool_ctx.ephemeral_root / _sid  # type: ignore[possibly-undefined]
                 if _cleanup_dir.is_dir():
                     shutil.rmtree(_cleanup_dir, ignore_errors=True)

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -650,21 +650,7 @@ async def run_skill(
                             step_name, time.monotonic() - _start, order_id=effective_order_id
                         )
             finally:
-                if _cleanup_session_id is not None:
-                    _ssm = tool_ctx.session_skill_manager
-                    if _ssm is not None:
-                        try:
-                            _ssm.cleanup_session(_cleanup_session_id)
-                        except Exception:
-                            logger.warning(
-                                "session_skill_cleanup_failed",
-                                session_id=_cleanup_session_id,
-                                exc_info=True,
-                            )
-                    elif tool_ctx.ephemeral_root is not None:
-                        _cleanup_dir = tool_ctx.ephemeral_root / _cleanup_session_id
-                        if _cleanup_dir.is_dir():
-                            shutil.rmtree(_cleanup_dir, ignore_errors=True)
+                pass  # placeholder — cleanup lives at the outer try level
     except Exception as exc:
         logger.error("run_skill unhandled exception", exc_info=True)
         return SkillResult.crashed(
@@ -675,3 +661,19 @@ async def run_skill(
     except BaseException:
         logger.warning("run_skill cancelled", exc_info=True)
         raise
+    finally:
+        if _cleanup_session_id is not None:
+            _ssm = tool_ctx.session_skill_manager
+            if _ssm is not None:
+                try:
+                    _ssm.cleanup_session(_cleanup_session_id)
+                except Exception:
+                    logger.warning(
+                        "session_skill_cleanup_failed",
+                        session_id=_cleanup_session_id,
+                        exc_info=True,
+                    )
+            elif tool_ctx.ephemeral_root is not None:
+                _cleanup_dir = tool_ctx.ephemeral_root / _cleanup_session_id
+                if _cleanup_dir.is_dir():
+                    shutil.rmtree(_cleanup_dir, ignore_errors=True)

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -310,6 +310,10 @@ async def run_skill(
                 "error": f"run_skill: cwd does not exist: {cwd}",
             }
         )
+    from autoskillit.server import _get_ctx
+
+    _cleanup_session_id: str | None = None
+    tool_ctx = _get_ctx()
     try:
         with structlog.contextvars.bound_contextvars(tool="run_skill", cwd=cwd):
             logger.info("run_skill", command=skill_command[:80], cwd=cwd)
@@ -321,7 +325,7 @@ async def run_skill(
                 extra={"cwd": cwd, "model": model or "default"},
             )
 
-            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import _get_config
 
             # Auto-enrich order_id from the fleet dispatcher's env variable when the
             # caller did not pass an explicit value. AUTOSKILLIT_DISPATCH_ID is injected
@@ -334,7 +338,6 @@ async def run_skill(
                 if (gate_error := _check_dry_walkthrough(skill_command, cwd)) is not None:
                     return gate_error
 
-            tool_ctx = _get_ctx()
             if tool_ctx.executor is None:
                 return json.dumps({"success": False, "error": "Executor not configured"})
 
@@ -497,7 +500,6 @@ async def run_skill(
             invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
 
             skill_add_dirs: list[ValidatedAddDir] = []
-            _cleanup_session_id: str | None = None
             replay_snapshot_used = False
             _runner = tool_ctx.runner
             if (

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -723,7 +723,7 @@ class DefaultSessionSkillManager:
             return True
         return False
 
-    def cleanup_stale(self, max_age_seconds: int = 259200) -> int:
+    def cleanup_stale(self, max_age_seconds: int = 86400) -> int:
         """Remove session dirs not accessed within max_age_seconds.
 
         Returns count of removed directories.

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -250,3 +250,37 @@ async def test_lifespan_skips_codex_registration_for_non_codex_backend():
             pass
 
     reg_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_cleanup_stale_loop_calls_cleanup_periodically(monkeypatch):
+    """_cleanup_stale_loop calls cleanup_stale with explicit max_age after each sleep."""
+    from autoskillit.server._lifespan import _cleanup_stale_loop
+
+    calls: list[dict] = []
+    sleep_count = 0
+
+    async def fake_sleep(seconds):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count >= 2:
+            raise asyncio.CancelledError
+
+    def fake_cleanup_stale(max_age_seconds=86400):
+        calls.append({"max_age_seconds": max_age_seconds})
+        return 1
+
+    mock_ssm = MagicMock()
+    mock_ssm.cleanup_stale = fake_cleanup_stale
+
+    monkeypatch.setattr("autoskillit.server._lifespan._asyncio.sleep", fake_sleep)
+    monkeypatch.setattr(
+        "autoskillit.server._lifespan._get_ctx_or_none",
+        lambda: MagicMock(session_skill_manager=mock_ssm),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await _cleanup_stale_loop(interval=1800.0)
+
+    assert len(calls) == 1
+    assert calls[0]["max_age_seconds"] == 86400

--- a/tests/server/test_run_skill_add_dirs.py
+++ b/tests/server/test_run_skill_add_dirs.py
@@ -11,7 +11,7 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 @pytest.mark.anyio
 async def test_raw_skills_extended_excluded_from_run_skill_add_dirs(
-    tool_ctx_kitchen_open, tmp_path
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
 ):
     """T-OVR-014: run_skill passes ephemeral session dir (not raw skills_extended/) as add_dirs."""
     from autoskillit.server.tools.tools_execution import run_skill
@@ -19,6 +19,11 @@ async def test_raw_skills_extended_excluded_from_run_skill_add_dirs(
 
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
+
+    # Prevent cleanup_session from removing the session dir before we inspect it
+    ssm = tool_ctx_kitchen_open.session_skill_manager
+    if ssm is not None:
+        monkeypatch.setattr(ssm, "cleanup_session", lambda _sid: True)
 
     await run_skill("/autoskillit:investigate foo", str(tmp_path))
 

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -242,22 +242,13 @@ class TestDispatchFoodTruckExecution:
         assert "quota_post_dispatch_refresh" in submitted_labels
 
     @pytest.mark.anyio
-    async def test_dispatch_food_truck_cleans_session_skills(
+    async def test_dispatch_food_truck_does_not_call_cleanup_session(
         self, tool_ctx, monkeypatch, tmp_path
     ):
-        """Completed L3 session skill dir is cleaned up."""
+        """Fleet dispatch does not call cleanup_session (no init_session on this path)."""
         from autoskillit.fleet._api import execute_dispatch
 
         self._setup_standard_dispatch(tool_ctx, monkeypatch)
-        from tests.fakes import _DEFAULT_SKILL_RESULT
-
-        tool_ctx.executor = InMemoryHeadlessExecutor(
-            default_result=dataclasses.replace(
-                _DEFAULT_SKILL_RESULT,
-                success=True,
-                session_id="l2-session-xyz",
-            )
-        )
 
         cleanup_calls: list[str] = []
 
@@ -278,7 +269,7 @@ class TestDispatchFoodTruckExecution:
             quota_checker=_no_sleep_quota_checker,
             quota_refresher=_noop_quota_refresher,
         )
-        assert "l2-session-xyz" in cleanup_calls
+        assert len(cleanup_calls) == 0
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_invalidates_quota_cache_file(self, tool_ctx, monkeypatch):
@@ -306,54 +297,3 @@ class TestDispatchFoodTruckExecution:
         )
 
         assert tool_ctx.config.quota_guard.cache_path in invalidate_calls
-
-    @pytest.mark.anyio
-    @pytest.mark.parametrize("exc_cls", [RuntimeError, OSError])
-    async def test_dispatch_food_truck_succeeds_when_cleanup_session_raises(
-        self, tool_ctx, monkeypatch, exc_cls
-    ):
-        """Dispatch result is success even when cleanup_session raises an exception."""
-        import json
-
-        from autoskillit.fleet._api import execute_dispatch
-        from autoskillit.fleet.result_parser import L3ParseResult
-        from tests.fakes import _DEFAULT_SKILL_RESULT
-
-        self._setup_standard_dispatch(tool_ctx, monkeypatch)
-        tool_ctx.executor = InMemoryHeadlessExecutor(
-            default_result=dataclasses.replace(
-                _DEFAULT_SKILL_RESULT,
-                success=True,
-                session_id="l2-session-err",
-            )
-        )
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.parse_l3_result_block",
-            lambda **_kwargs: L3ParseResult(
-                outcome="completed_clean",
-                payload={"success": True},
-                raw_body=None,
-                parse_error=None,
-                source="stdout",
-            ),
-        )
-
-        def _raise_error(session_id: str) -> bool:
-            raise exc_cls("simulated cleanup failure")
-
-        monkeypatch.setattr(tool_ctx.session_skill_manager, "cleanup_session", _raise_error)
-
-        result_json = await execute_dispatch(
-            tool_ctx=tool_ctx,
-            recipe="test-recipe",
-            task="t",
-            ingredients=None,
-            dispatch_name=None,
-            timeout_sec=None,
-            prompt_builder=_simple_prompt_builder,
-            quota_checker=_no_sleep_quota_checker,
-            quota_refresher=_noop_quota_refresher,
-        )
-
-        result = json.loads(result_json.outcome.to_envelope())
-        assert result["success"] is True

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -511,4 +511,5 @@ async def test_run_skill_succeeds_when_cleanup_session_raises(
 
     result = json.loads(await run_skill("/autoskillit:test-skill", str(tmp_path)))
 
+    mock_ssm.cleanup_session.assert_called_once()
     assert result.get("success") is True

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -407,3 +407,82 @@ async def test_run_skill_provider_extras_none_when_default_profile(
 
     assert executor.calls[0].provider_extras is None
     assert executor.calls[0].profile_name == ""
+
+
+@pytest.mark.anyio
+async def test_run_skill_calls_cleanup_session_after_execution(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+):
+    """cleanup_session is called with the session_id after executor.run completes."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    cleanup_calls: list[str] = []
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = ValidatedAddDir(path=str(tmp_path))
+    mock_ssm.compute_skill_closure.return_value = None
+    mock_ssm.cleanup_session.side_effect = lambda sid: cleanup_calls.append(sid) or True
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/autoskillit:test-skill", str(tmp_path))
+
+    assert len(cleanup_calls) == 1
+    assert cleanup_calls[0].startswith("headless-")
+
+
+@pytest.mark.anyio
+async def test_run_skill_cleans_up_on_skill_md_not_found(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+):
+    """Early return when SKILL.md not found still triggers session cleanup."""
+    import json
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+
+    cleanup_calls: list[str] = []
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = ValidatedAddDir(path=str(tmp_path))
+    mock_ssm.compute_skill_closure.return_value = frozenset({"target-skill"})
+    mock_ssm.cleanup_session.side_effect = lambda sid: cleanup_calls.append(sid) or True
+    # Return None from resolver so resolve_target_skill returns (cmd, name)
+    # without accessing .source on the info object
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = None
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    result = json.loads(await run_skill("/autoskillit:target-skill", str(tmp_path)))
+
+    assert len(cleanup_calls) == 1
+    assert not result.get("success", True)
+
+
+@pytest.mark.anyio
+async def test_run_skill_succeeds_when_cleanup_session_raises(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+):
+    """cleanup_session failure is swallowed — run_skill still returns the result."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = ValidatedAddDir(path=str(tmp_path))
+    mock_ssm.compute_skill_closure.return_value = None
+    mock_ssm.cleanup_session.side_effect = PermissionError("locked")
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    result = await run_skill("/autoskillit:test-skill", str(tmp_path))
+
+    assert "success" in result or "exception" in result

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -465,6 +465,31 @@ async def test_run_skill_cleans_up_on_skill_md_not_found(
 
 
 @pytest.mark.anyio
+async def test_run_skill_cleans_up_on_init_session_failure(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+):
+    """Partial init_session failure still triggers cleanup for the session_id."""
+    from unittest.mock import MagicMock
+
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    cleanup_calls: list[str] = []
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.side_effect = OSError("disk full")
+    mock_ssm.compute_skill_closure.return_value = None
+    mock_ssm.cleanup_session.side_effect = lambda sid: cleanup_calls.append(sid) or True
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/autoskillit:test-skill", str(tmp_path))
+
+    assert len(cleanup_calls) == 1
+    assert cleanup_calls[0].startswith("headless-")
+
+
+@pytest.mark.anyio
 async def test_run_skill_succeeds_when_cleanup_session_raises(
     tool_ctx_kitchen_open, monkeypatch, tmp_path
 ):

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -494,6 +494,7 @@ async def test_run_skill_succeeds_when_cleanup_session_raises(
     tool_ctx_kitchen_open, monkeypatch, tmp_path
 ):
     """cleanup_session failure is swallowed — run_skill still returns the result."""
+    import json
     from unittest.mock import MagicMock
 
     from autoskillit.core import ValidatedAddDir
@@ -508,6 +509,6 @@ async def test_run_skill_succeeds_when_cleanup_session_raises(
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
-    result = await run_skill("/autoskillit:test-skill", str(tmp_path))
+    result = json.loads(await run_skill("/autoskillit:test-skill", str(tmp_path)))
 
-    assert "success" in result or "exception" in result
+    assert result.get("success") is True

--- a/tests/workspace/test_session_skills_filtering.py
+++ b/tests/workspace/test_session_skills_filtering.py
@@ -155,12 +155,12 @@ def test_init_session_includes_non_disabled_skills(tmp_path: Path) -> None:
 
 
 # REQ-EPH-002
-def test_cleanup_stale_default_is_72_hours() -> None:
+def test_cleanup_stale_default_is_24_hours() -> None:
     import inspect
 
     sig = inspect.signature(DefaultSessionSkillManager.cleanup_stale)
     default = sig.parameters["max_age_seconds"].default
-    assert default == 259200, f"Expected 259200 (72h), got {default}"
+    assert default == 86400, f"Expected 86400 (24h), got {default}"
 
 
 # REQ-PACK-005 / REQ-PACK-006: _resolve_effective_disabled


### PR DESCRIPTION
## Summary

Ephemeral session skill directories on `/dev/shm/autoskillit-sessions/` accumulate without cleanup (~4 GB/day) because `run_skill` creates a session dir via `init_session()` but never calls `cleanup_session()`. The fleet dispatch path in `_api.py` had a dead `cleanup_session` call operating on the wrong ID type, and the `cleanup_stale()` defense-in-depth sweep only ran at server startup with a 3-day threshold disagreeing with its Protocol docstring's 1-day default.

This PR adds a `finally`-block cleanup to `run_skill`, removes the dead fleet cleanup call, aligns the `cleanup_stale` threshold default to 86400s, adds a periodic background sweep every 30 minutes, and adds a missing T3 test for `init_session` failure cleanup coverage.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Fix Session Skill Directory Cleanup — /dev/shm Leak

Adds `cleanup_session(session_id_local)` to a `finally` block in `run_skill`, removes the dead fleet dispatch cleanup call, reduces `cleanup_stale()` default from 259200s to 86400s, and adds a 30-minute periodic `cleanup_stale()` background sweep.

### Group 2: Add Missing T3 Test — init_session Failure Cleanup

Adds `test_run_skill_cleans_up_on_init_session_failure` to verify REQ-CLEANUP-002: when `init_session()` raises, the outer `finally` block still calls `cleanup_session` with the pre-assigned `_cleanup_session_id`.

</details>

## Requirements

### REQ-CLEANUP-001: Clean up session skill dir after subprocess exits in `run_skill`
Add `cleanup_session(session_id_local)` to a `finally` block in `run_skill` in `tools_execution.py`. The `session_id_local` must be tracked and used for cleanup — NOT `skill_result.session_id`. The `finally` block must wrap the entire post-`init_session` body, including the early-return path.

### REQ-CLEANUP-002: Handle partial init_session failures
If `init_session()` raises after partially creating the directory, the cleanup `finally` block should check whether `session_id` was assigned and call `cleanup_session` regardless of whether `init_session` completed successfully.

### REQ-CLEANUP-003: Remove dead cleanup_session call from fleet dispatch
`_post_dispatch_cleanup` in `fleet/_api.py` calls `cleanup_session(skill_result.session_id)` but the fleet dispatch path never calls `init_session`. No ephemeral skill directory is created for fleet dispatches. Remove this dead code.

### REQ-CLEANUP-004: Ensure subprocess has fully exited before cleanup
The cleanup must only fire after the subprocess process tree has been confirmed dead (zombie reaped). Document this invariant.

### REQ-CLEANUP-005: Resume safety — cleanup must not break session resume
Resume always creates a fresh skill dir via `init_session()`. The `--resume` flag uses the Claude Code session ID (conversation history), independent of the tmpfs skill dir. No lazy recreation needed.

### REQ-CLEANUP-006: Reduce `cleanup_stale()` threshold as defense-in-depth
Change the concrete default in `DefaultSessionSkillManager.cleanup_stale()` from 259200 seconds (3 days) to 86400 seconds (1 day), aligning with the Protocol docstring.

### REQ-CLEANUP-007: Add periodic `cleanup_stale()` as background task
Add a periodic call (every 30 minutes) as a background task in `_lifespan.py`, following the `_quota_refresh_loop` pattern.

## Conflict Resolution Decisions

None

Closes #3214

## Implementation Plan

Plan files:
- `.autoskillit/temp/make-plan/fix_session_skill_dir_cleanup_plan_2026-05-28_194830.md`
- `.autoskillit/temp/make-plan/fix_session_skill_dir_cleanup_t3_remediation_plan_2026-05-28_210500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 5.0k | 34.1k | 3.0M | 112.8k | 266 | 152.5k | 22m 51s |
| review_approach* | sonnet | 1 | 1.3k | 6.2k | 218.0k | 41.7k | 39 | 28.8k | 2m 54s |
| verify* | sonnet | 2 | 336 | 39.7k | 2.5M | 98.0k | 123 | 120.5k | 10m 49s |
| implement* | sonnet | 2 | 20.6M | 140.3k | 9.1M | 30.9k | 660 | 215.6k | 1h 1m |
| audit_impl* | sonnet | 2 | 170 | 15.0k | 690.5k | 50.4k | 53 | 66.5k | 4m 50s |
| prepare_pr* | sonnet | 1 | 86.4k | 4.5k | 247.1k | 30.9k | 23 | 43.7k | 1m 22s |
| compose_pr* | sonnet | 1 | 79.7k | 2.6k | 275.1k | 30.9k | 21 | 15.5k | 52s |
| review_pr* | sonnet | 2 | 3.7k | 71.0k | 3.2M | 111.2k | 231 | 167.9k | 22m 14s |
| resolve_review* | opus | 2 | 92 | 18.0k | 2.8M | 76.9k | 100 | 130.6k | 12m 50s |
| **Total** | | | 20.8M | 331.4k | 22.0M | 112.8k | | 941.7k | 2h 20m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 437 | 20778.5 | 493.3 | 321.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 150 | 18756.5 | 870.8 | 119.9 |
| **Total** | **587** | 37495.9 | 1604.3 | 564.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 5.0k | 34.1k | 3.0M | 152.5k | 22m 51s |
| sonnet | 7 | 20.8M | 279.3k | 16.2M | 658.5k | 1h 44m |
| opus | 1 | 92 | 18.0k | 2.8M | 130.6k | 12m 50s |