### PR TITLE
Rectify: GitHub Reviews Batch POST Serialization — Cross-Skill Immunity

### DIFF
--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -651,7 +651,8 @@ def _check_reviews_post_requires_input_flag(ctx: ValidationContext) -> list[Rule
         except OSError:
             continue
         for subsection in _extract_subsections(content):
-            if _REVIEWS_POST_RE.search(subsection) and "--input -" not in subsection:
+            collapsed = re.sub(r"\\\n\s*", " ", subsection)
+            if _REVIEWS_POST_RE.search(collapsed) and "--input -" not in subsection:
                 findings.append(
                     RuleFinding(
                         rule="reviews-post-requires-input-flag",

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -487,6 +487,12 @@ def _extract_sections(content: str) -> list[str]:
     return [p for p in parts if p.strip()]
 
 
+def _extract_subsections(content: str) -> list[str]:
+    """Split SKILL.md content into subsections at the ### level."""
+    parts = re.split(r"(?m)^(?=###\s)", content)
+    return [p for p in parts if p.strip()]
+
+
 @semantic_rule(
     name="transition-boundary-anti-confirmation",
     description=(
@@ -602,6 +608,61 @@ def _check_executable_field_content_validity(
                             f"V-rule {m.group(1)} in {skill_name} mentions an executable "
                             f"field but lacks content-validity criteria "
                             f"(placeholder/template rejection language)."
+                        ),
+                    )
+                )
+    return findings
+
+
+_REVIEWS_POST_RE: re.Pattern[str] = re.compile(
+    r"pulls/\{[^}]*\}/reviews[^\n]*--method\s+POST"
+    r"|--method\s+POST[^\n]*pulls/\{[^}]*\}/reviews"
+    r"|POST\s+/repos/\{[^}]*\}/\{[^}]*\}/pulls/\{[^}]*\}/reviews",
+    re.IGNORECASE,
+)
+
+
+@semantic_rule(
+    name="reviews-post-requires-input-flag",
+    severity=Severity.ERROR,
+    description=(
+        "A SKILL.md section mentions POST to the GitHub Reviews API with a comments[] "
+        "array but does not contain '--input -'. The --field approach serializes JSON "
+        "arrays as string literals, causing HTTP 422."
+    ),
+)
+def _check_reviews_post_requires_input_flag(ctx: ValidationContext) -> list[RuleFinding]:
+    """Fire when a SKILL.md ### subsection has a reviews POST endpoint but no --input -."""
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        if not skill_cmd:
+            continue
+        skill_name = resolve_skill_name(skill_cmd)
+        if skill_name is None:
+            continue
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
+        if skill_md is None:
+            continue
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for subsection in _extract_subsections(content):
+            if _REVIEWS_POST_RE.search(subsection) and "--input -" not in subsection:
+                findings.append(
+                    RuleFinding(
+                        rule="reviews-post-requires-input-flag",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Skill '{skill_name}' has a section that POSTs to the GitHub "
+                            f"Reviews endpoint but does not use '--input -'. The --field "
+                            f"approach serializes JSON arrays as string literals, causing "
+                            f"HTTP 422. Use: jq -n ... | gh api .../reviews "
+                            f"--method POST --input -"
                         ),
                     )
                 )

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -652,7 +652,7 @@ def _check_reviews_post_requires_input_flag(ctx: ValidationContext) -> list[Rule
             continue
         for subsection in _extract_subsections(content):
             collapsed = re.sub(r"\\\n\s*", " ", subsection)
-            if _REVIEWS_POST_RE.search(collapsed) and "--input -" not in subsection:
+            if _REVIEWS_POST_RE.search(collapsed) and "--input -" not in collapsed:
                 findings.append(
                     RuleFinding(
                         rule="reviews-post-requires-input-flag",

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -151,6 +151,33 @@ If the file exists and contains entries:
        <!-- REVIEW-FLAG: severity={severity} dimension={dimension} -->
        ```
 
+   Build the payload and post via stdin. The `--field` approach creates one array entry per flag (not one object per comment), so it must not be used for the `comments` array.
+
+   ```bash
+   # Build comments JSON array from deferred observations (exclude info severity)
+   COMMENTS_JSON=$(jq -n --argjson observations "$(cat "$DEFERRED_FILE")" '
+     $observations | map(select(.severity != "info")) | map({
+       path: .path,
+       line: (if .line then .line else null end),
+       side: "RIGHT",
+       body: ("**Observation from local review round \(.round):**\n\n\(.body)\n\n**Evidence:** \(.evidence)\n\n<!-- REVIEW-FLAG: severity=\(.severity) dimension=\(.dimension) -->")
+     }) | map(if .line == null then del(.line) + {position: 1} else . end)
+   ')
+
+   COMMIT_SHA=$(gh pr view ${PR_NUMBER} --json headRefOid -q .headRefOid)
+   ROUND_COUNT=$(jq -n --argjson obs "$(cat "$DEFERRED_FILE")" '$obs | map(.round) | unique | length')
+
+   # Build and post the full review payload via stdin
+   jq -n \
+     --arg body "Observations accumulated from ${ROUND_COUNT} local review rounds:" \
+     --arg event "COMMENT" \
+     --arg commit_id "$COMMIT_SHA" \
+     --argjson comments "$COMMENTS_JSON" \
+     '{body: $body, event: $event, commit_id: $commit_id, comments: $comments}' | \
+   gh api /repos/{owner}/{repo}/pulls/${PR_NUMBER}/reviews \
+     --method POST --input -
+   ```
+
 4. Use the batch review endpoint (never post individual comments unless the batch call fails)
 5. **Fallback:** If the batch POST returns HTTP 422 (e.g., stale line numbers), retry by posting each observation individually via `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --method POST` with 1s delay between calls
 6. After all deferred observations are posted successfully, rename the file to `deferred_observations_${PR_NUMBER}_posted.json` to prevent re-posting on retry

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -138,7 +138,7 @@ If the file exists and contains entries:
    - `commit_id`: current HEAD commit SHA (from `gh pr view {pr_number} --json headRefOid -q .headRefOid`)
    - `comments[]` array where each entry has:
      - `path`: from the deferred entry
-     - `line`: from the deferred entry (if `line` is null, omit `line` and use `position: 1` as file-level comment)
+     - `line`: from the deferred entry (if `line` is null, omit `line` and set `subject_type: "file"` for a file-level comment)
      - `side`: `"RIGHT"`
      - `body`:
        ```
@@ -154,17 +154,24 @@ If the file exists and contains entries:
    Build the payload and post via stdin. The `--field` approach creates one array entry per flag (not one object per comment), so it must not be used for the `comments` array.
 
    ```bash
+   # Guard: verify deferred file exists and is non-empty before processing
+   if [[ ! -s "$DEFERRED_FILE" ]]; then
+     echo "Deferred file missing or empty — skipping observation posting"
+     # Skip to Step 2
+   fi
+
    # Build comments JSON array from deferred observations (exclude info severity)
    COMMENTS_JSON=$(jq -n --argjson observations "$(cat "$DEFERRED_FILE")" '
      $observations | map(select(.severity != "info")) | map({
        path: .path,
        line: (if .line then .line else null end),
        side: "RIGHT",
+       subject_type: (if .line then "line" else "file" end),
        body: ("**Observation from local review round \(.round):**\n\n\(.body)\n\n**Evidence:** \(.evidence)\n\n<!-- REVIEW-FLAG: severity=\(.severity) dimension=\(.dimension) -->")
-     }) | map(if .line == null then del(.line) + {position: 1} else . end)
+     }) | map(if .line == null then del(.line) else . end)
    ')
 
-   COMMIT_SHA=$(gh pr view ${PR_NUMBER} --json headRefOid -q .headRefOid)
+   COMMIT_SHA=$(gh pr view "${PR_NUMBER}" --json headRefOid -q .headRefOid)
    ROUND_COUNT=$(jq -n --argjson obs "$(cat "$DEFERRED_FILE")" '$obs | map(.round) | unique | length')
 
    # Build and post the full review payload via stdin
@@ -174,7 +181,7 @@ If the file exists and contains entries:
      --arg commit_id "$COMMIT_SHA" \
      --argjson comments "$COMMENTS_JSON" \
      '{body: $body, event: $event, commit_id: $commit_id, comments: $comments}' | \
-   gh api /repos/{owner}/{repo}/pulls/${PR_NUMBER}/reviews \
+   gh api /repos/{owner}/{repo}/pulls/"${PR_NUMBER}"/reviews \
      --method POST --input -
    ```
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -650,6 +650,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "skills/test_skill_placeholder_contracts.py",
             "skills/test_make_campaign_compliance.py",
             "skills/test_review_design_guards.py",
+            "skills/test_skill_compliance.py",
             "skills/test_skill_tool_syntax_contracts.py",
             "skills/test_vis_lens_methodology_norms.py",
             "skills/test_audit_impl_diff_discipline.py",

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -998,3 +998,139 @@ def test_executable_field_content_validity_checks_all_v_rules(tmp_path: Path) ->
         f"Expected 2 findings (V7 + V9), got {len(exec_findings)}: "
         + "; ".join(f.message for f in exec_findings)
     )
+
+
+# ---------------------------------------------------------------------------
+# reviews-post-requires-input-flag
+# ---------------------------------------------------------------------------
+
+_REVIEWS_RULE_ID = "reviews-post-requires-input-flag"
+
+
+def test_reviews_post_requires_input_flag_rule(tmp_path: Path) -> None:
+    """Rule fires when a SKILL.md section mentions reviews POST but lacks --input -."""
+    skill_dir = tmp_path / "test-reviews-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # test-reviews-skill
+
+            ### Step 1
+            Post the findings:
+            gh api /repos/{owner}/{repo}/pulls/{pr_number}/reviews \\
+              --method POST \\
+              --field event=COMMENT
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("test-reviews-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    rule_ids = [f.rule for f in findings]
+    assert _REVIEWS_RULE_ID in rule_ids, (
+        f"Expected '{_REVIEWS_RULE_ID}' finding when reviews POST lacks --input -, got: {rule_ids}"
+    )
+    matching = [f for f in findings if f.rule == _REVIEWS_RULE_ID]
+    assert all(f.severity == Severity.ERROR for f in matching)
+
+
+def test_reviews_post_requires_input_flag_rule_passes_with_input_flag(
+    tmp_path: Path,
+) -> None:
+    """Rule does NOT fire when --input - is present in the same section as the reviews POST."""
+    skill_dir = tmp_path / "good-reviews-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # good-reviews-skill
+
+            ### Step 1
+            Post the findings via stdin:
+            jq -n --arg body "summary" --arg event COMMENT --argjson comments "$C" \\
+              '{body: $body, event: $event, comments: $comments}' | \\
+            gh api /repos/{owner}/{repo}/pulls/{pr_number}/reviews \\
+              --method POST --input -
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("good-reviews-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    rule_ids = [f.rule for f in findings]
+    assert _REVIEWS_RULE_ID not in rule_ids, (
+        f"Rule must not fire when --input - is present alongside the reviews POST, got: {rule_ids}"
+    )
+
+
+def test_reviews_post_rule_subsection_granularity(tmp_path: Path) -> None:
+    """Rule uses ### granularity: --input - in a different ### step does not satisfy the guard.
+
+    If the implementation mistakenly used ## granularity (_extract_sections), --input - from
+    any step in the same ## Workflow section would suppress the finding. This test catches
+    that false-negative regression.
+    """
+    skill_dir = tmp_path / "granularity-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # granularity-skill
+
+            ## Workflow
+
+            ### Step A
+            Do something with --input - for an unrelated purpose.
+            gh api /repos/{owner}/{repo}/something --method POST --input -
+
+            ### Step B
+            Post the findings:
+            gh api /repos/{owner}/{repo}/pulls/{pr_number}/reviews \\
+              --method POST \\
+              --field event=COMMENT
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("granularity-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    rule_ids = [f.rule for f in findings]
+    assert _REVIEWS_RULE_ID in rule_ids, (
+        f"Rule must fire when --input - is in a different ### step than the reviews POST "
+        f"(### granularity required, not ## granularity). Got findings: {rule_ids}"
+    )
+
+
+def test_reviews_post_regex_flag_before_path(tmp_path: Path) -> None:
+    """Rule fires when --method POST appears before the endpoint path (flag-before-path form)."""
+    skill_dir = tmp_path / "flag-before-path-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # flag-before-path-skill
+
+            ### Step 1
+            Post the review:
+            gh api --method POST repos/{owner}/{repo}/pulls/{pr_number}/reviews \\
+              --field event=COMMENT
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("flag-before-path-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    rule_ids = [f.rule for f in findings]
+    assert _REVIEWS_RULE_ID in rule_ids, (
+        f"Rule must fire for 'gh api --method POST URL' form (flag before path). "
+        f"Got findings: {rule_ids}"
+    )

--- a/tests/skills/test_review_pr_inline_comment_guards.py
+++ b/tests/skills/test_review_pr_inline_comment_guards.py
@@ -146,6 +146,29 @@ def test_step6_uses_input_flag_not_field_for_comments():
     )
 
 
+def test_step15_resolve_review_uses_input_flag_not_field_for_comments():
+    """resolve-review Step 1.5 must prescribe --input - for the batch reviews POST.
+
+    Step 1.5 posts accumulated deferred observations via POST /reviews. Using
+    --field for the comments[] array serializes it as a string literal, causing
+    HTTP 422. Guarded here to prevent silent regression of Issue #3244.
+
+    To verify this test is effective: temporarily remove '--input -' from
+    resolve-review/SKILL.md Step 1.5 and confirm this test fails. Then restore it.
+    """
+    text = RESOLVE_SKILL_TEXT
+    step15_start = text.find("### Step 1.5")
+    step2_start = text.find("### Step 2")
+    assert step15_start != -1, "resolve-review/SKILL.md must contain '### Step 1.5'"
+    assert step2_start != -1, "resolve-review/SKILL.md must contain '### Step 2'"
+    step15_section = text[step15_start:step2_start]
+    assert "--input -" in step15_section, (
+        "resolve-review/SKILL.md Step 1.5 must use '--input -' for the batch reviews "
+        "POST payload. The --field approach serializes JSON arrays as string literals, "
+        "causing HTTP 422. This flag must appear within Step 1.5 specifically."
+    )
+
+
 def test_step6_does_not_prescribe_deprecated_position_field():
     """Comments payload must not include a 'position' field.
 

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -436,3 +436,42 @@ def test_implement_skills_have_anti_blame_prohibition(skill_dir: Path) -> None:
         'Add: \'- Blame pre-commit or lint failures on "pre-existing issues" '
         "\u2014 ALL pre-commit checks must pass on the committed code'"
     )
+
+
+_REVIEWS_POST_RE = re.compile(
+    r"pulls/\{[^}]*\}/reviews[^\n]*--method\s+POST"
+    r"|--method\s+POST[^\n]*pulls/\{[^}]*\}/reviews"
+    r"|POST\s+/repos/\{[^}]*\}/\{[^}]*\}/pulls/\{[^}]*\}/reviews",
+    re.IGNORECASE,
+)
+
+
+def _extract_skill_subsections(content: str) -> list[str]:
+    """Split SKILL.md content into subsections at the ### level."""
+    parts = re.split(r"(?m)^(?=###\s)", content)
+    return [p for p in parts if p.strip()]
+
+
+@pytest.mark.parametrize("skill_dir", _all_skill_dirs(), ids=lambda p: p.name)
+def test_reviews_post_requires_input_flag(skill_dir: Path) -> None:
+    """Any SKILL.md section that POSTs to the GitHub Reviews endpoint must use --input -.
+
+    The --field approach serializes JSON arrays as string literals, causing HTTP 422.
+    Catches any future skill that adds a POST /pulls/{N}/reviews endpoint without --input -,
+    regardless of which skill or which step.
+
+    To verify this test is effective: temporarily remove '--input -' from a reviews POST
+    section in any SKILL.md and confirm this test fails. Then restore it.
+    """
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return
+    content = skill_md.read_text(encoding="utf-8")
+    for subsection in _extract_skill_subsections(content):
+        if _REVIEWS_POST_RE.search(subsection):
+            assert "--input -" in subsection, (
+                f"{skill_dir.name}/SKILL.md: a section mentions POST to the GitHub Reviews "
+                f"endpoint but does not contain '--input -'. The --field approach serializes "
+                f"JSON arrays as string literals, causing HTTP 422. "
+                f"Use: jq -n ... | gh api .../reviews --method POST --input -"
+            )

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -18,6 +18,10 @@ from pathlib import Path
 import pytest
 
 from autoskillit.core.paths import pkg_root
+from autoskillit.recipe.rules.rules_skill_content import (
+    _REVIEWS_POST_RE,
+    _extract_subsections,
+)
 from autoskillit.workspace.skills import DefaultSkillResolver
 from tests.contracts._anti_fab_helpers import FABRICATION_GUARD_RE
 
@@ -438,20 +442,6 @@ def test_implement_skills_have_anti_blame_prohibition(skill_dir: Path) -> None:
     )
 
 
-_REVIEWS_POST_RE = re.compile(
-    r"pulls/\{[^}]*\}/reviews[^\n]*--method\s+POST"
-    r"|--method\s+POST[^\n]*pulls/\{[^}]*\}/reviews"
-    r"|POST\s+/repos/\{[^}]*\}/\{[^}]*\}/pulls/\{[^}]*\}/reviews",
-    re.IGNORECASE,
-)
-
-
-def _extract_skill_subsections(content: str) -> list[str]:
-    """Split SKILL.md content into subsections at the ### level."""
-    parts = re.split(r"(?m)^(?=###\s)", content)
-    return [p for p in parts if p.strip()]
-
-
 @pytest.mark.parametrize("skill_dir", _all_skill_dirs(), ids=lambda p: p.name)
 def test_reviews_post_requires_input_flag(skill_dir: Path) -> None:
     """Any SKILL.md section that POSTs to the GitHub Reviews endpoint must use --input -.
@@ -465,9 +455,9 @@ def test_reviews_post_requires_input_flag(skill_dir: Path) -> None:
     """
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.exists():
-        return
+        pytest.skip(f"{skill_dir.name} has no SKILL.md")
     content = skill_md.read_text(encoding="utf-8")
-    for subsection in _extract_skill_subsections(content):
+    for subsection in _extract_subsections(content):
         if _REVIEWS_POST_RE.search(subsection):
             assert "--input -" in subsection, (
                 f"{skill_dir.name}/SKILL.md: a section mentions POST to the GitHub Reviews "


### PR DESCRIPTION
## Summary

The resolve-review SKILL.md Step 1.5 describes a `POST /repos/{owner}/{repo}/pulls/{pr_number}/reviews` payload with a `comments[]` array in prose only — no executable shell snippet using `--input -`. Agents default to `--field`, which serializes JSON arrays as string literals, causing HTTP 422. Three sibling skills (review-pr, review-research-pr, audit-claims) have the correct `jq ... | gh api --input -` pattern. This is the second time this exact bug class has surfaced (first: Issue #206 in review-pr).

The architectural weakness: the `--input -` discipline is enforced per-skill by copy-pasting code blocks and per-skill by writing individual tests. No cross-skill invariant prevents new or modified skills from introducing the same flaw. The fix strategy adds a **semantic rule** to `rules_skill_content.py` that automatically catches any SKILL.md containing a `POST` to the GitHub Reviews endpoint without `--input -` in the same section, plus structural tests and the direct fix to resolve-review.

Closes #3244

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232223-765925/.autoskillit/temp/rectify/rectify_review_batch_comment_input_flag_2026-05-28_234228.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 49 | 7.2k | 542.1k | 59.0k | 190 | 45.3k | 5m 47s |
| rectify* | opus[1m] | 1 | 3.8k | 18.4k | 1.7M | 113.7k | 247 | 121.2k | 13m 56s |
| review_approach* | sonnet | 1 | 52 | 5.3k | 179.7k | 40.0k | 39 | 26.8k | 2m 58s |
| dry_walkthrough* | opus | 2 | 4.3k | 11.9k | 1.3M | 72.2k | 159 | 98.1k | 7m 16s |
| implement* | sonnet | 1 | 1.4k | 19.7k | 1.6M | 79.3k | 92 | 63.5k | 6m 47s |
| audit_impl* | sonnet | 1 | 888 | 11.7k | 335.3k | 51.5k | 35 | 36.0k | 4m 29s |
| prepare_pr* | sonnet | 1 | 111.0k | 3.9k | 247.2k | 30.9k | 25 | 43.6k | 1m 29s |
| compose_pr* | sonnet | 1 | 47.7k | 1.6k | 213.4k | 30.9k | 15 | 15.4k | 47s |
| review_pr* | sonnet | 2 | 240 | 46.0k | 1.4M | 82.5k | 74 | 112.7k | 11m 29s |
| resolve_review* | opus | 1 | 72 | 13.2k | 2.3M | 76.5k | 68 | 60.7k | 7m 29s |
| **Total** | | | 169.5k | 139.1k | 9.9M | 113.7k | | 623.3k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 286 | 5760.8 | 222.0 | 68.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 40 | 56560.7 | 1518.6 | 329.7 |
| **Total** | **326** | 30274.1 | 1912.0 | 426.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 3 | 4.4k | 32.3k | 4.1M | 204.2k | 20m 33s |
| opus[1m] | 1 | 3.8k | 18.4k | 1.7M | 121.2k | 13m 56s |
| sonnet | 6 | 161.3k | 88.3k | 4.0M | 298.0k | 27m 59s |