### PR TITLE
Rectify: Non-Anthropic Provider Turn Instrumentation

### DIFF
--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -105,7 +105,7 @@ def iter_merged_assistant_turns(text: str, *, cap: int = _TOOL_USE_CAP) -> Itera
         else:
             key = str(no_rid_counter)
             no_rid_counter += 1
-            no_rid_turns[key] = AssistantTurn("", ts, tuple(tools[:cap]))
+            no_rid_turns[key] = AssistantTurn(f"turn-{key}", ts, tuple(tools[:cap]))
             insertion_order.append(("no_rid", key))
 
     for kind, key in insertion_order:

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -206,8 +206,6 @@ def flush_session_log(
         try:
             _text = cc_log.read_text(encoding="utf-8", errors="replace")
             for _turn in iter_merged_assistant_turns(_text):
-                if not _turn.request_id:
-                    continue
                 _cb_request_ids.append(_turn.request_id)
                 _cb_turn_timestamps.append(_turn.timestamp)
                 _cb_turn_tool_calls.append(_turn.tool_names)

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -47,6 +47,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_make_context_env_boundary.py` | AST guard: _factory.py functions must not read AUTOSKILLIT_PRIVATE_ENV_VARS from os.environ |
 | `test_never_raises_contracts.py` | Structural enforcement of 'Never raises' docstring contracts in server/ |
 | `test_no_error_dict_return.py` | AST guard: load_and_validate must not return dicts with 'error' key — errors flow via exceptions |
+| `test_flush_no_rid_guard.py` | AST guard: no requestId truthiness guard in flush_session_log turn extraction loop |
 | `test_no_inline_jsonl_request_id_dedup.py` | AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py |
 | `test_protocol_names.py` | T5-T6: Protocol naming and DefaultSkillResolver export smoke tests |
 | `test_provider_profile_contract.py` | Tier 3 contract: _resolve_provider_profile must never return step_name as profile |

--- a/tests/arch/test_flush_no_rid_guard.py
+++ b/tests/arch/test_flush_no_rid_guard.py
@@ -1,0 +1,90 @@
+"""AST guard: no requestId truthiness guard in flush_session_log turn extraction loop.
+
+iter_merged_assistant_turns() now produces synthetic IDs for no-requestId turns,
+so all turns have a non-empty request_id. Filtering on _turn.request_id truthiness
+inside flush_session_log would silently drop non-Anthropic turns. This guard
+prevents regression.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+SESSION_LOG = SRC / "execution" / "session_log.py"
+
+
+def _find_flush_session_log(tree: ast.AST) -> ast.FunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == "flush_session_log":
+                return node  # type: ignore[return-value]
+    return None
+
+
+def _iter_merged_loop_bodies(func: ast.FunctionDef) -> list[ast.stmt]:
+    """Return the body statements of for-loops iterating iter_merged_assistant_turns."""
+    bodies: list[ast.stmt] = []
+    for node in ast.walk(func):
+        if not isinstance(node, ast.For):
+            continue
+        iter_node = node.iter
+        call = None
+        if isinstance(iter_node, ast.Call):
+            call = iter_node
+        if call is None:
+            continue
+        func_node = call.func
+        name = ""
+        if isinstance(func_node, ast.Name):
+            name = func_node.id
+        elif isinstance(func_node, ast.Attribute):
+            name = func_node.attr
+        if name == "iter_merged_assistant_turns":
+            bodies.extend(node.body)
+    return bodies
+
+
+def _has_request_id_truthiness_guard(stmts: list[ast.stmt]) -> list[int]:
+    """Return line numbers of if-statements guarding on _turn.request_id truthiness."""
+    hits: list[int] = []
+    for stmt in stmts:
+        if not isinstance(stmt, ast.If):
+            continue
+        test = stmt.test
+        # Match: `if not _turn.request_id:` → UnaryOp(Not, Attribute(request_id))
+        if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+            operand = test.operand
+            if isinstance(operand, ast.Attribute) and operand.attr == "request_id":
+                hits.append(stmt.lineno)
+        # Match: `if _turn.request_id:` with continue body — also detect positive guard
+        elif isinstance(test, ast.Attribute) and test.attr == "request_id":
+            body_has_continue = any(isinstance(s, ast.Continue) for s in stmt.body)
+            if body_has_continue:
+                hits.append(stmt.lineno)
+    return hits
+
+
+class TestFlushNoRidGuard:
+    def test_flush_turn_loop_has_no_request_id_guard(self) -> None:
+        tree = ast.parse(SESSION_LOG.read_text(encoding="utf-8"))
+        flush_func = _find_flush_session_log(tree)
+        assert flush_func is not None, "flush_session_log not found in session_log.py"
+        loop_bodies = _iter_merged_loop_bodies(flush_func)
+        assert loop_bodies, (
+            "No for-loop over iter_merged_assistant_turns found in flush_session_log. "
+            "Was the turn extraction loop removed or renamed?"
+        )
+        hits = _has_request_id_truthiness_guard(loop_bodies)
+        assert not hits, (
+            "flush_session_log re-introduced a request_id truthiness guard in the "
+            "iter_merged_assistant_turns loop. This silently drops non-Anthropic turns.\n"
+            "iter_merged_assistant_turns() now assigns synthetic turn-N IDs so all turns "
+            "have a non-empty request_id — remove the guard entirely.\n"
+            "Offending lines: " + ", ".join(str(ln) for ln in hits)
+        )

--- a/tests/core/test_tool_sequence_analysis.py
+++ b/tests/core/test_tool_sequence_analysis.py
@@ -430,12 +430,14 @@ class TestIterMergedAssistantTurns:
         assert len(turns) == 2
         assert turns[0].tool_names == ("A",)
         assert turns[1].tool_names == ("B",)
+        assert turns[0].request_id == "turn-0"
+        assert turns[1].request_id == "turn-1"
 
     def test_records_without_request_id_included(self) -> None:
         line = self._make_record(tools=["Bash"])
         turns = self._parse(line)
         assert len(turns) == 1
-        assert turns[0].request_id == ""
+        assert turns[0].request_id == "turn-0"
         assert turns[0].tool_names == ("Bash",)
 
     def test_preserves_insertion_order(self) -> None:
@@ -452,7 +454,7 @@ class TestIterMergedAssistantTurns:
         turns = self._parse(l_a, l_no, l_b)
         assert len(turns) == 3
         assert turns[0].request_id == "r-A"
-        assert turns[1].request_id == ""
+        assert turns[1].request_id == "turn-0"
         assert turns[2].request_id == "r-B"
 
     def test_timestamp_from_first_record_preferred(self) -> None:

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -260,6 +260,223 @@ def test_flush_session_log_summary_contains_per_turn_fields(tmp_path, monkeypatc
     assert summary["turn_timestamps"] == ["2026-04-15T07:00:00Z", "2026-04-15T07:00:05Z"]
 
 
+def test_flush_session_log_includes_no_request_id_turns(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        _make_cc_jsonl_record(
+            request_id="req-001",
+            timestamp="2026-05-01T10:00:00Z",
+            content=[_make_tool_block("Read")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            timestamp="2026-05-01T10:00:05Z",
+            content=[_make_tool_block("Edit")],
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-05-01T10:00:00Z",
+        proc_snapshots=None,
+        telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert len(summary["turn_timestamps"]) == 2
+    assert len(summary["turn_tool_calls"]) == 2
+    assert len(summary["request_ids"]) == 2
+    assert summary["request_ids"][0] == "req-001"
+    assert summary["request_ids"][1].startswith("turn-")
+    assert (
+        len(summary["turn_timestamps"])
+        == len(summary["turn_tool_calls"])
+        == len(summary["request_ids"])
+    )
+
+
+def test_flush_session_log_all_no_rid_turns_still_recorded(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        _make_cc_jsonl_record(
+            timestamp="2026-05-01T10:00:00Z",
+            content=[_make_tool_block("Bash")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            timestamp="2026-05-01T10:00:05Z",
+            content=[_make_tool_block("Read")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            timestamp="2026-05-01T10:00:10Z",
+            content=[_make_tool_block("Edit")],
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-05-01T10:00:00Z",
+        proc_snapshots=None,
+        telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert len(summary["turn_timestamps"]) == 3
+    assert len(summary["turn_tool_calls"]) == 3
+    assert len(summary["request_ids"]) == 3
+    assert summary["turn_timestamps"] == [
+        "2026-05-01T10:00:00Z",
+        "2026-05-01T10:00:05Z",
+        "2026-05-01T10:00:10Z",
+    ]
+    assert all(rid.startswith("turn-") for rid in summary["request_ids"])
+
+
+def test_channel_b_turn_count_bounded_by_channel_a(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        _make_cc_jsonl_record(
+            timestamp="2026-05-01T10:00:00Z",
+            content=[_make_tool_block("Bash")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            timestamp="2026-05-01T10:00:05Z",
+            content=[_make_tool_block("Read")],
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    telemetry = SessionTelemetry(
+        token_usage={"input_tokens": 0, "output_tokens": 0, "turn_count": 2},
+        timing_seconds=None,
+        audit_record=None,
+        github_api_usage=None,
+        github_api_requests=0,
+        loc_insertions=0,
+        loc_deletions=0,
+    )
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-05-01T10:00:00Z",
+        proc_snapshots=None,
+        telemetry=telemetry,
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    tu = json.loads((tmp_path / "sessions" / "s" / "token_usage.json").read_text())
+    turn_count = tu.get("turn_count", 0)
+    assert len(summary["turn_timestamps"]) > 0
+    assert turn_count >= len(summary["turn_timestamps"])
+
+
+def test_parallel_lists_aligned_mixed_rid_no_rid(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        _make_cc_jsonl_record(
+            request_id="req-a",
+            timestamp="2026-05-01T10:00:00Z",
+            content=[_make_tool_block("ToolA")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            timestamp="2026-05-01T10:00:01Z",
+            content=[_make_tool_block("ToolB")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            request_id="req-b",
+            timestamp="2026-05-01T10:00:02Z",
+            content=[_make_tool_block("ToolC")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            timestamp="2026-05-01T10:00:03Z",
+            content=[_make_tool_block("ToolD")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            request_id="req-c",
+            timestamp="2026-05-01T10:00:04Z",
+            content=[_make_tool_block("ToolE")],
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-05-01T10:00:00Z",
+        proc_snapshots=None,
+        telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert (
+        len(summary["request_ids"])
+        == len(summary["turn_timestamps"])
+        == len(summary["turn_tool_calls"])
+        == 5
+    )
+    assert summary["request_ids"] == ["req-a", "turn-0", "req-b", "turn-1", "req-c"]
+    assert summary["turn_tool_calls"] == [
+        ["ToolA"],
+        ["ToolB"],
+        ["ToolC"],
+        ["ToolD"],
+        ["ToolE"],
+    ]
+    assert summary["turn_timestamps"] == [
+        "2026-05-01T10:00:00Z",
+        "2026-05-01T10:00:01Z",
+        "2026-05-01T10:00:02Z",
+        "2026-05-01T10:00:03Z",
+        "2026-05-01T10:00:04Z",
+    ]
+
+
 # turn_tool_calls
 
 

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -399,7 +399,7 @@ def test_channel_b_turn_count_bounded_by_channel_a(tmp_path, monkeypatch):
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     tu = json.loads((tmp_path / "sessions" / "s" / "token_usage.json").read_text())
     turn_count = tu.get("turn_count", 0)
-    assert len(summary["turn_timestamps"]) > 0
+    assert len(summary["turn_timestamps"]) == 2
     assert turn_count >= len(summary["turn_timestamps"])
 
 


### PR DESCRIPTION
## Summary

Sessions routed through non-Anthropic provider profiles produce empty `turn_timestamps`, `turn_tool_calls`, and `request_ids` arrays in `summary.json`. The root cause is a guard `if not _turn.request_id: continue` in `flush_session_log()` at `session_log.py:208` that silently drops all turns lacking a `requestId` — a field populated exclusively by Anthropic's API. The architectural weakness is that Channel B turn extraction in `flush_session_log` is tightly coupled to an Anthropic-specific metadata field, while the semantically identical Channel A turn counting in `extract_token_usage` is provider-agnostic.

The fix: synthetic IDs (`turn-N`) are generated in `iter_merged_assistant_turns` for no-`requestId` turns (centralizing turn-ID logic per existing arch contracts), the `requestId` guard is removed from `flush_session_log`, and a structural AST contract test prevents re-introduction of the provider-specific filter.

Closes #3241

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232149-035147/.autoskillit/temp/rectify/rectify_non_anthropic_turn_instrumentation_2026-05-29_063539.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 64 | 8.7k | 894.1k | 116.5k | 203 | 52.0k | 5m 56s |
| rectify* | opus[1m] | 1 | 72 | 25.1k | 3.2M | 124.5k | 214 | 176.4k | 21m 18s |
| review_approach* | sonnet | 1 | 7.3k | 4.9k | 183.4k | 45.2k | 61 | 32.2k | 4m 46s |
| dry_walkthrough* | opus | 1 | 53 | 8.0k | 925.0k | 71.2k | 104 | 56.2k | 6m 8s |
| implement* | sonnet | 1 | 284 | 16.4k | 2.1M | 79.3k | 98 | 63.5k | 6m 20s |
| audit_impl* | sonnet | 2 | 1.1k | 17.1k | 539.0k | 50.6k | 84 | 64.9k | 7m 29s |
| post_run_diagnostics* | sonnet | 1 | 118 | 16.9k | 545.9k | 80.9k | 262 | 89.0k | 13m 33s |
| prepare_pr* | sonnet | 1 | 120.2k | 2.5k | 305.8k | 30.9k | 21 | 15.7k | 57s |
| compose_pr* | sonnet | 1 | 47.3k | 1.6k | 213.2k | 30.9k | 14 | 15.4k | 43s |
| review_pr* | sonnet | 2 | 458 | 74.3k | 3.0M | 91.5k | 147 | 197.3k | 18m 52s |
| resolve_review* | opus | 2 | 73 | 12.5k | 1.5M | 68.7k | 68 | 99.8k | 16m 21s |
| **Total** | | | 177.0k | 187.8k | 13.3M | 124.5k | | 862.3k | 1h 42m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 227 | 9149.7 | 279.9 | 72.1 |
| audit_impl | 0 | — | — | — |
| post_run_diagnostics | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 765531.5 | 49913.0 | 6231.5 |
| **Total** | **229** | 58271.6 | 3765.7 | 820.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 3 | 190 | 29.1k | 3.4M | 208.0k | 28m 26s |
| opus[1m] | 1 | 72 | 25.1k | 3.2M | 176.4k | 21m 18s |
| sonnet | 7 | 176.8k | 133.6k | 6.8M | 477.9k | 52m 43s |