### PR TITLE
[FIX] Rectify: Markdown HR Delimiter Collision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,6 +361,10 @@ ignore_imports = [
     # narrowest place where both the recipe schema and config defaults are simultaneously
     # available. Do not expand fleet's config access beyond this single call site.
     "autoskillit.fleet._api -> autoskillit.config",
+    # result_parser applies _collapse_hr_split_delimiters to normalize HR-split sentinel
+    # tokens before rfind-based scanning. The function is a pure regex substitution with
+    # no execution-layer side effects.
+    "autoskillit.fleet.result_parser -> autoskillit.execution",
 ]
 
 # IL-011 | _dag_ops: shared DAG primitives with no planner-internal imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,7 +364,7 @@ ignore_imports = [
     # result_parser applies _collapse_hr_split_delimiters to normalize HR-split sentinel
     # tokens before rfind-based scanning. The function is a pure regex substitution with
     # no execution-layer side effects.
-    "autoskillit.fleet.result_parser -> autoskillit.execution.session",
+    "autoskillit.fleet.result_parser -> autoskillit.execution",
 ]
 
 # IL-011 | _dag_ops: shared DAG primitives with no planner-internal imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,7 +364,7 @@ ignore_imports = [
     # result_parser applies _collapse_hr_split_delimiters to normalize HR-split sentinel
     # tokens before rfind-based scanning. The function is a pure regex substitution with
     # no execution-layer side effects.
-    "autoskillit.fleet.result_parser -> autoskillit.execution",
+    "autoskillit.fleet.result_parser -> autoskillit.execution.session",
 ]
 
 # IL-011 | _dag_ops: shared DAG primitives with no planner-internal imports

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -111,6 +111,7 @@ from autoskillit.execution.session import (
     ClaudeSessionResult,
     ContentState,
     SessionState,
+    _collapse_hr_split_delimiters,  # noqa: F401 — re-exported for fleet.result_parser
     classify_infra_exit,
     clear_session_state,
     extract_token_usage,

--- a/src/autoskillit/execution/session/CLAUDE.md
+++ b/src/autoskillit/execution/session/CLAUDE.md
@@ -10,7 +10,7 @@ Session result processing — parse, validate content, compute retry, adjudicate
 | `_exit_classification.py` | Infrastructure exit classification: `classify_infra_exit()`, `InfraExitCategory` detection from session + stderr |
 | `_session_state.py` | Session state persistence for resume: `SessionState`, `persist_session_state()`, `read_session_state()`, `clear_session_state()` |
 | `_session_model.py` | `ClaudeSessionResult`, `ContentState`, `parse_session_result()`, `extract_token_usage()` |
-| `_session_content.py` | Content validation: `_check_session_content()`, `_check_expected_patterns()` |
+| `_session_content.py` | Content validation: `_check_session_content()`, `_check_expected_patterns()`, `_normalize_model_output()`, `_collapse_hr_split_delimiters()` |
 | `_retry_fsm.py` | Retry FSM: `_compute_retry()`, maps `(TerminationReason, CliSubtype)` to `RetryReason` |
 | `_session_outcome.py` | High-level adjudication: `_compute_success()`, `_compute_outcome()` |
 

--- a/src/autoskillit/execution/session/__init__.py
+++ b/src/autoskillit/execution/session/__init__.py
@@ -28,6 +28,7 @@ from autoskillit.execution.session._retry_fsm import (
 from autoskillit.execution.session._session_content import (
     _check_expected_patterns,  # noqa: F401 — re-export for callers
     _check_session_content,  # noqa: F401 — re-export for callers
+    _collapse_hr_split_delimiters,  # noqa: F401 — re-export for callers
     _evaluate_content_state,  # noqa: F401 — re-export for callers
 )
 from autoskillit.execution.session._session_model import (

--- a/src/autoskillit/execution/session/_session_content.py
+++ b/src/autoskillit/execution/session/_session_content.py
@@ -38,7 +38,7 @@ _MARKDOWN_ITALIC_COLON_RE: re.Pattern[str] = re.compile(
 # Backtick: `key` = value → key = value
 _MARKDOWN_BACKTICK_RE: re.Pattern[str] = re.compile(r"`(\w[\w_-]*)`(\s*=)", re.MULTILINE)
 # HR-split delimiter: ---\n[/]name--- → ---[/]name--- (open and close delimiter variants)
-_HR_SPLIT_DELIMITER_RE: re.Pattern[str] = re.compile(r"---\n+(/?\w[\w-]*---)")
+_HR_SPLIT_DELIMITER_RE: re.Pattern[str] = re.compile(r"---\n+(/?\w[\w:.-]*---)")
 # Bold-wrapped delimiter: **---[/]name---** or *---[/]name---* → ---[/]name---
 _DELIMITER_BOLD_RE: re.Pattern[str] = re.compile(r"\*{1,2}(---/?\w[\w-]*---)\*{1,2}")
 # Backtick-wrapped delimiter: `---[/]name---` → ---[/]name---

--- a/src/autoskillit/execution/session/_session_content.py
+++ b/src/autoskillit/execution/session/_session_content.py
@@ -37,28 +37,50 @@ _MARKDOWN_ITALIC_COLON_RE: re.Pattern[str] = re.compile(
 )
 # Backtick: `key` = value → key = value
 _MARKDOWN_BACKTICK_RE: re.Pattern[str] = re.compile(r"`(\w[\w_-]*)`(\s*=)", re.MULTILINE)
+# HR-split delimiter: ---\n[/]name--- → ---[/]name--- (open and close delimiter variants)
+_HR_SPLIT_DELIMITER_RE: re.Pattern[str] = re.compile(r"---\n+(/?\w[\w-]*---)")
+# Bold-wrapped delimiter: **---[/]name---** or *---[/]name---* → ---[/]name---
+_DELIMITER_BOLD_RE: re.Pattern[str] = re.compile(r"\*{1,2}(---/?\w[\w-]*---)\*{1,2}")
+# Backtick-wrapped delimiter: `---[/]name---` → ---[/]name---
+_DELIMITER_BACKTICK_RE: re.Pattern[str] = re.compile(r"`(---/?\w[\w-]*---)`")
 
 
-def _strip_markdown_from_tokens(text: str) -> str:
-    """Remove bold/italic markdown decorators from structured output token names.
+def _collapse_hr_split_delimiters(text: str) -> str:
+    """Collapse markdown HR + delimiter suffix into a contiguous delimiter token.
 
-    Transforms model output like:
-        **plan_path** = /abs/path/plan.md
-        **Plan_Path:** /abs/path/plan.md
-        `plan_path` = /abs/path/plan.md
-    into the canonical form:
-        plan_path = /abs/path/plan.md
-
-    Applied before regex pattern matching to make adjudication tolerant of the
-    model's choice to visually style its output summary. Three decorator variants
-    are handled: bold/italic with equals, bold/italic with colon, and backtick
-    wrapping. Decorators elsewhere in the text are left unchanged.
+    When a model emits a markdown horizontal rule (``---``) on its own line
+    immediately before the name portion of a ``---X---`` or ``---/X---`` token,
+    the three leading hyphens land on a separate line and pattern matching fails.
+    This function rejoins them so downstream regex searches find the full token.
     """
+    return _HR_SPLIT_DELIMITER_RE.sub(r"---\1", text)
+
+
+def _normalize_model_output(text: str) -> str:
+    """Normalize model output formatting variations that interfere with pattern matching.
+
+    Applies three sequential normalization stages:
+
+    Stage 1 — HR-split collapse: rejoins ``---\\n[/]name---`` into ``---[/]name---``
+    when the model emits a markdown horizontal rule immediately before a delimiter
+    token name on a separate line.
+
+    Stage 2 — Key=value decorator strip: removes bold/italic/backtick decorators
+    from ``key = value`` structured output token names so ``**plan_path** = /path``
+    is treated identically to ``plan_path = /path``.
+
+    Stage 3 — Delimiter decorator strip: removes bold and backtick wrapping from
+    ``---X---`` delimiter tokens so ``**---pipeline-health-result---**`` is treated
+    identically to ``---pipeline-health-result---``.
+    """
+    text = _collapse_hr_split_delimiters(text)
     text = _MARKDOWN_BOLD_EQUALS_RE.sub(lambda m: m.group(1).lower() + m.group(2), text)
     text = _MARKDOWN_BOLD_COLON_RE.sub(lambda m: m.group(1).lower() + " = ", text)
     text = _MARKDOWN_ITALIC_EQUALS_RE.sub(lambda m: m.group(1).lower() + m.group(2), text)
     text = _MARKDOWN_ITALIC_COLON_RE.sub(lambda m: m.group(1).lower() + " = ", text)
     text = _MARKDOWN_BACKTICK_RE.sub(lambda m: m.group(1).lower() + m.group(2), text)
+    text = _DELIMITER_BOLD_RE.sub(r"\1", text)
+    text = _DELIMITER_BACKTICK_RE.sub(r"\1", text)
     return text
 
 
@@ -70,14 +92,16 @@ def _check_expected_patterns(result: str, patterns: Sequence[str]) -> bool:
     AND semantics are intentional: patterns represent content contracts (e.g.,
     block start/end delimiters) that must all be present simultaneously.
 
-    Normalizes bold/italic markdown decorators on token names before matching,
-    so ``**plan_path** = /path`` is treated identically to ``plan_path = /path``.
+    Normalizes model formatting variations on token names before matching,
+    so ``**plan_path** = /path`` is treated identically to ``plan_path = /path``
+    and ``---\\npipeline-health-result---`` is treated identically to
+    ``---pipeline-health-result---``.
 
     If any pattern is an invalid regex, returns False rather than raising.
     """
     if not patterns:
         return True
-    normalized = _strip_markdown_from_tokens(result)
+    normalized = _normalize_model_output(result)
     for p in patterns:
         try:
             if not re.search(p, normalized):

--- a/src/autoskillit/execution/session/_session_content.py
+++ b/src/autoskillit/execution/session/_session_content.py
@@ -40,9 +40,9 @@ _MARKDOWN_BACKTICK_RE: re.Pattern[str] = re.compile(r"`(\w[\w_-]*)`(\s*=)", re.M
 # HR-split delimiter: ---\n[/]name--- → ---[/]name--- (open and close delimiter variants)
 _HR_SPLIT_DELIMITER_RE: re.Pattern[str] = re.compile(r"---\n+(/?\w[\w:.-]*---)")
 # Bold-wrapped delimiter: **---[/]name---** or *---[/]name---* → ---[/]name---
-_DELIMITER_BOLD_RE: re.Pattern[str] = re.compile(r"\*{1,2}(---/?\w[\w-]*---)\*{1,2}")
+_DELIMITER_BOLD_RE: re.Pattern[str] = re.compile(r"\*{1,2}(---/?\w[\w:.-]*---)\*{1,2}")
 # Backtick-wrapped delimiter: `---[/]name---` → ---[/]name---
-_DELIMITER_BACKTICK_RE: re.Pattern[str] = re.compile(r"`(---/?\w[\w-]*---)`")
+_DELIMITER_BACKTICK_RE: re.Pattern[str] = re.compile(r"`(---/?\w[\w:.-]*---)`")
 
 
 def _collapse_hr_split_delimiters(text: str) -> str:

--- a/src/autoskillit/fleet/result_parser.py
+++ b/src/autoskillit/fleet/result_parser.py
@@ -11,6 +11,7 @@ from typing import Literal
 import regex as re
 
 from autoskillit.core import ClaudeContentBlockType, get_logger
+from autoskillit.execution.session import _collapse_hr_split_delimiters
 
 logger = get_logger(__name__)
 
@@ -162,7 +163,7 @@ def parse_l3_result_block(
     open_sentinel = f"---l3-result::{expected_dispatch_id}---"
     close_sentinel = f"---end-l3-result::{expected_dispatch_id}---"
 
-    cleaned = _ANSI_RE.sub("", stdout)
+    cleaned = _collapse_hr_split_delimiters(_ANSI_RE.sub("", stdout))
 
     positions = _scan_for_sentinel(cleaned, open_sentinel, close_sentinel)
     if positions is not None:
@@ -171,7 +172,9 @@ def parse_l3_result_block(
 
     jsonl_text: str | None = None
     if assistant_messages_path is not None:
-        jsonl_text = _extract_text_from_jsonl(assistant_messages_path)
+        jsonl_text = _collapse_hr_split_delimiters(
+            _extract_text_from_jsonl(assistant_messages_path)
+        )
         positions = _scan_for_sentinel(jsonl_text, open_sentinel, close_sentinel)
         if positions is not None:
             open_pos, close_pos = positions
@@ -203,7 +206,7 @@ def parse_l3_result_block(
     # Stage 4: scan additional JSONL paths (cross-session recovery for resume)
     if additional_jsonl_paths:
         for jsonl_path in additional_jsonl_paths:
-            additional_text = _extract_text_from_jsonl(jsonl_path)
+            additional_text = _collapse_hr_split_delimiters(_extract_text_from_jsonl(jsonl_path))
             if not additional_text:
                 continue
             positions = _scan_for_sentinel(additional_text, open_sentinel, close_sentinel)

--- a/src/autoskillit/fleet/result_parser.py
+++ b/src/autoskillit/fleet/result_parser.py
@@ -11,7 +11,7 @@ from typing import Literal
 import regex as re
 
 from autoskillit.core import ClaudeContentBlockType, get_logger
-from autoskillit.execution.session import _collapse_hr_split_delimiters
+from autoskillit.execution import _collapse_hr_split_delimiters
 
 logger = get_logger(__name__)
 

--- a/src/autoskillit/recipe/rules/rules_contracts.py
+++ b/src/autoskillit/recipe/rules/rules_contracts.py
@@ -28,6 +28,23 @@ _RESULT_FIELD_DRIFT_SKILLS = frozenset(
 
 logger = get_logger(__name__)
 
+_HR_SPLIT_RE = re.compile(r"---\n+(/?\w[\w-]*---)")
+_DELIM_BOLD_RE = re.compile(r"\*{1,2}(---/?\w[\w-]*---)\*{1,2}")
+_DELIM_BACKTICK_RE = re.compile(r"`(---/?\w[\w-]*---)`")
+
+
+def _normalize_for_pattern_match(text: str) -> str:
+    """Collapse HR-split delimiters and strip delimiter decorators.
+
+    Mirrors the normalization stages in execution/session/_session_content.py
+    that are relevant to delimiter tokens. Duplicated here because IL-2 (recipe)
+    cannot import IL-1 (execution).
+    """
+    text = _HR_SPLIT_RE.sub(r"---\1", text)
+    text = _DELIM_BOLD_RE.sub(r"\1", text)
+    text = _DELIM_BACKTICK_RE.sub(r"\1", text)
+    return text
+
 
 @semantic_rule(
     name="missing-output-patterns",
@@ -96,7 +113,10 @@ def _check_pattern_examples_match(ctx: ValidationContext) -> list[RuleFinding]:
             continue
         for pattern in contract.expected_output_patterns:
             try:
-                matched = any(re.search(pattern, ex) for ex in contract.pattern_examples)
+                matched = any(
+                    re.search(pattern, _normalize_for_pattern_match(ex))
+                    for ex in contract.pattern_examples
+                )
             except re.error:
                 findings.append(
                     RuleFinding(
@@ -512,7 +532,7 @@ def _check_all_examples_match_all_patterns(ctx: ValidationContext) -> list[RuleF
         for example in contract.pattern_examples:
             for pattern in contract.expected_output_patterns:
                 try:
-                    matched = bool(re.search(pattern, example))
+                    matched = bool(re.search(pattern, _normalize_for_pattern_match(example)))
                 except re.error:
                     continue  # invalid regex — covered by pattern-examples-match
                 if not matched:

--- a/src/autoskillit/recipe/rules/rules_contracts.py
+++ b/src/autoskillit/recipe/rules/rules_contracts.py
@@ -28,17 +28,15 @@ _RESULT_FIELD_DRIFT_SKILLS = frozenset(
 
 logger = get_logger(__name__)
 
-_HR_SPLIT_RE = re.compile(r"---\n+(/?\w[\w-]*---)")
-_DELIM_BOLD_RE = re.compile(r"\*{1,2}(---/?\w[\w-]*---)\*{1,2}")
-_DELIM_BACKTICK_RE = re.compile(r"`(---/?\w[\w-]*---)`")
+_HR_SPLIT_RE = re.compile(r"---\n+(/?\w[\w:.-]*---)")
+_DELIM_BOLD_RE = re.compile(r"\*{1,2}(---/?\w[\w:.-]*---)\*{1,2}")
+_DELIM_BACKTICK_RE = re.compile(r"`(---/?\w[\w:.-]*---)`")
 
 
 def _normalize_for_pattern_match(text: str) -> str:
     """Collapse HR-split delimiters and strip delimiter decorators.
 
-    Mirrors the normalization stages in execution/session/_session_content.py
-    that are relevant to delimiter tokens. Duplicated here because IL-2 (recipe)
-    cannot import IL-1 (execution).
+    Duplicated from IL-1 because IL-2 (recipe) cannot import IL-1 (execution).
     """
     text = _HR_SPLIT_RE.sub(r"---\1", text)
     text = _DELIM_BOLD_RE.sub(r"\1", text)

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1207,7 +1207,8 @@ skills:
     expected_output_patterns:
     - "---prepare-issue-result---"
     pattern_examples:
-    - "---prepare-issue-result---"
+    - "## Parsed Issue\n\n---prepare-issue-result---\n{\"title\": \"Fix bug\"}\n---/prepare-issue-result---\n\n%%ORDER_UP%%"
+    - "Analysis complete.\n\n---\nprepare-issue-result---\n{\"title\": \"Fix bug\"}\n---/prepare-issue-result---\n\n%%ORDER_UP%%"
 
   enrich-issues:
     inputs: []
@@ -1215,7 +1216,8 @@ skills:
     expected_output_patterns:
     - "---enrich-issues-result---"
     pattern_examples:
-    - "---enrich-issues-result---"
+    - "Enrichment complete.\n\n---enrich-issues-result---\n[{\"issue\": 1}]\n---/enrich-issues-result---\n\n%%ORDER_UP%%"
+    - "Processing issues.\n\n---\nenrich-issues-result---\n[{\"issue\": 1}]\n---/enrich-issues-result---\n\n%%ORDER_UP%%"
 
   report-bug:
     inputs: []
@@ -1223,7 +1225,8 @@ skills:
     expected_output_patterns:
     - "---bug-fingerprint---"
     pattern_examples:
-    - "---bug-fingerprint---"
+    - "Bug analyzed.\n\n---bug-fingerprint---\nroot_cause = missing_guard\n---/bug-fingerprint---\n\n%%ORDER_UP%%"
+    - "Bug analyzed.\n\n---\nbug-fingerprint---\nroot_cause = missing_guard\n---/bug-fingerprint---\n\n%%ORDER_UP%%"
     write_behavior: always
 
   collapse-issues:
@@ -1232,7 +1235,8 @@ skills:
     expected_output_patterns:
     - "---collapse-issues-result---"
     pattern_examples:
-    - "---collapse-issues-result---"
+    - "Collapse complete.\n\n---collapse-issues-result---\n[{\"issue\": 1}]\n---/collapse-issues-result---\n\n%%ORDER_UP%%"
+    - "Collapse complete.\n\n---\ncollapse-issues-result---\n[{\"issue\": 1}]\n---/collapse-issues-result---\n\n%%ORDER_UP%%"
 
   issue-splitter:
     inputs: []
@@ -1240,7 +1244,8 @@ skills:
     expected_output_patterns:
     - "---issue-splitter-result---"
     pattern_examples:
-    - "---issue-splitter-result---"
+    - "Split complete.\n\n---issue-splitter-result---\n[{\"issue\": 1}]\n---/issue-splitter-result---\n\n%%ORDER_UP%%"
+    - "Split complete.\n\n---\nissue-splitter-result---\n[{\"issue\": 1}]\n---/issue-splitter-result---\n\n%%ORDER_UP%%"
 
   process-issues:
     inputs: []
@@ -1250,7 +1255,8 @@ skills:
     expected_output_patterns:
     - "---process-issues-result---"
     pattern_examples:
-    - "---process-issues-result---"
+    - "Processing complete.\n\n---process-issues-result---\n[{\"dispatched\": 1}]\n---/process-issues-result---\n\n%%ORDER_UP%%"
+    - "Processing complete.\n\n---\nprocess-issues-result---\n[{\"dispatched\": 1}]\n---/process-issues-result---\n\n%%ORDER_UP%%"
 
   design-guards:
     inputs:
@@ -2256,6 +2262,7 @@ skills:
     pattern_examples:
     - "Pipeline health check: no issues found\n---pipeline-health-result---\n%%ORDER_UP%%"
     - "## Findings\n### confirmed_bug\n...\n---pipeline-health-result---\n%%ORDER_UP%%"
+    - "Analysis complete.\n\n---\npipeline-health-result---\n%%ORDER_UP%%"
     read_only: true
 callable_contracts:
   autoskillit.smoke_utils.check_loop_iteration:

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -85,7 +85,6 @@ def _extract_block(text: str, start_delim: str, end_delim: str) -> list[str]:
                 skip_next = True
                 continue
             if combined == end_delim and in_block:
-                skip_next = True
                 return block_lines
         if stripped == start_delim:
             in_block = True

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -71,11 +71,26 @@ def _extract_block(text: str, start_delim: str, end_delim: str) -> list[str]:
     """
     in_block = False
     block_lines: list[str] = []
-    for line in text.splitlines():
-        if line.strip() == start_delim:
+    lines = text.splitlines()
+    skip_next = False
+    for i, line in enumerate(lines):
+        if skip_next:
+            skip_next = False
+            continue
+        stripped = line.strip()
+        if stripped == "---" and i + 1 < len(lines):
+            combined = "---" + lines[i + 1].strip()
+            if combined == start_delim and not in_block:
+                in_block = True
+                skip_next = True
+                continue
+            if combined == end_delim and in_block:
+                skip_next = True
+                return block_lines
+        if stripped == start_delim:
             in_block = True
             continue
-        if line.strip() == end_delim:
+        if stripped == end_delim:
             if not in_block:
                 return []
             return block_lines

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -287,6 +287,7 @@ MODULE_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
         {
             "cli",
             "execution",
+            "fleet",
             "server",
             "migration/test_engine.py",
             "test_llm_triage.py",

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -98,7 +98,7 @@ NEW_MQ_MODULES = ["_merge_queue_classifier.py", "_merge_queue_repo_state.py"]
 SESSION_SIZE_BUDGETS = {
     "session/__init__.py": 65,  # was 420; facade is ~40 lines after P2
     "session/_session_model.py": 500,
-    "session/_session_content.py": 200,
+    "session/_session_content.py": 230,
 }
 NEW_SESSION_FSM_MODULES = ["_retry_fsm.py", "_session_outcome.py"]
 SESSION_FSM_SIZE_BUDGETS = {
@@ -146,8 +146,9 @@ def test_session_facade_does_not_define_content_functions():
     for sym in (
         "def _check_expected_patterns",
         "def _check_session_content",
+        "def _collapse_hr_split_delimiters",
         "def _evaluate_content_state",
-        "def _strip_markdown_from_tokens",
+        "def _normalize_model_output",
     ):
         assert sym not in src, f"{sym} must live in _session_content.py"
 

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -96,7 +96,7 @@ NEW_SESSION_MODULES = ["_session_model.py", "_session_content.py"]
 NEW_MQ_MODULES = ["_merge_queue_classifier.py", "_merge_queue_repo_state.py"]
 
 SESSION_SIZE_BUDGETS = {
-    "session/__init__.py": 65,  # was 420; facade is ~40 lines after P2
+    "session/__init__.py": 66,  # was 420; facade is ~40 lines after P2
     "session/_session_model.py": 500,
     "session/_session_content.py": 230,
 }

--- a/tests/contracts/test_analyze_pipeline_health_contracts.py
+++ b/tests/contracts/test_analyze_pipeline_health_contracts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 import yaml
 
+from autoskillit.execution.session._session_content import _check_expected_patterns
+
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _OUTPUT_DELIMITER = "---pipeline-health-result---"
@@ -51,12 +53,12 @@ def test_analyze_pipeline_health_has_pattern_examples():
 
 
 def test_analyze_pipeline_health_pattern_examples_match_delimiter():
-    """Each pattern_example must contain the output delimiter."""
+    """Each pattern_example must match the output delimiter via the normalizer."""
     contract = _load_contract()
     assert contract, "analyze-pipeline-health entry missing from skill_contracts.yaml"
     examples = contract.get("pattern_examples", [])
     assert examples, "pattern_examples must be non-empty"
     for example in examples:
-        assert _OUTPUT_DELIMITER in example, (
-            f"pattern_example must contain '{_OUTPUT_DELIMITER}': {example!r}"
+        assert _check_expected_patterns(example, [_OUTPUT_DELIMITER]), (
+            f"pattern_example must match '{_OUTPUT_DELIMITER}' after normalization: {example!r}"
         )

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -9,6 +9,8 @@ from typing import Any, Final
 import pytest
 import yaml
 
+from autoskillit.execution.session._session_content import _check_expected_patterns
+
 _CONTRACTS_YAML = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_contracts.yaml"
 
 
@@ -66,8 +68,6 @@ def test_every_pattern_example_matches_its_patterns(skills):
 
     Permanent architectural guard: pattern/SKILL.md divergence fails CI before production.
     """
-    import re
-
     failures = []
     for skill_name, contract in skills.items():
         patterns = contract.get("expected_output_patterns", [])
@@ -75,7 +75,7 @@ def test_every_pattern_example_matches_its_patterns(skills):
         if not patterns or not examples:
             continue
         for pattern in patterns:
-            if not any(re.search(pattern, ex) for ex in examples):
+            if not any(_check_expected_patterns(ex, [pattern]) for ex in examples):
                 failures.append(
                     f"Skill '{skill_name}': pattern {pattern!r} "
                     f"matches none of the examples {examples!r}"
@@ -288,7 +288,7 @@ def test_every_pattern_example_satisfies_all_patterns(skills):
             continue
         for i, example in enumerate(examples):
             for pattern in patterns:
-                if not re.search(pattern, example):
+                if not _check_expected_patterns(example, [pattern]):
                     failures.append(
                         f"Skill '{skill_name}': example[{i}] does not match pattern "
                         f"{pattern!r}.\n  Example: {example!r}"
@@ -494,4 +494,62 @@ def test_cross_newline_patterns_anchored(skills: dict[str, Any]) -> None:
                 )
     assert not failures, (
         r"Patterns with \s* matched cross-newline inputs:" + "\n" + "\n".join(failures)
+    )
+
+
+def test_pattern_examples_are_not_trivial(skills: dict[str, Any]) -> None:
+    """For every skill with expected_output_patterns and pattern_examples, no pattern_example
+    may be identical to any of its patterns (after stripping whitespace).
+
+    Trivial examples (example == pattern) produce a circular test that passes regardless
+    of normalizer behavior — they cannot detect formatting-related adjudication failures.
+    Examples must contain realistic model output context surrounding the token.
+    """
+    failures = []
+    for skill_name, contract in skills.items():
+        patterns = contract.get("expected_output_patterns", [])
+        examples = contract.get("pattern_examples", [])
+        if not patterns or not examples:
+            continue
+        for example in examples:
+            for pattern in patterns:
+                if example.strip() == pattern.strip():
+                    failures.append(
+                        f"Skill '{skill_name}': pattern_example {example!r} is identical "
+                        f"to pattern {pattern!r} — add surrounding context to the example"
+                    )
+    assert not failures, (
+        "Trivial pattern_examples detected (example == pattern). "
+        "Examples must contain surrounding model output context:\n" + "\n".join(failures)
+    )
+
+
+def test_delimiter_patterns_have_hr_split_example(skills: dict[str, Any]) -> None:
+    r"""For every skill with a ---X--- delimiter pattern, at least one pattern_example must
+    contain the HR-split variant (``---\n`` followed by the token name suffix).
+
+    This ensures the normalizer's HR-split handling is exercised by contract tests,
+    not just the inline delimiter happy path.
+    """
+    import re as _re
+
+    failures = []
+    for skill_name, contract in skills.items():
+        patterns = contract.get("expected_output_patterns", [])
+        examples = contract.get("pattern_examples", [])
+        if not patterns or not examples:
+            continue
+        for pattern in patterns:
+            if not _re.match(r"^---\w", pattern):
+                continue
+            name_suffix = pattern[3:]
+            hr_split_variant = f"---\n{name_suffix}"
+            if not any(hr_split_variant in ex for ex in examples):
+                failures.append(
+                    f"Skill '{skill_name}': pattern {pattern!r} has no pattern_example "
+                    f"containing the HR-split variant {hr_split_variant!r}"
+                )
+    assert not failures, (
+        "Delimiter patterns lack HR-split examples. Add an example with "
+        "---\\n<name>--- to each listed skill:\n" + "\n".join(failures)
     )

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -540,7 +540,7 @@ def test_delimiter_patterns_have_hr_split_example(skills: dict[str, Any]) -> Non
         if not patterns or not examples:
             continue
         for pattern in patterns:
-            if not _re.match(r"^---\w", pattern):
+            if not _re.match(r"^---[/\w]", pattern):
                 continue
             name_suffix = pattern[3:]
             hr_split_variant = f"---\n{name_suffix}"

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -100,7 +100,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_session_adjudication_outcome.py` | Tests for _compute_outcome, content state evaluation, and session adjudication consistency |
 | `test_session_adjudication_retry.py` | Tests for _compute_retry, _is_kill_anomaly, and related retry adjudication logic |
 | `test_session_adjudication_success.py` | Tests for _compute_success adjudication logic |
-| `test_session_content.py` | Tests for session content validation and token normalization (`_strip_markdown_from_tokens`) |
+| `test_session_content.py` | Tests for session content validation and token normalization (`_normalize_model_output`) |
 | `test_session_debug_logging.py` | Tests for debug logging instrumentation in session.py |
 | `test_session_state_persistence.py` | Tests for persist_session_state, read_session_state, and clear_session_state |
 | `test_session_index_roundtrip.py` | Tests verifying sessions.jsonl keys match SessionIndexEntry annotations |

--- a/tests/execution/test_session_content.py
+++ b/tests/execution/test_session_content.py
@@ -5,61 +5,62 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.execution.session._session_content import (
+    _check_expected_patterns,
     _check_session_content,
     _evaluate_content_state,
-    _strip_markdown_from_tokens,
+    _normalize_model_output,
 )
 from autoskillit.execution.session._session_model import ClaudeSessionResult, ContentState
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
-class TestStripMarkdownFromTokens:
-    """_strip_markdown_from_tokens normalizes model output decorators to canonical form."""
+class TestNormalizeModelOutput:
+    """_normalize_model_output normalizes model output decorators to canonical form."""
 
     def test_bold_equals_lowercase(self) -> None:
         """**plan_path** = /abs/path → plan_path = /abs/path"""
-        result = _strip_markdown_from_tokens("**plan_path** = /abs/path/plan.md")
+        result = _normalize_model_output("**plan_path** = /abs/path/plan.md")
         assert result == "plan_path = /abs/path/plan.md"
 
     def test_bold_equals_uppercase_key_lowercased(self) -> None:
         """**Plan_Path** = /abs/path → plan_path = /abs/path"""
-        result = _strip_markdown_from_tokens("**Plan_Path** = /abs/path/plan.md")
+        result = _normalize_model_output("**Plan_Path** = /abs/path/plan.md")
         assert result == "plan_path = /abs/path/plan.md"
 
     def test_italic_equals(self) -> None:
         """*plan_path* = /abs/path → plan_path = /abs/path"""
-        result = _strip_markdown_from_tokens("*plan_path* = /abs/path/plan.md")
+        result = _normalize_model_output("*plan_path* = /abs/path/plan.md")
         assert result == "plan_path = /abs/path/plan.md"
 
     def test_bold_colon_separator(self) -> None:
         """**Plan_Path:** /abs/path → plan_path = /abs/path"""
-        result = _strip_markdown_from_tokens("**Plan_Path:** /abs/path/plan.md")
+        result = _normalize_model_output("**Plan_Path:** /abs/path/plan.md")
         assert result == "plan_path = /abs/path/plan.md"
 
     def test_backtick_equals(self) -> None:
         """`plan_path` = /abs/path → plan_path = /abs/path"""
-        result = _strip_markdown_from_tokens("`plan_path` = /abs/path/plan.md")
+        result = _normalize_model_output("`plan_path` = /abs/path/plan.md")
         assert result == "plan_path = /abs/path/plan.md"
 
     def test_backtick_equals_uppercase_key_lowercased(self) -> None:
         """`Plan_Path` = /abs/path → plan_path = /abs/path"""
-        result = _strip_markdown_from_tokens("`Plan_Path` = /abs/path/plan.md")
+        result = _normalize_model_output("`Plan_Path` = /abs/path/plan.md")
         assert result == "plan_path = /abs/path/plan.md"
 
     def test_canonical_no_change(self) -> None:
         """Already-canonical token is unchanged."""
-        result = _strip_markdown_from_tokens("plan_path = /abs/path/plan.md")
+        result = _normalize_model_output("plan_path = /abs/path/plan.md")
         assert result == "plan_path = /abs/path/plan.md"
 
     def test_non_adjacent_bold_untouched(self) -> None:
         """Bold decorators not adjacent to = or : are left unchanged."""
-        result = _strip_markdown_from_tokens("Some text with **bold** words here")
+        result = _normalize_model_output("Some text with **bold** words here")
         assert result == "Some text with **bold** words here"
 
     def test_multiple_tokens_all_normalized(self) -> None:
         """Multiple decorated tokens in one string are all normalized."""
-        result = _strip_markdown_from_tokens(
+        result = _normalize_model_output(
             "**worktree_path** = /tmp/wt\n`branch_name` = impl-xyz\n*status* = running\n"
         )
         assert "worktree_path = /tmp/wt" in result
@@ -68,8 +69,68 @@ class TestStripMarkdownFromTokens:
 
     def test_worktree_path_bold_colon_variant(self) -> None:
         """The colon-decorated variant that caused #1716 contract failures."""
-        result = _strip_markdown_from_tokens("**worktree_path:** /tmp/wt")
+        result = _normalize_model_output("**worktree_path:** /tmp/wt")
         assert result == "worktree_path = /tmp/wt"
+
+    def test_hr_split_open_delimiter(self) -> None:
+        """HR on its own line followed by token name rejoins into full delimiter."""
+        assert _check_expected_patterns(
+            "Section content\n\n---\npipeline-health-result---\n\n%%ORDER_UP::abc%%",
+            ["---pipeline-health-result---"],
+        )
+
+    def test_hr_split_double_newline_delimiter(self) -> None:
+        """Double-newline between HR and token name is still collapsed."""
+        assert _check_expected_patterns(
+            "Content\n\n---\n\npipeline-health-result---\n%%ORDER_UP::abc%%",
+            ["---pipeline-health-result---"],
+        )
+
+    def test_inline_delimiter_no_regression(self) -> None:
+        """Inline delimiter on same line as other text continues to match."""
+        assert _check_expected_patterns(
+            "Result: ---pipeline-health-result---\n%%ORDER_UP::abc%%",
+            ["---pipeline-health-result---"],
+        )
+
+    def test_bold_wrapped_delimiter(self) -> None:
+        """Bold-wrapped delimiter token is stripped and matched."""
+        assert _check_expected_patterns(
+            "**---pipeline-health-result---**\n%%ORDER_UP::abc%%",
+            ["---pipeline-health-result---"],
+        )
+
+    def test_backtick_wrapped_delimiter(self) -> None:
+        """Backtick-wrapped delimiter token is stripped and matched."""
+        assert _check_expected_patterns(
+            "`---pipeline-health-result---`\n%%ORDER_UP::abc%%",
+            ["---pipeline-health-result---"],
+        )
+
+    def test_multiple_delimiters_mixed_hr_split_and_inline(self) -> None:
+        """Open delimiter HR-split and close delimiter inline both match."""
+        assert _check_expected_patterns(
+            "---\nbug-fingerprint---\nfp-001\n---/bug-fingerprint---\n%%ORDER_UP::abc%%",
+            ["---bug-fingerprint---", "---/bug-fingerprint---"],
+        )
+
+    def test_hr_split_close_delimiter_with_slash(self) -> None:
+        """Close delimiter HR-split (with / prefix) is collapsed and matched."""
+        assert _check_expected_patterns(
+            "---bug-fingerprint---\nfp-001\n---\n/bug-fingerprint---\n%%ORDER_UP::abc%%",
+            ["---bug-fingerprint---", "---/bug-fingerprint---"],
+        )
+
+    def test_italic_colon_dedicated(self) -> None:
+        """Italic-colon variant is normalized and the pattern matches."""
+        assert _check_expected_patterns(
+            "*worktree_path*: /tmp/worktrees/impl-foo\n%%ORDER_UP%%",
+            [r"worktree_path\s*=\s*/.+"],
+        )
+
+    def test_invalid_regex_returns_false(self) -> None:
+        """Invalid regex pattern returns False without raising."""
+        assert _check_expected_patterns("any text", ["[invalid regex"]) is False
 
 
 _PREP_RESULT = "prep_path = /tmp/plan.md\nselected_lenses = dev\nlens_context_paths = /tmp/ctx.md"

--- a/tests/fleet/test_result_parser.py
+++ b/tests/fleet/test_result_parser.py
@@ -529,3 +529,26 @@ def test_ansi_only_stdout_no_sentinel() -> None:
     )
     result = parse_l3_result_block(ANSI_TUI_CLEANUP, DISPATCH_ID)
     assert result.outcome == "no_sentinel"
+
+
+# ---------------------------------------------------------------------------
+# HR-split sentinel immunity tests
+# ---------------------------------------------------------------------------
+
+
+def test_hr_split_open_sentinel_recovered() -> None:
+    """HR-split open sentinel (--- on own line before dispatch_id---) is recovered."""
+    payload = {"status": "ok"}
+    stdout = f"output text\n---\nl3-result::{DISPATCH_ID}---\n{json.dumps(payload)}\n{_close()}"
+    result = parse_l3_result_block(stdout=stdout, expected_dispatch_id=DISPATCH_ID)
+    assert result.outcome == "completed_clean"
+    assert result.payload == payload
+
+
+def test_clean_sentinel_regression_guard() -> None:
+    """Clean (non-split) sentinels continue to work after normalization is applied."""
+    payload = {"status": "ok"}
+    stdout = f"output\n{_open()}\n{json.dumps(payload)}\n{_close()}\n"
+    result = parse_l3_result_block(stdout=stdout, expected_dispatch_id=DISPATCH_ID)
+    assert result.outcome == "completed_clean"
+    assert result.payload == payload

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -182,6 +182,28 @@ def test_extract_block_preserves_whitespace_in_lines():
     assert _extract_block(text, "---start---", "---end---") == ["  indented"]
 
 
+def test_extract_block_hr_split_start_delimiter():
+    text = "preamble\n---\nbug-fingerprint---\nfp-001\n---/bug-fingerprint---"
+    assert _extract_block(text, "---bug-fingerprint---", "---/bug-fingerprint---") == ["fp-001"]
+
+
+def test_extract_block_hr_split_end_delimiter():
+    text = "preamble\n---bug-fingerprint---\nfp-001\n---\n/bug-fingerprint---"
+    assert _extract_block(text, "---bug-fingerprint---", "---/bug-fingerprint---") == ["fp-001"]
+
+
+def test_extract_block_clean_delimiter_regression():
+    text = "preamble\n---bug-fingerprint---\nfp-001\n---/bug-fingerprint---"
+    assert _extract_block(text, "---bug-fingerprint---", "---/bug-fingerprint---") == ["fp-001"]
+
+
+def test_extract_block_content_not_mutated():
+    text = '---bug-fingerprint---\n{"note": "see ---\\nchanges---"}\n---/bug-fingerprint---'
+    assert _extract_block(text, "---bug-fingerprint---", "---/bug-fingerprint---") == [
+        '{"note": "see ---\\nchanges---"}'
+    ]
+
+
 # ---------------------------------------------------------------------------
 # _parse_prepare_result unit tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The adjudication pipeline's `_strip_markdown_from_tokens` normalizer only handles `key = value` style tokens (5 regexes, all `\w`-anchored). When a model emits a markdown horizontal rule (`---` on its own line) immediately before a `---X---` delimiter token, the three leading hyphens land on a separate line and `re.search` cannot find the contiguous pattern. This has caused false `adjudicated_failure` classification for 7 skills.

Part A covers: normalizer extension for `---X---` tokens + regression tests + contract test hardening. The plan adds HR-split collapse (collapsing `---\n` before delimiter tokens), delimiter decorator stripping (bold/backtick wrapped delimiters), and contract test hardening to reject trivial pattern_examples that are identical to their patterns.

Closes #3278

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260529-172646-668878/.autoskillit/temp/rectify/rectify_markdown_hr_delimiter_collision_2026-05-29_175500_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 49 | 6.8k | 503.6k | 118.8k | 260 | 60.1k | 13m 47s |
| rectify* | opus[1m] | 1 | 8.5k | 37.5k | 4.1M | 150.0k | 284 | 135.9k | 30m 54s |
| review_approach* | sonnet | 1 | 52 | 5.9k | 177.0k | 49.7k | 71 | 30.2k | 6m 0s |
| dry_walkthrough* | opus | 2 | 8.5k | 27.0k | 3.9M | 96.7k | 216 | 148.4k | 13m 38s |
| implement* | sonnet | 2 | 1.1k | 45.3k | 4.1M | 104.7k | 183 | 149.5k | 17m 12s |
| audit_impl* | sonnet | 3 | 314 | 39.1k | 1.0M | 65.6k | 160 | 145.9k | 17m 35s |
| prepare_pr* | sonnet | 1 | 117.3k | 4.7k | 283.7k | 36.4k | 25 | 54.1k | 1m 42s |
| compose_pr* | sonnet | 1 | 63.2k | 1.6k | 244.5k | 30.9k | 18 | 15.5k | 46s |
| review_pr* | sonnet | 2 | 2.3k | 115.0k | 3.1M | 134.7k | 148 | 211.5k | 30m 2s |
| resolve_review* | opus | 2 | 668 | 19.9k | 2.8M | 89.0k | 127 | 120.6k | 20m 27s |
| **Total** | | | 202.0k | 302.8k | 20.2M | 150.0k | | 1.1M | 2h 32m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 315 | 12897.0 | 474.6 | 143.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 19 | 146634.8 | 6348.7 | 1048.9 |
| **Total** | **334** | 60352.6 | 3208.7 | 906.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 3 | 9.2k | 53.7k | 7.1M | 329.1k | 47m 53s |
| opus[1m] | 1 | 8.5k | 37.5k | 4.1M | 135.9k | 30m 54s |
| sonnet | 6 | 184.3k | 211.6k | 9.0M | 606.6k | 1h 13m |