### PR TITLE
Rectify: Silent Scanner Failure Indistinguishable from Clean Scan

### DIFF
--- a/src/autoskillit/agents/pipeline-health-scanner.md
+++ b/src/autoskillit/agents/pipeline-health-scanner.md
@@ -1,7 +1,7 @@
 ---
 name: pipeline-health-scanner
 description: "Analyze a batch of pipeline session logs for anomalies, bugs, and regressions. Reads session data, investigates anything suspicious as deeply as warranted, and reports findings with evidence."
-tools: [Read, Bash, Grep, Glob]
+tools: [Read, Bash, Grep, Glob, Agent]
 model: haiku
 maxTurns: 40
 ---
@@ -53,4 +53,22 @@ If the adversarial agent confirms the finding holds up, report it as confirmed. 
 
 ## Output
 
-Report findings with evidence. Not a fixed schema — natural language description of what you found, why you think it's a problem, what sessions are affected, and what you learned from investigating. If nothing is wrong, report that clearly.
+Report findings with evidence. Natural language description of what you found, why you think it's a problem, what sessions are affected, and what you learned from investigating. If nothing is wrong, report that clearly.
+
+After the narrative findings, emit a structured completion token as the final line:
+
+```
+scan_result: {step_group: "<step_name>", sessions_scanned: <N>, findings_count: <M>, status: "complete"}
+```
+
+When no issues are found:
+```
+scan_result: {step_group: "plan", sessions_scanned: 3, findings_count: 0, status: "complete"}
+```
+
+When the scan cannot complete (access failures, errors):
+```
+scan_result: {step_group: "plan", sessions_scanned: 0, findings_count: 0, status: "incomplete", reason: "<why>"}
+```
+
+The `findings_count` is the number of confirmed findings reported above. The token is always the last line of output.

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2251,6 +2251,11 @@ skills:
       type: string
       required: false
     outputs: []
+    expected_output_patterns:
+    - "---pipeline-health-result---"
+    pattern_examples:
+    - "Pipeline health check: no issues found\n---pipeline-health-result---\n%%ORDER_UP%%"
+    - "## Findings\n### confirmed_bug\n...\n---pipeline-health-result---\n%%ORDER_UP%%"
     read_only: true
 callable_contracts:
   autoskillit.smoke_utils.check_loop_iteration:

--- a/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
@@ -58,12 +58,16 @@ Each scanner receives in its prompt:
 
 Issue ALL Agent calls in a single message for parallel execution.
 
-### Step 4: Consolidate findings
+### Step 4: Validate scanner completion and consolidate findings
 
-Collect results from all scanners. Produce a consolidated report:
+Collect results from all scanners. For each scanner result:
+1. Check that the result contains a `scan_result:` completion token.
+2. If a scanner result is empty or lacks the `scan_result:` token, record it as an anomaly finding with severity "anomaly" and summary "Scanner for step group '<name>' did not complete — results may be missing."
+3. Only report "Pipeline health check: no issues found" when ALL scanners emitted `status: "complete"` tokens with `findings_count: 0`.
+
+Produce a consolidated report:
 - Group findings by severity (confirmed bugs > regressions > anomalies > informational)
 - Include the scanner's evidence and adversarial validation status for each finding
-- If no scanners found issues, report "Pipeline health check: no issues found"
 
 ### Step 5: Write report file (fleet dispatches only)
 
@@ -87,4 +91,10 @@ If --dispatch-id was not provided or is empty, skip this step entirely.
 
 ### Step 6: Output
 
-Present the consolidated report as your final output text. The calling orchestrator session will receive this as the run_skill result.
+Present the consolidated report as your final output text. After the report body, emit the completion delimiter as the final line:
+
+```
+---pipeline-health-result---
+```
+
+The calling orchestrator session will receive this as the run_skill result.

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -12,6 +12,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `conftest.py` | Shared constants for contract tests — REFUSAL_SIGNALS |
 | `test_activate_deps_completeness.py` | Contracts: SKILL.md activate_deps must cover invoked Skill tool calls |
 | `test_advisory_coverage.py` | Contracts: SKILL_FILE_ADVISORY_MAP advisory hook coverage |
+| `test_analyze_pipeline_health_contracts.py` | Contract tests for the analyze-pipeline-health skill — output patterns and delimiter |
 | `test_api_surface_alignment.py` | REQ-C8-01 / C2-01: API surface alignment tests |
 | `test_backend_protocol.py` | Protocol conformance for CodingAgentBackend, StreamParser, ResultParser, and ClaudeCodeBackend |
 | `test_claim_issue_contracts.py` | Contract tests for claim_issue and release_issue MCP tools |

--- a/tests/contracts/test_analyze_pipeline_health_contracts.py
+++ b/tests/contracts/test_analyze_pipeline_health_contracts.py
@@ -1,0 +1,58 @@
+"""Contract tests for the analyze-pipeline-health skill."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_OUTPUT_DELIMITER = "---pipeline-health-result---"
+
+
+def _load_contract() -> dict:
+    from autoskillit.core import pkg_root
+
+    contracts_path = pkg_root() / "recipe" / "skill_contracts.yaml"
+    raw = yaml.safe_load(contracts_path.read_text())
+    return raw.get("skills", {}).get("analyze-pipeline-health", {})
+
+
+def test_analyze_pipeline_health_has_expected_output_patterns():
+    """analyze-pipeline-health contract must declare non-empty expected_output_patterns."""
+    contract = _load_contract()
+    patterns = contract.get("expected_output_patterns", [])
+    assert patterns, (
+        "analyze-pipeline-health skill_contracts.yaml entry must have "
+        "a non-empty 'expected_output_patterns' list"
+    )
+
+
+def test_analyze_pipeline_health_output_patterns_include_delimiter():
+    """analyze-pipeline-health expected_output_patterns must include the result delimiter."""
+    contract = _load_contract()
+    patterns = contract.get("expected_output_patterns", [])
+    assert any(_OUTPUT_DELIMITER in p for p in patterns), (
+        f"analyze-pipeline-health expected_output_patterns must include "
+        f"'{_OUTPUT_DELIMITER}' — got: {patterns}"
+    )
+
+
+def test_analyze_pipeline_health_has_pattern_examples():
+    """analyze-pipeline-health contract must declare pattern_examples."""
+    contract = _load_contract()
+    examples = contract.get("pattern_examples", [])
+    assert examples, (
+        "analyze-pipeline-health skill_contracts.yaml entry must have "
+        "a non-empty 'pattern_examples' list"
+    )
+
+
+def test_analyze_pipeline_health_pattern_examples_match_delimiter():
+    """Each pattern_example must contain the output delimiter."""
+    contract = _load_contract()
+    examples = contract.get("pattern_examples", [])
+    for example in examples:
+        assert _OUTPUT_DELIMITER in example, (
+            f"pattern_example must contain '{_OUTPUT_DELIMITER}': {example!r}"
+        )

--- a/tests/contracts/test_analyze_pipeline_health_contracts.py
+++ b/tests/contracts/test_analyze_pipeline_health_contracts.py
@@ -14,7 +14,8 @@ def _load_contract() -> dict:
     from autoskillit.core import pkg_root
 
     contracts_path = pkg_root() / "recipe" / "skill_contracts.yaml"
-    raw = yaml.safe_load(contracts_path.read_text())
+    assert contracts_path.is_file(), f"skill_contracts.yaml not found at {contracts_path}"
+    raw = yaml.safe_load(contracts_path.read_text()) or {}
     return raw.get("skills", {}).get("analyze-pipeline-health", {})
 
 
@@ -31,6 +32,7 @@ def test_analyze_pipeline_health_has_expected_output_patterns():
 def test_analyze_pipeline_health_output_patterns_include_delimiter():
     """analyze-pipeline-health expected_output_patterns must include the result delimiter."""
     contract = _load_contract()
+    assert contract, "analyze-pipeline-health entry missing from skill_contracts.yaml"
     patterns = contract.get("expected_output_patterns", [])
     assert any(_OUTPUT_DELIMITER in p for p in patterns), (
         f"analyze-pipeline-health expected_output_patterns must include "
@@ -51,7 +53,9 @@ def test_analyze_pipeline_health_has_pattern_examples():
 def test_analyze_pipeline_health_pattern_examples_match_delimiter():
     """Each pattern_example must contain the output delimiter."""
     contract = _load_contract()
+    assert contract, "analyze-pipeline-health entry missing from skill_contracts.yaml"
     examples = contract.get("pattern_examples", [])
+    assert examples, "pattern_examples must be non-empty"
     for example in examples:
         assert _OUTPUT_DELIMITER in example, (
             f"pattern_example must contain '{_OUTPUT_DELIMITER}': {example!r}"

--- a/tests/contracts/test_callable_skill_parity.py
+++ b/tests/contracts/test_callable_skill_parity.py
@@ -44,7 +44,6 @@ def _has_contract_tests(skill_name: str) -> bool:
 def test_recipe_skills_have_contract_tests() -> None:
     """Every skill dispatched by a recipe run_skill step should have contract tests."""
     KNOWN_EXCEPTIONS = {
-        "analyze-pipeline-health",
         "audit-tests",
         "audit-cohesion",
         "audit-arch",

--- a/tests/recipe/test_diagnostic_steps.py
+++ b/tests/recipe/test_diagnostic_steps.py
@@ -21,6 +21,24 @@ def test_analyze_pipeline_health_skill_exists():
     )
 
 
+# DIAG_C8: coordinator SKILL.md validates scanner completion and emits output delimiter
+def test_analyze_pipeline_health_coordinator_validates_scanners():
+    """analyze-pipeline-health SKILL.md must instruct scanner validation and emit a delimiter."""
+    from autoskillit.core import pkg_root
+
+    skill_path = pkg_root() / "skills_extended" / "analyze-pipeline-health" / "SKILL.md"
+    content = skill_path.read_text()
+
+    assert "scan_result:" in content, (
+        "analyze-pipeline-health SKILL.md Step 4 must instruct validation of 'scan_result:' "
+        "completion token from each scanner"
+    )
+    assert "---pipeline-health-result---" in content, (
+        "analyze-pipeline-health SKILL.md Step 6 must instruct emitting "
+        "the '---pipeline-health-result---' delimiter"
+    )
+
+
 # DIAG_C9: run_diagnostic steps have required fields in implementation recipe
 @pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "merge-prs"])
 def test_run_diagnostic_steps_have_required_fields(recipe_name):

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -367,9 +367,97 @@ def test_wp_elaborator_is_packless():
 # DIAG_C6: pipeline-health-scanner agent exists
 def test_pipeline_health_scanner_agent_exists():
     """pipeline-health-scanner.md agent definition must exist with required frontmatter."""
+    import yaml
+
     from autoskillit.core import pkg_root
 
     agent_path = pkg_root() / "agents" / "pipeline-health-scanner.md"
     assert agent_path.is_file(), f"pipeline-health-scanner.md not found at {agent_path}"
     content = agent_path.read_text()
     assert "name: pipeline-health-scanner" in content
+
+    parts = content.split("---", 2)
+    assert len(parts) >= 3, "pipeline-health-scanner.md must have YAML frontmatter"
+    frontmatter = yaml.safe_load(parts[1])
+    tools = frontmatter.get("tools", [])
+    assert "Agent" in tools, (
+        "pipeline-health-scanner.md frontmatter tools must include 'Agent' "
+        "(body instructs spawning adversarial subagents)"
+    )
+
+    body = parts[2]
+    assert "scan_result:" in body, (
+        "pipeline-health-scanner.md body must contain a 'scan_result:' structured completion token"
+    )
+
+
+# DIAG_C10: all agent definitions have structured output contracts
+AGENTS_WITHOUT_STRUCTURED_OUTPUT: set[str] = set()
+
+
+def test_all_agents_have_structured_output():
+    """Every agent definition must have a structured output marker or be in the allowlist."""
+    from autoskillit.core import pkg_root
+
+    _STRUCTURED_MARKERS = ("Verdict:", "scan_result:", "```json")
+
+    agents_dir = pkg_root() / "agents"
+    failures: list[str] = []
+    for md_file in sorted(agents_dir.glob("*.md")):
+        if md_file.name == "CLAUDE.md":
+            continue
+        if md_file.stem in AGENTS_WITHOUT_STRUCTURED_OUTPUT:
+            continue
+        content = md_file.read_text()
+        parts = content.split("---", 2)
+        body = parts[2] if len(parts) >= 3 else content
+        if not any(marker in body for marker in _STRUCTURED_MARKERS):
+            failures.append(
+                f"  {md_file.name}: no structured output marker found "
+                f"(expected one of {_STRUCTURED_MARKERS}). "
+                f"Add a completion token/verdict/schema or list in "
+                f"AGENTS_WITHOUT_STRUCTURED_OUTPUT."
+            )
+    assert not failures, "Agent definitions must have structured output contracts:\n" + "\n".join(
+        failures
+    )
+
+
+# DIAG_C11: agent frontmatter tools must cover all tool references in body
+def test_agent_tool_list_covers_body_references():
+    """Agent frontmatter tools must include all tools referenced in the body."""
+    import re
+
+    import yaml
+
+    from autoskillit.core import pkg_root
+
+    _SPAWN_SUBAGENT_RE = re.compile(r"spawn\s+\w+\s+subagent", re.IGNORECASE)
+    _LSP_BODY_RE = re.compile(r"\bLSP\b")
+
+    agents_dir = pkg_root() / "agents"
+    failures: list[str] = []
+    for md_file in sorted(agents_dir.glob("*.md")):
+        if md_file.name == "CLAUDE.md":
+            continue
+        content = md_file.read_text()
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            continue
+        frontmatter = yaml.safe_load(parts[1])
+        tools: list[str] = frontmatter.get("tools", [])
+        body = parts[2]
+        if _SPAWN_SUBAGENT_RE.search(body) and "Agent" not in tools:
+            failures.append(
+                f"  {md_file.name}: body references spawning subagents but 'Agent' "
+                f"is not in frontmatter tools: {tools}"
+            )
+        if _LSP_BODY_RE.search(body) and "LSP" not in tools:
+            failures.append(
+                f"  {md_file.name}: body references 'LSP' but 'LSP' "
+                f"is not in frontmatter tools: {tools}"
+            )
+    assert not failures, (
+        "Agent frontmatter tools must cover all tool references in the body:\n"
+        + "\n".join(failures)
+    )

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -399,7 +399,14 @@ def test_all_agents_have_structured_output():
     """Every agent definition must have a structured output marker or be in the allowlist."""
     from autoskillit.core import pkg_root
 
-    _STRUCTURED_MARKERS = ("Verdict:", "scan_result:", "```json")
+    _STRUCTURED_MARKERS = (
+        "Verdict:",
+        "scan_result:",
+        "```json",
+        "# Verdict",
+        "## Verdict",
+        "### Verdict",
+    )
 
     agents_dir = pkg_root() / "agents"
     failures: list[str] = []

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -378,7 +378,7 @@ def test_pipeline_health_scanner_agent_exists():
 
     parts = content.split("---", 2)
     assert len(parts) >= 3, "pipeline-health-scanner.md must have YAML frontmatter"
-    frontmatter = yaml.safe_load(parts[1])
+    frontmatter = yaml.safe_load(parts[1]) or {}
     tools = frontmatter.get("tools", [])
     assert "Agent" in tools, (
         "pipeline-health-scanner.md frontmatter tools must include 'Agent' "
@@ -392,7 +392,7 @@ def test_pipeline_health_scanner_agent_exists():
 
 
 # DIAG_C10: all agent definitions have structured output contracts
-AGENTS_WITHOUT_STRUCTURED_OUTPUT: set[str] = set()
+AGENTS_WITHOUT_STRUCTURED_OUTPUT: frozenset[str] = frozenset()
 
 
 def test_all_agents_have_structured_output():
@@ -451,7 +451,7 @@ def test_agent_tool_list_covers_body_references():
         parts = content.split("---", 2)
         if len(parts) < 3:
             continue
-        frontmatter = yaml.safe_load(parts[1])
+        frontmatter = yaml.safe_load(parts[1]) or {}
         tools: list[str] = frontmatter.get("tools", [])
         body = parts[2]
         if _SPAWN_SUBAGENT_RE.search(body) and "Agent" not in tools:


### PR DESCRIPTION
## Summary

The `analyze-pipeline-health` skill spawns `pipeline-health-scanner` subagents via the Agent tool but has no mechanism to verify scanner completion. A scanner that times out, exits early, or returns empty output is indistinguishable from one that completed and found no issues. The coordinator treats any non-finding text as "clean," the skill contract declares `outputs: []` with no `expected_output_patterns`, and recipe steps wrap it with `optional: true` / `on_failure: done` — silently absorbing failures at every layer.

The architectural weakness is the absence of a **completion contract** between the coordinator and its scanners, combined with the absence of **output pattern enforcement** in the skill contract. This is not just a bug in one skill — it represents a gap in the agent output contract pattern that affects the scanner agent definition, the coordinator skill, and the contract validation infrastructure.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.



Closes #3234

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232030-351964/.autoskillit/temp/rectify/rectify_silent-scanner-failure_2026-05-28_233000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 59 | 6.8k | 533.9k | 77.0k | 167 | 36.6k | 5m 9s |
| rectify* | opus[1m] | 1 | 3.7k | 18.9k | 2.2M | 118.9k | 274 | 182.3k | 23m 54s |
| review_approach* | sonnet | 1 | 4.7k | 6.2k | 179.7k | 41.9k | 43 | 29.4k | 3m 10s |
| dry_walkthrough* | opus | 1 | 707 | 10.6k | 1.3M | 68.2k | 70 | 52.1k | 5m 2s |
| implement* | sonnet | 1 | 0 | 0 | 0 | 77.5k | 114 | 0 | 11m 13s |
| audit_impl* | sonnet | 1 | 378 | 8.6k | 232.4k | 38.1k | 23 | 31.1k | 3m 48s |
| prepare_pr* | sonnet | 1 | 150.1k | 3.5k | 367.6k | 30.9k | 24 | 15.7k | 1m 32s |
| compose_pr* | sonnet | 1 | 71.9k | 1.7k | 275.0k | 30.9k | 20 | 15.4k | 48s |
| review_pr* | sonnet | 2 | 298 | 66.9k | 1.9M | 85.3k | 99 | 137.3k | 15m 49s |
| resolve_review* | opus | 2 | 88 | 15.0k | 2.3M | 65.3k | 89 | 136.7k | 14m 27s |
| **Total** | | | 231.9k | 138.3k | 9.2M | 118.9k | | 636.8k | 1h 24m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 211 | 0.0 | 0.0 | 0.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 192101.8 | 11394.1 | 1249.2 |
| **Total** | **223** | 41415.1 | 2855.4 | 620.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 3 | 854 | 32.4k | 4.1M | 225.4k | 24m 39s |
| opus[1m] | 1 | 3.7k | 18.9k | 2.2M | 182.3k | 23m 54s |
| sonnet | 6 | 227.4k | 87.0k | 2.9M | 229.1k | 36m 22s |