### PR TITLE
Backend-Parametrized CLI Tests and Cross-Validation Contract Coverage

### DIFF
--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -460,6 +460,9 @@ class TestCLIOrderCommand:
 
         cli.order("test-script")
 
+        assert "cmd" in captured, (
+            "cli.order() did not invoke subprocess.run — check for early exit"
+        )
         cmd = captured["cmd"]
         env = captured["env"]
 

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -414,6 +414,74 @@ class TestCLIOrderCommand:
         env = mock_run.call_args[1].get("env") or {}
         assert "AUTOSKILLIT_LAUNCH_ID" in env
 
+    @pytest.mark.parametrize("backend_name", ["claude-code", "codex"])
+    def test_order_backend_produces_valid_command(
+        self,
+        backend_name: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """order() produces a valid command for each registered backend."""
+        from autoskillit.execution.backends import get_backend as _real_get_backend
+        from autoskillit.execution.backends.codex import CodexFlags
+
+        real_backend = _real_get_backend(backend_name)
+        captured: dict = {}
+
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.chdir(tmp_path)
+        scripts_dir = tmp_path / ".autoskillit" / "recipes"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "my-script.yaml").write_text(_SCRIPT_YAML)
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/fake-binary")
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+
+        mock_config = MagicMock()
+        mock_config.agent_backend.backend = backend_name
+        mock_config.features = {"codex_backend": True}
+        mock_config.experimental_enabled = True
+        mock_config.providers.profiles = {}
+        mock_config.subsets.disabled = []
+        mock_config.packs.enabled = []
+        monkeypatch.setattr("autoskillit.config.load_config", lambda *_a, **_kw: mock_config)
+        monkeypatch.setattr(
+            "autoskillit.execution.get_backend",
+            lambda name: _real_get_backend(name),
+        )
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-canary-key")
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            captured["env"] = kwargs.get("env", {}) or {}
+            return type("R", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        cli.order("test-script")
+
+        cmd = captured["cmd"]
+        env = captured["env"]
+
+        assert cmd[0] == real_backend.binary_name(), (
+            f"Expected {real_backend.binary_name()!r}, got {cmd[0]!r}"
+        )
+
+        claude_flag_values = {str(f) for f in ClaudeFlags}
+        codex_flag_values = {str(f) for f in CodexFlags}
+        claude_only = claude_flag_values - codex_flag_values
+        codex_only = codex_flag_values - claude_flag_values
+
+        if backend_name == "codex":
+            assert set(cmd).isdisjoint(claude_only), (
+                f"Claude-only flags found in codex command: {set(cmd) & claude_only}"
+            )
+            assert "ANTHROPIC_API_KEY" not in env, "Codex env must strip ANTHROPIC_API_KEY"
+        else:
+            assert set(cmd).isdisjoint(codex_only), (
+                f"Codex-only flags found in claude command: {set(cmd) & codex_only}"
+            )
+
 
 # SC-B-4: mark_onboarded() must NOT be called when the cook subprocess exits non-zero
 def test_cook_mark_onboarded_not_called_on_failure(

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -9,6 +9,7 @@ import pytest
 
 from autoskillit.cli.session._session_launch import _run_interactive_session
 from autoskillit.core import ClaudeFlags
+from autoskillit.execution.backends.codex import CodexFlags
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
@@ -38,6 +39,14 @@ def _stub_plugin_installed(monkeypatch: pytest.MonkeyPatch, *, installed: bool =
 
     prefix = MARKETPLACE_PREFIX if installed else DIRECT_PREFIX
     monkeypatch.setattr("autoskillit.core.detect_autoskillit_mcp_prefix", lambda: prefix)
+
+
+# Module-level flags map — shared by Tests B, C, and the registry guard.
+# Constructed from the enum values themselves so the enums ARE the ground truth.
+_BACKEND_FLAGS: dict[str, set[str]] = {
+    "claude-code": {str(f) for f in ClaudeFlags},
+    "codex": {str(f) for f in CodexFlags},
+}
 
 
 def _make_capturing_backend() -> tuple[object, list[dict]]:
@@ -740,3 +749,90 @@ def test_multi_backend_no_cross_flag_contamination(monkeypatch: pytest.MonkeyPat
             assert ClaudeFlags.TOOLS not in cmd, (
                 f"{backend_name}: must not contain {ClaudeFlags.TOOLS!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# T-1e: Real-backend parametrized — comprehensive foreign flag exclusion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend_name", ["claude-code", "codex"])
+def test_real_backend_no_foreign_flags(monkeypatch: pytest.MonkeyPatch, backend_name: str) -> None:
+    """Real backend instances must not produce flags from other backends' Flags enums."""
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    captured: dict = {}
+    monkeypatch.setattr(shutil, "which", lambda binary: f"/usr/bin/{binary}")
+
+    def mock_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    _stub_plugin_installed(monkeypatch, installed=False)
+
+    backend = BACKEND_REGISTRY[backend_name]()
+    _run_interactive_session(system_prompt="test", backend=backend)
+    cmd = captured.get("cmd", [])
+
+    assert cmd[0] == backend.binary_name(), (
+        f"{backend_name}: expected {backend.binary_name()!r} at cmd[0], got {cmd[0]!r}"
+    )
+
+    other_backend = "claude-code" if backend_name == "codex" else "codex"
+    foreign_only = _BACKEND_FLAGS[other_backend] - _BACKEND_FLAGS[backend_name]
+    assert set(cmd).isdisjoint(foreign_only), (
+        f"{backend_name}: foreign flags found in command: {set(cmd) & foreign_only}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T-1f: Cross-validation contract — every assembled flag must belong to backend
+# ---------------------------------------------------------------------------
+
+
+def test_cross_validation_contract_all_flags_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every flag-like token in the assembled command must be a member of the
+    backend's own Flags enum. This is the test that would have caught #3270."""
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    captured: dict = {}
+    monkeypatch.setattr(shutil, "which", lambda binary: f"/usr/bin/{binary}")
+
+    def mock_run(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    _stub_plugin_installed(monkeypatch, installed=False)
+
+    for backend_name, backend_cls in BACKEND_REGISTRY.items():
+        backend = backend_cls()
+        captured.clear()
+        _run_interactive_session(system_prompt="test", backend=backend)
+        cmd = captured.get("cmd", [])
+
+        assert cmd[0] == backend.binary_name(), (
+            f"{backend_name}: cmd[0] must be {backend.binary_name()!r}, got {cmd[0]!r}"
+        )
+
+        valid_flags = _BACKEND_FLAGS[backend_name]
+        flag_tokens = {t for t in cmd[1:] if t.startswith("-")}
+        unknown = flag_tokens - valid_flags
+        assert not unknown, (
+            f"{backend_name}: unknown flags in command: {sorted(unknown)}. "
+            f"Valid flags: {sorted(valid_flags)}"
+        )
+
+
+def test_backend_flags_mapping_covers_registry() -> None:
+    """Every backend in BACKEND_REGISTRY must have an entry in the flags validation map."""
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    missing = set(BACKEND_REGISTRY) - set(_BACKEND_FLAGS)
+    assert not missing, (
+        f"BACKEND_REGISTRY has backends not covered by _BACKEND_FLAGS: {missing}. "
+        "Add the new backend's Flags enum to _BACKEND_FLAGS in test_session_launch.py."
+    )

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -791,8 +791,10 @@ def test_real_backend_no_foreign_flags(monkeypatch: pytest.MonkeyPatch, backend_
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("backend_name", ["claude-code", "codex"])
 def test_cross_validation_contract_all_flags_known(
     monkeypatch: pytest.MonkeyPatch,
+    backend_name: str,
 ) -> None:
     """Every flag-like token in the assembled command must be a member of the
     backend's own Flags enum. This is the test that would have caught #3270."""
@@ -808,23 +810,26 @@ def test_cross_validation_contract_all_flags_known(
     monkeypatch.setattr(subprocess, "run", mock_run)
     _stub_plugin_installed(monkeypatch, installed=False)
 
-    for backend_name, backend_cls in BACKEND_REGISTRY.items():
-        backend = backend_cls()
-        captured.clear()
-        _run_interactive_session(system_prompt="test", backend=backend)
-        cmd = captured.get("cmd", [])
+    backend = BACKEND_REGISTRY[backend_name]()
+    _run_interactive_session(system_prompt="test", backend=backend)
+    cmd = captured.get("cmd", [])
 
-        assert cmd[0] == backend.binary_name(), (
-            f"{backend_name}: cmd[0] must be {backend.binary_name()!r}, got {cmd[0]!r}"
-        )
+    assert cmd[0] == backend.binary_name(), (
+        f"{backend_name}: cmd[0] must be {backend.binary_name()!r}, got {cmd[0]!r}"
+    )
 
-        valid_flags = _BACKEND_FLAGS[backend_name]
-        flag_tokens = {t for t in cmd[1:] if t.startswith("-")}
-        unknown = flag_tokens - valid_flags
-        assert not unknown, (
-            f"{backend_name}: unknown flags in command: {sorted(unknown)}. "
-            f"Valid flags: {sorted(valid_flags)}"
+    valid_flags = _BACKEND_FLAGS.get(backend_name)
+    if valid_flags is None:
+        pytest.fail(
+            f"{backend_name}: not in _BACKEND_FLAGS — "
+            "add it to _BACKEND_FLAGS in test_session_launch.py"
         )
+    flag_tokens = {t for t in cmd[1:] if t.startswith("-")}
+    unknown = flag_tokens - valid_flags
+    assert not unknown, (
+        f"{backend_name}: unknown flags in command: {sorted(unknown)}. "
+        f"Valid flags: {sorted(valid_flags)}"
+    )
 
 
 def test_backend_flags_mapping_covers_registry() -> None:


### PR DESCRIPTION
## Summary

Add backend-parametrized tests to `test_cook_order_command.py` and cross-validation contract tests to `test_session_launch.py`. These test-only additions verify that the order command flow produces valid commands for each registered backend, that no backend-specific flags leak into other backends' commands, and that every flag in an assembled command belongs to the target backend's Flags enum. This is the test coverage that would have caught #3270.

All changes are to test files only — zero production code modifications.

## Requirements

## Gap 1: Zero Backend Variation in `order` Command Tests
Mirror the cook command's backend parametrization pattern in `test_cook_order_command.py`. For each backend, mock `get_backend` to return the real backend instance and verify:
- The final subprocess command only contains flags valid for that backend's binary
- The env dict does not contain keys that the backend's `EnvPolicy` would strip
- The binary name in `cmd[0]` matches `backend.binary_name()`

## Gap 2: `_run_interactive_session` Tests Use Synthetic Stubs Instead of Real Backends
A parametrized test that creates real `ClaudeCodeBackend()` and `CodexBackend()` instances, runs them through `_run_interactive_session`'s command assembly (with `subprocess.run` mocked), and asserts the final `cmd` list is valid for the target binary. Specifically assert that no `ClaudeFlags.*` values appear in the Codex command, and no `CodexFlags.*` values appear in the Claude command.

## Gap 3: No Cross-Validation of Capabilities vs. Assembled Command
A contract-level cross-validation test: For each registered backend in BACKEND_REGISTRY, verify every flag in the final cmd list is either a known flag for that backend (member of its Flags enum), a positional argument, or a known cross-backend flag. This is the test that would have caught #3270.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260529-215107-085997/.autoskillit/temp/make-plan/backend_parametrized_cli_tests_plan_2026-05-29_220000.md`

Closes #3273

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 88 | 38.8k | 1.7M | 117.5k | 169 | 191.6k | 22m 34s |
| review_approach* | sonnet | 1 | 52 | 5.0k | 173.2k | 38.8k | 32 | 25.8k | 2m 34s |
| verify* | sonnet | 1 | 2.3k | 30.4k | 1.3M | 86.8k | 80 | 70.9k | 9m 31s |
| implement* | sonnet | 1 | 353.7k | 5.2k | 561.0k | 60.9k | 43 | 71.8k | 2m 14s |
| audit_impl* | sonnet | 1 | 76 | 9.0k | 301.3k | 44.1k | 30 | 33.8k | 2m 52s |
| prepare_pr* | sonnet | 1 | 93.6k | 3.9k | 216.4k | 30.9k | 24 | 43.7k | 1m 42s |
| compose_pr* | sonnet | 1 | 47.5k | 1.4k | 213.5k | 30.9k | 14 | 15.5k | 45s |
| review_pr* | sonnet | 1 | 166 | 40.9k | 1.0M | 92.5k | 60 | 77.0k | 9m 21s |
| resolve_review* | sonnet | 1 | 215 | 13.6k | 1.4M | 69.5k | 63 | 54.4k | 6m 26s |
| **Total** | | | 497.7k | 148.2k | 6.8M | 117.5k | | 584.5k | 58m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 164 | 3420.4 | 438.0 | 31.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 36 | 37873.8 | 1510.0 | 378.9 |
| **Total** | **200** | 34163.5 | 2922.4 | 741.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 88 | 38.8k | 1.7M | 191.6k | 22m 34s |
| sonnet | 8 | 497.6k | 109.5k | 5.2M | 392.9k | 35m 27s |