### PR TITLE
[FIX] Rectify: Parallel Dispatch Reinforcement — SKILL.md Three-Layer Pattern Enforcement

### DIFF
--- a/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
@@ -30,12 +30,14 @@ Coordinator skill that reads session logs from a pipeline run, groups them by st
 - Modify any source code files
 - Create issues or PRs (findings are reported to the calling session only)
 - Run subagents in the background (run_in_background: true is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Filter sessions.jsonl by kitchen_id to scope to this pipeline run
 - Spawn scanner subagents in parallel (one per step group)
 - Use model: "haiku" for scanner subagents
 - Report "no issues found" clearly when the pipeline is clean
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -47,7 +49,11 @@ Read ~/.local/share/autoskillit/logs/sessions.jsonl and filter entries where kit
 
 Group the filtered entries by step_name. Each group represents one phase of the pipeline (e.g., plan, implement, test, merge).
 
-### Step 3: Spawn scanner subagents
+### Step 3: Spawn scanner subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 For each step group, spawn a scanner subagent via the Agent tool with subagent_type: "autoskillit:pipeline-health-scanner".
 

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -31,6 +31,7 @@ complexity, and produce machine-readable output for the `merge-prs` recipe.
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/merge-prs/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents to fetch PR data in parallel
@@ -42,6 +43,7 @@ complexity, and produce machine-readable output for the `merge-prs` recipe.
   subagent batches. Processing PRs one-at-a-time without an explicit user instruction to do
   so is the wrong default. Up to 8 PRs should be processed in a single parallel batch;
   launch additional batches for larger sets.
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Arguments
 
@@ -103,7 +105,11 @@ is active on `{base_branch}` with `MERGEABLE` entries.
 | `QUEUE_MODE` | boolean | `true` when the merge queue has ≥1 MERGEABLE entry; `false` otherwise |
 | `QUEUE_ENTRIES` | list[dict] | Sorted queue entries `{position, state, pr_number, pr_title}` when `QUEUE_MODE = true`; empty list when `false` |
 
-### Step 1: Fetch PR Data
+### Step 1: Fetch PR Data (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 - **If `QUEUE_MODE = false`**: **ALWAYS launch subagents in parallel** — never process PRs
   sequentially. Launch one Explore subagent per PR (up to 8 simultaneously; batch in groups

--- a/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
@@ -48,6 +48,7 @@ hooks:
 - Include internal implementation details (that's for other lenses)
 - Show runtime behavior or state transitions
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on CONTAINERS (deployable units, not classes)
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-c4-container/arch_diag_c4_container_{YYYY-MM-DD_HHMMSS}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Conflate with general process flow (that's a different lens)
 - Ignore thread safety implications
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on PARALLEL execution specifically
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-concurrency/arch_diag_concurrency_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Focus on runtime behavior (that's process flow lens)
 - Show static structure without data context
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Trace data from INPUT to STORAGE
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-data-lineage/arch_diag_data_lineage_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Include code-level details
 - Show internal logic
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on PHYSICAL deployment
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-deployment/arch_diag_deployment_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Include runtime architecture details
 - Show business logic
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on BUILD and TEST infrastructure
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-development/arch_diag_development_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Show happy path details (that's process flow lens)
 - Ignore validation and fail-fast patterns
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on FAILURE paths and recovery
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-error-resilience/arch_diag_error_resilience_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Include runtime behavior details
 - Show external system integrations in detail
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on IMPORT relationships between modules
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-module-dependency/arch_diag_module_dependency_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Include internal implementation details
 - Show code-level patterns
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on OPERATOR experience
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-operational/arch_diag_operational_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Include static structure details (that's C4 lens)
 - Show data storage details (that's data lineage lens)
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on BEHAVIOR and STATE TRANSITIONS
@@ -61,6 +62,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-process-flow/arch_diag_process_flow_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -76,7 +78,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Focus on data flow (that's data lineage lens)
 - Include business logic details
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on REPOSITORIES and their methods
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-repository-access/arch_diag_repository_access_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Show internal component details
 - Include all possible scenarios (pick key ones)
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on END-TO-END journeys
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-scenarios/arch_diag_scenarios_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Expose actual secrets or credentials
 - Show implementation details that could aid attacks
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on TRUST BOUNDARIES
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-security/arch_diag_security_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Show business logic details
 - Focus on data content (focus on mutation rules)
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on STATE MUTATION RULES
@@ -62,6 +63,7 @@ hooks:
   ```
   diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/arch-lens-state-lifecycle/arch_diag_state_lifecycle_{"{"}YYYY-MM-DD_HHMMSS{}}.md
   ```
+- Issue all Task calls in a single message to maximize parallelism
 
 
 ## Analysis Workflow
@@ -77,7 +79,11 @@ If a `context_path` positional argument is present:
 
 If no `context_path` is provided, skip this step and explore the full CWD in Step 1.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/audit-arch/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-arch/SKILL.md
@@ -27,9 +27,11 @@ Audit the codebase for adherence to architectural standards and rules.
 - Modify any source code files
 - Update an existing report - always generate new
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents for parallel exploration
+- Issue all Task calls in a single message to maximize parallelism
 - Write report to `{{AUTOSKILLIT_TEMP}}/audit-arch/arch_audit_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 - Provide file paths and line numbers
 - Categorize by severity (CRITICAL, HIGH, MEDIUM, LOW)
@@ -238,7 +240,11 @@ These apply across all principles when evaluating architectural decisions:
    | **Code duplication** | Use the Read tool to retrieve the full body of each function. Compare the full signature (parameters, return type) and logic step-by-step. Same-named functions at different abstraction levels are NOT duplicates. Discard if logically distinct. |
    | **Misplaced file or incorrect import path** | Use the Bash tool to run `git log --oneline -- {file_path}` (substituting the actual path). Inspect commit messages for intentional placement decisions. Discard the finding if a commit explains the placement. |
 
-2. **Launch parallel subagents** for each principle
+2. **Launch parallel subagents (SINGLE MESSAGE)** for each principle
+
+   **Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+   Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 3. **Consolidate findings** by principle and severity
 4. **Cross-reference:** Ensure findings are categorized by the principle they violate, not just where discovered
 5. **Suggest new principle** (optional) - see below

--- a/src/autoskillit/skills_extended/audit-bugs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-bugs/SKILL.md
@@ -33,6 +33,7 @@ The user may provide a "since" date (e.g., `2/7`, `2026-02-07`, `last week`). If
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-bugs/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents heavily for parallel log analysis
@@ -40,6 +41,7 @@ The user may provide a "since" date (e.g., `2/7`, `2026-02-07`, `last week`). If
 - Final report: `{{AUTOSKILLIT_TEMP}}/audit-bugs/bug_pattern_audit_{YYYY-MM-DD_HHMMSS}.md`
 - Subagents must NOT create their own files - they return findings in their response text only
 - Do not change any code
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -65,7 +67,11 @@ Verify the directory exists and contains `.jsonl` files.
 3. Also `grep -l '/autoskillit:investigate'` to catch user-typed invocations
 4. Combine and deduplicate. Only use top-level files (not subagent logs under `*/subagents/`)
 
-### Step 3: Dispatch Subagents for Parallel Analysis
+### Step 3: Dispatch Subagents for Parallel Analysis (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Split the matching files into batches of ~5 and dispatch general-purpose subagents in parallel. Each subagent should extract from each log file:
 

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -49,6 +49,7 @@ comments and emits a verdict for recipe routing.
 - Run deterministic diff annotation (claim positions are report-level, not line-level)
 - Generate findings for `experimental` claims — they are self-evidencing by definition
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use the explicit `pr_url` argument instead of re-discovering via `gh pr list`
@@ -57,6 +58,7 @@ comments and emits a verdict for recipe routing.
 - Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation)
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Deduplicate findings by (file, line) pairs before posting
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -107,7 +109,11 @@ line-level. Subagents use section structure, not line markers.
 
 ### Step 3: Two-Phase Claim Analysis
 
-#### Phase 1 — Claim Extraction (parallel subagents by report section)
+#### Phase 1 — Claim Extraction (parallel subagents by report section) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Divide the diff by top-level markdown section: `## Executive Summary`, `## Results`,
 `## Methodology`, `## Discussion`, `## Limitations`, and any other top-level `##` section.
@@ -153,7 +159,11 @@ Subagent prompt template:
 Aggregate all extracted claims from all subagents. Save to
 `{{AUTOSKILLIT_TEMP}}/audit-claims/claims_{pr_number}.json`.
 
-#### Phase 2 — Evidence Matching (parallel subagents by claim type)
+#### Phase 2 — Evidence Matching (parallel subagents by claim type) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Group extracted claims by `claim_type`. Launch one Task tool subagent (`model: "sonnet"`)
 per non-empty group. Each subagent receives the claim list and the full PR diff, and

--- a/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
@@ -32,9 +32,11 @@ Audit the codebase for internal cohesion: how well components integrate and main
 - Update an existing report — always generate new
 - Duplicate findings that belong in audit-arch (rule violations)
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents for parallel exploration (one per cohesion dimension)
+- Issue all Task calls in a single message to maximize parallelism
 - All output goes under `{{AUTOSKILLIT_TEMP}}/audit-cohesion/` (create if needed)
 - Final report: `{{AUTOSKILLIT_TEMP}}/audit-cohesion/cohesion_audit_{YYYY-MM-DD_HHMMSS}.md`
 - Subagents must NOT create their own files — they return findings in their response text only
@@ -372,7 +374,11 @@ Flag duplicates (same name in different agents).
 
 ## Audit Workflow
 
-### Step 1: Launch Parallel Subagents
+### Step 1: Launch Parallel Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn subagents for each cohesion dimension. Each subagent MUST be instructed:
 

--- a/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
@@ -31,6 +31,7 @@ Standards are added here when `/autoskillit:design-guards` recommends them and t
 - Modify any source code files
 - Update an existing report - always generate new
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents for parallel exploration (one per standard or group)
@@ -39,6 +40,7 @@ Standards are added here when `/autoskillit:design-guards` recommends them and t
 - Subagents must NOT create their own files - they return findings in their response text only
 - Provide file paths and line numbers for violations
 - Categorize by severity
+- Issue all Task calls in a single message to maximize parallelism
 
 ---
 
@@ -119,7 +121,11 @@ Defense standards come from the `/autoskillit:design-guards` pipeline:
 
 ---
 
-## Audit Workflow
+## Audit Workflow (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 1. **Launch parallel subagents** - one per standard or group of related standards
 2. **Each subagent:** runs the audit strategy, reports violations with file paths and line numbers

--- a/src/autoskillit/skills_extended/audit-docs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-docs/SKILL.md
@@ -33,9 +33,11 @@ Audit all documentation sources for drift, staleness, and inconsistency against 
 - Update an existing report — always generate a new one
 - Compare doc-to-doc without first grounding claims in actual code behavior
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Ground every cross-reference finding in what the code actually does (not what other docs say)
+- Issue all Task calls in a single message to maximize parallelism
 - Use subagents for parallel exploration
 - Write report to `{{AUTOSKILLIT_TEMP}}/audit-docs/docs_audit_{YYYY-MM-DD_HHMMSS}.md`
 - Provide file:line references for every finding
@@ -74,7 +76,11 @@ Flag findings in these categories (maps to REQ-SKILL-004):
 
 1. **Pre-flight**: Verify `{{AUTOSKILLIT_TEMP}}/audit-docs/` directory exists; create it if not.
 
-2. **Familiarization wave** — spawn 6 parallel subagents, one per subsystem group. Each subagent reports: actual module/component names, exported symbols, behavioral summary (2–5 sentences per module). If any subagent fails, record the gap and continue.
+2. **Familiarization wave (SINGLE MESSAGE)** — spawn 6 parallel subagents, one per subsystem group. Each subagent reports: actual module/component names, exported symbols, behavioral summary (2–5 sentences per module). If any subagent fails, record the gap and continue.
+
+   **Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+   Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
    | Agent | Subsystems | Focus |
    |---|---|---|

--- a/src/autoskillit/skills_extended/audit-friction/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-friction/SKILL.md
@@ -35,12 +35,14 @@ The user may provide a "since" date (e.g., `2/7`, `2026-02-07`, `last month`). I
 - Have subagents write files — they return all findings in response text only
 - Analyze subagent log subdirectories (`*/subagents/`) — top-level session files only
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents heavily for parallel log analysis
 - All output goes under `{{AUTOSKILLIT_TEMP}}/audit-friction/` (create if needed)
 - Final report: `{{AUTOSKILLIT_TEMP}}/audit-friction/friction_audit_{YYYY-MM-DD_HHMMSS}.md`
 - Report the file and line counts to the terminal before choosing analysis mode
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Friction Categories
 
@@ -126,7 +128,11 @@ EOF
 
 Report both counts to the terminal. If zero files match, extend the window by 15 days and retry, noting the adjustment.
 
-### Step 3: Haiku Batch Scan
+### Step 3: Haiku Batch Scan (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Split the log file list into batches. Use batches of ~5 files for smaller corpora; reduce to ~3 files per batch when the corpus is large so each Haiku agent isn't overloaded. Dispatch one **Haiku model** subagent per batch in parallel.
 
@@ -145,7 +151,11 @@ For each confirmed friction event record: `{file, line_start, line_end, category
 
 Return all findings as structured text. Do not write any files.
 
-### Step 4: Sonnet Deep Analysis per Category
+### Step 4: Sonnet Deep Analysis per Category (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 After all Haiku agents return, group all indicators by category. Dispatch **Sonnet model** subagents to analyze the grouped indicators in parallel. Any category with at least one indicator warrants a subagent. Spawn one subagent per category when there are many; batch smaller related groups when overall volume is low. The orchestrator decides the grouping.
 

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -53,12 +53,14 @@ requirements, scope creep, and unexpected changes. Produces a GO or NO GO verdic
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-impl/`
 - Emit a GO verdict when any `MISSING` or `CONFLICT` finding exists
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use Explore subagents for all file reads and diff retrieval
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Resolve all plan files before starting (abort early if any are missing)
 - Write `Dry-walkthrough verified = TRUE` as the absolute first line of any remediation file
+- Issue all Task calls in a single message to maximize parallelism
 - On a NO GO verdict, after writing the remediation file, emit the **absolute path** as a
   structured output token as your final output. Resolve the relative
   `temp/audit-impl/...` save path to absolute by prepending the full CWD:
@@ -119,7 +121,11 @@ exist (e.g., plan file arguments, `{{AUTOSKILLIT_TEMP}}/investigate/` reports, e
 `Glob` or `ls` to confirm the path exists first. This prevents ENOENT errors that cascade into
 sibling parallel-call cancellations.
 
-### Step 1 — Load Plans via Parallel Subagents
+### Step 1 — Load Plans via Parallel Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch one Explore subagent per plan file in parallel. Each returns:
 
@@ -219,7 +225,11 @@ Record all findings from this cross-reference alongside the standard Step 3 audi
 Each `CONFLICT` or `MISSING` finding here forces a `NO GO` verdict per the existing verdict
 logic (Step 4).
 
-### Step 3 — Audit via Parallel Subagents
+### Step 3 — Audit via Parallel Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 **Data source discipline:** Do NOT call Read, Grep, or Glob to verify file existence or
 content — the diff is the single source of truth for implementation state. The working

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -43,6 +43,7 @@ implemented. Identify review debt before it compounds.
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Use `gh pr list` without `--limit` to avoid pagination truncation
 - Use `\|` in Grep patterns — use `|` for alternation (ERE, not BRE)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Save raw PR JSON to temp before any analysis (Step 1)
@@ -54,6 +55,7 @@ implemented. Identify review debt before it compounds.
 - Skip threads that already contain an `[AUDIT]` comment
 - Resolve owner/repo from `git remote get-url origin` — never hardcode
 - Use `/autoskillit:` prefix when invoking any other skill
+- Issue all Task calls in a single message to maximize parallelism
 
 ---
 
@@ -138,7 +140,11 @@ implemented. Identify review debt before it compounds.
 
 ---
 
-### Step 2: Triage (Haiku — Broad Pass)
+### Step 2: Triage (Haiku — Broad Pass) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 1. List all JSON files in `raw/`. Split into batches of ~5 files per agent.
 
@@ -170,7 +176,11 @@ implemented. Identify review debt before it compounds.
 
 ---
 
-### Step 3: Validation (Sonnet — Deep Pass)
+### Step 3: Validation (Sonnet — Deep Pass) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 1. Group candidates into batches of ~10. Launch **parallel Sonnet subagents**
    (`model: "sonnet"`) per batch.

--- a/src/autoskillit/skills_extended/audit-tests/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-tests/SKILL.md
@@ -31,9 +31,11 @@ Audit the test suite to identify useless tests, consolidation opportunities, qua
 - Recommend removing tests that guard against real regressions
 - Recommend changes that would reduce meaningful coverage
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents for parallel exploration
+- Issue all Task calls in a single message to maximize parallelism
 - Read both the test AND the code it tests before judging
 - Provide file paths, line numbers, and an explanation for each finding
 - Write the improvement plan to `{{AUTOSKILLIT_TEMP}}/audit-tests/test_audit_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
@@ -179,7 +181,11 @@ Tests and configuration that maintain the path-based test filter's correctness. 
 
 ## Audit Workflow
 
-### Step 1: Launch Parallel Subagents
+### Step 1: Launch Parallel Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn 6 domain-based subagents. Each covers all issue categories (C1–C11) within its area. Group by source domain, not by issue category. Each subagent must read both test files AND the corresponding production code before making judgements.
 

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -47,6 +47,7 @@ Space-separated issue numbers (required, minimum 2), plus optional flags:
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Treat a medium-severity cross-assessment as grounds for deferral — only critical severity defers
 - Emit has_deferred / deferred_count / dispatched_count with markdown decorators
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use parallel subagents (up to 8) for issue fetching in Step 1
@@ -57,6 +58,7 @@ Space-separated issue numbers (required, minimum 2), plus optional flags:
 - Check the actual codebase when uncertain whether two issues' changes overlap
 - Capture per-pair reasoning in `pairwise_assessments` for auditability
 - Anchor all output paths to the current working directory
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -72,7 +74,11 @@ with `"Error: --max-parallel must be a positive integer"`. Validate the issue co
 - **One issue**: emit a warning and write a trivial single-group map (single issue always gets `parallel: false`).
 - **Two or more issues**: proceed to Step 0.5.
 
-### Step 1 — Fetch Issue Data (parallel subagents)
+### Step 1 — Fetch Issue Data (parallel subagents) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch up to 8 parallel `sonnet` subagents, one per issue. Each subagent:
 1. Calls `gh issue view {N} --json number,title,body,labels`. If the call fails (non-zero

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -39,6 +39,7 @@ decomposed PR flow (prepare → run_arch_lenses → compose).
 - Invent mermaid classDef colors — when embedding validated diagrams, include them verbatim.
   Using ONLY classDef styles from the mermaid skill (no invented colors).
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Check `gh auth status` before attempting GitHub operations
@@ -48,6 +49,7 @@ decomposed PR flow (prepare → run_arch_lenses → compose).
   (omit Architecture Impact section; do not include a placeholder)
 - Handle `no diagrams` case: when `all_diagram_paths is empty` or every path fails
   marker check, set `validated_diagrams = []` and omit the Architecture Impact section
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -108,7 +110,11 @@ For each path:
 
 If `all_diagram_paths` is empty or all diagrams fail → `validated_diagrams = []`.
 
-### Step 3: Compose PR Body
+### Step 3: Compose PR Body (SINGLE MESSAGE)
+
+**Issue ALL Task/Explore subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Write PR body to `{{AUTOSKILLIT_TEMP}}/compose-pr/pr_body_$ts.md` (using the `ts` variable from Step 0).
 

--- a/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
@@ -41,11 +41,13 @@ Does NOT invoke lens skills or other sub-skills.
 - Invent mermaid classDef colors — when embedding validated diagrams, include them verbatim.
   Using ONLY classDef styles from the mermaid skill when composing the PR body.
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Check `gh auth status` before attempting GitHub operations
 - Emit `pr_url` token as your final output (even if empty)
 - Use Agent subagents to read the prep file
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Diagram Validation Keywords
 
@@ -76,7 +78,11 @@ Create temp directory:
 
 Generate a timestamp `ts` for unique file naming.
 
-### Step 1: Read prep file via Agent subagent
+### Step 1: Read prep file via Agent subagent (SINGLE MESSAGE)
+
+**Issue ALL Task/Explore subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn an **Explore** subagent to read `{prep_path}` and extract:
 - `report_path` (from Metadata section)

--- a/src/autoskillit/skills_extended/design-guards/SKILL.md
+++ b/src/autoskillit/skills_extended/design-guards/SKILL.md
@@ -33,6 +33,7 @@ Path to a bug pattern audit report (typically under `{{AUTOSKILLIT_TEMP}}/audit-
 - Propose bandaid fixes or direct-only patches
 - Create files outside `{{AUTOSKILLIT_TEMP}}/design-guards/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents for parallel codebase exploration
@@ -42,6 +43,7 @@ Path to a bug pattern audit report (typically under `{{AUTOSKILLIT_TEMP}}/audit-
 - Final report: `{{AUTOSKILLIT_TEMP}}/design-guards/defense_guards_{YYYY-MM-DD_HHMMSS}.md`
 - Subagents must NOT create their own files - they return findings in their response text only
 - Do not change any code
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -52,7 +54,11 @@ Read the input report and extract each pattern:
 - Affected components and sessions
 - The root architectural gap identified
 
-### Step 2: Investigate Each Pattern in Parallel
+### Step 2: Investigate Each Pattern in Parallel (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 For each pattern (or group of related patterns), launch subagents to explore:
 

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -49,6 +49,7 @@ The plan file must remain a **clean, self-contained implementation instruction s
 - Consider effort as a reason for choosing one approach over another
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Write plan content, corrections, or the verification marker to any file other than the original plan file path provided as input. If the Edit tool is denied on the plan file, do NOT create a copy elsewhere — output a failure message instead.
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Keep the plan as clean implementation instructions only (information/background helpful to implementation is okay)
@@ -59,6 +60,7 @@ The plan file must remain a **clean, self-contained implementation instruction s
 - Remove deprecation code/notes and rollback mechanisms
 - Make sure the plan includes warning against using the codebase as a notepad with useless comments
 - Prefer the long term health of project over quick, easy, and minimal fixes
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -93,7 +95,11 @@ After resolving the plan path, check whether this is a part file of a multi-part
    ```
    If the block is absent, or contains the wrong part label or wording, insert or correct it as your **first** edit to the plan file before proceeding to phase validation.
 
-### Step 2: Extract and Validate Each Phase
+### Step 2: Extract and Validate Each Phase (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 For each phase, verify using subagents:
 

--- a/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
@@ -38,6 +38,7 @@ Elaborate a single phase from a high-level migration plan into a complete, self-
 - Make assumptions about codebase state without verifying
 - Read previous `Phase#.md` files unless you have a specific question that requires looking up a detail
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Assess current codebase state with subagents FIRST
@@ -47,6 +48,7 @@ Elaborate a single phase from a high-level migration plan into a complete, self-
 - Include verification commands and success criteria
 - Report findings to terminal output
 - Update the master plan if dry walkthrough reveals issues affecting subsequent phases
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Plan Directory Structure
 
@@ -111,7 +113,11 @@ Load and understand:
 
 **IMPORTANT:** Do NOT read previous `Phase#.md` files. They exist in the directory but reading them wastes context. Only look up a specific detail from a previous phase if you encounter a concrete question during assessment that cannot be answered from the codebase itself.
 
-### Step 3: Assess Current Codebase State
+### Step 3: Assess Current Codebase State (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch **parallel Explore subagents** to understand the current state:
 

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -96,7 +96,11 @@ For each candidate issue, check whether its body already contains
 
 If no candidates remain after filtering, emit the result block immediately and exit.
 
-### Step 5: Per-Issue Analysis
+### Step 5: Per-Issue Analysis (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Process up to 8 candidates in parallel using subagents (`model: "sonnet"`).
 For each candidate:
@@ -233,9 +237,11 @@ After processing all candidates, emit to stdout:
 - Use `--body` shell substitution (`--body "$(...)`) for `gh issue edit` — always write to
   `{{AUTOSKILLIT_TEMP}}/enrich-issues/edit_body_{timestamp}.md` and use `--body-file`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Respect `--dry-run`: never call `gh issue edit` when this flag is set
 - Verify codebase claims before incorporating them into requirements
 - Use `model: "sonnet"` for per-issue analysis subagents
 - Emit the `---enrich-issues-result---` block as the final output
+- Issue all Task calls in a single message to maximize parallelism

--- a/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-benchmark-representativeness/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on GENERALIZATION GAP between benchmark coverage and claimed scope
@@ -54,6 +55,7 @@ hooks:
 - Include a coverage matrix mapping scenarios to metrics
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-benchmark-representativeness/exp_diag_benchmark_representativeness_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-causal-assumptions/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Classify every variable as Treatment, Outcome, Confounder, Mediator, Collider, Instrument, or Selection variable
@@ -54,6 +55,7 @@ hooks:
 - Document the identification strategy with testable assumptions
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-causal-assumptions/exp_diag_causal_assumptions_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Accept at face value that baselines received symmetric treatment
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-comparator-construction/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Build a fairness matrix covering all treatment-vs-comparator pairs
@@ -55,6 +56,7 @@ hooks:
 - Identify temporal drift in baseline relevance
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-comparator-construction/exp_diag_comparator_construction_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -75,7 +77,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Accept default alpha=0.05 without checking whether it is appropriate for the decision context
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-error-budget/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Enumerate every statistical test and account for its error contribution
@@ -55,6 +56,7 @@ hooks:
 - Evaluate whether the minimum detectable effect is practically meaningful, not just statistically chosen
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-error-budget/exp_diag_error_budget_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -75,7 +77,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-estimand-clarity/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Decompose every stated claim into formal contrast notation (Treatment A vs Treatment B on Outcome Y in Population Z)
@@ -54,6 +55,7 @@ hooks:
 - Document how complications (missing data, failures, exclusions) are handled
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-estimand-clarity/exp_diag_estimand_clarity_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
@@ -45,6 +45,7 @@ hooks:
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-exploratory-confirmatory/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Map the full analytic timeline — what was decided before vs. after seeing data
@@ -53,6 +54,7 @@ hooks:
 - Flag absent preregistration as a finding without assuming bad faith
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-exploratory-confirmatory/exp_diag_exploratory_confirmatory_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -73,7 +75,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-fair-comparison/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Build the full symmetry matrix — every method against every resource dimension
@@ -54,6 +55,7 @@ hooks:
 - Assess the winner's curse: did the proposed method benefit from more selection pressure?
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-fair-comparison/exp_diag_fair_comparison_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
@@ -45,6 +45,7 @@ hooks:
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-governance-risk/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Identify subgroups for whom the experimental evidence may not generalize
@@ -53,6 +54,7 @@ hooks:
 - Distinguish risks that are monitored from risks that are merely acknowledged
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-governance-risk/exp_diag_governance_risk_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -73,7 +75,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Recommend one-factor-at-a-time exploration when interactions are plausible
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-iterative-learning/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Evaluate exploration efficiency against the key uncertainty being reduced
@@ -54,6 +55,7 @@ hooks:
 - Surface interaction structure that one-factor-at-a-time designs would miss
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-iterative-learning/exp_diag_iterative_learning_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-measurement-validity/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Treat every reported metric as a claim requiring a validity argument
@@ -54,6 +55,7 @@ hooks:
 - Identify where metric-construct alignment is weak or unsupported by evidence
 - BEFORE creating any optional diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-measurement-validity/exp_diag_measurement_validity_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-pipeline-integrity/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Classify every pipeline stage as pre-split or post-split
@@ -54,6 +55,7 @@ hooks:
 - Document pipeline invariants that guard against leakage
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-pipeline-integrity/exp_diag_pipeline_integrity_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Assume comparability without tracing its source
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-randomization-blocking/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Trace the exact mechanism that creates comparability between treatment groups
@@ -54,6 +55,7 @@ hooks:
 - Verify that replication is adequate for the claimed inferential precision
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-randomization-blocking/exp_diag_randomization_blocking_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-reproducibility-artifacts/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Trace the full chain from "clone repo" to "reproduce figures"
@@ -54,6 +55,7 @@ hooks:
 - Flag all silent non-determinism risks
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-reproducibility-artifacts/exp_diag_reproducibility_artifacts_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
@@ -47,6 +47,7 @@ hooks:
 - Treat "untested" as equivalent to "robust"
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-sensitivity-robustness/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Build a full sensitivity matrix (choices x perturbation types)
@@ -55,6 +56,7 @@ hooks:
 - Distinguish between ablations that were run and choices that were simply fixed
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-sensitivity-robustness/exp_diag_sensitivity_robustness_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -75,7 +77,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
@@ -45,6 +45,7 @@ hooks:
 - Accept a "pass" result without asking what a false result would have looked like under this design
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-severity-testing/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - For every positive claim, identify what error the test was capable of detecting
@@ -53,6 +54,7 @@ hooks:
 - Flag confirmatory theater: experiments designed to confirm rather than risk refutation
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-severity-testing/exp_diag_severity_testing_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -73,7 +75,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-unit-interference/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Focus on the unit definition and whether SUTVA is plausible
@@ -54,6 +55,7 @@ hooks:
 - Distinguish direct spillover (shared cache) from indirect spillover (market equilibrium)
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-unit-interference/exp_diag_unit_interference_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
@@ -45,6 +45,7 @@ hooks:
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-validity-threats/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Apply Campbell & Stanley's full threat taxonomy — do not skip threats just because they seem unlikely
@@ -53,6 +54,7 @@ hooks:
 - Distinguish threats that are ruled out by design from those that remain plausible
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-validity-threats/exp_diag_validity_threats_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -73,7 +75,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
@@ -46,6 +46,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-variance-stability/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Count the actual number of independent runs — single-run results must be flagged prominently
@@ -54,6 +55,7 @@ hooks:
 - Report when confidence intervals are absent — absence is a finding, not an omission
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/exp-lens-variance-stability/exp_diag_variance_stability_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -74,7 +76,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1-5; skip the CWD
 exploration for these fields if the context file supplies them. For any field absent from the context file, perform CWD exploration for that specific field only.
 
-### Step 1: Launch Parallel Exploration Subagents
+### Step 1: Launch Parallel Exploration Subagents (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn Explore subagents to investigate:
 

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -79,6 +79,7 @@ In addition to the arguments above, this skill reads from the worktree:
 - Frame inconclusive results as failures — they are valid findings
 - Create the report outside the worktree's `research/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
@@ -87,6 +88,7 @@ In addition to the arguments above, this skill reads from the worktree:
 - Commit the report to the worktree before returning
 - Include a "What We Learned" section regardless of outcome
 - Link back to the originating GitHub issue if an issue number is available
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -54,6 +54,7 @@ tokens after the skill name for the first path-like token (starts with `/`,
   `git cherry-pick` or `git checkout <branch> -- <file>`)
 - Blame pre-commit or lint failures on "pre-existing issues" — ALL pre-commit checks must pass on the committed code
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Create a new worktree from the current branch
@@ -66,6 +67,7 @@ tokens after the skill name for the first path-like token (starts with `/`,
 - Write `tests/test_{script_name}.py` alongside each experiment script created in Step 4
 - Run `pytest --collect-only` after creating tests to verify discovery before committing
 - **Read before editing**: Before issuing an `Edit` call on any file, ensure you have issued a `Read` on that file earlier in this session. Claude Code rejects `Edit` on unread files — the retry wastes a full API turn at current context size. If you are uncertain whether a file was read, issue a targeted `Read` (offset + limit to the region you plan to edit) rather than risk an error.
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -118,7 +120,11 @@ worktree_path = ${WORKTREE_PATH}
 branch_name = ${BRANCH_NAME}
 ```
 
-### Step 2 — Deep Context Understanding (Subagents)
+### Step 2 — Deep Context Understanding (Subagents) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before implementing anything, launch subagents (model: "sonnet") to understand
 the codebase context needed for the experiment. The following are **minimum

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -43,6 +43,7 @@ The worktree is left intact for the orchestrator to test and merge separately.
 - Pipe test output through `tail`, `head`, or other truncation commands
 - **Execute `git merge` commands** (including `--no-ff`, `--no-commit`, or any variant). All branch content must be applied via `git cherry-pick <commit>` for individual commits or `git checkout <branch> -- <file>` for specific files. `merge_worktree` requires linear commit history — merge commits cannot be rebased and will cause `WORKTREE_INTACT_MERGE_COMMITS_DETECTED` failure.
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Create a new worktree from the current branch
@@ -53,6 +54,7 @@ The worktree is left intact for the orchestrator to test and merge separately.
 - Leave the worktree intact when done
 - **Read before editing**: Before issuing an `Edit` call on any file, ensure you have issued a `Read` on that file earlier in this session. Claude Code rejects `Edit` on unread files — the retry wastes a full API turn at current context size. If you are uncertain whether a file was read, issue a targeted `Read` (offset + limit to the region you plan to edit) rather than risk an error.
 - **Read files fully**: When reading a file to understand it in full, read it in a single call without a `limit` parameter. Do not paginate files with sequential offset reads — read once completely. Use `limit`/`offset` only for targeted section reads of files you have already read in full.
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -127,7 +129,11 @@ execution layer scans `assistant_messages` for `worktree_path=` and surfaces
 it as a top-level field in the `run_skill` JSON response. The orchestrator
 reads this field directly without filesystem discovery heuristics.
 
-### Step 2: Deep System Understanding (Subagents)
+### Step 2: Deep System Understanding (Subagents) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before implementing ANY code, launch parallel Explore subagents to understand affected systems:
 - **Affected files** — current implementation, dependencies, consumers

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -36,6 +36,7 @@ Implement a provided plan in an isolated git worktree branched from the current 
 - Blame test failures on "pre-existing issues" — ALL tests must pass
 - Re-run tests just to see failures — grep the saved output file instead
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Create a new worktree from the current branch
@@ -45,6 +46,7 @@ Implement a provided plan in an isolated git worktree branched from the current 
 - Run the project's test suite after implementation
 - Rebase onto base branch before completion (ready for squash-and-merge)
 - **Read before editing**: Before issuing an `Edit` call on any file, ensure you have issued a `Read` on that file earlier in this session. Claude Code rejects `Edit` on unread files — the retry wastes a full API turn at current context size. If you are uncertain whether a file was read, issue a targeted `Read` (offset + limit to the region you plan to edit) rather than risk an error.
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -94,7 +96,11 @@ WORKTREE_NAME="impl-{plan_name}-$(date +%Y%m%d-%H%M%S)"
 eval "$(bash "{{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh" "${WORKTREE_NAME}" "{{AUTOSKILLIT_TEMP}}")"
 ```
 
-### Step 2: Deep System Understanding (Subagents)
+### Step 2: Deep System Understanding (Subagents) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before implementing ANY code, launch parallel Explore subagents to understand affected systems:
 - **Affected files** — current implementation, dependencies, consumers

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -378,6 +378,8 @@ Spawn one adversarial subagent (model: "sonnet") whose role is to disconfirm the
 
 ### Step D5: Solution Convergence
 
+**Issue ALL blast radius subagent calls in a single message — one per candidate — so they execute in parallel. Do not iterate across multiple turns.**
+
 Spawn solution-space subagents to enumerate candidate fixes. For each candidate, spawn one blast radius subagent (model: "sonnet") to assess:
 
 - Which components would be affected by this fix

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -76,9 +76,11 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 - Choose or accept approaches, solutions, and/or fixes that are chosen simply because they are easier
 - File GitHub issues automatically (issue filing is always a separate, user-directed action)
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents for parallel exploration
+- Issue all Task calls in a single message to maximize parallelism
 - Limit total subagent spawns to 9 across all batches (standard and deep mode). If the investigation requires more exploration vectors, consolidate related questions into fewer, broader subagent prompts rather than spawning additional agents.
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Write findings as a markdown report with unique name to `{{AUTOSKILLIT_TEMP}}/investigate/` directory (relative to the current working directory)
@@ -107,7 +109,11 @@ Identify what needs investigation:
 - **Module Investigation**: Identify the module/component to understand
 - **Question Investigation**: Clarify the specific question being asked
 
-### Step 2: Launch Parallel Subagents
+### Step 2: Launch Parallel Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn explore subagents to investigate different aspects simultaneously (some aspects may and should require multiple subagents):
 

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -60,6 +60,7 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 - Create groups that cannot be independently planned
 - Include implementation steps or technical approach in the group descriptions
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents to verify codebase structure before finalizing groups
@@ -77,6 +78,7 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
   group_files = /absolute/cwd/{{AUTOSKILLIT_TEMP}}/make-groups/{groups_filename}.md
   ```
   These tokens are MANDATORY — the pipeline cannot proceed without them.
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -84,7 +86,11 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 
 Read the full document. Inventory every requirement (REQ-*), feature, and deliverable. Build a raw list with original IDs preserved.
 
-### Step 2: Verify Against Codebase
+### Step 2: Verify Against Codebase (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch **parallel Explore subagents** to understand:
 

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -66,7 +66,7 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 
 ## Planning Steps
 
-1. **Understand related systems and validate details** - Use subagents to study the architecture, how components work together, their purpose, patterns, and standards. Validate any details provided in the task description. When the plan involves adding tests that call mutating methods on singleton or module-level objects (enable/disable, register/unregister, connect/disconnect), use a subagent to read the target test directory's existing isolation patterns (conftest fixtures, setup_method/teardown_method, autouse fixtures) before proceeding to Step 3.
+1. **Understand related systems and validate details** (SINGLE MESSAGE) — **Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.** Do not output any prose between subagent dispatches. Use subagents to study the architecture, how components work together, their purpose, patterns, and standards. Validate any details provided in the task description. When the plan involves adding tests that call mutating methods on singleton or module-level objects (enable/disable, register/unregister, connect/disconnect), use a subagent to read the target test directory's existing isolation patterns (conftest fixtures, setup_method/teardown_method, autouse fixtures) before proceeding to Step 3.
 
 2. **Explore and design approaches** - Use subagents to investigate different ways to solve the problem. Use subagents with web search to research modern solutions, approaches, designs, and architectures relevant to the problem. For each approach, focus on:
    - Does it solve the problem correctly?
@@ -281,6 +281,7 @@ Before writing the final plan, verify:
 - Create files outside `{{AUTOSKILLIT_TEMP}}/make-plan/` directory
 - **Use `git merge` in implementation plans.** When a plan needs to bring in changes from another branch, use `git cherry-pick <commit>` for individual commits or `git checkout <branch> -- <file>` for specific files. `merge_worktree` requires linear commit history — merge commits cannot be rebased and will cause `WORKTREE_INTACT_MERGE_COMMITS_DETECTED` failure. See "Conflict-Resolution Plan Requirements" section for full guidance.
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Write to `{{AUTOSKILLIT_TEMP}}/make-plan/` directory (relative to the current working directory)
@@ -297,6 +298,7 @@ Before writing the final plan, verify:
 - Ground decisions in design quality and correctness
 - Include verification steps
 - Be willing to recommend significant refactoring if that's the right answer
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Output
 

--- a/src/autoskillit/skills_extended/make-req/SKILL.md
+++ b/src/autoskillit/skills_extended/make-req/SKILL.md
@@ -38,6 +38,7 @@ Decompose a task, plan, roadmap, or feature description into a structured set of
 - Include implementation steps disguised as requirements ("Refactor X to use Y" is an instruction, not a requirement)
 - Write requirements that can only be verified by reading source code
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents to understand the source material and relevant codebase context
@@ -45,6 +46,7 @@ Decompose a task, plan, roadmap, or feature description into a structured set of
 - Provide background and context for each group
 - State requirements as verifiable conditions
 - Write to `{{AUTOSKILLIT_TEMP}}/make-req/` directory (relative to the current working directory)
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -52,7 +54,7 @@ Decompose a task, plan, roadmap, or feature description into a structured set of
 
 Identify the input: a task description, plan document, roadmap, conversation context, or file reference. Read it fully.
 
-If the input references existing systems or codebases, launch parallel Explore subagents to understand:
+If the input references existing systems or codebases, launch parallel Explore subagents (SINGLE MESSAGE — issue ALL Task calls at once) to understand:
 
 - What exists today that the requirements relate to
 - Current capabilities and boundaries

--- a/src/autoskillit/skills_extended/merge-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/merge-pr/SKILL.md
@@ -42,6 +42,7 @@ conflicts from earlier merges in the queue.
 - Leave the git working tree in a dirty state
 - Create files outside `{{AUTOSKILLIT_TEMP}}/merge-prs/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Run `git status` before any operation to verify clean state
@@ -50,6 +51,7 @@ conflicts from earlier merges in the queue.
 - Use `gh pr merge {pr_number} --squash` when `autoMergeAllowed=false` — GitHub merges synchronously without waiting for checks
 - Poll `gh pr view {pr_number} --json state,mergedAt` to confirm the merge completed
 - Fetch the PR branch from remote before the deletion regression scan and conflict analysis
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -221,7 +223,11 @@ In both cases, poll `gh pr view {pr_number} --json state,mergedAt` until:
 
 Do NOT fall back to local git merge regardless of `AUTO_MERGE_ALLOWED`.
 
-### Step 3: Complexity Path — `needs_check` (Re-assessment)
+### Step 3: Complexity Path — `needs_check` (Re-assessment) (SINGLE MESSAGE)
+
+**Issue ALL Task/Explore subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before attempting any merge, re-assess complexity against the current integration branch state.
 

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -53,12 +53,14 @@ PR, and output `pr_url=<url>`.
 - Fail the pipeline if `gh` is unavailable or not authenticated — output `pr_url=` (empty) and exit successfully
 - Close original PRs before the integration PR is successfully created
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Check `gh auth status` before attempting any GitHub operations
 - Output `pr_url=<url>` on the last output line (empty string when GitHub unavailable)
 - Carry forward ALL `Closes #N` and `Fixes #N` lines found in original PR bodies
 - Use `gh pr create --body-file` (never inline body via `--body`)
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -65,6 +65,7 @@ incorporate the feedback before writing the plan.
   any external dataset identifier) in the data_manifest without first confirming their
   existence via web search — accession patterns learned during training are frequently
   hallucinated
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
@@ -78,6 +79,7 @@ incorporate the feedback before writing the plan.
 - Apply all 10 validation rules before writing the frontmatter block
 - Log V1–V4, V9, V10 ERRORs in a ## Frontmatter Validation Errors section instead of writing frontmatter
 - Log V5–V8, V10 network failure WARNINGs as # WARNING: ... YAML comments on the relevant field lines
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -104,7 +106,11 @@ Detect and read inputs:
    your initial analysis in Step 2. Note which sections of the plan need rework.
    When absent or empty, omit this sub-step and proceed normally (first pass).
 
-### Step 2 — Explore Feasibility
+### Step 2 — Explore Feasibility (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch subagents (model: "sonnet") to assess feasibility. The following are
 **minimum required** — launch as many additional subagents as needed to fill

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -38,12 +38,14 @@ outputs, and synthesizes a complete visualization plan.
 - Write outputs outside `{{AUTOSKILLIT_TEMP}}/plan-visualization/`
 - Fabricate lens recommendations or validation conclusions not supported by the data — report what the experiment plan and scope show, not what you assume they should show
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Write a vis-lens context file for each selected lens before invoking it
 - Log every conflict resolution decision in the Conflict Resolution Log table
 - Emit `visualization_plan_path` and `report_plan_path` tokens as your final output
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -186,7 +188,11 @@ routing_triple:
   candidate_set: [{candidates}]
 ```
 
-### Step 3 — Run Vis-Lens Skills in Parallel
+### Step 3 — Run Vis-Lens Skills in Parallel (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 In a **single assistant message**, invoke all `selected_lenses` as slash commands:
 

--- a/src/autoskillit/skills_extended/planner-analyze/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-analyze/SKILL.md
@@ -32,6 +32,7 @@ Detect language, framework, test infrastructure, project structure, and existing
 - Modify any target project files
 - Write analysis.json outside `$1/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -39,10 +40,15 @@ Detect language, framework, test infrastructure, project structure, and existing
 - Use Explore subagents for all file reads
 - Spawn all 4 subagents in parallel
 - Write valid JSON to `analysis.json`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
-### Step 1: Launch 4 parallel Explore subagents
+### Step 1: Launch 4 parallel Explore subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn all four concurrently with `model: "sonnet"`:
 

--- a/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
@@ -34,6 +34,7 @@ writes `review_approach_assessment.json` to the planner directory. Does NOT invo
 - Write output outside `$2/`
 - Modify input files
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -43,6 +44,7 @@ writes `review_approach_assessment.json` to the planner directory. Does NOT invo
 - Read `$2/analysis.json` for codebase technology context
 - Write `$2/review_approach_assessment.json`
 - Emit: `review_approach_assessment_path = <absolute path to review_approach_assessment.json>`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -59,7 +61,11 @@ for codebase technology context: available libraries, architectural patterns in 
 established conventions. This context informs whether a WP is "following established patterns"
 (no-benefit) versus "introducing something new" (benefit signal).
 
-### Step 3: Evaluate each WP
+### Step 3: Evaluate each WP (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn 1–2 subagents (model: "sonnet") to evaluate WPs in parallel batches. For each WP,
 evaluate against these signals:

--- a/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
@@ -47,6 +47,7 @@ merging).
 - Allow an L0 to write files outside `$2/work_packages/consolidation/`
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Spawn more than 6 L0s in a single parallel batch
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -55,6 +56,7 @@ merging).
 - Validate each L0 response before writing its manifest
 - Write a manifest for every phase, even if it contains only singleton groups
 - Emit: `consolidation_manifest_dir = {planner_dir}/work_packages/consolidation`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -94,7 +96,11 @@ For each phase, assemble a context packet containing:
     files). This is guidance, not a hard gate — use judgment about whether the combined
     work forms a coherent unit.
 
-### Step 4: Dispatch parallel L0 subagents
+### Step 4: Dispatch parallel L0 subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 If phase count ≤ 6: spawn all in one parallel batch.
 If phase count > 6: spawn sequential batches of 6.

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -36,6 +36,7 @@ is the sole writer for this phase's assignments — no concurrent write races.
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 - Read result files from other phases
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -44,6 +45,7 @@ is the sole writer for this phase's assignments — no concurrent write races.
 - Write the phase sentinel file before emitting the output token
 - Emit: `phase_assignments_result_dir = <absolute path to assignments/ directory>`
 - Write a stub result for any L0 that fails or returns invalid JSON
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -78,7 +80,11 @@ For each assignment in the phase, build a self-contained context packet:
 - The phase's `technical_approach` and `scope`
 - The planner directory path `$2` for reading prior results if needed
 
-### Step 4: Spawn L0 subagents in PARALLEL
+### Step 4: Spawn L0 subagents in PARALLEL (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Use the native Agent/Task tool to spawn one L0 per assignment simultaneously.
 All L0s must be launched in a single batch — do NOT wait for one before starting the next.

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -42,6 +42,7 @@ independently and writes a single elaborated phase result. No dependency on
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts outside your designated input files and output directory
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -50,6 +51,7 @@ independently and writes a single elaborated phase result. No dependency on
 - Write result to `$3/{phase_id}_result.json` (keep `_result.json` suffix — downstream consumers glob `*_result.json`)
 - Emit: `elab_result_path = <absolute path to {phase_id}_result.json>`
 - Include all `PhaseElaborated` fields in the result
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -77,7 +79,11 @@ phase — its `technical_approach`, `scope`, and `assignments[]` — must serve 
 Do not elaborate into work not requested by the task. Flag if the phase goal appears
 unrelated to the task.
 
-### Step 2: Launch parallel codebase exploration subagents
+### Step 2: Launch parallel codebase exploration subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn up to 5 simultaneous Explore subagents against the codebase in `source_dir`:
 

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -37,6 +37,7 @@ is the sole writer for this phase's WPs — no concurrent write races.
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 - Read result files from other phases
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -45,6 +46,7 @@ is the sole writer for this phase's WPs — no concurrent write races.
 - Write the phase sentinel file before emitting the output token
 - Emit: `phase_wps_result_dir = <absolute path to work_packages/ directory>`
 - Write a stub result for any L0 that fails or returns invalid JSON
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -89,7 +91,11 @@ Each packet contains:
 - Phase goal and scope
 - Task file path (absolute) — the agent reads this for scope-creep verification
 
-### Step 4: Spawn L0 subagents in PARALLEL
+### Step 4: Spawn L0 subagents in PARALLEL (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Use the native Agent tool with `subagent_type: "autoskillit:wp-elaborator"` to spawn one
 agent per WP simultaneously. If WP count > 6, spawn in sequential batches of 6 — await

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -34,6 +34,7 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 - Abort the calling recipe on failure — log a warning and return gracefully
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - If `$1` is empty or the file does not exist, STOP immediately and report failure
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -41,6 +42,7 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 - Read the analysis file from argument $1 before spawning subagents
 - Use Explore subagents for all file reads
 - Spawn subagents in parallel
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -48,7 +50,11 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 
 Read the `analysis.json` file from argument $1. Use its `language`, `framework`, `architecture_style`, and `key_patterns` fields to focus subagent queries.
 
-### Step 2: Launch 3–5 parallel Explore subagents
+### Step 2: Launch 3–5 parallel Explore subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Read the task description: if $2 is provided and non-empty, read the file at that path.
 

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -53,6 +53,7 @@ file to `$3/refine_contexts/{phase_id}_result.json`.
 - Write L0 prompts to intermediate `l0_prompts/` files and read them back into the L1 context — spawn L0 subagents directly from in-memory context packets
 - Read source code files, test files, or recipe YAML files directly — codebase exploration is the L0 subagents' responsibility
 - Run Bash, Grep, or Glob commands for codebase exploration between L0 spawns
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -63,6 +64,7 @@ file to `$3/refine_contexts/{phase_id}_result.json`.
 - Log `CRITICAL` to stdout for any L0 subagent that fails entirely (proceed with N-1, partial result)
 - When two assignments propose WPs covering the same files, assign ownership to the numerically earlier assignment_id using natural sort on numeric suffixes (e.g. `P1-A1` beats `P1-A2`; `P1-A2` beats `P1-A10`); log each resolution
 - Emit: `phase_refined_path = <absolute path to $3/refine_contexts/{phase_id}_result.json>`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -111,7 +113,11 @@ For each assignment in `assignments`, build a context packet containing:
 - `task_file_path` — the path to the task description on disk (pass the path reference only; do NOT read the task text into the L1 context or embed it in the L0 prompt)
 - Instructions: review the target assignment in light of peer_summaries; always read the task from disk at `task_file_path` for scope creep verification (flag scope creep if the assignment's goal, scope, or deliverables introduce work not requested by the task); return structured suggestions only — do NOT edit files
 
-### Step 3: Spawn parallel L0 subagents
+### Step 3: Spawn parallel L0 subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Since each phase has 3–5 assignments (always within the 6-L0 ceiling), spawn all in one
 parallel batch via Agent/Task. Do not spawn more than 6 L0s in a single parallel batch:

--- a/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
@@ -43,6 +43,7 @@ conflicts, applies field-level edits to the plan, and writes `refined_plan.json`
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Spawn more than 6 L0s in a single parallel batch
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -52,6 +53,7 @@ conflicts, applies field-level edits to the plan, and writes `refined_plan.json`
 - Log `CRITICAL` to stdout for any L0 subagent that fails entirely (proceed with N-1)
 - Log each conflict resolution to stdout before applying it
 - Emit: `refined_plan_path = <absolute path to refined_plan.json>`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -82,7 +84,11 @@ Input schema (PlanDocument with PhaseElaborated phases):
 }
 ```
 
-### Step 2: Spawn parallel L0 subagents
+### Step 2: Spawn parallel L0 subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Read the `task` field from the combined plan document. Each L0 subagent reviewing a phase
 must verify that the phase's goal and scope serve the stated task. Phases that appear to

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -48,6 +48,7 @@ directory.
 - Spawn one L0 per WP — L0s operate per PHASE
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -58,6 +59,7 @@ directory.
 - Log `CRITICAL` to stdout for any L0 subagent that fails entirely (proceed with N-1 suggestions)
 - When two WPs claim the same deliverable file, assign ownership to the WP with the numerically earlier ID using natural sort (e.g., `P1-A1-WP1` beats `P2-A1-WP1`)
 - Emit: `phase_wp_refined_path = <absolute path to $3/wp_refine_contexts/{phase_id}_result.json>`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -126,7 +128,11 @@ For each phase (one context file = one phase), build a context packet containing
 - Instructions: review this phase's WPs against peer stubs; return structured suggestions only — do NOT edit files
 - Use `overlap_notes` from the PhaseElaborated entry as a prior signal for subsumption detection
 
-### Step 3: Spawn parallel L0 subagents
+### Step 3: Spawn parallel L0 subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 If phase count ≤ 6: spawn all in one parallel batch via Agent/Task.
 If phase count > 6: spawn sequential batches of 6. Between batches, emit

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -34,6 +34,7 @@ zero findings.
 - Read files not passed as arguments
 - Modify input files
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 - Write, Edit, or use file-modifying Bash commands (sed -i, echo >, tee) on any file outside the planner output directory ($AUTOSKILLIT_ALLOWED_WRITE_PREFIX). Source code files must NEVER be modified.
 
@@ -42,6 +43,7 @@ zero findings.
 - Compare every phase goal and every WP description against the task
 - Write `$3/task_alignment.json` with findings array
 - Emit: `alignment_findings_path = <absolute path to task_alignment.json>`; also emit `alignment_finding_count`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -52,7 +54,11 @@ Read `refined_wps.json` from $1 and `refined_plan.json` from $2. Extract:
 - All phase `goal` and `scope` fields from $2
 - All WP `name`, `deliverables`, and `acceptance_criteria` fields from $1
 
-### Step 2: Spawn alignment-check subagents
+### Step 2: Spawn alignment-check subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn 1-2 subagents (model: "sonnet"):
 

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -91,7 +91,7 @@ Generate timestamp `ts` from the bash block above.
 
 ### Step 2: Extract PR Title from Plans
 
-Read all plan files. For each, extract the first `# ` heading line, strip the `# ` prefix,
+Read all plan files and extract the first `# ` heading line from each, strip the `# ` prefix,
 and strip any trailing `— PART [A-Z] ONLY` suffix.
 
 - **Single plan:** Use the heading directly as `task_title`.

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -39,10 +39,12 @@ in the decomposed PR flow (prepare → run_arch_lenses → compose).
 - Create files outside `{{AUTOSKILLIT_TEMP}}/prepare-pr/`
 - Fail if closing_issue is absent or gh is unavailable — degrade gracefully
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Emit all three output tokens (`prep_path`, `selected_lenses`, `lens_context_paths`)
 - Classify changed files as new (★) vs modified (●)
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -125,7 +127,11 @@ git diff --diff-filter=M --name-only $BASE_BRANCH..$FEATURE_BRANCH  # modified_f
 
 Store as separate lists: `new_files` (added, ★) and `modified_files` (modified, ●).
 
-### Step 5: Select Arch-Lens Slugs
+### Step 5: Select Arch-Lens Slugs (SINGLE MESSAGE)
+
+**Issue ALL Task/Explore subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn a subagent (Task tool, model: sonnet) with the list of changed file paths and the
 following lens menu:

--- a/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
@@ -39,11 +39,13 @@ Does NOT invoke any exp-lens skills or create a PR.
 - Create files outside `{{AUTOSKILLIT_TEMP}}/prepare-research-pr/` (relative to the current working directory)
 - Fail silently — always emit all three output tokens as your final output
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use Agent subagents (not slash commands) for reading and synthesis
 - Emit `prep_path`, `selected_lenses`, and `lens_context_paths` as your final output
 - Write all output paths as absolute paths
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Lens Selection Table
 
@@ -91,7 +93,11 @@ Create temp directory:
 
 Generate a timestamp `ts` (format: `YYYY-MM-DD_HHMMSS`) for unique file naming.
 
-### Step 1: Read report via Agent subagent
+### Step 1: Read report via Agent subagent (SINGLE MESSAGE)
+
+**Issue ALL Task/Explore subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn an **Explore** subagent to read `{report_path}` and extract:
 - Executive summary

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -35,6 +35,7 @@ issues upfront, load recipe, execute session, collect result, report.
 - Reimplement recipe steps inline — always use `load_recipe` to load the recipe YAML and
   follow it as an orchestrator
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Process batches in ascending order: batch 1 before batch 2 before batch 3
@@ -57,6 +58,7 @@ issues upfront, load recipe, execute session, collect result, report.
 - Emit `---process-issues-result---` result block on completion (success or failure)
 - Write the summary report to `{{AUTOSKILLIT_TEMP}}/process-issues/` (relative to the current working directory)
 - Use `model: "sonnet"` when spawning subagents via the Task tool
+- Issue all Task calls in a single message to maximize parallelism
 - Use `gh` CLI for all GitHub operations (not raw API calls)
 - Include `--force` in all `gh label create` calls
 

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -44,9 +44,11 @@ and creates a comprehensive promotion PR.
 - Use the Bash tool for file reads — use Read, Grep, Glob for all codebase inspection
 - Use `gh pr create --body` inline — always use `--body-file`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Run ALL pre-flight checks before any analysis work
+- Issue all Task calls in a single message to maximize parallelism
 - Check `gh auth status` before any GitHub operations
 - Output `pr_url = <url>` as a structured token (empty string when GitHub unavailable or dry-run)
 - Output `verdict = <value>` as a structured token
@@ -162,7 +164,11 @@ EOF
   contents and embed it in the PR body under `## Token Usage Summary`.
 - If empty or absent (standalone invocation, no pipeline sessions in this cwd), omit this section.
 
-### Phase 1: Pre-flight Checks (parallel, blocking)
+### Phase 1: Pre-flight Checks (parallel, blocking) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn three parallel Task subagents (model: sonnet) to validate promotion readiness.
 All three must pass before analysis proceeds. If any fails, report the failure clearly

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -41,6 +41,7 @@ Do not change any code.
 - Suggest backward compatibility shims
 - Create files outside `{{AUTOSKILLIT_TEMP}}/rectify/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents for parallel exploration
@@ -49,6 +50,7 @@ Do not change any code.
 - Identify how tests missed the issue and similar/related bugs
 - Map the components and their connections thoroughly
 - Write the plan as markdown to `{{AUTOSKILLIT_TEMP}}/rectify/` directory (relative to the current working directory)
+- Issue all Task calls in a single message to maximize parallelism
 - After writing the plan file, emit the **absolute path** as a structured output token
   as your final output. The save path is relative (`{{AUTOSKILLIT_TEMP}}/rectify/...`) but
   the token **must** use the absolute path (prepend the full CWD):
@@ -74,7 +76,11 @@ exist (e.g., plan file arguments, `{{AUTOSKILLIT_TEMP}}/investigate/` reports, e
 `Glob` or `ls` to confirm the path exists first. This prevents ENOENT errors that cascade into
 sibling parallel-call cancellations.
 
-### Step 2: Deep Exploration with Subagents
+### Step 2: Deep Exploration with Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch parallel subagents to investigate (some of the listed aspects may require multiple subagents):
 

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -48,6 +48,7 @@ Called by the research recipe when `audit_claims` routes `changes_requested` via
 - Modify tests to suppress failures introduced by reviewer fixes
 - Use file-path-segment grouping — claim comments are grouped by **dimension**, not by file path
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not a hardcoded number)
@@ -55,6 +56,7 @@ Called by the research recipe when `audit_claims` routes `changes_requested` via
 - Run intent validation BEFORE making any code changes
 - Gracefully degrade (exit 0, report skip) if `gh` is unavailable or no PR is found
 - Report a structured summary including escalation count
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Configuration
 
@@ -201,7 +203,11 @@ findings in `audit-claims`.
 
 Save `dimension_groups_{pr}.json` with findings keyed by group.
 
-### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes)
+### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before applying any fix, validate every critical and warning finding against the actual
 codebase and git history. This analysis phase runs entirely before code changes are made.

--- a/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
@@ -41,11 +41,13 @@ MCP-only — not user-invocable directly.
 - Modify the evaluation dashboard, experiment plan, or any source file
 - Apply fixes — this skill triages fixability only
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Exit 0 in all cases — resolution=revised and resolution=failed are both normal outcomes
 - Emit revision_guidance ONLY when resolution=revised
 - Use model: "sonnet" for all subagents
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -74,7 +76,11 @@ abandoning the partial triage.
    - Extract red_team critical findings
    - If no findings parseable: treat all as DISCUSS → emit resolution=revised with generic guidance; add a `> **Warning:** dashboard could not be parsed — falling back to generic guidance` annotation at the top of the revision_guidance file so the parse failure is visible in pipeline logs
 
-### Step 1: Feasibility Validation (Parallel Subagents — BEFORE any guidance is written)
+### Step 1: Feasibility Validation (Parallel Subagents — BEFORE any guidance is written) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 This is the analysis phase. It runs entirely before any guidance is generated.
 

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -47,6 +47,7 @@ Bounded by `retries: 2` — on exhaustion routes to `research_complete`.
 - Modify tests to suppress failures introduced by reviewer fixes
 - Use file-path-segment grouping — research comments are grouped by **dimension**, not by file path
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not a hardcoded number)
@@ -54,6 +55,7 @@ Bounded by `retries: 2` — on exhaustion routes to `research_complete`.
 - Run intent validation BEFORE making any code changes
 - Gracefully degrade (exit 0, report skip) if `gh` is unavailable or no PR is found
 - Report a structured summary including escalation count
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -182,7 +184,11 @@ Apply `DIMENSION_PATTERN` to each comment body to extract the dimension label.
 
 Save `dimension_groups_{pr}.json` with findings keyed by group.
 
-### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes)
+### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before applying any fix, validate every critical and warning finding against the actual
 codebase and git history. This analysis phase runs entirely before code changes are made.

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -47,6 +47,7 @@ branch already checked out.
 - Delete or discard the working directory on failure
 - Modify tests to suppress failures introduced by reviewer fixes
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not a hardcoded number)
@@ -58,6 +59,7 @@ branch already checked out.
 - Report a structured summary: findings fetched, fixes applied, fixes skipped (with reasons)
 - **Read before editing**: Before issuing an `Edit` call on any file, ensure you have issued a `Read` on that file earlier in this session. Claude Code rejects `Edit` on unread files — the retry wastes a full API turn at current context size. If you are uncertain whether a file was read, issue a targeted `Read` (offset + limit to the region you plan to edit) rather than risk an error.
 - **CWD awareness**: Before running `python3` or other interpreters, verify your current working directory is the worktree root (not the orchestrator's project root). Use absolute paths for imports or `cd` to the worktree first. A wrong-CWD import error wastes a full API turn.
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -341,7 +343,11 @@ When a finding matches multiple tiers, use the highest severity.
 
 Critical and warning findings proceed to intent validation (Step 3.5). Info findings are classified with `verdict="INFO"` — they do not enter Step 3.5. Only `ACCEPT`, `REJECT`, and `DISCUSS` verdicts are assigned by Step 3.5 sub-agents; `INFO` is assigned at classification time.
 
-### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes)
+### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before applying any fix, validate every critical and warning finding against the actual
 codebase and git history. This analysis phase runs entirely before code changes are made.

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -45,6 +45,7 @@ Continue implementing a plan in an **existing** git worktree. This skill is used
 - Pipe test output through `tail`, `head`, or other truncation commands — `tail -N` buffers the entire stream and produces no output if the process is killed before EOF
 - Default to `main` as the base branch — always discover it from git's upstream structure or the explicit base-branch store file
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use the provided worktree path (do NOT create a new one)
@@ -54,6 +55,7 @@ Continue implementing a plan in an **existing** git worktree. This skill is used
 - Run the project's test suite from the worktree directory
 - Rebase onto base branch before completion (ready for squash-and-merge)
 - **Read files fully**: When reading a file to understand it in full, read it in a single call without a `limit` parameter. Do not paginate files with sequential offset reads — read once completely. Use `limit`/`offset` only for targeted section reads of files you have already read in full.
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -141,7 +143,11 @@ Then assess what has been implemented:
    - Which phase is partially complete
    - Which phases haven't started
 
-### Step 2: Targeted Exploration (Only If Needed)
+### Step 2: Targeted Exploration (Only If Needed) (SINGLE MESSAGE)
+
+**Issue ALL Task/Explore subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Only explore systems related to the **remaining** phases. Do NOT re-explore already-completed work. Use Explore subagents for:
 - Files that will be modified in remaining phases

--- a/src/autoskillit/skills_extended/review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/review-approach/SKILL.md
@@ -29,6 +29,7 @@ Research modern solutions, approaches, and strategies relevant to the issues or 
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/review-approach/` directory
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use subagents with web search for parallel research
@@ -45,6 +46,7 @@ Research modern solutions, approaches, and strategies relevant to the issues or 
   review_path = /absolute/cwd/temp/review-approach/{filename}.md
   ```
   This token is MANDATORY — the pipeline cannot proceed without it.
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -52,7 +54,11 @@ Research modern solutions, approaches, and strategies relevant to the issues or 
 
 From the report, plan, or conversation context, identify the core problems and proposed features that need external research. Break them into distinct research topics.
 
-### Step 2: Launch Parallel Web Search Subagents
+### Step 2: Launch Parallel Web Search Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn general-purpose subagents (with web search) for each research topic. Each subagent should investigate:
 

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -50,9 +50,11 @@ best available plan.
 - Include code snippets, shell commands, or specific tool invocations in findings or revision guidance — findings describe gaps and risks, not implementation instructions
 - Prescribe HOW to fix an issue — findings must describe WHAT is lacking or at risk; the fix is the plan author's responsibility
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/review-design/` (relative to the current working directory)
 - After writing output files, emit the **absolute paths** as structured output tokens
   as your final output. Resolve relative save paths to absolute by prepending
@@ -254,7 +256,11 @@ Do NOT evaluate:
 If a code snippet in the plan reveals a design-level concern (e.g., the metric definition
 contradicts the hypothesis), flag the design concern, not the code bug.
 
-### Step 2: Level 1 Analysis — Fail-Fast (parallel)
+### Step 2: Level 1 Analysis — Fail-Fast (parallel) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Two subagents run in parallel. Both are always H-weight; severity thresholds are calibrated per experiment_type via the rubric below.
 

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -47,6 +47,7 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 - Review files outside the PR diff — scope all audit to diff content only
 - Modify any source code
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not from a pre-captured URL)
@@ -56,6 +57,7 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 - Tag the authenticated GitHub user (`gh api user -q .login`) in escalation comments (`needs_human` verdict) — omit the mention silently if username derivation fails
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Deduplicate findings by (file, line) pairs before posting
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -297,17 +299,18 @@ standard agents — this is the graceful-degradation fallback that preserves cur
 Note: Dimension 7 (the deletion regression audit) is NOT part of the dispatch plan — it remains
 unconditionally gated on `deletion_context` being non-null (unchanged from current behavior).
 
-### Step 3: Run Parallel Audit Subagents
+### Step 3: Run Parallel Audit Subagents (SINGLE MESSAGE)
 
-Spawn parallel subagents (Task tool, model: sonnet) for each audit dimension listed in
-`DISPATCH_AGENTS`. If `DISPATCH_AGENTS` is non-empty, spawn ONLY the dimensions it lists.
-If `DISPATCH_AGENTS` is empty, spawn all 6 standard dimensions (1-6).
+Parse `DISPATCH_AGENTS` (comma-separated string) into a list. If `DISPATCH_AGENTS` is
+non-empty, use ONLY the dimensions it lists. If empty, use all 6 standard dimensions (1-6).
 
-Parse `DISPATCH_AGENTS` (comma-separated string) into a list. For each dimension name in
-the list, spawn the corresponding subagent using the prompt template below.
+**Issue ALL Task tool calls in a single message — one per dimension — so they execute
+in parallel. Do NOT iterate through dimensions across multiple turns.**
 
-Each subagent receives only the PR diff content (not the full codebase) and returns
-findings in JSON format:
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
+
+Each subagent (model: sonnet) receives only the PR diff content (not the full codebase) and
+returns findings in JSON format:
 
 ```json
 [

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -46,9 +46,11 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
 - Flag the absence of a clear experimental conclusion as a deficiency — inconclusive
   results are valid outcomes for research PRs (do not flag them)
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not from a pre-captured URL)
+- Issue all Task calls in a single message to maximize parallelism
 - Output `verdict=` on the final line
 - Exit 0 in all normal cases; verdict drives recipe routing via on_result, not exit code
 - Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation has already output verdict=approved)
@@ -126,7 +128,11 @@ fi
 new-file line numbers present in the diff. When available, Step 4 uses set-membership for
 validation. `VALID_LINE_RANGES` is used as fallback for interval checking.
 
-### Step 3: Run Parallel Audit Subagents
+### Step 3: Run Parallel Audit Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn parallel subagents (Task tool, model: sonnet) for each research audit dimension.
 Each subagent receives only the PR diff content (not the full codebase) and returns

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -52,11 +52,13 @@ plan, executes what the plan describes, and reports what happened.
 - Assume what kind of experiment this is — read the plan and follow it
 - Commit files under `{{AUTOSKILLIT_TEMP}}/` — this directory is gitignored working space, NOT for version control. Do not use `git add -f` or `git add --force` to bypass the gitignore.
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Write results to `{{AUTOSKILLIT_TEMP}}/run-experiment/` in the worktree (disk only, never committed)
 - Report failures with enough detail for the `--adjust` retry to fix them
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Context Limit Behavior
 
@@ -84,7 +86,11 @@ Also scan the worktree for experiment-related files:
 
 Understand what the experiment requires before attempting to run anything.
 
-### Step 2 — Pre-flight Check
+### Step 2 — Pre-flight Check (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before running the experiment:
 1. Verify the project builds or that prerequisites are met.

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -50,12 +50,14 @@ text is supplementary context.
 - Skip the prior art survey — always check what already exists in the codebase
 - Fabricate research findings when external sources return no results — if web searches or literature searches yield nothing, state that explicitly and note what the codebase evidence shows instead
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Write output to `{{AUTOSKILLIT_TEMP}}/scope/` directory
 - Clearly separate facts (what the code does) from hypotheses (what might be true)
 - Include a known/unknown matrix in the output
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -65,7 +67,11 @@ text is supplementary context.
 2. If a GitHub issue reference is detected, fetch it via `fetch_github_issue`.
 3. Create the output directory: `mkdir -p {{AUTOSKILLIT_TEMP}}/scope/`
 
-### Step 1 — Parallel Exploration
+### Step 1 — Parallel Exploration (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch subagents via the Task tool (model: "sonnet") to explore in parallel.
 You **must launch at least 5 subagents**. Select from the suggested menu below,

--- a/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
+++ b/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
@@ -40,10 +40,12 @@ consumption. Does NOT invoke the vis-lens skills — that is handled by the
 - Fabricate lens recommendations or validation conclusions not supported by the data — report what the experiment plan and scope show, not what you assume they should show
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Invoke vis-lens skills — that belongs to the `run_vis_lenses` recipe step
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Write a vis-lens context file for each selected lens before emitting tokens
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -43,6 +43,7 @@ Explore a target project and generate tailored recipes and AutoSkillit config th
 - Include install instructions or "Getting Started" sections — user is already running the skill
 - Hardcode `base_branch = main` — detect the current branch
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Read the target project using Glob, Read, and Grep — no shell commands against target
@@ -51,6 +52,7 @@ Explore a target project and generate tailored recipes and AutoSkillit config th
 - Present candidate workflows one by one for user approval before generating scripts
 - Show a summary confirmation gate before writing anything to disk
 - Use the two-directory model (project_dir + work_dir) in generated recipes
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -76,7 +78,11 @@ Then prompt the user:
 
 Store the answer for Step 1.
 
-### Step 1: Explore Target Project (Parallel Subagents)
+### Step 1: Explore Target Project (Parallel Subagents) (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch parallel Explore subagents against `project_dir`. If the user opted into history mining, include Subagent E in the same parallel launch:
 

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -49,6 +49,7 @@ compute on doomed downloads.
 - Write files outside `{{AUTOSKILLIT_TEMP}}/stage-data/`
 - Emit a WARN or FAIL verdict without a specific, actionable explanation
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Read the `data_manifest` frontmatter section of the experiment plan
@@ -59,6 +60,7 @@ compute on doomed downloads.
   using `mkdir -p`
 - Write the resource feasibility report before emitting the verdict token
 - Use `model: "sonnet"` for all subagents
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 
@@ -75,7 +77,11 @@ Create any data directories for entries with non-null `location`. Emit
 `verdict = PASS` and exit. This covers plans containing only `synthetic`,
 `fixture`, `literature`, `database`, or `wet_lab` source types.
 
-### Step 3 — Launch Parallel Resource Probe Subagents
+### Step 3 — Launch Parallel Resource Probe Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Launch parallel subagents — one per `external`/`gitignored` entry — each
 performing:

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -37,9 +37,11 @@ Analyze open GitHub issues, classify each into a recipe route, group them into p
 - Use `--body` shell substitution (`--body "$(...)`) for `gh issue edit` — always write to
   `{{AUTOSKILLIT_TEMP}}/triage-issues/edit_body_{timestamp}.md` and use `--body-file`
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Issue all Task calls in a single message to maximize parallelism
 - Pause for human input on ambiguous classifications
 - Write the triage report and manifest to `{{AUTOSKILLIT_TEMP}}/triage-issues/` (relative to the current working directory)
 - Use `gh` CLI for all GitHub operations (not raw API calls)
@@ -79,7 +81,11 @@ If `gh auth status` fails, abort with a clear error message.
 
 If there are zero open issues (after filtering), skip to Step 7 and output an empty report.
 
-### Step 2a: Parallel Split Analysis
+### Step 2a: Parallel Split Analysis (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Before codebase analysis, run `issue-splitter` for every open issue to detect mixed-concern issues and expand the working set.
 

--- a/src/autoskillit/skills_extended/verify-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/verify-diag/SKILL.md
@@ -29,12 +29,14 @@ Verify an architecture diagram's factual accuracy against the actual codebase. A
 - Modify source code files
 - Modify the diagram during verification (report findings only)
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Verify every named component exists in the codebase
 - Trace actual code paths for every connection
 - Determine read/write directionality for every connection
 - Report findings to terminal, not to files
+- Issue all Task calls in a single message to maximize parallelism
 
 ---
 
@@ -204,7 +206,11 @@ Common patterns and how to represent them:
 
 ---
 
-## Launching Verification
+## Launching Verification (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn one Explore subagent per diagram. Each agent:
 1. Reads the full diagram file

--- a/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
@@ -101,6 +101,7 @@ metadata:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-chart-select/`
 - Use `radar` or `pie` chart types — these are perceptually inferior and excluded from the controlled vocabulary
+- Run subagents in the background (`run_in_background: true` is prohibited)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
@@ -101,6 +101,7 @@ metadata:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-chart-select/`
 - Use `radar` or `pie` chart types — these are perceptually inferior and excluded from the controlled vocabulary
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Apply the Cleveland-McGill perceptual hierarchy when ranking chart alternatives: **position > length > angle > area > color saturation > color hue**
@@ -109,6 +110,7 @@ metadata:
 - Use colorblind-safe palettes (wong, okabe-ito, viridis, cividis)
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
+- Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/vis-lens-chart-select/vis_spec_chart_select_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
@@ -129,7 +131,11 @@ arg 2 (experiment_plan_path) is provided and exists, read the experiment plan fo
 methodology. Use this structured context as the foundation for Steps 1–4; skip the CWD
 exploration for these fields if the context file supplies them.
 
-### Step 1: Parallel Exploration
+### Step 1: Parallel Exploration (SINGLE MESSAGE)
+
+**Issue ALL Explore/Task subagent calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
+
+Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Spawn parallel exploration tasks to investigate:
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -117,3 +117,26 @@ def extract_never_block(skill_text: str) -> str:
     block = skill_text[start:end]
     lines = [line for line in block.splitlines() if line.strip().startswith("- ")]
     return "\n".join(lines)
+
+
+def extract_always_block(skill_text: str) -> str:
+    """Extract the ALWAYS block from a SKILL.md text.
+
+    Finds the line starting with **ALWAYS:** or **ALWAYS** and collects all
+    subsequent ``- `` list items until the next ``**`` header or end of text.
+    Returns the raw text of the ALWAYS block (may be empty string if not found).
+    """
+    import re
+
+    always_match = re.search(r"(?m)^\*\*ALWAYS(?::\*\*|\*\*)\s*$", skill_text)
+    if not always_match:
+        return ""
+    start = always_match.end()
+    next_header = re.search(r"(?m)^\*\*[A-Z][^\n]*\*\*", skill_text[start:])
+    if next_header:
+        end = start + next_header.start()
+    else:
+        end = len(skill_text)
+    block = skill_text[start:end]
+    lines = [line for line in block.splitlines() if line.strip().startswith("- ")]
+    return "\n".join(lines)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 
 
@@ -103,7 +104,6 @@ def extract_never_block(skill_text: str) -> str:
     subsequent ``- `` list items until the next ``**`` header or end of text.
     Returns the raw text of the NEVER block (may be empty string if not found).
     """
-    import re
 
     never_match = re.search(r"(?m)^\*\*NEVER(?::\*\*|\*\*)\s*$", skill_text)
     if not never_match:
@@ -126,7 +126,6 @@ def extract_always_block(skill_text: str) -> str:
     subsequent ``- `` list items until the next ``**`` header or end of text.
     Returns the raw text of the ALWAYS block (may be empty string if not found).
     """
-    import re
 
     always_match = re.search(r"(?m)^\*\*ALWAYS(?::\*\*|\*\*)\s*$", skill_text)
     if not always_match:

--- a/tests/contracts/test_no_pagination_file_read.py
+++ b/tests/contracts/test_no_pagination_file_read.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._helpers import extract_always_block
+
 SKILLS_ROOT = (
     Path(__file__).resolve().parent.parent.parent / "src" / "autoskillit" / "skills_extended"
 )
@@ -22,18 +24,9 @@ def skill_text(request: pytest.FixtureRequest) -> str:
     return path.read_text()
 
 
-def _extract_always_block(text: str) -> str:
-    """Extract the ALWAYS block from Critical Constraints, or "" if absent."""
-    always_idx = text.find("**ALWAYS:**")
-    if always_idx == -1:
-        return ""
-    next_section = text.find("\n## ", always_idx)
-    return text[always_idx:next_section] if next_section != -1 else text[always_idx:]
-
-
 def test_no_pagination_instruction_present(skill_text: str) -> None:
     """The ALWAYS block must contain the no-pagination file read instruction."""
-    always_block = _extract_always_block(skill_text)
+    always_block = extract_always_block(skill_text)
     assert "single call without a `limit` parameter" in always_block, (
         "ALWAYS block must instruct reading files in a single call without limit"
     )
@@ -41,7 +34,7 @@ def test_no_pagination_instruction_present(skill_text: str) -> None:
 
 def test_no_pagination_instruction_prohibits_sequential_offset(skill_text: str) -> None:
     """The instruction must explicitly prohibit sequential offset reads."""
-    always_block = _extract_always_block(skill_text)
+    always_block = extract_always_block(skill_text)
     assert "Do not paginate" in always_block, (
         "ALWAYS block must explicitly prohibit paginated sequential offset reads"
     )
@@ -49,7 +42,7 @@ def test_no_pagination_instruction_prohibits_sequential_offset(skill_text: str) 
 
 def test_no_pagination_instruction_permits_targeted_reads(skill_text: str) -> None:
     """The instruction must permit targeted limit/offset for known files."""
-    always_block = _extract_always_block(skill_text)
+    always_block = extract_always_block(skill_text)
     assert "targeted section reads" in always_block, (
         "ALWAYS block must permit limit/offset for targeted reads of already-read files"
     )

--- a/tests/skills/test_review_pr_adaptive_dispatch_guards.py
+++ b/tests/skills/test_review_pr_adaptive_dispatch_guards.py
@@ -43,3 +43,21 @@ def test_full_fanout_for_medium_and_large():
     text = _skill_text()
     for agent in ["arch", "tests", "defense", "bugs", "cohesion", "slop"]:
         assert agent in text
+
+
+def test_step3_requires_single_message_dispatch():
+    """Step 3 must contain explicit single-message parallel dispatch instruction."""
+    import re
+
+    text = _skill_text()
+    step_blocks = re.split(r"(?m)^#{1,3}\s+Step\s+\d+", text)
+    step3_blocks = [
+        b
+        for b in step_blocks
+        if "DISPATCH_AGENTS" in b and ("spawn" in b.lower() or "task tool" in b.lower())
+    ]
+    assert step3_blocks, "Could not locate Step 3 (dispatch step) in review-pr SKILL.md"
+    assert any("single message" in b.lower() for b in step3_blocks), (
+        "review-pr/SKILL.md Step 3 must contain 'single message' dispatch "
+        "instruction to prevent sequential subagent dispatch"
+    )

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -23,7 +23,7 @@ from autoskillit.recipe.rules.rules_skill_content import (
     _extract_subsections,
 )
 from autoskillit.workspace.skills import DefaultSkillResolver
-from tests._helpers import extract_always_block
+from tests._helpers import extract_always_block, extract_never_block
 from tests.contracts._anti_fab_helpers import FABRICATION_GUARD_RE
 
 _SKILLS_DIRS = [pkg_root() / "skills", pkg_root() / "skills_extended"]
@@ -234,7 +234,6 @@ def _check_parallel_dispatch_reinforcement(skill_text: str) -> list[str]:
     2. ALWAYS block requires single-message dispatch
     3. Step body containing spawn language includes single-message instruction
     """
-    from tests._helpers import extract_never_block
 
     violations: list[str] = []
 
@@ -412,7 +411,6 @@ _FABRICATION_GUARD_RE = FABRICATION_GUARD_RE
 @pytest.mark.parametrize("skill_dir", _all_skill_dirs(), ids=lambda d: d.name)
 def test_all_skills_have_anti_fabrication_guard(skill_dir: Path) -> None:
     """Every skill with a NEVER block must include anti-fabrication language."""
-    from tests._helpers import extract_never_block
 
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.exists():
@@ -497,7 +495,6 @@ _ANTI_BLAME_RE = re.compile(r"(?i)\bblame\b.*\bpre-existing\b")
 def test_implement_skills_have_anti_blame_prohibition(skill_dir: Path) -> None:
     """All implement-* and retry-* skills must have the anti-blame
     prohibition in their NEVER block."""
-    from tests._helpers import extract_never_block
 
     text = (skill_dir / "SKILL.md").read_text()
     never_block = extract_never_block(text)
@@ -558,8 +555,8 @@ Spawn parallel subagents (Task tool) for each item in the list.
 For each item, spawn the corresponding subagent.
 """
     violations = _check_parallel_dispatch_reinforcement(missing_reinforcement)
-    assert len(violations) >= 1, (
-        "Detector failed to catch missing single-message dispatch reinforcement"
+    assert len(violations) == 3, (
+        f"Expected 3 violations (one per layer), got {len(violations)}: {violations}"
     )
 
 

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -185,8 +185,16 @@ def _check_loop_boundary(skill_text: str) -> list[str]:
             if not any(p.search(line) for p in _LOOP_HEADER_PATTERNS):
                 continue
 
-            # Extract loop body: from this line to next step header or end
-            loop_body = "\n".join(lines[line_idx:])
+            # Extract loop body: from this line to next sub-heading or end.
+            # Stop at #### or ### sub-headers so tool mentions in unrelated
+            # sections of the same step block aren't attributed to this loop.
+            remaining_lines = lines[line_idx:]
+            loop_end = len(remaining_lines)
+            for k, rl in enumerate(remaining_lines):
+                if k > 0 and re.match(r"^#{3,4}\s+", rl):
+                    loop_end = k
+                    break
+            loop_body = "\n".join(remaining_lines[:loop_end])
 
             # Check if loop body contains tool invocations
             has_tool = any(p.search(loop_body) for p in _LOOP_TOOL_PATTERNS)

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -23,6 +23,7 @@ from autoskillit.recipe.rules.rules_skill_content import (
     _extract_subsections,
 )
 from autoskillit.workspace.skills import DefaultSkillResolver
+from tests._helpers import extract_always_block
 from tests.contracts._anti_fab_helpers import FABRICATION_GUARD_RE
 
 _SKILLS_DIRS = [pkg_root() / "skills", pkg_root() / "skills_extended"]
@@ -60,6 +61,10 @@ _LOOP_TOOL_PATTERNS = [
     re.compile(r"(?i)merge_worktree\b"),
     re.compile(r"(?i)run_cmd\b"),
     re.compile(r"(?i)run_python\b"),
+    re.compile(r"(?i)\bspawn\b.*\bsubagent\b"),
+    re.compile(r"(?i)\blaunch\b.*\bsubagent\b"),
+    re.compile(r"(?i)\bTask\s+tool\b"),
+    re.compile(r"(?i)\bAgent\s+tool\b"),
 ]
 
 # Patterns that detect anti-prose guard instructions in loop prologues
@@ -68,7 +73,20 @@ _ANTI_PROSE_GUARD_PATTERNS = [
     re.compile(r"(?i)immediately\s+(?:begin|proceed|start)\b.*\bnext"),
     re.compile(r"(?i)no\s+(?:prose|text|status)\s+(?:between|output)"),
     re.compile(r"(?i)do\s+not\s+emit\s+(?:any\s+)?(?:prose|text|status)"),
+    re.compile(r"(?i)single\s+(?:message|batch)"),
+    re.compile(r"(?i)do\s+not\s+iterate.*(?:turns?|messages?)"),
 ]
+
+# Patterns for three-layer parallel dispatch reinforcement detection
+_PARALLEL_DISPATCH_NEVER_RE = re.compile(
+    r"(?i)sequentially.*single.*message|single.*parallel.*message",
+)
+_PARALLEL_DISPATCH_ALWAYS_RE = re.compile(
+    r"(?i)single\s+message",
+)
+_PARALLEL_DISPATCH_STEP_RE = re.compile(
+    r"(?i)single\s+(?:message|batch)|SINGLE\s+MESSAGE",
+)
 
 # Skills whose narration suppression is handled globally by _inject_narration_suppression()
 # in build_skill_session_cmd() (headless path) and sous-chef/SKILL.md (cook path).
@@ -192,6 +210,44 @@ def _check_loop_boundary(skill_text: str) -> list[str]:
                     f"Step block {block_idx}: loop '{loop_preview}' contains "
                     f"tool invocations but has no anti-prose guard instruction"
                 )
+
+    return violations
+
+
+def _check_parallel_dispatch_reinforcement(skill_text: str) -> list[str]:
+    """Check for missing three-layer single-message dispatch reinforcement.
+
+    Returns a list of violation descriptions (empty if compliant).
+    For skills that spawn parallel subagents, all three layers must be present:
+    1. NEVER block prohibits sequential dispatch
+    2. ALWAYS block requires single-message dispatch
+    3. Step body containing spawn language includes single-message instruction
+    """
+    from tests._helpers import extract_never_block
+
+    violations: list[str] = []
+
+    never_block = extract_never_block(skill_text)
+    always_block = extract_always_block(skill_text)
+
+    if not _PARALLEL_DISPATCH_NEVER_RE.search(never_block):
+        violations.append(
+            "NEVER block does not prohibit sequential dispatch "
+            "(expected: 'sequentially...single...message' or 'single...parallel...message')"
+        )
+
+    if not _PARALLEL_DISPATCH_ALWAYS_RE.search(always_block):
+        violations.append(
+            "ALWAYS block does not require single-message dispatch (expected: 'single message')"
+        )
+
+    step_blocks = re.split(r"(?m)^#{1,3}\s+Step\s+\d+", skill_text)
+    spawning_steps = [b for b in step_blocks if _SPAWN_INDICATOR_RE.search(b)]
+    if spawning_steps and not any(_PARALLEL_DISPATCH_STEP_RE.search(b) for b in spawning_steps):
+        violations.append(
+            "No step block containing spawn language has a single-message dispatch instruction "
+            "(expected: 'single message' or 'single batch' in a step with subagent spawning)"
+        )
 
     return violations
 
@@ -465,3 +521,104 @@ def test_reviews_post_requires_input_flag(skill_dir: Path) -> None:
                 f"JSON arrays as string literals, causing HTTP 422. "
                 f"Use: jq -n ... | gh api .../reviews --method POST --input -"
             )
+
+
+# --- Fixture-based tests for parallel dispatch reinforcement detector ---
+
+
+def test_detector_catches_missing_reinforcement() -> None:
+    """Verify _check_parallel_dispatch_reinforcement detects missing layers."""
+    missing_reinforcement = """\
+---
+name: example-skill
+---
+
+**NEVER:**
+- Fabricate information
+
+**ALWAYS:**
+- Do something useful
+
+## Workflow
+
+### Step 1: Launch Subagents
+
+Spawn parallel subagents (Task tool) for each item in the list.
+For each item, spawn the corresponding subagent.
+"""
+    violations = _check_parallel_dispatch_reinforcement(missing_reinforcement)
+    assert len(violations) >= 1, (
+        "Detector failed to catch missing single-message dispatch reinforcement"
+    )
+
+
+def test_detector_passes_full_reinforcement() -> None:
+    """Verify _check_parallel_dispatch_reinforcement passes a skill with all three layers."""
+    full_reinforcement = """\
+---
+name: example-skill
+---
+
+**NEVER:**
+- Fabricate information
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
+
+**ALWAYS:**
+- Do something useful
+- Issue all Task calls in a single message to maximize parallelism
+
+## Workflow
+
+### Step 1: Launch Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per item — so they execute in parallel.**
+
+Spawn parallel subagents (Task tool) for each item in the list.
+"""
+    violations = _check_parallel_dispatch_reinforcement(full_reinforcement)
+    assert not violations, f"Detector falsely flagged fully reinforced skill: {violations}"
+
+
+def test_detector_catches_unguarded_subagent_spawn_loop() -> None:
+    """Verify _check_loop_boundary catches a 'For each...spawn subagent' loop without guard."""
+    vulnerable_pattern = """\
+### Step 3: Run Subagents
+
+For each dimension name in the list, spawn the corresponding subagent using the Task tool.
+"""
+    violations = _check_loop_boundary(vulnerable_pattern)
+    assert len(violations) >= 1, (
+        "Detector failed to catch unguarded 'For each...spawn...Task tool' loop"
+    )
+
+
+def test_detector_passes_guarded_subagent_spawn_loop() -> None:
+    """Verify _check_loop_boundary passes a guarded 'For each...Task tool' loop."""
+    guarded_pattern = """\
+### Step 3: Run Subagents (SINGLE MESSAGE)
+
+**Issue ALL Task tool calls in a single message — one per dimension — so they execute in parallel.
+Do not iterate through dimensions across multiple turns.**
+
+For each dimension name in the list, spawn the corresponding subagent using the Task tool.
+"""
+    violations = _check_loop_boundary(guarded_pattern)
+    assert not violations, (
+        f"Detector falsely flagged single-message guarded spawn loop: {violations}"
+    )
+
+
+@pytest.mark.parametrize("skill_dir", _all_skill_dirs(), ids=lambda d: d.name)
+def test_parallel_dispatch_has_single_message_reinforcement(skill_dir: Path) -> None:
+    """Skills that spawn parallel subagents must include three-layer
+    single-message dispatch reinforcement (NEVER + ALWAYS + step body)."""
+    text = (skill_dir / "SKILL.md").read_text()
+    if skill_dir.name in _NON_SPAWNING_SKILL_DIRS:
+        return
+    if not _SPAWN_INDICATOR_RE.search(text):
+        return
+    violations = _check_parallel_dispatch_reinforcement(text)
+    assert not violations, (
+        f"{skill_dir.name}/SKILL.md spawns parallel subagents but lacks "
+        f"single-message dispatch reinforcement:\n" + "\n".join(f"  - {v}" for v in violations)
+    )

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -200,8 +200,11 @@ def _check_loop_boundary(skill_text: str) -> list[str]:
             else:
                 prologue = loop_body
 
-            # Check for anti-prose guard in prologue or full loop body
-            search_text = prologue + "\n" + loop_body
+            # Check for anti-prose guard in step preamble (before loop header),
+            # loop prologue (header to first numbered sub-step), or full loop body.
+            # Guard text often appears above the "for each" line in the same step.
+            step_preamble = "\n".join(lines[:line_idx])
+            search_text = step_preamble + "\n" + prologue + "\n" + loop_body
             has_guard = any(p.search(search_text) for p in _ANTI_PROSE_GUARD_PATTERNS)
 
             if not has_guard:


### PR DESCRIPTION
## Summary

The `review-pr` SKILL.md tells the LLM to "Spawn parallel subagents" but uses "For each dimension name in the list, spawn the corresponding subagent" — classic sequential-loop language that LLMs interpret literally. This caused 7 subagents to dispatch across 7 separate assistant turns (83 seconds) instead of in a single parallel batch (~10-15 seconds). The same pattern exists in **57+ SKILL.md files** across the codebase. The architectural fix is a two-part immunity: (1) extend the existing `test_skill_compliance.py` checker to detect skills that spawn subagents but lack explicit single-message dispatch reinforcement, and (2) fix all affected SKILL.md files to use the three-layer reinforcement pattern already proven in `validate-audit`.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
None

### Modified (●):
tests/_helpers.py
tests/contracts/test_no_pagination_file_read.py
tests/skills/test_review_pr_adaptive_dispatch_guards.py
tests/skills/test_skill_compliance.py
src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
src/autoskillit/skills_extended/analyze-prs/SKILL.md
src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
src/autoskillit/skills_extended/arch-lens-development/SKILL.md
src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
src/autoskillit/skills_extended/arch-lens-security/SKILL.md
src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
src/autoskillit/skills_extended/audit-arch/SKILL.md
src/autoskillit/skills_extended/audit-bugs/SKILL.md
src/autoskillit/skills_extended/audit-claims/SKILL.md
src/autoskillit/skills_extended/audit-cohesion/SKILL.md
src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
src/autoskillit/skills_extended/audit-docs/SKILL.md
src/autoskillit/skills_extended/audit-friction/SKILL.md
src/autoskillit/skills_extended/audit-impl/SKILL.md
src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
src/autoskillit/skills_extended/audit-tests/SKILL.md
src/autoskillit/skills_extended/build-execution-map/SKILL.md
src/autoskillit/skills_extended/compose-pr/SKILL.md
src/autoskillit/skills_extended/compose-research-pr/SKILL.md
src/autoskillit/skills_extended/design-guards/SKILL.md
src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
src/autoskillit/skills_extended/elaborate-phase/SKILL.md
src/autoskillit/skills_extended/enrich-issues/SKILL.md
src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
src/autoskillit/skills_extended/generate-report/SKILL.md
src/autoskillit/skills_extended/implement-experiment/SKILL.md
src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
src/autoskillit/skills_extended/implement-worktree/SKILL.md
src/autoskillit/skills_extended/investigate/SKILL.md
src/autoskillit/skills_extended/make-groups/SKILL.md
src/autoskillit/skills_extended/make-plan/SKILL.md
src/autoskillit/skills_extended/make-req/SKILL.md
src/autoskillit/skills_extended/merge-pr/SKILL.md
src/autoskillit/skills_extended/open-integration-pr/SKILL.md
src/autoskillit/skills_extended/plan-experiment/SKILL.md
src/autoskillit/skills_extended/plan-visualization/SKILL.md
src/autoskillit/skills_extended/planner-analyze/SKILL.md
src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
src/autoskillit/skills_extended/prepare-pr/SKILL.md
src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
src/autoskillit/skills_extended/process-issues/SKILL.md
src/autoskillit/skills_extended/promote-to-main/SKILL.md
src/autoskillit/skills_extended/rectify/SKILL.md
src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
src/autoskillit/skills_extended/resolve-design-review/SKILL.md
src/autoskillit/skills_extended/resolve-research-review/SKILL.md
src/autoskillit/skills_extended/resolve-review/SKILL.md
src/autoskillit/skills_extended/retry-worktree/SKILL.md
src/autoskillit/skills_extended/review-approach/SKILL.md
src/autoskillit/skills_extended/review-design/SKILL.md
src/autoskillit/skills_extended/review-pr/SKILL.md
src/autoskillit/skills_extended/review-research-pr/SKILL.md
src/autoskillit/skills_extended/run-experiment/SKILL.md
src/autoskillit/skills_extended/scope/SKILL.md
src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
src/autoskillit/skills_extended/setup-project/SKILL.md
src/autoskillit/skills_extended/stage-data/SKILL.md
src/autoskillit/skills_extended/triage-issues/SKILL.md
src/autoskillit/skills_extended/verify-diag/SKILL.md
src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md

Closes #3290

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-001551-817087/.autoskillit/temp/rectify/rectify_parallel_dispatch_reinforcement_2026-05-30_001551.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.4k | 26.3k | 4.4M | 126.7k | 325 | 118.0k | 34m 31s |
| review_approach* | sonnet | 1 | 52 | 6.8k | 184.5k | 48.8k | 112 | 36.9k | 6m 13s |
| dry_walkthrough* | opus | 1 | 99 | 11.0k | 964.9k | 60.6k | 131 | 44.3k | 7m 52s |
| implement* | sonnet | 1 | 943 | 26.9k | 2.8M | 113.4k | 477 | 85.4k | 18m 47s |
| audit_impl* | sonnet | 1 | 68 | 5.9k | 259.6k | 41.6k | 43 | 34.6k | 3m 38s |
| prepare_pr* | sonnet | 1 | 105.0k | 6.4k | 185.5k | 30.9k | 21 | 43.8k | 1m 56s |
| compose_pr* | sonnet | 1 | 120.9k | 3.2k | 275.3k | 30.9k | 18 | 15.5k | 1m 4s |
| review_pr* | sonnet | 1 | 222 | 35.8k | 1.6M | 101.0k | 138 | 86.0k | 11m 39s |
| resolve_review* | opus | 1 | 68 | 8.8k | 1.2M | 63.0k | 70 | 47.5k | 11m 8s |
| **Total** | | | 229.7k | 131.1k | 11.9M | 126.7k | | 512.1k | 1h 36m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 974 | 2914.1 | 87.7 | 27.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 101510.3 | 3956.2 | 737.5 |
| **Total** | **986** | 12029.3 | 519.3 | 133.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.4k | 26.3k | 4.4M | 118.0k | 34m 31s |
| sonnet | 6 | 227.2k | 85.0k | 5.3M | 302.2k | 43m 19s |
| opus | 2 | 167 | 19.8k | 2.2M | 91.8k | 19m 1s |