### PR TITLE
Rectify: Provider-Agnostic Turn Deduplication in `iter_merged_assistant_turns`

### DIFF
--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -54,15 +54,15 @@ class AnalysisResult:
     session_count: int
 
 
-def _resolve_turn_id(rec: dict) -> str:
+def _resolve_turn_id(rec: dict[str, object]) -> str:
     """Extract canonical turn dedup key: requestId > message.id > empty."""
     rid = rec.get("requestId", "")
-    if rid:
+    if isinstance(rid, str) and rid:
         return rid
     message = rec.get("message")
     if isinstance(message, dict):
         mid = message.get("id", "")
-        if mid:
+        if isinstance(mid, str) and mid:
             return mid
     return ""
 

--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -54,16 +54,29 @@ class AnalysisResult:
     session_count: int
 
 
+def _resolve_turn_id(rec: dict) -> str:
+    """Extract canonical turn dedup key: requestId > message.id > empty."""
+    rid = rec.get("requestId", "")
+    if rid:
+        return rid
+    message = rec.get("message")
+    if isinstance(message, dict):
+        mid = message.get("id", "")
+        if mid:
+            return mid
+    return ""
+
+
 def iter_merged_assistant_turns(text: str, *, cap: int = _TOOL_USE_CAP) -> Iterator[AssistantTurn]:
     """Yield one AssistantTurn per logical assistant turn, merging across records.
 
-    When multiple JSONL records share the same requestId (e.g., extended thinking
-    emits a thinking-only record followed by a tool-bearing record), tool calls
-    are accumulated across all records for that requestId. The cap is applied
-    after accumulation.
+    When multiple JSONL records share the same canonical turn ID (requestId or
+    message.id) (e.g., extended thinking emits a thinking-only record followed
+    by a tool-bearing record), tool calls are accumulated across all records for
+    that turn ID. The cap is applied after accumulation.
 
-    Records without a requestId are yielded individually (no dedup possible).
-    Turns are yielded in the order their requestId (or no-rid record) was first
+    Records with neither requestId nor message.id are yielded individually (no dedup possible).
+    Turns are yielded in the order their turn ID (or no-rid record) was first
     encountered — preserving file-order interleaving for correct DFG bigram analysis.
     """
     pending: OrderedDict[str, tuple[str, list[str]]] = OrderedDict()
@@ -82,7 +95,7 @@ def iter_merged_assistant_turns(text: str, *, cap: int = _TOOL_USE_CAP) -> Itera
         if not isinstance(rec, dict) or rec.get("type") != "assistant":
             continue
 
-        rid = rec.get("requestId", "")
+        rid = _resolve_turn_id(rec)
         ts = rec.get("timestamp", "")
         message = rec.get("message")
         content = message.get("content", []) if isinstance(message, dict) else []

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -54,6 +54,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_no_error_dict_return.py` | AST guard: load_and_validate must not return dicts with 'error' key — errors flow via exceptions |
 | `test_flush_no_rid_guard.py` | AST guard: no requestId truthiness guard in flush_session_log turn extraction loop |
 | `test_no_inline_jsonl_request_id_dedup.py` | AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py |
+| `test_resolve_turn_id_guard.py` | AST guard: no direct .get("requestId") calls outside _resolve_turn_id() in tool_sequence_analysis.py |
 | `test_protocol_names.py` | T5-T6: Protocol naming and DefaultSkillResolver export smoke tests |
 | `test_provider_profile_contract.py` | Tier 3 contract: _resolve_provider_profile must never return step_name as profile |
 | `test_pty_coherence.py` | Dispatch-type-aware PTY allocation guards: AST enforcement that dispatch_food_truck passes pty_override=False and _attempt_contract_nudge accepts pty_override |

--- a/tests/arch/test_no_inline_jsonl_request_id_dedup.py
+++ b/tests/arch/test_no_inline_jsonl_request_id_dedup.py
@@ -1,8 +1,8 @@
 """AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py.
 
 Both files previously contained independent first-occurrence-wins dedup logic using
-a local `seen_request_ids` set. The dedup is now centralised in
-`iter_merged_assistant_turns()`. This guard prevents regression.
+a local `seen_request_ids` set. The dedup key resolution is centralised in
+`_resolve_turn_id()` (called by `iter_merged_assistant_turns()`). This guard prevents regression.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ class TestNoInlineJsonlRequestIdDedup:
         hits = _function_scoped_names(tree, "seen_request_ids")
         assert not hits, (
             "execution/session_log.py re-introduced an inline requestId dedup set.\n"
-            "Use iter_merged_assistant_turns() instead.\n"
+            "Use _resolve_turn_id() (called by iter_merged_assistant_turns()) instead.\n"
             "Offending lines: " + ", ".join(str(ln) for ln in hits)
         )
 
@@ -47,6 +47,6 @@ class TestNoInlineJsonlRequestIdDedup:
         hits = _function_scoped_names(tree, "seen_request_ids")
         assert not hits, (
             "core/tool_sequence_analysis.py re-introduced an inline requestId dedup set.\n"
-            "Use iter_merged_assistant_turns() instead.\n"
+            "Use _resolve_turn_id() (called by iter_merged_assistant_turns()) instead.\n"
             "Offending lines: " + ", ".join(str(ln) for ln in hits)
         )

--- a/tests/arch/test_resolve_turn_id_guard.py
+++ b/tests/arch/test_resolve_turn_id_guard.py
@@ -1,0 +1,53 @@
+"""AST guard: _resolve_turn_id is the sole turn ID resolution point.
+
+No function other than _resolve_turn_id in tool_sequence_analysis.py may
+call .get("requestId", ...). Direct requestId access bypasses the provider-
+agnostic resolution chain and re-introduces the MiniMax dedup regression.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+TOOL_SEQ = SRC / "core" / "tool_sequence_analysis.py"
+
+
+def _direct_request_id_get_lines(tree: ast.AST) -> list[tuple[str, int]]:
+    """Return (func_name, lineno) for .get("requestId") calls outside _resolve_turn_id."""
+    hits: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name == "_resolve_turn_id":
+            continue
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            func = child.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "get"):
+                continue
+            args = child.args
+            if not args:
+                continue
+            first = args[0]
+            if isinstance(first, ast.Constant) and first.value == "requestId":
+                hits.append((node.name, child.lineno))
+    return hits
+
+
+class TestResolveTurnIdGuard:
+    def test_no_direct_request_id_get_outside_resolver(self) -> None:
+        tree = ast.parse(TOOL_SEQ.read_text(encoding="utf-8"))
+        hits = _direct_request_id_get_lines(tree)
+        assert not hits, (
+            'core/tool_sequence_analysis.py contains direct .get("requestId") '
+            "calls outside _resolve_turn_id().\n"
+            "Use _resolve_turn_id() (called by iter_merged_assistant_turns()) instead.\n"
+            "Offending (function, line): " + ", ".join(f"{fn}:{ln}" for fn, ln in hits)
+        )

--- a/tests/core/test_tool_sequence_analysis.py
+++ b/tests/core/test_tool_sequence_analysis.py
@@ -390,13 +390,17 @@ class TestIterMergedAssistantTurns:
         ts: str = "",
         tools: list[str] | None = None,
         thinking: bool = False,
+        message_id: str = "",
     ) -> str:
         content: list[dict] = []
         if thinking:
             content.append({"type": "thinking", "thinking": "..."})
         for name in tools or []:
             content.append({"type": "tool_use", "name": name})
-        rec: dict = {"type": "assistant", "message": {"content": content}}
+        msg: dict = {"content": content}
+        if message_id:
+            msg["id"] = message_id
+        rec: dict = {"type": "assistant", "message": msg}
         if rid:
             rec["requestId"] = rid
         if ts:
@@ -464,3 +468,109 @@ class TestIterMergedAssistantTurns:
         assert len(turns) == 1
         assert turns[0].timestamp == "first-ts"
         assert turns[0].tool_names == ("Bash",)
+
+    def test_message_id_fallback_when_request_id_absent(self) -> None:
+        """Records sharing message.id but lacking requestId merge into one turn."""
+        mid = "0669d3ed14adce24ccf227c37a5884d4"
+        rec1 = json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-30T08:33:53.843Z",
+                "message": {"id": mid, "content": [{"type": "thinking", "thinking": "..."}]},
+            }
+        )
+        rec2 = json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-30T08:33:54.810Z",
+                "message": {"id": mid, "content": [{"type": "tool_use", "name": "Bash"}]},
+            }
+        )
+        turns = self._parse(rec1, rec2)
+        assert len(turns) == 1
+        assert turns[0].request_id == mid
+        assert turns[0].timestamp == "2026-05-30T08:33:53.843Z"
+        assert turns[0].tool_names == ("Bash",)
+
+    def test_request_id_takes_precedence_over_message_id(self) -> None:
+        """When both requestId and message.id are present, requestId wins."""
+        rec = json.dumps(
+            {
+                "type": "assistant",
+                "requestId": "req_001",
+                "message": {"id": "hex-mid", "content": [{"type": "tool_use", "name": "Read"}]},
+            }
+        )
+        turns = self._parse(rec)
+        assert len(turns) == 1
+        assert turns[0].request_id == "req_001"
+
+    def test_mixed_request_id_and_message_id_interleaved(self) -> None:
+        """Anthropic records (requestId) and MiniMax records (message.id only) coexist."""
+        r1 = json.dumps(
+            {
+                "type": "assistant",
+                "requestId": "req-A",
+                "message": {"content": [{"type": "tool_use", "name": "A"}]},
+            }
+        )
+        r2 = json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "ts2",
+                "message": {"id": "mid-B", "content": [{"type": "tool_use", "name": "B"}]},
+            }
+        )
+        r3 = json.dumps(
+            {
+                "type": "assistant",
+                "requestId": "req-C",
+                "message": {"content": [{"type": "tool_use", "name": "C"}]},
+            }
+        )
+        turns = self._parse(r1, r2, r3)
+        assert len(turns) == 3
+        assert turns[0].request_id == "req-A"
+        assert turns[1].request_id == "mid-B"
+        assert turns[2].request_id == "req-C"
+
+    def test_no_request_id_no_message_id_gets_synthetic(self) -> None:
+        """Records with neither requestId nor message.id get synthetic turn-N."""
+        rec = json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "tool_use", "name": "Bash"}]},
+            }
+        )
+        turns = self._parse(rec)
+        assert len(turns) == 1
+        assert turns[0].request_id == "turn-0"
+
+    def test_merged_turns_preserve_first_timestamp_monotonicity(self) -> None:
+        """Multi-record turns with non-monotonic chunk timestamps use first ts only."""
+        mid = "mid-mono"
+        rec1 = json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-30T08:33:53.843Z",
+                "message": {"id": mid, "content": [{"type": "thinking", "thinking": "..."}]},
+            }
+        )
+        rec2 = json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-30T08:33:54.810Z",
+                "message": {"id": mid, "content": [{"type": "tool_use", "name": "A"}]},
+            }
+        )
+        rec3 = json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-05-30T08:33:54.538Z",
+                "message": {"id": mid, "content": [{"type": "tool_use", "name": "B"}]},
+            }
+        )
+        turns = self._parse(rec1, rec2, rec3)
+        assert len(turns) == 1
+        assert turns[0].timestamp == "2026-05-30T08:33:53.843Z"
+        assert turns[0].tool_names == ("A", "B")

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -162,14 +162,20 @@ def _make_cc_jsonl_record(
     timestamp: str = "",
     content: list[dict] | None = None,
     record_type: str = "assistant",
+    message_id: str = "",
 ) -> str:
     rec: dict[str, object] = {"type": record_type}
     if request_id:
         rec["requestId"] = request_id
     if timestamp:
         rec["timestamp"] = timestamp
-    if content is not None:
-        rec["message"] = {"content": content}
+    if content is not None or message_id:
+        msg: dict[str, object] = {}
+        if content is not None:
+            msg["content"] = content
+        if message_id:
+            msg["id"] = message_id
+        rec["message"] = msg
     return json.dumps(rec)
 
 

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -20,8 +20,6 @@ pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 # Helpers
 # ---------------------------------------------------------------------------
 
-_NOW = datetime.now(UTC)
-
 
 def _run(
     run_id: int = 12345,
@@ -38,7 +36,7 @@ def _run(
         "conclusion": conclusion,
         "head_sha": head_sha,
         "event": event,
-        "updated_at": updated_at or _NOW.isoformat(),
+        "updated_at": updated_at or datetime.now(UTC).isoformat(),
     }
 
 

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1551,3 +1551,54 @@ class TestModelAliasDriftIntegration:
         lines = anomalies_path.read_text().strip().splitlines() if anomalies_path.exists() else []
         rss = [json.loads(line) for line in lines if json.loads(line).get("kind") == "rss_growth"]
         assert len(rss) == 0
+
+
+def test_flush_session_log_minimax_message_id_turn_dedup(tmp_path, monkeypatch):
+    """MiniMax-shaped JSONL (message.id, no requestId) deduplicates into correct turn count."""
+    mid = "0669d3ed14adce24ccf227c37a5884d4"
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        _make_cc_jsonl_record(
+            message_id=mid,
+            timestamp="2026-05-30T08:33:53.843Z",
+            content=[_make_thinking_block("reasoning...")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            message_id=mid,
+            timestamp="2026-05-30T08:33:54.810Z",
+            content=[_make_tool_block("Bash")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            message_id="aabbccddeeff00112233445566778899",
+            timestamp="2026-05-30T08:34:01.000Z",
+            content=[_make_tool_block("Read")],
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="minimax-dedup-001",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-05-30T08:33:53.843Z",
+        proc_snapshots=None,
+        telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
+    )
+    summary = json.loads(
+        (tmp_path / "sessions" / "minimax-dedup-001" / "summary.json").read_text()
+    )
+    assert summary["request_ids"] == [mid, "aabbccddeeff00112233445566778899"]
+    assert len(summary["turn_timestamps"]) == 2
+    assert len(summary["turn_tool_calls"]) == 2
+    assert summary["turn_timestamps"][0] == "2026-05-30T08:33:53.843Z"


### PR DESCRIPTION
## Summary

`iter_merged_assistant_turns()` in `core/tool_sequence_analysis.py` uses `requestId` as the sole deduplication key for merging multi-record assistant turns. MiniMax-routed sessions omit the `requestId` top-level field but populate `message.id` — a semantically equivalent grouping key. Without fallback, every MiniMax record becomes an individual synthetic `turn-N`, inflating turn counts, producing out-of-order timestamps, and degrading diagnostic accuracy.

The architectural weakness is that the function hardcodes an Anthropic-specific field name instead of resolving a canonical turn identifier from whichever field is available. The test suite compounds this by never constructing records with `message.id` but without `requestId`, making the gap invisible.

### Changed Files

**New:**
- `tests/arch/test_resolve_turn_id_guard.py`

**Modified:**
- `src/autoskillit/core/tool_sequence_analysis.py`
- `tests/arch/CLAUDE.md`
- `tests/arch/test_no_inline_jsonl_request_id_dedup.py`
- `tests/core/test_tool_sequence_analysis.py`
- `tests/execution/conftest.py`
- `tests/execution/test_ci.py`
- `tests/execution/test_session_log_fields.py`

Closes #3311

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-093957-176059/.autoskillit/temp/rectify/rectify_turn_dedup_provider_agnostic_2026-05-30_100500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 10.9k | 18.9k | 2.4M | 104.2k | 305 | 87.1k | 20m 54s |
| review_approach* | sonnet | 1 | 60 | 6.4k | 221.0k | 42.3k | 40 | 29.3k | 3m 15s |
| dry_walkthrough* | opus | 1 | 52 | 12.4k | 788.9k | 72.6k | 113 | 73.0k | 7m 51s |
| implement* | sonnet | 1 | 304 | 16.8k | 2.1M | 77.6k | 105 | 113.5k | 6m 34s |
| audit_impl* | sonnet | 2 | 754 | 14.8k | 546.3k | 41.0k | 64 | 58.6k | 8m 43s |
| post_run_diagnostics* | sonnet | 1 | 36 | 10.7k | 99.5k | 86.1k | 174 | 27.8k | 8m 49s |
| prepare_pr* | sonnet | 1 | 83.1k | 5.3k | 185.6k | 30.9k | 22 | 43.9k | 1m 46s |
| compose_pr* | sonnet | 1 | 79.3k | 3.3k | 275.5k | 30.9k | 22 | 15.5k | 1m 12s |
| review_pr* | sonnet | 1 | 156 | 48.8k | 1.1M | 103.5k | 58 | 88.6k | 12m 39s |
| resolve_review* | opus | 1 | 47 | 8.1k | 1.1M | 65.1k | 43 | 49.5k | 7m 32s |
| **Total** | | | 174.7k | 145.4k | 8.9M | 104.2k | | 586.8k | 1h 19m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 262 | 8072.5 | 433.1 | 64.1 |
| audit_impl | 0 | — | — | — |
| post_run_diagnostics | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 187633.3 | 8251.8 | 1342.2 |
| **Total** | **268** | 33066.6 | 2189.7 | 542.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 10.9k | 18.9k | 2.4M | 87.1k | 20m 54s |
| sonnet | 7 | 163.6k | 106.1k | 4.6M | 377.2k | 43m 1s |
| opus | 2 | 99 | 20.4k | 1.9M | 122.5k | 15m 23s |