### PR TITLE
Rectify: False-Positive Write Evidence from Init Manifest Triggers CONTRACT_RECOVERY

### DIFF
--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -149,7 +150,31 @@ def _extract_file_changes(stdout: str, backend: CodingAgentBackend) -> list[str]
 
 
 def _stdout_mentions_write_tools(stdout: str) -> bool:
-    return '"Edit"' in stdout or '"Write"' in stdout
+    """Return True if stdout contains a write tool call in an assistant NDJSON record.
+
+    Filters by type=assistant to avoid matching tool names in system/init manifests or
+    other non-assistant events. For truncated lines that fail JSON parsing, falls back
+    to an assistant-prefix + substring check to preserve truncation recovery behavior.
+    """
+    _write_names = {"Write", "Edit"}
+    for line in stdout.splitlines():
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            # Truncated line: check if it looks like an assistant record with a write tool name.
+            if (
+                line.startswith('{"type":"assistant"') or line.startswith('{"type": "assistant"')
+            ) and ('"Write"' in line or '"Edit"' in line):
+                return True
+            continue
+        if obj.get("type") != "assistant":
+            continue
+        for block in obj.get("message", {}).get("content", []):
+            if block.get("type") == "tool_use" and block.get("name") in _write_names:
+                return True
+    return False
 
 
 def _build_session_telemetry(

--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -150,12 +150,7 @@ def _extract_file_changes(stdout: str, backend: CodingAgentBackend) -> list[str]
 
 
 def _stdout_mentions_write_tools(stdout: str) -> bool:
-    """Return True if stdout contains a write tool call in an assistant NDJSON record.
-
-    Filters by type=assistant to avoid matching tool names in system/init manifests or
-    other non-assistant events. For truncated lines that fail JSON parsing, falls back
-    to an assistant-prefix + substring check to preserve truncation recovery behavior.
-    """
+    """For truncated lines that fail JSON parsing, falls back to prefix + substring check."""
     _write_names = {"Write", "Edit"}
     for line in stdout.splitlines():
         if not line:

--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -172,7 +172,11 @@ def _stdout_mentions_write_tools(stdout: str) -> bool:
         if obj.get("type") != "assistant":
             continue
         for block in obj.get("message", {}).get("content", []):
-            if block.get("type") == "tool_use" and block.get("name") in _write_names:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") in _write_names
+            ):
                 return True
     return False
 

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -404,6 +404,7 @@ async def _execute_claude_headless(
             provider_used=current_provider_name,
             supports_claude_format_stdout=_supports_fmt,
             backend=_step_backend,
+            readonly_skill=_readonly_skill,
         )
 
         if (

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -149,6 +149,7 @@ def _build_skill_result(
     provider_used: str = "",
     supports_claude_format_stdout: bool = True,
     backend: CodingAgentBackend,
+    readonly_skill: bool = False,
 ) -> SkillResult:
     """Route SubprocessResult fields into the standard run_skill response."""
     file_changes = _extract_file_changes(result.stdout, backend)
@@ -551,6 +552,7 @@ def _build_skill_result(
         and not needs_retry
         and normalized_subtype == "adjudicated_failure"
         and _has_write_evidence
+        and not readonly_skill
     ):
         _audit_needs_retry = True
         _audit_retry_reason = RetryReason.CONTRACT_RECOVERY
@@ -647,6 +649,7 @@ def _build_skill_result(
         and not sr.needs_retry
         and sr.subtype == "adjudicated_failure"
         and _has_write_evidence
+        and not readonly_skill
     ):
         sr = dataclasses.replace(
             sr,

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -18,7 +18,7 @@ NEW_HEADLESS_MODULES = [
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 460,
     "headless/_headless_helpers.py": 175,
-    "headless/_headless_execute.py": 590,
+    "headless/_headless_execute.py": 591,
     "headless/_headless_recovery.py": 366,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1246,6 +1246,8 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     "tests/execution/test_session_log_retention.py": frozenset({"autoskillit.fleet"}),
     # provider forwarding test verifies budget guard preserves provider_used — needs DefaultAuditLog
     "tests/execution/test_headless_provider_forwarding.py": frozenset({"autoskillit.pipeline"}),
+    # CONTRACT_RECOVERY suppression test uses DefaultAuditLog to verify audit entries — needs pipeline
+    "tests/execution/test_headless_result.py": frozenset({"autoskillit.pipeline"}),
     # planner write isolation integration test verifies audit log entries from clone guard
     "tests/execution/test_planner_write_isolation.py": frozenset({"autoskillit.pipeline"}),
     # clone guard integration test uses DefaultAuditLog for check_and_revert_clone_contamination

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -440,6 +440,80 @@ async def test_dispatch_food_truck_forwards_marker_dir_and_session_id(
     assert execute_kwargs["session_id"] == "dispatch-uuid-123"
 
 
+# ── readonly_skill forwarding tests ───────────────────────────────────────────
+
+
+def test_build_skill_result_accepts_readonly_skill_kwarg() -> None:
+    import inspect
+
+    from autoskillit.execution.headless._headless_result import _build_skill_result
+
+    sig = inspect.signature(_build_skill_result)
+    param = sig.parameters["readonly_skill"]
+    assert param.default is False
+    assert param.kind == inspect.Parameter.KEYWORD_ONLY
+
+
+@pytest.mark.anyio
+async def test_execute_forwards_readonly_skill_to_build_result(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    import json
+
+    import autoskillit.execution.headless._headless_execute as _hx
+    from autoskillit.execution.commands import ClaudeHeadlessCmd
+    from autoskillit.execution.headless import PostSessionMetrics, _execute_claude_headless
+    from autoskillit.execution.headless._headless_result import _build_skill_result as _orig_bsr
+    from tests.execution.conftest import _sr
+
+    captured_readonly: list = []
+
+    def _spy_build(result, **kwargs):
+        captured_readonly.append(kwargs.get("readonly_skill", "NOT_PASSED"))
+        return _orig_bsr(result, **kwargs)
+
+    monkeypatch.setattr(_hx, "_build_skill_result", _spy_build)
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
+        lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
+        lambda *a: "",
+    )
+
+    result_line = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "done",
+            "session_id": "s1",
+            "is_error": False,
+        }
+    )
+
+    async def fake_runner(cmd, **kwargs):
+        return _sr(0, result_line)
+
+    minimal_ctx.runner = fake_runner
+    minimal_ctx.backend = _mock_backend()
+
+    spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
+    await _execute_claude_headless(
+        spec,
+        str(tmp_path),
+        minimal_ctx,
+        timeout=10.0,
+        stale_threshold=5.0,
+        readonly_skill=True,
+    )
+
+    assert captured_readonly, "_build_skill_result was not called"
+    assert captured_readonly[0] is True, (
+        "_execute_claude_headless must pass readonly_skill=True to _build_skill_result"
+    )
+
+
 @pytest.mark.anyio
 async def test_dispatch_food_truck_derives_marker_dir_from_cwd(
     minimal_ctx, tmp_path, monkeypatch

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -982,8 +982,15 @@ class TestWriteEvidenceCrossCheck:
                 "is_error": False,
             }
         )
-        # Truncated tool_use triggers cross-check → _has_write_evidence=True
-        stdout = _truncated_tool_use_line() + "\n" + result_line
+        write_tool_line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "tool_use", "name": "Write", "id": "t1", "input": {}}]
+                },
+            }
+        )
+        stdout = write_tool_line + "\n" + result_line
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
         audit = DefaultAuditLog()
 

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -31,6 +31,7 @@ from autoskillit.execution.headless import (
 from autoskillit.execution.headless._headless_evidence import (
     _adapt_agent_result,
     _compute_write_evidence,
+    _stdout_mentions_write_tools,
 )
 from autoskillit.execution.session import ClaudeSessionResult
 from autoskillit.execution.session._session_outcome import _compute_outcome
@@ -751,6 +752,97 @@ def _truncated_tool_use_line() -> str:
     return '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","id":"t1"'
 
 
+def _system_init_ndjson(tools: list[str] | None = None) -> str:
+    """Return a realistic system/init NDJSON line listing tools in a manifest array."""
+    if tools is None:
+        tools = ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "Agent", "Task", "WebSearch"]
+    return json.dumps(
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "test-session-id",
+            "tools": [{"name": t, "type": "tool"} for t in tools],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "stdout,expected",
+    [
+        # system/init only — must not match
+        pytest.param(
+            _system_init_ndjson(),
+            False,
+            id="system_init_only",
+        ),
+        # assistant/tool_use with Edit — must match
+        pytest.param(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "tool_use", "name": "Edit", "id": "t1", "input": {}}]
+                    },
+                }
+            ),
+            True,
+            id="assistant_edit_tool_use",
+        ),
+        # assistant/tool_use with Read only — must not match
+        pytest.param(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "tool_use", "name": "Read", "id": "t1", "input": {}}]
+                    },
+                }
+            ),
+            False,
+            id="assistant_read_only",
+        ),
+        # system/init + assistant/tool_use with Edit — must match
+        pytest.param(
+            _system_init_ndjson()
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "tool_use", "name": "Edit", "id": "t1", "input": {}}]
+                    },
+                }
+            ),
+            True,
+            id="init_plus_assistant_edit",
+        ),
+        # empty string — must not match
+        pytest.param("", False, id="empty_string"),
+        # parseable assistant with text content mentioning "Edit" — no tool_use block → False
+        pytest.param(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "text", "text": 'I will use "Edit" to change it'}]
+                    },
+                }
+            ),
+            False,
+            id="assistant_text_mentions_edit_no_tool_use",
+        ),
+        # truncated assistant record that fails JSON parse, containing "Edit" as tool name → True
+        pytest.param(
+            _truncated_tool_use_line(),
+            True,
+            id="truncated_assistant_edit",
+        ),
+    ],
+)
+def test_stdout_mentions_write_tools_unit(stdout: str, expected: bool) -> None:
+    assert _stdout_mentions_write_tools(stdout) is expected
+
+
 class TestWriteEvidenceCrossCheck:
     def test_cross_check_logs_mismatch(self) -> None:
         result_line = _success_result_json()
@@ -851,6 +943,69 @@ class TestWriteEvidenceCrossCheck:
         result = _idle_stall_result(result_line)
         sr = _build_skill_result(result, backend=ClaudeCodeBackend())
         assert sr.infra.exit_category == "api_error"
+
+    def test_cross_check_ignores_init_manifest(self) -> None:
+        stdout = _system_init_ndjson() + "\n" + _success_result_json()
+        result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
+        assert sr.evidence.write_call_count == 0, (
+            "system/init tool manifest must not trigger write-tool cross-check"
+        )
+        assert sr.retry_reason != RetryReason.CONTRACT_RECOVERY
+
+    def test_cross_check_detects_real_write_in_assistant_record(self) -> None:
+        stdout = (
+            _system_init_ndjson()
+            + "\n"
+            + _truncated_tool_use_line()
+            + "\n"
+            + _success_result_json()
+        )
+        result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
+        assert sr.evidence.write_call_count >= 1, (
+            "truncated assistant/tool_use with 'Edit' must still trigger cross-check "
+            "even when a system/init line also appears in stdout"
+        )
+
+    def test_contract_recovery_suppressed_for_read_only(self) -> None:
+        from autoskillit.pipeline.audit import DefaultAuditLog
+
+        # Produce adjudicated_failure: success subtype + completion_marker present in result
+        # but expected_output_patterns not matched.
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "plan summary\n%%ORDER_UP%%",
+                "session_id": "s1",
+                "is_error": False,
+            }
+        )
+        # Truncated tool_use triggers cross-check → _has_write_evidence=True
+        stdout = _truncated_tool_use_line() + "\n" + result_line
+        result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
+        audit = DefaultAuditLog()
+
+        sr = _build_skill_result(
+            result,
+            completion_marker="%%ORDER_UP%%",
+            expected_output_patterns=[r"plan_path\s*=\s*/.+"],
+            skill_command="/test:read-only-skill",
+            audit=audit,
+            readonly_skill=True,
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.retry_reason != RetryReason.CONTRACT_RECOVERY
+        assert sr.needs_retry is False
+        contract_recovery_entries = [
+            f
+            for f in audit.get_report()
+            if f.skill_command == "/test:read-only-skill" and f.retry_reason == "contract_recovery"
+        ]
+        assert not contract_recovery_entries, (
+            "Audit log must not record CONTRACT_RECOVERY for read-only skills"
+        )
 
 
 class TestCodexPipelineHappyPath:


### PR DESCRIPTION
## Summary

`_stdout_mentions_write_tools()` in `_headless_evidence.py` is a raw substring scan that matches tool names anywhere in the Claude Code NDJSON stdout stream — including the `system/init` event's tool manifest array, which lists all ~70 available tools. This produces false-positive write evidence for every session, but the false positive only triggers the cross-check mismatch guard when structured parsing also yields zero write tool calls (i.e., read-only skills, failed sessions, or truncated output). The CONTRACT_RECOVERY gate then fires on `adjudicated_failure` sessions with the synthetic `write_call_count=1`, causing spurious retries of read-only skills.

The architectural weakness is twofold: (1) a raw-string evidence probe operates at a different abstraction level than the NDJSON-aware parsers it's meant to cross-check, and (2) the CONTRACT_RECOVERY gate has no awareness of skill write contracts (`read_only`), so it cannot suppress itself for skills that structurally cannot produce write evidence.

Closes #3279

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260529-171109-334860/.autoskillit/temp/rectify/rectify_false_positive_write_evidence_2026-05-29_172500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 95 | 21.0k | 2.4M | 109.1k | 256 | 145.1k | 31m 5s |
| review_approach* | sonnet | 1 | 60 | 5.0k | 212.8k | 39.0k | 27 | 25.8k | 3m 45s |
| dry_walkthrough* | opus | 1 | 525 | 7.0k | 1.1M | 55.0k | 75 | 38.9k | 3m 24s |
| implement* | sonnet | 1 | 1.8k | 43.1k | 4.9M | 126.0k | 158 | 110.4k | 16m 0s |
| audit_impl* | sonnet | 1 | 68 | 4.5k | 264.5k | 44.7k | 22 | 31.5k | 1m 24s |
| prepare_pr* | sonnet | 1 | 102.2k | 3.3k | 216.5k | 30.9k | 23 | 43.8k | 1m 19s |
| compose_pr* | sonnet | 1 | 93.5k | 2.2k | 337.3k | 30.9k | 26 | 15.5k | 1m 1s |
| review_pr* | sonnet | 1 | 142 | 50.6k | 977.9k | 101.5k | 47 | 86.6k | 12m 25s |
| resolve_review* | sonnet | 1 | 239 | 15.1k | 1.5M | 71.3k | 69 | 78.1k | 10m 51s |
| diagnose_ci* | sonnet | 1 | 162.9k | 2.1k | 247.6k | 30.9k | 21 | 43.3k | 1m 6s |
| resolve_ci* | sonnet | 1 | 142 | 4.8k | 841.8k | 63.9k | 44 | 47.9k | 5m 41s |
| **Total** | | | 361.8k | 158.7k | 13.1M | 126.0k | | 667.0k | 1h 28m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 260 | 19010.8 | 424.8 | 165.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 18 | 85989.9 | 4338.6 | 841.3 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 2 | 420903.0 | 23969.0 | 2392.5 |
| **Total** | **280** | 46618.0 | 2382.2 | 566.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 95 | 21.0k | 2.4M | 145.1k | 31m 5s |
| sonnet | 9 | 361.1k | 130.6k | 9.6M | 483.0k | 53m 36s |
| opus | 1 | 525 | 7.0k | 1.1M | 38.9k | 3m 24s |