### PR TITLE
Rectify: GitHub API Log Cross-Step Misattribution

### DIFF
--- a/src/autoskillit/core/CLAUDE.md
+++ b/src/autoskillit/core/CLAUDE.md
@@ -22,6 +22,7 @@ Sub-packages: types/ (see types/CLAUDE.md) and runtime/ (see runtime/CLAUDE.md).
 | `_plugin_cache.py` | Plugin cache lifecycle: retiring cache, install locking, kitchen registry |
 | `_plugin_ids.py` | `DIRECT_PREFIX`, `MARKETPLACE_PREFIX`, `detect_autoskillit_mcp_prefix` (stdlib-only) |
 | `_install_detect.py` | `is_dev_install()` — editable-install detection for config resolution |
+| `_step_context.py` | `current_step_name`, `current_order_id` ContextVars for pipeline step attribution |
 | `feature_flags.py` | `is_feature_enabled()` — IL-0 feature gate resolution primitive |
 | `tool_sequence_analysis.py` | Cross-session tool call sequence DFG analysis (stdlib-only) |
 

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -26,6 +26,8 @@ from ._plugin_ids import MARKETPLACE_PREFIX as MARKETPLACE_PREFIX
 from ._plugin_ids import _get_autoskillit_install_path as _get_autoskillit_install_path
 from ._plugin_ids import _installed_plugins_path as _installed_plugins_path
 from ._plugin_ids import detect_autoskillit_mcp_prefix as detect_autoskillit_mcp_prefix
+from ._step_context import current_order_id as current_order_id
+from ._step_context import current_step_name as current_step_name
 from ._terminal_table import TerminalColumn as TerminalColumn
 from ._terminal_table import _render_gfm_table as _render_gfm_table
 from ._terminal_table import _render_terminal_table as _render_terminal_table

--- a/src/autoskillit/core/_step_context.py
+++ b/src/autoskillit/core/_step_context.py
@@ -1,0 +1,12 @@
+"""ContextVars for current pipeline step attribution.
+
+IL-0 module — stdlib only.  Read by execution/ and server/ layers at
+GitHub API recording time; set/reset by tools_execution.run_skill().
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+current_step_name: ContextVar[str] = ContextVar("current_step_name", default="")
+current_order_id: ContextVar[str] = ContextVar("current_order_id", default="")

--- a/src/autoskillit/core/types/_type_protocols_logging.py
+++ b/src/autoskillit/core/types/_type_protocols_logging.py
@@ -145,6 +145,8 @@ class GitHubApiLog(Protocol):
         rate_limit_used: int,
         rate_limit_reset: int,
         timestamp: str,
+        step_name: str = "",
+        order_id: str = "",
     ) -> None: ...
 
     async def record_gh_cli(
@@ -154,11 +156,21 @@ class GitHubApiLog(Protocol):
         exit_code: int,
         latency_ms: float,
         timestamp: str,
+        step_name: str = "",
+        order_id: str = "",
     ) -> None: ...
 
     def to_usage(self, session_id: str) -> dict[str, Any] | None: ...
 
+    def to_usage_for_step(
+        self, session_id: str, step_name: str, order_id: str
+    ) -> dict[str, Any] | None: ...
+
     def drain(self, session_id: str) -> dict[str, Any] | None: ...
+
+    def drain_step(
+        self, session_id: str, step_name: str, order_id: str
+    ) -> dict[str, Any] | None: ...
 
     def clear(self) -> None: ...
 

--- a/src/autoskillit/execution/github.py
+++ b/src/autoskillit/execution/github.py
@@ -96,6 +96,8 @@ class _TrackingTransport(httpx.AsyncBaseTransport):
         self._tracker = tracker
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        from autoskillit.core import current_order_id, current_step_name
+
         start = time.monotonic()
         response = await self._wrapped.handle_async_request(request)
         latency_ms = (time.monotonic() - start) * 1000.0
@@ -116,6 +118,8 @@ class _TrackingTransport(httpx.AsyncBaseTransport):
             rate_limit_used=_int("x-ratelimit-used"),
             rate_limit_reset=_int("x-ratelimit-reset"),
             timestamp=datetime.now(UTC).isoformat(),
+            step_name=current_step_name.get(""),
+            order_id=current_order_id.get(""),
         )
         return response
 

--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -160,10 +160,13 @@ def _build_session_telemetry(
     github_api_log: GitHubApiLog | None,
     loc_insertions: int,
     loc_deletions: int,
+    step_name: str = "",
+    order_id: str = "",
 ) -> SessionTelemetry:
-    _api_usage = (
-        github_api_log.drain(skill_result.session_id) if github_api_log is not None else None
-    )
+    if github_api_log is not None:
+        _api_usage = github_api_log.drain_step(skill_result.session_id, step_name, order_id)
+    else:
+        _api_usage = None
     return SessionTelemetry(
         token_usage=skill_result.token_usage,
         timing_seconds=timing_seconds,
@@ -178,9 +181,17 @@ def _build_session_telemetry(
 def _build_error_path_telemetry(
     github_api_log: GitHubApiLog | None,
     session_id: str = "",
+    step_name: str = "",
+    order_id: str = "",
 ) -> SessionTelemetry:
     """Build SessionTelemetry for crash/cancel paths where no SkillResult exists."""
-    _api_usage = github_api_log.drain(session_id) if github_api_log is not None else None
+    if github_api_log is not None:
+        if step_name and order_id:
+            _api_usage = github_api_log.drain_step(session_id, step_name, order_id)
+        else:
+            _api_usage = github_api_log.drain(session_id)
+    else:
+        _api_usage = None
     return SessionTelemetry(
         token_usage=None,
         timing_seconds=None,

--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -186,10 +186,7 @@ def _build_error_path_telemetry(
 ) -> SessionTelemetry:
     """Build SessionTelemetry for crash/cancel paths where no SkillResult exists."""
     if github_api_log is not None:
-        if step_name and order_id:
-            _api_usage = github_api_log.drain_step(session_id, step_name, order_id)
-        else:
-            _api_usage = github_api_log.drain(session_id)
+        _api_usage = github_api_log.drain_step(session_id, step_name, order_id)
     else:
         _api_usage = None
     return SessionTelemetry(

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -277,7 +277,12 @@ async def _execute_claude_headless(
                     ),
                     max_sessions=ctx.config.linux_tracing.max_sessions,
                     model_identifier=model_identifier,
-                    telemetry=_build_error_path_telemetry(ctx.github_api_log),
+                    telemetry=_build_error_path_telemetry(
+                        ctx.github_api_log,
+                        session_id="",
+                        step_name=step_name,
+                        order_id=order_id,
+                    ),
                 )
             except Exception:
                 logger.debug("flush_session_log during crash failed", exc_info=True)
@@ -333,7 +338,12 @@ async def _execute_claude_headless(
                         ),
                         max_sessions=ctx.config.linux_tracing.max_sessions,
                         model_identifier=model_identifier,
-                        telemetry=_build_error_path_telemetry(ctx.github_api_log),
+                        telemetry=_build_error_path_telemetry(
+                            ctx.github_api_log,
+                            session_id="",
+                            step_name=step_name,
+                            order_id=order_id,
+                        ),
                     )
             except Exception:
                 logger.debug("flush_session_log during cancel failed", exc_info=True)
@@ -489,6 +499,8 @@ async def _execute_claude_headless(
                     github_api_log=ctx.github_api_log,
                     loc_insertions=_metrics.loc_insertions,
                     loc_deletions=_metrics.loc_deletions,
+                    step_name=step_name,
+                    order_id=order_id,
                 ),
                 api_retry_count=skill_result.api_retry.count,
                 api_retry_last_error=skill_result.api_retry.last_error,

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -11,6 +11,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from autoskillit.core import current_order_id, current_step_name
+
+__all__ = ["ToolContext", "current_step_name", "current_order_id"]
+
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     AuditLog,

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -11,10 +11,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import current_order_id, current_step_name
-
-__all__ = ["ToolContext", "current_step_name", "current_order_id"]
-
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     AuditLog,
@@ -47,9 +43,13 @@ from autoskillit.core import (
     TokenLog,
     WorkspaceManager,
     WriteExpectedResolver,
+    current_order_id,
+    current_step_name,
 )
 from autoskillit.pipeline.background import DefaultBackgroundSupervisor
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog
+
+__all__ = ["ToolContext", "current_step_name", "current_order_id"]
 
 # Must-supply-or-raise: fields defaulting to _MISSING are required by __post_init__.
 _MISSING: Any = object()

--- a/src/autoskillit/pipeline/github_api_log.py
+++ b/src/autoskillit/pipeline/github_api_log.py
@@ -1,8 +1,8 @@
 """Session-scoped GitHub API request accumulator.
 
-Mirrors the tokens.py / timings.py pattern: a lock-guarded list of entries
-aggregated on demand by to_usage(). Flushed to github_api_usage.json at
-session log-write time via flush_session_log().
+Mirrors the tokens.py / timings.py pattern: a lock-guarded dict of entries keyed
+by (order_id, step_name), aggregated on demand by to_usage(). Flushed to
+github_api_usage.json at session log-write time via flush_session_log().
 """
 
 from __future__ import annotations
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import regex as re
+
+from autoskillit.pipeline.tokens import canonical_step_name
 
 
 @dataclass
@@ -26,6 +28,8 @@ class GitHubApiEntry:
     timestamp: str
     source: str  # "httpx" or "gh_cli"
     subcommand: str = field(default="")
+    step_name: str = field(default="")
+    order_id: str = field(default="")
 
 
 _CATEGORY_PATTERNS: list[tuple[re.Pattern[str], str]] = [
@@ -44,12 +48,52 @@ def _categorize(path: str) -> str:
     return "other"
 
 
+def _aggregate_entries(entries: list[GitHubApiEntry], session_id: str) -> dict[str, Any] | None:
+    if not entries:
+        return None
+    by_category: dict[str, int] = {}
+    by_source: dict[str, int] = {}
+    total_latency = 0.0
+    min_remaining: int | None = None
+    errors: dict[str, int] = {"4xx": 0, "5xx": 0}
+    timestamps = [e.timestamp for e in entries if e.timestamp]
+    for e in entries:
+        cat = _categorize(e.path) if e.source == "httpx" else "other"
+        by_category[cat] = by_category.get(cat, 0) + 1
+        by_source[e.source] = by_source.get(e.source, 0) + 1
+        total_latency += e.latency_ms
+        if e.source == "httpx" and e.rate_limit_remaining >= 0:
+            if min_remaining is None or e.rate_limit_remaining < min_remaining:
+                min_remaining = e.rate_limit_remaining
+        if e.source == "httpx":
+            if 400 <= e.status_code < 500:
+                errors["4xx"] += 1
+            elif 500 <= e.status_code < 600:
+                errors["5xx"] += 1
+    count = len(entries)
+    return {
+        "session_id": session_id,
+        "total_requests": count,
+        "by_category": by_category,
+        "by_source": by_source,
+        "total_latency_ms": round(total_latency, 2),
+        "avg_latency_ms": round(total_latency / count, 2) if count else 0.0,
+        "min_rate_limit_remaining": min_remaining,
+        "errors": errors,
+        "first_request_ts": min(timestamps) if timestamps else None,
+        "last_request_ts": max(timestamps) if timestamps else None,
+    }
+
+
 class DefaultGitHubApiLog:
     """asyncio.Lock-guarded accumulator of GitHub API call entries."""
 
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
-        self._entries: list[GitHubApiEntry] = []
+        self._entries: dict[tuple[str, str], list[GitHubApiEntry]] = {}
+
+    def _key(self, order_id: str, step_name: str) -> tuple[str, str]:
+        return (order_id, canonical_step_name(step_name))
 
     async def record_httpx(
         self,
@@ -62,21 +106,25 @@ class DefaultGitHubApiLog:
         rate_limit_used: int,
         rate_limit_reset: int,
         timestamp: str,
+        step_name: str = "",
+        order_id: str = "",
     ) -> None:
+        key = self._key(order_id, step_name)
+        entry = GitHubApiEntry(
+            method=method,
+            path=path,
+            status_code=status_code,
+            latency_ms=latency_ms,
+            rate_limit_remaining=rate_limit_remaining,
+            rate_limit_used=rate_limit_used,
+            rate_limit_reset=rate_limit_reset,
+            timestamp=timestamp,
+            source="httpx",
+            step_name=canonical_step_name(step_name),
+            order_id=order_id,
+        )
         async with self._lock:
-            self._entries.append(
-                GitHubApiEntry(
-                    method=method,
-                    path=path,
-                    status_code=status_code,
-                    latency_ms=latency_ms,
-                    rate_limit_remaining=rate_limit_remaining,
-                    rate_limit_used=rate_limit_used,
-                    rate_limit_reset=rate_limit_reset,
-                    timestamp=timestamp,
-                    source="httpx",
-                )
-            )
+            self._entries.setdefault(key, []).append(entry)
 
     async def record_gh_cli(
         self,
@@ -85,69 +133,56 @@ class DefaultGitHubApiLog:
         exit_code: int,
         latency_ms: float,
         timestamp: str,
+        step_name: str = "",
+        order_id: str = "",
     ) -> None:
+        key = self._key(order_id, step_name)
+        entry = GitHubApiEntry(
+            method="",
+            path="",
+            status_code=exit_code,
+            latency_ms=latency_ms,
+            rate_limit_remaining=-1,
+            rate_limit_used=0,
+            rate_limit_reset=0,
+            timestamp=timestamp,
+            source="gh_cli",
+            subcommand=subcommand,
+            step_name=canonical_step_name(step_name),
+            order_id=order_id,
+        )
         async with self._lock:
-            self._entries.append(
-                GitHubApiEntry(
-                    method="",
-                    path="",
-                    status_code=exit_code,
-                    latency_ms=latency_ms,
-                    rate_limit_remaining=-1,
-                    rate_limit_used=0,
-                    rate_limit_reset=0,
-                    timestamp=timestamp,
-                    source="gh_cli",
-                    subcommand=subcommand,
-                )
-            )
+            self._entries.setdefault(key, []).append(entry)
 
     def to_usage(self, session_id: str) -> dict[str, Any] | None:
-        if not self._entries:
-            return None
-        by_category: dict[str, int] = {}
-        by_source: dict[str, int] = {}
-        total_latency = 0.0
-        min_remaining: int | None = None
-        errors: dict[str, int] = {"4xx": 0, "5xx": 0}
-        timestamps = [e.timestamp for e in self._entries if e.timestamp]
-        for e in self._entries:
-            cat = _categorize(e.path) if e.source == "httpx" else "other"
-            by_category[cat] = by_category.get(cat, 0) + 1
-            by_source[e.source] = by_source.get(e.source, 0) + 1
-            total_latency += e.latency_ms
-            if e.source == "httpx" and e.rate_limit_remaining >= 0:
-                if min_remaining is None or e.rate_limit_remaining < min_remaining:
-                    min_remaining = e.rate_limit_remaining
-            if e.source == "httpx":
-                if 400 <= e.status_code < 500:
-                    errors["4xx"] += 1
-                elif 500 <= e.status_code < 600:
-                    errors["5xx"] += 1
-        count = len(self._entries)
-        return {
-            "session_id": session_id,
-            "total_requests": count,
-            "by_category": by_category,
-            "by_source": by_source,
-            "total_latency_ms": round(total_latency, 2),
-            "avg_latency_ms": round(total_latency / count, 2) if count else 0.0,
-            "min_rate_limit_remaining": min_remaining,
-            "errors": errors,
-            "first_request_ts": min(timestamps) if timestamps else None,
-            "last_request_ts": max(timestamps) if timestamps else None,
-        }
+        all_entries: list[GitHubApiEntry] = [
+            e for bucket in self._entries.values() for e in bucket
+        ]
+        return _aggregate_entries(all_entries, session_id)
+
+    def to_usage_for_step(
+        self, session_id: str, step_name: str, order_id: str
+    ) -> dict[str, Any] | None:
+        key = self._key(order_id, step_name)
+        entries = self._entries.get(key, [])
+        return _aggregate_entries(entries, session_id)
 
     def drain(self, session_id: str) -> dict[str, Any] | None:
-        """Snapshot current entries as a usage dict and clear the accumulator.
+        """Snapshot all entries as a usage dict and clear the accumulator.
 
-        List replacement (not .clear()) is used so a concurrent record_* call that
-        appended to the old list after drain() snapshotted it will appear in the
-        next session's drain rather than being silently dropped.
+        Dict replacement (not .clear()) is used so a concurrent record_* call that
+        inserted into the old dict after drain() snapshotted it will appear in the
+        next drain rather than being silently dropped.
         """
         usage = self.to_usage(session_id)
-        self._entries = []
+        self._entries = {}
         return usage
 
+    def drain_step(self, session_id: str, step_name: str, order_id: str) -> dict[str, Any] | None:
+        """Snapshot and remove only the entries for a specific (order_id, step_name) key."""
+        key = self._key(order_id, step_name)
+        entries = self._entries.pop(key, [])
+        return _aggregate_entries(entries, session_id)
+
     def clear(self) -> None:
-        self._entries = []
+        self._entries = {}

--- a/src/autoskillit/server/_subprocess.py
+++ b/src/autoskillit/server/_subprocess.py
@@ -71,6 +71,8 @@ async def _run_subprocess(
     returncode, stdout, stderr = _process_runner_result(result, timeout)
 
     if is_gh:
+        from autoskillit.core import current_order_id, current_step_name
+
         latency_ms = (time.monotonic() - start) * 1000.0
         log = _get_ctx().github_api_log
         if log is not None:
@@ -79,6 +81,8 @@ async def _run_subprocess(
                 exit_code=returncode,
                 latency_ms=latency_ms,
                 timestamp=datetime.now(UTC).isoformat(),
+                step_name=current_step_name.get(""),
+                order_id=current_order_id.get(""),
             )
 
     return returncode, stdout, stderr

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -311,6 +311,7 @@ async def run_skill(
             }
         )
     try:
+        _sn_token = _oid_token = None
         from autoskillit.server import _get_ctx
 
         _cleanup_session_id: str | None = None
@@ -579,6 +580,19 @@ async def run_skill(
             if _local_dir is not None:
                 skill_add_dirs.append(_local_dir)
 
+            from autoskillit.pipeline.context import (  # noqa: PLC0415
+                current_order_id as _current_order_id,
+            )
+            from autoskillit.pipeline.context import (
+                current_step_name as _current_step_name,
+            )
+            from autoskillit.pipeline.tokens import (  # noqa: PLC0415
+                canonical_step_name as _canonical_step_name,
+            )
+
+            _sn_token = _current_step_name.set(_canonical_step_name(step_name))
+            _oid_token = _current_order_id.set(effective_order_id)
+
             _start = time.monotonic()
             try:
                 skill_result = await tool_ctx.executor.run(
@@ -661,6 +675,10 @@ async def run_skill(
         logger.warning("run_skill cancelled", exc_info=True)
         raise
     finally:
+        if _sn_token is not None:
+            _current_step_name.reset(_sn_token)  # type: ignore[possibly-undefined]
+        if _oid_token is not None:
+            _current_order_id.reset(_oid_token)  # type: ignore[possibly-undefined]
         _sid: str | None = locals().get("_cleanup_session_id")  # type: ignore[assignment]
         if _sid is not None:
             _ssm = tool_ctx.session_skill_manager  # type: ignore[possibly-undefined]

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -583,7 +583,7 @@ async def run_skill(
             from autoskillit.pipeline.context import (  # noqa: PLC0415
                 current_order_id as _current_order_id,
             )
-            from autoskillit.pipeline.context import (
+            from autoskillit.pipeline.context import (  # noqa: PLC0415
                 current_step_name as _current_step_name,
             )
             from autoskillit.pipeline.tokens import (  # noqa: PLC0415

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -25,6 +25,7 @@ from autoskillit.core import (
     ProcessStaleError,
     _collect_disabled_feature_tags,
     atomic_write,
+    fast_dumps,
     find_latest_session_id,
     get_logger,
     pkg_root,
@@ -253,6 +254,15 @@ def _close_kitchen_handler() -> None:
     ctx.recipe_composite_hash = ""
     ctx.recipe_version = ""
     logger.info("close_kitchen", gate_state="closed")
+    if (log := ctx.github_api_log) is not None:
+        orphan_usage = log.drain(ctx.kitchen_id)
+        if orphan_usage is not None:
+            try:
+                log_dir = resolve_log_dir(ctx.config.linux_tracing.log_dir)
+                orphan_path = log_dir / "github_api_usage_orchestrator.json"
+                atomic_write(orphan_path, fast_dumps(orphan_usage))
+            except Exception:
+                logger.warning("close_kitchen_orphan_drain_failed", exc_info=True)
     hook_cfg_path = _hook_config_path(ctx.project_dir)
     try:
         hook_cfg_path.unlink(missing_ok=True)

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -165,7 +165,7 @@ _CORE_UNIVERSAL_EXCLUSIONS: dict[str, frozenset[str]] = {
 
 MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_cmd_runner": frozenset({"core", "recipe"}),
-    "_json": frozenset({"core", "execution", "pipeline", "recipe"}),
+    "_json": frozenset({"core", "execution", "pipeline", "recipe", "server"}),
     "feature_flags": frozenset(
         {"core", "cli", "config", "execution", "recipe", "server", "workspace"}
     ),

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -18,7 +18,7 @@ NEW_HEADLESS_MODULES = [
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 460,
     "headless/_headless_helpers.py": 175,
-    "headless/_headless_execute.py": 562,
+    "headless/_headless_execute.py": 575,
     "headless/_headless_recovery.py": 366,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -90,6 +90,7 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         "_type_backend",  # core/types/_type_backend.py: CLAUDE_CODE_CAPABILITIES constant
         # _REMOVE_LABELS = sorted(...) — stable label list derived from LABEL_LIFECYCLE_REGISTRY
         "_label_cleanup",  # fleet/_label_cleanup.py: _REMOVE_LABELS constant (see comment above)
+        "_step_context",  # core/_step_context.py: current_step_name, current_order_id ContextVars
     }
 )
 _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -132,8 +132,12 @@ def test_github_api_log_protocol_includes_step_attribution_params():
     sig_cli = inspect.signature(GitHubApiLog.record_gh_cli)
     assert "step_name" in sig_cli.parameters
     assert "order_id" in sig_cli.parameters
-    assert "drain_step" in dir(GitHubApiLog)
-    assert "to_usage_for_step" in dir(GitHubApiLog)
+    sig_drain = inspect.signature(GitHubApiLog.drain_step)
+    assert "step_name" in sig_drain.parameters
+    assert "order_id" in sig_drain.parameters
+    sig_usage_step = inspect.signature(GitHubApiLog.to_usage_for_step)
+    assert "step_name" in sig_usage_step.parameters
+    assert "order_id" in sig_usage_step.parameters
 
 
 def test_default_token_log_satisfies_token_store_with_order_id():

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -114,6 +114,28 @@ def test_default_timing_log_satisfies_timing_store_protocol():
     assert isinstance(DefaultTimingLog(), TimingLog)
 
 
+def test_default_github_api_log_satisfies_github_api_log():
+    from autoskillit.core import GitHubApiLog
+    from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+
+    assert isinstance(DefaultGitHubApiLog(), GitHubApiLog)
+
+
+def test_github_api_log_protocol_includes_step_attribution_params():
+    import inspect
+
+    from autoskillit.core import GitHubApiLog
+
+    sig_httpx = inspect.signature(GitHubApiLog.record_httpx)
+    assert "step_name" in sig_httpx.parameters
+    assert "order_id" in sig_httpx.parameters
+    sig_cli = inspect.signature(GitHubApiLog.record_gh_cli)
+    assert "step_name" in sig_cli.parameters
+    assert "order_id" in sig_cli.parameters
+    assert "drain_step" in dir(GitHubApiLog)
+    assert "to_usage_for_step" in dir(GitHubApiLog)
+
+
 def test_default_token_log_satisfies_token_store_with_order_id():
     """F-1: DefaultTokenLog satisfies updated TokenLog Protocol (includes order_id params)."""
     from autoskillit.core import TokenLog

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -681,17 +681,53 @@ class InMemoryGitHubApiLog:
         self.httpx_calls: list[dict[str, Any]] = []
         self.gh_cli_calls: list[dict[str, Any]] = []
 
-    async def record_httpx(self, **kwargs: Any) -> None:
-        self.httpx_calls.append(kwargs)
+    async def record_httpx(
+        self, *, step_name: str = "", order_id: str = "", **kwargs: Any
+    ) -> None:
+        self.httpx_calls.append({"step_name": step_name, "order_id": order_id, **kwargs})
 
-    async def record_gh_cli(self, **kwargs: Any) -> None:
-        self.gh_cli_calls.append(kwargs)
+    async def record_gh_cli(
+        self, *, step_name: str = "", order_id: str = "", **kwargs: Any
+    ) -> None:
+        self.gh_cli_calls.append({"step_name": step_name, "order_id": order_id, **kwargs})
 
     def to_usage(self, session_id: str) -> dict[str, Any] | None:
         total = len(self.httpx_calls) + len(self.gh_cli_calls)
         if total == 0:
             return None
         return {"session_id": session_id, "total_requests": total}
+
+    def to_usage_for_step(
+        self, session_id: str, step_name: str, order_id: str
+    ) -> dict[str, Any] | None:
+        total = sum(
+            1
+            for c in (*self.httpx_calls, *self.gh_cli_calls)
+            if c.get("step_name") == step_name and c.get("order_id") == order_id
+        )
+        if total == 0:
+            return None
+        return {"session_id": session_id, "total_requests": total}
+
+    def drain(self, session_id: str) -> dict[str, Any] | None:
+        usage = self.to_usage(session_id)
+        self.httpx_calls.clear()
+        self.gh_cli_calls.clear()
+        return usage
+
+    def drain_step(self, session_id: str, step_name: str, order_id: str) -> dict[str, Any] | None:
+        usage = self.to_usage_for_step(session_id, step_name, order_id)
+        self.httpx_calls = [
+            c
+            for c in self.httpx_calls
+            if not (c.get("step_name") == step_name and c.get("order_id") == order_id)
+        ]
+        self.gh_cli_calls = [
+            c
+            for c in self.gh_cli_calls
+            if not (c.get("step_name") == step_name and c.get("order_id") == order_id)
+        ]
+        return usage
 
     def clear(self) -> None:
         self.httpx_calls.clear()

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import re
 from collections import deque
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
@@ -674,6 +675,12 @@ class InMemoryDatabaseReader(DatabaseReader):
 # ---------------------------------------------------------------------------
 
 
+def _canonical_step_name(step_name: str) -> str:
+    if not step_name or ":" in step_name or step_name.startswith("("):
+        return step_name
+    return re.sub(r"-\d+$", "", step_name)
+
+
 class InMemoryGitHubApiLog:
     """In-memory fake for the GitHubApiLog protocol. Records calls for assertions."""
 
@@ -684,12 +691,16 @@ class InMemoryGitHubApiLog:
     async def record_httpx(
         self, *, step_name: str = "", order_id: str = "", **kwargs: Any
     ) -> None:
-        self.httpx_calls.append({"step_name": step_name, "order_id": order_id, **kwargs})
+        self.httpx_calls.append(
+            {"step_name": _canonical_step_name(step_name), "order_id": order_id, **kwargs}
+        )
 
     async def record_gh_cli(
         self, *, step_name: str = "", order_id: str = "", **kwargs: Any
     ) -> None:
-        self.gh_cli_calls.append({"step_name": step_name, "order_id": order_id, **kwargs})
+        self.gh_cli_calls.append(
+            {"step_name": _canonical_step_name(step_name), "order_id": order_id, **kwargs}
+        )
 
     def to_usage(self, session_id: str) -> dict[str, Any] | None:
         total = len(self.httpx_calls) + len(self.gh_cli_calls)
@@ -700,10 +711,11 @@ class InMemoryGitHubApiLog:
     def to_usage_for_step(
         self, session_id: str, step_name: str, order_id: str
     ) -> dict[str, Any] | None:
+        sn = _canonical_step_name(step_name)
         total = sum(
             1
             for c in (*self.httpx_calls, *self.gh_cli_calls)
-            if c.get("step_name") == step_name and c.get("order_id") == order_id
+            if c.get("step_name") == sn and c.get("order_id") == order_id
         )
         if total == 0:
             return None
@@ -716,16 +728,17 @@ class InMemoryGitHubApiLog:
         return usage
 
     def drain_step(self, session_id: str, step_name: str, order_id: str) -> dict[str, Any] | None:
+        sn = _canonical_step_name(step_name)
         usage = self.to_usage_for_step(session_id, step_name, order_id)
         self.httpx_calls = [
             c
             for c in self.httpx_calls
-            if not (c.get("step_name") == step_name and c.get("order_id") == order_id)
+            if not (c.get("step_name") == sn and c.get("order_id") == order_id)
         ]
         self.gh_cli_calls = [
             c
             for c in self.gh_cli_calls
-            if not (c.get("step_name") == step_name and c.get("order_id") == order_id)
+            if not (c.get("step_name") == sn and c.get("order_id") == order_id)
         ]
         return usage
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -117,9 +117,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 64),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools/tools_kitchen.py", 124),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 143),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 679),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 125),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 144),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 689),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 491),
     # tools_github.py — bug report dict

--- a/tests/pipeline/test_github_api_log.py
+++ b/tests/pipeline/test_github_api_log.py
@@ -244,6 +244,114 @@ async def test_drain_returns_usage_and_clears():
     assert usage["session_id"] == "sess-drain"
 
     # After drain the accumulator is empty — to_usage and drain both return None
-    assert len(log._entries) == 0
+    assert not log._entries
     assert log.to_usage("sess-drain") is None
     assert log.drain("sess-drain") is None
+
+
+async def test_entries_are_attributed_to_correct_step():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        step_name="plan",
+        order_id="o1",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=10.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
+    )
+    await log.record_gh_cli(
+        step_name="implement",
+        order_id="o1",
+        subcommand="gh pr create",
+        exit_code=0,
+        latency_ms=50.0,
+        timestamp="2026-04-27T10:00:01Z",
+    )
+
+    plan_usage = log.to_usage_for_step("s1", "plan", "o1")
+    impl_usage = log.to_usage_for_step("s1", "implement", "o1")
+
+    assert plan_usage is not None
+    assert plan_usage["total_requests"] == 1
+    assert plan_usage["by_source"]["httpx"] == 1
+    assert impl_usage is not None
+    assert impl_usage["total_requests"] == 1
+    assert impl_usage["by_source"]["gh_cli"] == 1
+
+
+async def test_drain_per_step_returns_only_that_steps_entries():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        step_name="plan",
+        order_id="o1",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=10.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
+    )
+    plan_usage = log.drain_step("s1", "plan", "o1")
+    await log.record_httpx(
+        step_name="implement",
+        order_id="o1",
+        method="GET",
+        path="/repos/o/r/pulls/2",
+        status_code=200,
+        latency_ms=15.0,
+        rate_limit_remaining=4998,
+        rate_limit_used=2,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:01Z",
+    )
+    impl_usage = log.drain_step("s2", "implement", "o1")
+
+    assert plan_usage is not None
+    assert plan_usage["total_requests"] == 1
+    assert plan_usage["session_id"] == "s1"
+    assert impl_usage is not None
+    assert impl_usage["total_requests"] == 1
+    assert impl_usage["session_id"] == "s2"
+    assert not log._entries
+
+
+async def test_crash_during_step_b_does_not_sweep_step_a_entries():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        step_name="plan",
+        order_id="o1",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=10.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
+    )
+    await log.record_httpx(
+        step_name="implement",
+        order_id="o1",
+        method="POST",
+        path="/repos/o/r/pulls",
+        status_code=201,
+        latency_ms=20.0,
+        rate_limit_remaining=4998,
+        rate_limit_used=2,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:01Z",
+    )
+
+    crash_usage = log.drain_step("crash", "implement", "o1")
+    assert crash_usage is not None
+    assert crash_usage["total_requests"] == 1
+
+    plan_usage = log.drain_step("s1", "plan", "o1")
+    assert plan_usage is not None
+    assert plan_usage["total_requests"] == 1

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -641,6 +641,7 @@ class TestRunHeadlessCoreFlushTelemetry:
             exit_code=0,
             latency_ms=50.0,
             timestamp="2026-05-02T10:00:00Z",
+            step_name="implement",
         )
         tool_ctx_kitchen_open.github_api_log = log
 

--- a/tests/server/test_tools_github_api_tracking.py
+++ b/tests/server/test_tools_github_api_tracking.py
@@ -101,7 +101,8 @@ async def test_gh_cli_records_exit_code_and_latency(build_ctx):
     usage = log.to_usage("sess-1")
     assert usage["total_requests"] == 1
     assert usage["total_latency_ms"] > 0
-    assert log._entries[0].status_code == 1
+    first_entry = next(iter(log._entries.values()))[0]
+    assert first_entry.status_code == 1
 
 
 async def test_flush_session_log_writes_github_api_usage(tmp_path):

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -292,3 +292,52 @@ async def test_open_kitchen_generates_uuid_without_campaign_env(tmp_path, monkey
 
     kitchen_id = mock_ctx.kitchen_id
     assert len(kitchen_id) == 36 and kitchen_id.count("-") == 4
+
+
+# ---------------------------------------------------------------------------
+# Kitchen-close orphan drain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_close_kitchen_drains_orphaned_github_api_entries(tmp_path, monkeypatch):
+    """Entries accumulated after last run_skill are flushed to disk at close."""
+    import json
+
+    from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+
+    monkeypatch.chdir(tmp_path)
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=10.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
+    )
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.github_api_log = log
+    mock_ctx.kitchen_id = "test-kitchen-123"
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    mock_ctx.config.linux_tracing.log_dir = str(log_dir)
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen.resolve_log_dir", return_value=log_dir
+            ):
+                from autoskillit.server.tools.tools_kitchen import _close_kitchen_handler
+
+                _close_kitchen_handler()
+
+    orphan_path = log_dir / "github_api_usage_orchestrator.json"
+    assert orphan_path.exists()
+    data = json.loads(orphan_path.read_text())
+    assert data["total_requests"] == 1
+    assert not log._entries

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -173,7 +173,7 @@ class TestModuleCascadeCore:
 
     def test_json_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_json"] == frozenset(
-            {"core", "execution", "pipeline", "recipe"}
+            {"core", "execution", "pipeline", "recipe", "server"}
         )
 
 


### PR DESCRIPTION
## Summary

`DefaultGitHubApiLog` is the only telemetry accumulator in the pipeline that stores entries without per-step attribution. Its sibling classes (`DefaultTokenLog`, `DefaultTimingLog`) key entries by `(order_id, step_name)` at record time, making misattribution structurally impossible. `DefaultGitHubApiLog` instead uses a flat `list[GitHubApiEntry]` with no step context, relying on `drain()` at session boundaries to attribute all accumulated entries to the current session. This causes two compounding defects:

1. **Cross-step misattribution**: Orchestrator-level GitHub API calls (httpx via `_TrackingTransport` and gh CLI via `_run_subprocess`) accumulate in the shared log between `run_skill` calls. The next headless session's `drain()` sweeps them and attributes them to the wrong step.
2. **Lost entries at kitchen close**: No `drain()` is called during `close_kitchen`. Entries accumulated after the last headless session are silently discarded.

The architectural fix is to align `DefaultGitHubApiLog` with the `DefaultTokenLog`/`DefaultTimingLog` pattern: tag every entry with `step_name` at record time, key the internal store by `(order_id, step_name)`, and eliminate the session-boundary `drain()` in favor of step-scoped retrieval.

Closes #3233

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232029-211508/.autoskillit/temp/rectify/rectify_github_api_log_misattribution_2026-05-28_232029.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 69 | 22.5k | 2.5M | 137.8k | 310 | 139.4k | 24m 54s |
| review_approach* | sonnet | 1 | 60 | 6.6k | 220.0k | 45.7k | 58 | 33.6k | 4m 17s |
| dry_walkthrough* | opus | 1 | 5.2k | 11.7k | 1.4M | 96.4k | 140 | 48.7k | 5m 54s |
| implement* | sonnet | 1 | 420 | 31.2k | 4.5M | 117.9k | 155 | 102.8k | 9m 17s |
| audit_impl* | sonnet | 2 | 1.8k | 18.6k | 759.4k | 59.4k | 118 | 84.0k | 7m 1s |
| post_run_diagnostics* | sonnet | 1 | 78 | 13.1k | 283.0k | 76.0k | 333 | 49.5k | 17m 10s |
| prepare_pr* | sonnet | 1 | 147.8k | 5.1k | 277.9k | 30.9k | 27 | 43.6k | 1m 31s |
| compose_pr* | sonnet | 1 | 48.9k | 1.5k | 213.2k | 30.9k | 14 | 15.5k | 43s |
| review_pr* | sonnet | 1 | 6.2k | 36.7k | 1.8M | 116.8k | 91 | 102.1k | 12m 0s |
| resolve_review* | opus | 1 | 601 | 16.8k | 2.3M | 83.5k | 89 | 68.1k | 9m 52s |
| diagnose_ci* | sonnet | 1 | 76.6k | 1.3k | 185.4k | 30.9k | 16 | 43.3k | 42s |
| resolve_ci* | opus | 1 | 46 | 4.1k | 853.0k | 54.8k | 34 | 38.8k | 8m 39s |
| **Total** | | | 287.9k | 169.1k | 15.3M | 137.8k | | 769.2k | 1h 42m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 445 | 10052.5 | 230.9 | 70.0 |
| audit_impl | 0 | — | — | — |
| post_run_diagnostics | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 46 | 50842.4 | 1479.6 | 364.8 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 2 | 426505.5 | 19421.0 | 2030.5 |
| **Total** | **493** | 31079.0 | 1560.3 | 343.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 69 | 22.5k | 2.5M | 139.4k | 24m 54s |
| sonnet | 8 | 282.0k | 114.1k | 8.3M | 474.2k | 52m 45s |
| opus | 3 | 5.8k | 32.6k | 4.6M | 155.6k | 24m 26s |