### PR TITLE
Rectify: Mention Guard Prose-Zone Immunity

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -175,6 +175,7 @@ tests/
 ├── test_backend_gating_root.py
 ├── test_conftest.py                     # Tests for conftest fixtures
 ├── test_fakes_conformance.py
+├── test_helpers_strip.py                # Unit tests for strip_markdown_code_regions shared utility
 ├── test_llm_triage.py
 ├── test_no_orchestration_tier_language.py
 ├── test_smoke_utils.py

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -5,6 +5,20 @@ from __future__ import annotations
 import re
 import sys
 
+_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def strip_markdown_code_regions(text: str) -> str:
+    """Remove fenced code blocks and inline code spans from markdown text.
+
+    Use before applying content-scanning rules that should only match
+    prose, not code examples.
+    """
+    text = _CODE_BLOCK_RE.sub("", text)
+    text = _INLINE_CODE_RE.sub("", text)
+    return text
+
 
 def _flush_structlog_proxy_caches() -> None:
     """Reconnect autoskillit module-level loggers to the current structlog config.

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -77,6 +77,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_watcher_signal_consistency.py` | Structural guard: all process watchers must call `_has_active_dispatch_marker` |
 | `test_write_restriction_coverage.py` | Architectural invariant: skills with prose write restrictions in NEVER blocks have runtime enforcement (read_only, output_dir, or allowlist) |
 | `test_model_identity_contract.py` | AST guard: detect_model_drift must use normalize_model_id and _models_match — raw alias/full-ID comparison is a false-positive source |
+| `test_helpers_exports.py` | Asserts shared test helpers export required symbols (strip_markdown_code_regions) |
 
 ## Architecture Notes
 

--- a/tests/arch/test_helpers_exports.py
+++ b/tests/arch/test_helpers_exports.py
@@ -1,0 +1,13 @@
+"""Asserts shared test helpers export required symbols."""
+
+from __future__ import annotations
+
+
+def test_strip_markdown_code_regions_exported_from_helpers() -> None:
+    """strip_markdown_code_regions must be importable from tests._helpers."""
+    from tests._helpers import strip_markdown_code_regions
+
+    assert callable(strip_markdown_code_regions)
+    result = strip_markdown_code_regions("```python\n@dataclass\n```\nprose")
+    assert "@dataclass" not in result
+    assert "prose" in result

--- a/tests/docs/test_banned_phrases.py
+++ b/tests/docs/test_banned_phrases.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._helpers import strip_markdown_code_regions
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCS_DIR = REPO_ROOT / "docs"
 ROOT_README = REPO_ROOT / "README.md"
@@ -37,14 +39,11 @@ BANNED_PHRASES = [
 # the canonical and banned spellings of every term it covers.
 EXEMPT_FILES = {"glossary.md"}
 
-CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
-INLINE_CODE_RE = re.compile(r"`[^`]*`")
 QUOTED_RE = re.compile(r'"[^"]*"|\'[^\']*\'')
 
 
 def _strip_examples(text: str) -> str:
-    text = CODE_BLOCK_RE.sub("", text)
-    text = INLINE_CODE_RE.sub("", text)
+    text = strip_markdown_code_regions(text)
     text = QUOTED_RE.sub("", text)
     return text
 

--- a/tests/docs/test_glossary_spelling.py
+++ b/tests/docs/test_glossary_spelling.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._helpers import strip_markdown_code_regions
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCS_DIR = REPO_ROOT / "docs"
 GLOSSARY = DOCS_DIR / "glossary.md"
@@ -27,15 +29,6 @@ BANNED_VARIANTS: list[tuple[str, str]] = [
     (r"\btier-3\b", "Tier 3"),
     (r"retry reason\b", "retry_reason"),
 ]
-
-CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
-INLINE_CODE_RE = re.compile(r"`[^`]*`")
-
-
-def _strip_examples(text: str) -> str:
-    text = CODE_BLOCK_RE.sub("", text)
-    text = INLINE_CODE_RE.sub("", text)
-    return text
 
 
 def _doc_files() -> list[Path]:
@@ -55,7 +48,7 @@ def test_glossary_has_at_least_17_terms() -> None:
 
 @pytest.mark.parametrize("md", _doc_files(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
 def test_no_banned_variants(md: Path) -> None:
-    text = _strip_examples(md.read_text(encoding="utf-8"))
+    text = strip_markdown_code_regions(md.read_text(encoding="utf-8"))
     hits: list[tuple[str, str, int]] = []
     for line_no, line in enumerate(text.splitlines(), start=1):
         for pat, canonical in BANNED_VARIANTS:

--- a/tests/skills/test_investigate_design_intent_contracts.py
+++ b/tests/skills/test_investigate_design_intent_contracts.py
@@ -8,6 +8,7 @@ REQ-INTENT-002: Adversarial Breakage subagent — challenges removal/change reco
 
 import pytest
 
+from tests._helpers import strip_markdown_code_regions
 from tests.skills.conftest import extract_step_section
 
 
@@ -43,18 +44,6 @@ def design_intent_content(step2_section: str) -> str:
     if next_header != -1:
         return step2_section[start:next_header]
     return step2_section[start:]
-
-
-def _strip_code_fences(text: str) -> str:
-    """Remove lines inside triple-backtick code fences (template content vs. instructions)."""
-    result = []
-    in_fence = False
-    for line in text.split("\n"):
-        if line.strip().startswith("```"):
-            in_fence = not in_fence
-        elif not in_fence:
-            result.append(line)
-    return "\n".join(result)
 
 
 @pytest.fixture(scope="module")
@@ -234,7 +223,7 @@ def test_standard_mode_no_adversarial_breakage(standard_workflow_section: str) -
     # Strip code fences: the Step 4 report template documents what deep mode output looks
     # like, which legitimately contains '## Breakage Analysis'. The intent of this guard
     # is that the *execution instructions* don't spawn adversarial breakage in standard mode.
-    instructions = _strip_code_fences(standard_workflow_section)
+    instructions = strip_markdown_code_regions(standard_workflow_section)
     has_adversarial = "adversarial breakage" in instructions.lower()
     has_breakage_analysis = "breakage analysis" in instructions.lower()
     assert not has_adversarial and not has_breakage_analysis, (

--- a/tests/test_helpers_strip.py
+++ b/tests/test_helpers_strip.py
@@ -1,0 +1,66 @@
+"""Unit tests for strip_markdown_code_regions shared utility."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._helpers import strip_markdown_code_regions
+
+pytestmark = pytest.mark.small
+
+
+def test_fenced_code_block_is_stripped() -> None:
+    text = "prose before\n```python\n@dataclass\nclass Foo:\n    pass\n```\nprose after"
+    result = strip_markdown_code_regions(text)
+    assert "@dataclass" not in result
+    assert "prose before" in result
+    assert "prose after" in result
+
+
+def test_inline_code_is_stripped() -> None:
+    text = "Use `@mcp.tool()` for registration."
+    result = strip_markdown_code_regions(text)
+    assert "@mcp" not in result
+    assert "Use" in result
+    assert "for registration." in result
+
+
+def test_prose_outside_code_is_preserved() -> None:
+    text = "This is plain prose with no code blocks."
+    result = strip_markdown_code_regions(text)
+    assert result == text
+
+
+def test_adjacent_fenced_blocks_both_stripped() -> None:
+    text = "```\nblock one\n```\nmiddle prose\n```\nblock two\n```\nend"
+    result = strip_markdown_code_regions(text)
+    assert "block one" not in result
+    assert "block two" not in result
+    assert "middle prose" in result
+    assert "end" in result
+
+
+def test_multiple_inline_codes_stripped() -> None:
+    text = "Call `foo()` and `bar()` then done."
+    result = strip_markdown_code_regions(text)
+    assert "foo()" not in result
+    assert "bar()" not in result
+    assert "Call" in result
+    assert "then done." in result
+
+
+def test_language_specifier_line_stripped_with_fence() -> None:
+    text = "```python\nimport os\n```\nprose"
+    result = strip_markdown_code_regions(text)
+    assert "import os" not in result
+    assert "python" not in result
+    assert "prose" in result
+
+
+def test_empty_string_returns_empty() -> None:
+    assert strip_markdown_code_regions("") == ""
+
+
+def test_no_code_regions_returns_unchanged() -> None:
+    text = "Just some prose text.\nWith multiple lines."
+    assert strip_markdown_code_regions(text) == text

--- a/tests/test_helpers_strip.py
+++ b/tests/test_helpers_strip.py
@@ -64,3 +64,12 @@ def test_empty_string_returns_empty() -> None:
 def test_no_code_regions_returns_unchanged() -> None:
     text = "Just some prose text.\nWith multiple lines."
     assert strip_markdown_code_regions(text) == text
+
+
+def test_unclosed_fence_is_fail_open() -> None:
+    text = "prose before\n```python\nunclosed content\nprose after"
+    result = strip_markdown_code_regions(text)
+    assert "prose before" in result
+    # Fail-open: regex requires both opening+closing ```, so unclosed fence is not consumed.
+    assert "unclosed content" in result
+    assert "prose after" in result

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -104,12 +104,8 @@ class TestSkillResolver:
         assert resolver.resolve("nonexistent") is None
 
     def test_no_hardcoded_username_mentions_in_skill_mds(self) -> None:
-        """No SKILL.md may contain a hardcoded GitHub @-mention in any line.
-
-        Includes code fences — all lines are checked.
-        """
-        # Negative lookbehind prevents matching email local-parts (e.g. noreply@anthropic.com)
-        # and decorator-like patterns where @ follows alphanumeric or dot.
+        """No SKILL.md may contain a hardcoded GitHub @-mention in prose."""
+        # Negative lookbehind prevents matching email local-parts (e.g. noreply@anthropic.com).
         mention_pattern = re.compile(r"(?<![a-zA-Z0-9.])@[A-Za-z][A-Za-z0-9_-]{2,}")
         # Known-safe @-tokens that are not GitHub usernames (e.g. template variables, org names
         # used in documentation context rather than as literal mentions).
@@ -119,17 +115,81 @@ class TestSkillResolver:
         for skills_dir in _all_skill_roots():
             for skill_md in sorted(skills_dir.rglob("SKILL.md")):
                 skill_name = skill_md.parent.name
-                for lineno, raw_line in enumerate(skill_md.read_text().splitlines(), start=1):
-                    for match in mention_pattern.finditer(raw_line):
+                content = skill_md.read_text()
+                in_fence = False
+                for lineno, raw_line in enumerate(content.splitlines(), start=1):
+                    stripped = raw_line.strip()
+                    if stripped.startswith("```"):
+                        in_fence = not in_fence
+                        continue
+                    if in_fence:
+                        continue
+                    # Strip inline code before matching
+                    prose_line = re.sub(r"`[^`]*`", "", raw_line)
+                    for match in mention_pattern.finditer(prose_line):
                         token = match.group()
                         if token in SAFE_TOKENS:
                             continue
                         violations.append(f"{skill_name}/SKILL.md:{lineno}: {token!r}")
 
         assert violations == [], (
-            "Hardcoded GitHub @-mentions found in SKILL.md files. "
+            "Hardcoded GitHub @-mentions found in SKILL.md prose. "
             "Use dynamic derivation (e.g., `gh api user -q .login`) instead:\n"
             + "\n".join(violations)
+        )
+
+    def test_mention_guard_ignores_python_decorators_in_code_fences(self, tmp_path: Path) -> None:
+        """Python decorators inside code fences must not trigger the @-mention guard."""
+        from tests._helpers import strip_markdown_code_regions
+
+        mention_pattern = re.compile(r"(?<![a-zA-Z0-9.])@[A-Za-z][A-Za-z0-9_-]{2,}")
+        SAFE_TOKENS: frozenset[str] = frozenset({"@anthropic"})
+
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "---\nname: test-skill\n---\n"
+            "# Test Skill\n\n"
+            "```python\n"
+            "@dataclass\n"
+            "class Foo:\n"
+            "    pass\n"
+            "\n"
+            "@pytest.mark.parametrize('x', [1, 2])\n"
+            "def test_bar(x):\n"
+            "    assert x > 0\n"
+            "```\n"
+            "\n"
+            "Use `@mcp.tool()` for registration.\n"
+        )
+
+        prose = strip_markdown_code_regions(skill_md.read_text())
+        violations = [
+            match.group()
+            for line in prose.splitlines()
+            for match in mention_pattern.finditer(line)
+            if match.group() not in SAFE_TOKENS
+        ]
+        assert violations == [], f"False positives on code-zone content: {violations}"
+
+    def test_mention_guard_catches_prose_at_mention(self, tmp_path: Path) -> None:
+        """A GitHub @-mention in prose (not code) must be caught by the guard."""
+        from tests._helpers import strip_markdown_code_regions
+
+        mention_pattern = re.compile(r"(?<![a-zA-Z0-9.])@[A-Za-z][A-Za-z0-9_-]{2,}")
+        SAFE_TOKENS: frozenset[str] = frozenset({"@anthropic"})
+
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("---\nname: test-skill\n---\n# Test\n\nContact @SomeUser for help.\n")
+
+        prose = strip_markdown_code_regions(skill_md.read_text())
+        violations = [
+            match.group()
+            for line in prose.splitlines()
+            for match in mention_pattern.finditer(line)
+            if match.group() not in SAFE_TOKENS
+        ]
+        assert "@SomeUser" in violations, (
+            f"Guard failed to catch prose @-mention; got {violations}"
         )
 
     def test_list_all_returns_bundled_skills(self) -> None:


### PR DESCRIPTION
## Summary

The plan consolidates three duplicate `_strip_examples` / `_strip_code_fences` implementations (in `tests/docs/test_banned_phrases.py`, `tests/docs/test_glossary_spelling.py`, and `tests/skills/test_investigate_design_intent_contracts.py`) into a single shared `strip_markdown_code_regions()` utility in `tests/_helpers.py`. The mention-guard test (`test_no_hardcoded_username_mentions_in_skill_mds`) is updated to skip code zones, eliminating false positives from Python decorators in code examples. New regression tests and unit tests for the utility are added. The false-claim comment about decorator exclusion in the lookbehind is corrected.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
- tests/arch/test_helpers_exports.py
- tests/test_helpers_strip.py

### Modified (●):
- tests/CLAUDE.md
- tests/_helpers.py
- tests/arch/CLAUDE.md
- tests/docs/test_banned_phrases.py
- tests/docs/test_glossary_spelling.py
- tests/skills/test_investigate_design_intent_contracts.py
- tests/workspace/test_skills.py

Closes #3330

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-152530-777371/.autoskillit/temp/rectify/rectify_mention_guard_prose_zone_immunity_2026-05-30_153500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 9.4k | 20.8k | 5.0M | 125.7k | 387 | 151.7k | 23m 44s |
| review_approach* | sonnet | 1 | 76 | 7.6k | 342.8k | 50.1k | 80 | 39.6k | 5m 13s |
| dry_walkthrough* | opus | 2 | 82 | 13.4k | 695.1k | 54.0k | 146 | 83.9k | 8m 50s |
| implement* | sonnet | 2 | 677 | 18.9k | 2.6M | 161.4k | 248 | 95.9k | 9m 52s |
| audit_impl* | sonnet | 2 | 1.1k | 25.8k | 617.4k | 58.3k | 61 | 82.8k | 8m 8s |
| make_plan* | sonnet | 1 | 81 | 4.2k | 297.9k | 43.4k | 29 | 31.5k | 1m 53s |
| prepare_pr* | sonnet | 1 | 56.3k | 2.5k | 182.9k | 31.0k | 17 | 15.9k | 1m 14s |
| compose_pr* | sonnet | 1 | 46.9k | 1.7k | 213.8k | 31.0k | 14 | 15.6k | 54s |
| review_pr* | sonnet | 1 | 126 | 32.9k | 784.6k | 84.2k | 55 | 69.4k | 7m 26s |
| resolve_review* | sonnet | 1 | 151 | 19.5k | 950.3k | 72.7k | 51 | 57.6k | 11m 24s |
| **Total** | | | 114.8k | 147.3k | 11.6M | 161.4k | | 643.8k | 1h 18m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 217 | 11822.8 | 441.8 | 86.9 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **217** | 53505.4 | 2966.8 | 678.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 9.4k | 20.8k | 5.0M | 151.7k | 23m 44s |
| sonnet | 8 | 105.4k | 113.1k | 6.0M | 408.2k | 46m 6s |
| opus | 1 | 82 | 13.4k | 695.1k | 83.9k | 8m 50s |