### PR TITLE
[FIX] Rectify: Anomaly Detector False Positives — Model Identity Normalization & RSS Baseline Hardening

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_execution.py
+++ b/src/autoskillit/core/types/_type_protocols_execution.py
@@ -97,6 +97,7 @@ class HeadlessExecutor(Protocol):
         provider_name: str = "",
         provider_fallback_env: dict[str, str] | None = None,
         provider_fallback_name: str = "",
+        profile_name: str = "",
         sentinel_contract: str = "",
         marker_dir: Path | None = None,
         session_id: str | None = None,

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -526,6 +526,7 @@ class SessionIndexEntry(TypedDict):
     provider_fallback: bool
     model_identifier: str
     configured_model: str
+    profile_name: str
     caller_session_id: str
     api_retry_count: int
     api_retry_exhausted: bool

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -475,6 +475,7 @@ class TokenUsageFileEntry(TypedDict):
     provider_used: str
     model_identifier: str
     configured_model: str
+    profile_name: str
     dispatch_id: str
     campaign_id: str
     schema_version: int

--- a/src/autoskillit/execution/anomaly_detection.py
+++ b/src/autoskillit/execution/anomaly_detection.py
@@ -295,7 +295,6 @@ def detect_anomalies(
     if initial_rss is not None and initial_rss > 0 and len(snapshots) >= 5:
         last_rss = snapshots[-1].get("vm_rss_kb", 0)
         if isinstance(last_rss, int):
-            is_anomalous: bool
             if initial_rss >= RSS_BASELINE_FLOOR_KB:
                 is_anomalous = last_rss > 2 * initial_rss
             else:

--- a/src/autoskillit/execution/anomaly_detection.py
+++ b/src/autoskillit/execution/anomaly_detection.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from enum import StrEnum
 
+import regex as _re
+
 
 class AnomalyKind(StrEnum):
     OOM_SPIKE = "oom_spike"
@@ -53,6 +55,45 @@ BENIGN_WCHANS: frozenset[str] = frozenset(
         "0",  # kernel reports literal "0" when thread is runnable
     }
 )
+
+RSS_BASELINE_FLOOR_KB: int = 50_000
+RSS_ABSOLUTE_GROWTH_KB: int = 500_000
+
+_MODEL_SHORT_ALIASES: dict[str, str] = {
+    "sonnet": "claude-sonnet",
+    "opus": "claude-opus",
+    "haiku": "claude-haiku",
+}
+
+
+_DATE_SUFFIX_RE = _re.compile(r"-\d{8}$")
+
+
+def normalize_model_id(model: str) -> str:
+    """Normalize a model identifier to its canonical prefix for comparison.
+
+    Handles three cases:
+    1. Short aliases: "sonnet" → "claude-sonnet"
+    2. Full IDs with date suffixes: "claude-haiku-4-5-20251001" → "claude-haiku-4-5"
+    3. Full IDs without dates: "claude-sonnet-4-6" → "claude-sonnet-4-6" (unchanged)
+
+    Non-Anthropic model names pass through unchanged.
+    """
+    expanded = _MODEL_SHORT_ALIASES.get(model, model)
+    return _DATE_SUFFIX_RE.sub("", expanded)
+
+
+def _models_match(a: str, b: str) -> bool:
+    """True if normalized model IDs refer to the same model.
+
+    Handles alias-to-full-ID matching via hyphen-bounded prefix:
+    'claude-sonnet' matches 'claude-sonnet-4-6' (alias prefix),
+    'claude-sonnet-4-5' does NOT match 'claude-sonnet-4-6' (version drift).
+    """
+    if a == b:
+        return True
+    shorter, longer = (a, b) if len(a) <= len(b) else (b, a)
+    return longer.startswith(shorter + "-")
 
 
 def _safe_int(value: object, *, default: int) -> int:
@@ -250,25 +291,31 @@ def detect_anomalies(
                     )
                 )
 
-    # RSS growth: total growth exceeds 2x initial over 5+ snapshots
+    # RSS growth: dual-threshold to avoid startup-artifact false positives
     if initial_rss is not None and initial_rss > 0 and len(snapshots) >= 5:
         last_rss = snapshots[-1].get("vm_rss_kb", 0)
-        if isinstance(last_rss, int) and last_rss > 2 * initial_rss:
-            anomalies.append(
-                _anomaly(
-                    AnomalyKind.RSS_GROWTH,
-                    AnomalySeverity.WARNING,
-                    {
-                        "initial_rss_kb": initial_rss,
-                        "final_rss_kb": last_rss,
-                        "growth_factor": round(last_rss / initial_rss, 2),
-                        "snapshot_count": len(snapshots),
-                    },
-                    snapshots[-1],
-                    len(snapshots) - 1,
-                    pid,
+        if isinstance(last_rss, int):
+            is_anomalous: bool
+            if initial_rss >= RSS_BASELINE_FLOOR_KB:
+                is_anomalous = last_rss > 2 * initial_rss
+            else:
+                is_anomalous = (last_rss - initial_rss) > RSS_ABSOLUTE_GROWTH_KB
+            if is_anomalous:
+                anomalies.append(
+                    _anomaly(
+                        AnomalyKind.RSS_GROWTH,
+                        AnomalySeverity.WARNING,
+                        {
+                            "initial_rss_kb": initial_rss,
+                            "final_rss_kb": last_rss,
+                            "growth_factor": round(last_rss / initial_rss, 2),
+                            "snapshot_count": len(snapshots),
+                        },
+                        snapshots[-1],
+                        len(snapshots) - 1,
+                        pid,
+                    )
                 )
-            )
 
     return anomalies
 
@@ -366,22 +413,36 @@ def detect_outcome_anomalies(
 def detect_model_drift(
     configured_model: str,
     observed_model: str,
+    *,
+    profile_name: str = "",
 ) -> list[dict[str, object]]:
     """Detect model drift: configured model differs from the dominant observed model.
 
-    Returns a MODEL_DRIFT anomaly if both are non-empty and differ.
+    Returns a MODEL_DRIFT anomaly if both are non-empty and the normalized
+    identifiers do not match. Normalizes aliases (e.g. "sonnet") and strips
+    date suffixes before comparison.
     The caller computes the observed model via _primary_model_identifier().
     """
     anomalies: list[dict[str, object]] = []
     if not configured_model or not observed_model:
         return anomalies
-    if observed_model == configured_model:
+    norm_cfg = normalize_model_id(configured_model)
+    norm_obs = normalize_model_id(observed_model)
+    if _models_match(norm_cfg, norm_obs):
         return anomalies
+    detail: dict[str, object] = {
+        "configured_model": configured_model,
+        "observed_model": observed_model,
+        "configured_model_normalized": norm_cfg,
+        "observed_model_normalized": norm_obs,
+    }
+    if profile_name:
+        detail["profile_name"] = profile_name
     anomalies.append(
         _anomaly(
             AnomalyKind.MODEL_DRIFT,
             AnomalySeverity.WARNING,
-            {"configured_model": configured_model, "observed_model": observed_model},
+            detail,
             {},
             OUTCOME_ANOMALY_SEQ_SENTINEL,
             OUTCOME_ANOMALY_PID_SENTINEL,

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -231,6 +231,7 @@ async def run_headless_core(
             provider_extras=provider_extras,
             step_backend=step_backend,
             model_identifier=resolved_model or "",
+            profile_name=profile_name,
         )
 
 
@@ -339,6 +340,7 @@ class DefaultHeadlessExecutor:
         provider_name: str = "",
         provider_fallback_env: dict[str, str] | None = None,
         provider_fallback_name: str = "",
+        profile_name: str = "",
         sentinel_contract: str = "",
         marker_dir: Path | None = None,
         session_id: str | None = None,
@@ -445,4 +447,5 @@ class DefaultHeadlessExecutor:
             marker_dir=effective_marker_dir,
             session_id=session_id,
             model_identifier=resolved_model or "",
+            profile_name=profile_name,
         )

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -107,6 +107,7 @@ async def _execute_claude_headless(
     session_id: str | None = None,
     step_backend: CodingAgentBackend | None = None,
     model_identifier: str = "",
+    profile_name: str = "",
 ) -> SkillResult:
     """Shared subprocess execution for headless Claude sessions.
 
@@ -294,6 +295,7 @@ async def _execute_claude_headless(
                     ),
                     max_sessions=ctx.config.linux_tracing.max_sessions,
                     model_identifier=model_identifier,
+                    profile_name=profile_name,
                     telemetry=_build_error_path_telemetry(
                         ctx.github_api_log,
                         session_id="",
@@ -355,6 +357,7 @@ async def _execute_claude_headless(
                         ),
                         max_sessions=ctx.config.linux_tracing.max_sessions,
                         model_identifier=model_identifier,
+                        profile_name=profile_name,
                         telemetry=_build_error_path_telemetry(
                             ctx.github_api_log,
                             session_id="",
@@ -551,6 +554,7 @@ async def _execute_claude_headless(
                 ),
                 max_sessions=ctx.config.linux_tracing.max_sessions,
                 model_identifier=model_identifier,
+                profile_name=profile_name,
                 is_resume="--resume" in spec.cmd,
                 codex_log_path=_codex_log,
             )

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -148,6 +148,7 @@ def flush_session_log(
     api_retry_exhausted: bool = False,
     versions: dict[str, Any] | None = None,
     model_identifier: str = "",
+    profile_name: str = "",
     max_sessions: int | None = None,
     is_resume: bool = False,
     codex_log_path: Path | None = None,
@@ -307,7 +308,7 @@ def flush_session_log(
 
     effective_model_id = model_identifier or _primary_model_identifier(token_usage)
     _observed = _primary_model_identifier(token_usage) if token_usage else ""
-    anomalies.extend(detect_model_drift(model_identifier, _observed))
+    anomalies.extend(detect_model_drift(model_identifier, _observed, profile_name=profile_name))
 
     # Write anomalies.jsonl (only if anomalies exist)
     if anomalies:
@@ -443,6 +444,7 @@ def flush_session_log(
             "provider_used": provider_outcome.provider_used,
             "model_identifier": effective_model_id,
             "configured_model": model_identifier,
+            "profile_name": profile_name,
             "dispatch_id": dispatch_id,
             "campaign_id": campaign_id,
         }
@@ -513,6 +515,7 @@ def flush_session_log(
         "api_retry_last_status": api_retry_last_status,
         "model_identifier": effective_model_id,
         "configured_model": model_identifier,
+        "profile_name": profile_name,
         "schema_version": 3,
     }
     index_path = log_root / "sessions.jsonl"

--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -65,6 +65,7 @@ TOKEN_USAGE_FILE_KEYS: frozenset[str] = frozenset(
         "provider_used",
         "model_identifier",
         "configured_model",
+        "profile_name",
         "dispatch_id",
         "campaign_id",
         "schema_version",

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -73,6 +73,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_variadic_ordering.py` | Architectural invariant: positional initial_prompt must precede all variadic CLI flags in build_interactive_cmd |
 | `test_watcher_signal_consistency.py` | Structural guard: all process watchers must call `_has_active_dispatch_marker` |
 | `test_write_restriction_coverage.py` | Architectural invariant: skills with prose write restrictions in NEVER blocks have runtime enforcement (read_only, output_dir, or allowlist) |
+| `test_model_identity_contract.py` | AST guard: detect_model_drift must use normalize_model_id and _models_match — raw alias/full-ID comparison is a false-positive source |
 
 ## Architecture Notes
 

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -18,7 +18,7 @@ NEW_HEADLESS_MODULES = [
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 460,
     "headless/_headless_helpers.py": 175,
-    "headless/_headless_execute.py": 591,
+    "headless/_headless_execute.py": 595,
     "headless/_headless_recovery.py": 366,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,

--- a/tests/arch/test_model_identity_contract.py
+++ b/tests/arch/test_model_identity_contract.py
@@ -1,0 +1,38 @@
+"""AST guard: detect_model_drift must use normalize_model_id and _models_match.
+
+Raw string comparison between the alias domain (config) and the full-ID domain
+(API response) is a structural false-positive source. This guard prevents
+regression where someone modifies detect_model_drift without going through
+normalization and prefix matching.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+ANOMALY_DETECTION = SRC / "execution" / "anomaly_detection.py"
+
+
+def test_detect_model_drift_uses_normalize_model_id():
+    """detect_model_drift must normalize both operands — AST enforcement."""
+    source = ANOMALY_DETECTION.read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "detect_model_drift":
+            body_src = ast.dump(node)
+            assert "normalize_model_id" in body_src, (
+                "detect_model_drift must call normalize_model_id — "
+                "raw string comparison between alias and full-ID domains is a false-positive"
+            )
+            assert "_models_match" in body_src, (
+                "detect_model_drift must use _models_match for prefix-aware comparison — "
+                "strict equality after normalization fails for alias-to-full-ID pairs"
+            )
+            return
+    pytest.fail("detect_model_drift not found in anomaly_detection.py")

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -319,6 +319,7 @@ def _flush(tmp_path: Path, **overrides) -> None:
         "audit_record": None,
         "loc_insertions": 0,
         "loc_deletions": 0,
+        "profile_name": "",
     }
     defaults.update(overrides)
 

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -11,6 +11,8 @@ from autoskillit.execution.anomaly_detection import (
     AnomalyKind,
     AnomalySeverity,
     detect_anomalies,
+    detect_model_drift,
+    normalize_model_id,
 )
 from tests.execution.conftest import _snap as _snap_full
 
@@ -415,23 +417,19 @@ def test_anomaly_kind_model_drift_value():
 
 
 def test_detect_model_drift_emits_anomaly():
-    """detect_model_drift returns MODEL_DRIFT anomaly when configured != observed."""
-    from autoskillit.execution.anomaly_detection import detect_model_drift
-
+    """detect_model_drift returns MODEL_DRIFT anomaly for genuinely different model families."""
     anomalies = detect_model_drift(
-        configured_model="claude-opus-4-6",
-        observed_model="claude-sonnet-4-6",
+        configured_model="sonnet",
+        observed_model="claude-opus-4-6",
     )
     assert len(anomalies) == 1
     assert anomalies[0]["kind"] == "model_drift"
-    assert anomalies[0]["detail"]["configured_model"] == "claude-opus-4-6"
-    assert anomalies[0]["detail"]["observed_model"] == "claude-sonnet-4-6"
+    assert anomalies[0]["detail"]["configured_model"] == "sonnet"
+    assert anomalies[0]["detail"]["observed_model"] == "claude-opus-4-6"
 
 
 def test_detect_model_drift_no_anomaly_when_matching():
     """No anomaly when configured model matches the dominant observed model."""
-    from autoskillit.execution.anomaly_detection import detect_model_drift
-
     anomalies = detect_model_drift(
         configured_model="claude-opus-4-6",
         observed_model="claude-opus-4-6",
@@ -439,9 +437,17 @@ def test_detect_model_drift_no_anomaly_when_matching():
     assert anomalies == []
 
 
+def test_detect_model_drift_no_anomaly_alias_to_full_id():
+    """No anomaly when configured alias matches the API-returned full model ID."""
+    anomalies = detect_model_drift(
+        configured_model="sonnet",
+        observed_model="claude-sonnet-4-6",
+    )
+    assert anomalies == []
+
+
 def test_detect_model_drift_skips_when_configured_empty():
     """No anomaly when configured_model is empty (fallback-only sessions)."""
-    from autoskillit.execution.anomaly_detection import detect_model_drift
 
     anomalies = detect_model_drift(
         configured_model="",
@@ -452,10 +458,97 @@ def test_detect_model_drift_skips_when_configured_empty():
 
 def test_detect_model_drift_skips_when_observed_empty():
     """No anomaly when observed_model is empty (no token breakdown)."""
-    from autoskillit.execution.anomaly_detection import detect_model_drift
 
     anomalies = detect_model_drift(
         configured_model="claude-opus-4-6",
         observed_model="",
     )
     assert anomalies == []
+
+
+@pytest.mark.parametrize(
+    "configured, observed, expect_drift",
+    [
+        ("sonnet", "claude-sonnet-4-6", False),
+        ("opus", "claude-opus-4-6", False),
+        ("haiku", "claude-haiku-4-5-20251001", False),
+        ("claude-sonnet-4-6", "claude-sonnet-4-6", False),
+        ("sonnet", "claude-opus-4-6", True),
+        ("claude-sonnet-4-5", "claude-sonnet-4-6", True),
+    ],
+)
+def test_detect_model_drift_alias_normalization(configured, observed, expect_drift):
+    anomalies = detect_model_drift(configured, observed)
+    assert bool(anomalies) == expect_drift
+
+
+def test_normalize_model_id_short_alias():
+    assert normalize_model_id("sonnet") == "claude-sonnet"
+    assert normalize_model_id("opus") == "claude-opus"
+    assert normalize_model_id("haiku") == "claude-haiku"
+
+
+def test_normalize_model_id_strips_date_suffix():
+    assert normalize_model_id("claude-haiku-4-5-20251001") == "claude-haiku-4-5"
+
+
+def test_normalize_model_id_full_id_unchanged():
+    assert normalize_model_id("claude-sonnet-4-6") == "claude-sonnet-4-6"
+
+
+def test_normalize_model_id_non_anthropic_passthrough():
+    assert normalize_model_id("gpt-4o") == "gpt-4o"
+
+
+def test_rss_growth_startup_artifact_suppressed():
+    """Early-startup RSS (5MB) should not trigger RSS_GROWTH at normal working set."""
+    snaps = [
+        _snap(vm_rss_kb=5000),
+        _snap(vm_rss_kb=50000),
+        _snap(vm_rss_kb=150000),
+        _snap(vm_rss_kb=270000),
+        _snap(vm_rss_kb=280000),
+    ]
+    anomalies = detect_anomalies(snaps, pid=1234)
+    rss = [a for a in anomalies if a["kind"] == AnomalyKind.RSS_GROWTH]
+    assert len(rss) == 0
+
+
+def test_rss_growth_real_growth_still_detected():
+    """Genuine RSS growth from a stable baseline should still be detected."""
+    snaps = [
+        _snap(vm_rss_kb=200000),
+        _snap(vm_rss_kb=220000),
+        _snap(vm_rss_kb=300000),
+        _snap(vm_rss_kb=380000),
+        _snap(vm_rss_kb=450000),
+    ]
+    anomalies = detect_anomalies(snaps, pid=1234)
+    rss = [a for a in anomalies if a["kind"] == AnomalyKind.RSS_GROWTH]
+    assert len(rss) == 1
+
+
+def test_rss_growth_low_baseline_with_genuine_anomalous_growth():
+    """Genuine anomalous growth from a low baseline should be detected via absolute threshold."""
+    snaps = [
+        _snap(vm_rss_kb=10000),
+        _snap(vm_rss_kb=100000),
+        _snap(vm_rss_kb=200000),
+        _snap(vm_rss_kb=400000),
+        _snap(vm_rss_kb=800000),
+    ]
+    anomalies = detect_anomalies(snaps, pid=1234)
+    rss = [a for a in anomalies if a["kind"] == AnomalyKind.RSS_GROWTH]
+    assert len(rss) == 1
+
+
+def test_rss_baseline_floor_is_reasonable():
+    from autoskillit.execution.anomaly_detection import RSS_BASELINE_FLOOR_KB
+
+    assert RSS_BASELINE_FLOOR_KB >= 10_000
+
+
+def test_rss_absolute_growth_threshold_is_reasonable():
+    from autoskillit.execution.anomaly_detection import RSS_ABSOLUTE_GROWTH_KB
+
+    assert RSS_ABSOLUTE_GROWTH_KB >= 300_000

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -58,7 +58,7 @@ async def test_run_headless_core_forwards_provider_extras_to_build_cmd(
     assert config.provider_extras == {"AWS_REGION": "us-east-1"}
     assert config.profile_name == "bedrock"
     assert execute_kwargs.get("provider_extras") == {"AWS_REGION": "us-east-1"}
-    assert "profile_name" not in execute_kwargs
+    assert execute_kwargs.get("profile_name") == "bedrock"
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1426,3 +1426,128 @@ class TestSessionIndexSummaryConsistency:
             assert entry[field] == summary[field], (
                 f"Field '{field}' differs: index={entry[field]!r}, summary={summary[field]!r}"
             )
+
+
+class TestModelAliasDriftIntegration:
+    """Integration tests: alias normalization and profile_name in flush_session_log."""
+
+    def test_alias_configured_full_observed_no_drift(self, tmp_path):
+        """Alias 'sonnet' vs API-returned 'claude-sonnet-4-6' should produce no MODEL_DRIFT."""
+        _flush(
+            tmp_path,
+            session_id="alias-no-drift-001",
+            proc_snapshots=None,
+            model_identifier="sonnet",
+            token_usage={
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
+                "model_breakdown": {
+                    "claude-sonnet-4-6": {"input_tokens": 1000, "output_tokens": 500},
+                },
+            },
+        )
+        anomalies_path = tmp_path / "sessions" / "alias-no-drift-001" / "anomalies.jsonl"
+        if anomalies_path.exists():
+            lines = anomalies_path.read_text().strip().splitlines()
+            drift = [
+                json.loads(line) for line in lines if json.loads(line).get("kind") == "model_drift"
+            ]
+            assert len(drift) == 0
+
+    def test_alias_configured_wrong_family_observed_emits_drift(self, tmp_path):
+        """'sonnet' configured but 'claude-opus-4-6' observed: MODEL_DRIFT should fire."""
+        _flush(
+            tmp_path,
+            session_id="alias-real-drift-001",
+            proc_snapshots=None,
+            model_identifier="sonnet",
+            token_usage={
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
+                "model_breakdown": {
+                    "claude-opus-4-6": {"input_tokens": 1000, "output_tokens": 500},
+                },
+            },
+        )
+        anomalies_path = tmp_path / "sessions" / "alias-real-drift-001" / "anomalies.jsonl"
+        assert anomalies_path.exists()
+        lines = anomalies_path.read_text().strip().splitlines()
+        drift = [
+            json.loads(line) for line in lines if json.loads(line).get("kind") == "model_drift"
+        ]
+        assert len(drift) == 1
+
+    def test_profile_name_recorded_in_sessions_jsonl(self, tmp_path):
+        """profile_name is written to sessions.jsonl index entry."""
+        _flush(
+            tmp_path,
+            session_id="profile-record-001",
+            proc_snapshots=None,
+            profile_name="minimax",
+        )
+        entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip())
+        assert entry["profile_name"] == "minimax"
+
+    def test_profile_name_recorded_in_token_usage(self, tmp_path):
+        """profile_name is written to token_usage.json."""
+        _flush(
+            tmp_path,
+            session_id="profile-tu-001",
+            proc_snapshots=None,
+            step_name="step-with-profile",
+            profile_name="minimax",
+            token_usage={"input_tokens": 100, "output_tokens": 50},
+        )
+        tu = json.loads(
+            (tmp_path / "sessions" / "profile-tu-001" / "token_usage.json").read_text()
+        )
+        assert tu["profile_name"] == "minimax"
+
+    def test_profile_name_in_drift_detail_when_drifting(self, tmp_path):
+        """When MODEL_DRIFT fires and profile_name is set, it appears in the anomaly detail."""
+        _flush(
+            tmp_path,
+            session_id="profile-drift-detail-001",
+            proc_snapshots=None,
+            model_identifier="sonnet",
+            profile_name="minimax",
+            token_usage={
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
+                "model_breakdown": {
+                    "claude-opus-4-6": {"input_tokens": 1000, "output_tokens": 500},
+                },
+            },
+        )
+        anomalies_path = tmp_path / "sessions" / "profile-drift-detail-001" / "anomalies.jsonl"
+        assert anomalies_path.exists()
+        lines = anomalies_path.read_text().strip().splitlines()
+        drift = [
+            json.loads(line) for line in lines if json.loads(line).get("kind") == "model_drift"
+        ]
+        assert len(drift) == 1
+        assert drift[0]["detail"]["profile_name"] == "minimax"
+
+    def test_rss_startup_artifact_suppressed_through_flush(self, tmp_path):
+        """5MB startup RSS → 270MB working set should produce no RSS_GROWTH via flush."""
+        snaps = [
+            _snap(vm_rss_kb=5000),
+            _snap(vm_rss_kb=50000),
+            _snap(vm_rss_kb=150000),
+            _snap(vm_rss_kb=270000),
+            _snap(vm_rss_kb=280000),
+        ]
+        _flush(tmp_path, session_id="rss-startup-flush-001", proc_snapshots=snaps)
+        anomalies_path = tmp_path / "sessions" / "rss-startup-flush-001" / "anomalies.jsonl"
+        if anomalies_path.exists():
+            lines = anomalies_path.read_text().strip().splitlines()
+            rss = [
+                json.loads(line) for line in lines if json.loads(line).get("kind") == "rss_growth"
+            ]
+            assert len(rss) == 0

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1449,12 +1449,11 @@ class TestModelAliasDriftIntegration:
             },
         )
         anomalies_path = tmp_path / "sessions" / "alias-no-drift-001" / "anomalies.jsonl"
-        if anomalies_path.exists():
-            lines = anomalies_path.read_text().strip().splitlines()
-            drift = [
-                json.loads(line) for line in lines if json.loads(line).get("kind") == "model_drift"
-            ]
-            assert len(drift) == 0
+        lines = anomalies_path.read_text().strip().splitlines() if anomalies_path.exists() else []
+        drift = [
+            json.loads(line) for line in lines if json.loads(line).get("kind") == "model_drift"
+        ]
+        assert len(drift) == 0
 
     def test_alias_configured_wrong_family_observed_emits_drift(self, tmp_path):
         """'sonnet' configured but 'claude-opus-4-6' observed: MODEL_DRIFT should fire."""
@@ -1545,9 +1544,6 @@ class TestModelAliasDriftIntegration:
         ]
         _flush(tmp_path, session_id="rss-startup-flush-001", proc_snapshots=snaps)
         anomalies_path = tmp_path / "sessions" / "rss-startup-flush-001" / "anomalies.jsonl"
-        if anomalies_path.exists():
-            lines = anomalies_path.read_text().strip().splitlines()
-            rss = [
-                json.loads(line) for line in lines if json.loads(line).get("kind") == "rss_growth"
-            ]
-            assert len(rss) == 0
+        lines = anomalies_path.read_text().strip().splitlines() if anomalies_path.exists() else []
+        rss = [json.loads(line) for line in lines if json.loads(line).get("kind") == "rss_growth"]
+        assert len(rss) == 0

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -119,6 +119,7 @@ class DispatchFoodTruckCall:
     allowed_write_prefix: str = ""
     allowed_write_prefixes: tuple[str, ...] = ()
     sentinel_contract: str = ""
+    profile_name: str = ""
     prior_completion_markers: Sequence[str] | None = None
     marker_dir: Path | None = None
     session_id: str | None = None
@@ -251,6 +252,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         provider_name: str = "",
         provider_fallback_env: dict[str, str] | None = None,
         provider_fallback_name: str = "",
+        profile_name: str = "",
         sentinel_contract: str = "",
         prior_completion_markers: Sequence[str] | None = None,
         marker_dir: Path | None = None,
@@ -281,6 +283,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
                 allowed_write_prefix=allowed_write_prefix,
                 allowed_write_prefixes=allowed_write_prefixes,
                 sentinel_contract=sentinel_contract,
+                profile_name=profile_name,
                 prior_completion_markers=prior_completion_markers,
                 marker_dir=marker_dir,
                 session_id=session_id,


### PR DESCRIPTION
## Summary

The anomaly detection system has three structural false-positive sources:

1. **Model alias normalization gap**: `detect_model_drift()` compares configured model aliases (`"sonnet"`) against API-returned full IDs (`"claude-sonnet-4-6"`) using strict string equality. Since `CoreRunConfig.default_model = "sonnet"`, virtually every production session fires a false `MODEL_DRIFT`.

2. **Provider override unawareness**: Sessions intentionally routed via `ProviderProfileDef` are flagged as model drift because `detect_model_drift()` receives the recipe's configured model, not the post-override resolved model. The `profile_name` is never recorded in session telemetry.

3. **RSS growth startup artifact**: `initial_rss` is set from the first non-zero `vm_rss_kb` snapshot (often 5MB at process startup). Normal working-set growth to 270MB trivially exceeds the 2x threshold, producing 54x growth factor false positives.

Fix: Add `normalize_model_id()` with alias expansion and date-suffix stripping; update `detect_model_drift()` to use prefix-aware comparison via `_models_match()`; thread `profile_name` through headless execution chain to session telemetry; add dual-threshold RSS growth detection (≥50MB: relative 2x, <50MB: absolute 500MB growth); add `profile_name` to `SessionIndexEntry` TypedDict.

## Requirements

*(No ## Requirements section found in issue #3280)*

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

*(No conflict report provided)*

Closes #3280

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-001015-608663/.autoskillit/temp/rectify/rectify_anomaly_detector_false_positives_2026-05-30_010500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 94 | 32.1k | 3.5M | 145.5k | 291 | 129.5k | 24m 41s |
| review_approach* | sonnet | 1 | 6.0k | 7.4k | 202.0k | 51.9k | 76 | 40.4k | 5m 12s |
| dry_walkthrough* | opus | 1 | 66 | 21.8k | 2.1M | 99.0k | 116 | 82.7k | 10m 27s |
| implement* | sonnet | 1 | 558 | 32.9k | 5.8M | 167.2k | 255 | 106.3k | 11m 43s |
| audit_impl* | sonnet | 1 | 84 | 9.9k | 377.9k | 59.4k | 30 | 45.4k | 3m 17s |
| prepare_pr* | sonnet | 1 | 141.7k | 4.8k | 275.4k | 30.9k | 23 | 15.8k | 1m 46s |
| compose_pr* | sonnet | 1 | 52.5k | 1.9k | 213.5k | 30.9k | 17 | 15.5k | 54s |
| review_pr* | sonnet | 1 | 158 | 39.3k | 1.1M | 111.5k | 113 | 98.6k | 10m 32s |
| resolve_review* | opus | 1 | 58 | 17.5k | 1.6M | 91.6k | 52 | 77.6k | 10m 55s |
| **Total** | | | 201.2k | 167.7k | 15.2M | 167.2k | | 611.8k | 1h 19m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 398 | 14567.9 | 267.1 | 82.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 21 | 75999.7 | 3697.5 | 834.0 |
| **Total** | **419** | 36267.3 | 1460.1 | 400.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 94 | 32.1k | 3.5M | 129.5k | 24m 41s |
| sonnet | 6 | 201.0k | 96.2k | 8.0M | 321.9k | 33m 26s |
| opus | 2 | 124 | 39.3k | 3.7M | 160.4k | 21m 23s |