### PR TITLE
[FIX] Rectify: Filesystem Snapshot Modification Blind Spot

### DIFF
--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -48,11 +48,11 @@ from autoskillit.execution.headless._headless_helpers import (
     PostSessionMetrics,
     _compute_post_session_metrics,  # noqa: F401
     _derive_step_name_from_skill_command,
-    _recursive_snapshot,  # noqa: F401
     _resolve_model,
     _resolve_pty_mode,  # noqa: F401
     _resolve_session_log_dir,
     _session_log_dir,  # noqa: F401
+    _stat_snapshot,  # noqa: F401
 )
 from autoskillit.execution.headless._headless_path_tokens import (  # noqa: F401
     _INTENTIONALLY_EXCLUDED_PATH_TOKENS,

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -378,14 +378,12 @@ async def _execute_claude_headless(
         for _wd in _watch_dirs:
             if _wd.is_dir():
                 try:
-                    _post: dict[str, tuple[int, int]] | None = _stat_snapshot(_wd)
+                    _post = _stat_snapshot(_wd)
                 except OSError:
                     logger.warning("watch_dir_post_scan_failed", watch_dir=str(_wd), exc_info=True)
                     continue
                 _pre = _temp_snapshots_pre.get(_wd)
-                if _pre is None:
-                    continue
-                if _post != _pre:
+                if _pre is not None and _post != _pre:
                     _fs_writes_detected = True
                     break
 

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -215,14 +215,14 @@ async def _execute_claude_headless(
         if _default:
             _watch_dirs.append(_default)
 
-    _temp_snapshots_pre: dict[Path, dict[str, tuple[int, int]]] = {}
+    _temp_snapshots_pre: dict[Path, dict[str, tuple[int, int]] | None] = {}
     for _wd in _watch_dirs:
         if _wd.is_dir():
             try:
                 _temp_snapshots_pre[_wd] = _stat_snapshot(_wd)
             except OSError:
                 logger.warning("watch_dir_pre_scan_failed", watch_dir=str(_wd), exc_info=True)
-                _temp_snapshots_pre[_wd] = {}
+                _temp_snapshots_pre[_wd] = None
 
     _pre_session_sha = _capture_git_head_sha(cwd)
     _result: SubprocessResult | None = None
@@ -378,11 +378,13 @@ async def _execute_claude_headless(
         for _wd in _watch_dirs:
             if _wd.is_dir():
                 try:
-                    _post = _stat_snapshot(_wd)
+                    _post: dict[str, tuple[int, int]] | None = _stat_snapshot(_wd)
                 except OSError:
                     logger.warning("watch_dir_post_scan_failed", watch_dir=str(_wd), exc_info=True)
-                    _post = {}
-                _pre = _temp_snapshots_pre.get(_wd, {})
+                    continue
+                _pre = _temp_snapshots_pre.get(_wd)
+                if _pre is None:
+                    continue
                 if _post != _pre:
                     _fs_writes_detected = True
                     break

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -53,9 +53,9 @@ from autoskillit.execution.headless._headless_git import (
 )
 from autoskillit.execution.headless._headless_helpers import (
     _compute_post_session_metrics,
-    _recursive_snapshot,
     _resolve_pty_mode,
     _resolve_session_log_dir,
+    _stat_snapshot,
     assert_headless_cmd,
 )
 from autoskillit.execution.headless._headless_recovery import _attempt_contract_nudge
@@ -215,14 +215,14 @@ async def _execute_claude_headless(
         if _default:
             _watch_dirs.append(_default)
 
-    _temp_snapshots_pre: dict[Path, set[str]] = {}
+    _temp_snapshots_pre: dict[Path, dict[str, tuple[int, int]]] = {}
     for _wd in _watch_dirs:
         if _wd.is_dir():
             try:
-                _temp_snapshots_pre[_wd] = _recursive_snapshot(_wd)
+                _temp_snapshots_pre[_wd] = _stat_snapshot(_wd)
             except OSError:
                 logger.warning("watch_dir_pre_scan_failed", watch_dir=str(_wd), exc_info=True)
-                _temp_snapshots_pre[_wd] = set()
+                _temp_snapshots_pre[_wd] = {}
 
     _pre_session_sha = _capture_git_head_sha(cwd)
     _result: SubprocessResult | None = None
@@ -378,12 +378,12 @@ async def _execute_claude_headless(
         for _wd in _watch_dirs:
             if _wd.is_dir():
                 try:
-                    _post = _recursive_snapshot(_wd)
+                    _post = _stat_snapshot(_wd)
                 except OSError:
                     logger.warning("watch_dir_post_scan_failed", watch_dir=str(_wd), exc_info=True)
-                    _post = set()
-                _pre = _temp_snapshots_pre.get(_wd, set())
-                if _post - _pre:
+                    _post = {}
+                _pre = _temp_snapshots_pre.get(_wd, {})
+                if _post != _pre:
                     _fs_writes_detected = True
                     break
 

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -105,7 +105,7 @@ def _stat_snapshot(directory: Path) -> dict[str, tuple[int, int]]:
                 st = os.stat(full)
                 result[rel] = (st.st_mtime_ns, st.st_size)
             except OSError:
-                pass
+                logger.debug("stat_snapshot_skipped", path=full)
     return result
 
 

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -95,10 +95,18 @@ def _derive_step_name_from_skill_command(skill_command: str) -> str:
     return token
 
 
-def _recursive_snapshot(directory: Path) -> set[str]:
-    return {
-        str(Path(dp).relative_to(directory) / f) for dp, _, fns in os.walk(directory) for f in fns
-    }
+def _stat_snapshot(directory: Path) -> dict[str, tuple[int, int]]:
+    result: dict[str, tuple[int, int]] = {}
+    for dp, _, fns in os.walk(directory):
+        for f in fns:
+            rel = str(Path(dp).relative_to(directory) / f)
+            full = os.path.join(dp, f)
+            try:
+                st = os.stat(full)
+                result[rel] = (st.st_mtime_ns, st.st_size)
+            except OSError:
+                pass
+    return result
 
 
 @dataclasses.dataclass(frozen=True, slots=True)

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -74,7 +74,7 @@ def test_headless_facade_does_not_define_helpers():
         "def _resolve_session_log_dir",
         "def _resolve_model",
         "def _derive_step_name_from_skill_command",
-        "def _recursive_snapshot",
+        "def _stat_snapshot",
         "class PostSessionMetrics",
         "def _compute_post_session_metrics",
     ):

--- a/tests/execution/headless/test_headless_helpers_execute_split_integrity.py
+++ b/tests/execution/headless/test_headless_helpers_execute_split_integrity.py
@@ -39,10 +39,10 @@ class TestHeadlessHelpersModuleExists:
 
         assert callable(_derive_step_name_from_skill_command)
 
-    def test_recursive_snapshot_importable(self):
-        from autoskillit.execution.headless._headless_helpers import _recursive_snapshot
+    def test_stat_snapshot_importable(self):
+        from autoskillit.execution.headless._headless_helpers import _stat_snapshot
 
-        assert callable(_recursive_snapshot)
+        assert callable(_stat_snapshot)
 
     def test_post_session_metrics_importable(self):
         from autoskillit.execution.headless._headless_helpers import PostSessionMetrics

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -194,35 +194,35 @@ class TestRecursiveSnapshot:
     """Recursive snapshot detects writes in pre-existing subdirectories."""
 
     def test_detects_write_in_preexisting_subdir(self, tmp_path: Path) -> None:
-        from autoskillit.execution.headless import _recursive_snapshot
+        from autoskillit.execution.headless import _stat_snapshot
 
         watch_dir = tmp_path / "planner_run"
         sub_dir = watch_dir / "refine_contexts"
         sub_dir.mkdir(parents=True)
         (sub_dir / "context_P1.json").write_text("{}")
 
-        pre = _recursive_snapshot(watch_dir)
+        pre = _stat_snapshot(watch_dir)
 
         (sub_dir / "P1_result.json").write_text('{"assignments": []}')
 
-        post = _recursive_snapshot(watch_dir)
+        post = _stat_snapshot(watch_dir)
 
-        assert post - pre == {"refine_contexts/P1_result.json"}
+        assert post.keys() - pre.keys() == {"refine_contexts/P1_result.json"}
 
     def test_detects_write_in_nested_subdir(self, tmp_path: Path) -> None:
-        from autoskillit.execution.headless import _recursive_snapshot
+        from autoskillit.execution.headless import _stat_snapshot
 
         watch_dir = tmp_path / "planner_run"
         nested = watch_dir / "work_packages" / "wp_sentinels"
         nested.mkdir(parents=True)
 
-        pre = _recursive_snapshot(watch_dir)
+        pre = _stat_snapshot(watch_dir)
 
         (nested / "P1_result.json").write_text("{}")
 
-        post = _recursive_snapshot(watch_dir)
+        post = _stat_snapshot(watch_dir)
 
-        assert post - pre == {"work_packages/wp_sentinels/P1_result.json"}
+        assert post.keys() - pre.keys() == {"work_packages/wp_sentinels/P1_result.json"}
 
     @pytest.mark.anyio
     async def test_run_headless_core_detects_subdir_write(
@@ -282,22 +282,6 @@ class TestRecursiveSnapshot:
             write_watch_dirs=[watch_dir],
         )
         assert result.evidence.fs_writes_detected is False
-
-    def test_snapshot_misses_modification_of_existing_file(self, tmp_path: Path) -> None:
-        """Current _recursive_snapshot cannot detect in-place file modifications."""
-        from autoskillit.execution.headless import _recursive_snapshot
-
-        watch_dir = tmp_path / "output"
-        watch_dir.mkdir()
-        target = watch_dir / "plan.md"
-        target.write_text("original content")
-
-        pre = _recursive_snapshot(watch_dir)
-        time.sleep(0.01)
-        target.write_text("modified content — dry walkthrough verified")
-
-        post = _recursive_snapshot(watch_dir)
-        assert post - pre == set()
 
 
 class TestStatSnapshot:

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -190,8 +190,8 @@ class TestBashFilePathEnrichment:
         assert "/tmp/output/" in paths
 
 
-class TestRecursiveSnapshot:
-    """Recursive snapshot detects writes in pre-existing subdirectories."""
+class TestSubdirSnapshot:
+    """Stat-based snapshot detects writes in pre-existing subdirectories."""
 
     def test_detects_write_in_preexisting_subdir(self, tmp_path: Path) -> None:
         from autoskillit.execution.headless import _stat_snapshot
@@ -396,11 +396,7 @@ class TestSnapshotTypeContract:
 
         sig = _inspect.signature(_stat_snapshot)
         ret = sig.return_annotation
-        assert (
-            "dict" in str(ret).lower()
-            or ret is dict
-            or (hasattr(ret, "__origin__") and ret.__origin__ is dict)
-        )
+        assert "dict" in str(ret).lower()
 
 
 class TestPlannerSkillEndToEnd:

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import inspect
 import json
 import os
+import time
 from pathlib import Path
 
 import pytest
@@ -281,6 +282,141 @@ class TestRecursiveSnapshot:
             write_watch_dirs=[watch_dir],
         )
         assert result.evidence.fs_writes_detected is False
+
+    def test_snapshot_misses_modification_of_existing_file(self, tmp_path: Path) -> None:
+        """Current _recursive_snapshot cannot detect in-place file modifications."""
+        from autoskillit.execution.headless import _recursive_snapshot
+
+        watch_dir = tmp_path / "output"
+        watch_dir.mkdir()
+        target = watch_dir / "plan.md"
+        target.write_text("original content")
+
+        pre = _recursive_snapshot(watch_dir)
+        time.sleep(0.01)
+        target.write_text("modified content — dry walkthrough verified")
+
+        post = _recursive_snapshot(watch_dir)
+        assert post - pre == set()
+
+
+class TestStatSnapshot:
+    """Stat-based snapshot detects creation, modification, and deletion."""
+
+    def test_stat_snapshot_detects_modified_file(self, tmp_path: Path) -> None:
+        """Stat-based snapshot detects in-place file modification via mtime+size change."""
+        from autoskillit.execution.headless import _stat_snapshot
+
+        watch_dir = tmp_path / "output"
+        watch_dir.mkdir()
+        target = watch_dir / "plan.md"
+        target.write_text("original content")
+
+        pre = _stat_snapshot(watch_dir)
+        time.sleep(0.01)
+        target.write_text("modified content — longer text means different size")
+
+        post = _stat_snapshot(watch_dir)
+        assert pre != post
+        assert "plan.md" in pre
+        assert "plan.md" in post
+        assert pre["plan.md"] != post["plan.md"]
+
+    def test_stat_snapshot_detects_new_file(self, tmp_path: Path) -> None:
+        """Stat-based snapshot still detects new file creation."""
+        from autoskillit.execution.headless import _stat_snapshot
+
+        watch_dir = tmp_path / "output"
+        watch_dir.mkdir()
+        (watch_dir / "existing.md").write_text("content")
+
+        pre = _stat_snapshot(watch_dir)
+        (watch_dir / "new_file.md").write_text("new content")
+        post = _stat_snapshot(watch_dir)
+
+        assert set(post.keys()) - set(pre.keys()) == {"new_file.md"}
+
+    def test_stat_snapshot_detects_deleted_file(self, tmp_path: Path) -> None:
+        """Stat-based snapshot detects file deletion."""
+        from autoskillit.execution.headless import _stat_snapshot
+
+        watch_dir = tmp_path / "output"
+        watch_dir.mkdir()
+        target = watch_dir / "ephemeral.md"
+        target.write_text("content")
+
+        pre = _stat_snapshot(watch_dir)
+        target.unlink()
+        post = _stat_snapshot(watch_dir)
+
+        assert "ephemeral.md" in pre
+        assert "ephemeral.md" not in post
+
+    def test_stat_snapshot_return_type_encodes_file_state(self, tmp_path: Path) -> None:
+        """Structural contract: snapshot values must be tuples, not bare strings."""
+        from autoskillit.execution.headless import _stat_snapshot
+
+        watch_dir = tmp_path / "output"
+        watch_dir.mkdir()
+        (watch_dir / "file.md").write_text("content")
+
+        snapshot = _stat_snapshot(watch_dir)
+        for path, state in snapshot.items():
+            assert isinstance(path, str), "Keys must be relative path strings"
+            assert isinstance(state, tuple), "Values must be (mtime_ns, size) tuples"
+            assert len(state) == 2, "State tuple must have exactly 2 elements"
+            assert isinstance(state[0], int), "mtime_ns must be int"
+            assert isinstance(state[1], int), "size must be int"
+
+    @pytest.mark.anyio
+    async def test_run_headless_core_detects_existing_file_modification(
+        self, tmp_path: Path, minimal_ctx
+    ) -> None:
+        """run_headless_core sets fs_writes_detected=True when existing file is modified."""
+        from autoskillit.execution.headless import run_headless_core
+        from tests.execution.conftest import _success_session_json
+
+        watch_dir = tmp_path / "output"
+        watch_dir.mkdir()
+        existing_file = watch_dir / "plan.md"
+        existing_file.write_text("original plan content")
+
+        async def mock_runner(cmd, **kwargs):
+            if cmd[0] == "git":
+                return _make_result(returncode=1, stdout="")
+            existing_file.write_text("modified plan — dry walkthrough verified = TRUE")
+            return _make_result(returncode=0, stdout=_success_session_json("done"))
+
+        minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
+        proj = tmp_path / "proj"
+        proj.mkdir()
+
+        result = await run_headless_core(
+            "/autoskillit:test-skill",
+            str(proj),
+            minimal_ctx,
+            write_watch_dirs=[watch_dir],
+        )
+        assert result.evidence.fs_writes_detected is True
+
+
+class TestSnapshotTypeContract:
+    """Structural contract: snapshot function must return state-bearing type, not path-only."""
+
+    def test_snapshot_return_type_is_dict_not_set(self) -> None:
+        """Guard against regression to set[str] return type."""
+        import inspect as _inspect
+
+        from autoskillit.execution.headless._headless_helpers import _stat_snapshot
+
+        sig = _inspect.signature(_stat_snapshot)
+        ret = sig.return_annotation
+        assert (
+            "dict" in str(ret).lower()
+            or ret is dict
+            or (hasattr(ret, "__origin__") and ret.__origin__ is dict)
+        )
 
 
 class TestPlannerSkillEndToEnd:

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import inspect
 import json
 import os
-import time
 from pathlib import Path
 
 import pytest
@@ -288,7 +287,6 @@ class TestStatSnapshot:
     """Stat-based snapshot detects creation, modification, and deletion."""
 
     def test_stat_snapshot_detects_modified_file(self, tmp_path: Path) -> None:
-        """Stat-based snapshot detects in-place file modification via mtime+size change."""
         from autoskillit.execution.headless import _stat_snapshot
 
         watch_dir = tmp_path / "output"
@@ -297,7 +295,7 @@ class TestStatSnapshot:
         target.write_text("original content")
 
         pre = _stat_snapshot(watch_dir)
-        time.sleep(0.01)
+        # Detection relies on size difference, not mtime — no sleep needed.
         target.write_text("modified content — longer text means different size")
 
         post = _stat_snapshot(watch_dir)

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -720,25 +720,25 @@ class TestTempDirSnapshot:
 
     def test_snapshot_detects_new_file(self, tmp_path: Path) -> None:
         """A file created between pre and post snapshot is detected."""
-        from autoskillit.execution.headless import _recursive_snapshot
+        from autoskillit.execution.headless import _stat_snapshot
 
         temp_dir = tmp_path / ".autoskillit" / "temp" / "prepare-pr"
         temp_dir.mkdir(parents=True)
-        pre = _recursive_snapshot(temp_dir)
+        pre = _stat_snapshot(temp_dir)
         (temp_dir / "pr_prep_20260425.md").write_text("content")
-        post = _recursive_snapshot(temp_dir)
-        assert len(post - pre) > 0
+        post = _stat_snapshot(temp_dir)
+        assert len(post.keys() - pre.keys()) > 0
 
     def test_snapshot_empty_when_no_new_files(self, tmp_path: Path) -> None:
         """No new files between snapshots yields empty diff."""
-        from autoskillit.execution.headless import _recursive_snapshot
+        from autoskillit.execution.headless import _stat_snapshot
 
         temp_dir = tmp_path / ".autoskillit" / "temp" / "prepare-pr"
         temp_dir.mkdir(parents=True)
         (temp_dir / "existing.md").write_text("content")
-        pre = _recursive_snapshot(temp_dir)
-        post = _recursive_snapshot(temp_dir)
-        assert post - pre == set()
+        pre = _stat_snapshot(temp_dir)
+        post = _stat_snapshot(temp_dir)
+        assert post.keys() - pre.keys() == set()
 
 
 class TestGitWritesClonePath:

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -738,7 +738,7 @@ class TestTempDirSnapshot:
         (temp_dir / "existing.md").write_text("content")
         pre = _stat_snapshot(temp_dir)
         post = _stat_snapshot(temp_dir)
-        assert post.keys() - pre.keys() == set()
+        assert post == pre
 
 
 class TestGitWritesClonePath:


### PR DESCRIPTION
## Summary

`_recursive_snapshot()` returns `set[str]` (path names only), making the post-session set-difference comparison (`_post - _pre`) structurally blind to in-place file modifications. This is a type-level defect: the snapshot's return type cannot represent file state, only file presence. The fix upgrades the snapshot to capture `(mtime_ns, size)` per file — a stat-based comparison that detects creation, modification, deletion, and truncation. The approach mirrors the proven `_LoadCacheEntry` pattern already in production at `recipe/_api_cache.py`.

Closes #3309

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-130303-981480/.autoskillit/temp/rectify/rectify_fs_writes_snapshot_blind_spot_2026-05-30_131500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.6k | 17.7k | 1.9M | 108.7k | 241 | 99.8k | 15m 36s |
| review_approach* | sonnet | 1 | 62 | 6.9k | 170.4k | 51.8k | 81 | 110.0k | 5m 18s |
| dry_walkthrough* | opus | 1 | 50 | 9.3k | 675.4k | 62.4k | 81 | 46.4k | 4m 47s |
| implement* | sonnet | 1 | 286 | 24.2k | 2.2M | 81.7k | 106 | 65.9k | 7m 0s |
| audit_impl* | sonnet | 1 | 627 | 11.9k | 354.5k | 50.4k | 32 | 36.0k | 4m 4s |
| prepare_pr* | sonnet | 1 | 135.7k | 3.1k | 337.2k | 30.9k | 23 | 15.8k | 1m 14s |
| compose_pr* | sonnet | 1 | 38.3k | 1.2k | 182.6k | 30.9k | 14 | 15.5k | 36s |
| review_pr* | sonnet | 3 | 609 | 135.2k | 3.6M | 99.1k | 190 | 294.4k | 32m 27s |
| resolve_review* | opus | 3 | 120 | 22.9k | 4.2M | 89.0k | 142 | 188.3k | 27m 3s |
| **Total** | | | 178.3k | 232.4k | 13.5M | 108.7k | | 872.2k | 1h 38m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 194 | 11127.7 | 339.7 | 124.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 28 | 149026.4 | 6726.5 | 816.5 |
| **Total** | **222** | 60955.8 | 3928.9 | 1046.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.6k | 17.7k | 1.9M | 99.8k | 15m 36s |
| sonnet | 6 | 175.6k | 182.5k | 6.8M | 537.7k | 50m 41s |
| opus | 2 | 170 | 32.2k | 4.8M | 234.7k | 31m 51s |