### PR TITLE
Rectify: Namespace Prefix Mismatch for Bundled Extended Skills — PART A ONLY

### DIFF
--- a/src/autoskillit/recipe/_skill_helpers.py
+++ b/src/autoskillit/recipe/_skill_helpers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from autoskillit.core import SkillLister
 
+MULTIPART_SKILL_NAMES: frozenset[str] = frozenset({"make-plan", "rectify"})
+
 
 def _get_skill_category_map(lister: SkillLister | None = None) -> dict[str, frozenset[str]]:
     """Return {skill_name: categories} for all bundled skills."""

--- a/src/autoskillit/recipe/rules/rules_clone.py
+++ b/src/autoskillit/recipe/rules/rules_clone.py
@@ -90,7 +90,7 @@ def _check_skill_command_prefix(ctx: ValidationContext) -> list[RuleFinding]:
                     step_name=step_name,
                     message=(
                         f"skill_command {skill_cmd!r} does not start with '/'. "
-                        "run_skill requires a slash-prefix (e.g. /autoskillit:investigate). "
+                        "run_skill requires a slash-prefix (e.g. /autoskillit:sous-chef). "
                         "Prose prompts bypass the skill contract and run with "
                         "--dangerously-skip-permissions."
                     ),

--- a/src/autoskillit/recipe/rules/rules_clone.py
+++ b/src/autoskillit/recipe/rules/rules_clone.py
@@ -23,6 +23,7 @@ from autoskillit.core import (
     SKILL_COMMAND_PREFIX,
     SKILL_TOOLS,
     Severity,
+    extract_skill_name,
     get_logger,
 )
 from autoskillit.recipe._analysis import ValidationContext
@@ -40,14 +41,14 @@ logger = get_logger(__name__)
 )
 def _check_plan_parts_captured(ctx: ValidationContext) -> list[RuleFinding]:
     wf = ctx.recipe
-    _MULTIPART_SKILLS = {"/autoskillit:make-plan", "/autoskillit:rectify"}
+    _MULTIPART_SKILL_NAMES: frozenset[str] = frozenset({"make-plan", "rectify"})
     findings: list[RuleFinding] = []
 
     for step_name, step in wf.steps.items():
         if step.tool not in SKILL_TOOLS:
             continue
         skill_cmd = step.with_args.get("skill_command", "")
-        if not any(s in skill_cmd for s in _MULTIPART_SKILLS):
+        if extract_skill_name(skill_cmd) not in _MULTIPART_SKILL_NAMES:
             continue
         if "plan_parts" not in step.capture_list:
             findings.append(

--- a/src/autoskillit/recipe/rules/rules_clone.py
+++ b/src/autoskillit/recipe/rules/rules_clone.py
@@ -28,6 +28,7 @@ from autoskillit.core import (
 )
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe._analysis_bfs import bfs_reachable
+from autoskillit.recipe._skill_helpers import MULTIPART_SKILL_NAMES
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 from autoskillit.recipe.schema import _TERMINAL_TARGETS
 
@@ -41,14 +42,13 @@ logger = get_logger(__name__)
 )
 def _check_plan_parts_captured(ctx: ValidationContext) -> list[RuleFinding]:
     wf = ctx.recipe
-    _MULTIPART_SKILL_NAMES: frozenset[str] = frozenset({"make-plan", "rectify"})
     findings: list[RuleFinding] = []
 
     for step_name, step in wf.steps.items():
         if step.tool not in SKILL_TOOLS:
             continue
         skill_cmd = step.with_args.get("skill_command", "")
-        if extract_skill_name(skill_cmd) not in _MULTIPART_SKILL_NAMES:
+        if extract_skill_name(skill_cmd) not in MULTIPART_SKILL_NAMES:
             continue
         if "plan_parts" not in step.capture_list:
             findings.append(

--- a/src/autoskillit/recipe/rules/rules_dataflow_multipart.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow_multipart.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from autoskillit.core import SKILL_TOOLS, Severity, extract_skill_name
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._skill_helpers import MULTIPART_SKILL_NAMES
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 
@@ -14,12 +15,11 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 )
 def _check_multipart_iteration_notes(ctx: ValidationContext) -> list[RuleFinding]:
     wf = ctx.recipe
-    _MULTIPART_SKILL_NAMES: frozenset[str] = frozenset({"make-plan", "rectify"})
     findings: list[RuleFinding] = []
 
     has_multipart_step = any(
         step.tool in SKILL_TOOLS
-        and extract_skill_name(step.with_args.get("skill_command", "")) in _MULTIPART_SKILL_NAMES
+        and extract_skill_name(step.with_args.get("skill_command", "")) in MULTIPART_SKILL_NAMES
         for step in wf.steps.values()
     )
     if not has_multipart_step:
@@ -32,7 +32,7 @@ def _check_multipart_iteration_notes(ctx: ValidationContext) -> list[RuleFinding
         (step.note or "")
         for step in wf.steps.values()
         if step.tool in SKILL_TOOLS
-        and extract_skill_name(step.with_args.get("skill_command", "")) in _MULTIPART_SKILL_NAMES
+        and extract_skill_name(step.with_args.get("skill_command", "")) in MULTIPART_SKILL_NAMES
     ]
     if "*_part_*.md" not in plan_note and not any(
         "*_part_*.md" in note for note in multipart_step_notes

--- a/src/autoskillit/recipe/rules/rules_dataflow_multipart.py
+++ b/src/autoskillit/recipe/rules/rules_dataflow_multipart.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from autoskillit.core import SKILL_TOOLS, Severity
+from autoskillit.core import SKILL_TOOLS, Severity, extract_skill_name
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
@@ -14,12 +14,12 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 )
 def _check_multipart_iteration_notes(ctx: ValidationContext) -> list[RuleFinding]:
     wf = ctx.recipe
-    _MULTIPART_SKILLS = {"/autoskillit:make-plan", "/autoskillit:rectify"}
+    _MULTIPART_SKILL_NAMES: frozenset[str] = frozenset({"make-plan", "rectify"})
     findings: list[RuleFinding] = []
 
     has_multipart_step = any(
         step.tool in SKILL_TOOLS
-        and any(s in step.with_args.get("skill_command", "") for s in _MULTIPART_SKILLS)
+        and extract_skill_name(step.with_args.get("skill_command", "")) in _MULTIPART_SKILL_NAMES
         for step in wf.steps.values()
     )
     if not has_multipart_step:
@@ -32,7 +32,7 @@ def _check_multipart_iteration_notes(ctx: ValidationContext) -> list[RuleFinding
         (step.note or "")
         for step in wf.steps.values()
         if step.tool in SKILL_TOOLS
-        and any(s in step.with_args.get("skill_command", "") for s in _MULTIPART_SKILLS)
+        and extract_skill_name(step.with_args.get("skill_command", "")) in _MULTIPART_SKILL_NAMES
     ]
     if "*_part_*.md" not in plan_note and not any(
         "*_part_*.md" in note for note in multipart_step_notes

--- a/src/autoskillit/recipe/rules/rules_skills.py
+++ b/src/autoskillit/recipe/rules/rules_skills.py
@@ -10,7 +10,7 @@ from autoskillit.recipe._skill_helpers import _get_bundled_skill_names, _get_ski
 from autoskillit.recipe.contracts import resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
-_SKILL_TOKEN_RE = re.compile(r"/autoskillit:(\S+)")
+_SKILL_TOKEN_RE = re.compile(r"/(?:autoskillit:)?(\S+)")
 
 
 def _has_dynamic_skill_name(skill_cmd: str) -> bool:

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -136,6 +136,25 @@ def _strip_marker_from_body(content: str, marker: str = "%%ORDER_UP%%") -> str:
 
 _ACTIVATE_DEPS_PATTERN = re.compile(r"^activate_deps:\s*\[([^\]]*)\]", re.MULTILINE)
 
+_SKILL_NS_REF_RE = re.compile(r"/autoskillit:([a-z][a-z0-9-]*)")
+
+
+def _rewrite_skill_namespace_refs(content: str, resolver: SkillResolver) -> str:
+    """Rewrite /autoskillit:<name> → /<name> for BUNDLED_EXTENDED targets.
+
+    BUNDLED_EXTENDED skills are delivered via --add-dir as bare /name; the
+    /autoskillit: prefix only works for BUNDLED skills delivered via --plugin-dir.
+    """
+
+    def _replace(m: re.Match) -> str:  # type: ignore[type-arg]
+        name = m.group(1)
+        info = resolver.resolve(name)
+        if info is not None and info.source == SkillSource.BUNDLED_EXTENDED:
+            return f"/{name}"
+        return m.group(0)
+
+    return _SKILL_NS_REF_RE.sub(_replace, content)
+
 
 def _parse_activate_deps(content: str) -> list[str]:
     """Extract activate_deps list from SKILL.md frontmatter.
@@ -597,6 +616,7 @@ class DefaultSessionSkillManager:
                     )
                 format_rejected.add(skill_info.name)
                 continue
+            content = _rewrite_skill_namespace_refs(content, self._provider.resolver)
             skill_dir = skills_base / skill_info.name
             skill_dir.mkdir(exist_ok=True)
             atomic_write(skill_dir / "SKILL.md", content)
@@ -671,6 +691,7 @@ class DefaultSessionSkillManager:
                     )
                 return False
             skill_dir.mkdir(parents=True, exist_ok=True)
+            fetched = _rewrite_skill_namespace_refs(fetched, self._provider.resolver)
             atomic_write(skill_md, fetched)
             logger.debug("activate_deps_materialise", skill=skill_name)
 

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -24,6 +24,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_diagnose_ci_steps.py` | Contract tests for diagnose-ci SKILL.md step numbering and cross-reference integrity |
 | `test_docstring_skill_prefix.py` | Contract: source files must not use /autoskillit: prefix for skills_extended skills |
 | `test_environment_setup_design_contracts.py` | Contract tests verifying the environment-setup skill design doc completeness |
+| `test_ephemeral_skill_namespace.py` | Contract: ephemeral SKILL.md bodies use the correct namespace for the session delivery channel |
 | `test_enrich_issues_contracts.py` | Contract tests for the enrich-issues skill SKILL.md |
 | `test_execution_map_contracts.py` | Contract tests for the build-execution-map skill SKILL.md |
 | `test_exogenous_string_coupling.py` | Exogenous string coupling tests: orchestrator prompt triggers coupled to emitting module |

--- a/tests/contracts/test_docstring_skill_prefix.py
+++ b/tests/contracts/test_docstring_skill_prefix.py
@@ -16,6 +16,7 @@ _SCAN_DIRS_AND_GLOBS: list[tuple[str, list[str]]] = [
     ("server/tools", ["tools_*.py"]),
     ("server", ["_guards.py"]),
     ("hooks", ["*.py"]),
+    ("recipe/rules", ["rules_*.py"]),
 ]
 _PREFIX_RE = re.compile(r"/autoskillit:([a-z][\w-]*)")
 

--- a/tests/contracts/test_ephemeral_skill_namespace.py
+++ b/tests/contracts/test_ephemeral_skill_namespace.py
@@ -1,0 +1,53 @@
+"""Contract: ephemeral SKILL.md bodies use the correct namespace for the session context.
+
+After init_session(), every written SKILL.md must reference cross-skills using the
+namespace that matches how those skills are delivered in the session:
+- BUNDLED_EXTENDED skills are delivered via --add-dir as bare /name
+- BUNDLED skills are delivered via --plugin-dir as /autoskillit:name
+
+A /autoskillit:<ref> reference in an ephemeral SKILL.md for a BUNDLED_EXTENDED target
+is wrong — the agent will not find it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from autoskillit.core import SkillSource
+from autoskillit.workspace.session_skills import (
+    _SKILLS_SUBDIR,
+    DefaultSessionSkillManager,
+    SkillsDirectoryProvider,
+)
+from autoskillit.workspace.skills import DefaultSkillResolver
+
+_PREFIXED_REF_RE = re.compile(r"/autoskillit:([a-z][a-z0-9-]*)")
+
+
+def test_ephemeral_skill_md_namespace_matches_session_delivery(tmp_path: Path) -> None:
+    provider = SkillsDirectoryProvider()
+    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+    session_path = mgr.init_session("ns-check-session", cook_session=True)
+
+    skills_base = session_path / _SKILLS_SUBDIR
+    resolver = DefaultSkillResolver()
+    violations: list[str] = []
+
+    for skill_md in sorted(skills_base.glob("*/SKILL.md")):
+        skill_name = skill_md.parent.name
+        body = skill_md.read_text()
+        for m in _PREFIXED_REF_RE.finditer(body):
+            ref_name = m.group(1)
+            info = resolver.resolve(ref_name)
+            if info is not None and info.source == SkillSource.BUNDLED_EXTENDED:
+                line_no = body[: m.start()].count("\n") + 1
+                violations.append(
+                    f"{skill_name}/SKILL.md:{line_no}: /autoskillit:{ref_name} "
+                    f"is BUNDLED_EXTENDED — must be /{ref_name} in ephemeral content"
+                )
+
+    assert not violations, (
+        "Ephemeral SKILL.md bodies contain /autoskillit: references for BUNDLED_EXTENDED skills "
+        "(delivered as bare /name via --add-dir):\n" + "\n".join(f"  - {v}" for v in violations)
+    )

--- a/tests/workspace/CLAUDE.md
+++ b/tests/workspace/CLAUDE.md
@@ -28,6 +28,7 @@ Workspace cleanup, clone lifecycle, session skills, and worktree tests.
 | `test_skill_format.py` | Unit tests for skill frontmatter validation functions |
 | `test_session_skills_format_gate.py` | Format gate tests for init_session and activate_with_deps |
 | `test_skill_content_substitution.py` | Tests for SkillsDirectoryProvider.get_skill_content placeholder substitution |
+| `test_session_skills_namespace.py` | Phase 2 tests: session_skills module — namespace rewriting for ephemeral SKILL.md content |
 | `test_skills.py` | Tests for skill resolution hierarchy |
 | `test_worktree.py` | Worktree tests |
 

--- a/tests/workspace/test_session_skills_namespace.py
+++ b/tests/workspace/test_session_skills_namespace.py
@@ -1,0 +1,117 @@
+"""Phase 2 tests: session_skills module — namespace rewriting for ephemeral SKILL.md content."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from autoskillit.workspace.session_skills import (
+    _SKILLS_SUBDIR,
+    DefaultSessionSkillManager,
+    SkillsDirectoryProvider,
+    _rewrite_skill_namespace_refs,
+)
+from autoskillit.workspace.skills import DefaultSkillResolver
+
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.medium]
+
+
+def _make_resolver() -> DefaultSkillResolver:
+    return DefaultSkillResolver()
+
+
+def test_rewrite_bundled_extended_ref_is_stripped() -> None:
+    resolver = _make_resolver()
+    content = "Use the /autoskillit:mermaid skill to render diagrams."
+    result = _rewrite_skill_namespace_refs(content, resolver)
+    assert "/autoskillit:mermaid" not in result
+    assert "/mermaid" in result
+
+
+def test_rewrite_bundled_ref_is_preserved() -> None:
+    resolver = _make_resolver()
+    content = "Run /autoskillit:open-kitchen to start."
+    result = _rewrite_skill_namespace_refs(content, resolver)
+    assert "/autoskillit:open-kitchen" in result
+
+
+def test_rewrite_unknown_ref_is_preserved() -> None:
+    resolver = _make_resolver()
+    content = "Call /autoskillit:nonexistent-skill for help."
+    result = _rewrite_skill_namespace_refs(content, resolver)
+    assert "/autoskillit:nonexistent-skill" in result
+
+
+def test_rewrite_already_bare_ref_unaffected() -> None:
+    resolver = _make_resolver()
+    content = "Use /make-plan to plan the work."
+    result = _rewrite_skill_namespace_refs(content, resolver)
+    assert result == content
+
+
+def test_rewrite_multiple_refs_in_document() -> None:
+    resolver = _make_resolver()
+    content = (
+        "Step 1: /autoskillit:mermaid to draw.\n"
+        "Step 2: /autoskillit:open-kitchen to open.\n"
+        "Step 3: /autoskillit:make-plan to plan.\n"
+    )
+    result = _rewrite_skill_namespace_refs(content, resolver)
+    assert "/autoskillit:mermaid" not in result
+    assert "/mermaid" in result
+    assert "/autoskillit:open-kitchen" in result
+    assert "/autoskillit:make-plan" not in result
+    assert "/make-plan" in result
+
+
+def test_rewrite_refs_inside_code_fence() -> None:
+    resolver = _make_resolver()
+    content = "```\nSkill tool: /autoskillit:mermaid\n```"
+    result = _rewrite_skill_namespace_refs(content, resolver)
+    assert "/autoskillit:mermaid" not in result
+    assert "/mermaid" in result
+
+
+def test_activate_with_deps_materialised_content_has_namespace_rewritten(
+    tmp_path: Path,
+) -> None:
+    """Materialised absent skill has /autoskillit: refs rewritten to bare names."""
+    from tests._helpers import make_skills_config, make_test_config
+
+    provider = SkillsDirectoryProvider()
+    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+    config = make_test_config(
+        skills=make_skills_config(
+            tier1=["open-kitchen", "close-kitchen"],
+            tier2=["mermaid"],
+            tier3=[],
+        )
+    )
+    mgr.init_session(
+        "session-ns-activate",
+        cook_session=False,
+        config=config,
+    )
+
+    mermaid_md = tmp_path / "session-ns-activate" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    assert not mermaid_md.exists()
+
+    result = mgr.activate_skill_deps("session-ns-activate", "mermaid")
+    assert result is True
+    assert mermaid_md.exists()
+
+    content = mermaid_md.read_text()
+    prefixed_re = re.compile(r"/autoskillit:([a-z][a-z0-9-]*)")
+    from autoskillit.core import SkillSource
+    from autoskillit.workspace.skills import DefaultSkillResolver as _Resolver
+
+    resolver = _Resolver()
+    for m in prefixed_re.finditer(content):
+        ref_name = m.group(1)
+        info = resolver.resolve(ref_name)
+        assert info is None or info.source != SkillSource.BUNDLED_EXTENDED, (
+            f"Materialised mermaid/SKILL.md still contains /autoskillit:{ref_name} "
+            f"which is BUNDLED_EXTENDED — namespace was not rewritten"
+        )


### PR DESCRIPTION
## Summary

BUNDLED_EXTENDED skills (`skills_extended/`) are delivered to headless child sessions via `--add-dir`, registering them as bare `/name`. But SKILL.md content inside those skills references other skills as `/autoskillit:name` — a namespace that only exists for `--plugin-dir`-delivered skills. The parent MCP server's `resolve_target_skill()` rewrites prefixes for `run_skill` tool calls, but that function never runs inside headless child sessions where the Skill tool is invoked directly by the agent.

Part A addresses: content-time namespace rewriting during session provisioning (both `init_session` and `_activate_with_deps` write paths), contract enforcement that validates rewritten content, and reproduction tests. Part B (separate task) covers static analysis tooling.

Closes #3235

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232146-323633/.autoskillit/temp/rectify/rectify_namespace_prefix_mismatch_2026-05-28_232713.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 90 | 28.0k | 3.4M | 148.6k | 276 | 261.3k | 16m 17s |
| review_approach* | sonnet | 1 | 1.4k | 4.8k | 251.9k | 40.6k | 38 | 27.0k | 2m 44s |
| dry_walkthrough* | opus | 1 | 1.4k | 12.7k | 1.7M | 78.0k | 159 | 62.1k | 7m 14s |
| implement* | sonnet | 1 | 338 | 20.8k | 2.9M | 89.8k | 141 | 74.3k | 7m 20s |
| audit_impl* | sonnet | 1 | 60 | 13.6k | 224.8k | 47.6k | 81 | 44.2k | 5m 44s |
| prepare_pr* | sonnet | 1 | 116.8k | 3.9k | 275.0k | 30.9k | 26 | 15.7k | 1m 32s |
| compose_pr* | sonnet | 1 | 69.7k | 1.6k | 275.0k | 30.9k | 19 | 15.5k | 51s |
| review_pr* | sonnet | 1 | 118 | 25.6k | 571.9k | 66.4k | 57 | 55.3k | 6m 29s |
| resolve_review* | opus | 1 | 51 | 8.8k | 1.5M | 71.3k | 52 | 55.6k | 5m 46s |
| **Total** | | | 189.9k | 119.8k | 11.0M | 148.6k | | 611.1k | 54m 0s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 209 | 13758.1 | 355.4 | 99.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 120844.8 | 4635.8 | 729.7 |
| **Total** | **221** | 49791.7 | 2765.3 | 542.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 90 | 28.0k | 3.4M | 261.3k | 16m 17s |
| sonnet | 6 | 188.4k | 70.3k | 4.5M | 232.0k | 24m 42s |
| opus | 2 | 1.4k | 21.5k | 3.2M | 117.8k | 13m 0s |