### PR TITLE
[FIX] Rectify: CLI Variadic Flag Positional Argument Consumption

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -182,6 +182,7 @@ from .types import SKILL_TOOLS as SKILL_TOOLS
 from .types import SOUS_CHEF_MANDATORY_SECTIONS as SOUS_CHEF_MANDATORY_SECTIONS
 from .types import TOOL_SUBSET_TAGS as TOOL_SUBSET_TAGS
 from .types import UNGATED_TOOLS as UNGATED_TOOLS
+from .types import VARIADIC_CLAUDE_FLAGS as VARIADIC_CLAUDE_FLAGS
 from .types import WORKTREE_SKILLS as WORKTREE_SKILLS
 from .types import AgentPackDef as AgentPackDef
 from .types import AgentSessionResult as AgentSessionResult
@@ -295,7 +296,6 @@ from .types import TokenFactory as TokenFactory
 from .types import TokenLog as TokenLog
 from .types import ValidatedAddDir as ValidatedAddDir
 from .types import ValidatedWorktreePath as ValidatedWorktreePath
-from .types import VARIADIC_CLAUDE_FLAGS as VARIADIC_CLAUDE_FLAGS
 from .types import WorkspaceManager as WorkspaceManager
 from .types import WriteBehaviorSpec as WriteBehaviorSpec
 from .types import WriteEvidence as WriteEvidence

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -295,6 +295,7 @@ from .types import TokenFactory as TokenFactory
 from .types import TokenLog as TokenLog
 from .types import ValidatedAddDir as ValidatedAddDir
 from .types import ValidatedWorktreePath as ValidatedWorktreePath
+from .types import VARIADIC_CLAUDE_FLAGS as VARIADIC_CLAUDE_FLAGS
 from .types import WorkspaceManager as WorkspaceManager
 from .types import WriteBehaviorSpec as WriteBehaviorSpec
 from .types import WriteEvidence as WriteEvidence

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -15,6 +15,7 @@ __all__ = [
     "SkillSource",
     "RecipeSource",
     "ClaudeFlags",
+    "VARIADIC_CLAUDE_FLAGS",
     "OutputFormat",
     "Severity",
     "TerminationReason",
@@ -159,6 +160,9 @@ class ClaudeFlags(StrEnum):
     # Interactive session restrictions
     TOOLS = "--tools"
     APPEND_SYSTEM_PROMPT = "--append-system-prompt"
+
+
+VARIADIC_CLAUDE_FLAGS: frozenset[str] = frozenset({ClaudeFlags.ADD_DIR, ClaudeFlags.TOOLS})
 
 
 class OutputFormat(StrEnum):

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -375,12 +375,12 @@ class ClaudeCodeBackend:
                 pass
             case None:
                 pass
+        if initial_prompt is not None:
+            cmd.append(initial_prompt)
         for d in add_dirs:
             cmd += [ClaudeFlags.ADD_DIR, str(d)]
         for t in tools:
             cmd += [ClaudeFlags.TOOLS, t]
-        if initial_prompt is not None:
-            cmd.append(initial_prompt)
         merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)
         if env_extras:
             merged.update(env_extras)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -576,12 +576,12 @@ class CodexBackend:
         if model:
             cmd += [CodexFlags.MODEL, model]
         # plugin_source: explicit no-op for Codex
+        if initial_prompt is not None:
+            cmd.append(initial_prompt)
         for d in add_dirs:
             cmd += [CodexFlags.ADD_DIR, str(d)]
         if system_prompt is not None and isinstance(resume_spec, NoResume):
             cmd += [CodexFlags.CONFIG_OVERRIDE, f"developer_instructions={system_prompt}"]
-        if initial_prompt is not None:
-            cmd.append(initial_prompt)
         base_env = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
         merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}
         if add_dirs:

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -70,6 +70,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_tool_annotation_completeness.py` | AST annotation test shield for MCP tool readOnlyHint semantics (layers 1a, 1b) |
 | `test_tools_execution_decomposition.py` | Structural decomposition guard for tools_execution.py split |
 | `test_transforms_hygiene.py` | Structural guards for FastMCP visibility tag hygiene |
+| `test_variadic_ordering.py` | Architectural invariant: positional initial_prompt must precede all variadic CLI flags in build_interactive_cmd |
 | `test_watcher_signal_consistency.py` | Structural guard: all process watchers must call `_has_active_dispatch_marker` |
 | `test_write_restriction_coverage.py` | Architectural invariant: skills with prose write restrictions in NEVER blocks have runtime enforcement (read_only, output_dir, or allowlist) |
 

--- a/tests/arch/test_variadic_ordering.py
+++ b/tests/arch/test_variadic_ordering.py
@@ -1,0 +1,32 @@
+"""Architectural test: positional initial_prompt must precede all variadic CLI flags."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import VARIADIC_CLAUDE_FLAGS
+from autoskillit.execution.commands import build_interactive_cmd
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+@pytest.mark.parametrize(
+    "variadic_kwargs",
+    [
+        {"tools": ("AskUserQuestion",)},
+        {"add_dirs": [Path("/tmp/a")]},
+        {"tools": ("AskUserQuestion",), "add_dirs": [Path("/tmp/a")]},
+    ],
+)
+def test_positional_precedes_all_variadic_flags(variadic_kwargs):
+    result = build_interactive_cmd(initial_prompt="test prompt", **variadic_kwargs)
+    prompt_idx = result.cmd.index("test prompt")
+    for flag in VARIADIC_CLAUDE_FLAGS:
+        if flag in result.cmd:
+            flag_idx = result.cmd.index(flag)
+            assert prompt_idx < flag_idx, (
+                f"Positional arg at index {prompt_idx} must precede "
+                f"variadic flag {flag!r} at index {flag_idx}"
+            )

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -707,9 +707,9 @@ class TestCodexBuildInteractiveCmd:
             spec.cmd[spec.cmd.index(CodexFlags.ADD_DIR) + 1],
         )
 
-    def test_initial_prompt_is_final_element(self) -> None:
+    def test_initial_prompt_is_present_when_no_variadic_flags(self) -> None:
         spec = CodexBackend().build_interactive_cmd(initial_prompt="hello")
-        assert spec.cmd[-1] == "hello"
+        assert "hello" in spec.cmd
 
     def test_plugin_source_is_silently_ignored(self) -> None:
         from pathlib import Path

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -707,9 +707,9 @@ class TestCodexBuildInteractiveCmd:
             spec.cmd[spec.cmd.index(CodexFlags.ADD_DIR) + 1],
         )
 
-    def test_initial_prompt_is_present_when_no_variadic_flags(self) -> None:
+    def test_initial_prompt_is_final_element(self) -> None:
         spec = CodexBackend().build_interactive_cmd(initial_prompt="hello")
-        assert "hello" in spec.cmd
+        assert spec.cmd[-1] == "hello"
 
     def test_plugin_source_is_silently_ignored(self) -> None:
         from pathlib import Path

--- a/tests/execution/backends/test_codex_interactive.py
+++ b/tests/execution/backends/test_codex_interactive.py
@@ -130,3 +130,14 @@ class TestCodexInteractiveCmdCodexHome:
             env_extras={"CODEX_HOME": "/override"},
         )
         assert spec.env["CODEX_HOME"] == "/override"
+
+
+class TestCodexInteractiveCmdPositionalOrdering:
+    def test_codex_initial_prompt_precedes_add_dir(self) -> None:
+        result = CodexBackend().build_interactive_cmd(
+            initial_prompt="hello",
+            add_dirs=[Path("/tmp/a")],
+        )
+        prompt_idx = list(result.cmd).index("hello")
+        add_dir_idx = list(result.cmd).index(CodexFlags.ADD_DIR)
+        assert prompt_idx < add_dir_idx

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -68,9 +68,36 @@ class TestBuildInteractiveCmd:
         assert ClaudeFlags.MODEL not in result.cmd
 
     def test_includes_initial_prompt_as_positional_arg(self) -> None:
-        result = build_interactive_cmd(initial_prompt="Hello chef")
+        result = build_interactive_cmd(initial_prompt="Hello chef", tools=("AskUserQuestion",))
         assert "Hello chef" in result.cmd
         assert ClaudeFlags.PRINT not in result.cmd  # still interactive, not headless
+        prompt_idx = result.cmd.index("Hello chef")
+        tools_idx = result.cmd.index(ClaudeFlags.TOOLS)
+        assert prompt_idx < tools_idx
+
+    def test_initial_prompt_precedes_tools_flag(self) -> None:
+        result = build_interactive_cmd(initial_prompt="Hello chef", tools=("AskUserQuestion",))
+        prompt_idx = result.cmd.index("Hello chef")
+        tools_idx = result.cmd.index(ClaudeFlags.TOOLS)
+        assert prompt_idx < tools_idx
+
+    def test_initial_prompt_precedes_add_dir_flag(self) -> None:
+        result = build_interactive_cmd(initial_prompt="Hello chef", add_dirs=[Path("/tmp/skills")])
+        prompt_idx = result.cmd.index("Hello chef")
+        add_dir_idx = result.cmd.index(ClaudeFlags.ADD_DIR)
+        assert prompt_idx < add_dir_idx
+
+    def test_initial_prompt_precedes_all_variadic_flags_combined(self) -> None:
+        result = build_interactive_cmd(
+            initial_prompt="Hello chef",
+            tools=("AskUserQuestion",),
+            add_dirs=[Path("/tmp/skills")],
+        )
+        prompt_idx = result.cmd.index("Hello chef")
+        tools_idx = result.cmd.index(ClaudeFlags.TOOLS)
+        add_dir_idx = result.cmd.index(ClaudeFlags.ADD_DIR)
+        assert prompt_idx < tools_idx
+        assert prompt_idx < add_dir_idx
 
     def test_omits_prompt_when_initial_prompt_is_none(self) -> None:
         result = build_interactive_cmd()

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -68,18 +68,9 @@ class TestBuildInteractiveCmd:
         assert ClaudeFlags.MODEL not in result.cmd
 
     def test_includes_initial_prompt_as_positional_arg(self) -> None:
-        result = build_interactive_cmd(initial_prompt="Hello chef", tools=("AskUserQuestion",))
+        result = build_interactive_cmd(initial_prompt="Hello chef")
         assert "Hello chef" in result.cmd
         assert ClaudeFlags.PRINT not in result.cmd  # still interactive, not headless
-        prompt_idx = result.cmd.index("Hello chef")
-        tools_idx = result.cmd.index(ClaudeFlags.TOOLS)
-        assert prompt_idx < tools_idx
-
-    def test_initial_prompt_precedes_tools_flag(self) -> None:
-        result = build_interactive_cmd(initial_prompt="Hello chef", tools=("AskUserQuestion",))
-        prompt_idx = result.cmd.index("Hello chef")
-        tools_idx = result.cmd.index(ClaudeFlags.TOOLS)
-        assert prompt_idx < tools_idx
 
     def test_initial_prompt_precedes_add_dir_flag(self) -> None:
         result = build_interactive_cmd(initial_prompt="Hello chef", add_dirs=[Path("/tmp/skills")])


### PR DESCRIPTION
## Summary

`ClaudeCodeBackend.build_interactive_cmd()` appends the `initial_prompt` positional argument **after** variadic CLI flags (`--tools`, `--add-dir`). Claude Code's CLI parser treats these flags as variadic (`<tools...>`, `<directories...>`), so the parser greedily consumes the greeting string as a tool/directory name rather than as the auto-submit initial prompt. The session launches but sits idle at an empty `>` prompt. The fix moves `initial_prompt` before variadic flags, adds `VARIADIC_CLAUDE_FLAGS` metadata to the flags registry, and adds ordering contract tests. The same fix is applied to the Codex backend.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
- tests/arch/test_variadic_ordering.py

### Modified (●):
- src/autoskillit/core/__init__.pyi
- src/autoskillit/core/types/_type_enums.py
- src/autoskillit/execution/backends/claude.py
- src/autoskillit/execution/backends/codex.py
- tests/arch/CLAUDE.md
- tests/execution/backends/test_codex_backend.py
- tests/execution/backends/test_codex_interactive.py
- tests/execution/test_commands.py

Closes #3298

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_variadic_flag_ordering_2026-05-29_220000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 64 | 21.5k | 1.9M | 136.8k | 258 | 169.3k | 23m 24s |
| review_approach* | sonnet | 1 | 52 | 5.9k | 189.3k | 47.8k | 88 | 32.5k | 8m 25s |
| dry_walkthrough* | opus | 1 | 45 | 10.2k | 936.5k | 71.0k | 100 | 54.8k | 6m 53s |
| implement* | sonnet | 1 | 262 | 11.4k | 1.7M | 69.1k | 92 | 53.7k | 5m 0s |
| audit_impl* | sonnet | 1 | 68 | 4.4k | 231.2k | 38.3k | 19 | 25.8k | 1m 30s |
| prepare_pr* | sonnet | 1 | 108.8k | 3.7k | 247.3k | 30.9k | 25 | 43.8k | 1m 28s |
| compose_pr* | sonnet | 1 | 78.3k | 1.5k | 244.4k | 30.9k | 16 | 15.5k | 44s |
| review_pr* | sonnet | 1 | 142 | 42.2k | 837.0k | 89.2k | 53 | 74.6k | 9m 5s |
| resolve_review* | sonnet | 1 | 237 | 19.2k | 1.7M | 78.8k | 84 | 63.4k | 9m 53s |
| **Total** | | | 188.0k | 119.8k | 8.0M | 136.8k | | 533.3k | 1h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 90 | 18404.2 | 596.7 | 126.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 15 | 115990.6 | 4223.9 | 1277.3 |
| **Total** | **105** | 75826.5 | 5078.7 | 1140.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 64 | 21.5k | 1.9M | 169.3k | 23m 24s |
| sonnet | 7 | 187.9k | 88.2k | 5.1M | 309.1k | 36m 7s |
| opus | 1 | 45 | 10.2k | 936.5k | 54.8k | 6m 53s |