### PR TITLE
Add Bun Socket-Closed Error to Exit Classification API Error Patterns

### DIFF
--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -23,6 +23,7 @@ _API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"socket hang up", re.IGNORECASE),
     re.compile(r"network error", re.IGNORECASE),
     re.compile(r"connection reset", re.IGNORECASE),
+    re.compile(r"socket connection was closed", re.IGNORECASE),  # Bun HTTP client
     re.compile(r"rate[\s_\-]limited", re.IGNORECASE),
 )
 

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -47,6 +47,7 @@ API_ERROR_SIGNALS: list[str] = [
     "socket hang up",
     "network error",
     "connection reset",
+    "socket connection was closed",
     "Rate limited",
     "rate_limit_exceeded",
     # OpenAI/Codex API error types

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -109,6 +109,21 @@ class TestClassifyInfraExit:
         result = _sr(returncode=0, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
 
+    def test_api_error_socket_connection_closed_in_assistant_messages(self):
+        """Bun socket-closed error in assistant_messages → API_ERROR."""
+        session = ClaudeSessionResult(
+            subtype="empty_output",
+            is_error=True,
+            result="",
+            session_id="",
+            assistant_messages=[
+                "The socket connection was closed unexpectedly. "
+                "For more information, pass 'verbose: true' in the second argument to fetch()",
+            ],
+        )
+        result = _sr(returncode=0, stderr="")
+        assert classify_infra_exit(session, result) == InfraExitCategory.API_ERROR
+
     def test_process_killed_sigkill(self):
         """returncode=-9 (SIGKILL) → PROCESS_KILLED."""
         session = ClaudeSessionResult(


### PR DESCRIPTION
## Summary

Add `"socket connection was closed"` to `_API_ERROR_PATTERNS` in `_exit_classification.py` so that Bun's socket-closed error (`"The socket connection was closed unexpectedly"`) is classified as `InfraExitCategory.API_ERROR` instead of `InfraExitCategory.COMPLETED`. This enables retry routing for sessions hitting stale HTTP/2 connections. Update the mirror list `API_ERROR_SIGNALS` in the invariant test file and add a direct classification test.

## Requirements

- REQ-EXIT-001: Add pattern matching `"socket connection was closed"` to `_API_ERROR_PATTERNS` in `src/autoskillit/execution/session/_exit_classification.py` so sessions hitting this error are classified as `InfraExitCategory.API_ERROR`
- REQ-EXIT-002: Add test coverage verifying the new pattern matches the full Bun error message `"The socket connection was closed unexpectedly"` and triggers `API_ERROR` classification
- REQ-EXIT-003: Verify existing patterns (`"socket hang up"`, `"ECONNRESET"`, `"connection reset"`) remain unaffected by the addition
- REQ-EXIT-004: Add `"socket connection was closed"` to the `API_ERROR_SIGNALS` list in `tests/execution/test_api_error_signal_invariants.py` (line 34-46) — this manually maintained list mirrors `_API_ERROR_PATTERNS` and drives 4 parametrized invariant test classes that verify detection across PTY/non-PTY channels

## Changed Files

| File | Change |
|------|--------|
| `src/autoskillit/execution/session/_exit_classification.py` | Add `★ socket connection was closed` regex pattern to `_API_ERROR_PATTERNS` |
| `tests/execution/test_api_error_signal_invariants.py` | Add `"socket connection was closed"` to `API_ERROR_SIGNALS` mirror list |
| `tests/execution/test_exit_classification.py` | Add direct classification test for Bun socket-closed error |

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/add_bun_socket_closed_error_plan_2026-05-30_004500.md`

### Step 1: Add pattern to `_API_ERROR_PATTERNS`

**File:** `src/autoskillit/execution/session/_exit_classification.py`

Add one line after the `"connection reset"` pattern:

```python
_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
    re.compile(r"overloaded", re.IGNORECASE),
    re.compile(r"\b529\b"),
    re.compile(r"\b503\b"),
    re.compile(r"ECONNRESET", re.IGNORECASE),
    re.compile(r"ECONNREFUSED", re.IGNORECASE),
    re.compile(r"socket hang up", re.IGNORECASE),
    re.compile(r"network error", re.IGNORECASE),
    re.compile(r"connection reset", re.IGNORECASE),
    re.compile(r"socket connection was closed", re.IGNORECASE),  # Bun HTTP client
    re.compile(r"rate[\s_\-]limited", re.IGNORECASE),
)
```

`_KNOWN_API_ERROR_PATTERNS` auto-composes via tuple concatenation and `_has_api_error()` imports at call time — no separate update needed.

### Step 2: Add signal to `API_ERROR_SIGNALS` in invariant test

**File:** `tests/execution/test_api_error_signal_invariants.py`

Add `"socket connection was closed"` after `"connection reset"`. This drives 4 parametrized invariant test classes (`TestApiErrorChannelInvariant`, `TestApiErrorPtyModeEndToEnd`, etc.) that verify detection across PTY/non-PTY channels.

### Step 3: Add direct classification test

**File:** `tests/execution/test_exit_classification.py`

Add `test_api_error_socket_connection_closed_in_assistant_messages` that creates a `ClaudeSessionResult` with the full Bun error message `"The socket connection was closed unexpectedly. For more information, pass 'verbose: true' in the second argument to fetch()"` in `assistant_messages` and asserts `classify_infra_exit` returns `InfraExitCategory.API_ERROR`.

## Tests

- New `test_api_error_socket_connection_closed_in_assistant_messages` — direct classification test
- Parametrized invariant tests generate 5 new cases for this signal across PTY/non-PTY channels
- All existing pattern tests unchanged (regression guard)

Closes #3282

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 69 | 6.5k | 743.5k | 67.2k | 60 | 53.8k | 5m 15s |
| review_approach* | opus | 1 | 36 | 4.4k | 323.1k | 49.7k | 39 | 35.7k | 2m 58s |
| verify* | opus | 1 | 45 | 6.9k | 406.9k | 64.5k | 47 | 48.3k | 4m 10s |
| implement* | opus | 1 | 91.2k | 2.6k | 704.1k | 21.6k | 44 | 0 | 2m 45s |
| audit_impl* | opus | 1 | 156 | 5.1k | 135.0k | 32.4k | 20 | 19.7k | 2m 30s |
| prepare_pr* | opus | 1 | 53.7k | 2.2k | 193.5k | 0 | 16 | 0 | 1m 18s |
| compose_pr* | opus | 1 | 45.6k | 2.8k | 467.6k | 0 | 26 | 0 | 1m 38s |
| review_pr* | sonnet | 3 | 360 | 48.0k | 1.7M | 57.0k | 121 | 143.4k | 12m 23s |
| **Total** | | | 191.2k | 78.6k | 4.7M | 67.2k | | 300.9k | 33m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 17 | 41414.9 | 0.0 | 155.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **17** | 273721.1 | 17699.6 | 4625.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 69 | 6.5k | 743.5k | 53.8k | 5m 15s |
| opus | 6 | 190.7k | 24.1k | 2.2M | 103.7k | 15m 22s |
| sonnet | 1 | 360 | 48.0k | 1.7M | 143.4k | 12m 23s |