### PR TITLE
[FIX] Bridge provider_used telemetry gap in run_skill and report_bug

### DIFF
--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -202,6 +202,7 @@ async def run_headless_core(
             add_dirs=list(add_dirs) if add_dirs else None,
         )
 
+        effective_provider = provider_name or profile_name
         return await _execute_claude_headless(
             spec,
             cwd,
@@ -225,7 +226,7 @@ async def run_headless_core(
             recipe_version=recipe_version,
             readonly_skill=readonly_skill,
             write_watch_dirs=write_watch_dirs,
-            provider_name=provider_name,
+            provider_name=effective_provider,
             provider_fallback_env=provider_fallback_env,
             provider_fallback_name=provider_fallback_name,
             provider_extras=provider_extras,

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -632,6 +632,7 @@ async def run_skill(
                     write_watch_dirs=write_watch_dirs,
                     provider_extras=provider_extras,
                     profile_name=profile_name_out,
+                    provider_name=profile_name_out,
                     backend_override=backend_override,
                     resume_session_id=resume_session_id,
                 )

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -286,6 +286,7 @@ async def report_bug(
                     write_behavior=write_spec,
                     provider_extras=report_provider_extras,
                     profile_name=report_profile_name,
+                    provider_name=report_profile_name,
                 )
                 if not result["success"]:
                     await _notify(
@@ -325,6 +326,7 @@ async def report_bug(
                     status_path=status_path,
                     provider_extras=report_provider_extras,
                     profile_name=report_profile_name,
+                    provider_name=report_profile_name,
                 ),
                 label=step_name or "report_bug",
             )
@@ -608,6 +610,7 @@ async def _run_report_session(
     status_path: Path | None = None,
     provider_extras: dict[str, str] | None = None,
     profile_name: str = "",
+    provider_name: str = "",
 ) -> dict[str, Any]:
     """Run the headless session, write the report, and handle GitHub filing.
 
@@ -626,6 +629,7 @@ async def _run_report_session(
             write_behavior=write_behavior,
             provider_extras=provider_extras,
             profile_name=profile_name,
+            provider_name=provider_name,
         )
 
         report_text = skill_result.result or skill_result.stderr or "No report generated."

--- a/tests/arch/test_provider_profile_contract.py
+++ b/tests/arch/test_provider_profile_contract.py
@@ -59,3 +59,25 @@ def test_tier3_unresolvable_step_provider_returns_anthropic():
     )
     assert profile_name == "anthropic"
     assert env_dict == {}
+
+
+def test_all_executor_run_callsites_pass_provider_name_when_profile_name_set():
+    """Every call that passes profile_name= must also pass provider_name=."""
+    import ast
+    from pathlib import Path
+
+    files_to_scan = [
+        "src/autoskillit/server/tools/tools_execution.py",
+        "src/autoskillit/server/tools/tools_github.py",
+        "src/autoskillit/server/tools/tools_issue_headless.py",
+    ]
+    violations = []
+    for rel_path in files_to_scan:
+        source = Path(rel_path).read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                keywords = {kw.arg for kw in node.keywords if kw.arg is not None}
+                if "profile_name" in keywords and "provider_name" not in keywords:
+                    violations.append(f"{rel_path}:{node.lineno}")
+    assert not violations, f"Calls with profile_name= but no provider_name=: {violations}"

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -199,6 +199,39 @@ async def test_run_headless_core_forwards_provider_name_and_fallback_env(
 
 
 @pytest.mark.anyio
+async def test_run_headless_core_bridges_profile_to_provider_when_empty(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    """When provider_name is empty, profile_name is used as the effective provider."""
+    from autoskillit.core import CmdSpec
+    from autoskillit.execution.headless import run_headless_core
+
+    execute_kwargs: dict = {}
+
+    backend = _mock_backend()
+    backend.build_skill_session_cmd.return_value = CmdSpec(
+        cmd=("claude", "--print", "test"), env={}
+    )
+    minimal_ctx.backend = backend
+
+    async def fake_execute(spec, cwd, ctx, **kwargs):  # noqa: ARG001
+        execute_kwargs.update(kwargs)
+        return _STUB_RESULT
+
+    monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
+
+    await run_headless_core(
+        "/autoskillit:probe",
+        str(tmp_path),
+        minimal_ctx,
+        profile_name="vertex",
+        provider_name="",
+    )
+
+    assert execute_kwargs["provider_name"] == "vertex"
+
+
+@pytest.mark.anyio
 async def test_default_executor_run_forwards_provider_name_and_fallback_env(
     minimal_ctx, tmp_path, monkeypatch
 ) -> None:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -87,6 +87,9 @@ class ExecutorCall:
     write_watch_dirs: tuple[Any, ...] = ()
     provider_extras: Mapping[str, str] | None = None
     profile_name: str = ""
+    provider_name: str = ""
+    provider_fallback_env: dict[str, str] | None = None
+    provider_fallback_name: str = ""
     resume_session_id: str = ""
     resume_checkpoint: SessionCheckpoint | None = None
     resume_message: str | None = None
@@ -182,6 +185,9 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         write_watch_dirs: Sequence[Any] = (),
         provider_extras: Mapping[str, str] | None = None,
         profile_name: str = "",
+        provider_name: str = "",
+        provider_fallback_env: dict[str, str] | None = None,
+        provider_fallback_name: str = "",
         resume_session_id: str = "",
         resume_checkpoint: SessionCheckpoint | None = None,
         resume_message: str | None = None,
@@ -212,6 +218,9 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
                 write_watch_dirs=tuple(write_watch_dirs),
                 provider_extras=provider_extras,
                 profile_name=profile_name,
+                provider_name=provider_name,
+                provider_fallback_env=provider_fallback_env,
+                provider_fallback_name=provider_fallback_name,
                 resume_session_id=resume_session_id,
                 resume_checkpoint=resume_checkpoint,
                 resume_message=resume_message,

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -123,7 +123,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 491),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools/tools_github.py", 302),
+    ("src/autoskillit/server/tools/tools_github.py", 303),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -78,6 +78,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_git_split.py` | Git split structural guard |
 | `test_tools_github.py` | Tests for server/tools_github.py — fetch_github_issue and get_issue_title |
 | `test_tools_github_api_tracking.py` | GitHub API tracking tests |
+| `test_tools_github_provider.py` | Tests for provider_name forwarding through the report_bug call chain |
 | `test_tools_integrations.py` | Integration tests for issue lifecycle, headless tool diagnostics, and PR ops |
 | `test_tools_integrations_release.py` | Tests for release_issue staged lifecycle behaviour |
 | `test_claim_liveness.py` | Tests for liveness-aware claiming — dead dispatch recovery, alive dispatch blocking, shared helper parity |

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -93,6 +93,7 @@ async def test_run_skill_provider_extras_forwarded_for_non_anthropic(
 
     assert captured.get("provider_extras") == {"AWS_REGION": "us-east-1"}
     assert captured.get("profile_name") == "bedrock"
+    assert captured.get("provider_name") == "bedrock"
 
 
 @pytest.mark.anyio
@@ -128,6 +129,7 @@ async def test_run_skill_model_as_profile_resolves_provider(
     assert captured.get("model") == "M2.7"
     assert captured.get("provider_extras") == {"BASE_URL": "https://api.minimax.chat/v1"}
     assert captured.get("profile_name") == "minimax"
+    assert captured.get("provider_name") == "minimax"
 
 
 @pytest.mark.anyio
@@ -582,3 +584,25 @@ async def test_run_skill_backend_override_none_providers_disabled(
     await run_skill("/autoskillit:probe", str(tmp_path))
 
     assert captured.get("backend_override") is None
+
+
+@pytest.mark.anyio
+async def test_run_skill_forwards_provider_name_matching_profile(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """run_skill must pass provider_name=profile_name_out so telemetry is populated."""
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("minimax", {"BASE_URL": "https://api.minimax.chat/v1"}),
+    )
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert executor.calls[0].profile_name == "minimax"
+    assert executor.calls[0].provider_name == "minimax"

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -367,6 +367,7 @@ async def test_run_skill_injects_provider_extras_when_feature_enabled(
 
     assert executor.calls[0].provider_extras == {"ANTHROPIC_API_KEY": "test-key-xyz"}
     assert executor.calls[0].profile_name == "vertex"
+    assert executor.calls[0].provider_name == "vertex"
 
 
 @pytest.mark.anyio
@@ -385,6 +386,7 @@ async def test_run_skill_provider_extras_none_when_feature_disabled(
 
     assert executor.calls[0].provider_extras is None
     assert executor.calls[0].profile_name == ""
+    assert executor.calls[0].provider_name == ""
 
 
 @pytest.mark.anyio
@@ -407,6 +409,7 @@ async def test_run_skill_provider_extras_none_when_default_profile(
 
     assert executor.calls[0].provider_extras is None
     assert executor.calls[0].profile_name == ""
+    assert executor.calls[0].provider_name == ""
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_github_provider.py
+++ b/tests/server/test_tools_github_provider.py
@@ -1,0 +1,38 @@
+"""Tests for provider_name forwarding through the report_bug call chain."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.server.tools.tools_github import report_bug
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_report_bug_forwards_provider_name_as_distinct_parameter(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """_run_report_session must thread provider_name as a distinct parameter to executor.run()."""
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.config.report_bug.github_filing = False
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("bedrock", {"AWS_REGION": "us-east-1"}),
+    )
+
+    result = json.loads(await report_bug("test error context", str(tmp_path), severity="blocking"))
+
+    assert result["success"] is True
+    assert len(executor.calls) == 1
+    assert executor.calls[0].profile_name == "bedrock"
+    assert executor.calls[0].provider_name == "bedrock"

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -743,6 +743,7 @@ async def test_report_bug_model_as_profile_resolves_provider(
         "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"
     }
     assert call_kwargs.get("profile_name") == "minimax"
+    assert call_kwargs.get("provider_name") == "minimax"
 
 
 @pytest.mark.anyio
@@ -797,3 +798,4 @@ async def test_report_bug_config_model_as_profile(tool_ctx_kitchen_open, tmp_pat
         "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"
     }
     assert call_kwargs.get("profile_name") == "minimax"
+    assert call_kwargs.get("provider_name") == "minimax"

--- a/tests/test_fakes_conformance.py
+++ b/tests/test_fakes_conformance.py
@@ -18,6 +18,7 @@ from autoskillit.core.types import (
     TestRunner,
 )
 from tests.fakes import (
+    ExecutorCall,
     InMemoryCIWatcher,
     InMemoryDatabaseReader,
     InMemoryHeadlessExecutor,
@@ -331,3 +332,40 @@ async def test_in_memory_executor_accepts_resume_session_id():
     await executor.run("/implement foo", "/tmp", resume_session_id="sess-123")
     assert len(executor.calls) == 1
     assert executor.calls[0].resume_session_id == "sess-123"
+
+
+def test_executor_fake_captures_all_protocol_parameters():
+    """InMemoryHeadlessExecutor.run() must accept every HeadlessExecutor.run() parameter."""
+    import dataclasses
+    import inspect
+
+    protocol_params = set(inspect.signature(HeadlessExecutor.run).parameters.keys())
+    fake_params = set(inspect.signature(InMemoryHeadlessExecutor.run).parameters.keys())
+    call_fields = {f.name for f in dataclasses.fields(ExecutorCall)}
+    protocol_params.discard("self")
+    missing_in_fake = protocol_params - fake_params
+    missing_in_call = protocol_params - call_fields - {"self"}
+    assert not missing_in_fake, f"InMemoryHeadlessExecutor.run() missing params: {missing_in_fake}"
+    assert not missing_in_call, f"ExecutorCall missing fields: {missing_in_call}"
+
+
+@pytest.mark.anyio
+async def test_in_memory_executor_accepts_provider_name():
+    """InMemoryHeadlessExecutor.run() must accept provider_name kwarg."""
+    executor = InMemoryHeadlessExecutor()
+    await executor.run("/skill", "/cwd", provider_name="bedrock")
+    assert executor.calls[0].provider_name == "bedrock"
+
+
+@pytest.mark.anyio
+async def test_in_memory_executor_accepts_provider_fallback_env():
+    executor = InMemoryHeadlessExecutor()
+    await executor.run("/skill", "/cwd", provider_fallback_env={"KEY": "val"})
+    assert executor.calls[0].provider_fallback_env == {"KEY": "val"}
+
+
+@pytest.mark.anyio
+async def test_in_memory_executor_accepts_provider_fallback_name():
+    executor = InMemoryHeadlessExecutor()
+    await executor.run("/skill", "/cwd", provider_fallback_name="anthropic")
+    assert executor.calls[0].provider_fallback_name == "anthropic"


### PR DESCRIPTION
## Summary

`provider_used` is always `""` in `sessions.jsonl` for all `run_skill` invocations because `profile_name` (the resolved provider identity) and `provider_name` (the telemetry-facing parameter) are parallel data channels that never intersect. The root cause is **architectural**: there is no single point where the resolved provider identity is bridged from the config/command channel (`profile_name`) to the telemetry channel (`provider_name`).

The immunity approach:
1. Bridges `profile_name` to `provider_name` at every entry point call site (`run_skill`, `report_bug`)
2. Adds a defense-in-depth bridge in `run_headless_core` so that even if a caller omits `provider_name`, the `profile_name` value is used
3. Makes the test fake (`InMemoryHeadlessExecutor`) structurally complete via a conformance test that catches parameter drift
4. Adds an AST-based arch test to enforce co-presence of `profile_name=` and `provider_name=` at all `executor.run()` call sites
5. Updates existing test assertions to verify the new `provider_name` forwarding

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Architecture Impact

## Changed Files

### New (★):
- `tests/server/test_tools_github_provider.py`

### Modified (●):
- `src/autoskillit/execution/headless/__init__.py`
- `src/autoskillit/server/tools/tools_execution.py`
- `src/autoskillit/server/tools/tools_github.py`
- `tests/arch/test_provider_profile_contract.py`
- `tests/execution/test_headless_provider_forwarding.py`
- `tests/fakes.py`
- `tests/infra/test_schema_version_convention.py`
- `tests/server/CLAUDE.md`
- `tests/server/test_tools_execution_provider.py`
- `tests/server/test_tools_execution_routing.py`
- `tests/server/test_tools_report_bug.py`
- `tests/test_fakes_conformance.py`

Closes #3289

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-001345-651692/.autoskillit/temp/rectify/rectify_provider_used_telemetry_gap_2026-05-30_014500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 103 | 35.3k | 3.3M | 139.6k | 253 | 123.5k | 17m 48s |
| review_approach* | sonnet | 1 | 60 | 7.2k | 248.4k | 55.5k | 78 | 43.6k | 5m 21s |
| dry_walkthrough* | opus | 1 | 4.4k | 8.7k | 1.1M | 77.6k | 101 | 61.7k | 5m 2s |
| implement* | sonnet | 1 | 1.5k | 25.5k | 4.4M | 107.0k | 164 | 91.6k | 8m 45s |
| audit_impl* | sonnet | 2 | 128 | 13.1k | 502.0k | 53.9k | 104 | 71.9k | 6m 3s |
| prepare_pr* | sonnet | 1 | 73.5k | 3.6k | 154.6k | 30.9k | 18 | 43.8k | 1m 16s |
| compose_pr* | sonnet | 1 | 51.6k | 1.9k | 213.5k | 30.9k | 15 | 15.5k | 46s |
| review_pr* | sonnet | 1 | 164 | 37.6k | 1.1M | 91.0k | 56 | 76.0k | 9m 31s |
| resolve_review* | sonnet | 1 | 1.2k | 9.3k | 602.1k | 49.3k | 52 | 34.1k | 7m 34s |
| **Total** | | | 132.7k | 142.3k | 11.6M | 139.6k | | 561.6k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 178 | 24813.4 | 514.7 | 143.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **178** | 65261.7 | 3155.2 | 799.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 103 | 35.3k | 3.3M | 123.5k | 17m 48s |
| sonnet | 7 | 128.2k | 98.3k | 7.3M | 376.4k | 39m 17s |
| opus | 1 | 4.4k | 8.7k | 1.1M | 61.7k | 5m 2s |