### PR TITLE
[FIX] Diagnostic Signals Mask Reaper Kills — PART A ONLY

### DIFF
--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -115,7 +115,7 @@ def _build_fleet_campaign_prompt(
     max_quota_wait_sec: int = 3600,
     resumable_dispatch_name: str = "",
     resume_session_id: str = "",
-    resume_kill_reason: str = "",
+    resume_retry_reason: str = "",
     ingredients_table: str | None = None,
     prior_dispatch_id: str = "",
     resume_checkpoint: dict[str, Any] | None = None,
@@ -211,7 +211,7 @@ dispatch name NOT listed above.
         _prior_dispatch_id_clause = (
             f" {_prior_dispatch_id_line}" if _prior_dispatch_id_line else ""
         )
-        _reason_guidance = _resume_reason_guidance(resume_kill_reason)
+        _reason_guidance = _resume_reason_guidance(resume_retry_reason)
         _reenter_clause = (
             f" issue_urls=<remaining> and allow_reentry=true as ingredient overrides"
             f"{_resume_session_clause}{_prior_dispatch_id_clause}{_resume_checkpoint_line}"

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -142,7 +142,7 @@ def _launch_fleet_session(
             if resume_metadata is not None and resume_metadata.is_resumable
             else ""
         )
-        resume_kill_reason = (
+        resume_retry_reason = (
             resume_metadata.retry_reason
             if resume_metadata is not None and resume_metadata.is_resumable
             else ""
@@ -160,7 +160,7 @@ def _launch_fleet_session(
             campaign_id,
             resumable_dispatch_name=resumable_dispatch_name,
             resume_session_id=resume_session_id,
-            resume_kill_reason=resume_kill_reason,
+            resume_retry_reason=resume_retry_reason,
             ingredients_table=ingredients_table,
             prior_dispatch_id=resume_dispatch_id,
             resume_checkpoint=resume_checkpoint,
@@ -232,7 +232,9 @@ def _launch_fleet_session(
                 fresh_metadata.dispatched_session_id if fresh_metadata.is_resumable else ""
             )
             resume_dispatch_id = fresh_metadata.dispatch_id if fresh_metadata.is_resumable else ""
-            resume_kill_reason = fresh_metadata.retry_reason if fresh_metadata.is_resumable else ""
+            resume_retry_reason = (
+                fresh_metadata.retry_reason if fresh_metadata.is_resumable else ""
+            )
             resume_checkpoint = (
                 fresh_metadata.resume_checkpoint if fresh_metadata.is_resumable else None
             )
@@ -244,7 +246,7 @@ def _launch_fleet_session(
                 campaign_id,
                 resumable_dispatch_name=resumable_dispatch_name,
                 resume_session_id=resume_session_id,
-                resume_kill_reason=resume_kill_reason,
+                resume_retry_reason=resume_retry_reason,
                 ingredients_table=ingredients_table,
                 prior_dispatch_id=resume_dispatch_id,
                 resume_checkpoint=resume_checkpoint,

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -143,7 +143,7 @@ def _launch_fleet_session(
             else ""
         )
         resume_kill_reason = (
-            resume_metadata.kill_reason
+            resume_metadata.retry_reason
             if resume_metadata is not None and resume_metadata.is_resumable
             else ""
         )
@@ -232,7 +232,7 @@ def _launch_fleet_session(
                 fresh_metadata.dispatched_session_id if fresh_metadata.is_resumable else ""
             )
             resume_dispatch_id = fresh_metadata.dispatch_id if fresh_metadata.is_resumable else ""
-            resume_kill_reason = fresh_metadata.kill_reason if fresh_metadata.is_resumable else ""
+            resume_kill_reason = fresh_metadata.retry_reason if fresh_metadata.is_resumable else ""
             resume_checkpoint = (
                 fresh_metadata.resume_checkpoint if fresh_metadata.is_resumable else None
             )

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -222,6 +222,7 @@ class TerminationReason(StrEnum):
     STALE = "stale"
     IDLE_STALL = "idle_stall"
     TIMED_OUT = "timed_out"
+    SIGNAL_DEATH = "signal_death"
 
 
 class TerminationAction(StrEnum):

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -140,7 +140,7 @@ def decide_termination_action(
     if process_exited:
         return TerminationAction.NO_KILL
     match termination:
-        case TerminationReason.NATURAL_EXIT:
+        case TerminationReason.NATURAL_EXIT | TerminationReason.SIGNAL_DEATH:
             return TerminationAction.NO_KILL
         case TerminationReason.COMPLETED:
             return TerminationAction.DRAIN_THEN_KILL_IF_ALIVE

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -18,6 +18,7 @@ from autoskillit.execution.process._process_monitor import (
     _heartbeat,
     _session_log_monitor,
 )
+from autoskillit.execution.session._exit_classification import is_signal_death_code
 
 if TYPE_CHECKING:
     from autoskillit.core import StreamParser
@@ -453,7 +454,12 @@ def resolve_termination(
 
     # Termination reason: priority order (process exit > idle stall > stale > channel win)
     if signals.process_exited:
-        termination = TerminationReason.NATURAL_EXIT
+        if signals.process_returncode is not None and is_signal_death_code(
+            signals.process_returncode
+        ):
+            termination = TerminationReason.SIGNAL_DEATH
+        else:
+            termination = TerminationReason.NATURAL_EXIT
     elif signals.idle_stall:
         termination = TerminationReason.IDLE_STALL
     else:

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -79,13 +79,16 @@ def has_rate_limit_signal(
     )
 
 
+_SHELL_SIGNAL_MAX = 192  # 128 + SIGRTMAX (64 on Linux)
+
+
 def is_signal_death_code(returncode: int) -> bool:
     """Return True if returncode indicates death by signal.
 
     Covers both Python convention (negative: -(signal_number)) and shell
     convention (positive: 128 + signal_number, range 129–192).
     """
-    return returncode < 0 or (128 < returncode <= 192)
+    return returncode < 0 or (128 < returncode <= _SHELL_SIGNAL_MAX)
 
 
 def classify_infra_exit(

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -79,6 +79,15 @@ def has_rate_limit_signal(
     )
 
 
+def is_signal_death_code(returncode: int) -> bool:
+    """Return True if returncode indicates death by signal.
+
+    Covers both Python convention (negative: -(signal_number)) and shell
+    convention (positive: 128 + signal_number, range 129–192).
+    """
+    return returncode < 0 or (128 < returncode <= 192)
+
+
 def classify_infra_exit(
     session: ClaudeSessionResult,
     result: SubprocessResult,
@@ -113,6 +122,6 @@ def classify_infra_exit(
         return InfraExitCategory.API_ERROR
     if session.api_error_status is not None and session.api_error_status >= 400:
         return InfraExitCategory.API_ERROR
-    if result.returncode is not None and result.returncode < 0:
+    if result.returncode is not None and is_signal_death_code(result.returncode):
         return InfraExitCategory.PROCESS_KILLED
     return InfraExitCategory.COMPLETED

--- a/src/autoskillit/execution/session/_retry_fsm.py
+++ b/src/autoskillit/execution/session/_retry_fsm.py
@@ -83,6 +83,14 @@ def _compute_retry(
 
     # Phase 2: Exhaustive termination dispatch
     match termination:
+        case TerminationReason.SIGNAL_DEATH:
+            logger.debug(
+                "compute_retry_result",
+                termination="SIGNAL_DEATH",
+                needs_retry=True,
+            )
+            return True, RetryReason.RESUME
+
         case TerminationReason.NATURAL_EXIT:
             if channel_confirmation in (
                 ChannelConfirmation.CHANNEL_A,

--- a/src/autoskillit/execution/session/_retry_fsm.py
+++ b/src/autoskillit/execution/session/_retry_fsm.py
@@ -84,11 +84,7 @@ def _compute_retry(
     # Phase 2: Exhaustive termination dispatch
     match termination:
         case TerminationReason.SIGNAL_DEATH:
-            logger.debug(
-                "compute_retry_result",
-                termination="SIGNAL_DEATH",
-                needs_retry=True,
-            )
+            logger.debug("compute_retry_result", termination="SIGNAL_DEATH", needs_retry=True)
             return True, RetryReason.RESUME
 
         case TerminationReason.NATURAL_EXIT:
@@ -202,20 +198,11 @@ def _compute_retry(
                 case _ as _unreachable_cc:
                     assert_never(_unreachable_cc)
 
-        case TerminationReason.STALE:
-            # _build_skill_result intercepts STALE before calling _compute_retry.
-            # Explicit arm exists for exhaustiveness; unreachable in production.
-            logger.debug("compute_retry_result", termination="STALE", needs_retry=False)
-            return False, RetryReason.NONE
-
-        case TerminationReason.IDLE_STALL:
-            # _build_skill_result intercepts IDLE_STALL before calling _compute_retry.
-            # Explicit arm exists for exhaustiveness; unreachable in production.
-            logger.debug("compute_retry_result", termination="IDLE_STALL", needs_retry=False)
+        case TerminationReason.STALE | TerminationReason.IDLE_STALL:
+            logger.debug("compute_retry_result", termination=termination.value, needs_retry=False)
             return False, RetryReason.NONE
 
         case TerminationReason.TIMED_OUT:
-            # Wall-clock timeout: non-retriable (permanent infrastructure limit).
             logger.debug("compute_retry_result", termination="TIMED_OUT", needs_retry=False)
             return False, RetryReason.NONE
 

--- a/src/autoskillit/execution/session/_session_outcome.py
+++ b/src/autoskillit/execution/session/_session_outcome.py
@@ -102,6 +102,9 @@ def _compute_success(
             )
             return content_ok
 
+        case TerminationReason.SIGNAL_DEATH:
+            return False
+
         case TerminationReason.NATURAL_EXIT:
             # The process exited on its own. A non-zero returncode is normally
             # authoritative evidence of failure — no asymmetric bypass.

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -764,7 +764,7 @@ async def _run_dispatch(
         dispatched_boot_id=_dispatched_boot_id[0] if _dispatched_boot_id else "",
         dispatched_create_time=_dispatched_create_time[0] if _dispatched_create_time else 0.0,
         reason=reason,
-        kill_reason=skill_result.retry_reason or "",
+        retry_reason=skill_result.retry_reason or "",
         infra_exit_category=skill_result.infra.exit_category or "",
         token_usage=normalize_dispatch_token_usage(skill_result.token_usage or {}),
         started_at=started_at,

--- a/src/autoskillit/fleet/_dispatch_reaper.py
+++ b/src/autoskillit/fleet/_dispatch_reaper.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -18,10 +19,32 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _append_reaper_event(dispatch: DispatchRecord, reason: str, reaper_dispatch_id: str) -> None:
+    from autoskillit.core import default_log_dir  # noqa: PLC0415
+
+    log_path = default_log_dir() / "reaper_events.jsonl"
+    event = {
+        "ts": time.time(),
+        "action": reason,
+        "victim_dispatch_id": dispatch.dispatch_id,
+        "victim_pid": dispatch.dispatched_pid,
+        "victim_session_id": dispatch.dispatched_session_id,
+        "reaper_dispatch_id": reaper_dispatch_id,
+        "campaign_id": dispatch.campaign_id,
+    }
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(event) + "\n")
+    except OSError:
+        logger.warning("reaper: failed to append reaper event", exc_info=True)
+
+
 def _apply_stale_dispatch(
     dispatch: DispatchRecord,
     reason: str,
     m: CampaignStateMutator,
+    reaper_dispatch_id: str = "",
 ) -> None:
     from autoskillit.fleet import classify_stale_dispatch  # noqa: PLC0415
 
@@ -31,6 +54,29 @@ def _apply_stale_dispatch(
     if sidecar:
         dispatch.sidecar_path = sidecar
     dispatch.ended_at = time.time()
+
+    dispatch.reaper_reason = reason
+    dispatch.reaper_dispatch_id = reaper_dispatch_id
+
+    if dispatch.dispatched_session_log_dir:
+        tombstone_dir = Path(dispatch.dispatched_session_log_dir)
+        if tombstone_dir.exists():
+            tombstone = {
+                "ts": dispatch.ended_at,
+                "action": reason,
+                "reaper_dispatch_id": reaper_dispatch_id,
+                "victim_pid": dispatch.dispatched_pid,
+                "victim_dispatch_id": dispatch.dispatch_id,
+                "campaign_id": dispatch.campaign_id,
+            }
+            try:
+                (tombstone_dir / "reaper_action.json").write_text(
+                    json.dumps(tombstone), encoding="utf-8"
+                )
+            except OSError:
+                logger.warning("reaper: failed to write tombstone", exc_info=True)
+
+    _append_reaper_event(dispatch, reason, reaper_dispatch_id)
     m.mark_dirty()
 
 
@@ -40,11 +86,12 @@ def _mark_dead_pid(
     pid: int,
     dispatch: DispatchRecord,
     m: CampaignStateMutator,
+    reaper_dispatch_id: str = "",
 ) -> None:
     if dry_run:
         logger.info("reap: [WOULD MARK]  %s  pid=%d  (process dead)", name, pid)
     else:
-        _apply_stale_dispatch(dispatch, "reaped_dead_pid", m)
+        _apply_stale_dispatch(dispatch, "reaped_dead_pid", m, reaper_dispatch_id)
         logger.info("reap: [MARKED]      %s  pid=%d  (process dead)", name, pid)
 
 
@@ -55,6 +102,7 @@ def reap_stale_dispatches(
     skip_dispatch_ids: frozenset[str] | None = None,
     own_campaign_id: str | None = None,
     min_reap_age_seconds: float = 60.0,
+    reaper_dispatch_id: str = "",
 ) -> None:
     """Reap stale RUNNING dispatches with PID-recycling-safe identity checks.
 
@@ -124,7 +172,7 @@ def reap_stale_dispatches(
                 if dry_run:
                     logger.info("reap: [WOULD MARK]  %s  pid=0  (no PID recorded)", name)
                 else:
-                    _apply_stale_dispatch(dispatch, "reaped_dead_pid", m)
+                    _apply_stale_dispatch(dispatch, "reaped_dead_pid", m, reaper_dispatch_id)
                     logger.info("reap: [MARKED]      %s  (no PID recorded)", name)
                 continue
 
@@ -138,7 +186,7 @@ def reap_stale_dispatches(
                         "reap: [WOULD MARK]  %s  pid=%d  (rebooted, pid_recycled)", name, pid
                     )
                 else:
-                    _apply_stale_dispatch(dispatch, "reaped_pid_recycled", m)
+                    _apply_stale_dispatch(dispatch, "reaped_pid_recycled", m, reaper_dispatch_id)
                     logger.info(
                         "reap: [MARKED]      %s  pid=%d  (rebooted, pid_recycled)",
                         name,
@@ -147,7 +195,7 @@ def reap_stale_dispatches(
                 continue
 
             if not psutil.pid_exists(pid):
-                _mark_dead_pid(dry_run, name, pid, dispatch, m)
+                _mark_dead_pid(dry_run, name, pid, dispatch, m, reaper_dispatch_id)
                 continue
 
             current_ticks = read_starttime_ticks(pid)
@@ -158,7 +206,7 @@ def reap_stale_dispatches(
                     actual_ct = psutil.Process(pid).create_time()
                     identity_confirmed = abs(actual_ct - dispatch.dispatched_create_time) < 1.0
                 except psutil.NoSuchProcess:
-                    _mark_dead_pid(dry_run, name, pid, dispatch, m)
+                    _mark_dead_pid(dry_run, name, pid, dispatch, m, reaper_dispatch_id)
                     continue
                 except psutil.AccessDenied:
                     identity_confirmed = False
@@ -170,7 +218,7 @@ def reap_stale_dispatches(
                     identity_confirmed = abs(actual_ct - dispatch.dispatched_create_time) < 1.0
                     logger.info("reap: ticks=0 fallback to create_time for %s pid=%d", name, pid)
                 except psutil.NoSuchProcess:
-                    _mark_dead_pid(dry_run, name, pid, dispatch, m)
+                    _mark_dead_pid(dry_run, name, pid, dispatch, m, reaper_dispatch_id)
                     continue
                 except psutil.AccessDenied:
                     identity_confirmed = False
@@ -189,7 +237,7 @@ def reap_stale_dispatches(
                         logger.warning(
                             "reap: kill_process_tree failed for pid=%d", pid, exc_info=True
                         )
-                    _apply_stale_dispatch(dispatch, "reaped_orphan", m)
+                    _apply_stale_dispatch(dispatch, "reaped_orphan", m, reaper_dispatch_id)
                     logger.info("reap: [KILLED]      %s  pid=%d  (orphan reaped)", name, pid)
             else:
                 if dry_run:
@@ -197,7 +245,7 @@ def reap_stale_dispatches(
                         "reap: [WOULD MARK]  %s  pid=%d  (PID recycled, no kill)", name, pid
                     )
                 else:
-                    _apply_stale_dispatch(dispatch, "reaped_pid_recycled", m)
+                    _apply_stale_dispatch(dispatch, "reaped_pid_recycled", m, reaper_dispatch_id)
                     logger.info(
                         "reap: [MARKED]      %s  pid=%d  (PID recycled, no kill)",
                         name,
@@ -211,6 +259,7 @@ async def reap_stale_dispatches_async(
     skip_dispatch_ids: frozenset[str] | None = None,
     own_campaign_id: str | None = None,
     min_reap_age_seconds: float = 60.0,
+    reaper_dispatch_id: str = "",
 ) -> None:
     import functools  # noqa: PLC0415
 
@@ -224,5 +273,6 @@ async def reap_stale_dispatches_async(
                 skip_dispatch_ids=skip_dispatch_ids,
                 own_campaign_id=own_campaign_id,
                 min_reap_age_seconds=min_reap_age_seconds,
+                reaper_dispatch_id=reaper_dispatch_id,
             ),
         )

--- a/src/autoskillit/fleet/_dispatch_reaper.py
+++ b/src/autoskillit/fleet/_dispatch_reaper.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import psutil
 
-from autoskillit.core import get_logger
+from autoskillit.core import default_log_dir, get_logger
 from autoskillit.execution import kill_process_tree, read_boot_id, read_starttime_ticks
 
 if TYPE_CHECKING:
@@ -20,8 +20,6 @@ logger = get_logger(__name__)
 
 
 def _append_reaper_event(dispatch: DispatchRecord, reason: str, reaper_dispatch_id: str) -> None:
-    from autoskillit.core import default_log_dir  # noqa: PLC0415
-
     log_path = default_log_dir() / "reaper_events.jsonl"
     event = {
         "ts": time.time(),
@@ -70,9 +68,8 @@ def _apply_stale_dispatch(
                 "campaign_id": dispatch.campaign_id,
             }
             try:
-                (tombstone_dir / "reaper_action.json").write_text(
-                    json.dumps(tombstone), encoding="utf-8"
-                )
+                with (tombstone_dir / "reaper_action.json").open("w", encoding="utf-8") as f:
+                    f.write(json.dumps(tombstone))
             except OSError:
                 logger.warning("reaper: failed to write tombstone", exc_info=True)
 

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -212,7 +212,7 @@ def reset_blocking_dispatch(state_path: Path, dispatch_name: str) -> bool:
         return False
 
 
-_LEGACY_SCHEMA_VERSIONS = frozenset({4})
+_LEGACY_SCHEMA_VERSIONS: frozenset[int] = frozenset({4, 5})
 
 
 def _read_raw_json(state_path: Path) -> dict[str, Any] | None:
@@ -363,7 +363,7 @@ def mark_dispatch_running(
             raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
         for d in m.state.dispatches:
             if d.name == dispatch_name:
-                d.kill_reason = ""
+                d.retry_reason = ""
                 d.infra_exit_category = ""
                 _validate_transition(d.status, DispatchStatus.RUNNING, d.name)
                 d.status = DispatchStatus.RUNNING

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -503,6 +503,10 @@ def upsert_dispatch_record_by_name(state_path: Path, record: DispatchRecord) -> 
                         else:
                             snapshot[f.name] = val
                     record.attempt_history = [snapshot] + list(record.attempt_history)
+                if d.reaper_reason and not record.reaper_reason:
+                    record.reaper_reason = d.reaper_reason
+                if d.reaper_dispatch_id and not record.reaper_dispatch_id:
+                    record.reaper_dispatch_id = d.reaper_dispatch_id
                 m.state.dispatches[i] = record
                 m.mark_dirty()
                 return

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -241,7 +241,7 @@ def resume_campaign_from_state(
         is_resumable = False
         resumable_dispatched_session_id = ""
         resumable_dispatch_id = ""
-        resumable_kill_reason = ""
+        resumable_retry_reason = ""
         resumable_checkpoint: dict[str, Any] = {}
         for d in m.state.dispatches:
             if d.status in _VISIBLE_IN_BLOCK_STATUSES:
@@ -265,7 +265,7 @@ def resume_campaign_from_state(
                     is_resumable = True
                     resumable_dispatched_session_id = d.dispatched_session_id
                     resumable_dispatch_id = d.dispatch_id
-                    resumable_kill_reason = d.retry_reason
+                    resumable_retry_reason = d.retry_reason
                     resumable_checkpoint = d.resume_checkpoint
             elif (
                 d.status
@@ -289,7 +289,7 @@ def resume_campaign_from_state(
             is_resumable=is_resumable,
             dispatched_session_id=resumable_dispatched_session_id,
             dispatch_id=resumable_dispatch_id,
-            retry_reason=resumable_kill_reason,
+            retry_reason=resumable_retry_reason,
             resume_checkpoint=resumable_checkpoint,
         )
 

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -116,12 +116,12 @@ def has_blocking_dispatch(state_path: Path) -> bool:
     return False
 
 
-def _is_abandon_kill_metadata(kill_reason: str, infra_exit_category: str) -> bool:
+def _is_abandon_kill_metadata(retry_reason: str, infra_exit_category: str) -> bool:
     """Return True when stored kill metadata indicates resume would be futile."""
-    if kill_reason in _ABANDON_REASONS:
+    if retry_reason in _ABANDON_REASONS:
         return True
     if (
-        kill_reason == RetryReason.RESUME
+        retry_reason == RetryReason.RESUME
         and infra_exit_category == InfraExitCategory.CONTEXT_EXHAUSTED
     ):
         return True
@@ -168,7 +168,7 @@ def classify_stale_dispatch(
                 # treat as having entries to avoid conflating parse errors with 'no entries'.
                 has_entries = bool(raw_lines)
             if not raw_lines or has_entries:
-                if _is_abandon_kill_metadata(dispatch.kill_reason, dispatch.infra_exit_category):
+                if _is_abandon_kill_metadata(dispatch.retry_reason, dispatch.infra_exit_category):
                     return (DispatchStatus.INTERRUPTED, "")
                 return (DispatchStatus.RESUMABLE, sidecar_path_str)
     logger.debug(
@@ -265,7 +265,7 @@ def resume_campaign_from_state(
                     is_resumable = True
                     resumable_dispatched_session_id = d.dispatched_session_id
                     resumable_dispatch_id = d.dispatch_id
-                    resumable_kill_reason = d.kill_reason
+                    resumable_kill_reason = d.retry_reason
                     resumable_checkpoint = d.resume_checkpoint
             elif (
                 d.status
@@ -289,7 +289,7 @@ def resume_campaign_from_state(
             is_resumable=is_resumable,
             dispatched_session_id=resumable_dispatched_session_id,
             dispatch_id=resumable_dispatch_id,
-            kill_reason=resumable_kill_reason,
+            retry_reason=resumable_kill_reason,
             resume_checkpoint=resumable_checkpoint,
         )
 

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -13,7 +13,7 @@ from autoskillit.core import FleetErrorCode, RetryReason
 
 _resume_lock = threading.Lock()
 
-FLEET_STATE_SCHEMA_VERSION = 5
+FLEET_STATE_SCHEMA_VERSION = 6
 
 FLEET_HALTED_SENTINEL = "fleet_halted_on_failure"
 
@@ -112,7 +112,7 @@ class DispatchRecord:
     identity_degraded: bool = False
     reason: str = ""
     diagnostic_message: str = ""
-    kill_reason: str = ""
+    retry_reason: str = ""
     infra_exit_category: str = ""
     reaper_reason: str = ""
     reaper_dispatch_id: str = ""
@@ -143,7 +143,7 @@ class DispatchRecord:
             "identity_degraded": self.identity_degraded,
             "reason": self.reason,
             "diagnostic_message": self.diagnostic_message,
-            "kill_reason": self.kill_reason,
+            "retry_reason": self.retry_reason,
             "infra_exit_category": self.infra_exit_category,
             "reaper_reason": self.reaper_reason,
             "reaper_dispatch_id": self.reaper_dispatch_id,
@@ -200,7 +200,7 @@ class DispatchRecord:
             identity_degraded=d.get("identity_degraded", False),
             reason=d.get("reason", ""),
             diagnostic_message=d.get("diagnostic_message", ""),
-            kill_reason=d.get("kill_reason", ""),
+            retry_reason=d.get("retry_reason", "") or d.get("kill_reason", ""),
             infra_exit_category=d.get("infra_exit_category", ""),
             reaper_reason=d.get("reaper_reason", ""),
             reaper_dispatch_id=d.get("reaper_dispatch_id", ""),
@@ -288,7 +288,7 @@ class ResumeDecision:
     is_resumable: bool = False
     dispatched_session_id: str = ""
     dispatch_id: str = ""
-    kill_reason: str = ""
+    retry_reason: str = ""
     resume_checkpoint: dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -114,6 +114,8 @@ class DispatchRecord:
     diagnostic_message: str = ""
     kill_reason: str = ""
     infra_exit_category: str = ""
+    reaper_reason: str = ""
+    reaper_dispatch_id: str = ""
     token_usage: dict[str, Any] = field(default_factory=dict)
     started_at: float = 0.0
     ended_at: float = 0.0
@@ -143,6 +145,8 @@ class DispatchRecord:
             "diagnostic_message": self.diagnostic_message,
             "kill_reason": self.kill_reason,
             "infra_exit_category": self.infra_exit_category,
+            "reaper_reason": self.reaper_reason,
+            "reaper_dispatch_id": self.reaper_dispatch_id,
             "token_usage": dict(self.token_usage),
             "started_at": self.started_at,
             "ended_at": self.ended_at,
@@ -198,6 +202,8 @@ class DispatchRecord:
             diagnostic_message=d.get("diagnostic_message", ""),
             kill_reason=d.get("kill_reason", ""),
             infra_exit_category=d.get("infra_exit_category", ""),
+            reaper_reason=d.get("reaper_reason", ""),
+            reaper_dispatch_id=d.get("reaper_dispatch_id", ""),
             token_usage=d.get("token_usage", {}),
             started_at=d.get("started_at", 0.0),
             ended_at=d.get("ended_at", 0.0),

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -200,7 +200,7 @@ class DispatchRecord:
             identity_degraded=d.get("identity_degraded", False),
             reason=d.get("reason", ""),
             diagnostic_message=d.get("diagnostic_message", ""),
-            retry_reason=d.get("retry_reason", "") or d.get("kill_reason", ""),
+            retry_reason=d["retry_reason"] if "retry_reason" in d else d.get("kill_reason", ""),
             infra_exit_category=d.get("infra_exit_category", ""),
             reaper_reason=d.get("reaper_reason", ""),
             reaper_dispatch_id=d.get("reaper_dispatch_id", ""),

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -253,6 +253,7 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
                 _campaign_state_paths,
                 own_campaign_id=ctx.kitchen_id,
                 min_reap_age_seconds=60.0,
+                reaper_dispatch_id=os.environ.get("AUTOSKILLIT_DISPATCH_ID", ""),
             )
         except Exception:
             logger.warning("fleet_auto_gate_boot_reap_failed", exc_info=True)
@@ -382,6 +383,7 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
                 skip_dispatch_ids=_skip,
                 own_campaign_id=_own_campaign_id,
                 min_reap_age_seconds=60.0,
+                reaper_dispatch_id=os.environ.get("AUTOSKILLIT_DISPATCH_ID", ""),
             )
         except Exception:
             logger.warning("food_truck_auto_gate_boot_reap_failed", exc_info=True)

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -326,7 +326,7 @@ def test_launch_fleet_session_forwards_initial_message_campaign(
             next_dispatch_name="",
             is_resumable=False,
             dispatched_session_id="",
-            kill_reason="",
+            retry_reason="",
         ),
     )
     from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
@@ -379,7 +379,7 @@ def test_launch_fleet_session_clears_initial_message_on_reload_campaign(
             next_dispatch_name="",
             is_resumable=False,
             dispatched_session_id="",
-            kill_reason="",
+            retry_reason="",
         ),
     )
     from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
@@ -401,3 +401,16 @@ def test_launch_fleet_session_clears_initial_message_on_reload_campaign(
     )
     assert captured_messages[0] == "Hello!"
     assert captured_messages[1] is None
+
+
+def test_resume_decision_retry_reason_field() -> None:
+    """ResumeDecision.retry_reason stores RetryReason values."""
+    from autoskillit.fleet import ResumeDecision
+
+    decision = ResumeDecision(
+        completed_dispatches_block="",
+        next_dispatch_name="",
+        is_resumable=True,
+        retry_reason="idle_stall",
+    )
+    assert decision.retry_reason == "idle_stall"

--- a/tests/cli/test_l3_orchestrator_prompt.py
+++ b/tests/cli/test_l3_orchestrator_prompt.py
@@ -604,7 +604,7 @@ class TestResumeReasonInPrompt:
         prompt = _build(
             resumable_dispatch_name="impl-1",
             resume_session_id="sess-1",
-            resume_kill_reason="idle_stall",
+            resume_retry_reason="idle_stall",
         )
         assert "RESUMABLE DISPATCH: impl-1" in prompt
         assert "idle timeout" in prompt
@@ -613,7 +613,7 @@ class TestResumeReasonInPrompt:
     def test_context_exhausted_absent_from_resumable(self) -> None:
         prompt = _build(
             resumable_dispatch_name="impl-1",
-            resume_kill_reason="context_exhausted",
+            resume_retry_reason="context_exhausted",
         )
         assert "RESUMABLE DISPATCH: impl-1" in prompt
         idx = prompt.index("RESUMABLE DISPATCH: impl-1")
@@ -625,7 +625,7 @@ class TestResumeReasonInPrompt:
     def test_api_error_resume_includes_retry_guidance(self) -> None:
         prompt = _build(
             resumable_dispatch_name="impl-1",
-            resume_kill_reason="resume",
+            resume_retry_reason="resume",
         )
         assert "RESUMABLE DISPATCH: impl-1" in prompt
         assert "transient infrastructure failure" in prompt

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -630,7 +630,7 @@ class TestGroupDApiContractPreservation:
     # ------------------------------------------------------------------
 
     def test_req_api_006_termination_reason_members(self):
-        """TerminationReason must have exactly the 4 canonical values."""
+        """TerminationReason must have exactly the 6 canonical values."""
         from autoskillit.core.types import TerminationReason
 
         assert set(TerminationReason) == {
@@ -639,6 +639,7 @@ class TestGroupDApiContractPreservation:
             TerminationReason.STALE,
             TerminationReason.IDLE_STALL,
             TerminationReason.TIMED_OUT,
+            TerminationReason.SIGNAL_DEATH,
         }
 
     def test_req_api_006_termination_reason_string_values(self):

--- a/tests/execution/test_boundary_pty_dispatch.py
+++ b/tests/execution/test_boundary_pty_dispatch.py
@@ -76,7 +76,10 @@ class TestBoundaryPtyDispatch:
         assert result.returncode in {143, -signal.SIGTERM}, (
             f"Expected SIGTERM exit (143 or -{signal.SIGTERM}), got {result.returncode}"
         )
-        assert result.termination == TerminationReason.NATURAL_EXIT
+        assert result.termination in {
+            TerminationReason.NATURAL_EXIT,
+            TerminationReason.SIGNAL_DEATH,
+        }
         # ESC byte (0x1B) must appear — ANSI sequences were written to stdout
         assert "\x1b" in result.stdout, (
             f"Expected ANSI escape bytes in stdout, got: {result.stdout!r}"

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -18,6 +18,7 @@ from autoskillit.execution.session._exit_classification import (
     _CODEX_API_ERROR_PATTERNS,
     _RATE_LIMIT_PATTERNS,
     classify_infra_exit,
+    is_signal_death_code,
 )
 from autoskillit.execution.session._session_model import ClaudeSessionResult
 from tests.execution.conftest import CODEX_API_ERROR_SIGNAL_STRINGS
@@ -423,6 +424,53 @@ class TestRateLimitClassification:
         )
         result = _sr(returncode=0, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.RATE_LIMITED
+
+
+@pytest.mark.parametrize(
+    "returncode",
+    [130, 134, 137, 139, 143],
+    ids=["SIGINT(130)", "SIGABRT(134)", "SIGKILL(137)", "SIGSEGV(139)", "SIGTERM(143)"],
+)
+def test_positive_signal_death_codes_classified_as_process_killed(returncode: int) -> None:
+    """Shell-convention signal codes (128+N) must classify as PROCESS_KILLED (Test 1A)."""
+    session = ClaudeSessionResult(
+        subtype="empty_output",
+        is_error=True,
+        result="",
+        session_id="s1",
+    )
+    result = _sr(returncode=returncode, stderr="")
+    assert classify_infra_exit(session, result) == InfraExitCategory.PROCESS_KILLED
+
+
+@pytest.mark.parametrize(
+    "returncode,expected",
+    [
+        (-9, True),
+        (-15, True),
+        (137, True),
+        (143, True),
+        (128, False),
+        (0, False),
+        (1, False),
+        (127, False),
+        (193, False),
+    ],
+    ids=[
+        "neg_sigkill",
+        "neg_sigterm",
+        "shell_sigkill",
+        "shell_sigterm",
+        "exactly_128",
+        "zero",
+        "one",
+        "cmd_not_found",
+        "above_range",
+    ],
+)
+def test_is_signal_death_code_boundary_cases(returncode: int, expected: bool) -> None:
+    """is_signal_death_code boundary cases (Test 1B)."""
+    assert is_signal_death_code(returncode) is expected
 
 
 def test_codex_api_error_patterns_count() -> None:

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -1439,3 +1439,24 @@ def test_build_skill_result_ansi_only_stdout_exit_143() -> None:
     )
     assert skill_result.success is False
     assert skill_result.lifespan_started is False
+
+
+def test_build_skill_result_signal_death_returncode_yields_resume() -> None:
+    """SIGNAL_DEATH + rc=143 yields retry_reason=RESUME and exit_category=process_killed."""
+    proc_result = SubprocessResult(
+        returncode=143,
+        stdout="",
+        stderr="",
+        termination=TerminationReason.SIGNAL_DEATH,
+        pid=12345,
+        kill_reason=KillReason.NATURAL_EXIT,
+    )
+    skill_result = _build_skill_result(
+        result=proc_result,
+        backend=ClaudeCodeBackend(),
+        skill_command="test",
+        completion_marker="%%DONE%%",
+    )
+    assert skill_result.success is False
+    assert skill_result.retry_reason == RetryReason.RESUME
+    assert skill_result.infra.exit_category == "process_killed"

--- a/tests/execution/test_process_pty.py
+++ b/tests/execution/test_process_pty.py
@@ -477,6 +477,7 @@ class TestAdjudicationCoverageMatrix:
         {
             TerminationReason.COMPLETED,  # TestChannelBDrainRacePipelineAdjudication
             TerminationReason.NATURAL_EXIT,  # TestSTOPDelayPipelineAdjudication
+            TerminationReason.SIGNAL_DEATH,  # TestBoundaryPtyDispatch
             TerminationReason.STALE,  # TestStaleRecoveryPipelineAdjudication
             TerminationReason.TIMED_OUT,  # TestTimedOutPipelineAdjudication
             TerminationReason.IDLE_STALL,  # TestIdleStallWatchdog in test_process_run.py

--- a/tests/execution/test_process_race.py
+++ b/tests/execution/test_process_race.py
@@ -536,3 +536,51 @@ class TestExtractStdoutSessionIdStreamParser:
 
         assert acc.stdout_session_id == "conversation-uuid-BBB"
         assert ready.is_set()
+
+
+class TestResolveTerminationSignalDeath:
+    """resolve_termination returns SIGNAL_DEATH for shell-convention positive signal codes."""
+
+    @pytest.mark.parametrize(
+        "returncode",
+        [130, 137, 143],
+        ids=["SIGINT(130)", "SIGKILL(137)", "SIGTERM(143)"],
+    )
+    def test_positive_signal_code_yields_signal_death(self, returncode: int) -> None:
+        """process_exited=True with 128+N returncode → SIGNAL_DEATH (Test 1C)."""
+        signals = RaceSignals(
+            process_exited=True,
+            process_returncode=returncode,
+            channel_a_confirmed=False,
+            channel_b_status=ChannelBStatus.STALE,
+            channel_b_session_id="",
+            stdout_session_id=None,
+        )
+        termination, _ = resolve_termination(signals)
+        assert termination == TerminationReason.SIGNAL_DEATH
+
+    def test_returncode_zero_still_natural_exit(self) -> None:
+        """process_exited=True with returncode=0 → NATURAL_EXIT (regression guard)."""
+        signals = RaceSignals(
+            process_exited=True,
+            process_returncode=0,
+            channel_a_confirmed=False,
+            channel_b_status=ChannelBStatus.STALE,
+            channel_b_session_id="",
+            stdout_session_id=None,
+        )
+        termination, _ = resolve_termination(signals)
+        assert termination == TerminationReason.NATURAL_EXIT
+
+    def test_negative_signal_code_yields_signal_death(self) -> None:
+        """process_exited=True with returncode=-9 → SIGNAL_DEATH (negative codes still work)."""
+        signals = RaceSignals(
+            process_exited=True,
+            process_returncode=-9,
+            channel_a_confirmed=False,
+            channel_b_status=ChannelBStatus.STALE,
+            channel_b_session_id="",
+            stdout_session_id=None,
+        )
+        termination, _ = resolve_termination(signals)
+        assert termination == TerminationReason.SIGNAL_DEATH

--- a/tests/fleet/test_dispatch_reaper.py
+++ b/tests/fleet/test_dispatch_reaper.py
@@ -418,7 +418,106 @@ class TestReap:
             skip_dispatch_ids=frozenset({"skip-me"}),
             own_campaign_id=None,
             min_reap_age_seconds=60.0,
+            reaper_dispatch_id="",
         )
+
+    def test_reap_writes_tombstone_to_victim_session_log_dir(self, tmp_path: Path) -> None:
+        """Reaper writes reaper_action.json into victim's session log dir (Test 1E)."""
+        session_log_dir = tmp_path / "session-logs"
+        session_log_dir.mkdir()
+        sp = _make_running_state(
+            tmp_path,
+            dispatch_id="victim-dispatch-001",
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_boot_id=BOOT_ID,
+        )
+        raw = json.loads(sp.read_text())
+        raw["dispatches"][0]["dispatched_session_log_dir"] = str(session_log_dir)
+        sp.write_text(json.dumps(raw))
+
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.read_starttime_ticks", return_value=1000),
+            patch("autoskillit.fleet._dispatch_reaper.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree"),
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+        ):
+            from autoskillit.fleet import reap_stale_dispatches
+
+            reap_stale_dispatches(sp, reaper_dispatch_id="reaper-aaa-001")
+
+        tombstone_path = session_log_dir / "reaper_action.json"
+        assert tombstone_path.exists(), "reaper_action.json should be written to session log dir"
+        tombstone = json.loads(tombstone_path.read_text())
+        assert tombstone["action"] == "reaped_orphan"
+        assert tombstone["reaper_dispatch_id"] == "reaper-aaa-001"
+        assert tombstone["victim_dispatch_id"] == "victim-dispatch-001"
+        assert tombstone["victim_pid"] == 12345
+
+    def test_reap_appends_to_central_reaper_events_log(self, tmp_path: Path) -> None:
+        """Reaper appends event to reaper_events.jsonl (Test 1F)."""
+        sp = _make_running_state(
+            tmp_path,
+            dispatch_id="victim-dispatch-002",
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_boot_id=BOOT_ID,
+        )
+
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.read_starttime_ticks", return_value=1000),
+            patch("autoskillit.fleet._dispatch_reaper.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree"),
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+            patch("autoskillit.fleet._dispatch_reaper.default_log_dir", return_value=tmp_path),
+        ):
+            from autoskillit.fleet import reap_stale_dispatches
+
+            reap_stale_dispatches(sp, reaper_dispatch_id="reaper-bbb-002")
+
+        log_path = tmp_path / "reaper_events.jsonl"
+        assert log_path.exists(), "reaper_events.jsonl should be created"
+        lines = [ln for ln in log_path.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["action"] == "reaped_orphan"
+        assert event["victim_dispatch_id"] == "victim-dispatch-002"
+        assert event["victim_pid"] == 12345
+        assert event["reaper_dispatch_id"] == "reaper-bbb-002"
+        assert "ts" in event
+        assert "campaign_id" in event
+
+    def test_reaper_reason_survives_upsert_dispatch_record_by_name(self, tmp_path: Path) -> None:
+        """reaper_reason/reaper_dispatch_id survive a subsequent upsert (Test 1G)."""
+        from autoskillit.fleet import upsert_dispatch_record_by_name, write_initial_state
+
+        sp = tmp_path / "state.json"
+        write_initial_state(sp, "cid-1g", "1g-campaign", "/m.yaml", [DispatchRecord(name="d1")])
+
+        raw = json.loads(sp.read_text())
+        raw["dispatches"][0].update(
+            {
+                "status": "failure",
+                "reaper_reason": "reaped_orphan",
+                "reaper_dispatch_id": "abc-123",
+            }
+        )
+        sp.write_text(json.dumps(raw))
+
+        overwrite = DispatchRecord(
+            name="d1",
+            status=DispatchStatus.FAILURE,
+            reason="some_other_reason",
+            reaper_reason="",
+            reaper_dispatch_id="",
+        )
+        upsert_dispatch_record_by_name(sp, overwrite)
+
+        state = read_state(sp)
+        assert state is not None
+        record = state.dispatches[0]
+        assert record.reaper_reason == "reaped_orphan"
+        assert record.reaper_dispatch_id == "abc-123"
 
     def test_reap_skips_own_campaign_state_file(self, tmp_path: Path) -> None:
         sp = tmp_path / "state.json"

--- a/tests/fleet/test_resume_max_attempts.py
+++ b/tests/fleet/test_resume_max_attempts.py
@@ -30,7 +30,7 @@ class TestMaxResumeAttemptsGuard:
             ),
         ]
         state = CampaignState(
-            schema_version=5,
+            schema_version=6,
             campaign_id="test-id",
             campaign_name="test",
             manifest_path="manifest.yaml",
@@ -61,7 +61,7 @@ class TestMaxResumeAttemptsGuard:
             ),
         ]
         state = CampaignState(
-            schema_version=5,
+            schema_version=6,
             campaign_id="test-id",
             campaign_name="test",
             manifest_path="manifest.yaml",
@@ -94,7 +94,7 @@ class TestMaxResumeAttemptsGuard:
             ),
         ]
         state = CampaignState(
-            schema_version=5,
+            schema_version=6,
             campaign_id="test-id",
             campaign_name="test",
             manifest_path="manifest.yaml",

--- a/tests/fleet/test_retry_failed_dispatch.py
+++ b/tests/fleet/test_retry_failed_dispatch.py
@@ -76,7 +76,7 @@ class TestResetBlockingDispatch:
                 started_at=1000.0,
                 ended_at=2000.0,
                 sidecar_path="/old/sidecar",
-                kill_reason="stale",
+                retry_reason="stale",
                 infra_exit_category="timeout",
             ),
         )
@@ -99,7 +99,7 @@ class TestResetBlockingDispatch:
         assert d2.started_at == 0.0
         assert d2.ended_at == 0.0
         assert d2.sidecar_path is None
-        assert d2.kill_reason == ""
+        assert d2.retry_reason == ""
         assert d2.infra_exit_category == ""
 
     def test_returns_true_on_success(self, tmp_path: Path):
@@ -257,7 +257,7 @@ class TestResumeResetOnRetry:
             DispatchRecord(
                 name="d2",
                 status=DispatchStatus.FAILURE,
-                kill_reason="stale",
+                retry_reason="stale",
                 infra_exit_category="timeout",
             ),
         )
@@ -267,7 +267,7 @@ class TestResumeResetOnRetry:
         state = read_state(sp)
         assert state is not None
         d2 = next(d for d in state.dispatches if d.name == "d2")
-        assert d2.kill_reason == ""
+        assert d2.retry_reason == ""
         assert d2.infra_exit_category == ""
 
 
@@ -282,7 +282,7 @@ class TestAttemptHistoryOnRetry:
             dispatched_session_id="old-sess",
             dispatched_pid=12345,
             reason="task_failed",
-            kill_reason="stale",
+            retry_reason="stale",
             infra_exit_category="timeout",
             started_at=1000.0,
             ended_at=2000.0,
@@ -293,7 +293,7 @@ class TestAttemptHistoryOnRetry:
         attempt = d.attempt_history[0]
         assert attempt["dispatch_id"] == "old-id"
         assert attempt["status"] == "failure"
-        assert attempt["kill_reason"] == "stale"
+        assert attempt["retry_reason"] == "stale"
         assert attempt["started_at"] == 1000.0
         assert attempt["ended_at"] == 2000.0
 

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -71,7 +71,7 @@ class TestInitialState:
                 dispatched_starttime_ticks=9999,
                 dispatched_boot_id="b1",
                 reason="started",
-                kill_reason="",
+                retry_reason="",
                 infra_exit_category="",
                 token_usage={"input": 100},
                 started_at=1.0,
@@ -114,7 +114,7 @@ class TestDispatchRecordFromDict:
             "dispatched_starttime_ticks": 9999,
             "dispatched_boot_id": "b1",
             "reason": "started",
-            "kill_reason": "",
+            "retry_reason": "",
             "infra_exit_category": "",
             "token_usage": {"input": 100},
             "started_at": 1.0,
@@ -132,7 +132,7 @@ class TestDispatchRecordFromDict:
         assert rec.dispatched_starttime_ticks == 9999
         assert rec.dispatched_boot_id == "b1"
         assert rec.reason == "started"
-        assert rec.kill_reason == ""
+        assert rec.retry_reason == ""
         assert rec.infra_exit_category == ""
         assert rec.token_usage == {"input": 100}
         assert rec.started_at == 1.0
@@ -944,23 +944,23 @@ class TestHasFailedDispatchReasonAware:
         assert has_failed_dispatch(sp) is True
 
 
-class TestKillReasonPropagation:
+class TestRetryReasonPropagation:
     def test_kill_reason_stored_in_dispatch_record(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x"))
         record = DispatchRecord(
             name="x",
             status=DispatchStatus.FAILURE,
-            kill_reason="idle_stall",
+            retry_reason="idle_stall",
         )
         append_dispatch_record(sp, record)
         state = read_state(sp)
         assert state is not None
-        assert state.dispatches[0].kill_reason == "idle_stall"
+        assert state.dispatches[0].retry_reason == "idle_stall"
 
     def test_kill_reason_defaults_empty(self) -> None:
         record = DispatchRecord(name="x")
-        assert record.kill_reason == ""
+        assert record.retry_reason == ""
 
     def test_kill_reason_round_trips_through_json(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
@@ -968,16 +968,16 @@ class TestKillReasonPropagation:
         record = DispatchRecord(
             name="x",
             status=DispatchStatus.FAILURE,
-            kill_reason="context_exhausted",
+            retry_reason="context_exhausted",
             infra_exit_category="context_exhausted",
         )
         append_dispatch_record(sp, record)
         raw = sp.read_text(encoding="utf-8")
-        assert '"kill_reason"' in raw
+        assert '"retry_reason"' in raw
         assert '"infra_exit_category"' in raw
         state = read_state(sp)
         assert state is not None
-        assert state.dispatches[0].kill_reason == "context_exhausted"
+        assert state.dispatches[0].retry_reason == "context_exhausted"
         assert state.dispatches[0].infra_exit_category == "context_exhausted"
 
     def test_resume_decision_includes_kill_reason(self, tmp_path: Path) -> None:
@@ -990,14 +990,26 @@ class TestKillReasonPropagation:
         data = json.loads(sp.read_text())
         for d in data["dispatches"]:
             if d["name"] == "x":
-                d["kill_reason"] = "idle_stall"
+                d["retry_reason"] = "idle_stall"
                 d["infra_exit_category"] = ""
                 d["dispatched_session_id"] = "sess-1"
         sp.write_text(json.dumps(data))
         decision = resume_campaign_from_state(sp, continue_on_failure=False)
         assert decision is not None
         assert decision.is_resumable is True
-        assert decision.kill_reason == "idle_stall"
+        assert decision.retry_reason == "idle_stall"
+
+    def test_dispatch_record_retry_reason_field(self) -> None:
+        """DispatchRecord.retry_reason stores RetryReason values."""
+        record = DispatchRecord(name="test", retry_reason="resume")
+        assert record.retry_reason == "resume"
+        assert not hasattr(record, "kill_reason")
+
+    def test_dispatch_record_from_dict_reads_legacy_kill_reason_key(self) -> None:
+        """Old state files with 'kill_reason' JSON key deserialize into retry_reason."""
+        raw: dict[str, object] = {"name": "test", "status": "running", "kill_reason": "stale"}
+        record = DispatchRecord.from_dict(raw)
+        assert record.retry_reason == "stale"
 
 
 class TestOrchestratorSessionIdRoundTrip:
@@ -1081,7 +1093,7 @@ class TestClassifyStaleDispatch:
             name="d1",
             status=DispatchStatus.RUNNING,
             sidecar_path=str(sidecar),
-            kill_reason="idle_stall",
+            retry_reason="idle_stall",
         )
         _orig_read_text = Path.read_text
 
@@ -1103,7 +1115,7 @@ class TestClassifyStaleDispatch:
             name="d1",
             status=DispatchStatus.RUNNING,
             sidecar_path=str(sidecar),
-            kill_reason="resume",
+            retry_reason="resume",
             infra_exit_category="context_exhausted",
         )
         status, sidecar_path_out = classify_stale_dispatch(record)
@@ -1118,7 +1130,7 @@ class TestClassifyStaleDispatch:
             name="d1",
             status=DispatchStatus.RUNNING,
             sidecar_path=str(sidecar),
-            kill_reason="idle_stall",
+            retry_reason="idle_stall",
             infra_exit_category="",
         )
         status, sidecar_path_out = classify_stale_dispatch(record)
@@ -1416,7 +1428,7 @@ class TestAllInterruptedCampaignDoesNotSilentlyComplete:
 
         upsert_dispatch_record_by_name(
             sp,
-            DispatchRecord(name="A", status=DispatchStatus.INTERRUPTED, kill_reason="stale"),
+            DispatchRecord(name="A", status=DispatchStatus.INTERRUPTED, retry_reason="stale"),
         )
 
         decision = resume_campaign_from_state(sp, continue_on_failure=True, reset_on_retry=True)
@@ -1465,7 +1477,7 @@ class TestAllRefusedCampaignDoesNotSilentlyComplete:
         assert decision.next_dispatch_name == "A"
 
 
-class TestKillReasonNotStaleAfterResumableRedispatch:
+class TestRetryReasonNotStaleAfterResumableRedispatch:
     """kill_reason must be cleared when a RESUMABLE dispatch is redispatched to RUNNING."""
 
     def test_kill_reason_cleared_on_resumable_to_running(self, tmp_path: Path) -> None:
@@ -1483,7 +1495,7 @@ class TestKillReasonNotStaleAfterResumableRedispatch:
             DispatchRecord(
                 name="A",
                 status=DispatchStatus.RESUMABLE,
-                kill_reason="idle_stall",
+                retry_reason="idle_stall",
                 infra_exit_category="something",
                 sidecar_path=str(sidecar),
             ),
@@ -1494,7 +1506,7 @@ class TestKillReasonNotStaleAfterResumableRedispatch:
         state = read_state(sp)
         assert state is not None
         a = next(d for d in state.dispatches if d.name == "A")
-        assert a.kill_reason == "", "kill_reason was not cleared on RESUMABLE→RUNNING transition"
+        assert a.retry_reason == "", "retry_reason was not cleared on RESUMABLE→RUNNING transition"
         assert a.infra_exit_category == "", (
             "infra_exit_category was not cleared on RESUMABLE→RUNNING transition"
         )
@@ -1629,7 +1641,7 @@ class TestUpsertFailureToFailureSnapshotsPrior:
                 name="run-implement",
                 status=DispatchStatus.FAILURE,
                 reason="fleet_l3_parse_failed",
-                kill_reason="context_exhausted",
+                retry_reason="context_exhausted",
             ),
         )
 
@@ -1648,7 +1660,7 @@ class TestUpsertFailureToFailureSnapshotsPrior:
         assert len(disp.attempt_history) == 1
         snapshot = disp.attempt_history[0]
         assert snapshot["reason"] == "fleet_l3_parse_failed"
-        assert snapshot["kill_reason"] == "context_exhausted"
+        assert snapshot["retry_reason"] == "context_exhausted"
         assert disp.status == DispatchStatus.FAILURE
         assert disp.reason == "fleet_l3_no_result_block"
 

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -49,7 +49,7 @@ class TestInitialState:
 
         state = read_state(sp)
         assert state is not None
-        assert state.schema_version == 5
+        assert state.schema_version == 6
         assert state.campaign_id == "cid-1"
         assert state.campaign_name == "my-campaign"
         assert state.manifest_path == "/m.yaml"

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -199,6 +199,26 @@ class TestDispatchRecordFromDict:
         rec = DispatchRecord.from_dict(d)
         assert rec.dispatched_starttime_ticks == 0
 
+    def test_reaper_fields_round_trip_through_serialization(self) -> None:
+        """reaper_reason and reaper_dispatch_id survive to_dict/from_dict (Test 1H)."""
+        rec = DispatchRecord(
+            name="t",
+            reaper_reason="reaped_orphan",
+            reaper_dispatch_id="xyz-456",
+        )
+        d = rec.to_dict()
+        assert d["reaper_reason"] == "reaped_orphan"
+        assert d["reaper_dispatch_id"] == "xyz-456"
+        rec2 = DispatchRecord.from_dict(d)
+        assert rec2.reaper_reason == "reaped_orphan"
+        assert rec2.reaper_dispatch_id == "xyz-456"
+
+    def test_reaper_fields_default_to_empty_string(self) -> None:
+        """reaper fields default to empty string when absent from dict (Test 1H complement)."""
+        rec = DispatchRecord.from_dict({"name": "t"})
+        assert rec.reaper_reason == ""
+        assert rec.reaper_dispatch_id == ""
+
 
 class TestStateDecompositionImports:
     def test_state_types_importable(self) -> None:

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -945,7 +945,7 @@ class TestHasFailedDispatchReasonAware:
 
 
 class TestRetryReasonPropagation:
-    def test_kill_reason_stored_in_dispatch_record(self, tmp_path: Path) -> None:
+    def test_retry_reason_stored_in_dispatch_record(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x"))
         record = DispatchRecord(
@@ -958,11 +958,11 @@ class TestRetryReasonPropagation:
         assert state is not None
         assert state.dispatches[0].retry_reason == "idle_stall"
 
-    def test_kill_reason_defaults_empty(self) -> None:
+    def test_retry_reason_defaults_empty(self) -> None:
         record = DispatchRecord(name="x")
         assert record.retry_reason == ""
 
-    def test_kill_reason_round_trips_through_json(self, tmp_path: Path) -> None:
+    def test_retry_reason_round_trips_through_json(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x"))
         record = DispatchRecord(
@@ -1478,10 +1478,10 @@ class TestAllRefusedCampaignDoesNotSilentlyComplete:
 
 
 class TestRetryReasonNotStaleAfterResumableRedispatch:
-    """kill_reason must be cleared when a RESUMABLE dispatch is redispatched to RUNNING."""
+    """retry_reason must be cleared when a RESUMABLE dispatch is redispatched to RUNNING."""
 
-    def test_kill_reason_cleared_on_resumable_to_running(self, tmp_path: Path) -> None:
-        """mark_dispatch_running clears kill_reason when re-dispatching a RESUMABLE dispatch."""
+    def test_retry_reason_cleared_on_resumable_to_running(self, tmp_path: Path) -> None:
+        """mark_dispatch_running clears retry_reason when re-dispatching a RESUMABLE dispatch."""
         from autoskillit.fleet import upsert_dispatch_record_by_name
 
         sp = _state_path(tmp_path)

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -72,8 +72,8 @@ class TestDispatchRecordSchemaV2:
         assert dispatch_raw["dispatched_starttime_ticks"] == 42
         assert dispatch_raw["dispatched_boot_id"] == "abc-boot"
 
-    def test_schema_version_is_5(self) -> None:
-        assert FLEET_STATE_SCHEMA_VERSION == 5
+    def test_schema_version_is_6(self) -> None:
+        assert FLEET_STATE_SCHEMA_VERSION == 6
 
     def test_read_state_returns_none_on_version_mismatch(self, tmp_path: Path) -> None:
         """read_state returns None when schema_version is stale (v1)."""
@@ -375,7 +375,7 @@ class TestDispatchRecordToDict:
             "identity_degraded",
             "reason",
             "diagnostic_message",
-            "kill_reason",
+            "retry_reason",
             "infra_exit_category",
             "reaper_reason",
             "reaper_dispatch_id",

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -377,6 +377,8 @@ class TestDispatchRecordToDict:
             "diagnostic_message",
             "kill_reason",
             "infra_exit_category",
+            "reaper_reason",
+            "reaper_dispatch_id",
             "token_usage",
             "started_at",
             "ended_at",

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -968,6 +968,7 @@ class TestFoodTruckAutoGateBoot:
             skip_dispatch_ids=frozenset({"my-ft-dispatch"}),
             own_campaign_id="my-campaign-1",
             min_reap_age_seconds=60.0,
+            reaper_dispatch_id="my-ft-dispatch",
         )
 
     @pytest.mark.anyio
@@ -1018,6 +1019,7 @@ class TestFoodTruckAutoGateBoot:
             skip_dispatch_ids=None,
             own_campaign_id="my-campaign-2",
             min_reap_age_seconds=60.0,
+            reaper_dispatch_id="",
         )
 
 


### PR DESCRIPTION
## Summary

When the cross-dispatch reaper kills a sibling food truck via `kill_process_tree`, 8 independent diagnostic signals label the kill as a "natural exit" or "completed" — actively misleading investigators. The root architectural weakness: kill attribution is exclusively self-reported — only in-process kill actions annotate exit reasons. External kills (reaper, OOM, system signals) have no attribution path.

Part A introduces:
1. Signal-death exit code recognition — `is_signal_death_code()` recognizes both Python (-N) and shell (128+N) signal-death conventions
2. Kill Attribution Protocol — reaper writes durable tombstone + central log + non-overwritable dispatch fields
3. `TerminationReason.SIGNAL_DEATH` — distinguishes external signal kills from voluntary process exits

## Requirements

### REQ-DIAG-001: Signal-Death Exit Code Recognition
`classify_infra_exit` at `_exit_classification.py:116` must recognize exit codes in the 128-192 range (128+signal) as `PROCESS_KILLED`, not `COMPLETED`. This unblocks the process-kill override recovery path at `_headless_result.py:531-542`.

### REQ-DIAG-002: `kill_reason` Must Distinguish External Kills
`resolve_termination` at `_process_race.py:455` should check `process_returncode` when `process_exited=True`. If the return code is a signal-death code (< 0 or 128+N), set `TerminationReason.SIGNAL_DEATH` instead of `NATURAL_EXIT`. Add `KillReason.SIGNAL_DEATH` to the enum.

### REQ-DIAG-003: Dispatch State `kill_reason` Field Type Correction
`_api.py:767` stores `skill_result.retry_reason` in a field named `kill_reason`. Either rename the field to `retry_reason` or store `skill_result.kill_reason.value` instead. Having two different fields both named `kill_reason` storing different enum types is maximally confusing.

### REQ-DIAG-004: Reaper Evidence Preservation
The reaper's `"reaped_orphan"` annotation must survive the parent's classification write. Options:
- Add a non-overwritable `reaper_reason` field to `DispatchRecord`
- Write a tombstone file to `dispatch.dispatched_session_log_dir` (e.g., `reaper_action.json`)
- Both (defense in depth)

### REQ-DIAG-005: Centralized Reaper Activity Log
Write every reaper action (kill, mark-dead, mark-recycled) to a centralized `~/.local/share/autoskillit/logs/reaper_events.jsonl` file. Fields: `ts`, `action`, `victim_dispatch_id`, `victim_pid`, `victim_session_id`, `killer_dispatch_id`, `campaign_id`, `reason`. Parallels existing `quota_events.jsonl` pattern.

### REQ-DIAG-006: Reaper Tombstone in Victim Session Directory
When the reaper kills a process, write a JSON tombstone file to `Path(dispatch.dispatched_session_log_dir) / dispatch.dir_name / "reaper_action.json"` with the kill details. The `dispatched_session_log_dir` field already exists on `DispatchRecord` (`state_types.py:109`). This makes the kill visible to any investigator reading the victim's session logs.

Closes #3318

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-093747-811403/.autoskillit/temp/rectify/rectify_diagnostic_signals_mask_reaper_kills_2026-05-30_094500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 71 | 27.5k | 1.6M | 135.0k | 272 | 108.1k | 22m 53s |
| review_approach* | sonnet | 1 | 4.6k | 6.6k | 227.6k | 47.5k | 67 | 35.4k | 4m 25s |
| dry_walkthrough* | opus | 2 | 1.2k | 27.3k | 1.3M | 75.5k | 158 | 111.0k | 12m 28s |
| implement* | sonnet | 2 | 1.3k | 64.4k | 13.5M | 128.1k | 435 | 270.3k | 22m 8s |
| audit_impl* | sonnet | 2 | 1.8k | 16.2k | 500.4k | 37.7k | 53 | 71.0k | 6m 23s |
| prepare_pr* | sonnet | 1 | 135.8k | 4.5k | 247.3k | 30.9k | 29 | 43.9k | 1m 28s |
| compose_pr* | sonnet | 1 | 43.1k | 2.0k | 182.6k | 30.9k | 14 | 15.5k | 46s |
| review_pr* | sonnet | 1 | 174 | 44.0k | 1.5M | 132.0k | 96 | 117.7k | 11m 49s |
| resolve_review* | opus | 1 | 1.7k | 16.5k | 1.7M | 88.4k | 90 | 92.1k | 11m 5s |
| resolve_pre_review_conflicts* | opus | 1 | 47 | 14.6k | 2.1M | 96.6k | 54 | 81.0k | 4m 2s |
| **Total** | | | 189.8k | 223.6k | 23.0M | 135.0k | | 945.9k | 1h 37m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 494 | 27352.3 | 547.1 | 130.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 45 | 38700.1 | 2046.2 | 367.3 |
| resolve_pre_review_conflicts | 783 | 2739.1 | 103.4 | 18.7 |
| **Total** | **1322** | 17397.0 | 715.5 | 169.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 71 | 27.5k | 1.6M | 108.1k | 22m 53s |
| sonnet | 6 | 186.8k | 137.7k | 16.2M | 553.8k | 47m 0s |
| opus | 3 | 2.9k | 58.4k | 5.2M | 284.1k | 27m 36s |