### PR TITLE
[FIX] Rectify Pre-Staged Index Contamination: Execution-Layer Immunity (Part A)

### DIFF
--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -428,11 +428,13 @@ async def revert_contamination(
             if reset_result.returncode != 0:
                 return dataclasses.replace(report, reverted=False)
         else:
-            await runner(
+            reset_result = await runner(
                 ["git", "reset", snapshot.head_sha],
                 cwd=Path(cwd),
                 timeout=_GIT_TIMEOUT,
             )
+            if reset_result.returncode != 0:
+                return dataclasses.replace(report, reverted=False)
         checkout_result = await runner(
             ["git", "checkout", "--", "."],
             cwd=Path(cwd),

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -7,6 +7,7 @@ prevent contamination from propagating to retry sessions.
 Public API:
     is_worktree_skill(skill_command) -> bool
     snapshot_clone_state(cwd, runner) -> CloneSnapshot | None
+    validate_pre_session_index(cwd, runner) -> bool
     check_and_revert_clone_contamination(
         snapshot, skill_result, cwd, runner, audit
     ) -> tuple[SkillResult, bool]
@@ -226,6 +227,83 @@ async def snapshot_clone_state(cwd: str, runner: SubprocessRunner) -> CloneSnaps
     return CloneSnapshot(head_sha=head_sha, worktree_set=wt_set)
 
 
+async def validate_pre_session_index(
+    cwd: str,
+    runner: SubprocessRunner,
+    *,
+    exclude_prefix: str = ".autoskillit/",
+    pre_session_sha: str = "",
+) -> bool:
+    """Reset dirty index state from prior sessions before a new session starts.
+
+    Returns True if dirty state was found and reset, False if index was clean.
+    Uses pre_session_sha for mixed reset when available; falls back to
+    ``git rm --cached -r .`` on repos with no HEAD.
+    """
+    status_result = await runner(
+        ["git", "status", "--porcelain"],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    if status_result.returncode != 0:
+        return False
+    status_lines = [line for line in status_result.stdout.splitlines() if line.strip()]
+    if exclude_prefix:
+        status_lines = [
+            line for line in status_lines if not _status_path_under_prefix(line, exclude_prefix)
+        ]
+    if not status_lines:
+        return False
+
+    file_count = len(status_lines)
+    logger.warning(
+        "pre_session_dirty_index_detected",
+        file_count=file_count,
+        sample_files=status_lines[:5],
+    )
+
+    reset_sha = pre_session_sha
+    if not reset_sha:
+        head_result = await runner(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(cwd),
+            timeout=_GIT_TIMEOUT,
+        )
+        if head_result.returncode == 0 and head_result.stdout.strip():
+            reset_sha = head_result.stdout.strip()
+
+    if reset_sha:
+        await runner(
+            ["git", "reset", reset_sha],
+            cwd=Path(cwd),
+            timeout=_GIT_TIMEOUT,
+        )
+    else:
+        await runner(
+            ["git", "rm", "--cached", "-r", "."],
+            cwd=Path(cwd),
+            timeout=_GIT_TIMEOUT,
+        )
+
+    await runner(
+        ["git", "checkout", "--", "."],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    await runner(
+        ["git", "clean", "-fd"],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+
+    logger.info(
+        "index_reset_pre_session",
+        file_count=file_count,
+        reset_strategy="sha" if reset_sha else "rm_cached",
+    )
+    return True
+
+
 def _status_path_under_prefix(status_line: str, prefix: str) -> bool:
     """Return True if the file path in a git status --porcelain line is under prefix."""
     path_part = status_line[3:]  # Skip "XY " status chars
@@ -325,6 +403,12 @@ async def revert_contamination(
             )
             if reset_result.returncode != 0:
                 return dataclasses.replace(report, reverted=False)
+        else:
+            await runner(
+                ["git", "reset", snapshot.head_sha],
+                cwd=Path(cwd),
+                timeout=_GIT_TIMEOUT,
+            )
         checkout_result = await runner(
             ["git", "checkout", "--", "."],
             cwd=Path(cwd),

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -237,6 +237,7 @@ async def validate_pre_session_index(
     """Reset dirty index state from prior sessions before a new session starts.
 
     Returns True if dirty state was found and reset, False if index was clean.
+    Raises RuntimeError if git infrastructure commands fail.
     Uses pre_session_sha for mixed reset when available; falls back to
     ``git rm --cached -r .`` on repos with no HEAD.
     """
@@ -246,7 +247,9 @@ async def validate_pre_session_index(
         timeout=_GIT_TIMEOUT,
     )
     if status_result.returncode != 0:
-        return False
+        raise RuntimeError(
+            f"git status failed (rc={status_result.returncode}): {status_result.stderr.strip()}"
+        )
     status_lines = [line for line in status_result.stdout.splitlines() if line.strip()]
     if exclude_prefix:
         status_lines = [
@@ -273,17 +276,26 @@ async def validate_pre_session_index(
             reset_sha = head_result.stdout.strip()
 
     if reset_sha:
-        await runner(
+        reset_result = await runner(
             ["git", "reset", reset_sha],
             cwd=Path(cwd),
             timeout=_GIT_TIMEOUT,
         )
     else:
-        await runner(
+        reset_result = await runner(
             ["git", "rm", "--cached", "-r", "."],
             cwd=Path(cwd),
             timeout=_GIT_TIMEOUT,
         )
+
+    if reset_result.returncode != 0:
+        logger.warning(
+            "pre_session_reset_failed",
+            returncode=reset_result.returncode,
+            stderr=reset_result.stderr.strip(),
+            strategy="sha" if reset_sha else "rm_cached",
+        )
+        return False
 
     await runner(
         ["git", "checkout", "--", "."],

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -297,16 +297,28 @@ async def validate_pre_session_index(
         )
         return False
 
-    await runner(
+    co_result = await runner(
         ["git", "checkout", "--", "."],
         cwd=Path(cwd),
         timeout=_GIT_TIMEOUT,
     )
-    await runner(
+    if co_result.returncode != 0:
+        logger.warning(
+            "pre_session_checkout_failed",
+            returncode=co_result.returncode,
+            stderr=co_result.stderr.strip(),
+        )
+    clean_result = await runner(
         ["git", "clean", "-fd"],
         cwd=Path(cwd),
         timeout=_GIT_TIMEOUT,
     )
+    if clean_result.returncode != 0:
+        logger.warning(
+            "pre_session_clean_failed",
+            returncode=clean_result.returncode,
+            stderr=clean_result.stderr.strip(),
+        )
 
     logger.info(
         "index_reset_pre_session",

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -28,6 +28,7 @@ from autoskillit.core import (
     collect_version_snapshot,
     get_logger,
     is_feature_enabled,
+    is_git_main_checkout,
     is_git_worktree,
     is_in_git_repo,
 )
@@ -41,6 +42,7 @@ from autoskillit.execution.clone_guard import (
     is_path_under_exclude,
     is_worktree_skill,
     snapshot_clone_state,
+    validate_pre_session_index,
 )
 from autoskillit.execution.headless._headless_evidence import (
     _build_error_path_telemetry,
@@ -192,6 +194,18 @@ async def _execute_claude_headless(
         and _clone_guard_policy.should_snapshot
     ):
         _clone_snapshot = await snapshot_clone_state(cwd, runner)
+
+    if not skip_clone_guard and is_git_main_checkout(Path(cwd)):
+        _pre_sha = _clone_snapshot.head_sha if _clone_snapshot else ""
+        try:
+            await validate_pre_session_index(
+                cwd,
+                runner,
+                pre_session_sha=_pre_sha,
+                exclude_prefix=_derived_prefix or GUARD_EXCLUDE_PREFIX,
+            )
+        except Exception:
+            logger.debug("validate_pre_session_index_failed", exc_info=True)
 
     _watch_dirs: list[Path] = list(write_watch_dirs) if write_watch_dirs else []
     if not _watch_dirs:

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -205,7 +205,7 @@ async def _execute_claude_headless(
                 exclude_prefix=_derived_prefix or GUARD_EXCLUDE_PREFIX,
             )
         except Exception:
-            logger.debug("validate_pre_session_index_failed", exc_info=True)
+            logger.warning("validate_pre_session_index_failed", exc_info=True)
 
     _watch_dirs: list[Path] = list(write_watch_dirs) if write_watch_dirs else []
     if not _watch_dirs:

--- a/src/autoskillit/recipe/_cmd_rpc_guards.py
+++ b/src/autoskillit/recipe/_cmd_rpc_guards.py
@@ -152,6 +152,20 @@ def _count_numstat_net(numstat_output: str) -> int:
     return total
 
 
+def _parse_numstat_per_file(numstat_output: str) -> dict[str, int]:
+    """Parse per-file net line changes from git diff --numstat output."""
+    result: dict[str, int] = {}
+    for line in numstat_output.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) < 3:
+            continue
+        try:
+            result[parts[2]] = int(parts[0]) - int(parts[1])
+        except ValueError:
+            continue
+    return result
+
+
 def _check_regression(
     worktree_path: str,
     files_to_add: list[str],
@@ -189,14 +203,13 @@ def _check_regression(
     if regression_lines <= 10:
         return None  # within tolerance
 
+    committed_per_file = _parse_numstat_per_file(committed_diff.stdout)
+    wt_per_file = _parse_numstat_per_file(wt_diff.stdout)
+
     reverted_files: list[str] = []
     for f in files_to_add:
-        c_diff = run_git(["diff", "--numstat", merge_base, "HEAD", "--", f], cwd=worktree_path)
-        w_diff = run_git(["diff", "--numstat", merge_base, "--", f], cwd=worktree_path)
-        if c_diff.returncode != 0 or w_diff.returncode != 0:
-            continue
-        c_net = _count_numstat_net(c_diff.stdout)
-        w_net = _count_numstat_net(w_diff.stdout)
+        c_net = committed_per_file.get(f, 0)
+        w_net = wt_per_file.get(f, 0)
         if c_net - w_net > 5:
             reverted_files.append(f)
 

--- a/src/autoskillit/recipe/_cmd_rpc_guards.py
+++ b/src/autoskillit/recipe/_cmd_rpc_guards.py
@@ -132,7 +132,78 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
     return {"cleaned": "true"}
 
 
-def commit_guard(worktree_path: str) -> dict[str, str]:
+def _count_numstat_net(numstat_output: str) -> int:
+    """Sum net line changes (insertions - deletions) from git diff --numstat output."""
+    total = 0
+    for line in numstat_output.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) < 2:
+            continue
+        try:
+            total += int(parts[0]) - int(parts[1])
+        except ValueError:
+            continue  # binary files show "-"
+    return total
+
+
+def _check_regression(
+    worktree_path: str,
+    files_to_add: list[str],
+    base_branch: str,
+) -> dict[str, str] | None:
+    """Detect if pending changes would revert implementation commits.
+
+    Returns a regression dict if the pending dirty files would net-revert
+    more than 10 implementation lines. Returns None to proceed normally.
+    """
+    mb = run_git(["merge-base", "HEAD", base_branch], cwd=worktree_path)
+    if mb.returncode != 0:
+        return None  # fresh repo, no merge-base
+    merge_base = mb.stdout.strip()
+
+    committed_diff = run_git(
+        ["diff", "--numstat", merge_base, "HEAD", "--"] + files_to_add,
+        cwd=worktree_path,
+    )
+    if committed_diff.returncode != 0:
+        return None
+    committed_net = _count_numstat_net(committed_diff.stdout)
+    if committed_net <= 0:
+        return None  # no implementation lines to protect
+
+    wt_diff = run_git(
+        ["diff", "--numstat", merge_base, "--"] + files_to_add,
+        cwd=worktree_path,
+    )
+    if wt_diff.returncode != 0:
+        return None
+    wt_net = _count_numstat_net(wt_diff.stdout)
+
+    regression_lines = committed_net - wt_net
+    if regression_lines <= 10:
+        return None  # within tolerance
+
+    reverted_files: list[str] = []
+    for f in files_to_add:
+        c_diff = run_git(["diff", "--numstat", merge_base, "HEAD", "--", f], cwd=worktree_path)
+        w_diff = run_git(["diff", "--numstat", merge_base, "--", f], cwd=worktree_path)
+        if c_diff.returncode != 0 or w_diff.returncode != 0:
+            continue
+        c_net = _count_numstat_net(c_diff.stdout)
+        w_net = _count_numstat_net(w_diff.stdout)
+        if c_net - w_net > 5:
+            reverted_files.append(f)
+
+    return {
+        "committed": "regression_detected",
+        "reverted_files": ", ".join(reverted_files),
+        "implementation_net": str(committed_net),
+        "working_tree_net": str(wt_net),
+        "regression_lines": str(regression_lines),
+    }
+
+
+def commit_guard(worktree_path: str, base_branch: str = "") -> dict[str, str]:
     """Auto-commit pending changes if worktree is dirty, excluding generated files."""
     result = subprocess.run(
         ["git", "status", "--porcelain=v1", "-z", "-uall"],
@@ -161,6 +232,11 @@ def commit_guard(worktree_path: str) -> dict[str, str]:
 
     if not files_to_add:
         return {"committed": "false"}
+
+    if base_branch:
+        regression = _check_regression(worktree_path, files_to_add, base_branch)
+        if regression is not None:
+            return regression
 
     run_git(["add", "--", *files_to_add], cwd=worktree_path, check=True)
     run_git(

--- a/src/autoskillit/recipe/_cmd_rpc_guards.py
+++ b/src/autoskillit/recipe/_cmd_rpc_guards.py
@@ -100,6 +100,7 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
             stash_result.returncode,
             stash_result.stderr.strip(),
         )
+        run_git(["reset", "HEAD"], cwd=clone_path)
         co = run_git(["checkout", "--", "."], cwd=clone_path)
         if co.returncode != 0:
             logger.warning(

--- a/src/autoskillit/recipe/_cmd_rpc_guards.py
+++ b/src/autoskillit/recipe/_cmd_rpc_guards.py
@@ -100,7 +100,13 @@ def main_repo_guard(clone_path: str) -> dict[str, str]:
             stash_result.returncode,
             stash_result.stderr.strip(),
         )
-        run_git(["reset", "HEAD"], cwd=clone_path)
+        reset_result = run_git(["reset", "HEAD"], cwd=clone_path)
+        if reset_result.returncode != 0:
+            logger.warning(
+                "git reset HEAD failed (rc=%d): %s",
+                reset_result.returncode,
+                reset_result.stderr.strip(),
+            )
         co = run_git(["checkout", "--", "."], cwd=clone_path)
         if co.returncode != 0:
             logger.warning(

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -201,7 +201,7 @@ def _check_hardcoded_origin_remote(ctx: ValidationContext) -> list[RuleFinding]:
 
 
 _BLIND_GIT_ADD_RE = re.compile(
-    r"(?:^|\s)git\s+(?:-C\s+\S+\s+)?add\s+(?:-A|--all|\.\s*(?:&&|;|\n|$))",
+    r"(?:^|\s)git\s+(?:-C\s+\S+\s+)?add\s+(?:-A|--all|\.\s*(?:#|&&|;|\n|$))",
 )
 
 

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -200,6 +200,56 @@ def _check_hardcoded_origin_remote(ctx: ValidationContext) -> list[RuleFinding]:
     return findings
 
 
+_BLIND_GIT_ADD_RE = re.compile(
+    r"git\s+(?:-C\s+\S+\s+)?add\s+(?:-A|--all|\.\s*(?:&&|;|\n|$))",
+)
+
+
+@semantic_rule(
+    name="blind-git-add-in-skill",
+    description=(
+        "SKILL.md bash block uses 'git add -A', 'git add --all', or 'git add .' which "
+        "stages all files including contamination from prior sessions. Use "
+        "'git add -- <file>' or 'git add -u' instead."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_blind_git_add_in_skill(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        if not skill_cmd:
+            continue
+        skill_name = resolve_skill_name(skill_cmd)
+        if skill_name is None:
+            continue
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
+        if skill_md is None:
+            continue
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        bash_blocks = extract_bash_blocks(content)
+        for block in bash_blocks:
+            for line in block.splitlines():
+                if _BLIND_GIT_ADD_RE.search(line):
+                    findings.append(
+                        RuleFinding(
+                            rule="blind-git-add-in-skill",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Skill '{skill_name}' SKILL.md contains blind "
+                                f"'git add' in bash block: {line.strip()!r}"
+                            ),
+                        )
+                    )
+    return findings
+
+
 _AUTOSKILLIT_IMPORT_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"^\s*from\s+autoskillit[\s.]", re.MULTILINE),
     re.compile(r"^\s*import\s+autoskillit[\s,.]", re.MULTILINE),

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -201,7 +201,7 @@ def _check_hardcoded_origin_remote(ctx: ValidationContext) -> list[RuleFinding]:
 
 
 _BLIND_GIT_ADD_RE = re.compile(
-    r"(?:^|\s)git\s+(?:-C\s+\S+\s+)?add\s+(?:-A|--all|\.\s*(?:#|&&|;|\n|$))",
+    r"(?:^|\s)git\s+(?:-C\s+\S+\s+)?add\s+(?:-A|--all|\.\s*(?:#|&&|;|$))",
 )
 
 

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -201,7 +201,7 @@ def _check_hardcoded_origin_remote(ctx: ValidationContext) -> list[RuleFinding]:
 
 
 _BLIND_GIT_ADD_RE = re.compile(
-    r"git\s+(?:-C\s+\S+\s+)?add\s+(?:-A|--all|\.\s*(?:&&|;|\n|$))",
+    r"(?:^|\s)git\s+(?:-C\s+\S+\s+)?add\s+(?:-A|--all|\.\s*(?:&&|;|\n|$))",
 )
 
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2626,6 +2626,9 @@ callable_contracts:
     - name: worktree_path
       type: str
       required: true
+    - name: base_branch
+      type: str
+      required: false
     outputs:
     - name: committed
       type: str

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -388,7 +388,8 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.commit_guard",
-        "worktree_path": "${{ context.worktree_path }}"
+        "worktree_path": "${{ context.worktree_path }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "on_success": "main_repo_guard",
       "on_failure": "main_repo_guard",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -364,6 +364,7 @@ steps:
     with:
       callable: "autoskillit.recipe._cmd_rpc.commit_guard"
       worktree_path: "${{ context.worktree_path }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_success: main_repo_guard
     on_failure: main_repo_guard
     note: >

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -450,7 +450,8 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.commit_guard",
-        "worktree_path": "${{ context.worktree_path }}"
+        "worktree_path": "${{ context.worktree_path }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "on_success": "main_repo_guard",
       "on_failure": "main_repo_guard",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -436,6 +436,7 @@ steps:
     with:
       callable: autoskillit.recipe._cmd_rpc.commit_guard
       worktree_path: ${{ context.worktree_path }}
+      base_branch: ${{ inputs.base_branch }}
     on_success: main_repo_guard
     on_failure: main_repo_guard
     note: 'Belt-and-suspenders guard: auto-commits any uncommitted changes before

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -613,7 +613,8 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.commit_guard",
-        "worktree_path": "${{ context.implementation_ref }}"
+        "worktree_path": "${{ context.implementation_ref }}",
+        "base_branch": "${{ inputs.base_branch }}"
       },
       "on_success": "main_repo_guard",
       "on_failure": "main_repo_guard",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -564,6 +564,7 @@ steps:
     with:
       callable: autoskillit.recipe._cmd_rpc.commit_guard
       worktree_path: ${{ context.implementation_ref }}
+      base_branch: ${{ inputs.base_branch }}
     on_success: main_repo_guard
     on_failure: main_repo_guard
     note: 'Belt-and-suspenders guard: auto-commits any uncommitted changes before

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -96,7 +96,7 @@ preserving whatever was written.
 
 **Before emitting structured output tokens:**
 1. Run `git -C {worktree_path} status --porcelain`
-2. If any files are dirty: `git -C {worktree_path} add -A && git -C {worktree_path} commit -m "chore: commit partial report before context limit"`
+2. If any files are dirty: `git -C {worktree_path} add -- <files you modified> && git -C {worktree_path} commit -m "chore: commit partial report before context limit"`
 3. Only then emit the structured output tokens
 
 This ensures the partial report is committed and the downstream test step can

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -72,7 +72,7 @@ commit protocol during the fix loop.
 
 **Before every test run and before emitting structured output tokens:**
 1. Run `git -C {worktree_path} status --porcelain`
-2. If any files are dirty: `git -C {worktree_path} add -A && git -C {worktree_path} commit -m "fix: commit pending changes before context limit"`
+2. If any files are dirty: `git -C {worktree_path} add -- <files you modified> && git -C {worktree_path} commit -m "fix: commit pending changes before context limit"`
 3. Only then proceed with the test or structured output
 
 This ensures that even if context exhaustion interrupts the fix loop, all applied
@@ -118,7 +118,8 @@ Read the configured test command(s) from `.autoskillit/config.yaml`: check `test
 ### Step 0.5: Commit Uncommitted Files
 1. Run `git -C {worktree_path} status --porcelain`
 2. If output is non-empty (dirty tree):
-   - Run `git -C {worktree_path} add -A`
+   - If more than 10 files are dirty, log a warning listing all files before staging
+   - Run `git -C {worktree_path} add -- <files you modified>` (never use `add -A`)
    - Run `git -C {worktree_path} commit -m "chore: commit auto-generated files"`
    - Log: "Committed {N} uncommitted file(s) before test run"
 3. If output is empty: continue (worktree is clean)
@@ -235,7 +236,7 @@ the failure could not be reproduced locally, which is a flaky-test signal.
 3. Commit ALL modified files (not just intentionally changed ones):
    a. If the project has pre-commit hooks, run `pre-commit run --all-files` first
    b. Run `git -C {worktree_path} status --porcelain` to capture the full set of modified files, including any auto-fixed by hooks
-   c. Stage and commit: `git -C {worktree_path} add -A && git -C {worktree_path} commit -m "fix: {what was wrong and why}"`
+   c. Stage and commit: `git -C {worktree_path} add -- <files you modified> && git -C {worktree_path} commit -m "fix: {what was wrong and why}"`
    d. Run `git -C {worktree_path} status --porcelain` again to verify the tree is clean; if any files remain dirty, stage and commit them too
 4. Write a fix log entry to `{{AUTOSKILLIT_TEMP}}/resolve-failures/` (relative to
    the current working directory) to satisfy the write_behavior contract

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -67,7 +67,7 @@ normal commit protocol.
 
 **Before every test run and before emitting structured output tokens:**
 1. Run `git -C {work_dir} status --porcelain`
-2. If any files are dirty: `git -C {work_dir} add -A && git -C {work_dir} commit -m "fix: commit pending review changes"`
+2. If any files are dirty: `git -C {work_dir} add -- <files you modified> && git -C {work_dir} commit -m "fix: commit pending review changes"`
 3. Only then proceed with the test or structured output
 
 This ensures that even if context exhaustion interrupts the fix loop, all applied

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -62,7 +62,7 @@ not yet committed. The recipe routes to `on_context_limit`, preserving the workt
 
 **Before emitting structured output tokens:**
 1. Run `git -C {WORKTREE_PATH} status --porcelain`
-2. If any files are dirty: `git -C {WORKTREE_PATH} add -A && git -C {WORKTREE_PATH} commit -m "chore: commit pending changes before context limit"`
+2. If any files are dirty: `git -C {WORKTREE_PATH} add -- <files you modified> && git -C {WORKTREE_PATH} commit -m "chore: commit pending changes before context limit"`
 3. Only then emit the `worktree_path`, `branch_name`, and `phases_implemented` tokens
 
 This ensures that all implementation progress is committed and the downstream

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -18,7 +18,7 @@ NEW_HEADLESS_MODULES = [
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 460,
     "headless/_headless_helpers.py": 175,
-    "headless/_headless_execute.py": 575,
+    "headless/_headless_execute.py": 590,
     "headless/_headless_recovery.py": 366,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -15,6 +15,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_ci.py` | L1 unit tests for execution/ci.py — CIWatcher service |
 | `test_ci_params.py` | Tests for CIRunScope query param composition and workflow scoping |
 | `test_clone_guard.py` | Tests for clone contamination guard — detect and revert direct changes |
+| `test_clone_guard_pre_session.py` | Tests for pre-session index validation and selective-revert staged-entry fix |
 | `test_clone_guard_policy.py` | Tests for CloneGuardPolicy construction and decision logic |
 | `test_headless_clone_guard_integration.py` | Integration tests — policy-based clone guard replaces _effective_readonly |
 | `test_conftest_import_guard.py` | Structural guard: conftest.py must not import merge_queue at module level |

--- a/tests/execution/test_clone_guard_pre_session.py
+++ b/tests/execution/test_clone_guard_pre_session.py
@@ -104,17 +104,12 @@ class _RealAsyncRunner:
                 pid=proc.pid,
             )
         return SubprocessResult(
-            returncode=proc.returncode if proc.returncode is not None else 0,
+            returncode=proc.returncode if proc.returncode is not None else -1,
             stdout=stdout_bytes.decode("utf-8", errors="replace"),
             stderr=stderr_bytes.decode("utf-8", errors="replace"),
             termination=TerminationReason.NATURAL_EXIT,
             pid=proc.pid,
         )
-
-
-# ---------------------------------------------------------------------------
-# Step 1: validate_pre_session_index
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
@@ -227,11 +222,6 @@ async def test_validate_pre_session_index_handles_no_commits_repo(tmp_path):
     assert _git_status(repo) == ""
 
 
-# ---------------------------------------------------------------------------
-# Step 2: selective revert clears staged-only entries
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.anyio
 async def test_selective_revert_clears_staged_only_entries(tmp_path):
     repo = tmp_path / "repo"
@@ -286,11 +276,6 @@ async def test_selective_revert_clears_staged_and_uncommitted(tmp_path):
 
     assert result.reverted
     assert _git_status(repo) == ""
-
-
-# ---------------------------------------------------------------------------
-# Step 4: cross-session contamination blocked end-to-end
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_clone_guard_pre_session.py
+++ b/tests/execution/test_clone_guard_pre_session.py
@@ -291,7 +291,5 @@ async def test_cross_session_contamination_blocked(tmp_path):
     await validate_pre_session_index(str(repo), runner)
 
     assert _git_status(repo) == ""
-    assert (
-        not (repo / "evil.py").exists()
-        or _git(["git", "ls-files", "--error-unmatch", "evil.py"], repo).returncode != 0
-    )
+    assert not (repo / "evil.py").exists()
+    assert _git(["git", "ls-files", "--error-unmatch", "evil.py"], repo).returncode != 0

--- a/tests/execution/test_clone_guard_pre_session.py
+++ b/tests/execution/test_clone_guard_pre_session.py
@@ -1,0 +1,312 @@
+"""Tests for pre-session index validation and selective-revert staged-entry fix."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autoskillit.core.types import SubprocessResult, TerminationReason
+from autoskillit.execution.clone_guard import (
+    CloneSnapshot,
+    ContaminationReport,
+    revert_contamination,
+    validate_pre_session_index,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
+
+_GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "test@test.local",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "test@test.local",
+}
+
+
+def _init_git_repo(repo_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True, env=_GIT_ENV)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.local"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(args, cwd=cwd, capture_output=True, env=_GIT_ENV)
+
+
+def _git_status(cwd: Path) -> str:
+    result = _git(["git", "status", "--porcelain"], cwd)
+    return result.stdout.decode().strip()
+
+
+def _head_sha(cwd: Path) -> str:
+    result = _git(["git", "rev-parse", "HEAD"], cwd)
+    return result.stdout.decode().strip()
+
+
+class _RealAsyncRunner:
+    """Async SubprocessRunner backed by asyncio.create_subprocess_exec."""
+
+    async def __call__(
+        self,
+        cmd: list[str],
+        *,
+        cwd: Path,
+        timeout: float,
+        env: Mapping[str, str] | None = None,
+        **kwargs: Any,
+    ) -> SubprocessResult:
+        run_env = dict(env) if env is not None else _GIT_ENV
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=run_env,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+        except TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            return SubprocessResult(
+                returncode=-1,
+                stdout="",
+                stderr="timeout",
+                termination=TerminationReason.TIMED_OUT,
+                pid=proc.pid,
+            )
+        return SubprocessResult(
+            returncode=proc.returncode if proc.returncode is not None else 0,
+            stdout=stdout_bytes.decode("utf-8", errors="replace"),
+            stderr=stderr_bytes.decode("utf-8", errors="replace"),
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=proc.pid,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 1: validate_pre_session_index
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_validate_pre_session_index_detects_dirty_index(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "somefile.py").write_text("original")
+    _git(["git", "add", "somefile.py"], repo)
+    _git(["git", "commit", "-m", "add file"], repo)
+    (repo / "somefile.py").write_text("modified")
+    _git(["git", "add", "somefile.py"], repo)
+
+    runner = _RealAsyncRunner()
+    result = await validate_pre_session_index(str(repo), runner)
+
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_validate_pre_session_index_clean_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    runner = _RealAsyncRunner()
+    result = await validate_pre_session_index(str(repo), runner)
+
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_validate_pre_session_index_clears_staged_only_entries(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "evil.py").write_text("contamination")
+    _git(["git", "add", "evil.py"], repo)
+
+    runner = _RealAsyncRunner()
+    await validate_pre_session_index(str(repo), runner)
+
+    assert _git_status(repo) == ""
+
+
+@pytest.mark.anyio
+async def test_validate_pre_session_index_clears_staged_and_modified(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "tracked.py").write_text("original")
+    _git(["git", "add", "tracked.py"], repo)
+    _git(["git", "commit", "-m", "add tracked"], repo)
+    (repo / "tracked.py").write_text("modified staged")
+    _git(["git", "add", "tracked.py"], repo)
+    (repo / "tracked.py").write_text("also unstaged change")
+    (repo / "new_untracked.py").write_text("new file")
+
+    runner = _RealAsyncRunner()
+    await validate_pre_session_index(str(repo), runner)
+
+    assert _git_status(repo) == ""
+
+
+@pytest.mark.anyio
+async def test_validate_pre_session_index_preserves_autoskillit_temp(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    autoskillit_dir = repo / ".autoskillit" / "temp"
+    autoskillit_dir.mkdir(parents=True)
+    (autoskillit_dir / "output.json").write_text("{}")
+    _git(["git", "add", ".autoskillit/"], repo)
+
+    runner = _RealAsyncRunner()
+    result = await validate_pre_session_index(str(repo), runner)
+
+    assert result is False
+    # The .autoskillit/ file remains staged
+    status = _git(["git", "status", "--porcelain"], repo).stdout.decode()
+    assert ".autoskillit" in status
+
+
+@pytest.mark.anyio
+async def test_validate_pre_session_index_handles_no_commits_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, env=_GIT_ENV)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.local"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    (repo / "staged.py").write_text("staged content")
+    _git(["git", "add", "staged.py"], repo)
+
+    runner = _RealAsyncRunner()
+    result = await validate_pre_session_index(str(repo), runner)
+
+    assert result is True
+    assert _git_status(repo) == ""
+
+
+# ---------------------------------------------------------------------------
+# Step 2: selective revert clears staged-only entries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_selective_revert_clears_staged_only_entries(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "somefile.py").write_text("original")
+    _git(["git", "add", "somefile.py"], repo)
+    _git(["git", "commit", "-m", "add file"], repo)
+    sha = _head_sha(repo)
+    (repo / "somefile.py").write_text("modified")
+    _git(["git", "add", "somefile.py"], repo)
+
+    snapshot = CloneSnapshot(head_sha=sha)
+    report = ContaminationReport(
+        pre_sha=sha,
+        post_sha=sha,
+        uncommitted_files=["M  somefile.py"],
+        direct_commits=False,
+        reverted=False,
+    )
+    runner = _RealAsyncRunner()
+    result = await revert_contamination(snapshot, report, str(repo), runner, selective=True)
+
+    assert result.reverted
+    assert _git_status(repo) == ""
+
+
+@pytest.mark.anyio
+async def test_selective_revert_clears_staged_and_uncommitted(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "a.py").write_text("original a")
+    (repo / "b.py").write_text("original b")
+    _git(["git", "add", "."], repo)
+    _git(["git", "commit", "-m", "add files"], repo)
+    sha = _head_sha(repo)
+    (repo / "a.py").write_text("modified a staged")
+    _git(["git", "add", "a.py"], repo)
+    (repo / "b.py").write_text("modified b unstaged")
+
+    snapshot = CloneSnapshot(head_sha=sha)
+    report = ContaminationReport(
+        pre_sha=sha,
+        post_sha=sha,
+        uncommitted_files=["M  a.py", " M b.py"],
+        direct_commits=False,
+        reverted=False,
+    )
+    runner = _RealAsyncRunner()
+    result = await revert_contamination(snapshot, report, str(repo), runner, selective=True)
+
+    assert result.reverted
+    assert _git_status(repo) == ""
+
+
+# ---------------------------------------------------------------------------
+# Step 4: cross-session contamination blocked end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cross_session_contamination_blocked(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    (repo / "evil.py").write_text("contamination")
+    _git(["git", "add", "evil.py"], repo)
+
+    runner = _RealAsyncRunner()
+    await validate_pre_session_index(str(repo), runner)
+
+    assert _git_status(repo) == ""
+    assert (
+        not (repo / "evil.py").exists()
+        or _git(["git", "ls-files", "--error-unmatch", "evil.py"], repo).returncode != 0
+    )

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -1010,11 +1010,6 @@ class TestReviewPathRebase:
             assert result == {"status": "conflicts"}
 
 
-# ---------------------------------------------------------------------------
-# commit_guard regression-check tests (Test 1a–1d)
-# ---------------------------------------------------------------------------
-
-
 def _init_git_repo_on_main(tmp_path: Path) -> None:
     """Init git repo with branch named 'main' and an initial empty commit."""
     subprocess.run(
@@ -1055,7 +1050,6 @@ def test_commit_guard_detects_regression(tmp_path: Path) -> None:
         capture_output=True,
         env=_GIT_ENV,
     )
-    # Add implementation: 3 files, 55 total lines
     (tmp_path / "module_a.py").write_text("\n".join(f"line_{i} = {i}" for i in range(20)) + "\n")
     (tmp_path / "module_b.py").write_text(
         "\n".join(f"x_{i} = 'value_{i}'" for i in range(20)) + "\n"
@@ -1075,7 +1069,6 @@ def test_commit_guard_detects_regression(tmp_path: Path) -> None:
         capture_output=True,
         env=_GIT_ENV,
     )
-    # Contaminate: overwrite files with minimal content (reverts ~52 lines)
     (tmp_path / "module_a.py").write_text("line_0 = 0\n")
     (tmp_path / "module_b.py").write_text("x_0 = 'value_0'\n")
     (tmp_path / "module_c.py").write_text("Y_0 = True\n")
@@ -1112,7 +1105,6 @@ def test_commit_guard_allows_normal_changes(tmp_path: Path) -> None:
         capture_output=True,
         env=_GIT_ENV,
     )
-    # Add 3 more lines — small incremental improvement, not a regression
     (tmp_path / "module_a.py").write_text(
         code_lines + "\nline_20 = 20\nline_21 = 21\nline_22 = 22\n"
     )

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -1008,3 +1008,136 @@ class TestReviewPathRebase:
             mock.return_value = {"status": "conflicts"}
             result = review_path_rebase(work_dir="/tmp/work", base_branch="main")
             assert result == {"status": "conflicts"}
+
+
+# ---------------------------------------------------------------------------
+# commit_guard regression-check tests (Test 1a–1d)
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo_on_main(tmp_path: Path) -> None:
+    """Init git repo with branch named 'main' and an initial empty commit."""
+    subprocess.run(
+        ["git", "init", "-b", "main"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.local"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+
+
+def test_commit_guard_detects_regression(tmp_path: Path) -> None:
+    """commit_guard must detect and refuse when pending changes revert implementation commits."""
+    _init_git_repo_on_main(tmp_path)
+    subprocess.run(
+        ["git", "checkout", "-b", "feature"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    # Add implementation: 3 files, 55 total lines
+    (tmp_path / "module_a.py").write_text("\n".join(f"line_{i} = {i}" for i in range(20)) + "\n")
+    (tmp_path / "module_b.py").write_text(
+        "\n".join(f"x_{i} = 'value_{i}'" for i in range(20)) + "\n"
+    )
+    (tmp_path / "module_c.py").write_text("\n".join(f"Y_{i} = True" for i in range(15)) + "\n")
+    subprocess.run(
+        ["git", "add", "--", "module_a.py", "module_b.py", "module_c.py"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "feat: add implementation"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    # Contaminate: overwrite files with minimal content (reverts ~52 lines)
+    (tmp_path / "module_a.py").write_text("line_0 = 0\n")
+    (tmp_path / "module_b.py").write_text("x_0 = 'value_0'\n")
+    (tmp_path / "module_c.py").write_text("Y_0 = True\n")
+    result = commit_guard(worktree_path=str(tmp_path), base_branch="main")
+    assert result["committed"] == "regression_detected", (
+        f"Expected regression_detected but got: {result}"
+    )
+    assert "reverted_files" in result
+
+
+def test_commit_guard_allows_normal_changes(tmp_path: Path) -> None:
+    """commit_guard must allow normal incremental changes after implementation commits."""
+    _init_git_repo_on_main(tmp_path)
+    subprocess.run(
+        ["git", "checkout", "-b", "feature"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    code_lines = "\n".join(f"line_{i} = {i}" for i in range(20))
+    (tmp_path / "module_a.py").write_text(code_lines + "\n")
+    subprocess.run(
+        ["git", "add", "--", "module_a.py"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "feat: add module_a"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    # Add 3 more lines — small incremental improvement, not a regression
+    (tmp_path / "module_a.py").write_text(
+        code_lines + "\nline_20 = 20\nline_21 = 21\nline_22 = 22\n"
+    )
+    result = commit_guard(worktree_path=str(tmp_path), base_branch="main")
+    assert result["committed"] == "true", (
+        f"Expected committed=true for normal changes but got: {result}"
+    )
+
+
+def test_commit_guard_skips_regression_check_without_base_branch(tmp_path: Path) -> None:
+    """commit_guard must commit normally when no base_branch is provided (backward compat)."""
+    _init_git_repo_on_main(tmp_path)
+    (tmp_path / "newfile.py").write_text("x = 1\n")
+    result = commit_guard(worktree_path=str(tmp_path))
+    assert result["committed"] == "true", (
+        f"Expected committed=true without base_branch but got: {result}"
+    )
+
+
+def test_commit_guard_skips_regression_no_implementation_commits(tmp_path: Path) -> None:
+    """commit_guard must commit normally when there are no implementation commits to protect."""
+    _init_git_repo_on_main(tmp_path)
+    # No feature branch divergence: merge-base == HEAD, committed_net == 0
+    (tmp_path / "new_file.py").write_text("x = 1\n")
+    result = commit_guard(worktree_path=str(tmp_path), base_branch="main")
+    assert result["committed"] == "true", (
+        f"Expected committed=true (no implementation commits) but got: {result}"
+    )

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -381,6 +381,44 @@ def test_main_repo_guard_post_clean_verify_on_stash_success(tmp_path):
     )
 
 
+@pytest.mark.medium
+def test_main_repo_guard_fallback_clears_staged_entries(tmp_path, monkeypatch):
+    """Stash-failure fallback path clears staged-only index entries via git reset HEAD."""
+    from autoskillit.core import run_git as real_run_git
+
+    _init_git_repo(tmp_path)
+    (tmp_path / "tracked.txt").write_text("original")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add tracked"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=_GIT_ENV,
+    )
+    (tmp_path / "tracked.txt").write_text("staged modification")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=tmp_path, check=True, capture_output=True)
+
+    def _stash_fails(args, **kwargs):
+        if args and args[0] == "stash":
+            return subprocess.CompletedProcess(
+                args=args, returncode=1, stdout="", stderr="stash failed"
+            )
+        return real_run_git(args, **kwargs)
+
+    monkeypatch.setattr("autoskillit.recipe._cmd_rpc_guards.run_git", _stash_fails)
+    result = main_repo_guard(clone_path=str(tmp_path))
+
+    assert result["cleaned"] == "force"
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert status.stdout.strip() == ""
+
+
 def test_export_local_bundle(tmp_path):
     source_dir = tmp_path / "source"
     source_dir.mkdir()

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -1134,3 +1134,110 @@ def test_reviews_post_regex_flag_before_path(tmp_path: Path) -> None:
         f"Rule must fire for 'gh api --method POST URL' form (flag before path). "
         f"Got findings: {rule_ids}"
     )
+
+
+# ---------------------------------------------------------------------------
+# blind-git-add-in-skill tests (Test 2a–2d)
+# ---------------------------------------------------------------------------
+
+_BLIND_GIT_ADD_RULE_ID = "blind-git-add-in-skill"
+
+
+def test_blind_git_add_in_skill_flagged(tmp_path: Path) -> None:
+    """blind-git-add-in-skill must fire for git add -A in a bash block."""
+    skill_dir = tmp_path / "bad-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # bad-skill
+
+            ### Step 1
+            ```bash
+            git -C {worktree_path} add -A && git -C {worktree_path} commit -m "save"
+            ```
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("bad-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    matching = [f for f in findings if f.rule == _BLIND_GIT_ADD_RULE_ID]
+    assert len(matching) >= 1, (
+        f"Expected blind-git-add-in-skill finding, got: {[f.rule for f in findings]}"
+    )
+    assert matching[0].severity == Severity.ERROR
+
+
+def test_scoped_git_add_in_skill_allowed(tmp_path: Path) -> None:
+    """blind-git-add-in-skill must NOT fire for scoped git add -- <file>."""
+    skill_dir = tmp_path / "good-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # good-skill
+
+            ### Step 1
+            ```bash
+            git add -- somefile.py
+            ```
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("good-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    assert _BLIND_GIT_ADD_RULE_ID not in [f.rule for f in findings]
+
+
+def test_git_add_u_in_skill_allowed(tmp_path: Path) -> None:
+    """blind-git-add-in-skill must NOT fire for git add -u (update-index is safe)."""
+    skill_dir = tmp_path / "update-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # update-skill
+
+            ### Step 1
+            ```bash
+            git add -u
+            ```
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("update-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    assert _BLIND_GIT_ADD_RULE_ID not in [f.rule for f in findings]
+
+
+def test_git_add_all_long_form_flagged(tmp_path: Path) -> None:
+    """blind-git-add-in-skill must fire for git add --all."""
+    skill_dir = tmp_path / "all-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """\
+            # all-skill
+
+            ### Step 1
+            ```bash
+            git add --all
+            ```
+            """
+        )
+    )
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill("all-skill", {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_rsc, "SKILL_SEARCH_DIRS", [tmp_path]):
+        findings = run_semantic_rules(recipe)
+    assert _BLIND_GIT_ADD_RULE_ID in [f.rule for f in findings]

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -18,6 +18,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_conflict_resolution_guards.py` | Structural guards for conflict resolution safeguards in SKILL.md files |
 | `test_deletion_regression_guards.py` | Structural guards for deletion regression detection in merge-pr and review-pr skills |
 | `test_dry_walkthrough_contracts.py` | Structural contracts for the dry-walkthrough historical regression check step |
+| `test_generate_report_guards.py` | Guards for generate-report SKILL.md: blind git add prevention |
 | `test_file_audit_issues_contracts.py` | Contract tests for file-audit-issues SKILL.md behavioral invariants |
 | `test_investigate_contracts.py` | Structural contracts for the investigate historical recurrence check step |
 | `test_investigate_deep_mode_contracts.py` | Structural contracts for the investigate deep analysis mode |
@@ -39,6 +40,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_resolve_failures_ci_aware.py` | Contract guards for resolve-failures CI-awareness: verdict decision tree |
 | `test_resolve_failures_guards.py` | Guards for resolve-failures SKILL.md: polling-cascade and output-bloat fixes |
 | `test_resolve_research_review_guards.py` | Behavioral guards for resolve-research-review/SKILL.md |
+| `test_resolve_review_guards.py` | Guards for resolve-review SKILL.md: blind git add prevention |
 | `test_resolve_review_diff_context_consumption.py` | Guards: resolve-review loads and uses diff_context handoff file from review-pr |
 | `test_resolve_review_diff_hunk_preference.py` | Guards: resolve-review Step 3.5 prefers diff_hunk over source file reads |
 | `test_resolve_review_duplicate_comments.py` | Resolve review duplicate comments guard |
@@ -48,6 +50,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_resolve_review_thread_resolution.py` | Resolve review thread resolution tests |
 | `test_resolve_review_token_optimizations.py` | Structural guards for resolve-review SKILL.md token-optimization edits |
 | `test_retired_skill_names.py` | Convention guard: RETIRED_SKILL_NAMES entries must not have live directories, must be lowercase, and runtime raises on retired skill |
+| `test_retry_worktree_guards.py` | Guards for retry-worktree SKILL.md: blind git add prevention |
 | `test_review_design_contracts.py` | Contract tests for review-design SKILL.md behavioral encoding |
 | `test_review_design_guards.py` | Guard tests for review-design SKILL.md — data_acquisition dimension |
 | `test_review_flag_marker.py` | Tests for the REVIEW-FLAG HTML comment marker used in resolve-review replies |

--- a/tests/skills/test_generate_report_guards.py
+++ b/tests/skills/test_generate_report_guards.py
@@ -8,6 +8,13 @@ SKILL_MD = pkg_root() / "skills_extended" / "generate-report" / "SKILL.md"
 
 
 def test_generate_report_no_blind_add() -> None:
-    """generate-report/SKILL.md must not contain blind 'git add -A'."""
+    """generate-report/SKILL.md must not contain any blind git add form."""
     text = SKILL_MD.read_text()
     assert "add -A" not in text, "generate-report/SKILL.md still contains 'add -A'"
+    assert "add --all" not in text, "generate-report/SKILL.md still contains 'add --all'"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "git add ." in stripped and "add -- " not in stripped:
+            raise AssertionError(
+                f"generate-report/SKILL.md contains blind 'git add .': {stripped!r}"
+            )

--- a/tests/skills/test_generate_report_guards.py
+++ b/tests/skills/test_generate_report_guards.py
@@ -1,0 +1,13 @@
+"""Guards for generate-report SKILL.md: blind git add prevention."""
+
+from __future__ import annotations
+
+from autoskillit.core.paths import pkg_root
+
+SKILL_MD = pkg_root() / "skills_extended" / "generate-report" / "SKILL.md"
+
+
+def test_generate_report_no_blind_add() -> None:
+    """generate-report/SKILL.md must not contain blind 'git add -A'."""
+    text = SKILL_MD.read_text()
+    assert "add -A" not in text, "generate-report/SKILL.md still contains 'add -A'"

--- a/tests/skills/test_resolve_failures_guards.py
+++ b/tests/skills/test_resolve_failures_guards.py
@@ -108,3 +108,18 @@ def test_resolve_failures_fix_loop_instructs_stdout_discard() -> None:
         "resolve-failures Step 3 must explicitly instruct discarding full pytest stdout "
         "after extracting failure info. This prevents context bloat across fix iterations."
     )
+
+
+# --- Blind git add guard ---
+
+
+def test_resolve_failures_no_blind_add() -> None:
+    """resolve-failures/SKILL.md must not use blind 'git add -A' as a command."""
+    text = _skill_text()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "add -A" in stripped and "never use" not in stripped.lower():
+            raise AssertionError(
+                f"resolve-failures/SKILL.md still uses 'add -A' as a command: {stripped!r}"
+            )
+    assert "add --" in text, "resolve-failures/SKILL.md should use scoped 'git add --'"

--- a/tests/skills/test_resolve_review_guards.py
+++ b/tests/skills/test_resolve_review_guards.py
@@ -8,6 +8,13 @@ SKILL_MD = pkg_root() / "skills_extended" / "resolve-review" / "SKILL.md"
 
 
 def test_resolve_review_no_blind_add() -> None:
-    """resolve-review/SKILL.md must not contain blind 'git add -A'."""
+    """resolve-review/SKILL.md must not contain any blind git add form."""
     text = SKILL_MD.read_text()
     assert "add -A" not in text, "resolve-review/SKILL.md still contains 'add -A'"
+    assert "add --all" not in text, "resolve-review/SKILL.md still contains 'add --all'"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "git add ." in stripped and "add -- " not in stripped:
+            raise AssertionError(
+                f"resolve-review/SKILL.md contains blind 'git add .': {stripped!r}"
+            )

--- a/tests/skills/test_resolve_review_guards.py
+++ b/tests/skills/test_resolve_review_guards.py
@@ -1,0 +1,13 @@
+"""Guards for resolve-review SKILL.md: blind git add prevention."""
+
+from __future__ import annotations
+
+from autoskillit.core.paths import pkg_root
+
+SKILL_MD = pkg_root() / "skills_extended" / "resolve-review" / "SKILL.md"
+
+
+def test_resolve_review_no_blind_add() -> None:
+    """resolve-review/SKILL.md must not contain blind 'git add -A'."""
+    text = SKILL_MD.read_text()
+    assert "add -A" not in text, "resolve-review/SKILL.md still contains 'add -A'"

--- a/tests/skills/test_retry_worktree_guards.py
+++ b/tests/skills/test_retry_worktree_guards.py
@@ -8,6 +8,13 @@ SKILL_MD = pkg_root() / "skills_extended" / "retry-worktree" / "SKILL.md"
 
 
 def test_retry_worktree_no_blind_add() -> None:
-    """retry-worktree/SKILL.md must not contain blind 'git add -A'."""
+    """retry-worktree/SKILL.md must not contain any blind git add form."""
     text = SKILL_MD.read_text()
     assert "add -A" not in text, "retry-worktree/SKILL.md still contains 'add -A'"
+    assert "add --all" not in text, "retry-worktree/SKILL.md still contains 'add --all'"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "git add ." in stripped and "add -- " not in stripped:
+            raise AssertionError(
+                f"retry-worktree/SKILL.md contains blind 'git add .': {stripped!r}"
+            )

--- a/tests/skills/test_retry_worktree_guards.py
+++ b/tests/skills/test_retry_worktree_guards.py
@@ -1,0 +1,13 @@
+"""Guards for retry-worktree SKILL.md: blind git add prevention."""
+
+from __future__ import annotations
+
+from autoskillit.core.paths import pkg_root
+
+SKILL_MD = pkg_root() / "skills_extended" / "retry-worktree" / "SKILL.md"
+
+
+def test_retry_worktree_no_blind_add() -> None:
+    """retry-worktree/SKILL.md must not contain blind 'git add -A'."""
+    text = SKILL_MD.read_text()
+    assert "add -A" not in text, "retry-worktree/SKILL.md still contains 'add -A'"


### PR DESCRIPTION
## Summary

Pipeline sessions inherit a contaminated git index from prior sessions because no pre-session validation exists at the execution layer. When a prior skill session stages files without committing, the next session inherits those staged files. Skills with blind `git add -A` instructions sweep contamination into commits.

Part A implements the primary execution-layer barriers:
1. **Pre-session index validation** — new `validate_pre_session_index()` in `clone_guard.py`, decoupled from `should_snapshot` so it covers `CLONE_COMMIT_SKILLS`
2. **Selective revert fix** — add `git reset <snapshot_sha>` to `revert_contamination(selective=True)` to clear staged-only entries
3. **`main_repo_guard` fallback fix** — add `git reset HEAD` to the stash-failure fallback path

## Problem

Commit `eac9d652` in PR #3086's worktree was supposed to fix only the `test_no_subpackage_exceeds_10_files` threshold (49→50) and a missing import. Instead it committed 67 files with 1,606 lines of deletions — sweeping in pre-staged index contamination from a prior pipeline step.

## Root Cause

The `resolve-merge-conflicts` session ran a diagnostic sequence that left the git index contaminated:
```bash
git stash && git checkout upstream/develop -- . 2>/dev/null; \
pre-commit run check-contract-freshness --all-files 2>&1; \
git checkout - -- . 2>/dev/null; git stash pop 2>/dev/null
```
- `git checkout upstream/develop -- .` staged ALL files from upstream/develop into the index
- `git checkout - -- .` was supposed to restore the index, but with stderr suppressed any failure was silently swallowed
- This left 50+ files staged with pre-Rectify versions (deletions relative to HEAD)

When the subsequent `resolve-failures` session started, its `git status` showed 50+ files already staged. Per SKILL.md Step 0.5, the agent committed them alongside its legitimate fixes.

## Impact

The contaminated commit deleted code from multiple recent Rectify PRs:
- `rules_merge.py` (86 lines), `rules_skill_content.py` (64 lines) — entire rule files removed
- `_cmd_rpc_guards.py` (102 lines), `test_cmd_rpc.py` (209 lines) — entire modules deleted
- `test_backend_protocol_completeness.py` (59 lines), `test_backend_protocol.py` (101 lines)
- `test_liveness.py` (120 lines reduced), `_liveness.py` (47 lines reduced)
- 40+ additional files with partial deletions

## Two Fixes Needed

1. **Immediate**: Clean up the contaminated branch
2. **Structural**: Prevent index contamination in pipeline handoffs — resolve-merge-conflicts should use `git stash push --keep-index` or explicit ref-based checkout instead of `-`, and resolve-failures SKILL.md Step 0.5 should warn/abort when the pre-staged file count is suspiciously high.

## Requirements

<!-- No additional requirements beyond the fix itself -->

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260528-232352-212742/.autoskillit/temp/rectify/rectify_pre_staged_index_contamination_2026-05-28_235500_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 63 | 10.3k | 875.8k | 126.9k | 340 | 57.2k | 7m 58s |
| rectify* | opus[1m] | 1 | 10.3k | 36.8k | 2.1M | 139.6k | 302 | 170.4k | 17m 50s |
| review_approach* | sonnet | 1 | 3.2k | 5.7k | 175.4k | 39.6k | 37 | 26.9k | 3m 14s |
| dry_walkthrough* | opus | 2 | 1.0k | 23.5k | 1.8M | 88.8k | 272 | 124.6k | 14m 35s |
| implement* | sonnet | 2 | 346 | 30.4k | 2.8M | 106.4k | 148 | 143.9k | 10m 10s |
| audit_impl* | sonnet | 3 | 236 | 30.1k | 937.4k | 70.9k | 124 | 127.4k | 11m 31s |
| post_run_diagnostics* | sonnet | 1 | 78 | 17.6k | 270.4k | 82.1k | 276 | 58.1k | 10m 31s |
| prepare_pr* | sonnet | 1 | 146.5k | 6.2k | 308.7k | 30.9k | 24 | 43.6k | 1m 47s |
| compose_pr* | sonnet | 1 | 80.3k | 2.2k | 275.0k | 30.9k | 21 | 15.5k | 45s |
| review_pr* | sonnet | 3 | 2.1k | 137.8k | 5.4M | 156.0k | 224 | 349.9k | 39m 20s |
| resolve_review* | opus | 3 | 233 | 82.7k | 9.3M | 130.4k | 281 | 409.3k | 46m 3s |
| resolve_pre_review_conflicts* | opus | 1 | 44 | 11.1k | 1.5M | 85.0k | 51 | 85.5k | 3m 8s |
| **Total** | | | 244.5k | 394.3k | 25.7M | 156.0k | | 1.6M | 2h 47m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 228 | 12253.3 | 631.3 | 133.1 |
| audit_impl | 0 | — | — | — |
| post_run_diagnostics | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 137 | 68016.0 | 2987.4 | 603.4 |
| resolve_pre_review_conflicts | 6082 | 251.8 | 14.1 | 1.8 |
| **Total** | **6447** | 3987.6 | 250.1 | 61.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 4 | 1.4k | 127.6k | 13.5M | 676.6k | 1h 11m |
| opus[1m] | 1 | 10.3k | 36.8k | 2.1M | 170.4k | 17m 50s |
| sonnet | 7 | 232.8k | 229.9k | 10.1M | 765.2k | 1h 17m |