### PR TITLE
Rectify: Write Guard Structural Command Parsing

### DIFF
--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -28,7 +28,7 @@ _SUBPROCESS_APIS_RE = re.compile(
     r"|os\.(?:system|popen|exec[lv]p?e?)\s*\("
 )
 
-_LITERAL_OPEN_PATH_RE = re.compile(r"""open\s*\(\s*(['"])(/[^'"]+)\1""")
+_LITERAL_OPEN_PATH_RE = re.compile(r"""open\s*\(\s*(['"])(/[^'"]+)\1\s*,\s*['"][wWaA]""")
 _LITERAL_PATH_CONSTRUCTOR_RE = re.compile(
     r"""Path\s*\(\s*(['"])(/[^'"]+)\1\s*\)\s*\.(?:write_text|write_bytes)\s*\("""
 )

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -7,6 +7,7 @@ To add coverage for a new interpreter, update _INTERPRETER_RE only.
 from __future__ import annotations
 
 import re
+import shlex
 from collections.abc import Sequence
 
 _INTERPRETER_RE = re.compile(
@@ -27,11 +28,85 @@ _SUBPROCESS_APIS_RE = re.compile(
     r"|os\.(?:system|popen|exec[lv]p?e?)\s*\("
 )
 
+_LITERAL_OPEN_PATH_RE = re.compile(r"""open\s*\(\s*(['"])(/[^'"]+)\1""")
+_LITERAL_PATH_CONSTRUCTOR_RE = re.compile(
+    r"""Path\s*\(\s*(['"])(/[^'"]+)\1\s*\)\s*\.(?:write_text|write_bytes)\s*\("""
+)
+
+_SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
+
+
+def tokenize_command_segments(command: str) -> list[list[str]]:
+    """Split a shell command into segments of (verb, args...) token lists.
+
+    Each segment is one logical command, separated by shell operators.
+    Returns [] on shlex parse error (unclosed quotes).
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return []
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in _SHELL_OPS:
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def command_verb(segment: list[str]) -> str:
+    """Return the command verb from a segment, skipping 'env' prefix."""
+    if not segment:
+        return ""
+    start = 0
+    if segment[0] == "env" and len(segment) > 1:
+        start = 1
+        while start < len(segment) and (segment[start].startswith("-") or "=" in segment[start]):
+            start += 1
+    return segment[start] if start < len(segment) else ""
+
+
+def is_gh_command(segment: list[str]) -> bool:
+    """Return True if the segment's command verb is 'gh'."""
+    return command_verb(segment) == "gh"
+
 
 def has_interpreter_write(command: str) -> bool:
     if not _INTERPRETER_RE.search(command):
         return False
     return bool(_WRITE_APIS_RE.search(command))
+
+
+def extract_interpreter_write_path(command: str) -> str | None:
+    """Extract the literal file path from an interpreter write command.
+
+    Returns the path string when a static literal is found.
+    Returns None when:
+    - The command is not an interpreter write (no interpreter prefix or no write API)
+    - The path is constructed dynamically (variable, f-string, concatenation)
+    - The write API is shutil.copy/move (two paths — ambiguous which is the target)
+
+    shutil.* calls intentionally return None (fall through to has_interpreter_write's
+    unconditional deny) because they have two path arguments and extracting the correct
+    target requires deeper parsing than regex can reliably provide.
+    """
+    if not _INTERPRETER_RE.search(command):
+        return None
+    if not _WRITE_APIS_RE.search(command):
+        return None
+    m = _LITERAL_OPEN_PATH_RE.search(command)
+    if m:
+        return m.group(2)
+    m = _LITERAL_PATH_CONSTRUCTOR_RE.search(command)
+    if m:
+        return m.group(2)
+    return None
 
 
 def has_interpreter_wrapped_command(command: str, *, target_commands: Sequence[str]) -> bool:

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -44,7 +44,7 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     """
     try:
         tokens = shlex.split(command)
-    except ValueError:
+    except Exception:
         return []
     segments: list[list[str]] = []
     current: list[str] = []

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -19,7 +19,7 @@ _NESTED_SHELL_RE = re.compile(r"(?:^|&&|\|\||;)\s*(?:bash|sh|zsh|dash)\s+-c\s+")
 
 _WRITE_APIS_RE = re.compile(
     r"\.write_text\s*\(|\.write_bytes\s*\("
-    r"|open\s*\([^)]*['\"][wWaA]\+?[bB]?['\"]"
+    r"|open\s*\([^)]*['\"][wWaAxX]\+?[bB]?['\"]"
     r"|shutil\.(?:copy|move|copyfile|copytree)\s*\("
 )
 
@@ -28,7 +28,7 @@ _SUBPROCESS_APIS_RE = re.compile(
     r"|os\.(?:system|popen|exec[lv]p?e?)\s*\("
 )
 
-_LITERAL_OPEN_PATH_RE = re.compile(r"""open\s*\(\s*(['"])(/[^'"]+)\1\s*,\s*['"][wWaA]""")
+_LITERAL_OPEN_PATH_RE = re.compile(r"""open\s*\(\s*(['"])(/[^'"]+)\1\s*,\s*['"][wWaAxX]""")
 _LITERAL_PATH_CONSTRUCTOR_RE = re.compile(
     r"""Path\s*\(\s*(['"])(/[^'"]+)\1\s*\)\s*\.(?:write_text|write_bytes)\s*\("""
 )

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -44,7 +44,7 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     """
     try:
         tokens = shlex.split(command)
-    except Exception:
+    except (ValueError, TypeError):
         return []
     segments: list[list[str]] = []
     current: list[str] = []

--- a/src/autoskillit/hooks/guards/artifact_download_guard.py
+++ b/src/autoskillit/hooks/guards/artifact_download_guard.py
@@ -13,10 +13,15 @@ from __future__ import annotations
 import json
 import shlex
 import sys
+from pathlib import Path
+
+_HOOKS_DIR = str(Path(__file__).resolve().parent.parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+from _command_classification import _SHELL_OPS  # type: ignore[import-not-found]  # noqa: E402
 
 ARTIFACT_DOWNLOAD_DENY_TRIGGER: str = "gh artifact download without --dir is prohibited"
-# Shell-separator tokens that introduce a new subcommand.
-_SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
 
 _DOWNLOAD_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(
     {("run", "download"), ("release", "download")}

--- a/src/autoskillit/hooks/guards/planner_gh_discovery_guard.py
+++ b/src/autoskillit/hooks/guards/planner_gh_discovery_guard.py
@@ -22,13 +22,12 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
+    _SHELL_OPS,
     has_interpreter_wrapped_command,
     has_nested_shell,
 )
 
 DISCOVERY_DENY_TRIGGER: str = "Planner skills cannot discover GitHub issues"
-
-_SHELL_OPS = frozenset({"&&", "||", ";", "!", "|", "("})
 
 _DENY_REASON = (
     "Planner skills cannot discover GitHub issues or PRs. "

--- a/src/autoskillit/hooks/guards/pr_create_guard.py
+++ b/src/autoskillit/hooks/guards/pr_create_guard.py
@@ -20,15 +20,13 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
+    _SHELL_OPS,
     has_interpreter_wrapped_command,
     has_nested_shell,
 )
 from _hook_settings import read_merged_hook_config  # type: ignore[import-not-found]  # noqa: E402
 
 PR_CREATE_DENY_TRIGGER: str = "PR creation via run_cmd is prohibited"
-
-# Shell-separator tokens that introduce a new subcommand.
-_SHELL_OPS = frozenset({"&&", "||", ";", "!", "|", "("})
 
 _DENY_REASON = (
     "PR creation via run_cmd is prohibited during recipe execution. "

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -157,36 +157,10 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
             found_any_write = True
             all_targets.extend(result)
 
-    # Redirect detection: per-segment on the raw command, skipping gh segments
-    # Reconstruct per-segment raw text isn't possible after shlex, so scan
-    # the full command but only for non-gh segments via raw regex on command.
-    # We check: if no gh command exists in any segment, apply redirect regex normally.
-    # If gh segments exist, we need to skip them. Since shlex parsing handles quoting,
-    # we apply the redirect regex to the full command but filter paths that come from
-    # gh segments. The simplest safe approach: only skip redirect detection if ALL
-    # segments are gh commands, otherwise apply it.
-    has_gh = any(is_gh_command(seg) for seg in segments)
+    # Apply redirect regex to full command; skip only when all segments are gh.
     has_non_gh = any(not is_gh_command(seg) for seg in segments)
 
     if not segments or has_non_gh:
-        for m in _REDIRECT_RE.finditer(command):
-            path = m.group(1)
-            if path not in _PSEUDO_DEVICE_PATHS:
-                found_any_write = True
-                all_targets.append(path)
-            else:
-                found_any_write = True
-
-    # Also check: if segments exist and all are gh, but we still had a redirect hit,
-    # treat it as no write (gh commands don't write to filesystem)
-    if has_gh and not has_non_gh:
-        # All commands are gh — no write detected via redirect
-        pass
-    elif not found_any_write and segments:
-        # No write-verb segments and no redirects found
-        return None
-    elif not found_any_write and not segments:
-        # shlex failed or empty — fallback: check redirect regex
         for m in _REDIRECT_RE.finditer(command):
             path = m.group(1)
             if path not in _PSEUDO_DEVICE_PATHS:

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -69,6 +69,8 @@ def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
             tok = segment[idx]
             if tok in _GIT_FLAG_WITH_VALUE:
                 idx += 2
+                if idx >= len(segment):
+                    break
             elif tok.startswith("-") and "=" not in tok and tok not in ("--", "--hard"):
                 idx += 1
             else:

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -277,7 +277,6 @@ def main() -> None:
                     f"Only writes to {display_prefix} are permitted."
                 )
                 return
-            sys.exit(0)
         elif has_interpreter_write(command):
             _deny(
                 f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -145,6 +145,8 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
     """
     segments = tokenize_command_segments(command)
     cwd = os.environ.get("AUTOSKILLIT_CWD", "")
+    if cwd and not os.path.isabs(cwd):
+        cwd = ""
 
     all_targets: list[str] = []
     found_any_write = False

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -14,23 +14,15 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
+    command_verb,
+    extract_interpreter_write_path,
     has_interpreter_write,
+    is_gh_command,
+    tokenize_command_segments,
 )
 
 WRITE_GUARD_DENY_TRIGGER = "read-only skill session"
 
-# Patterns that detect file-modifying commands in a bash command string.
-# Used to decide whether a Bash tool call warrants path extraction.
-_IS_WRITE_CMD_RE = re.compile(
-    r"\bsed\s+(?:\S+\s+)*(?:-i|--in-place)"
-    r"|>+\s*/"
-    r"|\btee\s+/"
-    r"|\b(?:mv|cp)\s+"
-    r"|\bpatch\s+"
-    r"|\bgit\s+checkout\s+--"
-    r"|\bgit\s+reset\s+--hard"
-    r"|\b(?:rm|unlink)\s+"
-)
 _PSEUDO_DEVICE_PATHS: frozenset[str] = frozenset(
     {
         "/dev/null",
@@ -41,39 +33,108 @@ _PSEUDO_DEVICE_PATHS: frozenset[str] = frozenset(
     }
 )
 
-# Each pattern extracts the target file path (group 1) from a file-modifying command.
-_BASH_TARGET_PATTERNS: list[re.Pattern[str]] = [
-    # sed -i 's/x/y/' /file  or  sed --in-place 's/x/y/' /file
-    re.compile(
-        r"\bsed\s+(?:\S+\s+)*(?:-i\S*|--in-place\S*)\s+"
-        r"(?:'[^']*'|\"[^\"]*\"|\S+)\s+(/[^\s;|&]+)"
-    ),
-    # anything > /file  or  >> /file  (redirect to absolute path)
-    re.compile(r">+\s*(/[^\s;|&>]+)"),
-    # tee /file
-    re.compile(r"\btee\s+(/[^\s;|&>]+)"),
-    # mv /src /dst  or  cp /src /dst  (captures destination)
-    re.compile(r"\b(?:mv|cp)\s+\S+\s+(/[^\s;|&>]+)"),
-    # patch /file
-    re.compile(r"\bpatch\s+(?:-\S+\s+)*(/[^\s;|&><]+)"),
-    # git checkout -- /file
-    re.compile(r"\bgit\s+checkout\s+--\s+(/[^\s;|&>]+)"),
-    # rm /file  or  unlink /file
-    re.compile(r"\b(?:rm|unlink)\s+(?:-\S+\s+)*(/[^\s;|&>]+)"),
-]
+_WRITE_VERBS: frozenset[str] = frozenset(
+    {
+        "sed",
+        "tee",
+        "mv",
+        "cp",
+        "patch",
+        "rm",
+        "unlink",
+    }
+)
 
-_BASH_TARGET_PATTERNS_RELATIVE: list[re.Pattern[str]] = [
-    # sed -i 's/x/y/' relative/file
-    re.compile(
-        r"\bsed\s+(?:\S+\s+)*(?:-i\S*|--in-place\S*)\s+"
-        r"(?:'[^']*'|\"[^\"]*\"|\S+)\s+([^\s;|&>/][^\s;|&>]*)"
-    ),
-    # mv src dst  or  cp src dst  (relative destination)
-    re.compile(r"\b(?:mv|cp)\s+\S+\s+([^\s;|&>/][^\s;|&>]*)"),
-    re.compile(r"\bmv\s+([^\s;|&>/][^\s;|&>]*)\s+\S+"),
-    # rm relative/file  or  unlink relative/file
-    re.compile(r"\b(?:rm|unlink)\s+(?:-\S+\s+)*([^\s;|&>/][^\s;|&>]*)"),
-]
+_GIT_WRITE_SUBCOMMANDS: frozenset[tuple[str, ...]] = frozenset(
+    {
+        ("checkout", "--"),
+        ("reset", "--hard"),
+    }
+)
+
+_REDIRECT_RE = re.compile(r">+\s*(/[^\s;|&>]+)")
+
+
+def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
+    """Extract write target paths from a single command segment.
+
+    Returns None if segment is not a write command, [] if write detected
+    but all targets are pseudo-devices, or [paths] otherwise.
+    """
+    if is_gh_command(segment):
+        return None
+
+    verb = command_verb(segment)
+    targets: list[str] = []
+    found_write = False
+
+    if verb == "git" and len(segment) >= 3:
+        sub = tuple(segment[1:3])
+        if sub in _GIT_WRITE_SUBCOMMANDS:
+            found_write = True
+            double_dash = None
+            for i, t in enumerate(segment):
+                if t == "--":
+                    double_dash = i
+                    break
+            if double_dash is not None:
+                for t in segment[double_dash + 1 :]:
+                    if t.startswith("/"):
+                        if t not in _PSEUDO_DEVICE_PATHS:
+                            targets.append(t)
+                    elif cwd:
+                        targets.append(os.path.join(cwd, t))
+    elif verb in _WRITE_VERBS:
+        found_write = True
+        non_flag = [t for t in segment[1:] if not t.startswith("-")]
+        if verb == "sed":
+            # -i flag must be present; last non-flag arg is the target
+            flags = [t for t in segment[1:] if t.startswith("-")]
+            has_inplace = any(t.startswith("-i") or t == "--in-place" for t in flags)
+            if has_inplace and non_flag:
+                # non_flag: first element is typically the sed expression, last is file
+                path = non_flag[-1]
+                if path.startswith("/"):
+                    if path not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(path)
+                elif cwd:
+                    targets.append(os.path.join(cwd, path))
+        elif verb == "tee":
+            if non_flag:
+                path = non_flag[0]
+                if path.startswith("/"):
+                    if path not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(path)
+                elif cwd:
+                    targets.append(os.path.join(cwd, path))
+        elif verb in ("mv", "cp"):
+            if len(non_flag) >= 2:
+                path = non_flag[-1]
+                if path.startswith("/"):
+                    if path not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(path)
+                elif cwd:
+                    targets.append(os.path.join(cwd, path))
+        elif verb == "patch":
+            for t in non_flag:
+                if t.startswith("/"):
+                    if t not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(t)
+                    break
+                elif cwd:
+                    targets.append(os.path.join(cwd, t))
+                    break
+        elif verb in ("rm", "unlink"):
+            for t in non_flag:
+                if t.startswith("/"):
+                    if t not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(t)
+                elif cwd:
+                    targets.append(os.path.join(cwd, t))
+
+    if found_write:
+        return targets
+    return None
 
 
 def _extract_bash_write_targets(command: str) -> list[str] | None:
@@ -82,23 +143,67 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
     Returns an empty list when a write command is detected but no path can be reliably
     extracted — callers treat this as fail-open (ambiguous = allow).
     """
-    if not _IS_WRITE_CMD_RE.search(command):
-        return None
-    targets: list[str] = []
-    for pattern in _BASH_TARGET_PATTERNS:
-        m = pattern.search(command)
-        if m:
+    segments = tokenize_command_segments(command)
+    cwd = os.environ.get("AUTOSKILLIT_CWD", "")
+
+    all_targets: list[str] = []
+    found_any_write = False
+
+    for segment in segments:
+        result = _extract_segment_targets(segment, cwd)
+        if result is not None:
+            found_any_write = True
+            all_targets.extend(result)
+
+    # Redirect detection: per-segment on the raw command, skipping gh segments
+    # Reconstruct per-segment raw text isn't possible after shlex, so scan
+    # the full command but only for non-gh segments via raw regex on command.
+    # We check: if no gh command exists in any segment, apply redirect regex normally.
+    # If gh segments exist, we need to skip them. Since shlex parsing handles quoting,
+    # we apply the redirect regex to the full command but filter paths that come from
+    # gh segments. The simplest safe approach: only skip redirect detection if ALL
+    # segments are gh commands, otherwise apply it.
+    has_gh = any(is_gh_command(seg) for seg in segments)
+    has_non_gh = any(not is_gh_command(seg) for seg in segments)
+
+    if not segments or has_non_gh:
+        for m in _REDIRECT_RE.finditer(command):
             path = m.group(1)
             if path not in _PSEUDO_DEVICE_PATHS:
-                targets.append(path)
-    cwd = os.environ.get("AUTOSKILLIT_CWD", "")
-    if cwd:
-        for pattern in _BASH_TARGET_PATTERNS_RELATIVE:
-            for m in pattern.finditer(command):
-                rel_path = m.group(1)
-                if not rel_path.startswith("/") and rel_path not in _PSEUDO_DEVICE_PATHS:
-                    targets.append(os.path.join(cwd, rel_path))
-    return targets
+                found_any_write = True
+                all_targets.append(path)
+            else:
+                found_any_write = True
+
+    # Also check: if segments exist and all are gh, but we still had a redirect hit,
+    # treat it as no write (gh commands don't write to filesystem)
+    if has_gh and not has_non_gh:
+        # All commands are gh — no write detected via redirect
+        pass
+    elif not found_any_write and segments:
+        # No write-verb segments and no redirects found
+        return None
+    elif not found_any_write and not segments:
+        # shlex failed or empty — fallback: check redirect regex
+        for m in _REDIRECT_RE.finditer(command):
+            path = m.group(1)
+            if path not in _PSEUDO_DEVICE_PATHS:
+                found_any_write = True
+                all_targets.append(path)
+            else:
+                found_any_write = True
+
+    if not found_any_write:
+        return None
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for t in all_targets:
+        if t not in seen:
+            seen.add(t)
+            unique.append(t)
+    return unique
 
 
 def _extract_paths_from_patch(command: str) -> list[str]:
@@ -163,12 +268,23 @@ def main() -> None:
 
     if tool_name == "Bash" or "run_cmd" in tool_name:
         command = tool_input.get("command", "") or tool_input.get("cmd", "")
-        if has_interpreter_write(command):
+
+        interp_path = extract_interpreter_write_path(command)
+        if interp_path is not None:
+            if not _within_any_prefix(interp_path):
+                _deny(
+                    f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
+                    f"Only writes to {display_prefix} are permitted."
+                )
+                return
+            sys.exit(0)
+        elif has_interpreter_write(command):
             _deny(
                 f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
                 f"Interpreter-mediated file writes are not permitted."
             )
             return
+
         targets = _extract_bash_write_targets(command)
         if targets is None:
             sys.exit(0)

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -45,12 +45,7 @@ _WRITE_VERBS: frozenset[str] = frozenset(
     }
 )
 
-_GIT_WRITE_SUBCOMMANDS: frozenset[tuple[str, ...]] = frozenset(
-    {
-        ("checkout", "--"),
-        ("reset", "--hard"),
-    }
-)
+_GIT_FLAG_WITH_VALUE: frozenset[str] = frozenset({"-C", "--git-dir", "--work-tree", "-c"})
 
 _REDIRECT_RE = re.compile(r">+\s*(/[^\s;|&>]+)")
 
@@ -68,22 +63,29 @@ def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
     targets: list[str] = []
     found_write = False
 
-    if verb == "git" and len(segment) >= 3:
-        sub = tuple(segment[1:3])
-        if sub in _GIT_WRITE_SUBCOMMANDS:
-            found_write = True
-            double_dash = None
-            for i, t in enumerate(segment):
-                if t == "--":
-                    double_dash = i
-                    break
-            if double_dash is not None:
+    if verb == "git" and len(segment) >= 2:
+        idx = 1
+        while idx < len(segment):
+            tok = segment[idx]
+            if tok in _GIT_FLAG_WITH_VALUE:
+                idx += 2
+            elif tok.startswith("-") and "=" not in tok and tok not in ("--", "--hard"):
+                idx += 1
+            else:
+                break
+        if idx < len(segment):
+            subcmd = segment[idx]
+            if subcmd == "checkout" and "--" in segment[idx + 1 :]:
+                found_write = True
+                double_dash = segment.index("--", idx + 1)
                 for t in segment[double_dash + 1 :]:
                     if t.startswith("/"):
                         if t not in _PSEUDO_DEVICE_PATHS:
                             targets.append(t)
                     elif cwd:
                         targets.append(os.path.join(cwd, t))
+            elif subcmd == "reset" and "--hard" in segment[idx + 1 :]:
+                found_write = True
     elif verb in _WRITE_VERBS:
         found_write = True
         non_flag = [t for t in segment[1:] if not t.startswith("-")]

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -148,6 +148,13 @@ REQUIRED_WRITE_GUARD_TEST_FAMILIES = {
     "sed",
     "redirect",
     "tee",
+    "mv",
+    "cp",
+    "rm",
+    "patch",
+    "git_checkout",
+    "git_reset",
+    "gh_api",
 }
 
 
@@ -175,16 +182,20 @@ def test_write_guard_has_interpreter_detection() -> None:
 
 
 def test_write_guard_tests_cover_required_command_families() -> None:
-    """Write guard test file must have test cases for all known file-writing command families."""
-    test_source = (
-        pathlib.Path(__file__).parent.parent / "hooks" / "test_write_guard.py"
-    ).read_text()
+    """Write guard test file must have test function names for all known writing families."""
+    test_path = pathlib.Path(__file__).parent.parent / "hooks" / "test_write_guard.py"
+    tree = ast.parse(test_path.read_text())
+    test_names = {
+        node.name.lower()
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+    }
     missing = []
     for family in REQUIRED_WRITE_GUARD_TEST_FAMILIES:
-        if family not in test_source.lower():
+        if not any(family.lower() in name for name in test_names):
             missing.append(family)
     assert not missing, (
-        f"test_write_guard.py missing test coverage for command families: {missing}. "
+        f"test_write_guard.py missing test function names for command families: {missing}. "
         f"Every known file-writing command family must have deny-path test coverage."
     )
 
@@ -194,6 +205,7 @@ COMMAND_CLASSIFYING_GUARDS = [
     SRC_ROOT / "hooks" / "guards" / "pr_create_guard.py",
     SRC_ROOT / "hooks" / "guards" / "planner_gh_discovery_guard.py",
     SRC_ROOT / "hooks" / "guards" / "unsafe_install_guard.py",
+    SRC_ROOT / "hooks" / "guards" / "artifact_download_guard.py",
 ]
 
 
@@ -232,3 +244,21 @@ def test_guard_handles_bypass_family(guard_file: str, bypass_family: str) -> Non
         assert "has_interpreter_write" in source or "_command_classification" in source
     elif bypass_family == "interpreter_subprocess":
         assert "has_interpreter_wrapped_command" in source or "_command_classification" in source
+
+
+def test_write_guard_uses_tokenization() -> None:
+    """write_guard.py must use the structural tokenization layer from _command_classification."""
+    source = (SRC_ROOT / "hooks" / "guards" / "write_guard.py").read_text()
+    assert "tokenize_command_segments" in source or "is_gh_command" in source, (
+        "write_guard.py must import and use the structural tokenization layer from "
+        "_command_classification (tokenize_command_segments or is_gh_command)"
+    )
+
+
+def test_command_classification_exports_tokenization() -> None:
+    """_command_classification.py must export the tokenization primitives."""
+    source = (SRC_ROOT / "hooks" / "_command_classification.py").read_text()
+    for name in ("tokenize_command_segments", "command_verb", "is_gh_command"):
+        assert f"def {name}" in source, (
+            f"_command_classification.py must define {name}() for structural command parsing"
+        )

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -169,11 +169,6 @@ class TestExtractInterpreterWritePath:
         cmd = "python3 -c \"import shutil; shutil.copy('/tmp/a', '/clone/src/f.py')\""
         assert extract_interpreter_write_path(cmd) is None
 
-    def test_has_interpreter_write_returns_path_when_literal(self):
-        cmd = "python3 -c \"open('/some/literal/path.txt', 'w').write('x')\""
-        result = extract_interpreter_write_path(cmd)
-        assert result == "/some/literal/path.txt"
-
     def test_has_interpreter_write_returns_none_for_dynamic_path(self):
         cmd = "python3 -c \"open(some_var, 'w').write('x')\""
         assert extract_interpreter_write_path(cmd) is None

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.hooks._command_classification import (
+    command_verb,
+    extract_interpreter_write_path,
     has_interpreter_wrapped_command,
     has_interpreter_write,
     has_nested_shell,
+    is_gh_command,
+    tokenize_command_segments,
 )
 
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
@@ -77,3 +81,93 @@ def test_detects_python_os_popen():
 def test_interpreter_wrapped_command_case_insensitive():
     cmd = "python3 -c \"import os; os.system('GH PR CREATE')\""
     assert has_interpreter_wrapped_command(cmd, target_commands=["gh pr create"])
+
+
+class TestTokenizeCommandSegments:
+    def test_single_command(self):
+        assert tokenize_command_segments("git status") == [["git", "status"]]
+
+    def test_chained_commands(self):
+        result = tokenize_command_segments("git add . && git commit -m msg")
+        assert result == [["git", "add", "."], ["git", "commit", "-m", "msg"]]
+
+    def test_quoted_args_not_split(self):
+        result = tokenize_command_segments("echo 'hello world'")
+        assert result == [["echo", "hello world"]]
+
+    def test_shell_op_separates_segments(self):
+        result = tokenize_command_segments("cmd1 || cmd2 ; cmd3")
+        assert len(result) == 3
+
+    def test_unclosed_quotes_returns_empty(self):
+        assert tokenize_command_segments("echo 'unclosed") == []
+
+    def test_pipe_separates_segments(self):
+        result = tokenize_command_segments("cat file | tee /tmp/out")
+        assert result == [["cat", "file"], ["tee", "/tmp/out"]]
+
+
+class TestCommandVerb:
+    def test_simple_verb(self):
+        assert command_verb(["git", "status"]) == "git"
+
+    def test_env_prefix_skipped(self):
+        assert command_verb(["env", "python3", "-c", "..."]) == "python3"
+
+    def test_env_with_key_val(self):
+        assert command_verb(["env", "FOO=bar", "python3", "-c", "x"]) == "python3"
+
+    def test_env_with_flag(self):
+        assert command_verb(["env", "-i", "python3", "-c", "x"]) == "python3"
+
+    def test_empty_segment(self):
+        assert command_verb([]) == ""
+
+
+class TestIsGhCommand:
+    def test_gh_at_position_0(self):
+        assert is_gh_command(["gh", "api", "/repos/foo"])
+
+    def test_not_gh(self):
+        assert not is_gh_command(["git", "push"])
+
+    def test_gh_as_argument(self):
+        assert not is_gh_command(["echo", "gh"])
+
+    def test_env_gh(self):
+        assert is_gh_command(["env", "gh", "pr", "view"])
+
+
+class TestExtractInterpreterWritePath:
+    def test_open_literal_path(self):
+        cmd = "python3 -c \"open('/clone/.autoskillit/temp/out.json', 'w').write('x')\""
+        assert extract_interpreter_write_path(cmd) == "/clone/.autoskillit/temp/out.json"
+
+    def test_path_write_text(self):
+        cmd = "python3 -c \"Path('/clone/temp/out.json').write_text('x')\""
+        assert extract_interpreter_write_path(cmd) == "/clone/temp/out.json"
+
+    def test_path_write_bytes(self):
+        cmd = "python3 -c \"Path('/clone/temp/out.bin').write_bytes(b'x')\""
+        assert extract_interpreter_write_path(cmd) == "/clone/temp/out.bin"
+
+    def test_dynamic_path_returns_none(self):
+        cmd = "python3 -c \"open(sys.argv[1], 'w').write('x')\""
+        assert extract_interpreter_write_path(cmd) is None
+
+    def test_no_interpreter_returns_none(self):
+        cmd = "open('/tmp/x', 'w')"
+        assert extract_interpreter_write_path(cmd) is None
+
+    def test_shutil_returns_none(self):
+        cmd = "python3 -c \"import shutil; shutil.copy('/tmp/a', '/clone/src/f.py')\""
+        assert extract_interpreter_write_path(cmd) is None
+
+    def test_has_interpreter_write_returns_path_when_literal(self):
+        cmd = "python3 -c \"open('/some/literal/path.txt', 'w').write('x')\""
+        result = extract_interpreter_write_path(cmd)
+        assert result == "/some/literal/path.txt"
+
+    def test_has_interpreter_write_returns_none_for_dynamic_path(self):
+        cmd = "python3 -c \"open(some_var, 'w').write('x')\""
+        assert extract_interpreter_write_path(cmd) is None

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -169,6 +169,6 @@ class TestExtractInterpreterWritePath:
         cmd = "python3 -c \"import shutil; shutil.copy('/tmp/a', '/clone/src/f.py')\""
         assert extract_interpreter_write_path(cmd) is None
 
-    def test_has_interpreter_write_returns_none_for_dynamic_path(self):
+    def test_dynamic_path_with_non_literal_var_returns_none(self):
         cmd = "python3 -c \"open(some_var, 'w').write('x')\""
         assert extract_interpreter_write_path(cmd) is None

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -137,6 +137,12 @@ class TestIsGhCommand:
     def test_env_gh(self):
         assert is_gh_command(["env", "gh", "pr", "view"])
 
+    def test_gh_after_shell_op(self):
+        segments = tokenize_command_segments("git status && gh pr view 123")
+        gh_segments = [seg for seg in segments if is_gh_command(seg)]
+        assert len(gh_segments) == 1
+        assert gh_segments[0][0] == "gh"
+
 
 class TestExtractInterpreterWritePath:
     def test_open_literal_path(self):

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -337,6 +337,27 @@ class TestExtractBashWriteTargets:
         result_real = _extract_bash_write_targets("echo x > /tmp/out.txt")
         assert result_real == ["/tmp/out.txt"]
 
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "sed -i 's/x/y/' /outside/file.txt",
+            "tee /outside/file.txt",
+            "mv /src /outside/dst",
+            "cp /src /outside/dst",
+            "patch /outside/file.txt",
+            "rm /outside/file.txt",
+            "unlink /outside/file.txt",
+        ],
+    )
+    def test_all_write_cmd_families_have_deny_coverage(
+        self, cmd: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/allowed/prefix/")
+        result = _run_hook(_build_bash_event(cmd))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
 
 class TestWriteGuardRealisticCommands:
     """Integration tests: common agent-generated commands must not be blocked."""

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -483,13 +483,59 @@ class TestWriteGuardInterpreterBypass:
         parsed = json.loads(result)
         assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-    def test_python3_write_to_allowed_prefix_also_denied(self, monkeypatch: pytest.MonkeyPatch):
-        """Interpreter writes are denied unconditionally.
-
-        Target path cannot be reliably extracted from interpreter commands.
-        """
+    def test_python3_write_to_allowed_prefix_with_literal_path_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Interpreter writes with extractable literal paths are allowed within the prefix."""
         monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
         event = _build_bash_event(f"python3 -c \"open('{self.PREFIX}out.txt','w').write('x')\"")
+        result = _run_hook(event)
+        assert result == ""
+
+    def test_python3_write_to_allowed_prefix_with_literal_open_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+        event = _build_bash_event(
+            "python3 -c \"open('/clone/.autoskillit/temp/planner/out.json', 'w').write('x')\""
+        )
+        result = _run_hook(event)
+        assert result == ""
+
+    def test_python3_write_to_allowed_prefix_with_literal_write_text_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+        event = _build_bash_event(
+            'python3 -c "from pathlib import Path; '
+            "Path('/clone/.autoskillit/temp/planner/out.json').write_text('x')\""
+        )
+        result = _run_hook(event)
+        assert result == ""
+
+    def test_python3_write_to_allowed_prefix_with_literal_write_bytes_allowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+        event = _build_bash_event(
+            'python3 -c "from pathlib import Path; '
+            "Path('/clone/.autoskillit/temp/planner/out.bin').write_bytes(b'x')\""
+        )
+        result = _run_hook(event)
+        assert result == ""
+
+    def test_python3_write_outside_prefix_with_literal_path_denied(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+        event = _build_bash_event("python3 -c \"open('/clone/src/foo.py', 'w').write('x')\"")
+        result = _run_hook(event)
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_python3_write_with_dynamic_path_denied(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+        event = _build_bash_event("python3 -c \"open(sys.argv[1], 'w').write('x')\"")
         result = _run_hook(event)
         parsed = json.loads(result)
         assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
@@ -567,3 +613,92 @@ class TestWriteGuardMultiPrefix:
         monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/a/")
         monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIXES", "/a/:/b/")
         assert _run_hook(_build_event("Edit", "/b/file.py")) == ""
+
+
+class TestWriteGuardGhCommands:
+    """gh CLI commands must never be blocked by the write guard."""
+
+    PREFIX = "/clone/.autoskillit/temp/compose-pr/"
+
+    @pytest.fixture(autouse=True)
+    def _enable_headless(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+
+    def test_gh_api_post_reviews_allowed(self):
+        result = _run_hook(
+            _build_bash_event("gh api /repos/Owner/Repo/pulls/123/reviews --method POST --input -")
+        )
+        assert result == ""
+
+    def test_gh_api_method_patch_allowed(self):
+        result = _run_hook(
+            _build_bash_event("gh api --method patch /repos/Owner/Repo/pulls/123 --field body=foo")
+        )
+        assert result == ""
+
+    def test_gh_pr_view_allowed(self):
+        result = _run_hook(_build_bash_event("gh pr view 123 --json body"))
+        assert result == ""
+
+    def test_gh_issue_list_allowed(self):
+        result = _run_hook(_build_bash_event("gh issue list --state open"))
+        assert result == ""
+
+    def test_gh_api_url_not_extracted_as_filesystem_path(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("gh api --method patch /repos/Owner/Repo/pulls/123")
+        assert result is None or result == []
+
+
+class TestExtractBashWriteTargetsNewFamilies:
+    """Parameterized coverage for write-command families missing from original tests."""
+
+    @pytest.mark.parametrize(
+        "cmd,expected_targets",
+        [
+            ("mv /src/a.py /dst/b.py", ["/dst/b.py"]),
+            ("cp /src/a.py /dst/b.py", ["/dst/b.py"]),
+            ("patch /clone/src/main.py", ["/clone/src/main.py"]),
+            ("rm /clone/src/old.py", ["/clone/src/old.py"]),
+            ("unlink /clone/src/old.py", ["/clone/src/old.py"]),
+            ("rm -rf /clone/src/dir/", ["/clone/src/dir/"]),
+        ],
+    )
+    def test_mv_cp_rm_patch_write_cmd_family_extraction(
+        self, cmd: str, expected_targets: list[str]
+    ):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets(cmd)
+        assert result == expected_targets
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh api /repos/Owner/Repo/pulls/123/reviews --method POST --input -",
+            "gh api --method patch /repos/Owner/Repo/pulls/123 --field body=...",
+            "gh pr view 123 --json body",
+            "gh issue list --state open",
+            "gh api /repos/Owner/Repo/issues/42/comments --method POST -f body=test",
+        ],
+    )
+    def test_gh_commands_not_extracted(self, cmd: str):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets(cmd)
+        assert result is None or result == []
+
+    def test_git_checkout_dash_dash_extracted(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("git checkout -- /clone/src/main.py")
+        assert result is not None
+        assert "/clone/src/main.py" in result
+
+    def test_git_reset_hard_allowed_no_path(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("git reset --hard HEAD")
+        assert result is not None or result == []

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -723,3 +723,16 @@ class TestExtractBashWriteTargetsNewFamilies:
 
         result = _extract_bash_write_targets("git reset --hard HEAD")
         assert result is None or result == []
+
+    def test_git_with_flag_prefix_checkout_detected(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("git -C /repo checkout -- /clone/src/main.py")
+        assert result is not None
+        assert "/clone/src/main.py" in result
+
+    def test_git_with_flag_prefix_reset_hard_detected(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets("git -C /repo reset --hard")
+        assert result is not None

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -722,4 +722,4 @@ class TestExtractBashWriteTargetsNewFamilies:
         from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
 
         result = _extract_bash_write_targets("git reset --hard HEAD")
-        assert result is not None or result == []
+        assert result is None or result == []


### PR DESCRIPTION
## Summary

The write guard subsystem uses raw regex to classify Bash commands and extract filesystem targets, but regex fundamentally cannot distinguish command verbs from string arguments, or filesystem paths from URL paths. The architectural solution introduces a shared `shlex`-based command tokenization layer in `_command_classification.py` that all guards use, replacing raw regex with structural token-position analysis. This part covers the core tokenization layer, the write guard's migration to it, and the `has_interpreter_write` path-awareness fix.

## Requirements

Write guard false-positives continue to block legitimate `gh api` and `python3 -c` commands in review_pr sessions despite prior fixes merged to develop (#2953, #3070, #3201, #3161). Three distinct defects were observed: (1) `has_interpreter_write` is not path-aware, blocking all interpreter writes regardless of destination; (2) `_IS_WRITE_CMD_RE` / `_BASH_TARGET_PATTERNS` extract `gh api` URL path args as filesystem targets; (3) operational impact from retry chains and lost comments.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
- src/autoskillit/hooks/_command_classification.py
- src/autoskillit/hooks/guards/artifact_download_guard.py
- src/autoskillit/hooks/guards/planner_gh_discovery_guard.py
- src/autoskillit/hooks/guards/pr_create_guard.py
- src/autoskillit/hooks/guards/write_guard.py
- tests/arch/test_regex_guards.py
- tests/hooks/test_command_classification.py
- tests/hooks/test_write_guard.py

Closes #3243

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232223-137623/.autoskillit/temp/rectify/rectify_write_guard_structural_command_parsing_2026-05-28_235500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 6.9k | 14.4k | 1.4M | 97.8k | 235 | 61.5k | 14m 15s |
| rectify* | opus[1m] | 1 | 1.6k | 30.0k | 4.0M | 138.2k | 219 | 151.7k | 26m 39s |
| review_approach* | sonnet | 1 | 60 | 7.1k | 233.6k | 46.4k | 49 | 34.3k | 3m 52s |
| dry_walkthrough* | opus | 3 | 129 | 22.4k | 2.8M | 91.4k | 233 | 174.0k | 11m 58s |
| implement* | sonnet | 2 | 562 | 66.2k | 4.2M | 97.9k | 175 | 117.6k | 24m 1s |
| audit_impl* | sonnet | 2 | 154 | 26.3k | 638.5k | 67.5k | 73 | 80.8k | 12m 22s |
| make_plan* | sonnet | 1 | 151 | 10.2k | 712.0k | 53.3k | 53 | 41.7k | 4m 5s |
| prepare_pr* | sonnet | 1 | 115.0k | 3.8k | 216.1k | 30.9k | 23 | 43.7k | 1m 20s |
| compose_pr* | sonnet | 1 | 62.1k | 2.1k | 244.1k | 30.9k | 19 | 15.5k | 59s |
| review_pr* | sonnet | 3 | 520 | 136.2k | 3.9M | 139.4k | 263 | 291.1k | 34m 58s |
| resolve_review* | opus | 3 | 1.2k | 64.2k | 8.0M | 96.0k | 252 | 325.5k | 36m 26s |
| **Total** | | | 188.4k | 382.8k | 26.3M | 139.4k | | 1.3M | 2h 51m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 1243 | 3371.4 | 94.6 | 53.3 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 97 | 82503.4 | 3355.9 | 661.6 |
| **Total** | **1340** | 19606.4 | 998.1 | 285.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 3 | 8.2k | 100.9k | 12.2M | 561.0k | 1h 2m |
| opus[1m] | 1 | 1.6k | 30.0k | 4.0M | 151.7k | 26m 39s |
| sonnet | 7 | 178.5k | 251.9k | 10.1M | 624.8k | 1h 21m |