### PR TITLE
[FIX] Rectify Merge Gate Flake Loop — Architectural Immunity (Part A)

### DIFF
--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -134,6 +134,7 @@ from autoskillit.recipe.rules import (  # noqa: E402
 )
 from autoskillit.recipe.rules import rules_features as _rules_features  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_fixing as _rules_fixing  # noqa: E402 F401
+from autoskillit.recipe.rules import rules_flake_loop as _rules_flake_loop  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_food_truck as _rules_food_truck  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_graph as _rules_graph  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_graph_output as _rules_graph_output  # noqa: E402 F401
@@ -144,6 +145,9 @@ from autoskillit.recipe.rules import rules_inputs as _rules_inputs  # noqa: E402
 from autoskillit.recipe.rules import rules_isolation as _rules_isolation  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_loop_progress as _rules_loop_progress  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_merge as _rules_merge  # noqa: E402 F401
+from autoskillit.recipe.rules import (  # noqa: E402 F401
+    rules_merge_context as _rules_merge_context,
+)
 from autoskillit.recipe.rules import rules_merge_queue as _rules_merge_queue  # noqa: E402 F401
 from autoskillit.recipe.rules import (  # noqa: E402
     rules_optional_capture as _rules_optional_capture,  # noqa: F401

--- a/src/autoskillit/recipe/_rule_helpers.py
+++ b/src/autoskillit/recipe/_rule_helpers.py
@@ -17,6 +17,16 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_SKILL_CMD_PATTERN = re.compile(r"/(?:autoskillit:)?([\w-]+)")
+_ARG_TOKEN_PATTERN = re.compile(r"\$\{\{[^}]+\}\}|[^\s]+")
+
+
+def count_skill_args(skill_command: str) -> int:
+    """Count positional args in a skill_command after the skill name."""
+    tokens = _ARG_TOKEN_PATTERN.findall(skill_command)
+    return max(0, len(tokens) - 1)
+
+
 # Maximum hops for BFS push-reachability checks.
 _MAX_HOPS = 6
 

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (48 rule files).
+Semantic validation rule modules for recipe analysis (50 rule files).
 
 ## Files
 
@@ -28,6 +28,7 @@ Semantic validation rule modules for recipe analysis (48 rule files).
 | `rules_dataflow_handoff.py` | Implicit handoff, uncaptured consumer, merge cleanup, stale ref |
 | `rules_dataflow_multipart.py` | Multi-part recipe iteration notes validation |
 | `rules_features.py` | Feature-gated tool/skill reference validation |
+| `rules_flake_loop.py` | Flake-suspected unwinnable loop detection for merge gate cycles |
 | `rules_food_truck.py` | Food-truck recipe validation: sentinel stop step requirement |
 | `rules_fixing.py` | Conditional-write skill must gate on declared verdict output |
 | `rules_graph.py` | Unbounded cycle detection (DFS) |
@@ -38,6 +39,7 @@ Semantic validation rule modules for recipe analysis (48 rule files).
 | `rules_inputs.py` | Input/ingredient validation; version compatibility checks; condition-value-domain checks |
 | `rules_isolation.py` | Workspace isolation rules (prevents operating on source repo) |
 | `rules_merge.py` | `merge_worktree` routing completeness |
+| `rules_merge_context.py` | Merge gate test output context forwarding enforcement |
 | `rules_merge_queue.py` | Merge queue push routing: `queued_branch` error route enforcement |
 | `rules_optional_capture.py` | Optional capture guard enforcement: detect steps with optional output patterns routing to consumers without a truthiness guard |
 | `rules_packs.py` | Pack validation (names must exist in `PACK_REGISTRY`) |
@@ -58,4 +60,4 @@ Semantic validation rule modules for recipe analysis (48 rule files).
 
 ## Architecture Notes
 
-Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 48 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.
+Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 50 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.

--- a/src/autoskillit/recipe/rules/rules_flake_loop.py
+++ b/src/autoskillit/recipe/rules/rules_flake_loop.py
@@ -1,0 +1,88 @@
+"""Semantic rules for flake-suspected unwinnable loop detection in merge gate cycles."""
+
+from __future__ import annotations
+
+import regex as re
+
+from autoskillit.core import Severity, get_logger
+from autoskillit.recipe._analysis import ValidationContext, bfs_reachable
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+logger = get_logger(__name__)
+
+_SKILL_CMD_PATTERN = re.compile(r"/(?:autoskillit:)?([\w-]+)")
+_ARG_TOKEN_PATTERN = re.compile(r"\$\{\{[^}]+\}\}|[^\s]+")
+
+
+def _count_skill_args(skill_command: str) -> int:
+    """Count positional args in a skill_command after the skill name."""
+    tokens = _ARG_TOKEN_PATTERN.findall(skill_command)
+    return max(0, len(tokens) - 1)
+
+
+@semantic_rule(
+    name="flake-suspected-unwinnable-loop",
+    description=(
+        "A run_skill step invoking resolve-failures routes flake_suspected to a step "
+        "that is part of a cycle passing through a merge_worktree step, AND the "
+        "resolve-failures invocation has no failure context arguments (only 3 args: "
+        "worktree, plan, branch). Without failure context, resolve-failures cannot "
+        "investigate the specific failing tests, always produces flake_suspected, "
+        "and the merge gate retry loop is structurally unwinnable on non-reproducible flakes."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_flake_suspected_unwinnable_loop(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+
+        cmd = step.with_args.get("skill_command", "")
+        m = _SKILL_CMD_PATTERN.search(cmd)
+        if not m or m.group(1) != "resolve-failures":
+            continue
+
+        flake_target: str | None = None
+        if step.on_result and step.on_result.conditions:
+            for cond in step.on_result.conditions:
+                if cond.when and "flake_suspected" in cond.when:
+                    flake_target = cond.route
+                    break
+
+        if flake_target is None:
+            continue
+
+        reachable = bfs_reachable(ctx.step_graph, flake_target)
+        reachable.add(flake_target)
+
+        merge_in_cycle = any(
+            ctx.recipe.steps.get(r) is not None and ctx.recipe.steps[r].tool == "merge_worktree"
+            for r in reachable
+        )
+
+        if not merge_in_cycle:
+            continue
+
+        if _count_skill_args(cmd) <= 3:
+            findings.append(
+                RuleFinding(
+                    rule="flake-suspected-unwinnable-loop",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' invokes resolve-failures with only "
+                        f"{_count_skill_args(cmd)} positional arg(s) and routes "
+                        f"flake_suspected → '{flake_target}', which leads back through "
+                        f"a merge_worktree step. Without failure context (ci_conclusion + "
+                        f"diagnosis_path), resolve-failures cannot diagnose the specific "
+                        f"failing tests, will always produce flake_suspected on a local-pass "
+                        f"flake, and the loop is unwinnable. Add a diagnose_merge_gate step "
+                        f"before this step and expand skill_command to 6 args including "
+                        f"merge_gate_ci_conclusion and merge_gate_diagnosis_path."
+                    ),
+                )
+            )
+
+    return findings

--- a/src/autoskillit/recipe/rules/rules_flake_loop.py
+++ b/src/autoskillit/recipe/rules/rules_flake_loop.py
@@ -2,22 +2,12 @@
 
 from __future__ import annotations
 
-import regex as re
-
 from autoskillit.core import Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext, bfs_reachable
+from autoskillit.recipe._rule_helpers import _SKILL_CMD_PATTERN, count_skill_args
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
-
-_SKILL_CMD_PATTERN = re.compile(r"/(?:autoskillit:)?([\w-]+)")
-_ARG_TOKEN_PATTERN = re.compile(r"\$\{\{[^}]+\}\}|[^\s]+")
-
-
-def _count_skill_args(skill_command: str) -> int:
-    """Count positional args in a skill_command after the skill name."""
-    tokens = _ARG_TOKEN_PATTERN.findall(skill_command)
-    return max(0, len(tokens) - 1)
 
 
 @semantic_rule(
@@ -65,7 +55,7 @@ def _check_flake_suspected_unwinnable_loop(ctx: ValidationContext) -> list[RuleF
         if not merge_in_cycle:
             continue
 
-        if _count_skill_args(cmd) <= 3:
+        if count_skill_args(cmd) <= 3:
             findings.append(
                 RuleFinding(
                     rule="flake-suspected-unwinnable-loop",
@@ -73,7 +63,7 @@ def _check_flake_suspected_unwinnable_loop(ctx: ValidationContext) -> list[RuleF
                     step_name=step_name,
                     message=(
                         f"Step '{step_name}' invokes resolve-failures with only "
-                        f"{_count_skill_args(cmd)} positional arg(s) and routes "
+                        f"{count_skill_args(cmd)} positional arg(s) and routes "
                         f"flake_suspected → '{flake_target}', which leads back through "
                         f"a merge_worktree step. Without failure context (ci_conclusion + "
                         f"diagnosis_path), resolve-failures cannot diagnose the specific "

--- a/src/autoskillit/recipe/rules/rules_merge_context.py
+++ b/src/autoskillit/recipe/rules/rules_merge_context.py
@@ -20,7 +20,7 @@ _ARG_TOKEN_PATTERN = re.compile(r"\$\{\{[^}]+\}\}|[^\s]+")
 def _count_skill_args(skill_command: str) -> int:
     """Count positional args in a skill_command after the skill name."""
     tokens = _ARG_TOKEN_PATTERN.findall(skill_command)
-    # First token is the skill name (e.g. /autoskillit:resolve-failures)
+    # First token is the skill name (e.g. /resolve-failures)
     return max(0, len(tokens) - 1)
 
 

--- a/src/autoskillit/recipe/rules/rules_merge_context.py
+++ b/src/autoskillit/recipe/rules/rules_merge_context.py
@@ -6,6 +6,7 @@ import regex as re
 
 from autoskillit.core import Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._rule_helpers import _SKILL_CMD_PATTERN, count_skill_args
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 from autoskillit.recipe.schema import RecipeStep
 
@@ -13,15 +14,6 @@ logger = get_logger(__name__)
 
 _FAILED_STEP_PATTERN = re.compile(r"result\.failed_step\s*==\s*['\"](\w+)['\"]")
 _TEST_GATE_FAILURES = frozenset({"test_gate", "post_rebase_test_gate"})
-_SKILL_CMD_PATTERN = re.compile(r"/(?:autoskillit:)?([\w-]+)")
-_ARG_TOKEN_PATTERN = re.compile(r"\$\{\{[^}]+\}\}|[^\s]+")
-
-
-def _count_skill_args(skill_command: str) -> int:
-    """Count positional args in a skill_command after the skill name."""
-    tokens = _ARG_TOKEN_PATTERN.findall(skill_command)
-    # First token is the skill name (e.g. /resolve-failures)
-    return max(0, len(tokens) - 1)
 
 
 def _find_resolve_failures_step(
@@ -113,7 +105,7 @@ def _check_merge_test_gate_context_not_forwarded(
                 )
 
             cmd = rf_step.with_args.get("skill_command", "")
-            if _count_skill_args(cmd) <= 3:
+            if count_skill_args(cmd) <= 3:
                 findings.append(
                     RuleFinding(
                         rule="merge-test-gate-context-not-forwarded",
@@ -121,7 +113,7 @@ def _check_merge_test_gate_context_not_forwarded(
                         step_name=rf_step_name,
                         message=(
                             f"Step '{rf_step_name}' invokes resolve-failures with only "
-                            f"{_count_skill_args(cmd)} positional arg(s) (worktree, plan, "
+                            f"{count_skill_args(cmd)} positional arg(s) (worktree, plan, "
                             f"branch), but is reachable from merge_worktree step "
                             f"'{step_name}' via test_gate/post_rebase_test_gate. "
                             f"Without failure context (ci_conclusion + diagnosis_path), "

--- a/src/autoskillit/recipe/rules/rules_merge_context.py
+++ b/src/autoskillit/recipe/rules/rules_merge_context.py
@@ -1,0 +1,135 @@
+"""Semantic rules for merge gate test output context forwarding enforcement."""
+
+from __future__ import annotations
+
+import regex as re
+
+from autoskillit.core import Severity, get_logger
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+from autoskillit.recipe.schema import RecipeStep
+
+logger = get_logger(__name__)
+
+_FAILED_STEP_PATTERN = re.compile(r"result\.failed_step\s*==\s*['\"](\w+)['\"]")
+_TEST_GATE_FAILURES = frozenset({"test_gate", "post_rebase_test_gate"})
+_SKILL_CMD_PATTERN = re.compile(r"/(?:autoskillit:)?([\w-]+)")
+_ARG_TOKEN_PATTERN = re.compile(r"\$\{\{[^}]+\}\}|[^\s]+")
+
+
+def _count_skill_args(skill_command: str) -> int:
+    """Count positional args in a skill_command after the skill name."""
+    tokens = _ARG_TOKEN_PATTERN.findall(skill_command)
+    # First token is the skill name (e.g. /autoskillit:resolve-failures)
+    return max(0, len(tokens) - 1)
+
+
+def _find_resolve_failures_step(
+    start: str, ctx: ValidationContext
+) -> tuple[str, RecipeStep] | None:
+    """BFS from start to find the first run_skill step invoking resolve-failures.
+
+    Returns (step_name, step) or None.
+    """
+    visited: set[str] = {start}
+    frontier: set[str] = ctx.step_graph.get(start, set()) - visited
+    while frontier:
+        visited |= frontier
+        next_frontier: set[str] = set()
+        for name in frontier:
+            step = ctx.recipe.steps.get(name)
+            if step is None:
+                continue
+            if step.tool == "run_skill":
+                cmd = step.with_args.get("skill_command", "")
+                m = _SKILL_CMD_PATTERN.search(cmd)
+                if m and m.group(1) == "resolve-failures":
+                    return name, step
+            next_frontier |= ctx.step_graph.get(name, set()) - visited
+        frontier = next_frontier
+    return None
+
+
+@semantic_rule(
+    name="merge-test-gate-context-not-forwarded",
+    description=(
+        "A merge_worktree step routes test_gate or post_rebase_test_gate failures to a "
+        "step chain that invokes resolve-failures, but either (1) the merge_worktree "
+        "capture block does not include test_stdout and test_stderr fields, or (2) the "
+        "downstream resolve-failures invocation has only 3 positional args (worktree, "
+        "plan, branch) with no failure context. Without test output context, "
+        "resolve-failures cannot diagnose the specific failing tests and defaults to "
+        "failure_subtype=unknown, making the merge gate retry loop unwinnable on flakes."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_merge_test_gate_context_not_forwarded(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "merge_worktree":
+            continue
+        if not step.on_result or not step.on_result.conditions:
+            continue
+
+        test_gate_routes: set[str] = set()
+        for cond in step.on_result.conditions:
+            if cond.when is None:
+                continue
+            m = _FAILED_STEP_PATTERN.search(cond.when)
+            if m and m.group(1) in _TEST_GATE_FAILURES:
+                test_gate_routes.add(cond.route)
+
+        if not test_gate_routes:
+            continue
+
+        has_stdout = any("test_stdout" in v for v in (step.capture or {}).values())
+        has_stderr = any("test_stderr" in v for v in (step.capture or {}).values())
+        capture_ok = has_stdout and has_stderr
+
+        for route_target in test_gate_routes:
+            result = _find_resolve_failures_step(route_target, ctx)
+            if result is None:
+                continue
+            rf_step_name, rf_step = result
+
+            if not capture_ok:
+                findings.append(
+                    RuleFinding(
+                        rule="merge-test-gate-context-not-forwarded",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"merge_worktree step '{step_name}' routes test_gate/"
+                            f"post_rebase_test_gate to a resolve-failures chain "
+                            f"(via '{route_target}' → '{rf_step_name}'), but its "
+                            f"capture block is missing test_stdout and/or test_stderr. "
+                            f"Add 'merge_test_stdout: ${{{{ result.test_stdout }}}}' and "
+                            f"'merge_test_stderr: ${{{{ result.test_stderr }}}}' to capture."
+                        ),
+                    )
+                )
+
+            cmd = rf_step.with_args.get("skill_command", "")
+            if _count_skill_args(cmd) <= 3:
+                findings.append(
+                    RuleFinding(
+                        rule="merge-test-gate-context-not-forwarded",
+                        severity=Severity.ERROR,
+                        step_name=rf_step_name,
+                        message=(
+                            f"Step '{rf_step_name}' invokes resolve-failures with only "
+                            f"{_count_skill_args(cmd)} positional arg(s) (worktree, plan, "
+                            f"branch), but is reachable from merge_worktree step "
+                            f"'{step_name}' via test_gate/post_rebase_test_gate. "
+                            f"Without failure context (ci_conclusion + diagnosis_path), "
+                            f"resolve-failures cannot investigate the specific failure. "
+                            f"Expand skill_command to 6 args including merge_gate_ci_conclusion "
+                            f"and merge_gate_diagnosis_path."
+                        ),
+                    )
+                )
+
+    return findings

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2890,6 +2890,22 @@ callable_contracts:
     outputs:
     - name: closed
       type: string
+  autoskillit.smoke_utils.diagnose_merge_gate:
+    inputs:
+    - name: test_stdout
+      type: string
+      required: false
+    - name: test_stderr
+      type: string
+      required: false
+    - name: output_dir
+      type: string
+      required: false
+    outputs:
+    - name: diagnosis_path
+      type: string
+    - name: ci_conclusion
+      type: string
 
 tool_output_contracts:
   wait_for_ci:

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -300,7 +300,7 @@
           "route": "release_issue_failure"
         },
         {
-          "route": "fix"
+          "route": "diagnose_merge_gate"
         }
       ],
       "on_failure": "release_issue_failure",
@@ -308,6 +308,26 @@
         "merge_fix_count"
       ],
       "note": "Merge-failure iteration guard (dirty_tree / test_gate / post_rebase_test_gate). Shares merge_fix_count with check_merge_rebase_loop and check_dirty_main_retry.\n"
+    },
+    "diagnose_merge_gate": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.diagnose_merge_gate",
+        "test_stdout": "${{ context.merge_test_stdout }}",
+        "test_stderr": "${{ context.merge_test_stderr }}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
+      },
+      "capture": {
+        "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
+        "merge_gate_ci_conclusion": "${{ result.ci_conclusion }}"
+      },
+      "on_success": "fix",
+      "on_failure": "fix",
+      "optional_context_refs": [
+        "merge_test_stdout",
+        "merge_test_stderr"
+      ],
+      "note": "Writes a structured diagnosis file from merge gate test output, mirroring diagnose-ci format. Routes to fix on both success and failure — fix proceeds without context if diagnosis fails. Uses distinct context keys (merge_gate_*) to avoid collision with ci_watch/diagnose_ci context variables from the CI path.\n"
     },
     "check_merge_rebase_loop": {
       "tool": "run_python",
@@ -413,7 +433,9 @@
       },
       "capture": {
         "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
-        "worktree_path": "${{ result.worktree_path }}"
+        "worktree_path": "${{ result.worktree_path }}",
+        "merge_test_stdout": "${{ result.test_stdout }}",
+        "merge_test_stderr": "${{ result.test_stderr }}"
       },
       "on_result": [
         {
@@ -463,7 +485,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.merge_gate_ci_conclusion }} - ${{ context.merge_gate_diagnosis_path }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "fix",
         "output_dir": "."
@@ -499,6 +521,10 @@
       ],
       "on_failure": "release_issue_failure",
       "on_context_limit": "test",
+      "optional_context_refs": [
+        "merge_gate_ci_conclusion",
+        "merge_gate_diagnosis_path"
+      ],
       "note": "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
     },
     "rebase_conflict_fix": {

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -290,7 +290,7 @@ steps:
     on_result:
     - when: "${{ result.max_exceeded }} == true"
       route: release_issue_failure
-    - route: fix
+    - route: diagnose_merge_gate
     on_failure: release_issue_failure
     optional_context_refs:
     - merge_fix_count
@@ -298,6 +298,28 @@ steps:
       Merge-failure iteration guard (dirty_tree / test_gate /
       post_rebase_test_gate). Shares merge_fix_count with
       check_merge_rebase_loop and check_dirty_main_retry.
+
+  diagnose_merge_gate:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.diagnose_merge_gate"
+      test_stdout: "${{ context.merge_test_stdout }}"
+      test_stderr: "${{ context.merge_test_stderr }}"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
+    capture:
+      merge_gate_diagnosis_path: "${{ result.diagnosis_path }}"
+      merge_gate_ci_conclusion: "${{ result.ci_conclusion }}"
+    on_success: fix
+    on_failure: fix
+    optional_context_refs:
+    - merge_test_stdout
+    - merge_test_stderr
+    note: >
+      Writes a structured diagnosis file from merge gate test output,
+      mirroring diagnose-ci format. Routes to fix on both success and
+      failure — fix proceeds without context if diagnosis fails. Uses
+      distinct context keys (merge_gate_*) to avoid collision with
+      ci_watch/diagnose_ci context variables from the CI path.
 
   check_merge_rebase_loop:
     tool: run_python
@@ -393,6 +415,8 @@ steps:
     capture:
       cleanup_succeeded: "${{ result.cleanup_succeeded }}"
       worktree_path: "${{ result.worktree_path }}"
+      merge_test_stdout: "${{ result.test_stdout }}"
+      merge_test_stderr: "${{ result.test_stderr }}"
     on_result:
     - when: "result.failed_step == 'dirty_tree'"
       route: check_merge_fix_loop
@@ -439,7 +463,7 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
+      skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.merge_gate_ci_conclusion }} - ${{ context.merge_gate_diagnosis_path }}"
       cwd: "${{ context.worktree_path }}"
       step_name: "fix"
       output_dir: '.'
@@ -460,6 +484,9 @@ steps:
     - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: test
+    optional_context_refs:
+    - merge_gate_ci_conclusion
+    - merge_gate_diagnosis_path
     note: "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
 
   rebase_conflict_fix:

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -362,7 +362,7 @@
           "route": "release_issue_failure"
         },
         {
-          "route": "fix"
+          "route": "diagnose_merge_gate"
         }
       ],
       "on_failure": "release_issue_failure",
@@ -370,6 +370,26 @@
         "merge_fix_count"
       ],
       "note": "Merge-failure iteration guard (dirty_tree / test_gate / post_rebase_test_gate). Shares merge_fix_count with check_merge_rebase_loop and check_dirty_main_retry.\n"
+    },
+    "diagnose_merge_gate": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.diagnose_merge_gate",
+        "test_stdout": "${{ context.merge_test_stdout }}",
+        "test_stderr": "${{ context.merge_test_stderr }}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
+      },
+      "capture": {
+        "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
+        "merge_gate_ci_conclusion": "${{ result.ci_conclusion }}"
+      },
+      "on_success": "fix",
+      "on_failure": "fix",
+      "optional_context_refs": [
+        "merge_test_stdout",
+        "merge_test_stderr"
+      ],
+      "note": "Writes a structured diagnosis file from merge gate test output, mirroring diagnose-ci format. Routes to fix on both success and failure — fix proceeds without context if diagnosis fails. Uses distinct context keys (merge_gate_*) to avoid collision with ci_watch/diagnose_ci context variables from the CI path.\n"
     },
     "check_merge_rebase_loop": {
       "tool": "run_python",
@@ -475,7 +495,9 @@
       },
       "capture": {
         "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
-        "worktree_path": "${{ result.worktree_path }}"
+        "worktree_path": "${{ result.worktree_path }}",
+        "merge_test_stdout": "${{ result.test_stdout }}",
+        "merge_test_stderr": "${{ result.test_stderr }}"
       },
       "on_result": [
         {
@@ -555,7 +577,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.merge_gate_ci_conclusion }} - ${{ context.merge_gate_diagnosis_path }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "fix",
         "output_dir": "."
@@ -588,6 +610,10 @@
       ],
       "on_failure": "release_issue_failure",
       "on_context_limit": "test",
+      "optional_context_refs": [
+        "merge_gate_ci_conclusion",
+        "merge_gate_diagnosis_path"
+      ],
       "note": "Fixes test failures without merging. Routes back to test for re-validation before merge_worktree. on_context_limit routes needs_retry=True to test (worktree may already be green) instead of re-running fix blindly."
     },
     "rebase_conflict_fix": {

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -363,7 +363,7 @@ steps:
     on_result:
     - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
-    - route: fix
+    - route: diagnose_merge_gate
     on_failure: release_issue_failure
     optional_context_refs:
     - merge_fix_count
@@ -371,6 +371,28 @@ steps:
       Merge-failure iteration guard (dirty_tree / test_gate /
       post_rebase_test_gate). Shares merge_fix_count with
       check_merge_rebase_loop and check_dirty_main_retry.
+
+  diagnose_merge_gate:
+    tool: run_python
+    with:
+      callable: autoskillit.smoke_utils.diagnose_merge_gate
+      test_stdout: ${{ context.merge_test_stdout }}
+      test_stderr: ${{ context.merge_test_stderr }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate'
+    capture:
+      merge_gate_diagnosis_path: ${{ result.diagnosis_path }}
+      merge_gate_ci_conclusion: ${{ result.ci_conclusion }}
+    on_success: fix
+    on_failure: fix
+    optional_context_refs:
+    - merge_test_stdout
+    - merge_test_stderr
+    note: >
+      Writes a structured diagnosis file from merge gate test output,
+      mirroring diagnose-ci format. Routes to fix on both success and
+      failure — fix proceeds without context if diagnosis fails. Uses
+      distinct context keys (merge_gate_*) to avoid collision with
+      ci_watch/diagnose_ci context variables from the CI path.
 
   check_merge_rebase_loop:
     tool: run_python
@@ -466,6 +488,8 @@ steps:
     capture:
       cleanup_succeeded: ${{ result.cleanup_succeeded }}
       worktree_path: ${{ result.worktree_path }}
+      merge_test_stdout: ${{ result.test_stdout }}
+      merge_test_stderr: ${{ result.test_stderr }}
     on_result:
     - when: result.failed_step == 'dirty_tree'
       route: check_merge_fix_loop
@@ -536,7 +560,8 @@ steps:
     model: ''
     with:
       skill_command: /autoskillit:resolve-failures ${{ context.worktree_path }} ${{
-        context.plan_path }} ${{ inputs.base_branch }}
+        context.plan_path }} ${{ inputs.base_branch }} ${{ context.merge_gate_ci_conclusion
+        }} - ${{ context.merge_gate_diagnosis_path }}
       cwd: ${{ context.worktree_path }}
       step_name: fix
       output_dir: '.'
@@ -556,6 +581,9 @@ steps:
       route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: test
+    optional_context_refs:
+    - merge_gate_ci_conclusion
+    - merge_gate_diagnosis_path
     note: Fixes test failures without merging. Routes back to test for re-validation
       before merge_worktree. on_context_limit routes needs_retry=True to test (worktree
       may already be green) instead of re-running fix blindly.

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -400,7 +400,7 @@
           "route": "release_issue_failure"
         },
         {
-          "route": "assess"
+          "route": "diagnose_merge_gate"
         }
       ],
       "on_failure": "release_issue_failure",
@@ -408,6 +408,26 @@
         "merge_fix_count"
       ],
       "note": "Merge-failure iteration guard (dirty_tree / test_gate / post_rebase_test_gate). Shares merge_fix_count with check_merge_rebase_loop and check_dirty_main_retry.\n"
+    },
+    "diagnose_merge_gate": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.diagnose_merge_gate",
+        "test_stdout": "${{ context.merge_test_stdout }}",
+        "test_stderr": "${{ context.merge_test_stderr }}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
+      },
+      "capture": {
+        "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
+        "merge_gate_ci_conclusion": "${{ result.ci_conclusion }}"
+      },
+      "on_success": "assess",
+      "on_failure": "assess",
+      "optional_context_refs": [
+        "merge_test_stdout",
+        "merge_test_stderr"
+      ],
+      "note": "Writes a structured diagnosis file from merge gate test output, mirroring diagnose-ci format. Routes to assess on both success and failure — assess proceeds without context if diagnosis fails. Uses distinct context keys (merge_gate_*) to avoid collision with ci_watch/diagnose_ci context variables from the CI path.\n"
     },
     "check_merge_rebase_loop": {
       "tool": "run_python",
@@ -488,7 +508,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.merge_gate_ci_conclusion }} - ${{ context.merge_gate_diagnosis_path }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "assess",
         "output_dir": "."
@@ -521,7 +541,11 @@
       ],
       "on_context_limit": "test",
       "on_failure": "release_issue_failure",
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "release_issue_failure",
+      "optional_context_refs": [
+        "merge_gate_ci_conclusion",
+        "merge_gate_diagnosis_path"
+      ]
     },
     "rebase_conflict_fix": {
       "tool": "run_skill",
@@ -638,7 +662,9 @@
       },
       "capture": {
         "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
-        "worktree_path": "${{ result.worktree_path }}"
+        "worktree_path": "${{ result.worktree_path }}",
+        "merge_test_stdout": "${{ result.test_stdout }}",
+        "merge_test_stderr": "${{ result.test_stderr }}"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -397,7 +397,7 @@ steps:
     on_result:
     - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
-    - route: assess
+    - route: diagnose_merge_gate
     on_failure: release_issue_failure
     optional_context_refs:
     - merge_fix_count
@@ -405,6 +405,28 @@ steps:
       Merge-failure iteration guard (dirty_tree / test_gate /
       post_rebase_test_gate). Shares merge_fix_count with
       check_merge_rebase_loop and check_dirty_main_retry.
+
+  diagnose_merge_gate:
+    tool: run_python
+    with:
+      callable: autoskillit.smoke_utils.diagnose_merge_gate
+      test_stdout: ${{ context.merge_test_stdout }}
+      test_stderr: ${{ context.merge_test_stderr }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate'
+    capture:
+      merge_gate_diagnosis_path: ${{ result.diagnosis_path }}
+      merge_gate_ci_conclusion: ${{ result.ci_conclusion }}
+    on_success: assess
+    on_failure: assess
+    optional_context_refs:
+    - merge_test_stdout
+    - merge_test_stderr
+    note: >
+      Writes a structured diagnosis file from merge gate test output,
+      mirroring diagnose-ci format. Routes to assess on both success and
+      failure — assess proceeds without context if diagnosis fails. Uses
+      distinct context keys (merge_gate_*) to avoid collision with
+      ci_watch/diagnose_ci context variables from the CI path.
 
   check_merge_rebase_loop:
     tool: run_python
@@ -470,7 +492,8 @@ steps:
     model: ''
     with:
       skill_command: /autoskillit:resolve-failures ${{ context.worktree_path }} ${{
-        context.plan_path }} ${{ inputs.base_branch }}
+        context.plan_path }} ${{ inputs.base_branch }} ${{ context.merge_gate_ci_conclusion
+        }} - ${{ context.merge_gate_diagnosis_path }}
       cwd: ${{ context.worktree_path }}
       step_name: assess
       output_dir: '.'
@@ -491,6 +514,9 @@ steps:
     on_context_limit: test
     on_failure: release_issue_failure
     on_exhausted: release_issue_failure
+    optional_context_refs:
+    - merge_gate_ci_conclusion
+    - merge_gate_diagnosis_path
   rebase_conflict_fix:
     tool: run_skill
     model: ''
@@ -594,6 +620,8 @@ steps:
     capture:
       cleanup_succeeded: ${{ result.cleanup_succeeded }}
       worktree_path: ${{ result.worktree_path }}
+      merge_test_stdout: ${{ result.test_stdout }}
+      merge_test_stderr: ${{ result.test_stderr }}
     on_result:
     - when: result.failed_step == 'dirty_tree'
       route: check_merge_fix_loop

--- a/src/autoskillit/smoke_utils/CLAUDE.md
+++ b/src/autoskillit/smoke_utils/CLAUDE.md
@@ -6,8 +6,9 @@ Utility callables for smoke-test pipeline `run_python` steps (decomposed from mo
 
 | File | Purpose |
 |------|---------|
-| `__init__.py` | Re-export facade — 19 public names via `__all__` |
+| `__init__.py` | Re-export facade — 21 public names via `__all__` |
 | `_helpers.py` | Shared JSON loading helpers (`_load_json`, `try_load_json`) |
+| `_merge_gate_diagnosis.py` | Merge gate test failure diagnosis file writer |
 | `_review.py` | PR diff annotation, review loop guards, diff context enrichment |
 | `_eval.py` | Eval manifest parsing, context building, scorecard compilation |
 | `_telemetry.py` | PR token summary patching, `_PR_SECTION_RE` |

--- a/src/autoskillit/smoke_utils/__init__.py
+++ b/src/autoskillit/smoke_utils/__init__.py
@@ -19,6 +19,7 @@ from autoskillit.smoke_utils._git import (
     fetch_merge_queue_data,
 )
 from autoskillit.smoke_utils._helpers import try_load_json
+from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
 from autoskillit.smoke_utils._review import (
     LOCAL_ROUND_EXEMPT_VERDICTS,
     annotate_pr_diff,
@@ -44,6 +45,7 @@ __all__ = [
     "compile_eval_scorecard",
     "compute_domain_partitions",
     "detect_zero_changes",
+    "diagnose_merge_gate",
     "enrich_diff_context",
     "fetch_merge_queue_data",
     "parse_agent_eval_manifests",

--- a/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
+++ b/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 import regex as re
 
-from autoskillit.core.io import atomic_write
-
 _FAILED_TEST_RE = re.compile(r"^FAILED\s+(\S+)", re.MULTILINE)
 _TIMEOUT_RE = re.compile(r"timeout|timed out|TimeoutError", re.IGNORECASE)
 _ENV_ERROR_RE = re.compile(
@@ -70,6 +68,8 @@ def diagnose_merge_gate(
         "## Structured Output\n"
         f"failure_subtype = {subtype}\n"
     )
+
+    from autoskillit.core import atomic_write  # noqa: PLC0415
 
     atomic_write(out_path, content)
     return {"diagnosis_path": str(out_path), "ci_conclusion": "failure"}

--- a/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
+++ b/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
@@ -49,10 +49,8 @@ def diagnose_merge_gate(
     else:
         out_path = Path(".autoskillit") / "temp" / "diagnose-merge-gate" / "diagnosis.md"
 
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-
     failed_section = "\n".join(f"- {t}" for t in failed_tests) if failed_tests else "- none"
-    log_excerpt = (test_stdout or test_stderr or "(no output captured)").strip()
+    log_excerpt = test_stdout.strip() or test_stderr.strip() or "(no output captured)"
     if len(log_excerpt) > 4000:
         log_excerpt = log_excerpt[-4000:]
 
@@ -71,5 +69,9 @@ def diagnose_merge_gate(
 
     from autoskillit.core import atomic_write  # noqa: PLC0415
 
-    atomic_write(out_path, content)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        atomic_write(out_path, content)
+    except OSError as exc:
+        raise RuntimeError(f"Failed to write diagnosis to {out_path}") from exc
     return {"diagnosis_path": str(out_path), "ci_conclusion": "failure"}

--- a/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
+++ b/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
@@ -1,0 +1,72 @@
+"""Merge gate test failure diagnosis file writer for smoke_utils run_python steps."""
+
+from __future__ import annotations
+
+import re as _re
+from pathlib import Path
+
+_FAILED_TEST_RE = _re.compile(r"^FAILED\s+(\S+)", _re.MULTILINE)
+_TIMEOUT_RE = _re.compile(r"timeout|timed out|TimeoutError", _re.IGNORECASE)
+_ENV_ERROR_RE = _re.compile(
+    r"ModuleNotFoundError|ImportError|FileNotFoundError|No such file", _re.IGNORECASE
+)
+
+
+def _classify_subtype(test_stdout: str, test_stderr: str) -> str:
+    combined = f"{test_stdout}\n{test_stderr}"
+    if _TIMEOUT_RE.search(combined):
+        return "timing_race"
+    if _ENV_ERROR_RE.search(combined):
+        return "env"
+    if _FAILED_TEST_RE.search(combined):
+        return "deterministic"
+    return "unknown"
+
+
+def _extract_failed_tests(test_stdout: str, test_stderr: str) -> list[str]:
+    combined = f"{test_stdout}\n{test_stderr}"
+    return _FAILED_TEST_RE.findall(combined)
+
+
+def diagnose_merge_gate(
+    test_stdout: str = "",
+    test_stderr: str = "",
+    output_dir: str = "",
+    **_kwargs: object,
+) -> dict[str, str]:
+    """Write a structured merge gate failure diagnosis file and return its path.
+
+    Called by run_python from the diagnose_merge_gate step in remediation.yaml,
+    implementation.yaml, and implementation-groups.yaml. Parses merge gate test
+    output and writes a diagnosis file in the same format as diagnose-ci output.
+    """
+    subtype = _classify_subtype(test_stdout, test_stderr)
+    failed_tests = _extract_failed_tests(test_stdout, test_stderr)
+
+    if output_dir:
+        out_path = Path(output_dir) / "diagnosis.md"
+    else:
+        out_path = Path(".autoskillit") / "temp" / "diagnose-merge-gate" / "diagnosis.md"
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    failed_section = "\n".join(f"- {t}" for t in failed_tests) if failed_tests else "- none"
+    log_excerpt = (test_stdout or test_stderr or "(no output captured)").strip()
+    if len(log_excerpt) > 4000:
+        log_excerpt = log_excerpt[-4000:]
+
+    content = (
+        "# Merge Gate Test Failure Diagnosis\n\n"
+        "## Classification\n"
+        "failure_type = test\n"
+        f"failure_subtype = {subtype}\n\n"
+        "## Failed Tests\n"
+        f"{failed_section}\n\n"
+        "## Log Excerpt\n"
+        f"```\n{log_excerpt}\n```\n\n"
+        "## Structured Output\n"
+        f"failure_subtype = {subtype}\n"
+    )
+
+    out_path.write_text(content, encoding="utf-8")
+    return {"diagnosis_path": str(out_path), "ci_conclusion": "failure"}

--- a/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
+++ b/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-import re as _re
 from pathlib import Path
 
-_FAILED_TEST_RE = _re.compile(r"^FAILED\s+(\S+)", _re.MULTILINE)
-_TIMEOUT_RE = _re.compile(r"timeout|timed out|TimeoutError", _re.IGNORECASE)
-_ENV_ERROR_RE = _re.compile(
-    r"ModuleNotFoundError|ImportError|FileNotFoundError|No such file", _re.IGNORECASE
+import regex as re
+
+from autoskillit.core.io import atomic_write
+
+_FAILED_TEST_RE = re.compile(r"^FAILED\s+(\S+)", re.MULTILINE)
+_TIMEOUT_RE = re.compile(r"timeout|timed out|TimeoutError", re.IGNORECASE)
+_ENV_ERROR_RE = re.compile(
+    r"ModuleNotFoundError|ImportError|FileNotFoundError|No such file", re.IGNORECASE
 )
 
 
@@ -68,5 +71,5 @@ def diagnose_merge_gate(
         f"failure_subtype = {subtype}\n"
     )
 
-    out_path.write_text(content, encoding="utf-8")
+    atomic_write(out_path, content)
     return {"diagnosis_path": str(out_path), "ci_conclusion": "failure"}

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -851,7 +851,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 11,
         "pipeline": 12,
         "fleet": 21,  # REQ-CNST-003-E9: _dispatch_reaper.py; +_sidecar_synthesis.py
-        "recipe/rules": 49,
+        "recipe/rules": 51,
         "server/tools": 22,  # _auto_overrides.py added for shared _build_auto_overrides() factory
         "hooks/guards": 23,  # artifact_download_guard.py added for gh run/release download guard
     }

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -272,8 +272,8 @@ def test_retry_reason_value_count_is_14() -> None:
     assert len(values) == 14, f"RetryReason has {len(values)} values: {values}"
 
 
-def test_semantic_rule_family_count_is_48() -> None:
-    assert _count_semantic_rule_files() == 48
+def test_semantic_rule_family_count_is_50() -> None:
+    assert _count_semantic_rule_files() == 50
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -132,6 +132,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_dataflow_nullable.py` | Tests for dataflow nullable semantic validation rule |
 | `test_rules_dedup.py` | Tests for dedup semantic validation rule |
 | `test_rules_features.py` | Tests for features semantic validation rule |
+| `test_rules_flake_loop_deadlock.py` | Tests for flake-suspected-unwinnable-loop semantic validation rule |
 | `test_rules_food_truck.py` | Tests for food_truck semantic validation rule |
 | `test_rules_graph.py` | Tests for graph semantic validation rule |
 | `test_rules_inline_script.py` | Tests for inline_script semantic validation rule |
@@ -143,6 +144,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_merge_queue_push.py` | Tests for merge_queue_push semantic validation rule |
 | `test_rules_merge_routing_incomplete.py` | Tests for merge_routing_incomplete semantic validation rule |
 | `test_rules_merge_failure_domain.py` | Tests for merge-failure-skill-domain-mismatch semantic validation rule |
+| `test_rules_merge_context_forward.py` | Tests for merge-test-gate-context-not-forwarded semantic validation rule |
 | `test_rules_multipart_iteration.py` | Tests for multipart_iteration semantic validation rule |
 | `test_rules_on_context_limit.py` | Tests for on_context_limit semantic validation rule |
 | `test_rules_on_result_failure_route.py` | Tests for on_result_failure_route semantic validation rule |

--- a/tests/recipe/test_rules_flake_loop_deadlock.py
+++ b/tests/recipe/test_rules_flake_loop_deadlock.py
@@ -235,7 +235,7 @@ def test_flake_suspected_not_in_merge_cycle_is_clean() -> None:
     "recipe_name",
     ["remediation.yaml", "implementation.yaml", "implementation-groups.yaml"],
 )
-def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> None:
+def test_rule_does_not_fire_for_fixed_recipes(recipe_name: str) -> None:
     """Post recipe fix: rule no longer fires for the three pipeline recipes."""
     from autoskillit.core import pkg_root
     from autoskillit.recipe.io import load_recipe

--- a/tests/recipe/test_rules_flake_loop_deadlock.py
+++ b/tests/recipe/test_rules_flake_loop_deadlock.py
@@ -245,4 +245,4 @@ def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> Non
     findings = run_semantic_rules(recipe)
     flagged = [f for f in findings if f.rule == "flake-suspected-unwinnable-loop"]
     # After recipe fixes are applied, this should be zero.
-    assert isinstance(flagged, list)
+    assert len(flagged) >= 1

--- a/tests/recipe/test_rules_flake_loop_deadlock.py
+++ b/tests/recipe/test_rules_flake_loop_deadlock.py
@@ -236,7 +236,7 @@ def test_flake_suspected_not_in_merge_cycle_is_clean() -> None:
     ["remediation.yaml", "implementation.yaml", "implementation-groups.yaml"],
 )
 def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> None:
-    """Before recipe fix: rule fires ERROR for all three pipeline recipes."""
+    """Post recipe fix: rule no longer fires for the three pipeline recipes."""
     from autoskillit.core import pkg_root
     from autoskillit.recipe.io import load_recipe
 
@@ -244,5 +244,4 @@ def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> Non
     recipe = load_recipe(recipe_path)
     findings = run_semantic_rules(recipe)
     flagged = [f for f in findings if f.rule == "flake-suspected-unwinnable-loop"]
-    # After recipe fixes are applied, this should be zero.
-    assert len(flagged) >= 1
+    assert len(flagged) == 0

--- a/tests/recipe/test_rules_flake_loop_deadlock.py
+++ b/tests/recipe/test_rules_flake_loop_deadlock.py
@@ -1,0 +1,248 @@
+"""Tests for rules_flake_loop.py: flake-suspected-unwinnable-loop rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import Severity
+from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, StepResultRoute
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
+    return Recipe(
+        name="test-flake-loop-deadlock",
+        description="Test recipe for flake-suspected-unwinnable-loop rule.",
+        version="0.2.0",
+        kitchen_rules=["test"],
+        steps=steps,
+    )
+
+
+def _merge_on_result() -> StepResultRoute:
+    return StepResultRoute(
+        conditions=[
+            StepResultCondition(when="result.failed_step == 'dirty_tree'", route="check_loop"),
+            StepResultCondition(when="result.failed_step == 'test_gate'", route="check_loop"),
+            StepResultCondition(
+                when="result.failed_step == 'post_rebase_test_gate'", route="check_loop"
+            ),
+            StepResultCondition(when="result.failed_step == 'rebase'", route="escalate"),
+            StepResultCondition(when="result.failed_step == 'dirty_main_repo'", route="escalate"),
+            StepResultCondition(when="result.error", route="escalate"),
+            StepResultCondition(when=None, route="done"),
+        ]
+    )
+
+
+def test_flake_suspected_to_merge_without_context_fires_error() -> None:
+    """assess routes flake_suspected → test, test is in cycle through merge, no context → ERROR."""
+    recipe = _make_recipe(
+        {
+            "merge": RecipeStep(
+                tool="merge_worktree",
+                with_args={"worktree_path": "${{ context.worktree_path }}", "base_branch": "main"},
+                capture={
+                    "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                    # No test_stdout/test_stderr capture
+                },
+                on_result=_merge_on_result(),
+                on_failure="escalate",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.merge_fix_count }}",
+                    "max_iterations": "3",
+                },
+                capture={"merge_fix_count": "${{ result.next_iteration }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.max_exceeded }} == true", route="escalate"
+                        ),
+                        StepResultCondition(when=None, route="assess"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "assess": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": (
+                        "/autoskillit:resolve-failures"
+                        " ${{ context.worktree_path }}"
+                        " ${{ context.plan_path }}"
+                        " ${{ inputs.base_branch }}"
+                        # Only 3 args — no context
+                    ),
+                    "step_name": "assess",
+                },
+                capture={
+                    "verdict": "${{ result.verdict }}",
+                    "fixes_applied": "${{ result.fixes_applied }}",
+                },
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.verdict }} == 'flake_suspected'", route="test"
+                        ),
+                        StepResultCondition(when=None, route="escalate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "test": RecipeStep(
+                tool="test_check",
+                with_args={"worktree_path": "${{ context.worktree_path }}"},
+                on_success="merge",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "flake-suspected-unwinnable-loop"]
+    assert len(flagged) >= 1
+    assert all(f.severity == Severity.ERROR for f in flagged)
+
+
+def test_flake_suspected_to_merge_with_context_is_clean() -> None:
+    """Same merge cycle but assess forwards failure context → no finding."""
+    recipe = _make_recipe(
+        {
+            "merge": RecipeStep(
+                tool="merge_worktree",
+                with_args={"worktree_path": "${{ context.worktree_path }}", "base_branch": "main"},
+                capture={
+                    "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "merge_test_stdout": "${{ result.test_stdout }}",
+                    "merge_test_stderr": "${{ result.test_stderr }}",
+                },
+                on_result=_merge_on_result(),
+                on_failure="escalate",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.merge_fix_count }}",
+                    "max_iterations": "3",
+                },
+                capture={"merge_fix_count": "${{ result.next_iteration }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.max_exceeded }} == true", route="escalate"
+                        ),
+                        StepResultCondition(when=None, route="assess"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "assess": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": (
+                        "/autoskillit:resolve-failures"
+                        " ${{ context.worktree_path }}"
+                        " ${{ context.plan_path }}"
+                        " ${{ inputs.base_branch }}"
+                        " ${{ context.merge_gate_ci_conclusion }}"
+                        " - ${{ context.merge_gate_diagnosis_path }}"
+                    ),
+                    "step_name": "assess",
+                },
+                capture={
+                    "verdict": "${{ result.verdict }}",
+                    "fixes_applied": "${{ result.fixes_applied }}",
+                },
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.verdict }} == 'flake_suspected'", route="test"
+                        ),
+                        StepResultCondition(when=None, route="escalate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "test": RecipeStep(
+                tool="test_check",
+                with_args={"worktree_path": "${{ context.worktree_path }}"},
+                on_success="merge",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "flake-suspected-unwinnable-loop"]
+    assert not flagged
+
+
+def test_flake_suspected_not_in_merge_cycle_is_clean() -> None:
+    """resolve_ci routes flake_suspected → re_push (no merge step in cycle) → no finding."""
+    recipe = _make_recipe(
+        {
+            "resolve_ci": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": (
+                        "/autoskillit:resolve-failures"
+                        " ${{ context.worktree_path }}"
+                        " ${{ context.plan_path }}"
+                        " ${{ inputs.base_branch }}"
+                    ),
+                    "step_name": "resolve_ci",
+                },
+                capture={
+                    "verdict": "${{ result.verdict }}",
+                },
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.verdict }} == 'flake_suspected'", route="re_push"
+                        ),
+                        StepResultCondition(when=None, route="escalate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "re_push": RecipeStep(
+                tool="push_to_remote",
+                with_args={"clone_path": "${{ context.work_dir }}", "remote_url": "origin"},
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "flake-suspected-unwinnable-loop"]
+    assert not flagged
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["remediation.yaml", "implementation.yaml", "implementation-groups.yaml"],
+)
+def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> None:
+    """Before recipe fix: rule fires ERROR for all three pipeline recipes."""
+    from autoskillit.core import pkg_root
+    from autoskillit.recipe.io import load_recipe
+
+    recipe_path = pkg_root() / "recipes" / recipe_name
+    recipe = load_recipe(recipe_path)
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "flake-suspected-unwinnable-loop"]
+    # After recipe fixes are applied, this should be zero.
+    assert isinstance(flagged, list)

--- a/tests/recipe/test_rules_merge_context_forward.py
+++ b/tests/recipe/test_rules_merge_context_forward.py
@@ -355,5 +355,4 @@ def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> Non
     findings = run_semantic_rules(recipe)
     flagged = [f for f in findings if f.rule == "merge-test-gate-context-not-forwarded"]
     # After recipe fixes are applied, this should be zero. Before fixes: may be non-zero.
-    # The presence of the rule (not a KeyError/crash) is what we verify here.
-    assert isinstance(flagged, list)
+    assert len(flagged) >= 1

--- a/tests/recipe/test_rules_merge_context_forward.py
+++ b/tests/recipe/test_rules_merge_context_forward.py
@@ -1,0 +1,359 @@
+"""Tests for rules_merge_context.py: merge-test-gate-context-not-forwarded rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import Severity
+from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, StepResultRoute
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
+    return Recipe(
+        name="test-merge-context-forward",
+        description="Test recipe for merge-test-gate-context-not-forwarded rule.",
+        version="0.2.0",
+        kitchen_rules=["test"],
+        steps=steps,
+    )
+
+
+def _merge_on_result_conditions() -> list[StepResultCondition]:
+    return [
+        StepResultCondition(when="result.failed_step == 'dirty_tree'", route="check_loop"),
+        StepResultCondition(when="result.failed_step == 'test_gate'", route="check_loop"),
+        StepResultCondition(
+            when="result.failed_step == 'post_rebase_test_gate'", route="check_loop"
+        ),
+        StepResultCondition(when="result.failed_step == 'rebase'", route="escalate"),
+        StepResultCondition(when="result.failed_step == 'dirty_main_repo'", route="escalate"),
+        StepResultCondition(when="result.error", route="escalate"),
+        StepResultCondition(when=None, route="done"),
+    ]
+
+
+def test_merge_step_missing_test_output_capture_fires_error() -> None:
+    """merge step routes test_gate but capture has no test_stdout/stderr → ERROR."""
+    recipe = _make_recipe(
+        {
+            "merge": RecipeStep(
+                tool="merge_worktree",
+                with_args={"worktree_path": "${{ context.worktree_path }}", "base_branch": "main"},
+                capture={
+                    "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                    # test_stdout and test_stderr are absent — should trigger the rule
+                },
+                on_result=StepResultRoute(conditions=_merge_on_result_conditions()),
+                on_failure="escalate",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.merge_fix_count }}",
+                    "max_iterations": "3",
+                },
+                capture={"merge_fix_count": "${{ result.next_iteration }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.max_exceeded }} == true", route="escalate"
+                        ),
+                        StepResultCondition(when=None, route="assess"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "assess": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": (
+                        "/autoskillit:resolve-failures"
+                        " ${{ context.worktree_path }}"
+                        " ${{ context.plan_path }}"
+                        " ${{ inputs.base_branch }}"
+                    ),
+                    "step_name": "assess",
+                },
+                capture={
+                    "verdict": "${{ result.verdict }}",
+                    "fixes_applied": "${{ result.fixes_applied }}",
+                },
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.verdict }} == 'flake_suspected'", route="test"
+                        ),
+                        StepResultCondition(when=None, route="escalate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "test": RecipeStep(
+                tool="test_check",
+                with_args={"worktree_path": "${{ context.worktree_path }}"},
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-test-gate-context-not-forwarded"]
+    assert len(flagged) >= 1
+    assert all(f.severity == Severity.ERROR for f in flagged)
+
+
+def test_merge_step_with_test_output_capture_is_clean() -> None:
+    """merge step captures test_stdout and test_stderr → no finding."""
+    recipe = _make_recipe(
+        {
+            "merge": RecipeStep(
+                tool="merge_worktree",
+                with_args={"worktree_path": "${{ context.worktree_path }}", "base_branch": "main"},
+                capture={
+                    "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "merge_test_stdout": "${{ result.test_stdout }}",
+                    "merge_test_stderr": "${{ result.test_stderr }}",
+                },
+                on_result=StepResultRoute(conditions=_merge_on_result_conditions()),
+                on_failure="escalate",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.merge_fix_count }}",
+                    "max_iterations": "3",
+                },
+                capture={"merge_fix_count": "${{ result.next_iteration }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.max_exceeded }} == true", route="escalate"
+                        ),
+                        StepResultCondition(when=None, route="assess"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "assess": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": (
+                        "/autoskillit:resolve-failures"
+                        " ${{ context.worktree_path }}"
+                        " ${{ context.plan_path }}"
+                        " ${{ inputs.base_branch }}"
+                        " ${{ context.merge_gate_ci_conclusion }}"
+                        " - ${{ context.merge_gate_diagnosis_path }}"
+                    ),
+                    "step_name": "assess",
+                },
+                capture={
+                    "verdict": "${{ result.verdict }}",
+                    "fixes_applied": "${{ result.fixes_applied }}",
+                },
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.verdict }} == 'flake_suspected'", route="test"
+                        ),
+                        StepResultCondition(when=None, route="escalate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "test": RecipeStep(
+                tool="test_check",
+                with_args={"worktree_path": "${{ context.worktree_path }}"},
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-test-gate-context-not-forwarded"]
+    assert not flagged
+
+
+def test_assess_step_missing_failure_context_fires_error() -> None:
+    """assess invokes resolve-failures with only 3 args when reachable from merge test_gate."""
+    recipe = _make_recipe(
+        {
+            "merge": RecipeStep(
+                tool="merge_worktree",
+                with_args={"worktree_path": "${{ context.worktree_path }}", "base_branch": "main"},
+                capture={
+                    "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                    # Missing test_stdout/test_stderr
+                },
+                on_result=StepResultRoute(conditions=_merge_on_result_conditions()),
+                on_failure="escalate",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.merge_fix_count }}",
+                    "max_iterations": "3",
+                },
+                capture={"merge_fix_count": "${{ result.next_iteration }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.max_exceeded }} == true", route="escalate"
+                        ),
+                        StepResultCondition(when=None, route="assess"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "assess": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": (
+                        "/autoskillit:resolve-failures"
+                        " ${{ context.worktree_path }}"
+                        " ${{ context.plan_path }}"
+                        " ${{ inputs.base_branch }}"
+                        # Only 3 args — no failure context
+                    ),
+                    "step_name": "assess",
+                },
+                capture={
+                    "verdict": "${{ result.verdict }}",
+                    "fixes_applied": "${{ result.fixes_applied }}",
+                },
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.verdict }} == 'flake_suspected'", route="test"
+                        ),
+                        StepResultCondition(when=None, route="escalate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "test": RecipeStep(
+                tool="test_check",
+                with_args={"worktree_path": "${{ context.worktree_path }}"},
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-test-gate-context-not-forwarded"]
+    assert len(flagged) >= 1
+    assert all(f.severity == Severity.ERROR for f in flagged)
+
+
+def test_assess_step_with_failure_context_is_clean() -> None:
+    """assess invokes resolve-failures with 6 args including merge_gate context → no finding."""
+    recipe = _make_recipe(
+        {
+            "merge": RecipeStep(
+                tool="merge_worktree",
+                with_args={"worktree_path": "${{ context.worktree_path }}", "base_branch": "main"},
+                capture={
+                    "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "merge_test_stdout": "${{ result.test_stdout }}",
+                    "merge_test_stderr": "${{ result.test_stderr }}",
+                },
+                on_result=StepResultRoute(conditions=_merge_on_result_conditions()),
+                on_failure="escalate",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.merge_fix_count }}",
+                    "max_iterations": "3",
+                },
+                capture={"merge_fix_count": "${{ result.next_iteration }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.max_exceeded }} == true", route="escalate"
+                        ),
+                        StepResultCondition(when=None, route="assess"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "assess": RecipeStep(
+                tool="run_skill",
+                with_args={
+                    "skill_command": (
+                        "/autoskillit:resolve-failures"
+                        " ${{ context.worktree_path }}"
+                        " ${{ context.plan_path }}"
+                        " ${{ inputs.base_branch }}"
+                        " ${{ context.merge_gate_ci_conclusion }}"
+                        " - ${{ context.merge_gate_diagnosis_path }}"
+                    ),
+                    "step_name": "assess",
+                },
+                capture={
+                    "verdict": "${{ result.verdict }}",
+                    "fixes_applied": "${{ result.fixes_applied }}",
+                },
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.verdict }} == 'flake_suspected'", route="test"
+                        ),
+                        StepResultCondition(when=None, route="escalate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "test": RecipeStep(
+                tool="test_check",
+                with_args={"worktree_path": "${{ context.worktree_path }}"},
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-test-gate-context-not-forwarded"]
+    assert not flagged
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["remediation.yaml", "implementation.yaml", "implementation-groups.yaml"],
+)
+def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> None:
+    """Before recipe fix: rule fires ERROR for all three pipeline recipes.
+
+    This test documents the pre-fix state. Once Step 5-6 fixes are applied,
+    this test should show zero findings — but until then it confirms the rule
+    detects the real structural problem.
+    """
+    from autoskillit.core import pkg_root
+    from autoskillit.recipe.io import load_recipe
+
+    recipe_path = pkg_root() / "recipes" / recipe_name
+    recipe = load_recipe(recipe_path)
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-test-gate-context-not-forwarded"]
+    # After recipe fixes are applied, this should be zero. Before fixes: may be non-zero.
+    # The presence of the rule (not a KeyError/crash) is what we verify here.
+    assert isinstance(flagged, list)

--- a/tests/recipe/test_rules_merge_context_forward.py
+++ b/tests/recipe/test_rules_merge_context_forward.py
@@ -341,12 +341,7 @@ def test_assess_step_with_failure_context_is_clean() -> None:
     ["remediation.yaml", "implementation.yaml", "implementation-groups.yaml"],
 )
 def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> None:
-    """Before recipe fix: rule fires ERROR for all three pipeline recipes.
-
-    This test documents the pre-fix state. Once Step 5-6 fixes are applied,
-    this test should show zero findings — but until then it confirms the rule
-    detects the real structural problem.
-    """
+    """Post recipe fix: rule no longer fires for the three pipeline recipes."""
     from autoskillit.core import pkg_root
     from autoskillit.recipe.io import load_recipe
 
@@ -354,5 +349,4 @@ def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> Non
     recipe = load_recipe(recipe_path)
     findings = run_semantic_rules(recipe)
     flagged = [f for f in findings if f.rule == "merge-test-gate-context-not-forwarded"]
-    # After recipe fixes are applied, this should be zero. Before fixes: may be non-zero.
-    assert len(flagged) >= 1
+    assert len(flagged) == 0

--- a/tests/recipe/test_rules_merge_context_forward.py
+++ b/tests/recipe/test_rules_merge_context_forward.py
@@ -340,7 +340,7 @@ def test_assess_step_with_failure_context_is_clean() -> None:
     "recipe_name",
     ["remediation.yaml", "implementation.yaml", "implementation-groups.yaml"],
 )
-def test_rule_fires_for_all_affected_recipes_before_fix(recipe_name: str) -> None:
+def test_rule_does_not_fire_for_fixed_recipes(recipe_name: str) -> None:
     """Post recipe fix: rule no longer fires for the three pipeline recipes."""
     from autoskillit.core import pkg_root
     from autoskillit.recipe.io import load_recipe

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2005,12 +2005,93 @@ def test_consolidate_health_reports_does_not_mutate_source_dicts(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# T_DIAGNOSE_1–T_DIAGNOSE_4: diagnose_merge_gate callable tests
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_merge_gate_writes_diagnosis_file(tmp_path: object) -> None:
+    """callable with test_stdout/test_stderr writes diagnosis file with correct format."""
+    from pathlib import Path
+
+    from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
+
+    output_dir = tmp_path  # type: ignore[union-attr]
+    result = diagnose_merge_gate(
+        test_stdout="FAILED tests/test_foo.py::test_bar - AssertionError\n1 failed in 0.5s",
+        test_stderr="",
+        output_dir=str(output_dir),
+    )
+    diag_path = Path(result["diagnosis_path"])
+    assert diag_path.exists()
+    content = diag_path.read_text()
+    assert "failure_subtype = " in content
+    assert "## Classification" in content
+    assert "## Failed Tests" in content
+    assert "## Structured Output" in content
+
+
+def test_diagnose_merge_gate_extracts_failure_subtype(tmp_path: object) -> None:
+    """Callable classifies failure_subtype from pytest output."""
+    from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
+
+    output_dir = tmp_path  # type: ignore[union-attr]
+
+    result_det = diagnose_merge_gate(
+        test_stdout="FAILED tests/test_foo.py::test_bar - AssertionError",
+        test_stderr="",
+        output_dir=str(output_dir),
+    )
+    from pathlib import Path
+
+    content = Path(result_det["diagnosis_path"]).read_text()
+    assert "failure_subtype = deterministic" in content
+
+    result_timeout = diagnose_merge_gate(
+        test_stdout="TimeoutError: timed out waiting for 30s",
+        test_stderr="",
+        output_dir=str(output_dir),
+    )
+    content_t = Path(result_timeout["diagnosis_path"]).read_text()
+    assert "failure_subtype = timing_race" in content_t
+
+
+def test_diagnose_merge_gate_handles_empty_output(tmp_path: object) -> None:
+    """callable with empty/absent test output returns graceful fallback."""
+    from pathlib import Path
+
+    from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
+
+    output_dir = tmp_path  # type: ignore[union-attr]
+    result = diagnose_merge_gate(test_stdout="", test_stderr="", output_dir=str(output_dir))
+    diag_path = Path(result["diagnosis_path"])
+    assert diag_path.exists()
+    content = diag_path.read_text()
+    assert "failure_subtype = unknown" in content
+
+
+def test_diagnose_merge_gate_returns_ci_conclusion_failure(tmp_path: object) -> None:
+    """Return dict has ci_conclusion='failure' and diagnosis_path pointing to existing file."""
+    from pathlib import Path
+
+    from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
+
+    output_dir = tmp_path  # type: ignore[union-attr]
+    result = diagnose_merge_gate(
+        test_stdout="FAILED tests/test_x.py::test_y",
+        test_stderr="",
+        output_dir=str(output_dir),
+    )
+    assert result["ci_conclusion"] == "failure"
+    assert Path(result["diagnosis_path"]).exists()
+
+
+# ---------------------------------------------------------------------------
 # T_FACADE_1–T_FACADE_2: smoke_utils package facade verification
 # ---------------------------------------------------------------------------
 
 
 def test_smoke_utils_all_exports_complete() -> None:
-    """smoke_utils.__all__ must list all 19 public names."""
+    """smoke_utils.__all__ must list all 21 public names."""
     import autoskillit.smoke_utils as su
 
     expected = {
@@ -2027,6 +2108,7 @@ def test_smoke_utils_all_exports_complete() -> None:
         "consolidate_health_reports",
         "compute_domain_partitions",
         "detect_zero_changes",
+        "diagnose_merge_gate",
         "enrich_diff_context",
         "fetch_merge_queue_data",
         "LOCAL_ROUND_EXEMPT_VERDICTS",
@@ -2054,6 +2136,7 @@ def test_smoke_utils_all_exports_complete() -> None:
         "consolidate_health_reports",
         "compute_domain_partitions",
         "detect_zero_changes",
+        "diagnose_merge_gate",
         "enrich_diff_context",
         "fetch_merge_queue_data",
         "parse_agent_eval_manifests",


### PR DESCRIPTION
## Summary

The merge gate retry loop (`merge → check_merge_fix_loop → assess/fix → test → merge`) is structurally unwinnable when test failures are non-reproducible flakes. Three architectural weaknesses combine to create this dead end:

1. **Lost context**: `perform_merge()` returns `test_stdout`/`test_stderr` on test gate failure, but the recipe `merge` step's `capture:` block doesn't capture them. The `assess`/`fix` step passes only 3 args to `resolve-failures` (worktree, plan, branch) — no failure context reaches the skill.

2. **Unwinnable loop**: Without failure context, `resolve-failures` defaults to `failure_subtype = unknown`. Local tests pass (the flake doesn't reproduce), so the verdict is `flake_suspected`. The recipe routes `flake_suspected → test`, which succeeds, then `merge` re-runs the test gate which flakes again. This cycle exhausts `merge_fix_max_retries` (3) without ever having a chance to succeed.

3. **No bypass verdict**: There is no verdict that means "tests pass locally, failure is non-reproducible, proceed with merge." The only continuation verdicts (`real_fix`, `already_green`, `flake_suspected`) all route back through `test → merge`, re-entering the flake loop.

Part A addresses gaps 1 and 2 (context forwarding + new semantic rules to prevent recurrence). Part B will address gap 3 (the `merge_safe` verdict and test gate retry-on-failure at `perform_merge()` level).

## Requirements

(No explicit ## Requirements section in issue #3268)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

(none — no conflict report provided)

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260529-130357-127795/.autoskillit/temp/rectify/rectify_merge_gate_flake_immunity_2026-05-29_133500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 7.5k | 34.9k | 5.3M | 145.5k | 344 | 139.6k | 25m 39s |
| review_approach* | sonnet | 1 | 2.3k | 5.9k | 182.3k | 42.2k | 45 | 31.6k | 2m 58s |
| dry_walkthrough* | opus | 1 | 55 | 12.8k | 1.8M | 78.8k | 134 | 64.7k | 7m 21s |
| implement* | sonnet | 1 | 728 | 54.5k | 11.3M | 172.8k | 268 | 159.5k | 19m 21s |
| audit_impl* | sonnet | 1 | 84 | 11.0k | 334.3k | 67.6k | 29 | 76.7k | 3m 9s |
| prepare_pr* | sonnet | 1 | 165.9k | 4.3k | 402.0k | 30.9k | 29 | 43.8k | 1m 31s |
| compose_pr* | sonnet | 1 | 48.2k | 1.5k | 213.5k | 30.9k | 14 | 15.5k | 41s |
| review_pr* | sonnet | 2 | 532 | 100.6k | 4.4M | 151.7k | 174 | 255.9k | 25m 25s |
| resolve_review* | opus | 2 | 105 | 19.9k | 3.3M | 86.2k | 114 | 123.5k | 15m 43s |
| **Total** | | | 225.4k | 245.2k | 27.2M | 172.8k | | 910.7k | 1h 41m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 1217 | 9285.1 | 131.0 | 44.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 70 | 47344.1 | 1763.6 | 283.6 |
| **Total** | **1287** | 21134.7 | 707.6 | 190.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 7.5k | 34.9k | 5.3M | 139.6k | 25m 39s |
| sonnet | 6 | 217.7k | 177.7k | 16.8M | 582.9k | 53m 6s |
| opus | 2 | 160 | 32.6k | 5.1M | 188.2k | 23m 4s |