### PR TITLE
Rectify: Write Guard Redirect Detection — Structural Tokenization Migration

### DIFF
--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -96,34 +96,6 @@ def extract_redirect_targets(tokens: list[str]) -> list[str]:
         if tok.endswith(")") and len(tok) > 1:
             if depth > 0:
                 depth -= 1
-            else:
-                stripped = tok[:-1]
-                if stripped in (">", ">>"):
-                    if i + 1 < len(tokens):
-                        path = tokens[i + 1]
-                        while path and path[-1] in _TRAILING_SHELL_CLOSERS:
-                            path = path[:-1]
-                        if path.startswith("/"):
-                            targets.append(path)
-                        i += 2
-                        continue
-                elif _REDIRECT_OP_ONLY_RE.match(stripped):
-                    if i + 1 < len(tokens):
-                        path = tokens[i + 1]
-                        while path and path[-1] in _TRAILING_SHELL_CLOSERS:
-                            path = path[:-1]
-                        if path.startswith("/"):
-                            targets.append(path)
-                        i += 2
-                        continue
-                else:
-                    m = _REDIRECT_TOKEN_RE.match(stripped)
-                    if m:
-                        path = m.group(2)
-                        while path and path[-1] in _TRAILING_SHELL_CLOSERS:
-                            path = path[:-1]
-                        if path.startswith("/"):
-                            targets.append(path)
             i += 1
             continue
         if depth > 0:

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -35,6 +35,10 @@ _LITERAL_PATH_CONSTRUCTOR_RE = re.compile(
 
 _SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
 
+_REDIRECT_TOKEN_RE = re.compile(r"^(\d*)>{1,2}(.+)$")
+_REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
+_TRAILING_SHELL_CLOSERS = frozenset({")", "`", "}", "'", '"', ";", "&", "|"})
+
 
 def tokenize_command_segments(command: str) -> list[list[str]]:
     """Split a shell command into segments of (verb, args...) token lists.
@@ -58,6 +62,71 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     if current:
         segments.append(current)
     return segments
+
+
+def extract_redirect_targets(tokens: list[str]) -> list[str]:
+    """Extract absolute redirect target paths from shlex-tokenized command tokens.
+
+    Returns ALL absolute paths including pseudo-devices — caller filters.
+
+    Handles three redirect forms at depth 0 only:
+    - Separate:  ['>', '/path'] or ['>>', '/path']
+    - Split:     ['2>', '/path'] (operator-only token + next token)
+    - Merged:    ['2>/path'] or ['2>>/path']
+
+    Tracks subshell nesting via '(' and ')' — both standalone and fused
+    with adjacent text (shlex merges '(' with following chars in POSIX mode).
+    """
+    targets: list[str] = []
+    depth = 0
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "(" or (tok.startswith("(") and len(tok) > 1):
+            depth += 1
+            i += 1
+            continue
+        if tok == ")":
+            if depth > 0:
+                depth -= 1
+            i += 1
+            continue
+        if tok.endswith(")") and len(tok) > 1:
+            if depth > 0:
+                depth -= 1
+            i += 1
+            continue
+        if depth > 0:
+            i += 1
+            continue
+        if tok in (">", ">>"):
+            if i + 1 < len(tokens):
+                path = tokens[i + 1]
+                while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                    path = path[:-1]
+                if path.startswith("/"):
+                    targets.append(path)
+                i += 2
+                continue
+        elif _REDIRECT_OP_ONLY_RE.match(tok):
+            if i + 1 < len(tokens):
+                path = tokens[i + 1]
+                while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                    path = path[:-1]
+                if path.startswith("/"):
+                    targets.append(path)
+                i += 2
+                continue
+        else:
+            m = _REDIRECT_TOKEN_RE.match(tok)
+            if m:
+                path = m.group(2)
+                while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                    path = path[:-1]
+                if path.startswith("/"):
+                    targets.append(path)
+        i += 1
+    return targets
 
 
 def command_verb(segment: list[str]) -> str:

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -84,6 +84,8 @@ def extract_redirect_targets(tokens: list[str]) -> list[str]:
         tok = tokens[i]
         if tok == "(" or (tok.startswith("(") and len(tok) > 1):
             depth += 1
+            if tok.endswith(")") and len(tok) > 1:
+                depth -= 1
             i += 1
             continue
         if tok == ")":
@@ -94,6 +96,34 @@ def extract_redirect_targets(tokens: list[str]) -> list[str]:
         if tok.endswith(")") and len(tok) > 1:
             if depth > 0:
                 depth -= 1
+            else:
+                stripped = tok[:-1]
+                if stripped in (">", ">>"):
+                    if i + 1 < len(tokens):
+                        path = tokens[i + 1]
+                        while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                            path = path[:-1]
+                        if path.startswith("/"):
+                            targets.append(path)
+                        i += 2
+                        continue
+                elif _REDIRECT_OP_ONLY_RE.match(stripped):
+                    if i + 1 < len(tokens):
+                        path = tokens[i + 1]
+                        while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                            path = path[:-1]
+                        if path.startswith("/"):
+                            targets.append(path)
+                        i += 2
+                        continue
+                else:
+                    m = _REDIRECT_TOKEN_RE.match(stripped)
+                    if m:
+                        path = m.group(2)
+                        while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                            path = path[:-1]
+                        if path.startswith("/"):
+                            targets.append(path)
             i += 1
             continue
         if depth > 0:

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -166,7 +166,7 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
     if not segments or has_non_gh:
         try:
             flat_tokens = shlex.split(command)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, AttributeError):
             flat_tokens = []
         redirect_paths = extract_redirect_targets(flat_tokens)
         for path in redirect_paths:

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import os
-import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -16,6 +16,7 @@ if _HOOKS_DIR not in sys.path:
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
     command_verb,
     extract_interpreter_write_path,
+    extract_redirect_targets,
     has_interpreter_write,
     is_gh_command,
     tokenize_command_segments,
@@ -46,8 +47,6 @@ _WRITE_VERBS: frozenset[str] = frozenset(
 )
 
 _GIT_FLAG_WITH_VALUE: frozenset[str] = frozenset({"-C", "--git-dir", "--work-tree", "-c"})
-
-_REDIRECT_RE = re.compile(r">+\s*(/[^\s;|&>]+)")
 
 
 def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
@@ -165,13 +164,15 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
     has_non_gh = any(not is_gh_command(seg) for seg in segments)
 
     if not segments or has_non_gh:
-        for m in _REDIRECT_RE.finditer(command):
-            path = m.group(1)
+        try:
+            flat_tokens = shlex.split(command)
+        except (ValueError, TypeError):
+            flat_tokens = []
+        redirect_paths = extract_redirect_targets(flat_tokens)
+        for path in redirect_paths:
+            found_any_write = True
             if path not in _PSEUDO_DEVICE_PATHS:
-                found_any_write = True
                 all_targets.append(path)
-            else:
-                found_any_write = True
 
     if not found_any_write:
         return None

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -114,6 +114,7 @@ def test_cmd_keyword_regexes_use_path_safe_guards():
 
 HOOK_GUARD_RULE_FILES = [
     SRC_ROOT / "hooks" / "guards" / "write_guard.py",
+    SRC_ROOT / "hooks" / "_command_classification.py",
 ]
 
 
@@ -147,6 +148,7 @@ REQUIRED_WRITE_GUARD_TEST_FAMILIES = {
     "heredoc",
     "sed",
     "redirect",
+    "subshell",
     "tee",
     "mv",
     "cp",
@@ -258,7 +260,32 @@ def test_write_guard_uses_tokenization() -> None:
 def test_command_classification_exports_tokenization() -> None:
     """_command_classification.py must export the tokenization primitives."""
     source = (SRC_ROOT / "hooks" / "_command_classification.py").read_text()
-    for name in ("tokenize_command_segments", "command_verb", "is_gh_command"):
+    for name in (
+        "tokenize_command_segments",
+        "command_verb",
+        "is_gh_command",
+        "extract_redirect_targets",
+    ):
         assert f"def {name}" in source, (
             f"_command_classification.py must define {name}() for structural command parsing"
         )
+
+
+def test_redirect_extraction_uses_tokenization() -> None:
+    """Redirect path extraction must operate on shlex-tokenized output,
+    not raw command strings, to prevent metacharacter contamination."""
+    source = (SRC_ROOT / "hooks" / "guards" / "write_guard.py").read_text()
+    assert "finditer(command)" not in source and "findall(command)" not in source, (
+        "write_guard.py must not apply redirect regex to the raw command string. "
+        "Redirect extraction must use shlex-tokenized tokens to prevent "
+        "metacharacter contamination (see issue #3291)."
+    )
+
+
+def test_command_classification_exports_redirect_extraction() -> None:
+    """_command_classification.py must export redirect extraction for structural parsing."""
+    source = (SRC_ROOT / "hooks" / "_command_classification.py").read_text()
+    assert "def extract_redirect_targets" in source, (
+        "_command_classification.py must define extract_redirect_targets() "
+        "for structural redirect path extraction"
+    )

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -280,12 +280,3 @@ def test_redirect_extraction_uses_tokenization() -> None:
         "Redirect extraction must use shlex-tokenized tokens to prevent "
         "metacharacter contamination (see issue #3291)."
     )
-
-
-def test_command_classification_exports_redirect_extraction() -> None:
-    """_command_classification.py must export redirect extraction for structural parsing."""
-    source = (SRC_ROOT / "hooks" / "_command_classification.py").read_text()
-    assert "def extract_redirect_targets" in source, (
-        "_command_classification.py must define extract_redirect_targets() "
-        "for structural redirect path extraction"
-    )

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -7,6 +7,7 @@ import pytest
 from autoskillit.hooks._command_classification import (
     command_verb,
     extract_interpreter_write_path,
+    extract_redirect_targets,
     has_interpreter_wrapped_command,
     has_interpreter_write,
     has_nested_shell,
@@ -172,3 +173,54 @@ class TestExtractInterpreterWritePath:
     def test_dynamic_path_with_non_literal_var_returns_none(self):
         cmd = "python3 -c \"open(some_var, 'w').write('x')\""
         assert extract_interpreter_write_path(cmd) is None
+
+
+class TestExtractRedirectTargets:
+    @pytest.mark.parametrize(
+        "tokens,expected",
+        [
+            (["echo", "data", ">", "/tmp/out.txt"], ["/tmp/out.txt"]),
+            (["cmd", "2>/dev/null"], ["/dev/null"]),
+            (["2>/dev/null)"], []),
+            (["cmd", "2>/dev/null`"], ["/dev/null"]),
+            (["cmd", "2>/dev/null;"], ["/dev/null"]),
+            (["cmd", ">>", "/tmp/log"], ["/tmp/log"]),
+            (["cmd", ">", "relative.txt"], []),
+            (["echo", "hello"], []),
+            (["cmd", ">", "/tmp/a", "2>/tmp/b"], ["/tmp/a", "/tmp/b"]),
+            (["cmd", "2>", "/tmp/err.log"], ["/tmp/err.log"]),
+            (["x=$(cmd", "2>/tmp/err.log)"], []),
+            (
+                ["x=$(cmd", "2>/tmp/err.log)", "&&", "echo", "done", ">", "/tmp/out.txt"],
+                ["/tmp/out.txt"],
+            ),
+            (["(", "cmd", ">", "/tmp/err.log", ")"], []),
+            (["(cmd", ">", "/tmp/err.log", ")"], []),
+            (["x=$(cmd", ">/tmp/err.log)"], []),
+            (["cmd", ">", "/dev/null"], ["/dev/null"]),
+            (["cmd", "2>/dev/null&"], ["/dev/null"]),
+            (["cmd", "2>/tmp/out|"], ["/tmp/out"]),
+        ],
+        ids=[
+            "separate_redirect",
+            "merged_fd_redirect",
+            "merged_with_trailing_paren_skipped",
+            "merged_trailing_backtick",
+            "merged_trailing_semicolon",
+            "append_redirect",
+            "non_absolute_path",
+            "no_redirects",
+            "multiple_redirects",
+            "split_redirect",
+            "subshell_fused_skipped",
+            "subshell_with_top_level_redirect",
+            "standalone_paren_nesting",
+            "fused_paren_nesting",
+            "only_subshell_redirect_fused",
+            "pseudo_device_returned",
+            "trailing_ampersand_stripped",
+            "trailing_pipe_stripped",
+        ],
+    )
+    def test_extract_redirect_targets(self, tokens, expected):
+        assert extract_redirect_targets(tokens) == expected

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -352,6 +352,61 @@ class TestExtractBashWriteTargets:
         assert result_real == ["/tmp/out.txt"]
 
     @pytest.mark.parametrize(
+        "command",
+        [
+            "x=$(grep foo 2>/dev/null)",
+            'BRANCH=$(cat "${STORE_FILE}" 2>/dev/null)',
+            "result=$(some_cmd 2>/dev/null) && echo $result",
+            "x=`cmd 2>/dev/null`",
+            "{ cmd 2>/dev/null; }",
+        ],
+        ids=["subshell_grep", "subshell_cat", "subshell_chain", "backtick", "brace_group"],
+    )
+    def test_subshell_redirect_to_dev_null_not_blocked(self, command):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets(command)
+        assert result is None or result == [], f"Should not detect writes in: {command}"
+
+    @pytest.mark.parametrize(
+        "command,expected_targets,excluded_targets",
+        [
+            (
+                "x=$(cmd 2>/tmp/err.log) && echo done > /tmp/out.txt",
+                ["/tmp/out.txt"],
+                ["/tmp/err.log"],
+            ),
+            (
+                "x=$(grep errors 2>/tmp/debug.log)",
+                [],
+                ["/tmp/debug.log"],
+            ),
+        ],
+        ids=["subshell_with_real_redirect", "subshell_only_real_path"],
+    )
+    def test_subshell_redirect_excludes_nested_real_paths(
+        self, command, expected_targets, excluded_targets
+    ):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets(command)
+        if not expected_targets:
+            assert result is None or result == [], f"Should not detect writes in: {command}"
+        else:
+            assert result is not None
+            for expected in expected_targets:
+                assert expected in result, f"Expected {expected} in result {result}"
+        if result:
+            for excluded in excluded_targets:
+                assert excluded not in result, (
+                    f"Subshell-internal redirect {excluded!r} must not appear in {result}"
+                )
+            for path in result:
+                assert not path.endswith(")"), f"Path should not end with ')': {path}"
+                assert not path.endswith("`"), f"Path should not end with backtick: {path}"
+                assert not path.endswith("}"), f"Path should not end with '}}': {path}"
+
+    @pytest.mark.parametrize(
         "cmd",
         [
             "sed -i 's/x/y/' /outside/file.txt",


### PR DESCRIPTION
## Summary

The write guard's redirect detection (`_REDIRECT_RE`) is the last raw-regex path extractor surviving from the pre-shlex era. It operates on the unprocessed command string and its character class `[^\s;|&>]` fails to exclude shell metacharacters (`)`, `` ` ``, `}`, `'`, `"`), causing false-positive denials when redirects appear inside subshell constructs like `$(cmd 2>/dev/null)`. This is the 6th false-positive incident in 31 days — each prior fix patched one symptom without completing the structural migration to tokenized parsing.

The immunity plan replaces `_REDIRECT_RE.finditer(command)` with a token-aware redirect extraction function in `_command_classification.py` that operates on `shlex.split()` output. After shlex tokenization, shell metacharacters like `)` are structurally separated from redirect paths, making this entire class of false positive impossible by construction.

## Changed Files

### Modified (●):
● src/autoskillit/hooks/_command_classification.py
● src/autoskillit/hooks/guards/write_guard.py
● tests/arch/test_regex_guards.py
● tests/hooks/test_command_classification.py
● tests/hooks/test_write_guard.py

Closes #3291

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_write_guard_redirect_tokenization_2026-05-29_214845.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 3.2k | 30.0k | 3.8M | 133.0k | 272 | 233.1k | 22m 21s |
| review_approach* | sonnet | 1 | 52 | 11.8k | 200.6k | 51.8k | 62 | 40.3k | 6m 18s |
| dry_walkthrough* | opus | 1 | 79 | 32.7k | 3.2M | 100.9k | 144 | 84.7k | 17m 43s |
| implement* | sonnet | 1 | 288 | 20.4k | 2.0M | 74.3k | 89 | 62.2k | 7m 43s |
| audit_impl* | sonnet | 1 | 84 | 13.9k | 389.8k | 60.8k | 60 | 45.5k | 5m 1s |
| prepare_pr* | sonnet | 1 | 152.3k | 3.4k | 278.3k | 30.9k | 20 | 43.8k | 1m 28s |
| compose_pr* | sonnet | 1 | 37.7k | 1.3k | 182.7k | 30.9k | 13 | 15.4k | 40s |
| review_pr* | sonnet | 1 | 230 | 38.4k | 1.6M | 90.6k | 80 | 75.9k | 9m 59s |
| resolve_review* | sonnet | 1 | 277 | 31.1k | 2.3M | 88.7k | 94 | 74.0k | 12m 7s |
| **Total** | | | 194.2k | 183.0k | 13.9M | 133.0k | | 675.0k | 1h 23m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 222 | 9155.3 | 280.3 | 91.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 174107.2 | 5695.5 | 2388.5 |
| **Total** | **235** | 59243.2 | 2872.3 | 778.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.2k | 30.0k | 3.8M | 233.1k | 22m 21s |
| sonnet | 7 | 190.9k | 120.3k | 6.9M | 357.2k | 43m 19s |
| opus | 1 | 79 | 32.7k | 3.2M | 84.7k | 17m 43s |