### PR TITLE
[FIX] Rectify Interactive Session Launch Multi-Backend Injection (Part A)

### DIFF
--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -44,7 +44,34 @@ def _run_interactive_session(
         from autoskillit.config import load_config
         from autoskillit.execution import get_backend
 
-        backend = get_backend(load_config().agent_backend.backend)
+        config = load_config()
+        backend = get_backend(config.agent_backend.backend)
+
+        from autoskillit.core import is_feature_enabled
+        from autoskillit.core.types._type_constants_features import FEATURE_REGISTRY
+
+        for feat_name, feat_def in FEATURE_REGISTRY.items():
+            if (
+                feat_def.requires_backend_alignment
+                and config.agent_backend.backend != "claude-code"
+                and not is_feature_enabled(
+                    feat_name,
+                    config.features,
+                    experimental_enabled=config.experimental_enabled,
+                )
+            ):
+                from autoskillit.core import get_logger
+
+                get_logger(__name__).warning(
+                    "feature_gate_blocked",
+                    extra={
+                        "feature": feat_name,
+                        "backend": config.agent_backend.backend,
+                    },
+                )
+                backend = get_backend("claude-code")
+                break
+
     if shutil.which(backend.binary_name()) is None:
         print(
             f"ERROR: '{backend.binary_name()}' not found. "
@@ -55,35 +82,34 @@ def _run_interactive_session(
     from autoskillit.cli.ui._terminal import terminal_guard
     from autoskillit.core import (
         MARKETPLACE_PREFIX,
-        ClaudeFlags,
+        DirectInstall,
         InfraExitCategory,
-        NoResume,
         detect_autoskillit_mcp_prefix,
         pkg_root,
     )
 
     _project_dir = project_dir if project_dir is not None else Path.cwd()
+    if backend.capabilities.skill_injection_capable:
+        plugin_source = (
+            None
+            if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX
+            else DirectInstall(plugin_dir=pkg_root())
+        )
+        tools_arg: tuple[str, ...] = ("AskUserQuestion",)
+    else:
+        plugin_source = None
+        tools_arg = ()
+
     spec = backend.build_interactive_cmd(
         initial_prompt=initial_message,
         resume_spec=resume_spec if resume_spec is not None else NoResume(),
         system_prompt=system_prompt,
         env_extras=extra_env,
         required_env=required_env,
+        plugin_source=plugin_source,
+        tools=tools_arg,
     )
-    if backend.capabilities.skill_injection_capable:
-        plugin_flags = (
-            []
-            if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX
-            else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
-        )
-        cmd = [
-            *spec.cmd,
-            *plugin_flags,
-            ClaudeFlags.TOOLS,
-            "AskUserQuestion",
-        ]
-    else:
-        cmd = [*spec.cmd]
+    cmd = [*spec.cmd]
     with terminal_guard():
         result = subprocess.run(cmd, env=spec.env)
     reload_session_id = consume_reload_sentinel(_project_dir)
@@ -130,6 +156,7 @@ def _launch_cook_session(
     resume_spec: ResumeSpec = NoResume(),
     project_dir: Path | None = None,
     required_env: frozenset[str] | None = None,
+    backend: CodingAgentBackend | None = None,
 ) -> None:
     """Launch an interactive Claude Code cook session with reload and infra-resume support."""
     _max_reloads = 10
@@ -146,6 +173,7 @@ def _launch_cook_session(
             resume_spec=current_resume_spec,
             project_dir=project_dir,
             required_env=required_env,
+            backend=backend,
         )
         if session_signal is None:
             break

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -47,8 +47,7 @@ def _run_interactive_session(
         config = load_config()
         backend = get_backend(config.agent_backend.backend)
 
-        from autoskillit.core import is_feature_enabled
-        from autoskillit.core.types._type_constants_features import FEATURE_REGISTRY
+        from autoskillit.core import FEATURE_REGISTRY, is_feature_enabled
 
         for feat_name, feat_def in FEATURE_REGISTRY.items():
             if (

--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -146,6 +146,7 @@ class CodingAgentBackend(Protocol):
         system_prompt: str | None = None,
         env_extras: Mapping[str, str] | None = None,
         required_env: frozenset[str] | None = None,
+        tools: Sequence[str] = (),
     ) -> CmdSpec: ...
 
     def validate_session_layout(self, session_dir: Path) -> list[str]: ...

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -314,6 +314,7 @@ class ClaudeCodeBackend:
         system_prompt: str | None = None,
         env_extras: Mapping[str, str] | None = None,
         required_env: frozenset[str] | None = None,
+        tools: Sequence[str] = (),
     ) -> CmdSpec:
         """Build a Claude interactive session command.
 
@@ -376,6 +377,8 @@ class ClaudeCodeBackend:
                 pass
         for d in add_dirs:
             cmd += [ClaudeFlags.ADD_DIR, str(d)]
+        for t in tools:
+            cmd += [ClaudeFlags.TOOLS, t]
         if initial_prompt is not None:
             cmd.append(initial_prompt)
         merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -561,6 +561,7 @@ class CodexBackend:
         system_prompt: str | None = None,
         env_extras: Mapping[str, str] | None = None,
         required_env: frozenset[str] | None = None,
+        tools: Sequence[str] = (),
     ) -> CmdSpec:
         cmd: list[str] = []
         match resume_spec:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -563,6 +563,11 @@ class CodexBackend:
         required_env: frozenset[str] | None = None,
         tools: Sequence[str] = (),
     ) -> CmdSpec:
+        if tools:
+            logger.warning(
+                "codex_tools_ignored",
+                extra={"tools": list(tools)},
+            )
         cmd: list[str] = []
         match resume_spec:
             case NoResume():

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -57,6 +57,7 @@ def build_interactive_cmd(
     system_prompt: str | None = None,
     env_extras: Mapping[str, str] | None = None,
     required_env: frozenset[str] | None = None,
+    tools: Sequence[str] = (),
 ) -> ClaudeInteractiveCmd:
     """Deprecated shim. Use ClaudeCodeBackend().build_interactive_cmd() directly."""
     spec = ClaudeCodeBackend().build_interactive_cmd(
@@ -68,6 +69,7 @@ def build_interactive_cmd(
         system_prompt=system_prompt,
         env_extras=env_extras,
         required_env=required_env,
+        tools=tools,
     )
     return ClaudeInteractiveCmd(cmd=list(spec.cmd), env=spec.env)
 

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -14,6 +14,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_anyio_migration.py` | Regression guards for the asyncio→anyio migration (C-6) |
 | `test_arch_deselection.py` | Tests for diff-aware parametrized deselection — REQ-ARCH-004 |
 | `test_ast_rules.py` | Architectural enforcement: AST-based visitor rules (ARCH-001 through ARCH-009) |
+| `test_backend_flag_isolation.py` | AST guard: ClaudeFlags must not appear in _session_launch.py — backend-specific flags belong inside each backend's build_interactive_cmd() |
 | `test_backend_coherence.py` | Architectural tests for backend coherence enforcement |
 | `test_backend_command_path.py` | AST tests enforcing ctx.backend usage for command construction in headless path |
 | `test_backend_protocol_completeness.py` | Protocol completeness tests for CodingAgentBackend command builders |

--- a/tests/arch/test_backend_flag_isolation.py
+++ b/tests/arch/test_backend_flag_isolation.py
@@ -1,0 +1,42 @@
+"""Structural guard: ClaudeFlags must not appear in _session_launch.py.
+
+If this guard fires, a backend-specific flag has leaked into the CLI layer.
+Backend flag translation belongs in each backend's build_interactive_cmd().
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def _session_launch_source() -> str:
+    from autoskillit.core import paths
+
+    return (paths.pkg_root() / "cli" / "session" / "_session_launch.py").read_text()
+
+
+def test_claude_flags_not_referenced_in_session_launch() -> None:
+    """ClaudeFlags must not appear anywhere in _session_launch.py.
+
+    Backend-specific flag logic belongs inside each backend's
+    build_interactive_cmd(), not in the CLI dispatch layer.
+    """
+    source = _session_launch_source()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == "ClaudeFlags":
+            pytest.fail(
+                "ClaudeFlags referenced in _session_launch.py — "
+                "backend-specific flags must live inside the backend's "
+                "build_interactive_cmd(), not in the CLI layer."
+            )
+        if isinstance(node, ast.Attribute) and node.attr == "ClaudeFlags":
+            pytest.fail(
+                "ClaudeFlags referenced in _session_launch.py — "
+                "backend-specific flags must live inside the backend's "
+                "build_interactive_cmd(), not in the CLI layer."
+            )

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -812,9 +812,19 @@ def test_cli_session_launch_gates_backend_alignment_features() -> None:
     if not alignment_features:
         pytest.skip("No requires_backend_alignment features in registry")
 
-    session_launch_src = (paths.pkg_root() / "cli" / "session" / "_session_launch.py").read_text()
+    import ast
 
-    assert "is_feature_enabled" in session_launch_src, (
-        "_session_launch.py must contain is_feature_enabled to gate CLI-path access "
-        f"for backend-alignment features: {alignment_features}"
+    session_launch_path = paths.pkg_root() / "cli" / "session" / "_session_launch.py"
+    tree = ast.parse(session_launch_path.read_text(), filename=str(session_launch_path))
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "is_feature_enabled"
+    ]
+    assert calls, (
+        "_session_launch.py must contain an is_feature_enabled() call to gate CLI-path "
+        f"access for backend-alignment features: {alignment_features}"
     )

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -796,3 +796,25 @@ def test_build_features_dict_warns_enabling_deprecated_feature(monkeypatch):
     with pytest.warns(DeprecationWarning, match="test_depr_cfg"):
         result, _ = AutomationConfig._build_features_dict({"test_depr_cfg": True})
     assert result["test_depr_cfg"] is True
+
+
+def test_cli_session_launch_gates_backend_alignment_features() -> None:
+    """For every FEATURE_REGISTRY entry with requires_backend_alignment=True,
+    _session_launch.py must contain an is_feature_enabled call.
+
+    This ensures future experimental backends automatically get CLI-path gates,
+    not just the server path gate in _factory.py.
+    """
+    from autoskillit.core import paths
+    from autoskillit.core.types._type_constants_features import FEATURE_REGISTRY
+
+    alignment_features = [k for k, v in FEATURE_REGISTRY.items() if v.requires_backend_alignment]
+    if not alignment_features:
+        pytest.skip("No requires_backend_alignment features in registry")
+
+    session_launch_src = (paths.pkg_root() / "cli" / "session" / "_session_launch.py").read_text()
+
+    assert "is_feature_enabled" in session_launch_src, (
+        "_session_launch.py must contain is_feature_enabled to gate CLI-path access "
+        f"for backend-alignment features: {alignment_features}"
+    )

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -261,14 +261,13 @@ def test_skill_injection_disabled_omits_flags(monkeypatch: pytest.MonkeyPatch) -
     assert build_kwargs[0]["system_prompt"] == "test"
 
 
-def test_skill_injection_enabled_preserves_flags(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When skill_injection_capable=True, tools flag is present and system_prompt forwarded."""
+def test_skill_injection_enabled_passes_tools_to_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When skill_injection_capable=True, tools=('AskUserQuestion',) is passed to
+    build_interactive_cmd and system_prompt is forwarded."""
     backend, captured_kwargs = _make_capturing_backend()
-    captured = _capture_subprocess(monkeypatch)
+    _capture_subprocess(monkeypatch)
     _run_interactive_session(system_prompt="test", backend=backend)
-    assert ClaudeFlags.TOOLS in captured["cmd"]
-    idx = captured["cmd"].index(ClaudeFlags.TOOLS)
-    assert captured["cmd"][idx + 1] == "AskUserQuestion"
+    assert captured_kwargs[0]["tools"] == ("AskUserQuestion",)
     assert captured_kwargs[0]["system_prompt"] == "test"
 
 
@@ -482,3 +481,201 @@ def test_skill_injection_false_via_get_backend_forwards_system_prompt_kwarg(
     monkeypatch.setattr(subprocess, "run", mock_run)
     _run_interactive_session(system_prompt="sentinel")
     assert build_kwargs[0]["system_prompt"] == "sentinel"
+
+
+# ---------------------------------------------------------------------------
+# T-1a: Injection mismatch — skill_injection_capable=True, binary_name="codex"
+# ---------------------------------------------------------------------------
+
+
+def test_codex_like_backend_no_claude_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A backend with skill_injection_capable=True but binary_name='codex' must not receive
+    Claude-specific flags (--plugin-dir / --tools AskUserQuestion) in the subprocess command."""
+    from autoskillit.core import BackendCapabilities, CmdSpec
+
+    caps = BackendCapabilities(
+        channel_b_capable=False,
+        pty_required=True,
+        session_resume_capable=True,
+        skill_injection_capable=True,
+        supports_thinking_blocks=False,
+        supports_claude_format_stdout=False,
+        exit_code_is_terminal=True,
+        mcp_config_capable=False,
+        food_truck_capable=False,
+        completion_record_types=frozenset(),
+        session_record_types=frozenset(),
+    )
+
+    class _CodexLikeBackend:
+        def binary_name(self) -> str:
+            return "codex"
+
+        @property
+        def capabilities(self):
+            return caps
+
+        def build_interactive_cmd(self, **kwargs):
+            return CmdSpec(cmd=("codex", "--dangerously-bypass-approvals-and-sandbox"), env={})
+
+    captured: dict = {}
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/codex")
+
+    def mock_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    _run_interactive_session(system_prompt="test", backend=_CodexLikeBackend())
+    assert ClaudeFlags.PLUGIN_DIR not in captured["cmd"]
+    assert ClaudeFlags.TOOLS not in captured["cmd"]
+    assert "AskUserQuestion" not in captured["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# T-1b: Feature flag gate — codex backend without codex_backend feature enabled
+# ---------------------------------------------------------------------------
+
+
+def test_feature_flag_gate_blocks_codex_backend_without_feature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When config specifies backend='codex' but codex_backend feature is disabled,
+    _run_interactive_session falls back to claude-code backend."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import CmdSpec
+
+    backends_used: list[str] = []
+
+    class _ClaudeStub:
+        def binary_name(self) -> str:
+            return "claude"
+
+        @property
+        def capabilities(self):
+            from autoskillit.core import CLAUDE_CODE_CAPABILITIES
+
+            return CLAUDE_CODE_CAPABILITIES
+
+        def build_interactive_cmd(self, **kwargs):
+            backends_used.append("claude-code")
+            return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+    class _CodexStub:
+        def binary_name(self) -> str:
+            return "codex"
+
+        @property
+        def capabilities(self):
+            from autoskillit.core import BackendCapabilities
+
+            return BackendCapabilities(
+                channel_b_capable=False,
+                pty_required=True,
+                session_resume_capable=True,
+                skill_injection_capable=True,
+                supports_thinking_blocks=False,
+                supports_claude_format_stdout=False,
+                exit_code_is_terminal=True,
+                mcp_config_capable=False,
+                food_truck_capable=False,
+                completion_record_types=frozenset(),
+                session_record_types=frozenset(),
+            )
+
+        def build_interactive_cmd(self, **kwargs):
+            backends_used.append("codex")
+            return CmdSpec(cmd=("codex", "--dangerously-bypass-approvals-and-sandbox"), env={})
+
+    mock_config = MagicMock()
+    mock_config.agent_backend.backend = "codex"
+    mock_config.features = {}
+    mock_config.experimental_enabled = False
+
+    def fake_get_backend(name: str):
+        if name == "claude-code":
+            return _ClaudeStub()
+        return _CodexStub()
+
+    monkeypatch.setattr("autoskillit.config.load_config", lambda: mock_config)
+    monkeypatch.setattr("autoskillit.execution.get_backend", fake_get_backend)
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **kw: type("Result", (), {"returncode": 0})()
+    )
+    _run_interactive_session(system_prompt="test")
+    assert backends_used == ["claude-code"], (
+        f"Expected fallback to claude-code, got: {backends_used}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T-1c: _launch_cook_session accepts backend= parameter
+# ---------------------------------------------------------------------------
+
+
+def test_launch_cook_session_accepts_backend_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_launch_cook_session must accept a backend= kwarg and forward it to
+    _run_interactive_session, which calls backend.build_interactive_cmd."""
+    from autoskillit.cli.session._session_launch import _launch_cook_session
+    from autoskillit.core import CLAUDE_CODE_CAPABILITIES, CmdSpec
+
+    build_calls: list[dict] = []
+
+    class _CapturingBackend:
+        def binary_name(self) -> str:
+            return "claude"
+
+        @property
+        def capabilities(self):
+            return CLAUDE_CODE_CAPABILITIES
+
+        def build_interactive_cmd(self, **kwargs):
+            build_calls.append(kwargs)
+            return CmdSpec(cmd=("claude", "--dangerously-skip-permissions"), env={})
+
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **kw: type("Result", (), {"returncode": 0})()
+    )
+    _stub_plugin_installed(monkeypatch, installed=True)
+    _launch_cook_session(system_prompt="test", backend=_CapturingBackend())
+    assert build_calls, "backend.build_interactive_cmd must be called via _launch_cook_session"
+
+
+# ---------------------------------------------------------------------------
+# T-1d: Multi-backend integration contract — no cross-backend flag contamination
+# ---------------------------------------------------------------------------
+
+
+def test_multi_backend_no_cross_flag_contamination(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each backend in BACKEND_REGISTRY must not produce flags from other backends."""
+    from autoskillit.core import ClaudeFlags
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    captured: dict = {}
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/fake-agent")
+
+    def mock_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    _stub_plugin_installed(monkeypatch, installed=False)
+
+    for backend_name, backend_cls in BACKEND_REGISTRY.items():
+        backend = backend_cls()
+        captured.clear()
+        _run_interactive_session(system_prompt="test", backend=backend)
+        cmd = captured.get("cmd", [])
+        assert cmd[0] == backend.binary_name(), (
+            f"{backend_name}: cmd must start with binary_name(), got {cmd[0]!r}"
+        )
+        if backend.binary_name() != "claude":
+            assert ClaudeFlags.PLUGIN_DIR not in cmd, (
+                f"{backend_name}: must not contain {ClaudeFlags.PLUGIN_DIR!r}"
+            )
+            assert ClaudeFlags.TOOLS not in cmd, (
+                f"{backend_name}: must not contain {ClaudeFlags.TOOLS!r}"
+            )

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -507,6 +507,8 @@ def test_codex_like_backend_no_claude_flags(monkeypatch: pytest.MonkeyPatch) -> 
         session_record_types=frozenset(),
     )
 
+    build_kwargs: list[dict] = []
+
     class _CodexLikeBackend:
         def binary_name(self) -> str:
             return "codex"
@@ -516,6 +518,7 @@ def test_codex_like_backend_no_claude_flags(monkeypatch: pytest.MonkeyPatch) -> 
             return caps
 
         def build_interactive_cmd(self, **kwargs):
+            build_kwargs.append(kwargs)
             return CmdSpec(cmd=("codex", "--dangerously-bypass-approvals-and-sandbox"), env={})
 
     captured: dict = {}
@@ -530,6 +533,10 @@ def test_codex_like_backend_no_claude_flags(monkeypatch: pytest.MonkeyPatch) -> 
     assert ClaudeFlags.PLUGIN_DIR not in captured["cmd"]
     assert ClaudeFlags.TOOLS not in captured["cmd"]
     assert "AskUserQuestion" not in captured["cmd"]
+    assert build_kwargs, "build_interactive_cmd must be called"
+    assert build_kwargs[0].get("tools") == ("AskUserQuestion",), (
+        "skill_injection_capable=True backend must receive tools=('AskUserQuestion',)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -607,6 +614,60 @@ def test_feature_flag_gate_blocks_codex_backend_without_feature(
     _run_interactive_session(system_prompt="test")
     assert backends_used == ["claude-code"], (
         f"Expected fallback to claude-code, got: {backends_used}"
+    )
+
+
+def test_feature_flag_gate_allows_codex_backend_when_feature_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When config specifies backend='codex' and codex_backend feature is enabled,
+    _run_interactive_session uses the codex backend (no fallback)."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import CmdSpec
+
+    backends_used: list[str] = []
+
+    class _CodexStub:
+        def binary_name(self) -> str:
+            return "codex"
+
+        @property
+        def capabilities(self):
+            from autoskillit.core import BackendCapabilities
+
+            return BackendCapabilities(
+                channel_b_capable=False,
+                pty_required=True,
+                session_resume_capable=True,
+                skill_injection_capable=True,
+                supports_thinking_blocks=False,
+                supports_claude_format_stdout=False,
+                exit_code_is_terminal=True,
+                mcp_config_capable=False,
+                food_truck_capable=False,
+                completion_record_types=frozenset(),
+                session_record_types=frozenset(),
+            )
+
+        def build_interactive_cmd(self, **kwargs):
+            backends_used.append("codex")
+            return CmdSpec(cmd=("codex", "--dangerously-bypass-approvals-and-sandbox"), env={})
+
+    mock_config = MagicMock()
+    mock_config.agent_backend.backend = "codex"
+    mock_config.features = {"codex_backend": True}
+    mock_config.experimental_enabled = True
+
+    monkeypatch.setattr("autoskillit.config.load_config", lambda: mock_config)
+    monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: _CodexStub())
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/codex")
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **kw: type("Result", (), {"returncode": 0})()
+    )
+    _run_interactive_session(system_prompt="test")
+    assert backends_used == ["codex"], (
+        f"Expected codex backend when feature enabled, got: {backends_used}"
     )
 
 

--- a/tests/core/test_backend_protocols.py
+++ b/tests/core/test_backend_protocols.py
@@ -137,6 +137,7 @@ def test_stub_class_satisfies_coding_agent_backend():
             system_prompt: str | None = None,
             env_extras: Mapping[str, str] | None = None,
             required_env: frozenset[str] | None = None,
+            tools: Sequence[str] = (),
         ) -> CmdSpec: ...
 
         def validate_session_layout(self, session_dir: Path) -> list[str]: ...


### PR DESCRIPTION
## Summary

Three tightly coupled bugs in `_session_launch.py` stem from a single architectural weakness: **backend-specific CLI flag logic lives outside the backend abstraction boundary**. The `_run_interactive_session()` function checks the backend-agnostic `skill_injection_capable` flag, then unconditionally appends Claude-specific CLI flags (`--plugin-dir`, `--tools AskUserQuestion`). When `CodexBackend` flows through this path — correctly declaring `skill_injection_capable=True` because it delivers skills via `CODEX_HOME` — the appended Claude flags crash the `codex` binary. Additionally, the CLI `order` path bypasses the `codex_backend` experimental feature flag gate that the MCP server path enforces, and `_launch_cook_session()` lacks a `backend=` parameter for test injection.

Part A addresses: the injection mismatch (Bug 1), the protocol gap that caused it, the feature flag bypass (Bug 2), and the `backend=` forwarding gap. Part B will cover broader `BackendCapabilities` naming audit and cross-cutting integration test infrastructure for multi-backend session paths.

Closes #3270

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260529-130051-055276/.autoskillit/temp/rectify/rectify_interactive_session_launch_multi_backend_2026-05-29_140000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 48 | 7.1k | 442.8k | 96.2k | 105 | 38.6k | 5m 9s |
| rectify* | opus[1m] | 1 | 72 | 24.4k | 3.0M | 115.1k | 190 | 108.4k | 21m 21s |
| review_approach* | sonnet | 1 | 52 | 6.5k | 176.1k | 42.1k | 42 | 31.9k | 3m 12s |
| dry_walkthrough* | opus | 1 | 54 | 11.9k | 1.5M | 71.1k | 170 | 56.8k | 7m 31s |
| implement* | sonnet | 1 | 1.1k | 27.5k | 4.2M | 102.5k | 160 | 88.8k | 8m 32s |
| audit_impl* | sonnet | 1 | 68 | 8.8k | 239.9k | 41.1k | 26 | 37.0k | 3m 34s |
| prepare_pr* | sonnet | 1 | 89.6k | 3.7k | 249.8k | 36.3k | 23 | 27.0k | 1m 21s |
| compose_pr* | sonnet | 1 | 70.4k | 1.6k | 275.3k | 30.9k | 21 | 15.4k | 50s |
| review_pr* | sonnet | 1 | 198 | 35.8k | 1.3M | 95.6k | 96 | 82.6k | 9m 39s |
| resolve_review* | opus | 1 | 42 | 12.6k | 1.7M | 89.3k | 53 | 126.4k | 9m 9s |
| **Total** | | | 161.6k | 139.9k | 13.0M | 115.1k | | 612.9k | 1h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 344 | 12070.2 | 258.1 | 79.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 84 | 19777.9 | 1505.0 | 149.8 |
| **Total** | **428** | 30462.5 | 1432.1 | 326.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 3 | 144 | 31.6k | 3.6M | 221.9k | 21m 50s |
| opus[1m] | 1 | 72 | 24.4k | 3.0M | 108.4k | 21m 21s |
| sonnet | 6 | 161.4k | 83.9k | 6.4M | 282.6k | 27m 11s |