### PR TITLE
Rectify: Git Write Detection Skips Clone-Based Sessions

### DIFF
--- a/src/autoskillit/core/CLAUDE.md
+++ b/src/autoskillit/core/CLAUDE.md
@@ -12,7 +12,7 @@ Sub-packages: types/ (see types/CLAUDE.md) and runtime/ (see runtime/CLAUDE.md).
 | `_cmd_runner.py` | `CmdRunner` protocol, `default_cmd_runner`, `run_git`, `run_gh` — sync subprocess for git/gh CLI |
 | `_json.py` | Fast JSON via orjson (with stdlib fallback) — `fast_loads`, `fast_dumps` |
 | `logging.py` | Logging configuration |
-| `paths.py` | `pkg_root()`, `is_git_worktree()` |
+| `paths.py` | `pkg_root()`, `is_git_worktree()`, `is_git_main_checkout()`, `is_in_git_repo()` |
 | `_claude_env.py` | IDE-scrubbing canonical env builder for agent subprocesses |
 | `_terminal_table.py` | IL-0 color-agnostic terminal table primitive |
 | `_version_snapshot.py` | Process-scoped version snapshot for session telemetry (`lru_cache`'d) |

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -65,6 +65,7 @@ from .paths import find_latest_session_id as find_latest_session_id
 from .paths import is_generated_path as is_generated_path
 from .paths import is_git_main_checkout as is_git_main_checkout
 from .paths import is_git_worktree as is_git_worktree
+from .paths import is_in_git_repo as is_in_git_repo
 from .paths import pkg_root as pkg_root
 from .paths import resolve_main_worktree as resolve_main_worktree
 from .runtime._linux_proc import is_session_alive as is_session_alive

--- a/src/autoskillit/core/paths.py
+++ b/src/autoskillit/core/paths.py
@@ -138,6 +138,20 @@ def is_git_main_checkout(path: Path) -> bool:
     return False
 
 
+def is_in_git_repo(path: Path) -> bool:
+    """Return True if path is inside any git repository (worktree or main checkout).
+
+    This is the union of is_git_worktree() and is_git_main_checkout().
+    Use this when the caller needs "any git context" without caring about
+    the worktree vs main checkout distinction.
+    """
+    for parent in [path, *path.parents]:
+        git_path = parent / ".git"
+        if git_path.is_file() or git_path.is_dir():
+            return True
+    return False
+
+
 def resolve_main_worktree(path: Path) -> Path | None:
     """Resolve ``path`` to the main git worktree root.
 

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -29,6 +29,7 @@ from autoskillit.core import (
     get_logger,
     is_feature_enabled,
     is_git_worktree,
+    is_in_git_repo,
 )
 from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
 from autoskillit.execution.clone_guard import (
@@ -357,7 +358,7 @@ async def _execute_claude_headless(
                     break
 
         _git_writes_detected = False
-        if is_git_worktree(Path(cwd)):
+        if is_in_git_repo(Path(cwd)):
             _git_writes_detected = _detect_branch_divergence(cwd)
 
         audit_count_before = len(ctx.audit.get_report())

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -26,7 +26,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_kitchen_state.py` | Tests for KitchenMarker hash field support |
 | `test_label_lifecycle.py` | Tests for IssueLabelState, LabelDef, LABEL_LIFECYCLE_REGISTRY, LABEL_TRANSITIONS, and validate_label_transition |
 | `test_logging.py` | Tests for autoskillit.core.logging — centralized structlog configuration |
-| `test_paths.py` | Tests for autoskillit.core.paths — is_git_worktree and pkg_root |
+| `test_paths.py` | Tests for autoskillit.core.paths — is_git_worktree, is_git_main_checkout, is_in_git_repo, and pkg_root |
 | `test_plugin_cache.py` | Tests for core/_plugin_cache.py — retiring cache, kitchen registry, and schema version validation |
 | `test_resolve_temp_dir.py` | Tests for autoskillit.core.io.resolve_temp_dir |
 | `test_resolve_main_worktree.py` | Tests for autoskillit.core.paths.resolve_main_worktree — resolves any git path to the main worktree root |

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -159,6 +159,94 @@ class TestPkgRoot:
         )
 
 
+class TestIsGitMainCheckout:
+    def test_plain_directory_returns_false(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_git_main_checkout
+
+        assert is_git_main_checkout(tmp_path) is False
+
+    def test_git_directory_returns_true(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_git_main_checkout
+
+        (tmp_path / ".git").mkdir()
+        assert is_git_main_checkout(tmp_path) is True
+
+    def test_git_file_returns_false(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_git_main_checkout
+
+        (tmp_path / ".git").write_text("gitdir: /path/to/main/.git/worktrees/foo\n")
+        assert is_git_main_checkout(tmp_path) is False
+
+    def test_nested_directory_returns_true(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_git_main_checkout
+
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "src" / "pkg"
+        subdir.mkdir(parents=True)
+        assert is_git_main_checkout(subdir) is True
+
+
+class TestIsInGitRepo:
+    def test_returns_true_for_git_directory(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_in_git_repo
+
+        (tmp_path / ".git").mkdir()
+        assert is_in_git_repo(tmp_path) is True
+
+    def test_returns_true_for_git_file(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_in_git_repo
+
+        (tmp_path / ".git").write_text("gitdir: /path/to/main/.git/worktrees/foo\n")
+        assert is_in_git_repo(tmp_path) is True
+
+    def test_returns_false_for_no_git(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_in_git_repo
+
+        assert is_in_git_repo(tmp_path) is False
+
+    def test_returns_true_for_nested_main_checkout(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_in_git_repo
+
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "src" / "pkg"
+        subdir.mkdir(parents=True)
+        assert is_in_git_repo(subdir) is True
+
+    def test_returns_true_for_nested_worktree(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_in_git_repo
+
+        (tmp_path / ".git").write_text("gitdir: /path/to/main/.git/worktrees/foo\n")
+        subdir = tmp_path / "src" / "pkg"
+        subdir.mkdir(parents=True)
+        assert is_in_git_repo(subdir) is True
+
+    def test_is_in_git_repo_is_union_of_predicates(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_git_main_checkout, is_git_worktree, is_in_git_repo
+
+        states = [
+            tmp_path,
+            tmp_path / "subdir",
+        ]
+
+        for path in states:
+            path.mkdir(exist_ok=True)
+
+        # Test all three states: non-git, main checkout, linked worktree
+        bare = tmp_path / "bare"
+        bare.mkdir()
+
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        (checkout / ".git").mkdir()
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / ".git").write_text("gitdir: /path/to/main/.git/worktrees/foo\n")
+
+        for p in (bare, checkout, worktree):
+            assert is_in_git_repo(p) == (is_git_worktree(p) or is_git_main_checkout(p))
+
+
 class TestDefaultLogDir:
     def test_linux_no_xdg(self, monkeypatch):
         monkeypatch.setattr("autoskillit.core.paths.sys.platform", "linux")

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -797,72 +797,6 @@ class TestGitWritesClonePath:
         result = _detect_branch_divergence(str(repo))
         assert result is True
 
-    def test_git_writes_guard_fires_for_clone_cwd(self, tmp_path: Path) -> None:
-        """Guard calls is_in_git_repo for clone paths and invokes _detect_branch_divergence."""
-        import subprocess
-        from unittest.mock import MagicMock, patch
-
-        repo = tmp_path / "repo"
-        bare = tmp_path / "bare.git"
-
-        subprocess.run(["git", "init", str(bare), "--bare"], check=True, capture_output=True)
-        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
-        subprocess.run(
-            ["git", "-C", str(repo), "remote", "add", "origin", str(bare)],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "config", "user.name", "Test"],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "push", "origin", "HEAD:main"],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "branch", "--set-upstream-to=origin/main"],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "ahead"],
-            check=True,
-            capture_output=True,
-        )
-
-        import autoskillit.execution.headless._headless_execute as _mod
-
-        is_in_git_spy = MagicMock(wraps=_mod.is_in_git_repo)
-        divergence_spy = MagicMock(return_value=True)
-
-        with (
-            patch.object(_mod, "is_in_git_repo", is_in_git_spy),
-            patch.object(_mod, "_detect_branch_divergence", divergence_spy),
-        ):
-            from pathlib import Path as _Path
-
-            _cwd = str(repo)
-            _git_writes_detected = False
-            if _mod.is_in_git_repo(_Path(_cwd)):
-                _git_writes_detected = _mod._detect_branch_divergence(_cwd)
-
-        is_in_git_spy.assert_called_once_with(_Path(str(repo)))
-        divergence_spy.assert_called_once_with(str(repo))
-        assert _git_writes_detected is True
-
 
 class TestGitWritesStateMatrix:
     """Parametrized matrix: all three workspace states × branch divergence."""
@@ -888,7 +822,10 @@ class TestGitWritesStateMatrix:
         if state == "non_git":
             non_git = tmp_path / "non_git"
             non_git.mkdir()
-            assert is_in_git_repo(non_git) is False
+            in_git = is_in_git_repo(non_git)
+            assert in_git is False
+            result = _detect_branch_divergence(str(non_git)) if in_git else False
+            assert result is expected
             return
 
         bare = tmp_path / "bare.git"

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -741,6 +741,213 @@ class TestTempDirSnapshot:
         assert post - pre == set()
 
 
+class TestGitWritesClonePath:
+    """Integration tests: clone-path git write detection reaches _detect_branch_divergence."""
+
+    def test_git_writes_detected_on_clone_path(self, tmp_path: Path) -> None:
+        """Clone path (main checkout) with commits ahead of origin returns True."""
+        import subprocess
+
+        from autoskillit.core.paths import is_git_worktree, is_in_git_repo
+        from autoskillit.execution.headless._headless_git import _detect_branch_divergence
+
+        repo = tmp_path / "repo"
+        bare = tmp_path / "bare.git"
+
+        subprocess.run(["git", "init", str(bare), "--bare"], check=True, capture_output=True)
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "remote", "add", "origin", str(bare)],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "push", "origin", "HEAD:main"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "branch", "--set-upstream-to=origin/main"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "ahead"],
+            check=True,
+            capture_output=True,
+        )
+
+        assert is_in_git_repo(repo) is True
+        assert is_git_worktree(repo) is False
+        result = _detect_branch_divergence(str(repo))
+        assert result is True
+
+    def test_git_writes_guard_fires_for_clone_cwd(self, tmp_path: Path) -> None:
+        """Guard calls is_in_git_repo for clone paths and invokes _detect_branch_divergence."""
+        import subprocess
+        from unittest.mock import MagicMock, patch
+
+        repo = tmp_path / "repo"
+        bare = tmp_path / "bare.git"
+
+        subprocess.run(["git", "init", str(bare), "--bare"], check=True, capture_output=True)
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "remote", "add", "origin", str(bare)],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "push", "origin", "HEAD:main"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "branch", "--set-upstream-to=origin/main"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "ahead"],
+            check=True,
+            capture_output=True,
+        )
+
+        import autoskillit.execution.headless._headless_execute as _mod
+
+        is_in_git_spy = MagicMock(wraps=_mod.is_in_git_repo)
+        divergence_spy = MagicMock(return_value=True)
+
+        with (
+            patch.object(_mod, "is_in_git_repo", is_in_git_spy),
+            patch.object(_mod, "_detect_branch_divergence", divergence_spy),
+        ):
+            from pathlib import Path as _Path
+
+            _cwd = str(repo)
+            _git_writes_detected = False
+            if _mod.is_in_git_repo(_Path(_cwd)):
+                _git_writes_detected = _mod._detect_branch_divergence(_cwd)
+
+        is_in_git_spy.assert_called_once_with(_Path(str(repo)))
+        divergence_spy.assert_called_once_with(str(repo))
+        assert _git_writes_detected is True
+
+
+class TestGitWritesStateMatrix:
+    """Parametrized matrix: all three workspace states × branch divergence."""
+
+    @pytest.mark.parametrize(
+        "state,commits_ahead,expected",
+        [
+            ("clone", True, True),
+            ("clone", False, False),
+            ("worktree", True, True),
+            ("worktree", False, False),
+            ("non_git", False, False),
+        ],
+    )
+    def test_git_writes_state_matrix(
+        self, tmp_path: Path, state: str, commits_ahead: bool, expected: bool
+    ) -> None:
+        import subprocess
+
+        from autoskillit.core.paths import is_in_git_repo
+        from autoskillit.execution.headless._headless_git import _detect_branch_divergence
+
+        if state == "non_git":
+            non_git = tmp_path / "non_git"
+            non_git.mkdir()
+            assert is_in_git_repo(non_git) is False
+            return
+
+        bare = tmp_path / "bare.git"
+        main_repo = tmp_path / "main"
+        subprocess.run(["git", "init", str(bare), "--bare"], check=True, capture_output=True)
+        subprocess.run(["git", "init", str(main_repo)], check=True, capture_output=True)
+        for cmd in [
+            ["git", "-C", str(main_repo), "config", "user.email", "test@test.com"],
+            ["git", "-C", str(main_repo), "config", "user.name", "Test"],
+            ["git", "-C", str(main_repo), "remote", "add", "origin", str(bare)],
+            ["git", "-C", str(main_repo), "commit", "--allow-empty", "-m", "init"],
+            ["git", "-C", str(main_repo), "push", "origin", "HEAD:main"],
+            ["git", "-C", str(main_repo), "branch", "--set-upstream-to=origin/main"],
+        ]:
+            subprocess.run(cmd, check=True, capture_output=True)
+
+        if state == "clone":
+            cwd = main_repo
+        else:
+            wt = tmp_path / "wt"
+            subprocess.run(
+                ["git", "-C", str(main_repo), "worktree", "add", str(wt), "-b", "feature/test"],
+                check=True,
+                capture_output=True,
+            )
+            cwd = wt
+            subprocess.run(
+                ["git", "-C", str(cwd), "config", "user.email", "test@test.com"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(cwd), "config", "user.name", "Test"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(main_repo), "push", "origin", "feature/test"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(cwd), "branch", "--set-upstream-to=origin/feature/test"],
+                check=True,
+                capture_output=True,
+            )
+
+        if commits_ahead:
+            subprocess.run(
+                ["git", "-C", str(cwd), "commit", "--allow-empty", "-m", "ahead"],
+                check=True,
+                capture_output=True,
+            )
+
+        assert is_in_git_repo(cwd) is True
+        result = _detect_branch_divergence(str(cwd))
+        assert result is expected
+
+
 class TestGitWritesDetection:
     """Git-level write detection suppresses zero_writes false positives."""
 


### PR DESCRIPTION
## Summary

The `_execute_claude_headless()` function gates `_detect_branch_divergence()` behind `is_git_worktree()`, a predicate that returns `True` only for linked worktrees (`.git` file), not for standalone clones (`.git` directory). This means clone-based sessions — the majority of production pipeline sessions — never get git-level write detection. When the other three evidence signals (`write_call_count`, `fs_writes_detected`, `file_changes_count`) also miss, `WriteEvidence.has_evidence` returns `False`, causing the zero-writes gate to demote successful sessions as "zero_writes" failures.

The fix adds a new `is_in_git_repo()` union predicate in `paths.py` that returns `True` for both worktrees (`.git` file) and main checkouts (`.git` directory), replaces the worktree-only guard with `is_in_git_repo()` at line 360 of `_headless_execute.py`, re-exports the new function, and adds comprehensive tests covering both git contexts.

Closes #3232

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232106-372446/.autoskillit/temp/rectify/rectify_git_writes_clone_sessions_2026-05-28_232106.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 79 | 23.5k | 2.2M | 101.3k | 228 | 178.9k | 19m 20s |
| review_approach* | sonnet | 1 | 52 | 7.1k | 198.2k | 49.3k | 136 | 37.4k | 6m 16s |
| dry_walkthrough* | opus | 1 | 49 | 8.6k | 572.3k | 66.1k | 134 | 46.7k | 6m 29s |
| implement* | sonnet | 1 | 899 | 11.1k | 1.4M | 83.4k | 69 | 68.0k | 3m 51s |
| audit_impl* | sonnet | 1 | 60 | 5.0k | 189.0k | 39.2k | 49 | 44.7k | 5m 27s |
| prepare_pr* | sonnet | 1 | 74.2k | 2.7k | 213.3k | 30.9k | 16 | 15.7k | 1m 5s |
| compose_pr* | sonnet | 1 | 38.2k | 1.2k | 182.4k | 30.9k | 14 | 15.5k | 38s |
| review_pr* | sonnet | 1 | 148 | 37.5k | 949.0k | 88.6k | 54 | 73.4k | 8m 50s |
| resolve_review* | opus | 1 | 53 | 11.3k | 1.0M | 70.1k | 40 | 54.5k | 9m 31s |
| **Total** | | | 113.7k | 107.9k | 6.9M | 101.3k | | 534.8k | 1h 1m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 317 | 4328.1 | 214.4 | 35.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 71 | 14376.1 | 767.3 | 158.8 |
| **Total** | **388** | 17786.1 | 1378.3 | 278.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 79 | 23.5k | 2.2M | 178.9k | 19m 20s |
| sonnet | 6 | 113.5k | 64.6k | 3.1M | 254.7k | 26m 9s |
| opus | 2 | 102 | 19.9k | 1.6M | 101.2k | 16m 1s |