### PR TITLE
[FEATURE] Rectify: Server-Side Input Contract Enforcement for `skill_command` Path Arguments

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -296,13 +296,13 @@ from .types import WorkspaceManager as WorkspaceManager
 from .types import WriteBehaviorSpec as WriteBehaviorSpec
 from .types import WriteEvidence as WriteEvidence
 from .types import WriteExpectedResolver as WriteExpectedResolver
-from .types import is_path_like_token as is_path_like_token
 from .types import assert_prompt_sentinel as assert_prompt_sentinel
 from .types import compute_remaining as compute_remaining
 from .types import extract_path_arg as extract_path_arg
 from .types import extract_positional_args as extract_positional_args
 from .types import extract_skill_name as extract_skill_name
 from .types import fleet_error as fleet_error
+from .types import is_path_like_token as is_path_like_token
 from .types import resolve_payload_field as resolve_payload_field
 from .types import resolve_skill_name as resolve_skill_name
 from .types import resolve_target_skill as resolve_target_skill

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -296,7 +296,7 @@ from .types import WorkspaceManager as WorkspaceManager
 from .types import WriteBehaviorSpec as WriteBehaviorSpec
 from .types import WriteEvidence as WriteEvidence
 from .types import WriteExpectedResolver as WriteExpectedResolver
-from .types import _looks_like_path as _looks_like_path
+from .types import is_path_like_token as is_path_like_token
 from .types import assert_prompt_sentinel as assert_prompt_sentinel
 from .types import compute_remaining as compute_remaining
 from .types import extract_path_arg as extract_path_arg

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -229,6 +229,8 @@ from .types import GitHubFetcher as GitHubFetcher
 from .types import HeadlessExecutor as HeadlessExecutor
 from .types import InfraExitCategory as InfraExitCategory
 from .types import InfraOutcome as InfraOutcome
+from .types import InputContractResolver as InputContractResolver
+from .types import InputSpec as InputSpec
 from .types import IssueLabelState as IssueLabelState
 from .types import KillReason as KillReason
 from .types import LabelDef as LabelDef
@@ -294,9 +296,11 @@ from .types import WorkspaceManager as WorkspaceManager
 from .types import WriteBehaviorSpec as WriteBehaviorSpec
 from .types import WriteEvidence as WriteEvidence
 from .types import WriteExpectedResolver as WriteExpectedResolver
+from .types import _looks_like_path as _looks_like_path
 from .types import assert_prompt_sentinel as assert_prompt_sentinel
 from .types import compute_remaining as compute_remaining
 from .types import extract_path_arg as extract_path_arg
+from .types import extract_positional_args as extract_positional_args
 from .types import extract_skill_name as extract_skill_name
 from .types import fleet_error as fleet_error
 from .types import resolve_payload_field as resolve_payload_field

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -19,7 +19,9 @@ from ._type_enums import SessionType, SkillSource
 from ._type_protocols_workspace import SkillResolver
 
 __all__ = [
+    "_looks_like_path",
     "extract_path_arg",
+    "extract_positional_args",
     "extract_skill_name",
     "fleet_error",
     "resolve_skill_name",
@@ -40,6 +42,21 @@ _PATH_PREFIXES: tuple[str, ...] = ("/", "./", ".autoskillit/")
 
 def _looks_like_path(token: str) -> bool:
     return any(token.startswith(p) for p in _PATH_PREFIXES)
+
+
+def extract_positional_args(skill_command: str) -> list[str]:
+    """Extract all positional tokens from a skill_command string.
+
+    Returns tokens after the skill name, split on whitespace, with
+    enclosing quotes stripped. Path-like and non-path tokens are both
+    included, preserving positional order.
+    """
+    stripped = skill_command.strip()
+    m = _SKILL_CMD_RE.match(stripped)
+    if m is None:
+        return []
+    tokens = stripped[m.end() :].split()
+    return [t.strip('"').strip("'") for t in tokens]
 
 
 def extract_path_arg(skill_command: str) -> str | None:

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -19,7 +19,7 @@ from ._type_enums import SessionType, SkillSource
 from ._type_protocols_workspace import SkillResolver
 
 __all__ = [
-    "_looks_like_path",
+    "is_path_like_token",
     "extract_path_arg",
     "extract_positional_args",
     "extract_skill_name",
@@ -40,7 +40,7 @@ _SKILL_RESOLVE_RE = re.compile(
 _PATH_PREFIXES: tuple[str, ...] = ("/", "./", ".autoskillit/")
 
 
-def _looks_like_path(token: str) -> bool:
+def is_path_like_token(token: str) -> bool:
     return any(token.startswith(p) for p in _PATH_PREFIXES)
 
 
@@ -73,7 +73,7 @@ def extract_path_arg(skill_command: str) -> str | None:
     tokens = stripped[m.end() :].split()
     for token in tokens:
         cleaned = token.strip('"').strip("'")
-        if _looks_like_path(cleaned):
+        if is_path_like_token(cleaned):
             return cleaned
     return None
 

--- a/src/autoskillit/core/types/_type_protocols_execution.py
+++ b/src/autoskillit/core/types/_type_protocols_execution.py
@@ -7,9 +7,10 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from ._type_checkpoint import SessionCheckpoint  # noqa: F401, TC001
-from ._type_results import SkillResult, TestResult, ValidatedAddDir, WriteBehaviorSpec
+from ._type_results import InputSpec, SkillResult, TestResult, ValidatedAddDir, WriteBehaviorSpec
 
 __all__ = [
+    "InputContractResolver",
     "TestRunner",
     "HeadlessExecutor",
     "OutputPatternResolver",
@@ -116,3 +117,10 @@ class WriteExpectedResolver(Protocol):
     """Protocol for resolving write-expectation metadata from skill contracts."""
 
     def __call__(self, skill_command: str) -> WriteBehaviorSpec: ...
+
+
+@runtime_checkable
+class InputContractResolver(Protocol):
+    """Protocol for resolving input contract specs from skill contracts."""
+
+    def __call__(self, skill_command: str) -> Sequence[InputSpec]: ...

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -20,6 +20,7 @@ T = TypeVar("T")
 
 __all__ = [
     "ContaminationOutcome",
+    "InputSpec",
     "LoadReport",
     "LoadResult",
     "TestResult",
@@ -144,6 +145,16 @@ class WriteBehaviorSpec:
 
     mode: str | None = None
     expected_when: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class InputSpec:
+    """Input contract specification for a single file_path or directory_path argument."""
+
+    name: str
+    type: Literal["file_path", "directory_path", "string"]
+    required: bool
+    position: int
 
 
 @dataclass

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -152,7 +152,7 @@ class InputSpec:
     """Input contract specification for a single file_path or directory_path argument."""
 
     name: str
-    type: Literal["file_path", "directory_path", "string"]
+    type: Literal["file_path", "directory_path"]
     required: bool
     position: int
 

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -156,6 +156,10 @@ class InputSpec:
     required: bool
     position: int
 
+    def __post_init__(self) -> None:
+        if self.position < 0:
+            raise ValueError(f"InputSpec.position must be >= 0, got {self.position}")
+
 
 @dataclass
 class FailureRecord:

--- a/src/autoskillit/hooks/guards/skill_cmd_guard.py
+++ b/src/autoskillit/hooks/guards/skill_cmd_guard.py
@@ -51,6 +51,14 @@ PATH_ARG_SKILLS: frozenset[str] = frozenset(
 # Token prefixes that unambiguously identify a filesystem path argument.
 _PATH_PREFIXES: tuple[str, ...] = ("/", "./", ".autoskillit/")
 
+# Position of the plan file among path-like tokens for each skill.
+_PLAN_PATH_POSITION: dict[str, int] = {
+    "implement-worktree-no-merge": 0,
+    "implement-worktree": 0,
+    "retry-worktree": 0,
+    "resolve-failures": 1,
+}
+
 # Captures the skill short-name from a skill_command string such as:
 #   /implement-worktree-no-merge ...
 #   implement-worktree-no-merge ...
@@ -103,8 +111,22 @@ def main() -> None:
     tokens = args_str.split()
     first = tokens[0]
 
-    # Correct format: first token is a path → allow.
+    # Correct format: first token is a path.
     if _looks_like_path(first):
+        plan_pos = _PLAN_PATH_POSITION.get(skill_name)
+        if plan_pos is not None:
+            path_tokens = [t for t in tokens if _looks_like_path(t)]
+            if plan_pos < len(path_tokens):
+                plan_token = path_tokens[plan_pos]
+                basename = plan_token.rsplit("/", 1)[-1] if "/" in plan_token else plan_token
+                if basename and "." not in basename:
+                    _deny(
+                        f"{SKILL_CMD_DENY_TRIGGER} '{skill_name}': "
+                        f"plan path argument '{plan_token}' has no file extension. "
+                        f"This may indicate a mangled path (e.g. stripped .md extension). "
+                        f"Verify the path is correct and includes the file extension."
+                    )
+                    sys.exit(0)
         sys.exit(0)
 
     # First token is not a path. Check whether a path token appears later.

--- a/src/autoskillit/hooks/guards/skill_cmd_guard.py
+++ b/src/autoskillit/hooks/guards/skill_cmd_guard.py
@@ -65,7 +65,7 @@ _PLAN_PATH_POSITION: dict[str, int] = {
 _SKILL_RE = re.compile(r"^/?(?:autoskillit:)?(\S+)")
 
 
-def _looks_like_path(token: str) -> bool:
+def is_path_like_token(token: str) -> bool:
     """Return True if token begins with a recognised filesystem path prefix."""
     return any(token.startswith(p) for p in _PATH_PREFIXES)
 
@@ -112,10 +112,10 @@ def main() -> None:
     first = tokens[0]
 
     # Correct format: first token is a path.
-    if _looks_like_path(first):
+    if is_path_like_token(first):
         plan_pos = _PLAN_PATH_POSITION.get(skill_name)
         if plan_pos is not None:
-            path_tokens = [t for t in tokens if _looks_like_path(t)]
+            path_tokens = [t for t in tokens if is_path_like_token(t)]
             if plan_pos < len(path_tokens):
                 plan_token = path_tokens[plan_pos]
                 basename = plan_token.rsplit("/", 1)[-1] if "/" in plan_token else plan_token
@@ -130,7 +130,7 @@ def main() -> None:
         sys.exit(0)
 
     # First token is not a path. Check whether a path token appears later.
-    path_token = next((t for t in tokens[1:] if _looks_like_path(t)), None)
+    path_token = next((t for t in tokens[1:] if is_path_like_token(t)), None)
     if path_token is None:
         # No path-like token found at all — could be pasted plan content.
         # Allow; the skill's Step 0 will handle it.
@@ -140,8 +140,8 @@ def main() -> None:
     # Reconstruct corrected command: all path tokens first, then non-path tokens.
     # When args_str is multiline, separate prose from paths with a blank line.
     has_newlines = "\n" in args_str
-    path_tokens = [t for t in tokens if _looks_like_path(t)]
-    non_path_tokens = [t for t in tokens if not _looks_like_path(t)]
+    path_tokens = [t for t in tokens if is_path_like_token(t)]
+    non_path_tokens = [t for t in tokens if not is_path_like_token(t)]
     path_part = " ".join(path_tokens)
     if has_newlines and non_path_tokens:
         prose_block = " ".join(non_path_tokens)

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -26,6 +26,7 @@ from autoskillit.core import (
     GitHubApiLog,
     GitHubFetcher,
     HeadlessExecutor,
+    InputContractResolver,
     McpResponseLog,
     MergeQueueWatcher,
     MigrationService,
@@ -132,6 +133,7 @@ class ToolContext:
     output_pattern_resolver: OutputPatternResolver | None = field(default=None)
     write_expected_resolver: WriteExpectedResolver | None = field(default=None)
     read_only_resolver: ReadOnlyResolver | None = field(default=None)
+    input_contract_resolver: InputContractResolver | None = field(default=None)
     backend: CodingAgentBackend | None = field(default=None)
     session_skill_manager: SessionSkillManager | None = field(default=None)
     skill_resolver: SkillResolver | None = field(default=None)

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -29,6 +29,7 @@ from autoskillit.recipe.contracts import (  # noqa: E402
     get_skill_contract,
     load_bundled_manifest,
     load_recipe_card,
+    resolve_input_specs,
     resolve_skill_name,
     validate_recipe_cards,
 )
@@ -234,6 +235,7 @@ __all__ = [
     "get_skill_contract",
     "load_bundled_manifest",
     "load_recipe_card",
+    "resolve_input_specs",
     "resolve_skill_name",
     "validate_recipe_cards",
     "DefaultRecipeRepository",

--- a/src/autoskillit/recipe/_contracts_manifest.py
+++ b/src/autoskillit/recipe/_contracts_manifest.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import hashlib
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
-
-if TYPE_CHECKING:
-    pass
+from typing import Any, Literal, cast
 
 from autoskillit.core import (
     InputSpec,

--- a/src/autoskillit/recipe/_contracts_manifest.py
+++ b/src/autoskillit/recipe/_contracts_manifest.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import hashlib
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     pass
 
 from autoskillit.core import (
+    InputSpec,
     get_logger,
     load_yaml,
     pkg_root,
@@ -85,6 +86,31 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
         read_only=read_only,
         result_fields=result_fields,
     )
+
+
+def resolve_input_specs(skill_command: str) -> tuple[InputSpec, ...]:
+    """Resolve InputSpec entries for file_path/directory_path inputs from a skill's contract."""
+    name = resolve_skill_name(skill_command)
+    if not name:
+        return ()
+    contract = get_skill_contract(name, load_bundled_manifest())
+    if contract is None:
+        return ()
+    path_position = 0
+    specs: list[InputSpec] = []
+    for inp in contract.inputs:
+        if inp.type in ("file_path", "directory_path"):
+            narrowed_type = cast(Literal["file_path", "directory_path"], inp.type)
+            specs.append(
+                InputSpec(
+                    name=inp.name,
+                    type=narrowed_type,
+                    required=inp.required,
+                    position=path_position,
+                )
+            )
+            path_position += 1
+    return tuple(specs)
 
 
 def get_callable_contract(

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -22,6 +22,7 @@ from autoskillit.recipe._contracts_manifest import (  # noqa: F401
     get_skill_contract,
     get_tool_output_contract,
     load_bundled_manifest,
+    resolve_input_specs,
 )
 from autoskillit.recipe._contracts_staleness import (  # noqa: F401
     check_contract_staleness,

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -13,14 +13,13 @@ import os
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any
 
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     MARKETPLACE_PREFIX,
     DirectInstall,
     FleetLock,
-    InputSpec,
     MarketplaceInstall,
     PluginSource,
     SubprocessRunner,
@@ -60,6 +59,7 @@ from autoskillit.recipe import (
     DefaultRecipeRepository,
     get_skill_contract,
     load_bundled_manifest,
+    resolve_input_specs,
     resolve_skill_name,
 )
 from autoskillit.workspace import (
@@ -393,33 +393,10 @@ def make_context(
         contract = get_skill_contract(name, load_bundled_manifest())
         return contract.read_only if contract else False
 
-    def _resolve_input_contracts(skill_command: str) -> tuple[InputSpec, ...]:
-        name = resolve_skill_name(skill_command)
-        if not name:
-            return ()
-        contract = get_skill_contract(name, load_bundled_manifest())
-        if contract is None:
-            return ()
-        path_position = 0
-        specs: list[InputSpec] = []
-        for inp in contract.inputs:
-            if inp.type in ("file_path", "directory_path"):
-                narrowed_type = cast(Literal["file_path", "directory_path", "string"], inp.type)
-                specs.append(
-                    InputSpec(
-                        name=inp.name,
-                        type=narrowed_type,
-                        required=inp.required,
-                        position=path_position,
-                    )
-                )
-                path_position += 1
-        return tuple(specs)
-
     ctx.output_pattern_resolver = _resolve_output_patterns
     ctx.write_expected_resolver = _resolve_write_behavior
     ctx.read_only_resolver = _resolve_read_only
-    ctx.input_contract_resolver = _resolve_input_contracts
+    ctx.input_contract_resolver = resolve_input_specs
     ctx.token_factory = token_factory
     ctx.build_protected_campaign_ids = build_protected_campaign_ids
     ctx.executor = DefaultHeadlessExecutor(ctx)

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -20,6 +20,7 @@ from autoskillit.core import (
     MARKETPLACE_PREFIX,
     DirectInstall,
     FleetLock,
+    InputSpec,
     MarketplaceInstall,
     PluginSource,
     SubprocessRunner,
@@ -392,9 +393,32 @@ def make_context(
         contract = get_skill_contract(name, load_bundled_manifest())
         return contract.read_only if contract else False
 
+    def _resolve_input_contracts(skill_command: str) -> tuple[InputSpec, ...]:
+        name = resolve_skill_name(skill_command)
+        if not name:
+            return ()
+        contract = get_skill_contract(name, load_bundled_manifest())
+        if contract is None:
+            return ()
+        path_position = 0
+        specs: list[InputSpec] = []
+        for inp in contract.inputs:
+            if inp.type in ("file_path", "directory_path"):
+                specs.append(
+                    InputSpec(
+                        name=inp.name,
+                        type=inp.type,  # type: ignore[arg-type]
+                        required=inp.required,
+                        position=path_position,
+                    )
+                )
+                path_position += 1
+        return tuple(specs)
+
     ctx.output_pattern_resolver = _resolve_output_patterns
     ctx.write_expected_resolver = _resolve_write_behavior
     ctx.read_only_resolver = _resolve_read_only
+    ctx.input_contract_resolver = _resolve_input_contracts
     ctx.token_factory = token_factory
     ctx.build_protected_campaign_ids = build_protected_campaign_ids
     ctx.executor = DefaultHeadlessExecutor(ctx)

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -13,7 +13,7 @@ import os
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
@@ -404,10 +404,11 @@ def make_context(
         specs: list[InputSpec] = []
         for inp in contract.inputs:
             if inp.type in ("file_path", "directory_path"):
+                narrowed_type = cast(Literal["file_path", "directory_path", "string"], inp.type)
                 specs.append(
                     InputSpec(
                         name=inp.name,
-                        type=inp.type,  # type: ignore[arg-type]
+                        type=narrowed_type,
                         required=inp.required,
                         position=path_position,
                     )

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -6,7 +6,16 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autoskillit.core import SessionType, extract_path_arg, get_logger, session_type
+from autoskillit.core import (
+    InputContractResolver,
+    SessionType,
+    _looks_like_path,
+    extract_path_arg,
+    extract_positional_args,
+    extract_skill_name,
+    get_logger,
+    session_type,
+)
 from autoskillit.pipeline import gate_error_result, headless_error_result
 
 if TYPE_CHECKING:
@@ -160,6 +169,56 @@ def _check_dry_walkthrough(skill_command: str, cwd: str) -> str | None:
             f"The implement gate requires the plan at its make-plan/ or rectify/ origin — "
             f"copies in other directories are not accepted."
         )
+
+    return None
+
+
+def _check_input_contracts(
+    skill_command: str,
+    cwd: str,
+    resolver: InputContractResolver | None,
+) -> str | None:
+    """Validate skill_command arguments against input contracts.
+
+    Returns gate_error_result JSON string on validation failure, None if OK.
+    Fails open if resolver is None or skill has no contracts.
+    """
+    if resolver is None:
+        return None
+    specs = resolver(skill_command)
+    if not specs:
+        return None
+
+    args = extract_positional_args(skill_command)
+    path_args = [a for a in args if _looks_like_path(a)]
+
+    if not path_args:
+        return None
+
+    for spec in specs:
+        if spec.position >= len(path_args):
+            if spec.required:
+                return gate_error_result(
+                    f"Missing required {spec.type} argument '{spec.name}' "
+                    f"for {extract_skill_name(skill_command)}"
+                )
+            continue
+
+        value = path_args[spec.position]
+        resolved = Path(cwd) / value if not Path(value).is_absolute() else Path(value)
+
+        if spec.type == "file_path":
+            if not resolved.is_file():
+                return gate_error_result(
+                    f"Input '{spec.name}' for {extract_skill_name(skill_command)}: "
+                    f"expected a file, path does not exist or is a directory: {resolved}"
+                )
+        elif spec.type == "directory_path":
+            if not resolved.is_dir():
+                return gate_error_result(
+                    f"Input '{spec.name}' for {extract_skill_name(skill_command)}: "
+                    f"expected a directory, path does not exist or is a file: {resolved}"
+                )
 
     return None
 

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -9,11 +9,11 @@ from typing import TYPE_CHECKING
 from autoskillit.core import (
     InputContractResolver,
     SessionType,
-    _looks_like_path,
     extract_path_arg,
     extract_positional_args,
     extract_skill_name,
     get_logger,
+    is_path_like_token,
     session_type,
 )
 from autoskillit.pipeline import gate_error_result, headless_error_result
@@ -194,7 +194,7 @@ def _check_input_contracts(
         return None
 
     args = extract_positional_args(skill_command)
-    path_args = [a for a in args if _looks_like_path(a)]
+    path_args = [a for a in args if is_path_like_token(a)]
 
     for spec in specs:
         if spec.position >= len(path_args):

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -192,9 +192,6 @@ def _check_input_contracts(
     args = extract_positional_args(skill_command)
     path_args = [a for a in args if _looks_like_path(a)]
 
-    if not path_args:
-        return None
-
     for spec in specs:
         if spec.position >= len(path_args):
             if spec.required:

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -185,7 +185,11 @@ def _check_input_contracts(
     """
     if resolver is None:
         return None
-    specs = resolver(skill_command)
+    try:
+        specs = resolver(skill_command)
+    except Exception:
+        logger.warning("input_contract_resolver_failed", skill_command=skill_command)
+        return None
     if not specs:
         return None
 

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -188,7 +188,9 @@ def _check_input_contracts(
     try:
         specs = resolver(skill_command)
     except Exception:
-        logger.warning("input_contract_resolver_failed", skill_command=skill_command)
+        logger.warning(
+            "input_contract_resolver_failed", skill_command=skill_command, exc_info=True
+        )
         return None
     if not specs:
         return None
@@ -201,7 +203,7 @@ def _check_input_contracts(
             if spec.required:
                 return gate_error_result(
                     f"Missing required {spec.type} argument '{spec.name}' "
-                    f"for {extract_skill_name(skill_command)}"
+                    f"for {extract_skill_name(skill_command) or skill_command}"
                 )
             continue
 

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -28,6 +28,7 @@ from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
 from autoskillit.server import mcp
 from autoskillit.server._guards import (
     _check_dry_walkthrough,
+    _check_input_contracts,
     _require_enabled,
     _require_orchestrator_or_higher,
     _validate_skill_command,
@@ -333,6 +334,14 @@ async def run_skill(
             # sub-sessions, ensuring token log entries carry the correct order_id without
             # requiring recipe authors to thread it through every run_skill call.
             effective_order_id = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
+
+            if not resume_session_id:
+                if (
+                    input_error := _check_input_contracts(
+                        skill_command, cwd, tool_ctx.input_contract_resolver
+                    )
+                ) is not None:
+                    return input_error
 
             if _get_config().safety.require_dry_walkthrough:
                 if (gate_error := _check_dry_walkthrough(skill_command, cwd)) is not None:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -622,6 +622,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_tools_bootstrap.py",
             "server/test_tools_kitchen_visibility.py",
             "server/test_tools_execution_step_resolution.py",
+            "server/test_tools_execution_input_gates.py",
             # CLI file-level entries (6 of 38 import autoskillit.recipe):
             "cli/test_cli_prompts.py",
             "cli/test_l3_orchestrator_prompt.py",

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -39,6 +39,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_session_type.py` | Tests for SessionType resolver and constants |
 | `test_skill_command_parsing.py` | Unit tests for extract_path_arg in core._type_helpers |
 | `test_tool_sequence_analysis.py` | Tool sequence analysis tests |
+| `test_type_helpers.py` | Tests for extract_positional_args helper |
 | `test_backend_capabilities.py` | Tests for BackendCapabilities frozen invariants and CLAUDE_CODE_CAPABILITIES field values |
 | `test_backend_event_kind.py` | Tests for BackendEventKind StrEnum — member exhaustiveness, values, importability |
 | `test_backend_dataclasses.py` | Tests for CmdSpec, SkillSessionConfig, ClaudeEventData, CodexEventData, SessionEvent, AgentSessionResult — frozen invariants, field types, defaults |

--- a/tests/core/test_type_helpers.py
+++ b/tests/core/test_type_helpers.py
@@ -1,0 +1,42 @@
+"""Tests for extract_positional_args helper."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+def test_extract_positional_args_returns_all_tokens():
+    from autoskillit.core import extract_positional_args
+
+    result = extract_positional_args("/resolve-failures /worktrees/foo /plans/bar.md main")
+    assert result == ["/worktrees/foo", "/plans/bar.md", "main"]
+
+
+def test_extract_positional_args_returns_empty_for_no_args():
+    from autoskillit.core import extract_positional_args
+
+    result = extract_positional_args("/skill-name")
+    assert result == []
+
+
+def test_extract_positional_args_preserves_order():
+    from autoskillit.core import extract_positional_args
+
+    result = extract_positional_args("/skill /b/second /a/first baz")
+    assert result == ["/b/second", "/a/first", "baz"]
+
+
+def test_extract_positional_args_strips_quotes():
+    from autoskillit.core import extract_positional_args
+
+    result = extract_positional_args('/skill "/path/quoted" plain')
+    assert result == ["/path/quoted", "plain"]
+
+
+def test_extract_positional_args_returns_non_path_only():
+    from autoskillit.core import extract_positional_args
+
+    result = extract_positional_args("/skill-name foo bar")
+    assert result == ["foo", "bar"]

--- a/tests/core/test_type_protocol_shards.py
+++ b/tests/core/test_type_protocol_shards.py
@@ -21,6 +21,7 @@ def test_execution_shard_all():
     from autoskillit.core.types._type_protocols_execution import __all__
 
     assert set(__all__) == {
+        "InputContractResolver",
         "TestRunner",
         "HeadlessExecutor",
         "OutputPatternResolver",

--- a/tests/infra/test_skill_cmd_check.py
+++ b/tests/infra/test_skill_cmd_check.py
@@ -4,7 +4,7 @@ import json
 from io import StringIO
 from unittest.mock import patch
 
-from autoskillit.hooks.guards.skill_cmd_guard import _looks_like_path, main
+from autoskillit.hooks.guards.skill_cmd_guard import is_path_like_token, main
 
 
 def _run_hook(tool_input: dict) -> dict | None:
@@ -29,31 +29,31 @@ def _decision(result: dict | None) -> str:
 
 
 # ---------------------------------------------------------------------------
-# _looks_like_path unit tests
+# is_path_like_token unit tests
 # ---------------------------------------------------------------------------
 
 
 class TestLooksLikePath:
     def test_slash_prefix(self):
-        assert _looks_like_path("/home/user/plan.md") is True
+        assert is_path_like_token("/home/user/plan.md") is True
 
     def test_dotslash_prefix(self):
-        assert _looks_like_path("./plan.md") is True
+        assert is_path_like_token("./plan.md") is True
 
     def test_temp_prefix_no_longer_valid(self):
-        assert _looks_like_path("temp/make-plan/plan.md") is False
+        assert is_path_like_token("temp/make-plan/plan.md") is False
 
     def test_autoskillit_prefix(self):
-        assert _looks_like_path(".autoskillit/temp/plan.md") is True
+        assert is_path_like_token(".autoskillit/temp/plan.md") is True
 
     def test_plain_word(self):
-        assert _looks_like_path("the") is False
+        assert is_path_like_token("the") is False
 
     def test_verified(self):
-        assert _looks_like_path("verified") is False
+        assert is_path_like_token("verified") is False
 
     def test_empty(self):
-        assert _looks_like_path("") is False
+        assert is_path_like_token("") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_write_guard_worktree_integration.py
+++ b/tests/integration/test_write_guard_worktree_integration.py
@@ -71,11 +71,13 @@ class TestWriteGuardWorktreeIntegration:
         monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
         clone_dir = tmp_path / "clone"
         clone_dir.mkdir()
+        plan = clone_dir / "plan.md"
+        plan.write_text("content")
 
         from autoskillit.server.tools.tools_execution import run_skill
 
         await run_skill(
-            skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+            skill_command=f"/autoskillit:implement-worktree-no-merge {plan}",
             cwd=str(clone_dir),
             output_dir=".",
         )
@@ -98,11 +100,13 @@ class TestWriteGuardWorktreeIntegration:
         monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
         clone_dir = tmp_path / "clone"
         clone_dir.mkdir()
+        plan = clone_dir / "plan.md"
+        plan.write_text("content")
 
         from autoskillit.server.tools.tools_execution import run_skill
 
         await run_skill(
-            skill_command="/autoskillit:dry-walkthrough plan.md",
+            skill_command=f"/autoskillit:dry-walkthrough {plan}",
             cwd=str(clone_dir),
             output_dir=".",
         )

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -117,6 +117,7 @@ def test_toolcontext_new_optional_fields_default_none(tmp_path):
     assert ctx.clone_mgr is None
     assert ctx.github_client is None
     assert ctx.backend is None
+    assert ctx.input_contract_resolver is None
 
 
 def test_tool_context_has_backend_field() -> None:
@@ -394,3 +395,23 @@ def test_tool_context_has_quota_refresh_task_field():
     fields = {f.name: f for f in dataclasses.fields(ToolContext)}
     assert "quota_refresh_task" in fields
     assert fields["quota_refresh_task"].default is None
+
+
+def test_tool_context_has_input_contract_resolver_field() -> None:
+    """ToolContext dataclass exposes input_contract_resolver as an optional Protocol field."""
+    import typing
+
+    from autoskillit.core import InputContractResolver
+    from autoskillit.pipeline.context import ToolContext
+
+    fields = {f.name: f for f in dataclasses.fields(ToolContext)}
+    assert "input_contract_resolver" in fields
+    assert fields["input_contract_resolver"].default is None
+
+    hints = typing.get_type_hints(ToolContext)
+    assert "input_contract_resolver" in hints
+    args = typing.get_args(hints["input_contract_resolver"])
+    assert InputContractResolver in args, (
+        f"input_contract_resolver type hint {hints['input_contract_resolver']} "
+        f"does not include InputContractResolver Protocol"
+    )

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -58,6 +58,7 @@ def _assert_ci_steps(recipe) -> None:
     assert resolve_ci.retries == 2
     assert resolve_ci.on_exhausted == "release_issue_failure"
     assert "context.work_dir" in skill_cmd
+    assert "context.plan_path" in skill_cmd
 
     # re_push step (T_CI6)
     assert "re_push" in recipe.steps

--- a/tests/server/test_guards_module.py
+++ b/tests/server/test_guards_module.py
@@ -30,3 +30,10 @@ def test_require_fleet_doc_mentions_l3():
     assert "L3" in doc
     assert "L1" in doc
     assert "L2" in doc
+
+
+def test_check_input_contracts_has_docstring():
+    from autoskillit.server._guards import _check_input_contracts
+
+    doc = _check_input_contracts.__doc__ or ""
+    assert "contract" in doc.lower()

--- a/tests/server/test_guards_module.py
+++ b/tests/server/test_guards_module.py
@@ -30,10 +30,3 @@ def test_require_fleet_doc_mentions_l3():
     assert "L3" in doc
     assert "L1" in doc
     assert "L2" in doc
-
-
-def test_check_input_contracts_has_docstring():
-    from autoskillit.server._guards import _check_input_contracts
-
-    doc = _check_input_contracts.__doc__ or ""
-    assert "contract" in doc.lower()

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -440,17 +440,6 @@ class TestInputContractValidation:
         parsed = json.loads(result)
         assert parsed["success"] is False
 
-    def test_guard_fires_when_called_directly(self, tmp_path):
-        from autoskillit.server._guards import _check_input_contracts
-
-        resolver = _make_input_contract_resolver()
-        result = _check_input_contracts(
-            "/resolve-failures /nonexistent/worktree /nonexistent/plan.md main",
-            str(tmp_path),
-            resolver,
-        )
-        assert result is not None
-
     def test_resolver_returns_none_skips_validation(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
@@ -483,13 +472,6 @@ class TestInputContractResolver:
         resolver = _make_input_contract_resolver()
         specs = resolver("/unknown-skill-not-in-contracts /some/path")
         assert list(specs) == []
-
-    def test_input_contract_resolver_skips_string_type_inputs(self):
-
-        resolver = _make_input_contract_resolver()
-        specs = resolver("/resolve-failures /worktrees/foo /plans/bar.md main")
-        names = [s.name for s in specs]
-        assert "base_branch" not in names
 
 
 def _make_input_contract_resolver():

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -316,6 +316,216 @@ class TestDryWalkthroughGateWithPrefix:
         assert "dry-walked" in result["result"].lower()
 
 
+class TestInputContractValidation:
+    """_check_input_contracts validates file_path and directory_path inputs."""
+
+    def test_file_path_input_rejects_nonexistent_path(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        resolver = _make_input_contract_resolver()
+        result = _check_input_contracts(
+            "/resolve-failures /nonexistent/worktree /nonexistent/plan.md main",
+            str(tmp_path),
+            resolver,
+        )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert parsed["subtype"] == "gate_error"
+
+    def test_file_path_input_rejects_directory_as_file(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        plan_as_dir = tmp_path / "plan.md"
+        plan_as_dir.mkdir()
+        resolver = _make_input_contract_resolver()
+        result = _check_input_contracts(
+            f"/resolve-failures {worktree} {plan_as_dir} main",
+            str(tmp_path),
+            resolver,
+        )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+
+    def test_file_path_input_rejects_missing_extension(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        plan_no_ext = tmp_path / "plan_no_ext"
+        plan_no_ext.write_text("content")
+        resolver = _make_input_contract_resolver()
+        result = _check_input_contracts(
+            f"/resolve-failures {worktree} {plan_no_ext} main",
+            str(tmp_path),
+            resolver,
+        )
+        # plan_no_ext exists as a file so is_file() passes — this tests the file exists check
+        assert result is None
+
+    def test_directory_path_input_rejects_file_as_directory(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        file_as_worktree = tmp_path / "worktree"
+        file_as_worktree.write_text("I am a file")
+        resolver = _make_input_contract_resolver()
+        result = _check_input_contracts(
+            f"/resolve-failures {file_as_worktree} /some/plan.md main",
+            str(tmp_path),
+            resolver,
+        )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+
+    def test_directory_path_input_accepts_valid_directory(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        plan = tmp_path / "plan.md"
+        plan.write_text("content")
+        resolver = _make_input_contract_resolver()
+        result = _check_input_contracts(
+            f"/resolve-failures {worktree} {plan} main",
+            str(tmp_path),
+            resolver,
+        )
+        assert result is None
+
+    def test_file_path_input_accepts_valid_file(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        plan = tmp_path / "my-plan.md"
+        plan.write_text("content")
+        resolver = _make_input_contract_resolver()
+        result = _check_input_contracts(
+            f"/resolve-failures {worktree} {plan} main",
+            str(tmp_path),
+            resolver,
+        )
+        assert result is None
+
+    def test_skill_without_contracts_passes(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        resolver = _make_input_contract_resolver()
+        result = _check_input_contracts(
+            "/nonexistent-skill-not-in-contracts /some/path.md",
+            str(tmp_path),
+            resolver,
+        )
+        assert result is None
+
+    def test_mangled_plan_path_with_timestamp_suffix(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        real_plan = tmp_path / "rectify_foo_2026-05-28_194500.md"
+        real_plan.write_text("Dry-walkthrough verified = TRUE")
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        mangled = tmp_path / "rectify_foo_2026-05-28_194500-20260528-201752"
+        resolver = _make_input_contract_resolver()
+        result = _check_input_contracts(
+            f"/resolve-failures {worktree} {mangled} main",
+            str(tmp_path),
+            resolver,
+        )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+
+    def test_input_contracts_not_called_for_resume(self, tool_ctx):
+        from autoskillit.server._guards import _check_input_contracts
+
+        resolver = _make_input_contract_resolver()
+        # When called directly with a valid resolver and a bad command,
+        # the guard fires. But the run_skill wiring skips it for resume_session_id.
+        # This test verifies the guard itself always runs when called — the
+        # skip-on-resume logic is tested via run_skill integration.
+        result = _check_input_contracts(
+            "/resolve-failures /nonexistent/worktree /nonexistent/plan.md main",
+            "/tmp",
+            resolver,
+        )
+        assert result is not None
+
+    def test_resolver_returns_none_skips_validation(self, tool_ctx, tmp_path):
+        from autoskillit.server._guards import _check_input_contracts
+
+        result = _check_input_contracts(
+            "/resolve-failures /nonexistent/worktree /nonexistent/plan.md main",
+            str(tmp_path),
+            None,
+        )
+        assert result is None
+
+
+class TestInputContractResolver:
+    """InputContractResolver loads input specs from skill_contracts.yaml."""
+
+    def test_input_contract_resolver_returns_specs_for_resolve_failures(self):
+        from autoskillit.core import InputSpec
+
+        resolver = _make_input_contract_resolver()
+        specs = resolver("/resolve-failures /worktrees/foo /plans/bar.md main")
+        assert len(specs) == 3
+        assert specs[0] == InputSpec(
+            name="worktree_path", type="directory_path", required=True, position=0
+        )
+        assert specs[1] == InputSpec(name="plan_path", type="file_path", required=True, position=1)
+        assert specs[2] == InputSpec(
+            name="diagnosis_path", type="file_path", required=False, position=2
+        )
+
+    def test_input_contract_resolver_returns_empty_for_unknown_skill(self):
+        resolver = _make_input_contract_resolver()
+        specs = resolver("/unknown-skill-not-in-contracts /some/path")
+        assert list(specs) == []
+
+    def test_input_contract_resolver_skips_string_type_inputs(self):
+
+        resolver = _make_input_contract_resolver()
+        specs = resolver("/resolve-failures /worktrees/foo /plans/bar.md main")
+        names = [s.name for s in specs]
+        assert "base_branch" not in names
+
+
+def _make_input_contract_resolver():
+    """Create a concrete InputContractResolver using the bundled manifest."""
+    from autoskillit.core import InputSpec, resolve_skill_name
+    from autoskillit.recipe._contracts_manifest import get_skill_contract, load_bundled_manifest
+
+    def _resolve(skill_command: str):
+        name = resolve_skill_name(skill_command)
+        if not name:
+            return ()
+        contract = get_skill_contract(name, load_bundled_manifest())
+        if contract is None:
+            return ()
+        path_position = 0
+        specs: list[InputSpec] = []
+        for inp in contract.inputs:
+            if inp.type in ("file_path", "directory_path"):
+                specs.append(
+                    InputSpec(
+                        name=inp.name,
+                        type=inp.type,
+                        required=inp.required,
+                        position=path_position,
+                    )
+                )
+                path_position += 1
+        return tuple(specs)
+
+    return _resolve
+
+
 class TestRunSkillCwdValidation:
     """run_skill rejects non-empty relative cwd at the boundary."""
 

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -440,7 +440,7 @@ class TestInputContractValidation:
         parsed = json.loads(result)
         assert parsed["success"] is False
 
-    def test_input_contracts_not_called_for_resume(self, tmp_path):
+    def test_guard_fires_when_called_directly(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         resolver = _make_input_contract_resolver()
@@ -494,32 +494,9 @@ class TestInputContractResolver:
 
 def _make_input_contract_resolver():
     """Create a concrete InputContractResolver using the bundled manifest."""
-    from autoskillit.core import InputSpec, resolve_skill_name
-    from autoskillit.recipe._contracts_manifest import get_skill_contract, load_bundled_manifest
+    from autoskillit.recipe._contracts_manifest import resolve_input_specs
 
-    def _resolve(skill_command: str):
-        name = resolve_skill_name(skill_command)
-        if not name:
-            return ()
-        contract = get_skill_contract(name, load_bundled_manifest())
-        if contract is None:
-            return ()
-        path_position = 0
-        specs: list[InputSpec] = []
-        for inp in contract.inputs:
-            if inp.type in ("file_path", "directory_path"):
-                specs.append(
-                    InputSpec(
-                        name=inp.name,
-                        type=inp.type,
-                        required=inp.required,
-                        position=path_position,
-                    )
-                )
-                path_position += 1
-        return tuple(specs)
-
-    return _resolve
+    return resolve_input_specs
 
 
 class TestRunSkillCwdValidation:

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -319,7 +319,7 @@ class TestDryWalkthroughGateWithPrefix:
 class TestInputContractValidation:
     """_check_input_contracts validates file_path and directory_path inputs."""
 
-    def test_file_path_input_rejects_nonexistent_path(self, tool_ctx, tmp_path):
+    def test_file_path_input_rejects_nonexistent_path(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         resolver = _make_input_contract_resolver()
@@ -333,7 +333,7 @@ class TestInputContractValidation:
         assert parsed["success"] is False
         assert parsed["subtype"] == "gate_error"
 
-    def test_file_path_input_rejects_directory_as_file(self, tool_ctx, tmp_path):
+    def test_file_path_input_rejects_directory_as_file(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         worktree = tmp_path / "worktree"
@@ -350,7 +350,7 @@ class TestInputContractValidation:
         parsed = json.loads(result)
         assert parsed["success"] is False
 
-    def test_file_path_input_rejects_missing_extension(self, tool_ctx, tmp_path):
+    def test_file_path_input_accepts_file_without_extension(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         worktree = tmp_path / "worktree"
@@ -366,7 +366,7 @@ class TestInputContractValidation:
         # plan_no_ext exists as a file so is_file() passes — this tests the file exists check
         assert result is None
 
-    def test_directory_path_input_rejects_file_as_directory(self, tool_ctx, tmp_path):
+    def test_directory_path_input_rejects_file_as_directory(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         file_as_worktree = tmp_path / "worktree"
@@ -381,7 +381,7 @@ class TestInputContractValidation:
         parsed = json.loads(result)
         assert parsed["success"] is False
 
-    def test_directory_path_input_accepts_valid_directory(self, tool_ctx, tmp_path):
+    def test_directory_path_input_accepts_valid_directory(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         worktree = tmp_path / "worktree"
@@ -396,7 +396,7 @@ class TestInputContractValidation:
         )
         assert result is None
 
-    def test_file_path_input_accepts_valid_file(self, tool_ctx, tmp_path):
+    def test_file_path_input_accepts_valid_file(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         worktree = tmp_path / "worktree"
@@ -411,7 +411,7 @@ class TestInputContractValidation:
         )
         assert result is None
 
-    def test_skill_without_contracts_passes(self, tool_ctx, tmp_path):
+    def test_skill_without_contracts_passes(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         resolver = _make_input_contract_resolver()
@@ -422,7 +422,7 @@ class TestInputContractValidation:
         )
         assert result is None
 
-    def test_mangled_plan_path_with_timestamp_suffix(self, tool_ctx, tmp_path):
+    def test_mangled_plan_path_with_timestamp_suffix(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         real_plan = tmp_path / "rectify_foo_2026-05-28_194500.md"
@@ -440,22 +440,18 @@ class TestInputContractValidation:
         parsed = json.loads(result)
         assert parsed["success"] is False
 
-    def test_input_contracts_not_called_for_resume(self, tool_ctx):
+    def test_input_contracts_not_called_for_resume(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         resolver = _make_input_contract_resolver()
-        # When called directly with a valid resolver and a bad command,
-        # the guard fires. But the run_skill wiring skips it for resume_session_id.
-        # This test verifies the guard itself always runs when called — the
-        # skip-on-resume logic is tested via run_skill integration.
         result = _check_input_contracts(
             "/resolve-failures /nonexistent/worktree /nonexistent/plan.md main",
-            "/tmp",
+            str(tmp_path),
             resolver,
         )
         assert result is not None
 
-    def test_resolver_returns_none_skips_validation(self, tool_ctx, tmp_path):
+    def test_resolver_returns_none_skips_validation(self, tmp_path):
         from autoskillit.server._guards import _check_input_contracts
 
         result = _check_input_contracts(

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -481,6 +481,26 @@ def _make_input_contract_resolver():
     return resolve_input_specs
 
 
+class TestInputContractIntegration:
+    """_check_input_contracts fires through run_skill when resolver is wired."""
+
+    @pytest.mark.anyio
+    async def test_run_skill_rejects_nonexistent_path_via_input_contract(
+        self, tool_ctx_kitchen_open
+    ):
+        tool_ctx_kitchen_open.input_contract_resolver = _make_input_contract_resolver()
+        result = json.loads(
+            await run_skill(
+                "/resolve-failures /nonexistent/worktree /nonexistent/plan.md main",
+                "/tmp",
+            )
+        )
+        assert result["success"] is False
+        assert result["subtype"] == "gate_error"
+        assert "Missing required" in result["result"] or "does not exist" in result["result"]
+        assert tool_ctx_kitchen_open.runner.call_args_list == []
+
+
 class TestRunSkillCwdValidation:
     """run_skill rejects non-empty relative cwd at the boundary."""
 

--- a/tests/server/test_tools_execution_step_resolution.py
+++ b/tests/server/test_tools_execution_step_resolution.py
@@ -28,7 +28,9 @@ async def test_run_skill_resolves_output_dir_from_recipe_step(
     tool_ctx_kitchen_open.active_recipe_steps = {"verify": step}
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
-    await run_skill("/dry-walkthrough ...", str(tmp_path), step_name="verify")
+    plan = tmp_path / "plan.md"
+    plan.write_text("content")
+    await run_skill(f"/dry-walkthrough {plan}", str(tmp_path), step_name="verify")
 
     assert len(executor.calls) == 1
     expected_prefix = str(tmp_path / ".autoskillit" / "temp") + "/"
@@ -97,9 +99,11 @@ async def test_run_skill_llm_provided_params_override_recipe_step(
     tool_ctx_kitchen_open.active_recipe_steps = {"verify": step}
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
+    plan = tmp_path / "plan.md"
+    plan.write_text("content")
     override_dir = str(tmp_path / "explicit-override")
     await run_skill(
-        "/dry-walkthrough ...",
+        f"/dry-walkthrough {plan}",
         str(tmp_path),
         step_name="verify",
         output_dir=override_dir,
@@ -136,8 +140,10 @@ async def test_run_skill_logs_warning_when_output_dir_resolved_from_recipe(
     tool_ctx_kitchen_open.active_recipe_steps = {"verify": step}
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
+    plan = tmp_path / "plan.md"
+    plan.write_text("content")
     with structlog.testing.capture_logs() as cap:
-        await run_skill("/dry-walkthrough ...", str(tmp_path), step_name="verify")
+        await run_skill(f"/dry-walkthrough {plan}", str(tmp_path), step_name="verify")
 
     assert any(entry.get("event") == "output_dir_resolved_from_recipe" for entry in cap)
 
@@ -153,19 +159,21 @@ async def test_run_skill_skips_auto_fill_when_output_dir_has_template(
 
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
+    plan = tmp_path / "plan.md"
+    plan.write_text("content")
     tool_ctx_kitchen_open.active_recipe_steps = {
         "verify": RecipeStep(
             name="verify",
             with_args={
                 "output_dir": "${{ context.work_dir }}/.autoskillit/temp",
-                "skill_command": "/autoskillit:dry-walkthrough path/to/plan.md",
+                "skill_command": f"/autoskillit:dry-walkthrough {plan}",
             },
         )
     }
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill(
-        skill_command="/autoskillit:dry-walkthrough path/to/plan.md",
+        skill_command=f"/autoskillit:dry-walkthrough {plan}",
         cwd=str(tmp_path),
         step_name="verify",
     )
@@ -185,6 +193,8 @@ async def test_run_skill_auto_fills_relative_output_dir_from_recipe(
 
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
+    plan = tmp_path / "plan.md"
+    plan.write_text("content")
     tool_ctx_kitchen_open.active_recipe_steps = {
         "verify": RecipeStep(
             name="verify",
@@ -194,7 +204,7 @@ async def test_run_skill_auto_fills_relative_output_dir_from_recipe(
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 
     await run_skill(
-        skill_command="/autoskillit:dry-walkthrough path/to/plan.md",
+        skill_command=f"/autoskillit:dry-walkthrough {plan}",
         cwd=str(tmp_path),
         step_name="verify",
     )

--- a/tests/server/test_tools_run_skill_retry.py
+++ b/tests/server/test_tools_run_skill_retry.py
@@ -135,8 +135,10 @@ class TestRunSkillAgentResult:
     """run_skill result field contains actionable text."""
 
     @pytest.mark.anyio
-    async def test_context_limit_result_is_actionable(self, tool_ctx_kitchen_open):
+    async def test_context_limit_result_is_actionable(self, tool_ctx_kitchen_open, monkeypatch):
         """When context is exhausted, result text must NOT say 'Prompt is too long'."""
+        tool_ctx_kitchen_open.input_contract_resolver = None
+        monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
         stdout = json.dumps(
             {
                 "type": "result",


### PR DESCRIPTION
## Summary

The orchestrator LLM mangles `context.plan_path` when constructing `skill_command` strings — stripping the `.md` extension and appending worktree timestamp fragments. This happens because `${{ context.* }}` substitution is entirely LLM-managed with no code-level enforcement of the substituted values. The `skill_contracts.yaml` declares `plan_path` as `type: file_path, required: true` for 35+ skills, and `worktree_path` as `type: directory_path` for 15+ skills, but these input type declarations are purely advisory — no runtime validator enforces them.

The architectural weakness is: **the server enforces output contracts (patterns, write behavior, read-only) but has zero enforcement of input contracts**. The `_check_dry_walkthrough` guard is a one-off hand-coded validation for implement skills only. It cannot scale to cover all 320+ `file_path`/`directory_path` input declarations across 80+ skills.

The immunity solution is a **contract-driven input validator** in the `run_skill` guard chain that reads input type declarations from `skill_contracts.yaml` and enforces them against the actual `skill_command` arguments at dispatch time. This catches `plan_path` mangling, `worktree_path` corruption, and any other `file_path`/`directory_path` violation — for every skill — without per-skill hand-coding.

## Related Issues Found

1. **Every `file_path` input across all skills is unvalidated.** There are 263 `type: file_path` declarations and 57 `type: directory_path` declarations in `skill_contracts.yaml`. None are enforced at dispatch time. Any LLM substitution error that produces a path-like token (starts with `/`) will pass through the hook chain and server guards uncaught.

2. **`skill_cmd_guard.py` and `_check_dry_walkthrough` duplicate path detection logic.** Both implement `_looks_like_path()` with the same `_PATH_PREFIXES = ("/", "./", ".autoskillit/")`. The hook checks argument ordering; the guard checks file existence + marker. Neither checks argument type conformance.

3. **`extract_path_arg()` returns only the first path-like token.** Skills like `resolve-failures` take multiple path arguments (`worktree_path`, `plan_path`, `diagnosis_path`). The server can only extract the first one — there's no `extract_all_path_args()` function to access positional arguments by index.

4. **`ValidatedWorktreePath` exists but `ValidatedPlanPath` does not.** PR #2782 introduced a type-safe wrapper for `worktree_path` with `is_absolute()` + `is_dir()` validation. No equivalent exists for `plan_path` (`is_absolute()` + `is_file()` + `.md` extension check). The same class of fix was applied to one path type but not the other.

5. **The `campaign-path-coherence` rule watches `worktree_path` staleness but not `plan_path` staleness.** The semantic rule in `rules_campaign_flow.py` catches cross-dispatch `worktree_path` decay. No analogous rule exists for `plan_path`.

## Changed Files

### New (★):
tests/core/test_type_helpers.py

### Modified (●):
- src/autoskillit/core/__init__.pyi
- src/autoskillit/core/types/_type_helpers.py
- src/autoskillit/core/types/_type_protocols_execution.py
- src/autoskillit/core/types/_type_results.py
- src/autoskillit/hooks/guards/skill_cmd_guard.py
- src/autoskillit/pipeline/context.py
- src/autoskillit/server/_factory.py
- src/autoskillit/server/_guards.py
- src/autoskillit/server/tools/tools_execution.py
- tests/_test_filter.py
- tests/core/CLAUDE.md
- tests/core/test_type_protocol_shards.py
- tests/pipeline/test_context.py
- tests/recipe/test_bundled_recipes_pipeline_structure.py
- tests/server/test_guards_module.py
- tests/server/test_tools_execution_input_gates.py

Closes #3245

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_plan_path_contract_enforcement_2026-05-28_234500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 75 | 11.4k | 1.8M | 116.4k | 325 | 70.8k | 8m 47s |
| rectify* | opus[1m] | 1 | 72 | 24.3k | 3.4M | 151.2k | 270 | 198.6k | 20m 59s |
| review_approach* | sonnet | 1 | 52 | 5.8k | 183.0k | 40.8k | 33 | 28.2k | 3m 24s |
| dry_walkthrough* | opus | 1 | 75 | 16.0k | 2.0M | 87.0k | 180 | 70.8k | 7m 29s |
| implement* | sonnet | 1 | 2.6k | 14.9k | 1.8M | 93.9k | 102 | 78.2k | 5m 18s |
| audit_impl* | sonnet | 1 | 558 | 15.5k | 381.6k | 60.6k | 69 | 45.7k | 6m 59s |
| prepare_pr* | sonnet | 1 | 161.0k | 4.0k | 367.6k | 30.9k | 24 | 15.7k | 1m 30s |
| compose_pr* | sonnet | 1 | 95.1k | 3.4k | 277.9k | 30.9k | 23 | 43.5k | 1m 26s |
| review_pr* | sonnet | 3 | 2.3k | 136.2k | 4.9M | 144.6k | 362 | 332.6k | 42m 31s |
| resolve_review* | opus | 4 | 420 | 101.9k | 21.3M | 126.1k | 557 | 401.4k | 57m 54s |
| post_run_diagnostics* | sonnet | 1 | 18 | 3.8k | 146.9k | 93.4k | 441 | 6.8k | 10m 33s |
| **Total** | | | 262.3k | 337.3k | 36.7M | 151.2k | | 1.3M | 2h 46m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 239 | 7597.4 | 327.1 | 62.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 269 | 79329.1 | 1492.4 | 378.7 |
| post_run_diagnostics | 0 | — | — | — |
| **Total** | **508** | 72155.9 | 2544.0 | 664.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 3 | 570 | 129.3k | 25.2M | 543.1k | 1h 14m |
| opus[1m] | 1 | 72 | 24.3k | 3.4M | 198.6k | 20m 59s |
| sonnet | 7 | 261.7k | 183.7k | 8.1M | 550.7k | 1h 11m |