### PR TITLE
Implementation Plan: Remediation — Add `serve()` Project Dir Env Test

### DIFF
--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -121,7 +121,9 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
             ",".join(cfg.safety.protected_branches),
         )
 
-    ctx = make_context(cfg)
+    _project_dir_env = os.environ.get("AUTOSKILLIT_PROJECT_DIR")
+    _explicit_project_dir = Path(_project_dir_env) if _project_dir_env else None
+    ctx = make_context(cfg, project_dir=_explicit_project_dir)
     _initialize(ctx)
 
     try:

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -122,7 +122,14 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
         )
 
     _project_dir_env = os.environ.get("AUTOSKILLIT_PROJECT_DIR")
-    _explicit_project_dir = Path(_project_dir_env) if _project_dir_env else None
+    if _project_dir_env:
+        _explicit_project_dir = Path(_project_dir_env)
+        if not _explicit_project_dir.is_dir():
+            raise ValueError(
+                f"AUTOSKILLIT_PROJECT_DIR={_project_dir_env!r} is not an existing directory"
+            )
+    else:
+        _explicit_project_dir = None
     ctx = make_context(cfg, project_dir=_explicit_project_dir)
     _initialize(ctx)
 

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -9,7 +9,6 @@ construction scattered across callers.
 
 from __future__ import annotations
 
-import dataclasses
 import os
 import subprocess
 from collections.abc import Callable
@@ -142,10 +141,7 @@ def _check_plugin_installed() -> bool:
 
 
 def _resolve_project_dir() -> Path:
-    """Resolve the project root: AUTOSKILLIT_PROJECT_DIR env -> git toplevel -> cwd."""
-    env_project_dir = os.environ.get("AUTOSKILLIT_PROJECT_DIR", "")
-    if env_project_dir:
-        return Path(env_project_dir)
+    """Resolve the project root: git toplevel -> cwd."""
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -167,6 +163,7 @@ def make_context(
     plugin_dir: str | None = _UNSET,
     plugin_source: PluginSource = _UNSET,
     fleet_lock: FleetLock | None = None,
+    project_dir: Path | None = None,
 ) -> ToolContext:
     """Create a fully-wired ToolContext with all 23 service fields populated.
 
@@ -192,6 +189,9 @@ def make_context(
         fleet_lock: FleetLock implementation to inject. Defaults to
                         FleetSemaphore(max_concurrent_dispatches) when None. Pass a
                         custom implementation in tests to substitute without monkey-patching.
+        project_dir: Explicit project root path. When supplied, used directly.
+                     When None, _resolve_project_dir() is called (git toplevel → cwd).
+                     Pass tmp_path in tests to avoid subprocess calls and ensure isolation.
 
     Returns:
         ToolContext with gate starting closed (enabled=False) in all contexts.
@@ -201,16 +201,6 @@ def make_context(
         config.agent_backend via the BACKEND_REGISTRY). When runner=None is
         passed explicitly, tester is left as None.
     """
-    env_profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE")
-    if env_profile and env_profile in config.providers.profiles:
-        config = dataclasses.replace(
-            config, providers=dataclasses.replace(config.providers, default_provider=env_profile)
-        )
-    elif env_profile:
-        logger.warning(
-            "AUTOSKILLIT_PROVIDER_PROFILE %r not in known profiles — ignored", env_profile
-        )
-
     if runner is _UNSET:
         from autoskillit.execution import DefaultSubprocessRunner
 
@@ -304,7 +294,7 @@ def make_context(
     plugin_source = resolved_plugin_source
     gate = DefaultGateState(enabled=False)
 
-    project_dir = _resolve_project_dir()
+    project_dir = project_dir if project_dir is not None else _resolve_project_dir()
     temp_dir = resolve_temp_dir(project_dir, config.workspace.temp_dir)
     temp_dir_relpath = temp_dir_display_str(config.workspace.temp_dir)
 

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -44,6 +44,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_kitchen_id_assignment.py` | AST guard: ctx.kitchen_id assignment only via resolve_kitchen_id() |
 | `test_layer_enforcement.py` | MCP tool registry + import layer contracts + cross-package rules |
 | `test_layer_markers.py` | Enforce pytestmark layer markers on all in-scope test files |
+| `test_make_context_env_boundary.py` | AST guard: _factory.py functions must not read AUTOSKILLIT_PRIVATE_ENV_VARS from os.environ |
 | `test_never_raises_contracts.py` | Structural enforcement of 'Never raises' docstring contracts in server/ |
 | `test_no_error_dict_return.py` | AST guard: load_and_validate must not return dicts with 'error' key — errors flow via exceptions |
 | `test_no_inline_jsonl_request_id_dedup.py` | AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py |

--- a/tests/arch/test_make_context_env_boundary.py
+++ b/tests/arch/test_make_context_env_boundary.py
@@ -39,7 +39,6 @@ def _extract_private_env_reads(factory_path: Path) -> list[tuple[str, str, int]]
                 continue
             env_var_name: str | None = None
 
-            # os.environ.get("KEY") or os.environ.get("KEY", default)
             if (
                 isinstance(child.func, ast.Attribute)
                 and child.func.attr == "get"
@@ -53,7 +52,6 @@ def _extract_private_env_reads(factory_path: Path) -> list[tuple[str, str, int]]
             ):
                 env_var_name = child.args[0].value
 
-            # os.getenv("KEY") or os.getenv("KEY", default)
             elif (
                 isinstance(child.func, ast.Attribute)
                 and child.func.attr == "getenv"
@@ -66,9 +64,10 @@ def _extract_private_env_reads(factory_path: Path) -> list[tuple[str, str, int]]
                 env_var_name = child.args[0].value
 
             if env_var_name and env_var_name in AUTOSKILLIT_PRIVATE_ENV_VARS:
-                violations.append((fn_name, env_var_name, child.col_offset))
+                violations.append((fn_name, env_var_name, child.lineno))
 
-    # Also catch os.environ["KEY"] subscript access
+    # Subscript (os.environ["KEY"]) is a distinct AST node from Call — needs separate walk
+
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef):
             continue
@@ -85,7 +84,7 @@ def _extract_private_env_reads(factory_path: Path) -> list[tuple[str, str, int]]
                 and isinstance(child.slice.value, str)
                 and child.slice.value in AUTOSKILLIT_PRIVATE_ENV_VARS
             ):
-                violations.append((fn_name, child.slice.value, child.col_offset))
+                violations.append((fn_name, child.slice.value, child.lineno))
 
     return violations
 
@@ -104,6 +103,6 @@ def test_factory_functions_do_not_read_private_env_vars() -> None:
     violations = _extract_private_env_reads(_FACTORY_PY)
     assert violations == [], (
         "_factory.py reads AUTOSKILLIT_PRIVATE_ENV_VARS members from os.environ:\n"
-        + "\n".join(f"  {fn}(): reads {var!r} (col {col})" for fn, var, col in violations)
+        + "\n".join(f"  {fn}(): reads {var!r} (line {lineno})" for fn, var, lineno in violations)
         + "\n\nMove env reads to cli/app.py and pass values explicitly to make_context()."
     )

--- a/tests/arch/test_make_context_env_boundary.py
+++ b/tests/arch/test_make_context_env_boundary.py
@@ -1,0 +1,109 @@
+"""Structural guard: make_context() and helpers in _factory.py must not read
+AUTOSKILLIT_PRIVATE_ENV_VARS members from os.environ.
+
+These variables are session-scoped internals.  Reading them inside the
+composition root promotes them to server-scoped state — a class of
+contamination bug that this AST test makes structurally impossible.
+
+The test operates purely on the AST (no runtime execution) so it catches
+any future attempt before it can merge.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.types._type_constants_env import AUTOSKILLIT_PRIVATE_ENV_VARS
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_FACTORY_PY = (
+    Path(__file__).parent.parent.parent / "src" / "autoskillit" / "server" / "_factory.py"
+)
+
+
+def _extract_private_env_reads(factory_path: Path) -> list[tuple[str, str, int]]:
+    """Return list of (function_name, env_var_name, lineno) for private env reads."""
+    tree = ast.parse(factory_path.read_text())
+    violations: list[tuple[str, str, int]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        fn_name = node.name
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            env_var_name: str | None = None
+
+            # os.environ.get("KEY") or os.environ.get("KEY", default)
+            if (
+                isinstance(child.func, ast.Attribute)
+                and child.func.attr == "get"
+                and isinstance(child.func.value, ast.Attribute)
+                and child.func.value.attr == "environ"
+                and isinstance(child.func.value.value, ast.Name)
+                and child.func.value.value.id == "os"
+                and child.args
+                and isinstance(child.args[0], ast.Constant)
+                and isinstance(child.args[0].value, str)
+            ):
+                env_var_name = child.args[0].value
+
+            # os.getenv("KEY") or os.getenv("KEY", default)
+            elif (
+                isinstance(child.func, ast.Attribute)
+                and child.func.attr == "getenv"
+                and isinstance(child.func.value, ast.Name)
+                and child.func.value.id == "os"
+                and child.args
+                and isinstance(child.args[0], ast.Constant)
+                and isinstance(child.args[0].value, str)
+            ):
+                env_var_name = child.args[0].value
+
+            if env_var_name and env_var_name in AUTOSKILLIT_PRIVATE_ENV_VARS:
+                violations.append((fn_name, env_var_name, child.col_offset))
+
+    # Also catch os.environ["KEY"] subscript access
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        fn_name = node.name
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Subscript):
+                continue
+            if (
+                isinstance(child.value, ast.Attribute)
+                and child.value.attr == "environ"
+                and isinstance(child.value.value, ast.Name)
+                and child.value.value.id == "os"
+                and isinstance(child.slice, ast.Constant)
+                and isinstance(child.slice.value, str)
+                and child.slice.value in AUTOSKILLIT_PRIVATE_ENV_VARS
+            ):
+                violations.append((fn_name, child.slice.value, child.col_offset))
+
+    return violations
+
+
+def test_factory_functions_do_not_read_private_env_vars() -> None:
+    """No function in _factory.py may read a member of AUTOSKILLIT_PRIVATE_ENV_VARS.
+
+    These variables are session-scoped.  Reading them inside make_context() or
+    any helper it calls in the same module promotes them to server-scoped state,
+    creating permanent contamination that scrubbing mechanisms cannot undo.
+
+    If a legitimate future use case requires reading a private var here, move
+    the read to the CLI entry point (cli/app.py) and pass the value explicitly
+    as a parameter to make_context().
+    """
+    violations = _extract_private_env_reads(_FACTORY_PY)
+    assert violations == [], (
+        "_factory.py reads AUTOSKILLIT_PRIVATE_ENV_VARS members from os.environ:\n"
+        + "\n".join(f"  {fn}(): reads {var!r} (col {col})" for fn, var, col in violations)
+        + "\n\nMove env reads to cli/app.py and pass values explicitly to make_context()."
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,6 +209,18 @@ def _clear_headless_env(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _clear_provider_profile_env(monkeypatch):
+    """Prevent AUTOSKILLIT_PROVIDER_PROFILE leaking between tests."""
+    monkeypatch.delenv("AUTOSKILLIT_PROVIDER_PROFILE", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clear_project_dir_env(monkeypatch):
+    """Prevent AUTOSKILLIT_PROJECT_DIR leaking between tests."""
+    monkeypatch.delenv("AUTOSKILLIT_PROJECT_DIR", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _clear_session_type_env(monkeypatch):
     """Prevent SESSION_TYPE leaking between tests."""
     monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
@@ -340,13 +352,11 @@ def tool_ctx(monkeypatch, tmp_path):
         AutomationConfig(features={"fleet": True}),
         runner=mock_runner,
         plugin_source=DirectInstall(plugin_dir=tmp_path),
+        project_dir=tmp_path,
     )
     ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
     ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
-    # Anchor temp_dir and project_dir to tmp_path so server tools use the
-    # per-test directory rather than the cwd or git-resolved project root.
     ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
-    ctx.project_dir = tmp_path
     monkeypatch.setattr(_state, "_ctx", ctx)
     monkeypatch.setattr(_state, "_startup_ready", None)
     return ctx
@@ -370,11 +380,13 @@ def tool_ctx_marketplace(monkeypatch, tmp_path):
         AutomationConfig(features={"fleet": True}),
         runner=mock_runner,
         plugin_source=MarketplaceInstall(cache_path=fake_cache),
+        project_dir=tmp_path,
     )
     ctx.gate = DefaultGateState(enabled=False)
     ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
     ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
     ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
+    ctx.project_dir = tmp_path
     monkeypatch.setattr(_state, "_ctx", ctx)
     monkeypatch.setattr(_state, "_startup_ready", None)
     return ctx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,7 +386,6 @@ def tool_ctx_marketplace(monkeypatch, tmp_path):
     ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
     ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
     ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
-    ctx.project_dir = tmp_path
     monkeypatch.setattr(_state, "_ctx", ctx)
     monkeypatch.setattr(_state, "_startup_ready", None)
     return ctx

--- a/tests/contracts/test_package_gateways.py
+++ b/tests/contracts/test_package_gateways.py
@@ -205,7 +205,7 @@ async def test_migration_check_and_migrate_up_to_date(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_factory_make_context_returns_toolcontext(monkeypatch):
+def test_factory_make_context_returns_toolcontext(monkeypatch, tmp_path):
     from autoskillit.config import AutomationConfig
     from autoskillit.core.paths import pkg_root
     from autoskillit.pipeline.audit import DefaultAuditLog
@@ -213,7 +213,7 @@ def test_factory_make_context_returns_toolcontext(monkeypatch):
     from autoskillit.server._factory import make_context
 
     monkeypatch.setattr("autoskillit.server._factory._check_plugin_installed", lambda: False)
-    ctx = make_context(AutomationConfig())
+    ctx = make_context(AutomationConfig(), project_dir=tmp_path)
     assert isinstance(ctx, ToolContext)
     assert ctx.gate.enabled is False  # starts closed
     assert isinstance(ctx.audit, DefaultAuditLog)
@@ -224,11 +224,11 @@ def test_factory_make_context_returns_toolcontext(monkeypatch):
     assert ctx.plugin_source.plugin_dir == pkg_root()
 
 
-def test_factory_make_context_accepts_runner():
+def test_factory_make_context_accepts_runner(tmp_path):
     from autoskillit.config import AutomationConfig
     from autoskillit.server._factory import make_context
 
-    ctx = make_context(AutomationConfig(), runner=None)
+    ctx = make_context(AutomationConfig(), runner=None, project_dir=tmp_path)
     assert ctx.runner is None
 
 
@@ -237,7 +237,7 @@ def test_factory_make_context_accepts_plugin_dir(tmp_path):
     from autoskillit.core.types._type_plugin_source import DirectInstall
     from autoskillit.server._factory import make_context
 
-    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path), project_dir=tmp_path)
     assert isinstance(ctx.plugin_source, DirectInstall)
     assert ctx.plugin_source.plugin_dir == tmp_path
 

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -15,6 +15,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_factory_recording.py` | Tests for make_context recording/replay runner wiring |
 | `test_factory_backend_coherence.py` | Tests for backend coherence enforcement in make_context() |
 | `test_factory_codex_backend_gate.py` | Tests for codex_backend feature flag gating in make_context() |
+| `test_factory_guards_integration.py` | Integration tests for factory→guards ambient env contamination path |
 | `test_git.py` | Tests for server/git.py perform_merge() |
 | `test_git_merge_dirty_check.py` | Tests for the pre-merge dirty check in perform_merge (Layer 3) |
 | `test_guards_module.py` | Smoke test: all 6 guards are importable from _guards |

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -486,19 +486,35 @@ def test_make_context_uses_explicit_project_dir(tmp_path):
     assert ctx.project_dir == tmp_path
 
 
+def test_serve_passes_project_dir_env_to_make_context(monkeypatch, tmp_path):
+    """serve() reads AUTOSKILLIT_PROJECT_DIR and passes it as project_dir to make_context()."""
+    captured: dict = {}
+
+    def fake_make_context(cfg, **kwargs):
+        captured.update(kwargs)
+        raise SystemExit(0)
+
+    monkeypatch.setenv("AUTOSKILLIT_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr("autoskillit.server.make_context", fake_make_context)
+
+    from autoskillit.cli.app import serve
+
+    with pytest.raises(SystemExit):
+        serve()
+
+    assert captured.get("project_dir") == tmp_path
+
+
 def test_make_context_project_dir_git_root_fallback(monkeypatch):
     """make_context() without explicit project_dir falls back to git toplevel."""
-    import subprocess as _sp
+    import subprocess as _subprocess
 
-    expected = Path(
-        _sp.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-    )
+    def fake_run(cmd, *, capture_output, text, timeout):
+        return _subprocess.CompletedProcess(cmd, 0, stdout="/fake/git/root\n", stderr="")
+
+    monkeypatch.setattr("autoskillit.server._factory.subprocess.run", fake_run)
     ctx = make_context(AutomationConfig(), runner=_runner())
-    assert ctx.project_dir == expected
+    assert ctx.project_dir == Path("/fake/git/root")
 
 
 # --- _resolve_project_dir unit tests ---

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -45,40 +45,40 @@ def _runner() -> MockSubprocessRunner:
     return r
 
 
-def test_make_context_returns_toolcontext():
-    ctx = make_context(AutomationConfig(), runner=_runner())
+def test_make_context_returns_toolcontext(tmp_path):
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert isinstance(ctx, ToolContext)
     assert ctx.gate is not None
     assert ctx.runner is not None
 
 
-def test_make_context_gate_starts_closed(monkeypatch):
+def test_make_context_gate_starts_closed(monkeypatch, tmp_path):
     monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert ctx.gate.enabled is False
 
 
-def test_make_context_gate_stays_closed_in_headless_session(monkeypatch):
+def test_make_context_gate_stays_closed_in_headless_session(monkeypatch, tmp_path):
     """Gate is NOT pre-enabled when AUTOSKILLIT_HEADLESS=1.
     Tag-based visibility (mcp.enable({'headless'})) handles tool reveal."""
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert ctx.gate.enabled is False
 
 
-def test_make_context_executor_is_default_headless():
-    ctx = make_context(AutomationConfig(), runner=_runner())
+def test_make_context_executor_is_default_headless(tmp_path):
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert isinstance(ctx.executor, DefaultHeadlessExecutor)
 
 
-def test_make_context_tester_is_default_test_runner():
-    ctx = make_context(AutomationConfig(), runner=_runner())
+def test_make_context_tester_is_default_test_runner(tmp_path):
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert isinstance(ctx.tester, DefaultTestRunner)
 
 
-def test_make_context_service_fields_are_typed_instances():
+def test_make_context_service_fields_are_typed_instances(tmp_path):
     """Core service fields are typed instances (skill_resolver, clone_mgr, repositories)."""
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert isinstance(ctx.skill_resolver, SkillResolver)
     assert isinstance(ctx.clone_mgr, DefaultCloneManager)
     assert isinstance(ctx.recipes, DefaultRecipeRepository)
@@ -87,70 +87,70 @@ def test_make_context_service_fields_are_typed_instances():
     assert isinstance(ctx.workspace_mgr, DefaultWorkspaceManager)
 
 
-def test_make_context_github_client_is_default_fetcher():
-    ctx = make_context(AutomationConfig(), runner=None, plugin_dir=".")
+def test_make_context_github_client_is_default_fetcher(tmp_path):
+    ctx = make_context(AutomationConfig(), runner=None, plugin_dir=".", project_dir=tmp_path)
     assert isinstance(ctx.github_client, DefaultGitHubFetcher)
 
 
-def test_make_context_github_client_uses_config_token(monkeypatch):
+def test_make_context_github_client_uses_config_token(monkeypatch, tmp_path):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     config = AutomationConfig()
     config.github.token = "config-token"
-    ctx = make_context(config, runner=None, plugin_dir=".")
+    ctx = make_context(config, runner=None, plugin_dir=".", project_dir=tmp_path)
     assert ctx.github_client.has_token is True
 
 
-def test_make_context_github_client_uses_env_token(monkeypatch):
+def test_make_context_github_client_uses_env_token(monkeypatch, tmp_path):
     monkeypatch.setenv("GITHUB_TOKEN", "env-token")
     config = AutomationConfig()
-    ctx = make_context(config, runner=None, plugin_dir=".")
+    ctx = make_context(config, runner=None, plugin_dir=".", project_dir=tmp_path)
     assert ctx.github_client.has_token is True
 
 
-def test_make_context_github_client_no_token(monkeypatch):
+def test_make_context_github_client_no_token(monkeypatch, tmp_path):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setattr("autoskillit.server._factory._gh_cli_token", lambda: None)
-    ctx = make_context(AutomationConfig(), runner=None, plugin_dir=".")
+    ctx = make_context(AutomationConfig(), runner=None, plugin_dir=".", project_dir=tmp_path)
     assert ctx.github_client.has_token is False
 
 
-def test_make_context_github_client_uses_gh_cli_fallback(monkeypatch):
+def test_make_context_github_client_uses_gh_cli_fallback(monkeypatch, tmp_path):
     """When no config token or GITHUB_TOKEN env var, fall back to gh auth token."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setattr("autoskillit.server._factory._gh_cli_token", lambda: "gh-cli-token")
     config = AutomationConfig()
-    ctx = make_context(config, runner=None, plugin_dir=".")
+    ctx = make_context(config, runner=None, plugin_dir=".", project_dir=tmp_path)
     assert ctx.github_client.has_token is True
 
 
-def test_make_context_github_client_config_token_takes_priority_over_gh_cli(monkeypatch):
+def test_make_context_github_client_config_token_takes_priority_over_gh_cli(monkeypatch, tmp_path):
     """Config token takes priority over gh CLI token."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setattr("autoskillit.server._factory._gh_cli_token", lambda: "gh-cli-token")
     config = AutomationConfig()
     config.github.token = "config-token"
-    ctx = make_context(config, runner=None, plugin_dir=".")
+    ctx = make_context(config, runner=None, plugin_dir=".", project_dir=tmp_path)
     assert ctx.github_client.has_token is True
     # After lazy resolution via has_token, verify the resolved value
     assert ctx.github_client._resolve_token() == "config-token"
 
 
-def test_make_context_github_client_token_snapshot_is_immutable(monkeypatch):
+def test_make_context_github_client_token_snapshot_is_immutable(monkeypatch, tmp_path):
     """Token is snapshotted at construction. Changing env after does not affect the fetcher."""
     monkeypatch.setenv("GITHUB_TOKEN", "startup-token")
-    ctx = make_context(AutomationConfig(), runner=None, plugin_dir=".")
+    ctx = make_context(AutomationConfig(), runner=None, plugin_dir=".", project_dir=tmp_path)
     assert ctx.github_client.has_token is True
     monkeypatch.delenv("GITHUB_TOKEN")
     assert ctx.github_client.has_token is True
 
 
-def test_make_context_tester_none_when_no_runner():
+def test_make_context_tester_none_when_no_runner(tmp_path):
     """When runner=None, DefaultTestRunner cannot be constructed; tester is None."""
-    ctx = make_context(AutomationConfig(), runner=None)
+    ctx = make_context(AutomationConfig(), runner=None, project_dir=tmp_path)
     assert ctx.tester is None
 
 
-def test_make_context_protocol_substitution():
+def test_make_context_protocol_substitution(tmp_path):
     """Any object satisfying HeadlessExecutor protocol can replace ctx.executor."""
     from autoskillit.core.types import HeadlessExecutor
 
@@ -201,7 +201,7 @@ def test_make_context_protocol_substitution():
                 token_usage=None,
             )
 
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     ctx.executor = FakeExecutor()
     assert isinstance(ctx.executor, HeadlessExecutor)
 
@@ -278,10 +278,10 @@ def test_output_patterns_nonempty_for_investigate() -> None:
     ],
 )
 def test_write_expected_resolver_mode(
-    invocation: str, expected_mode: str | None, required_tokens: list[str]
+    tmp_path, invocation: str, expected_mode: str | None, required_tokens: list[str]
 ) -> None:
     """write_expected_resolver returns the correct mode and token patterns per skill."""
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert ctx.write_expected_resolver is not None
     spec = ctx.write_expected_resolver(invocation)
     assert spec.mode == expected_mode
@@ -415,7 +415,7 @@ def test_token_factory_caches_none():
     assert call_count == 1, "TokenFactory resolved twice for None result"
 
 
-def test_gh_cli_token_not_called_during_make_context(monkeypatch):
+def test_gh_cli_token_not_called_during_make_context(monkeypatch, tmp_path):
     """make_context() must not call _gh_cli_token() — token resolves lazily."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
@@ -429,7 +429,7 @@ def test_gh_cli_token_not_called_during_make_context(monkeypatch):
     monkeypatch.setattr("autoskillit.server._factory.subprocess.run", tracking_run)
 
     config = AutomationConfig()
-    make_context(config, runner=None, plugin_dir=".")
+    make_context(config, runner=None, plugin_dir=".", project_dir=tmp_path)
 
     gh_calls = [c for c in calls if "gh" in str(c)]
     assert gh_calls == [], f"_gh_cli_token() called during make_context: {gh_calls}"
@@ -450,7 +450,7 @@ def test_make_context_marketplace_install_yields_marketplace_plugin_source(
         lambda: fake_cache,
     )
 
-    ctx = make_context(AutomationConfig(), runner=None)
+    ctx = make_context(AutomationConfig(), runner=None, project_dir=tmp_path)
     assert isinstance(ctx.plugin_source, MarketplaceInstall)
     assert ctx.plugin_source.cache_path == fake_cache
 
@@ -463,7 +463,9 @@ def test_make_context_direct_install_yields_direct_plugin_source(
 
     monkeypatch.setattr("autoskillit.server._factory._check_plugin_installed", lambda: False)
 
-    ctx = make_context(AutomationConfig(), runner=None, plugin_dir=str(tmp_path))
+    ctx = make_context(
+        AutomationConfig(), runner=None, plugin_dir=str(tmp_path), project_dir=tmp_path
+    )
     assert isinstance(ctx.plugin_source, DirectInstall)
     assert ctx.plugin_source.plugin_dir == tmp_path
 
@@ -471,24 +473,21 @@ def test_make_context_direct_install_yields_direct_plugin_source(
 def test_make_context_sets_token_factory(tmp_path):
     """make_context() sets token_factory on the returned ToolContext."""
     cfg = AutomationConfig()
-    ctx = make_context(cfg, runner=None, plugin_dir=str(tmp_path))
+    ctx = make_context(cfg, runner=None, plugin_dir=str(tmp_path), project_dir=tmp_path)
     assert callable(ctx.token_factory)
 
 
-# --- Group P-2: project_dir env inheritance ---
+# --- Group P-2: project_dir ---
 
 
-def test_make_context_reads_project_dir_env(tmp_path, monkeypatch):
-    """make_context reads AUTOSKILLIT_PROJECT_DIR and stores it on ctx.project_dir."""
-    monkeypatch.setenv("AUTOSKILLIT_PROJECT_DIR", str(tmp_path))
-    ctx = make_context(AutomationConfig(), runner=_runner())
+def test_make_context_uses_explicit_project_dir(tmp_path):
+    """make_context() uses project_dir when passed explicitly."""
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert ctx.project_dir == tmp_path
 
 
 def test_make_context_project_dir_git_root_fallback(monkeypatch):
-    """make_context resolves project_dir via git toplevel when env var is not set."""
-    monkeypatch.delenv("AUTOSKILLIT_PROJECT_DIR", raising=False)
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    """make_context() without explicit project_dir falls back to git toplevel."""
     import subprocess as _sp
 
     expected = Path(
@@ -498,25 +497,17 @@ def test_make_context_project_dir_git_root_fallback(monkeypatch):
             text=True,
         ).stdout.strip()
     )
+    ctx = make_context(AutomationConfig(), runner=_runner())
     assert ctx.project_dir == expected
 
 
 # --- _resolve_project_dir unit tests ---
 
 
-def test_resolve_project_dir_env_var(tmp_path, monkeypatch):
-    from autoskillit.server._factory import _resolve_project_dir
-
-    monkeypatch.setenv("AUTOSKILLIT_PROJECT_DIR", str(tmp_path))
-    assert _resolve_project_dir() == tmp_path
-
-
 def test_resolve_project_dir_git_root(monkeypatch):
     import subprocess as _subprocess
 
     from autoskillit.server._factory import _resolve_project_dir
-
-    monkeypatch.delenv("AUTOSKILLIT_PROJECT_DIR", raising=False)
 
     def fake_run(cmd, *, capture_output, text, timeout):
         return _subprocess.CompletedProcess(cmd, 0, stdout="/fake/git/root\n", stderr="")
@@ -530,8 +521,6 @@ def test_resolve_project_dir_cwd_fallback(monkeypatch):
 
     from autoskillit.server._factory import _resolve_project_dir
 
-    monkeypatch.delenv("AUTOSKILLIT_PROJECT_DIR", raising=False)
-
     def fake_run(cmd, *, capture_output, text, timeout):
         return _subprocess.CompletedProcess(cmd, 1, stdout="", stderr="not a git repo")
 
@@ -539,43 +528,23 @@ def test_resolve_project_dir_cwd_fallback(monkeypatch):
     assert _resolve_project_dir() == Path.cwd()
 
 
-def test_make_context_env_profile_overrides_default_provider(monkeypatch):
-    """AUTOSKILLIT_PROVIDER_PROFILE in env must set config.providers.default_provider."""
+def test_make_context_ignores_ambient_provider_profile(monkeypatch, tmp_path):
+    """Ambient AUTOSKILLIT_PROVIDER_PROFILE must not mutate default_provider."""
     monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
     config = AutomationConfig()
+    config.providers.profiles = {"minimax": {}}
     config.providers.default_provider = None
-    config.providers.profiles = {"minimax": {}}
-    ctx = make_context(config, runner=_runner())
-    assert ctx.config.providers.default_provider == "minimax"
+    ctx = make_context(config, runner=_runner(), project_dir=tmp_path)
+    assert ctx.config.providers.default_provider is None
 
 
-def test_make_context_env_profile_overrides_existing_default(monkeypatch):
-    """AUTOSKILLIT_PROVIDER_PROFILE overrides even a config-set default_provider."""
-    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
-    config = AutomationConfig()
-    config.providers.default_provider = "openai"
-    config.providers.profiles = {"minimax": {}}
-    ctx = make_context(config, runner=_runner())
-    assert ctx.config.providers.default_provider == "minimax"
-
-
-def test_make_context_unknown_env_profile_is_ignored(monkeypatch):
-    """AUTOSKILLIT_PROVIDER_PROFILE not in profiles is ignored — no mutation."""
-    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "stale-unknown")
-    config = AutomationConfig()
-    config.providers.default_provider = "anthropic"
-    config.providers.profiles = {}
-    ctx = make_context(config, runner=_runner())
-    assert ctx.config.providers.default_provider == "anthropic"
-
-
-def test_make_context_no_env_profile_preserves_config_default(monkeypatch):
+def test_make_context_no_env_profile_preserves_config_default(monkeypatch, tmp_path):
     """Without AUTOSKILLIT_PROVIDER_PROFILE in env, default_provider is unchanged."""
     monkeypatch.delenv("AUTOSKILLIT_PROVIDER_PROFILE", raising=False)
     config = AutomationConfig()
     config.providers.default_provider = "openai"
     config.providers.profiles = {}
-    ctx = make_context(config, runner=_runner())
+    ctx = make_context(config, runner=_runner(), project_dir=tmp_path)
     assert ctx.config.providers.default_provider == "openai"
 
 
@@ -620,7 +589,7 @@ def test_make_context_skips_replay_runner_for_non_claude_backend(
     monkeypatch.setattr("autoskillit.server._factory.build_replay_runner", mock_build)
 
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
-    ctx = make_context(cfg, plugin_dir=str(tmp_path))
+    ctx = make_context(cfg, plugin_dir=str(tmp_path), project_dir=tmp_path)
 
     assert mock_build.call_count == 0
     assert isinstance(ctx.runner, DefaultSubprocessRunner)
@@ -634,40 +603,40 @@ def test_make_context_skips_record_runner_for_non_claude_backend(
     monkeypatch.delenv("REPLAY_SCENARIO", raising=False)
 
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
-    ctx = make_context(cfg, plugin_dir=str(tmp_path))
+    ctx = make_context(cfg, plugin_dir=str(tmp_path), project_dir=tmp_path)
 
     assert isinstance(ctx.runner, DefaultSubprocessRunner)
     assert not isinstance(ctx.runner, RecordingSubprocessRunner)
 
 
-def test_make_context_backend_is_coding_agent_backend() -> None:
+def test_make_context_backend_is_coding_agent_backend(tmp_path) -> None:
     """make_context() sets ctx.backend to a CodingAgentBackend instance."""
     from autoskillit.core import CodingAgentBackend
 
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert isinstance(ctx.backend, CodingAgentBackend)
 
 
-def test_make_context_default_backend_is_claude_code() -> None:
+def test_make_context_default_backend_is_claude_code(tmp_path) -> None:
     """Default config (agent_backend.backend='claude-code') produces ClaudeCodeBackend."""
     from autoskillit.execution.backends import ClaudeCodeBackend
 
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert isinstance(ctx.backend, ClaudeCodeBackend)
 
 
-def test_make_context_unknown_backend_raises_value_error() -> None:
+def test_make_context_unknown_backend_raises_value_error(tmp_path) -> None:
     """Unknown agent_backend key raises ValueError with supported keys."""
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="nonexistent"))
     with pytest.raises(ValueError, match="nonexistent"):
-        make_context(cfg, runner=_runner())
+        make_context(cfg, runner=_runner(), project_dir=tmp_path)
 
 
-def test_make_context_codex_backend_not_none_plain_config() -> None:
+def test_make_context_codex_backend_not_none_plain_config(tmp_path) -> None:
     """AgentBackendConfig(backend='codex') with no feature flags produces CodexBackend."""
     from autoskillit.execution.backends.codex import CodexBackend
 
     cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="codex"))
-    ctx = make_context(cfg, runner=_runner())
+    ctx = make_context(cfg, runner=_runner(), project_dir=tmp_path)
     assert ctx.backend is not None
     assert isinstance(ctx.backend, CodexBackend)

--- a/tests/server/test_factory_backend_coherence.py
+++ b/tests/server/test_factory_backend_coherence.py
@@ -28,42 +28,42 @@ def _runner() -> MockSubprocessRunner:
     return r
 
 
-def test_make_context_rejects_codex_backend_when_config_is_claude_code():
+def test_make_context_rejects_codex_backend_when_config_is_claude_code(tmp_path):
     """experimental_enabled=True must NOT swap backend when config says claude-code."""
     cfg = AutomationConfig(
         experimental_enabled=True,
         agent_backend=AgentBackendConfig(backend="claude-code"),
     )
-    ctx = make_context(cfg, runner=_runner())
+    ctx = make_context(cfg, runner=_runner(), project_dir=tmp_path)
     assert ctx.backend is not None
     assert ctx.backend.name == "claude-code"
     assert isinstance(ctx.backend, ClaudeCodeBackend)
 
 
-def test_make_context_allows_codex_backend_when_config_is_codex():
+def test_make_context_allows_codex_backend_when_config_is_codex(tmp_path):
     """Explicit codex config + codex_backend feature flag should activate CodexBackend."""
     cfg = AutomationConfig(
         features={"codex_backend": True},
         agent_backend=AgentBackendConfig(backend="codex"),
     )
-    ctx = make_context(cfg, runner=_runner())
+    ctx = make_context(cfg, runner=_runner(), project_dir=tmp_path)
     assert ctx.backend is not None
     assert ctx.backend.name == "codex"
     assert isinstance(ctx.backend, CodexBackend)
 
 
-def test_experimental_enabled_does_not_promote_codex_when_config_is_claude():
+def test_experimental_enabled_does_not_promote_codex_when_config_is_claude(tmp_path):
     """experimental_enabled=True with claude-code config must keep ClaudeCodeBackend."""
     cfg = AutomationConfig(
         experimental_enabled=True,
         agent_backend=AgentBackendConfig(backend="claude-code"),
     )
-    ctx = make_context(cfg, runner=_runner())
+    ctx = make_context(cfg, runner=_runner(), project_dir=tmp_path)
     assert isinstance(ctx.backend, ClaudeCodeBackend)
     assert ctx.backend.write_tool_names() == frozenset({"Write", "Edit"})
 
 
-def test_codex_flag_ignored_warning_when_config_mismatch():
+def test_codex_flag_ignored_warning_when_config_mismatch(tmp_path):
     """When codex_backend is explicitly enabled but config says claude-code, warn and skip."""
     import structlog.testing
 
@@ -72,7 +72,7 @@ def test_codex_flag_ignored_warning_when_config_mismatch():
             features={"codex_backend": True},
             agent_backend=AgentBackendConfig(backend="claude-code"),
         )
-        ctx = make_context(cfg, runner=_runner())
+        ctx = make_context(cfg, runner=_runner(), project_dir=tmp_path)
 
     assert isinstance(ctx.backend, ClaudeCodeBackend)
     warning_logs = [rec for rec in logs if rec.get("event") == "codex_backend_flag_ignored"]

--- a/tests/server/test_factory_codex_backend_gate.py
+++ b/tests/server/test_factory_codex_backend_gate.py
@@ -27,7 +27,7 @@ def _runner() -> MockSubprocessRunner:
     return r
 
 
-def test_codex_backend_not_instantiated_when_disabled(monkeypatch):
+def test_codex_backend_not_instantiated_when_disabled(monkeypatch, tmp_path):
     """When codex_backend feature is disabled, CodexBackend is not the ctx.backend."""
     monkeypatch.setattr(
         "autoskillit.server._factory.is_feature_enabled",
@@ -37,11 +37,11 @@ def test_codex_backend_not_instantiated_when_disabled(monkeypatch):
     )
     from autoskillit.execution.backends.codex import CodexBackend
 
-    ctx = make_context(AutomationConfig(), runner=_runner())
+    ctx = make_context(AutomationConfig(), runner=_runner(), project_dir=tmp_path)
     assert not isinstance(ctx.backend, CodexBackend)
 
 
-def test_codex_backend_instantiated_when_enabled(monkeypatch):
+def test_codex_backend_instantiated_when_enabled(monkeypatch, tmp_path):
     """When codex_backend is enabled and config backend is codex, ctx.backend is CodexBackend."""
     monkeypatch.setattr(
         "autoskillit.server._factory.is_feature_enabled",
@@ -54,5 +54,5 @@ def test_codex_backend_instantiated_when_enabled(monkeypatch):
 
     config = AutomationConfig()
     config.agent_backend = AgentBackendConfig(backend="codex")
-    ctx = make_context(config, runner=_runner())
+    ctx = make_context(config, runner=_runner(), project_dir=tmp_path)
     assert isinstance(ctx.backend, CodexBackend)

--- a/tests/server/test_factory_guards_integration.py
+++ b/tests/server/test_factory_guards_integration.py
@@ -1,0 +1,64 @@
+"""Integration tests for the factory -> guards contamination path.
+
+Tests the two-stage contamination path that unit tests missed:
+  1. set AUTOSKILLIT_PROVIDER_PROFILE / AUTOSKILLIT_PROJECT_DIR in env
+  2. call make_context()
+  3. assert the result is NOT contaminated by the ambient env var
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def test_ambient_provider_profile_does_not_contaminate_tier4_default(
+    monkeypatch, tmp_path
+) -> None:
+    """Ambient AUTOSKILLIT_PROVIDER_PROFILE must not reach default_provider.
+
+    Primary assertion: checks the contamination target (the config object) directly.
+    Secondary assertion: verifies Tier 4 downstream behavior of _resolve_provider_profile.
+    """
+    from autoskillit.config import AutomationConfig
+    from autoskillit.server._factory import make_context
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
+    config = AutomationConfig()
+    config.providers.profiles = {"minimax": {"api_key_env": "MINIMAX_KEY"}}
+    config.providers.default_provider = None
+
+    ctx = make_context(config, runner=None, project_dir=tmp_path)
+
+    assert ctx.config.providers.default_provider != "minimax", (
+        "make_context() must not read AUTOSKILLIT_PROVIDER_PROFILE from os.environ — "
+        "ambient env contaminated config.providers.default_provider"
+    )
+
+    result = _resolve_provider_profile("plan", "my_recipe", ctx.config.providers)
+    assert result[0] != "minimax", "Tier 4 fallback must not use the ambient env profile"
+    assert result == ("anthropic", {}), f"Expected ('anthropic', {{}}) but got {result!r}"
+
+
+def test_ambient_project_dir_does_not_contaminate_context(monkeypatch, tmp_path) -> None:
+    """AUTOSKILLIT_PROJECT_DIR in ambient env must not reach ctx.project_dir.
+
+    make_context() must not read AUTOSKILLIT_PROJECT_DIR from os.environ.
+    The CLI entry point reads it and passes it explicitly.
+    """
+    from autoskillit.config import AutomationConfig
+    from autoskillit.server._factory import make_context
+
+    monkeypatch.setenv("AUTOSKILLIT_PROJECT_DIR", "/tmp/wrong-project")
+    config = AutomationConfig()
+
+    ctx = make_context(config, runner=None, project_dir=tmp_path)
+
+    assert ctx.project_dir != Path("/tmp/wrong-project"), (
+        "make_context() must not read AUTOSKILLIT_PROJECT_DIR from os.environ — "
+        "ambient env contaminated ctx.project_dir"
+    )

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -63,7 +63,9 @@ async def test_run_headless_core_auto_derives_step_name_when_recording(tmp_path)
     inner.set_default(_make_result())
     recording_runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
 
-    ctx = make_context(AutomationConfig(), runner=recording_runner, plugin_dir=str(tmp_path))
+    ctx = make_context(
+        AutomationConfig(), runner=recording_runner, plugin_dir=str(tmp_path), project_dir=tmp_path
+    )
     ctx.gate = DefaultGateState(enabled=True)
     ctx.config.linux_tracing.log_dir = str(tmp_path / "logs")
 
@@ -98,7 +100,7 @@ def test_make_context_wraps_runner_when_record_scenario(monkeypatch, tmp_path):
     from autoskillit.config import AutomationConfig
     from autoskillit.server._factory import make_context
 
-    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path), project_dir=tmp_path)
     assert isinstance(ctx.runner, RecordingSubprocessRunner)
     mock_atexit.assert_not_called()
 
@@ -114,7 +116,7 @@ def test_make_context_default_runner_without_record_scenario(monkeypatch, tmp_pa
     from autoskillit.execution.process import DefaultSubprocessRunner
     from autoskillit.server._factory import make_context
 
-    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path), project_dir=tmp_path)
     assert isinstance(ctx.runner, DefaultSubprocessRunner)
 
 
@@ -141,7 +143,7 @@ def test_make_context_wires_sequencing_runner_when_replay_scenario(monkeypatch, 
     from autoskillit.config import AutomationConfig
     from autoskillit.server._factory import make_context
 
-    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path), project_dir=tmp_path)
     assert isinstance(ctx.runner, ReplayingSubprocessRunner)
     mock_make_player.assert_called_once()
     call_kwargs = mock_make_player.call_args.kwargs
@@ -188,7 +190,7 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
     from autoskillit.config import AutomationConfig
     from autoskillit.server._factory import make_context
 
-    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path), project_dir=tmp_path)
     assert isinstance(ctx.runner, ReplayingSubprocessRunner)
     mock_make_recorder.assert_not_called()  # REPLAY takes precedence over RECORD
     mock_atexit.assert_not_called()

--- a/tests/server/test_kitchen_lifecycle.py
+++ b/tests/server/test_kitchen_lifecycle.py
@@ -22,6 +22,7 @@ async def test_kitchen_open_close_lifecycle(monkeypatch, tmp_path):
         AutomationConfig(),
         runner=None,
         plugin_source=DirectInstall(plugin_dir=tmp_path),
+        project_dir=tmp_path,
     )
     monkeypatch.setattr(_state, "_ctx", ctx)
     monkeypatch.setattr(_state, "_startup_ready", None)

--- a/tests/server/test_tools_workspace.py
+++ b/tests/server/test_tools_workspace.py
@@ -401,6 +401,7 @@ class TestTestCheckInfrastructure:
             config,
             runner=runner,
             plugin_source=DirectInstall(plugin_dir=tmp_path),
+            project_dir=tmp_path,
         )
         monkeypatch.setattr(_state, "_ctx", ctx)
         monkeypatch.setattr(_state, "_startup_ready", None)


### PR DESCRIPTION
## Summary

Adds the missing replacement test asserting that `serve()` reads `AUTOSKILLIT_PROJECT_DIR` and passes it as `project_dir` to `make_context()`. Also fixes `test_make_context_project_dir_git_root_fallback` to mock subprocess rather than invoke it directly — correcting an ODD audit finding and aligning with the file's established patching pattern.

**Context:** The rectify plan for `ambient_env_contamination` (Step 4b) moves the `AUTOSKILLIT_PROJECT_DIR` read from `_resolve_project_dir()` to `cli/app.py:serve()`, adds a `project_dir: Path | None = None` parameter to `make_context()`, and deletes `test_make_context_reads_project_dir_env`. Step 5 requires a replacement test verifying the new `serve()` path — this plan adds it.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
- tests/arch/test_make_context_env_boundary.py
- tests/server/test_factory_guards_integration.py

### Modified (●):
- src/autoskillit/cli/app.py
- src/autoskillit/server/_factory.py
- tests/arch/CLAUDE.md
- tests/conftest.py
- tests/contracts/test_package_gateways.py
- tests/server/CLAUDE.md
- tests/server/test_factory.py
- tests/server/test_factory_backend_coherence.py
- tests/server/test_factory_codex_backend_gate.py
- tests/server/test_factory_recording.py
- tests/server/test_kitchen_lifecycle.py
- tests/server/test_tools_workspace.py

## Architecture Impact

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232146-899627/.autoskillit/temp/make-plan/remediation_ambient_env_serve_test_plan_2026-05-29_072727.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 83 | 25.2k | 2.4M | 134.2k | 222 | 206.5k | 23m 22s |
| review_approach* | sonnet | 1 | 60 | 7.6k | 231.8k | 47.7k | 75 | 36.3k | 6m 6s |
| dry_walkthrough* | opus | 2 | 1.5k | 37.9k | 3.2M | 86.0k | 231 | 120.2k | 18m 49s |
| implement* | sonnet | 2 | 2.0k | 46.4k | 6.5M | 134.9k | 245 | 165.0k | 19m 46s |
| audit_impl* | sonnet | 2 | 226 | 26.3k | 1.2M | 76.3k | 114 | 104.9k | 10m 7s |
| make_plan* | sonnet | 1 | 950 | 21.8k | 630.2k | 78.6k | 42 | 69.3k | 7m 17s |
| prepare_pr* | sonnet | 1 | 125.8k | 3.5k | 339.6k | 30.9k | 25 | 43.6k | 1m 30s |
| compose_pr* | sonnet | 1 | 38.8k | 1.4k | 182.4k | 30.9k | 14 | 15.4k | 38s |
| review_pr* | sonnet | 1 | 1.5k | 32.3k | 1.1M | 113.7k | 108 | 99.0k | 9m 8s |
| resolve_review* | opus | 1 | 57 | 14.9k | 1.3M | 74.8k | 78 | 59.6k | 9m 31s |
| **Total** | | | 171.0k | 217.4k | 17.0M | 134.9k | | 919.6k | 1h 46m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 678 | 9534.1 | 243.3 | 68.4 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 21 | 60741.2 | 2837.4 | 709.3 |
| **Total** | **699** | 24279.8 | 1315.7 | 311.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 83 | 25.2k | 2.4M | 206.5k | 23m 22s |
| sonnet | 7 | 169.4k | 139.4k | 10.1M | 533.4k | 54m 34s |
| opus | 2 | 1.6k | 52.8k | 4.5M | 179.8k | 28m 20s |