### PR TITLE
[FIX] Rectify: Worktree Orphaning on Remediation Cycle Re-entry

### DIFF
--- a/src/autoskillit/recipe/_rule_helpers.py
+++ b/src/autoskillit/recipe/_rule_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections import deque
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -13,9 +14,41 @@ from autoskillit.core import get_logger
 from autoskillit.recipe._analysis import ValidationContext
 
 if TYPE_CHECKING:
-    from autoskillit.recipe.schema import CampaignDispatch, Recipe
+    from autoskillit.recipe.schema import CampaignDispatch, Recipe, RecipeStep
 
 logger = get_logger(__name__)
+
+
+def _find_cycle_members(
+    graph: dict[str, set[str]], recipe_steps: Mapping[str, RecipeStep]
+) -> list[frozenset[str]]:
+    """Find all sets of steps that participate in a routing cycle.
+
+    Uses DFS back-edge detection. Returns a list of frozensets of step names
+    that form cycles.
+    """
+    visited: set[str] = set()
+    rec_stack: set[str] = set()
+    cycles: list[frozenset[str]] = []
+
+    def dfs(node: str, path: list[str]) -> None:
+        visited.add(node)
+        rec_stack.add(node)
+        for neighbor in sorted(graph.get(node, set())):
+            if neighbor not in recipe_steps:
+                continue
+            if neighbor not in visited:
+                dfs(neighbor, path + [neighbor])
+            elif neighbor in rec_stack and neighbor in path:
+                cycles.append(frozenset(path[path.index(neighbor) :]))
+        rec_stack.discard(node)
+
+    for step_name in recipe_steps:
+        if step_name not in visited:
+            dfs(step_name, [step_name])
+
+    return cycles
+
 
 _SKILL_CMD_PATTERN = re.compile(r"/(?:autoskillit:)?([\w-]+)")
 _ARG_TOKEN_PATTERN = re.compile(r"\$\{\{[^}]+\}\}|[^\s]+")

--- a/src/autoskillit/recipe/rules/rules_loop_progress.py
+++ b/src/autoskillit/recipe/rules/rules_loop_progress.py
@@ -2,12 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from autoskillit.recipe.schema import RecipeStep
-
 from autoskillit.core import (
     SKILL_TOOLS,
     Severity,
@@ -15,6 +9,7 @@ from autoskillit.core import (
     resolve_skill_name,
 )
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._rule_helpers import _find_cycle_members
 from autoskillit.recipe.contracts import (
     get_skill_contract,
     load_bundled_manifest,
@@ -22,37 +17,6 @@ from autoskillit.recipe.contracts import (
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
-
-
-def _find_cycle_members(
-    graph: dict[str, set[str]], recipe_steps: Mapping[str, RecipeStep]
-) -> list[frozenset[str]]:
-    """Find all sets of steps that participate in a routing cycle.
-
-    Uses DFS back-edge detection (same pattern as _check_unbounded_cycles).
-    Returns a list of frozensets of step names that form cycles.
-    """
-    visited: set[str] = set()
-    rec_stack: set[str] = set()
-    cycles: list[frozenset[str]] = []
-
-    def dfs(node: str, path: list[str]) -> None:
-        visited.add(node)
-        rec_stack.add(node)
-        for neighbor in sorted(graph.get(node, set())):
-            if neighbor not in recipe_steps:
-                continue
-            if neighbor not in visited:
-                dfs(neighbor, path + [neighbor])
-            elif neighbor in rec_stack and neighbor in path:
-                cycles.append(frozenset(path[path.index(neighbor) :]))
-        rec_stack.discard(node)
-
-    for step_name in recipe_steps:
-        if step_name not in visited:
-            dfs(step_name, [step_name])
-
-    return cycles
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/rules/rules_worktree.py
+++ b/src/autoskillit/recipe/rules/rules_worktree.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import re
+
 from autoskillit.core import (
     SKILL_TOOLS,
     Severity,
     get_logger,
 )
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._analysis_bfs import _bfs_capped, _build_success_step_graph
+from autoskillit.recipe._rule_helpers import _find_cycle_members
 from autoskillit.recipe.contracts import INPUT_REF_RE, load_bundled_manifest, resolve_skill_name
 from autoskillit.recipe.io import iter_steps_with_context
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
@@ -301,4 +305,101 @@ def _check_capture_list_requires_retries_zero(ctx: ValidationContext) -> list[Ru
                     ),
                 )
             )
+    return findings
+
+
+# Context variable names that hold worktree filesystem paths.
+_WORKTREE_REF_KEYS = frozenset({"worktree_path", "implementation_ref"})
+
+# Matches 'git worktree remove' shell invocations used as cleanup barriers.
+_GIT_WORKTREE_REMOVE_RE = re.compile(r"git\s+worktree\s+remove")
+
+
+def _is_worktree_barrier(step_name: str, ctx_vars: frozenset[str], recipe) -> bool:
+    """Return True if step consumes or removes the worktree for any of the given ctx_vars."""
+    step = recipe.steps.get(step_name)
+    if step is None:
+        return False
+    if step.tool == "merge_worktree":
+        wt_arg = step.with_args.get("worktree_path", "")
+        return any(f"context.{v}" in wt_arg for v in ctx_vars)
+    if step.tool == "remove_clone":
+        cp_arg = step.with_args.get("clone_path", "")
+        return any(f"context.{v}" in cp_arg for v in ctx_vars)
+    if step.tool == "run_cmd":
+        cmd = step.with_args.get("cmd", "")
+        return bool(_GIT_WORKTREE_REMOVE_RE.search(cmd))
+    return False
+
+
+@semantic_rule(
+    name="worktree-clobber-without-merge",
+    description=(
+        "A worktree-modifying step is reachable again via a routing cycle without "
+        "an intervening merge_worktree or cleanup step consuming the captured variable. "
+        "The second invocation overwrites the context variable, orphaning the first worktree."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_worktree_clobber_without_merge(ctx: ValidationContext) -> list[RuleFinding]:
+    recipe = ctx.recipe
+    findings: list[RuleFinding] = []
+
+    success_graph = _build_success_step_graph(recipe)
+    cycle_sets = _find_cycle_members(success_graph, recipe.steps)
+
+    flagged_steps: set[str] = set()
+    for cycle_set in cycle_sets:
+        for step_name in cycle_set:
+            if step_name in flagged_steps:
+                continue
+            step = recipe.steps.get(step_name)
+            if step is None:
+                continue
+            if step.tool not in SKILL_TOOLS:
+                continue
+            skill_cmd = step.with_args.get("skill_command", "")
+            skill = resolve_skill_name(skill_cmd)
+            if not skill or skill not in _WORKTREE_MODIFYING_SKILLS:
+                continue
+            if not step.capture:
+                continue
+
+            captured_vars = frozenset(k for k in step.capture if k in _WORKTREE_REF_KEYS)
+            if not captured_vars:
+                continue
+
+            # Collect all barrier steps that consume ANY of the captured worktree variables.
+            # When a step captures both worktree_path and implementation_ref as aliases,
+            # a barrier consuming either is sufficient to break the orphan path.
+            barrier_steps = {
+                s for s in recipe.steps if _is_worktree_barrier(s, captured_vars, recipe)
+            }
+
+            # BFS from successors of the worktree step (within the cycle only)
+            # to check if the step itself is reachable without crossing a barrier.
+            cycle_successors = success_graph.get(step_name, set()) & cycle_set
+            visited = _bfs_capped(success_graph, cycle_successors, barrier_steps)
+
+            if step_name in visited:
+                cycle_path = "→".join(sorted(cycle_set))
+                vars_str = ", ".join(f"'{v}'" for v in sorted(captured_vars))
+                flagged_steps.add(step_name)
+                findings.append(
+                    RuleFinding(
+                        rule="worktree-clobber-without-merge",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Step '{step_name}' creates a worktree and captures "
+                            f"{vars_str} but is reachable again via [{cycle_path}] "
+                            f"without an intervening merge_worktree step consuming "
+                            f"any of those context variables. The second invocation "
+                            f"will overwrite the reference, orphaning the first worktree. "
+                            f"Add a merge or cleanup step before re-entering the "
+                            f"worktree-creating step."
+                        ),
+                    )
+                )
+
     return findings

--- a/src/autoskillit/recipe/rules/rules_worktree.py
+++ b/src/autoskillit/recipe/rules/rules_worktree.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import re
+import regex as re
 
 from autoskillit.core import (
     SKILL_TOOLS,

--- a/src/autoskillit/recipe/rules/rules_worktree.py
+++ b/src/autoskillit/recipe/rules/rules_worktree.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import regex as re
 
 from autoskillit.core import (
@@ -15,6 +17,9 @@ from autoskillit.recipe._rule_helpers import _find_cycle_members
 from autoskillit.recipe.contracts import INPUT_REF_RE, load_bundled_manifest, resolve_skill_name
 from autoskillit.recipe.io import iter_steps_with_context
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+if TYPE_CHECKING:
+    from autoskillit.recipe.schema import Recipe
 
 logger = get_logger(__name__)
 
@@ -315,7 +320,7 @@ _WORKTREE_REF_KEYS = frozenset({"worktree_path", "implementation_ref"})
 _GIT_WORKTREE_REMOVE_RE = re.compile(r"git\s+worktree\s+remove")
 
 
-def _is_worktree_barrier(step_name: str, ctx_vars: frozenset[str], recipe) -> bool:
+def _is_worktree_barrier(step_name: str, ctx_vars: frozenset[str], recipe: Recipe) -> bool:
     """Return True if step consumes or removes the worktree for any of the given ctx_vars."""
     step = recipe.steps.get(step_name)
     if step is None:
@@ -328,7 +333,9 @@ def _is_worktree_barrier(step_name: str, ctx_vars: frozenset[str], recipe) -> bo
         return any(f"context.{v}" in cp_arg for v in ctx_vars)
     if step.tool == "run_cmd":
         cmd = step.with_args.get("cmd", "")
-        return bool(_GIT_WORKTREE_REMOVE_RE.search(cmd))
+        if not _GIT_WORKTREE_REMOVE_RE.search(cmd):
+            return False
+        return any(f"context.{v}" in cmd for v in ctx_vars)
     return False
 
 

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -553,7 +553,9 @@
         "base_branch": "${{ context.merge_target }}"
       },
       "capture": {
-        "cleanup_succeeded": "${{ result.cleanup_succeeded }}"
+        "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+        "merge_test_stdout": "${{ result.test_stdout }}",
+        "merge_test_stderr": "${{ result.test_stderr }}"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -537,7 +537,7 @@
           "route": "release_issue_failure"
         },
         {
-          "route": "remediate"
+          "route": "pre_remediation_merge"
         }
       ],
       "on_failure": "release_issue_failure",
@@ -545,6 +545,70 @@
         "audit_remediation_count"
       ],
       "note": "Guards the audit_impl → remediate → plan → implement → test remediation cycle. Separate counter from merge_fix_count.\n"
+    },
+    "pre_remediation_merge": {
+      "tool": "merge_worktree",
+      "with": {
+        "worktree_path": "${{ context.implementation_ref }}",
+        "base_branch": "${{ context.merge_target }}"
+      },
+      "capture": {
+        "cleanup_succeeded": "${{ result.cleanup_succeeded }}"
+      },
+      "on_result": [
+        {
+          "when": "result.failed_step == 'dirty_tree'",
+          "route": "commit_guard_pre_remediation"
+        },
+        {
+          "when": "result.failed_step == 'test_gate'",
+          "route": "remediate"
+        },
+        {
+          "when": "result.failed_step == 'post_rebase_test_gate'",
+          "route": "remediate"
+        },
+        {
+          "when": "result.failed_step == 'rebase'",
+          "route": "remediate"
+        },
+        {
+          "when": "result.failed_step == 'dirty_main_repo'",
+          "route": "main_repo_guard_pre_remediation"
+        },
+        {
+          "when": "result.failed_step == 'ref_coherence'",
+          "route": "remediate"
+        },
+        {
+          "when": "result.error",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "remediate"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "note": "Merges the current worktree before the remediation cycle creates a new one. Audit NO GO means the implementation is incomplete, not wrong — merge it first, then remediate on top. This prevents orphaning the original worktree when implement re-runs. dirty_tree routes to commit_guard_pre_remediation to auto-commit before retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation to stash. test_gate and rebase route to remediate — the remediation plan will address these. Only hard errors escalate to release_issue_failure.\n"
+    },
+    "commit_guard_pre_remediation": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.recipe._cmd_rpc.commit_guard",
+        "worktree_path": "${{ context.implementation_ref }}",
+        "base_branch": "${{ inputs.base_branch }}"
+      },
+      "on_success": "pre_remediation_merge",
+      "on_failure": "pre_remediation_merge"
+    },
+    "main_repo_guard_pre_remediation": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.recipe._cmd_rpc.main_repo_guard",
+        "clone_path": "${{ context.work_dir }}"
+      },
+      "on_success": "pre_remediation_merge",
+      "on_failure": "pre_remediation_merge"
     },
     "assess": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -518,13 +518,62 @@ steps:
     on_result:
     - when: ${{ result.max_exceeded }} == true
       route: release_issue_failure
-    - route: remediate
+    - route: pre_remediation_merge
     on_failure: release_issue_failure
     optional_context_refs:
     - audit_remediation_count
     note: >
       Guards the audit_impl → remediate → plan → implement → test
       remediation cycle. Separate counter from merge_fix_count.
+
+  pre_remediation_merge:
+    tool: merge_worktree
+    with:
+      worktree_path: ${{ context.implementation_ref }}
+      base_branch: ${{ context.merge_target }}
+    capture:
+      cleanup_succeeded: ${{ result.cleanup_succeeded }}
+    on_result:
+    - when: result.failed_step == 'dirty_tree'
+      route: commit_guard_pre_remediation
+    - when: result.failed_step == 'test_gate'
+      route: remediate
+    - when: result.failed_step == 'post_rebase_test_gate'
+      route: remediate
+    - when: result.failed_step == 'rebase'
+      route: remediate
+    - when: result.failed_step == 'dirty_main_repo'
+      route: main_repo_guard_pre_remediation
+    - when: result.failed_step == 'ref_coherence'
+      route: remediate
+    - when: result.error
+      route: release_issue_failure
+    - route: remediate
+    on_failure: release_issue_failure
+    note: >
+      Merges the current worktree before the remediation cycle creates a new
+      one. Audit NO GO means the implementation is incomplete, not wrong —
+      merge it first, then remediate on top. This prevents orphaning the
+      original worktree when implement re-runs. dirty_tree routes to
+      commit_guard_pre_remediation to auto-commit before retrying merge.
+      dirty_main_repo routes to main_repo_guard_pre_remediation to stash.
+      test_gate and rebase route to remediate — the remediation plan will
+      address these. Only hard errors escalate to release_issue_failure.
+  commit_guard_pre_remediation:
+    tool: run_python
+    with:
+      callable: autoskillit.recipe._cmd_rpc.commit_guard
+      worktree_path: ${{ context.implementation_ref }}
+      base_branch: ${{ inputs.base_branch }}
+    on_success: pre_remediation_merge
+    on_failure: pre_remediation_merge
+  main_repo_guard_pre_remediation:
+    tool: run_python
+    with:
+      callable: autoskillit.recipe._cmd_rpc.main_repo_guard
+      clone_path: ${{ context.work_dir }}
+    on_success: pre_remediation_merge
+    on_failure: pre_remediation_merge
 
   assess:
     tool: run_skill

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -533,6 +533,8 @@ steps:
       base_branch: ${{ context.merge_target }}
     capture:
       cleanup_succeeded: ${{ result.cleanup_succeeded }}
+      merge_test_stdout: ${{ result.test_stdout }}
+      merge_test_stderr: ${{ result.test_stderr }}
     on_result:
     - when: result.failed_step == 'dirty_tree'
       route: commit_guard_pre_remediation

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -357,7 +357,7 @@
           "route": "escalate_stop"
         },
         {
-          "route": "plan_phase"
+          "route": "pre_remediation_cleanup"
         }
       ],
       "on_failure": "escalate_stop",
@@ -365,6 +365,15 @@
         "audit_retry_count"
       ],
       "note": "Guards the audit_impl → remediate → plan_phase remediation cycle. Allows up to 2 remediation attempts before escalating. This prevents unbounded re-planning when audit_impl repeatedly returns NO GO.\n"
+    },
+    "pre_remediation_cleanup": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "git worktree remove --force \"${{ context.worktree_path }}\""
+      },
+      "on_success": "plan_phase",
+      "on_failure": "plan_phase",
+      "note": "Removes the old worktree before the remediation cycle creates a new one via implement_phase. on_failure routes to plan_phase regardless — if the worktree is already gone (e.g., context_limit cleanup), the new worktree creation will still succeed.\n"
     },
     "run_experiment": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -294,7 +294,7 @@
           "route": "audit_impl"
         },
         {
-          "route": "plan_phase"
+          "route": "cleanup_phase_worktree"
         }
       ],
       "on_failure": "audit_impl",
@@ -302,6 +302,16 @@
         "phase_loop_count"
       ],
       "note": "Guards the plan_phase → implement_phase → next_phase_or_experiment cycle. The loop is data-bounded by the finite group_files list; this provides a structural bound. 15 iterations allows complex multi-phase setups.\n"
+    },
+    "cleanup_phase_worktree": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "git worktree remove --force \"${{ context.worktree_path }}\"",
+        "step_name": "cleanup_phase_worktree"
+      },
+      "on_success": "plan_phase",
+      "on_failure": "plan_phase",
+      "note": "Removes the previous phase worktree before implement_phase creates a new one. Each phase gets its own timestamped worktree via implement-experiment; this prevents orphaning the old worktree when the loop re-enters.\n"
     },
     "audit_impl": {
       "tool": "run_skill",
@@ -369,7 +379,8 @@
     "pre_remediation_cleanup": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "git worktree remove --force \"${{ context.worktree_path }}\""
+        "cmd": "git worktree remove --force \"${{ context.worktree_path }}\"",
+        "step_name": "pre_remediation_cleanup"
       },
       "on_success": "plan_phase",
       "on_failure": "plan_phase",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -296,7 +296,7 @@ steps:
     on_result:
     - when: "${{ result.max_exceeded }} == true"
       route: audit_impl
-    - route: plan_phase
+    - route: cleanup_phase_worktree
     on_failure: audit_impl
     optional_context_refs:
     - phase_loop_count
@@ -304,6 +304,18 @@ steps:
       Guards the plan_phase → implement_phase → next_phase_or_experiment cycle.
       The loop is data-bounded by the finite group_files list; this provides a
       structural bound. 15 iterations allows complex multi-phase setups.
+
+  cleanup_phase_worktree:
+    tool: run_cmd
+    with:
+      cmd: "git worktree remove --force \"${{ context.worktree_path }}\""
+      step_name: cleanup_phase_worktree
+    on_success: plan_phase
+    on_failure: plan_phase
+    note: >
+      Removes the previous phase worktree before implement_phase creates a new
+      one. Each phase gets its own timestamped worktree via implement-experiment;
+      this prevents orphaning the old worktree when the loop re-enters.
 
   audit_impl:
     tool: run_skill
@@ -367,6 +379,7 @@ steps:
     tool: run_cmd
     with:
       cmd: "git worktree remove --force \"${{ context.worktree_path }}\""
+      step_name: pre_remediation_cleanup
     on_success: plan_phase
     on_failure: plan_phase
     note: >

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -354,7 +354,7 @@ steps:
     on_result:
     - when: "${{ result.max_exceeded }} == true"
       route: escalate_stop
-    - route: plan_phase
+    - route: pre_remediation_cleanup
     on_failure: escalate_stop
     optional_context_refs:
     - audit_retry_count
@@ -362,6 +362,18 @@ steps:
       Guards the audit_impl → remediate → plan_phase remediation cycle.
       Allows up to 2 remediation attempts before escalating. This prevents
       unbounded re-planning when audit_impl repeatedly returns NO GO.
+
+  pre_remediation_cleanup:
+    tool: run_cmd
+    with:
+      cmd: "git worktree remove --force \"${{ context.worktree_path }}\""
+    on_success: plan_phase
+    on_failure: plan_phase
+    note: >
+      Removes the old worktree before the remediation cycle creates a new one
+      via implement_phase. on_failure routes to plan_phase regardless — if the
+      worktree is already gone (e.g., context_limit cleanup), the new worktree
+      creation will still succeed.
 
   # --- Experiment + Report ---
   run_experiment:

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -532,7 +532,7 @@
           "route": "audit_impl"
         },
         {
-          "route": "plan_phase"
+          "route": "cleanup_phase_worktree"
         }
       ],
       "on_failure": "audit_impl",
@@ -540,6 +540,16 @@
         "phase_loop_count"
       ],
       "note": "Guards the plan_phase → implement_phase → next_phase_or_experiment cycle. The loop is data-bounded by the finite group_files list; this provides a structural bound. 15 iterations allows complex multi-phase setups.\n"
+    },
+    "cleanup_phase_worktree": {
+      "tool": "run_cmd",
+      "with": {
+        "cmd": "git worktree remove --force \"${{ context.worktree_path }}\"",
+        "step_name": "cleanup_phase_worktree"
+      },
+      "on_success": "plan_phase",
+      "on_failure": "plan_phase",
+      "note": "Removes the previous phase worktree before implement_phase creates a new one. Each phase gets its own timestamped worktree via implement-experiment; this prevents orphaning the old worktree when the loop re-enters.\n"
     },
     "audit_impl": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -536,7 +536,7 @@ steps:
     on_result:
     - when: "${{ result.max_exceeded }} == true"
       route: audit_impl
-    - route: plan_phase
+    - route: cleanup_phase_worktree
     on_failure: audit_impl
     optional_context_refs:
     - phase_loop_count
@@ -544,6 +544,18 @@ steps:
       Guards the plan_phase → implement_phase → next_phase_or_experiment cycle.
       The loop is data-bounded by the finite group_files list; this provides a
       structural bound. 15 iterations allows complex multi-phase setups.
+
+  cleanup_phase_worktree:
+    tool: run_cmd
+    with:
+      cmd: "git worktree remove --force \"${{ context.worktree_path }}\""
+      step_name: cleanup_phase_worktree
+    on_success: plan_phase
+    on_failure: plan_phase
+    note: >
+      Removes the previous phase worktree before implement_phase creates a new
+      one. Each phase gets its own timestamped worktree via implement-experiment;
+      this prevents orphaning the old worktree when the loop re-enters.
 
   audit_impl:
     tool: run_skill

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core.types import Severity
+from autoskillit.recipe._analysis_bfs import _bfs_capped, _build_success_step_graph
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import analyze_dataflow, run_semantic_rules
 
@@ -1020,3 +1021,69 @@ class TestDisplayConditionContract:
                             f"display-only value '{operand}' for "
                             f"inputs.{ing_name} — use raw YAML value instead"
                         )
+
+
+# ---------------------------------------------------------------------------
+# Test 1b: Bundled recipe regression — worktree orphan immunity in remediation.yaml
+# ---------------------------------------------------------------------------
+
+
+def test_remediation_no_go_path_has_merge_before_implement_reentry() -> None:
+    """remediation.yaml: the NO GO remediation cycle must include a merge_worktree step
+    before re-entering the implement step, so the original worktree is consumed
+    rather than orphaned.
+
+    Checks:
+    1. The success-path BFS from remediate (the non-exhausted route of
+       check_audit_remediation_loop) to implement contains at least one
+       step with tool=merge_worktree consuming context.implementation_ref.
+    2. run_semantic_rules produces no worktree-clobber-without-merge finding.
+    """
+    recipe = load_recipe(builtin_recipes_dir() / "remediation.yaml")
+
+    success_graph = _build_success_step_graph(recipe)
+
+    # Find all steps reachable from remediate before hitting implement
+    # (implement is the barrier)
+    # Find the non-exhausted route from check_audit_remediation_loop (the entry to
+    # the remediation cycle) to understand what steps execute before implement re-entry.
+    loop_step = recipe.steps["check_audit_remediation_loop"]
+    assert loop_step.on_result is not None
+    non_exhausted_routes = [
+        c.route
+        for c in loop_step.on_result.conditions
+        if c.when is None or "max_exceeded" not in c.when
+    ]
+    assert non_exhausted_routes, "check_audit_remediation_loop must have a non-exhausted route"
+    cycle_entry = non_exhausted_routes[-1]
+
+    # BFS from cycle entry to implement — all steps on this path form the remediation cycle.
+    steps_before_implement = _bfs_capped(success_graph, {cycle_entry}, {"implement"})
+
+    merge_steps_on_path = [
+        step_name
+        for step_name in steps_before_implement
+        if step_name != "implement"
+        and recipe.steps.get(step_name) is not None
+        and recipe.steps[step_name].tool == "merge_worktree"
+        and (
+            "context.implementation_ref"
+            in recipe.steps[step_name].with_args.get("worktree_path", "")
+            or "context.worktree_path"
+            in recipe.steps[step_name].with_args.get("worktree_path", "")
+        )
+    ]
+
+    assert merge_steps_on_path, (
+        f"No merge_worktree step consuming context.implementation_ref or context.worktree_path "
+        f"found on the success path from {cycle_entry!r} to implement. "
+        f"The remediation cycle must merge the existing worktree before creating a new one. "
+        f"Steps on path before implement: {sorted(steps_before_implement)}"
+    )
+
+    findings = run_semantic_rules(recipe)
+    clobber_findings = [f for f in findings if f.rule == "worktree-clobber-without-merge"]
+    assert clobber_findings == [], (
+        f"remediation.yaml must not trigger worktree-clobber-without-merge after the fix, "
+        f"got: {clobber_findings}"
+    )

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -1043,10 +1043,8 @@ def test_remediation_no_go_path_has_merge_before_implement_reentry() -> None:
 
     success_graph = _build_success_step_graph(recipe)
 
-    # Find all steps reachable from remediate before hitting implement
-    # (implement is the barrier)
-    # Find the non-exhausted route from check_audit_remediation_loop (the entry to
-    # the remediation cycle) to understand what steps execute before implement re-entry.
+    # Find the non-exhausted route from check_audit_remediation_loop to understand
+    # what steps execute before implement re-entry (implement is the barrier).
     loop_step = recipe.steps["check_audit_remediation_loop"]
     assert loop_step.on_result is not None
     non_exhausted_routes = [

--- a/tests/recipe/test_research_audit_impl.py
+++ b/tests/recipe/test_research_audit_impl.py
@@ -205,12 +205,14 @@ class TestResearchImplementRemediationLoop:
         assert max_cond is not None
         assert max_cond.route == "escalate_stop"
 
-    def test_check_audit_retry_loop_default_routes_to_plan_phase(self, recipe) -> None:
+    def test_check_audit_retry_loop_default_routes_to_pre_remediation_cleanup(
+        self, recipe
+    ) -> None:
         step = recipe.steps["check_audit_retry_loop"]
         conditions = step.on_result.conditions
         default_cond = next((c for c in conditions if c.when is None), None)
         assert default_cond is not None
-        assert default_cond.route == "plan_phase"
+        assert default_cond.route == "pre_remediation_cleanup"
 
     def test_check_audit_retry_loop_on_failure_escalates(self, recipe) -> None:
         step = recipe.steps["check_audit_retry_loop"]

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -788,14 +788,15 @@ def test_bundled_recipes_push_between_parts(recipe_name: str) -> None:
     """Multi-part recipes must push the feature branch between parts.
 
     The merge step's success path must reach a push_to_remote step
-    before looping back for the next part.
+    before looping back for the next part.  Pre-remediation merge steps
+    are excluded — they clean up before replanning, not between parts.
     """
     recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
 
     merge_steps = {
         name: step
         for name, step in recipe.steps.items()
-        if getattr(step, "tool", None) == "merge_worktree"
+        if getattr(step, "tool", None) == "merge_worktree" and "pre_remediation" not in name
     }
     assert merge_steps, f"{recipe_name}: no merge_worktree step found"
 

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -1051,3 +1051,209 @@ class TestCaptureListRequiresRetriesZero:
             "capture-list-requires-retries-zero must not fire for empty capture_list, "
             f"got: {rule_findings}"
         )
+
+
+# ---------------------------------------------------------------------------
+# worktree-clobber-without-merge tests (Test 1a and 1c)
+# ---------------------------------------------------------------------------
+
+
+def _make_cycle_clobber_workflow(*, with_merge_barrier: bool = False) -> Recipe:
+    """Build a minimal recipe with a worktree-creating step inside a remediation cycle.
+
+    With with_merge_barrier=False: implement → audit → NO GO → remediate → implement
+    reproduces the cycle-clobber pattern.
+
+    With with_merge_barrier=True: a merge_worktree step is inserted before re-entering
+    implement, which should suppress the finding.
+    """
+    if with_merge_barrier:
+        steps = {
+            "implement": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:implement-worktree-no-merge plan"},
+                "capture": {
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "implementation_ref": "${{ result.worktree_path }}",
+                },
+                "retries": 0,
+                "on_context_limit": "retry_wt",
+                "on_success": "audit",
+                "on_failure": "fail_stop",
+            },
+            "retry_wt": {
+                "tool": "run_skill",
+                "with": {
+                    "skill_command": "/autoskillit:retry-worktree p ${{ context.worktree_path }}",
+                    "cwd": "${{ context.worktree_path }}",
+                },
+                "capture": {
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "implementation_ref": "${{ result.worktree_path }}",
+                },
+                "on_success": "audit",
+                "on_failure": "fail_stop",
+            },
+            "audit": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:audit-impl plan branch main"},
+                "capture": {"remediation_path": "${{ result.remediation_path }}"},
+                "on_result": [
+                    {"when": "${{ result.verdict }} == GO", "route": "merge"},
+                    {"route": "loop_guard"},
+                ],
+                "on_failure": "fail_stop",
+            },
+            "loop_guard": {
+                "tool": "run_python",
+                "with": {
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.audit_count }}",
+                    "max_iterations": "2",
+                },
+                "capture": {"audit_count": "${{ result.next_iteration }}"},
+                "on_result": [
+                    {"when": "${{ result.max_exceeded }} == true", "route": "fail_stop"},
+                    {"route": "pre_merge"},
+                ],
+                "on_failure": "fail_stop",
+                "optional_context_refs": ["audit_count"],
+            },
+            "pre_merge": {
+                "tool": "merge_worktree",
+                "with": {
+                    "worktree_path": "${{ context.implementation_ref }}",
+                    "base_branch": "main",
+                },
+                "on_success": "remediate",
+                "on_failure": "fail_stop",
+            },
+            "remediate": {
+                "action": "route",
+                "with": {"remediation_path": "${{ context.remediation_path }}"},
+                "on_success": "implement",
+            },
+            "merge": {
+                "tool": "merge_worktree",
+                "with": {
+                    "worktree_path": "${{ context.implementation_ref }}",
+                    "base_branch": "main",
+                },
+                "on_success": "done",
+                "on_failure": "fail_stop",
+            },
+            "done": {"action": "stop", "message": "Done."},
+            "fail_stop": {"action": "stop", "message": "Failed."},
+        }
+    else:
+        steps = {
+            "implement": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:implement-worktree-no-merge plan"},
+                "capture": {
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "implementation_ref": "${{ result.worktree_path }}",
+                },
+                "retries": 0,
+                "on_context_limit": "retry_wt",
+                "on_success": "audit",
+                "on_failure": "fail_stop",
+            },
+            "retry_wt": {
+                "tool": "run_skill",
+                "with": {
+                    "skill_command": "/autoskillit:retry-worktree p ${{ context.worktree_path }}",
+                    "cwd": "${{ context.worktree_path }}",
+                },
+                "capture": {
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "implementation_ref": "${{ result.worktree_path }}",
+                },
+                "on_success": "audit",
+                "on_failure": "fail_stop",
+            },
+            "audit": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:audit-impl plan branch main"},
+                "capture": {"remediation_path": "${{ result.remediation_path }}"},
+                "on_result": [
+                    {"when": "${{ result.verdict }} == GO", "route": "merge"},
+                    {"route": "loop_guard"},
+                ],
+                "on_failure": "fail_stop",
+            },
+            "loop_guard": {
+                "tool": "run_python",
+                "with": {
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.audit_count }}",
+                    "max_iterations": "2",
+                },
+                "capture": {"audit_count": "${{ result.next_iteration }}"},
+                "on_result": [
+                    {"when": "${{ result.max_exceeded }} == true", "route": "fail_stop"},
+                    {"route": "remediate"},
+                ],
+                "on_failure": "fail_stop",
+                "optional_context_refs": ["audit_count"],
+            },
+            "remediate": {
+                "action": "route",
+                "with": {"remediation_path": "${{ context.remediation_path }}"},
+                "on_success": "implement",
+            },
+            "merge": {
+                "tool": "merge_worktree",
+                "with": {
+                    "worktree_path": "${{ context.implementation_ref }}",
+                    "base_branch": "main",
+                },
+                "on_success": "done",
+                "on_failure": "fail_stop",
+            },
+            "done": {"action": "stop", "message": "Done."},
+            "fail_stop": {"action": "stop", "message": "Failed."},
+        }
+    return _make_workflow(steps)
+
+
+def test_worktree_clobber_without_merge_fires_on_cycle() -> None:
+    """worktree-clobber-without-merge ERROR fires when implement is in a cycle without merge."""
+    wf = _make_cycle_clobber_workflow(with_merge_barrier=False)
+    findings = run_semantic_rules(wf)
+    errors = [f for f in findings if f.severity == Severity.ERROR]
+    assert any(f.rule == "worktree-clobber-without-merge" for f in errors), (
+        f"Expected worktree-clobber-without-merge ERROR. Got errors: "
+        f"{[(f.rule, f.step_name) for f in errors]}"
+    )
+
+
+def test_worktree_clobber_without_merge_clean_with_barrier() -> None:
+    """worktree-clobber-without-merge does NOT fire when merge_worktree precedes re-entry."""
+    wf = _make_cycle_clobber_workflow(with_merge_barrier=True)
+    findings = run_semantic_rules(wf)
+    rule_findings = [f for f in findings if f.rule == "worktree-clobber-without-merge"]
+    assert rule_findings == [], (
+        f"worktree-clobber-without-merge must not fire when merge barrier is present, "
+        f"got: {rule_findings}"
+    )
+
+
+def test_existing_rules_do_not_catch_cycle_clobber_pattern() -> None:
+    """superseded-input-after-capture and loop-body-uncaptured-output do NOT catch cycle-clobber.
+
+    Documents the gap that worktree-clobber-without-merge fills: the existing rules
+    do not detect context variable overwrite across loop iterations.
+    """
+    wf = _make_cycle_clobber_workflow(with_merge_barrier=False)
+    findings = run_semantic_rules(wf)
+    superseded_findings = [f for f in findings if f.rule == "superseded-input-after-capture"]
+    uncaptured_findings = [f for f in findings if f.rule == "loop-body-uncaptured-output"]
+    assert superseded_findings == [], (
+        f"superseded-input-after-capture should NOT catch cycle-clobber pattern, "
+        f"got: {superseded_findings}"
+    )
+    assert uncaptured_findings == [], (
+        f"loop-body-uncaptured-output should NOT catch cycle-clobber pattern "
+        f"(implement step HAS a capture block), got: {uncaptured_findings}"
+    )


### PR DESCRIPTION
## Summary

Recipe pipelines that run `audit_impl` pre-merge (`remediation.yaml`, `research-implement.yaml`) orphan worktrees when the NO GO remediation path re-enters the `implement` step. The `implement` step's `capture:` block unconditionally overwrites `context.implementation_ref` / `context.worktree_path` with the new worktree path. The original worktree — containing the core implementation — is permanently lost from pipeline state, never merged, and never cleaned up.

The fix adds a new semantic rule `worktree-clobber-without-merge` that detects "worktree-modifying step reachable via a back-edge without an intervening `merge_worktree` step consuming the captured variable." Fix `remediation.yaml` by inserting `pre_remediation_merge` before the remediation cycle. Fix `research-implement.yaml` with `pre_remediation_cleanup` using `git worktree remove`. Also moves `_find_cycle_members` from `rules_loop_progress.py` to `_rule_helpers.py`.

Closes #3288

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-002120-885720/.autoskillit/temp/rectify/rectify_worktree_orphan_immunity_2026-05-30_002120.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 26.2k | 4.5k | 21.2M | 155.4k | 262 | 1.7M | 24m 34s |
| review_approach* | sonnet | 1 | 52 | 6.2k | 189.3k | 44.0k | 53 | 31.7k | 3m 37s |
| dry_walkthrough* | opus | 1 | 54 | 13.3k | 1.6M | 89.7k | 172 | 58.6k | 7m 58s |
| implement* | sonnet | 1 | 2.9k | 41.5k | 6.1M | 128.8k | 192 | 113.1k | 13m 34s |
| audit_impl* | sonnet | 1 | 92 | 12.4k | 453.8k | 68.7k | 45 | 53.3k | 4m 50s |
| prepare_pr* | sonnet | 1 | 59.2k | 2.5k | 154.6k | 30.9k | 15 | 43.8k | 56s |
| compose_pr* | sonnet | 1 | 38.4k | 1.5k | 182.6k | 30.9k | 14 | 15.5k | 39s |
| review_pr* | sonnet | 2 | 316 | 68.9k | 2.0M | 100.0k | 138 | 159.8k | 20m 2s |
| resolve_review* | opus | 2 | 117 | 26.3k | 3.3M | 79.0k | 117 | 121.1k | 20m 15s |
| **Total** | | | 127.2k | 177.1k | 35.2M | 155.4k | | 2.3M | 1h 36m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 593 | 10260.4 | 190.8 | 70.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 17 | 196816.2 | 7122.5 | 1546.7 |
| **Total** | **610** | 57723.8 | 3779.0 | 290.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 26.2k | 4.5k | 21.2M | 1.7M | 24m 34s |
| sonnet | 6 | 100.9k | 133.0k | 9.0M | 417.2k | 43m 40s |
| opus | 2 | 171 | 39.6k | 4.9M | 179.7k | 28m 14s |