### PR TITLE
[FEATURE] Fix sentinel values bypassing skip_when_false truthiness check

### DIFF
--- a/src/autoskillit/recipe/rules/rules_bypass.py
+++ b/src/autoskillit/recipe/rules/rules_bypass.py
@@ -155,6 +155,18 @@ def _check_skip_when_false_on_hidden(ctx: ValidationContext) -> list[RuleFinding
     return findings
 
 
+_KNOWN_BOOLEAN_DEFAULTS: frozenset[str] = frozenset(
+    {
+        "true",
+        "false",
+        "1",
+        "0",
+        "yes",
+        "no",
+    }
+)
+
+
 @semantic_rule(
     name="skip-when-false-on-non-boolean",
     description=(
@@ -178,21 +190,40 @@ def _check_skip_when_false_on_non_boolean(ctx: ValidationContext) -> list[RuleFi
         ing = ctx.recipe.ingredients.get(ingredient_name)
         if ing is None:
             continue
-        if ing.default in ("true", "false"):
+        if ing.default is not None and ing.default.lower() in _KNOWN_BOOLEAN_DEFAULTS:
             continue
         if ing.required and ing.default is None:
             continue
+
+        default_str = str(ing.default) if ing.default is not None else ""
+        is_sentinel = (
+            ing.default is not None
+            and default_str != ""
+            and default_str.lower() not in _KNOWN_BOOLEAN_DEFAULTS
+            and not default_str.startswith(("/", "http"))
+        )
+
+        if is_sentinel:
+            message = (
+                f"Step '{step_name}': skip_when_false references '{ingredient_name}' "
+                f"with sentinel default {ing.default!r}. Sentinel values evaluate as "
+                f"truthy — the step will always run unless an external orchestrator "
+                f"resolves the sentinel to 'true' or 'false' before recipe invocation. "
+                f"Verify the ingredient description documents this requirement."
+            )
+        else:
+            message = (
+                f"Step '{step_name}': skip_when_false references '{ingredient_name}' "
+                f"which is not a boolean ingredient (default: {ing.default!r}). "
+                "Truthiness evaluation treats any non-empty, non-falsy string as "
+                "truthy (presence check). Verify this is the intended behavior."
+            )
         findings.append(
             RuleFinding(
                 rule="skip-when-false-on-non-boolean",
                 severity=Severity.WARNING,
                 step_name=step_name,
-                message=(
-                    f"Step '{step_name}': skip_when_false references '{ingredient_name}' "
-                    f"which is not a boolean ingredient (default: {ing.default!r}). "
-                    "Truthiness evaluation treats any non-empty, non-falsy string as "
-                    "truthy (presence check). Verify this is the intended behavior."
-                ),
+                message=message,
             )
         )
     return findings

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -46,7 +46,7 @@
       "default": "false"
     },
     "investigate": {
-      "description": "Run the investigate step. \"auto\" (default) skips when the issue body contains an investigation-complete marker; \"true\" always runs; \"false\" always skips. When no issue_url is provided, \"auto\" resolves to \"true\" (always run) since there is no issue body to check.",
+      "description": "Run the investigate step. \"true\" (or \"auto\", the default) always runs; \"false\" always skips. In fleet/batch dispatch, external orchestrators resolve \"auto\" to \"false\" when the issue body contains an investigation-complete marker. In direct orders, \"auto\" behaves like \"true\".",
       "default": "auto"
     },
     "open_pr": {
@@ -168,7 +168,8 @@
         "issue_number": "${{ result.issue_number }}",
         "issue_title": "${{ result.issue_title }}",
         "issue_slug": "${{ result.issue_slug }}",
-        "claimed": "${{ result.claimed }}"
+        "claimed": "${{ result.claimed }}",
+        "investigation_complete": "${{ result.investigation_complete }}"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -58,10 +58,11 @@ ingredients:
     default: 'false'
   investigate:
     description: >-
-      Run the investigate step. "auto" (default) skips when the issue body
-      contains an investigation-complete marker; "true" always runs; "false"
-      always skips. When no issue_url is provided, "auto" resolves to "true"
-      (always run) since there is no issue body to check.
+      Run the investigate step. "true" (or "auto", the default) always runs;
+      "false" always skips. In fleet/batch dispatch, external orchestrators
+      resolve "auto" to "false" when the issue body contains an
+      investigation-complete marker. In direct orders, "auto" behaves like
+      "true".
     default: 'auto'
   open_pr:
     description: PR instead of direct merge
@@ -175,6 +176,7 @@ steps:
       issue_title: ${{ result.issue_title }}
       issue_slug: ${{ result.issue_slug }}
       claimed: ${{ result.claimed }}
+      investigation_complete: ${{ result.investigation_complete }}
     on_result:
     - when: ${{ result.claimed }} == true
       route: create_and_publish

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -298,6 +298,11 @@ def test_prune_skipped_steps_empty_string_is_falsy() -> None:
         ("/path/to/file.md", True),
         ("some-branch-name", True),
         ("enabled", True),
+        pytest.param("auto", True, id="auto-sentinel-truthy"),
+        pytest.param("none", True, id="none-sentinel-truthy"),
+        pytest.param("default", True, id="default-sentinel-truthy"),
+        pytest.param("inherit", True, id="inherit-sentinel-truthy"),
+        pytest.param("AUTO", True, id="auto-upper-sentinel-truthy"),
         ("false", False),
         ("False", False),
         ("FALSE", False),
@@ -337,6 +342,41 @@ def test_prune_skipped_steps_truthiness_boundary(value: str, expected_truthy: bo
         assert pruned.steps["guarded"].skip_when_false is None
     else:
         assert "guarded" not in pruned.steps
+
+
+def test_prune_investigate_auto_default_evaluates_truthy() -> None:
+    """The 'auto' sentinel evaluates truthy — investigate step is kept when
+    no override is provided. Direct invocation with investigate='auto' always runs the step."""
+    from autoskillit.recipe._recipe_composition import _prune_skipped_steps
+
+    recipe = Recipe(
+        name="test",
+        description="test",
+        ingredients={
+            "investigate": RecipeIngredient(
+                description="Run the investigate step",
+                default="auto",
+            )
+        },
+        steps={
+            "investigate": RecipeStep(
+                tool="run_skill",
+                optional=True,
+                skip_when_false="inputs.investigate",
+                on_success="done",
+                on_failure="done",
+                on_context_limit="done",
+                with_args={"skill_command": "/autoskillit:investigate plan.md", "cwd": "/tmp"},
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+        kitchen_rules=["test"],
+    )
+
+    pruned, resolutions = _prune_skipped_steps(recipe, ingredient_overrides={})
+    assert resolutions["investigate"] is True
+    assert "investigate" in pruned.steps
+    assert pruned.steps["investigate"].skip_when_false is None
 
 
 def test_load_and_validate_resolves_skip_guards_in_content(tmp_path: Path) -> None:

--- a/tests/recipe/test_issue_url_pipeline.py
+++ b/tests/recipe/test_issue_url_pipeline.py
@@ -139,6 +139,7 @@ class TestInvestigateFirstIssueUrl:
         assert "issue_number" in step.get("capture", {})
         assert "issue_title" in step.get("capture", {})
         assert "issue_slug" in step.get("capture", {})
+        assert "investigation_complete" in step.get("capture", {})
 
     def test_get_issue_title_between_set_merge_target_and_create_branch(self):
         """clone step must route to claim_and_resolve (set_merge_target is now part of clone)."""
@@ -498,4 +499,25 @@ def test_bundled_recipes_fire_skip_when_false_non_boolean_warning_for_issue_url(
     assert len(hits) >= 1, (
         f"{recipe_name}: expected at least one skip-when-false-on-non-boolean WARNING "
         f"for issue_url but found none"
+    )
+
+
+def test_remediation_fires_sentinel_warning_for_investigate() -> None:
+    """remediation.yaml fires the sentinel sub-classification message for investigate: auto.
+
+    Documentation-of-known-state: the 'auto' sentinel is truthy and requires external
+    orchestrator resolution. The warning is expected and intentional.
+    """
+    recipe = load_recipe(_recipe_path("remediation"))
+    findings = run_semantic_rules(recipe)
+    hits = [
+        f
+        for f in findings
+        if f.rule == "skip-when-false-on-non-boolean"
+        and "investigate" in f.message
+        and "sentinel" in f.message
+    ]
+    assert len(hits) >= 1, (
+        "remediation: expected at least one skip-when-false-on-non-boolean WARNING "
+        "with sentinel sub-classification for investigate but found none"
     )

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -250,3 +250,10 @@ def test_remediation_investigate_routes_to_bridge(recipe) -> None:
     """investigate step on_success must route to bridge_investigation."""
     step = recipe.steps["investigate"]
     assert step.on_success == "bridge_investigation"
+
+
+def test_claim_and_resolve_captures_investigation_complete(recipe) -> None:
+    """claim_and_resolve must capture investigation_complete from the tool response."""
+    step = recipe.steps["claim_and_resolve"]
+    assert step.capture is not None
+    assert "investigation_complete" in step.capture

--- a/tests/recipe/test_rules_bypass.py
+++ b/tests/recipe/test_rules_bypass.py
@@ -246,6 +246,92 @@ def test_skip_when_false_on_required_no_default_no_warning() -> None:
     assert findings == []
 
 
+def _make_non_boolean_recipe(default: str | None, required: bool = False) -> Recipe:
+    return Recipe(
+        name="test",
+        description="test",
+        steps={
+            "entry": RecipeStep(tool="run_cmd", on_success="guarded"),
+            "guarded": RecipeStep(
+                tool="run_skill",
+                optional=True,
+                skip_when_false="inputs.flag",
+                on_success="done",
+                on_failure="done",
+                with_args={"skill_command": "/autoskillit:foo /tmp/x.md", "cwd": "/tmp"},
+                on_context_limit="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+        ingredients={
+            "flag": RecipeIngredient(
+                description="Flag ingredient", required=required, default=default
+            )
+        },
+        kitchen_rules=["test"],
+    )
+
+
+def test_non_boolean_rule_sentinel_auto_fires_with_sentinel_message() -> None:
+    """skip-when-false-on-non-boolean fires sentinel-specific message for default='auto'."""
+    recipe = _make_non_boolean_recipe(default="auto")
+    findings = [
+        f for f in run_semantic_rules(recipe) if f.rule == "skip-when-false-on-non-boolean"
+    ]
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.WARNING
+    assert "sentinel" in findings[0].message
+    assert "flag" in findings[0].message
+
+
+def test_non_boolean_rule_sentinel_inherit_fires_with_sentinel_message() -> None:
+    """skip-when-false-on-non-boolean fires sentinel-specific message for default='inherit'."""
+    recipe = _make_non_boolean_recipe(default="inherit")
+    findings = [
+        f for f in run_semantic_rules(recipe) if f.rule == "skip-when-false-on-non-boolean"
+    ]
+    assert len(findings) == 1
+    assert "sentinel" in findings[0].message
+
+
+def test_non_boolean_rule_url_fires_with_presence_check_message() -> None:
+    """skip-when-false-on-non-boolean fires presence-check message for URL default."""
+    recipe = _make_non_boolean_recipe(default="https://example.com")
+    findings = [
+        f for f in run_semantic_rules(recipe) if f.rule == "skip-when-false-on-non-boolean"
+    ]
+    assert len(findings) == 1
+    assert "sentinel" not in findings[0].message
+    assert "presence check" in findings[0].message
+
+
+def test_non_boolean_rule_boolean_1_no_warning() -> None:
+    """skip-when-false-on-non-boolean does NOT fire when default is '1' (recognized boolean)."""
+    recipe = _make_non_boolean_recipe(default="1")
+    findings = [
+        f for f in run_semantic_rules(recipe) if f.rule == "skip-when-false-on-non-boolean"
+    ]
+    assert findings == []
+
+
+def test_non_boolean_rule_boolean_yes_no_warning() -> None:
+    """skip-when-false-on-non-boolean does NOT fire when default is 'yes' (recognized boolean)."""
+    recipe = _make_non_boolean_recipe(default="yes")
+    findings = [
+        f for f in run_semantic_rules(recipe) if f.rule == "skip-when-false-on-non-boolean"
+    ]
+    assert findings == []
+
+
+def test_non_boolean_rule_boolean_true_no_warning() -> None:
+    """skip-when-false-on-non-boolean does NOT fire for default='true' (regression guard)."""
+    recipe = _make_non_boolean_recipe(default="true")
+    findings = [
+        f for f in run_semantic_rules(recipe) if f.rule == "skip-when-false-on-non-boolean"
+    ]
+    assert findings == []
+
+
 # ---------------------------------------------------------------------------
 # hidden-input-ref-in-template rule tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `investigate` ingredient in `remediation.yaml` defaults to `"auto"` — a sentinel value intended to mean "skip when the issue already has a completed investigation." However, `_is_ingredient_truthy("auto")` returns `True` because `"auto"` is not in `FALSY_STRINGS`, so the `investigate` step is never skipped in direct-order mode. The recipe engine cannot deliver the auto-skip behavior the ingredient description promises.

The existing `skip-when-false-on-non-boolean` semantic rule (`rules_bypass.py:158-198`) already detects non-boolean defaults on `skip_when_false`-guarded ingredients, but its message is generic — it says "verify this is intended behavior" without distinguishing sentinel values from URL/path presence-check values.

**Proposed fix:** Enhance the existing `skip-when-false-on-non-boolean` rule to sub-classify findings: sentinel defaults (non-boolean, non-URL/path values like `"auto"`, `"default"`, `"inherit"`) get a targeted message explaining they evaluate as truthy and require orchestrator resolution. Add sentinel values to the truthiness boundary test. Update the ingredient description to accurately describe actual behavior. Capture `investigation_complete` in `claim_and_resolve`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232027-723720/.autoskillit/temp/rectify/rectify_auto_ingredient_dead_code_2026-05-28_232027.md`

Closes #3238

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 64 | 8.3k | 823.7k | 81.0k | 184 | 46.7k | 7m 44s |
| rectify* | opus[1m] | 1 | 83 | 28.2k | 3.4M | 132.8k | 280 | 195.4k | 24m 41s |
| review_approach* | sonnet | 1 | 1.7k | 6.1k | 182.7k | 41.8k | 43 | 29.2k | 3m 30s |
| dry_walkthrough* | opus | 1 | 48 | 11.3k | 1.2M | 75.9k | 91 | 59.8k | 5m 32s |
| implement* | sonnet | 1 | 254 | 15.2k | 2.1M | 88.9k | 96 | 73.5k | 6m 12s |
| audit_impl* | sonnet | 1 | 348 | 8.6k | 322.9k | 46.3k | 59 | 31.1k | 4m 10s |
| prepare_pr* | sonnet | 1 | 87.7k | 3.3k | 221.4k | 36.2k | 26 | 55.9k | 1m 19s |
| compose_pr* | sonnet | 1 | 80.0k | 1.7k | 305.8k | 30.9k | 22 | 15.5k | 51s |
| review_pr* | sonnet | 2 | 240 | 42.0k | 1.3M | 82.7k | 82 | 100.3k | 10m 12s |
| **Total** | | | 170.4k | 124.7k | 9.9M | 132.8k | | 607.4k | 1h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 215 | 9847.7 | 341.7 | 70.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **215** | 45967.1 | 2825.3 | 579.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 2 | 112 | 19.6k | 2.0M | 106.5k | 13m 16s |
| opus[1m] | 1 | 83 | 28.2k | 3.4M | 195.4k | 24m 41s |
| sonnet | 6 | 170.2k | 77.0k | 4.4M | 305.5k | 26m 16s |