### PR TITLE
[FEATURE] Create specialist subagent definition for diff-scoped requirements auditing

### DIFF
--- a/src/autoskillit/agents/CLAUDE.md
+++ b/src/autoskillit/agents/CLAUDE.md
@@ -50,6 +50,7 @@ agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{nam
 | `plan-review` | `plan-review` | 3 adversarial reviewers | make-plan Steps 6-9, rectify Steps 5-7 |
 | _(none)_ | _(none)_ | `wp-elaborator` | planner-elaborate-wps (subagent_type-only) |
 | _(none)_ | _(none)_ | `pipeline-health-scanner` | analyze-pipeline-health (subagent_type-only) |
+| _(none)_ | _(none)_ | `audit-impl-slice-auditor` | audit-impl Step 3 (subagent_type-only) |
 
 ## Adding Agents
 
@@ -63,4 +64,4 @@ agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{nam
 `subagent_type: "autoskillit:{name}"` and does NOT need MCP resource access via
 `unlock_agent_pack`, only step 1 is required. Steps 2–5 exist for the
 `agent://{pack}/{name}` resource path and can be skipped for packless agents.
-Current packless agents: `wp-elaborator`.
+Current packless agents: `wp-elaborator`, `pipeline-health-scanner`, `audit-impl-slice-auditor`.

--- a/src/autoskillit/agents/audit-impl-slice-auditor.md
+++ b/src/autoskillit/agents/audit-impl-slice-auditor.md
@@ -1,0 +1,48 @@
+---
+name: audit-impl-slice-auditor
+description: "Audits a requirements slice against an implementation diff. Checks coverage, correctness, scope creep, and test completeness — returns structured findings."
+tools: [Bash]
+model: sonnet
+maxTurns: 30
+---
+
+# audit-impl-slice-auditor
+
+You are a **Slice Auditor** — a specialist agent that audits whether an implementation diff satisfies a set of plan requirements. You receive a requirements slice and an implementation diff embedded in your prompt. The diff is your single source of truth for implementation state.
+
+## Tool Constraints
+
+You have access to Bash only. Read, Grep, and Glob are not available — the working directory may be checked out on a different branch than the implementation being audited, so filesystem reads would show the wrong branch's content.
+
+When you need to inspect a file's full content beyond what the diff shows (e.g., to verify import structure or function signatures), use `git show {implementation_ref}:{path}` via Bash. The `implementation_ref` is provided in your prompt.
+
+## Procedure
+
+For each requirement in your slice:
+
+1. **Coverage** — Is every file and function the plan named present in the diff?
+2. **Correctness** — Does the implementation match the plan's stated intent? Flag inversions, missing logic, or wrong approaches.
+3. **Scope creep** — What is in the diff that no plan requirement covers? Flag unexpected files or additions.
+4. **Test coverage** — Were the plan's specified tests added?
+5. **Cross-plan conflicts** (multi-plan only) — Do any two plans' changes interfere or contradict?
+
+## Output Format
+
+Return one finding per requirement using these verdict labels:
+
+- `COVERED` — requirement satisfied in the diff
+- `MISSING` — required change absent from diff
+- `ODD` — change in diff with no plan backing
+- `CONFLICT` — two plans' implementations interfere with each other
+
+## Verdict
+
+After all findings, emit a summary line:
+
+```
+Verdict: {COVERED_count} COVERED, {MISSING_count} MISSING, {ODD_count} ODD, {CONFLICT_count} CONFLICT
+```
+
+## Scope Guard
+
+Do not modify any files. Do not write remediation suggestions. Report findings only.

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -56,7 +56,8 @@ requirements, scope creep, and unexpected changes. Produces a GO or NO GO verdic
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use Explore subagents for all file reads and diff retrieval
+- Use Explore subagents for file reads and diff retrieval in Steps 1, 2, and 2.5
+- Use `Agent(subagent_type="autoskillit:audit-impl-slice-auditor")` for Step 3 audit slices
 - Use `model: "sonnet"` when spawning all subagents via the Task tool
 - Resolve all plan files before starting (abort early if any are missing)
 - Write `Dry-walkthrough verified = TRUE` as the absolute first line of any remediation file
@@ -231,16 +232,15 @@ logic (Step 4).
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-**Data source discipline:** Do NOT call Read, Grep, or Glob to verify file existence or
-content — the diff is the single source of truth for implementation state. The working
-directory (`cwd`) may be checked out on a different branch than the implementation being
-audited; filesystem reads will show the wrong branch's content. If you need to inspect a
-file's full content on the implementation branch (e.g., to verify import structure or
-function signatures beyond what the diff shows), use
-`git show {implementation_ref}:{path}` — never read the filesystem directly.
+**Data source discipline:** The diff is the single source of truth for implementation state.
+The working directory (`cwd`) may be on a different branch than the implementation being
+audited. Do NOT use Read, Grep, or Glob — subagents are tool-restricted to Bash only via
+their agent definition, blocking filesystem reads at the platform level. When full file
+content is needed beyond the diff, subagents use `git show {implementation_ref}:{path}`.
 
-Divide the requirements inventory into up to 3 slices. Launch parallel Explore subagents,
-each receiving its slice and the full diff. Each subagent checks:
+Divide the requirements inventory into up to 3 slices. Launch parallel subagents using
+`Agent(subagent_type="autoskillit:audit-impl-slice-auditor")`, each receiving its slice,
+the full diff, and the `implementation_ref`. Each subagent checks:
 
 1. **Coverage** — Is every file and function the plan named present in the diff?
 2. **Correctness** — Does the implementation match the plan's stated intent? Flag inversions,

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -327,6 +327,42 @@ def test_elaborate_wps_subagent_type_refs_resolve():
         )
 
 
+# T-NEW-4: audit-impl SKILL.md subagent_type refs resolve to agent files
+def test_audit_impl_subagent_type_refs_resolve():
+    """audit-impl SKILL.md subagent_type refs resolve to agent files."""
+    import re
+
+    from autoskillit.core import pkg_root
+
+    content = (pkg_root() / "skills_extended" / "audit-impl" / "SKILL.md").read_text()
+    refs = re.findall(r'subagent_type.*?["\']autoskillit:([a-z][a-z0-9-]+)["\']', content)
+    unique_refs = set(refs)
+    assert len(unique_refs) >= 1, (
+        f"Expected >=1 subagent_type ref in audit-impl SKILL.md, found {len(unique_refs)}"
+    )
+    agents_dir = pkg_root() / "agents"
+    for agent_name in unique_refs:
+        agent_file = agents_dir / f"{agent_name}.md"
+        assert agent_file.exists(), (
+            f"SKILL.md references autoskillit:{agent_name} but {agent_file} does not exist"
+        )
+
+
+# T-NEW-5: audit-impl-slice-auditor is subagent_type-only — not in any agent pack
+def test_audit_impl_slice_auditor_is_packless():
+    """audit-impl-slice-auditor is subagent_type-only — not in any agent pack."""
+    from autoskillit.core import pkg_root
+    from autoskillit.core.types._type_constants_registries import AGENT_PACK_REGISTRY
+
+    agent_path = pkg_root() / "agents" / "audit-impl-slice-auditor.md"
+    assert agent_path.exists(), "audit-impl-slice-auditor.md must exist"
+    for pack_name in AGENT_PACK_REGISTRY:
+        assert "audit-impl-slice-auditor" not in pack_name, (
+            f"audit-impl-slice-auditor must NOT appear in any AGENT_PACK_REGISTRY pack name — "
+            f"found in '{pack_name}'. It is subagent_type-only."
+        )
+
+
 # T-NEW-2: wp-elaborator.md JSON schema must contain all WPResult fields
 def test_wp_elaborator_schema_covers_all_wp_fields():
     """wp-elaborator.md JSON schema must contain all WPResult fields, not just WP_REQUIRED_KEYS."""


### PR DESCRIPTION
## Summary

Create `audit-impl-slice-auditor`, a packless agent definition that enforces diff-only data source discipline at the platform level via `tools: [Bash]`. Update audit-impl SKILL.md Step 3 to dispatch via `subagent_type` instead of generic Explore subagents. Add the agent to the packless agents list and Agent Packs table in `agents/CLAUDE.md`, add a subagent_type resolution test and a packless-identity guard test.

## Requirements

### Must do
- [ ] Create `src/autoskillit/agents/audit-impl-slice-auditor.md` with frontmatter and concise body
- [ ] Ensure body contains a structured output marker for DIAG_C10 (`test_all_agents_have_structured_output`)
- [ ] Update `audit-impl/SKILL.md` Step 3 to use `subagent_type: "autoskillit:audit-impl-slice-auditor"`
- [ ] Simplify the "Data source discipline" paragraph in Step 3 (remove tool-specific instructions that now live in agent definition, keep the conceptual framing for the parent)
- [ ] Keep Step 4 branch-mismatch guard as defense-in-depth
- [ ] Add subagent_type resolution test following `test_elaborate_wps_subagent_type_refs_resolve` pattern (`test_tools_agents.py:309`) — greps `audit-impl/SKILL.md` for `autoskillit:audit-impl-slice-auditor` and verifies the `.md` file exists
- [ ] Update `agents/CLAUDE.md` packless agents list (currently says "Current packless agents: `wp-elaborator`" at line 62 — add the new agent)

### Out of scope (future work)
Other skills with subagent constraint gaps:
- `audit-review-decisions` Step 2
- `audit-bugs` Step 3
- `audit-cohesion` Step 1
- `audit-defense-standards` Step 1

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None

## Changed Files

### New (★):
- `src/autoskillit/agents/audit-impl-slice-auditor.md`

### Modified (●):
- `src/autoskillit/agents/CLAUDE.md`
- `src/autoskillit/skills_extended/audit-impl/SKILL.md`
- `tests/server/test_tools_agents.py`

Closes #3317

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260530-130708-098401/.autoskillit/temp/make-plan/audit-impl-slice-auditor_plan_2026-05-30_131500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 88 | 20.8k | 1.3M | 90.2k | 147 | 79.4k | 11m 41s |
| verify* | sonnet | 1 | 1.3k | 9.4k | 184.2k | 51.9k | 40 | 106.2k | 3m 33s |
| implement* | sonnet | 1 | 579.5k | 5.9k | 711.0k | 30.9k | 55 | 78.1k | 2m 10s |
| audit_impl* | sonnet | 1 | 277 | 16.7k | 336.4k | 56.1k | 55 | 41.8k | 7m 50s |
| prepare_pr* | sonnet | 1 | 116.2k | 3.6k | 275.4k | 30.9k | 23 | 15.9k | 1m 18s |
| compose_pr* | sonnet | 1 | 82.7k | 1.9k | 244.4k | 30.9k | 20 | 15.5k | 44s |
| review_pr* | sonnet | 1 | 126 | 36.8k | 600.2k | 74.6k | 41 | 66.5k | 7m 59s |
| resolve_review* | sonnet | 1 | 189 | 14.3k | 1.2M | 69.8k | 63 | 54.9k | 6m 5s |
| **Total** | | | 780.4k | 109.4k | 4.9M | 90.2k | | 458.3k | 41m 22s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 107 | 6645.3 | 730.3 | 54.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **107** | 45649.7 | 4283.3 | 1022.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 88 | 20.8k | 1.3M | 79.4k | 11m 41s |
| sonnet | 7 | 780.3k | 88.6k | 3.6M | 378.9k | 29m 41s |