### PR TITLE
Rectify: Session Type Boundary Contract Immunity

### DIFF
--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -157,6 +157,7 @@ def cook(
         MarketplaceInstall,
         NamedResume,
         NoResume,
+        SessionType,
         _get_autoskillit_install_path,
         configure_logging,
         get_logger,
@@ -213,7 +214,7 @@ def cook(
             resume_spec = NoResume()
 
     _cook_env_extras: dict[str, str] = {
-        SESSION_TYPE_ENV_VAR: SESSION_TYPE_COOK,
+        SESSION_TYPE_ENV_VAR: SessionType.SKILL.value,
         LAUNCH_ID_ENV_VAR: session_id_local,
     }
     if profile is not None:

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -147,12 +147,13 @@ def _write_order_entry(project_dir: Path, recipe_name: str | None) -> dict[str, 
     from autoskillit.core import (
         LAUNCH_ID_ENV_VAR,
         SESSION_TYPE_ENV_VAR,
+        SessionType,
         write_registry_entry,
     )
 
     lid = uuid.uuid4().hex[:16]
     write_registry_entry(project_dir, lid, SESSION_TYPE_ORDER, recipe_name)
-    return {SESSION_TYPE_ENV_VAR: SESSION_TYPE_ORDER, LAUNCH_ID_ENV_VAR: lid}
+    return {SESSION_TYPE_ENV_VAR: SessionType.ORCHESTRATOR.value, LAUNCH_ID_ENV_VAR: lid}
 
 
 def _launch_cook_session(

--- a/src/autoskillit/core/_claude_env.py
+++ b/src/autoskillit/core/_claude_env.py
@@ -109,6 +109,18 @@ def build_agent_env(
     out.update(IDE_ENV_ALWAYS_EXTRAS)
     if extras:
         out.update(extras)
+    _session_type_raw = out.get("AUTOSKILLIT_SESSION_TYPE")
+    if _session_type_raw:
+        from .types._type_enums import SessionType
+
+        try:
+            SessionType(_session_type_raw)
+        except ValueError:
+            valid = ", ".join(m.value for m in SessionType)
+            raise ValueError(
+                f"AUTOSKILLIT_SESSION_TYPE={_session_type_raw!r} is not a valid SessionType. "
+                f"Valid values: {valid}"
+            )
     if required is not None:
         missing = required - frozenset(out.keys())
         if missing:

--- a/src/autoskillit/core/_claude_env.py
+++ b/src/autoskillit/core/_claude_env.py
@@ -120,7 +120,7 @@ def build_agent_env(
             raise ValueError(
                 f"AUTOSKILLIT_SESSION_TYPE={_session_type_raw!r} is not a valid SessionType. "
                 f"Valid values: {valid}"
-            )
+            ) from None
     if required is not None:
         missing = required - frozenset(out.keys())
         if missing:

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -191,13 +191,12 @@ def session_type() -> SessionType:
         try:
             return SessionType(raw_lower)
         except ValueError:
-            warnings.warn(
-                f"Invalid {SESSION_TYPE_ENV_VAR}={raw!r}, defaulting to SKILL. "
-                f"Valid values: {', '.join(m.value for m in SessionType)}",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return SessionType.SKILL
+            valid = ", ".join(m.value for m in SessionType)
+            raise ValueError(
+                f"AUTOSKILLIT_SESSION_TYPE={raw!r} is not a valid SessionType. "
+                f"Valid values: {valid}. "
+                f"CLI display labels ('cook', 'order') must not be used here."
+            ) from None
     if os.environ.get(HEADLESS_ENV_VAR) == "1":
         warnings.warn(
             f"{HEADLESS_ENV_VAR}=1 without {SESSION_TYPE_ENV_VAR} set. "

--- a/src/autoskillit/core/types/_type_session_env.py
+++ b/src/autoskillit/core/types/_type_session_env.py
@@ -19,6 +19,18 @@ class FleetSessionEnv:
     campaign_state_path: str = ""
     continue_on_failure: str = "false"
 
+    def __post_init__(self) -> None:
+        from ._type_enums import SessionType
+
+        try:
+            SessionType(self.session_type)
+        except ValueError:
+            valid = ", ".join(m.value for m in SessionType)
+            raise ValueError(
+                f"FleetSessionEnv.session_type must be a valid SessionType member, "
+                f"got {self.session_type!r}. Valid values: {valid}"
+            ) from None
+
     def to_dict(self) -> dict[str, str]:
         d = {
             "AUTOSKILLIT_SESSION_TYPE": self.session_type,

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -46,7 +46,12 @@ def _require_orchestrator_or_higher(tool_name: str = "") -> str | None:
     if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
         return None
 
-    st = session_type()
+    try:
+        st = session_type()
+    except ValueError:
+        return headless_error_result(
+            f"{tool_name}: invalid AUTOSKILLIT_SESSION_TYPE in environment." if tool_name else None
+        )
     if st in (SessionType.ORCHESTRATOR, SessionType.FLEET):
         return None
 
@@ -69,7 +74,12 @@ def _require_orchestrator_exact(tool_name: str = "") -> str | None:
     if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
         return None
 
-    st = session_type()
+    try:
+        st = session_type()
+    except ValueError:
+        return headless_error_result(
+            f"{tool_name}: invalid AUTOSKILLIT_SESSION_TYPE in environment." if tool_name else None
+        )
     if st is SessionType.ORCHESTRATOR:
         return None
 
@@ -97,7 +107,12 @@ def _require_fleet(tool_name: str = "") -> str | None:
     No interactive bypass — fleet is a specific orchestration level, not a headless guard.
     L1 (skill session) and L2 (orchestrator) sessions are both denied.
     """
-    st = session_type()
+    try:
+        st = session_type()
+    except ValueError:
+        return headless_error_result(
+            f"{tool_name}: invalid AUTOSKILLIT_SESSION_TYPE in environment." if tool_name else None
+        )
     if st is SessionType.FLEET:
         return None
 

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -48,10 +48,8 @@ def _require_orchestrator_or_higher(tool_name: str = "") -> str | None:
 
     try:
         st = session_type()
-    except ValueError:
-        return headless_error_result(
-            f"{tool_name}: invalid AUTOSKILLIT_SESSION_TYPE in environment." if tool_name else None
-        )
+    except ValueError as e:
+        return headless_error_result(f"{tool_name}: {e}" if tool_name else str(e))
     if st in (SessionType.ORCHESTRATOR, SessionType.FLEET):
         return None
 
@@ -76,10 +74,8 @@ def _require_orchestrator_exact(tool_name: str = "") -> str | None:
 
     try:
         st = session_type()
-    except ValueError:
-        return headless_error_result(
-            f"{tool_name}: invalid AUTOSKILLIT_SESSION_TYPE in environment." if tool_name else None
-        )
+    except ValueError as e:
+        return headless_error_result(f"{tool_name}: {e}" if tool_name else str(e))
     if st is SessionType.ORCHESTRATOR:
         return None
 
@@ -109,10 +105,8 @@ def _require_fleet(tool_name: str = "") -> str | None:
     """
     try:
         st = session_type()
-    except ValueError:
-        return headless_error_result(
-            f"{tool_name}: invalid AUTOSKILLIT_SESSION_TYPE in environment." if tool_name else None
-        )
+    except ValueError as e:
+        return headless_error_result(f"{tool_name}: {e}" if tool_name else str(e))
     if st is SessionType.FLEET:
         return None
 

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -616,7 +616,7 @@ class TestCookInteractive:
 
         assert captured_env_extras, "build_interactive_cmd must have been called"
         env_extras = captured_env_extras[0]
-        assert env_extras.get("AUTOSKILLIT_SESSION_TYPE") == "cook"
+        assert env_extras.get("AUTOSKILLIT_SESSION_TYPE") == "skill"
 
     def test_cook_launch_sets_launch_id_env(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -387,7 +387,7 @@ class TestCLIOrderCommand:
             cli.order("test-script")
 
         env = mock_run.call_args[1].get("env") or {}
-        assert env.get("AUTOSKILLIT_SESSION_TYPE") == "order"
+        assert env.get("AUTOSKILLIT_SESSION_TYPE") == "orchestrator"
 
     @patch("autoskillit.cli.subprocess.run")
     def test_order_launch_sets_launch_id_env(

--- a/tests/core/test_claude_env.py
+++ b/tests/core/test_claude_env.py
@@ -223,3 +223,11 @@ def test_agent_backend_not_scrubbed() -> None:
     result = build_agent_env(base={"AUTOSKILLIT_AGENT_BACKEND": "codex", "HOME": "/tmp"})
     assert "AUTOSKILLIT_AGENT_BACKEND" in result
     assert result["AUTOSKILLIT_AGENT_BACKEND"] == "codex"
+
+
+def test_build_agent_env_rejects_invalid_session_type() -> None:
+    with pytest.raises(ValueError, match="AUTOSKILLIT_SESSION_TYPE"):
+        build_agent_env(
+            base={},
+            extras={"AUTOSKILLIT_SESSION_TYPE": "order"},
+        )

--- a/tests/core/test_session_env_specs.py
+++ b/tests/core/test_session_env_specs.py
@@ -53,3 +53,21 @@ def test_fleet_session_env_to_dict_returns_dict_str_str() -> None:
     d = spec.to_dict()
     assert isinstance(d, dict)
     assert all(isinstance(k, str) and isinstance(v, str) for k, v in d.items())
+
+
+def test_fleet_session_env_rejects_invalid_session_type() -> None:
+    with pytest.raises(ValueError, match="SessionType"):
+        FleetSessionEnv(
+            session_type="bogus",
+            fleet_mode="dispatch",
+            project_dir="/tmp/test",
+        )
+
+
+def test_fleet_session_env_rejects_cli_display_label() -> None:
+    with pytest.raises(ValueError, match="SessionType"):
+        FleetSessionEnv(
+            session_type="order",
+            fleet_mode="dispatch",
+            project_dir="/tmp/test",
+        )

--- a/tests/core/test_session_type.py
+++ b/tests/core/test_session_type.py
@@ -15,31 +15,27 @@ pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 @pytest.mark.parametrize(
-    "env_val, expected, suppress_deprecation, strict_no_deprecation",
+    "env_val, expected, strict_no_deprecation",
     [
-        ("orchestrator", "ORCHESTRATOR", False, False),
-        ("skill", "SKILL", False, False),
-        ("ORCHESTRATOR", "ORCHESTRATOR", False, False),
-        (None, "SKILL", False, False),
-        ("bogus", "SKILL", True, False),
-        ("fleet", "FLEET", False, False),
-        ("FLEET", "FLEET", False, False),
-        ("fleet", "FLEET", False, True),
+        ("orchestrator", "ORCHESTRATOR", False),
+        ("skill", "SKILL", False),
+        ("ORCHESTRATOR", "ORCHESTRATOR", False),
+        (None, "SKILL", False),
+        ("fleet", "FLEET", False),
+        ("FLEET", "FLEET", False),
+        ("fleet", "FLEET", True),
     ],
     ids=[
         "orchestrator",
         "skill",
         "case-insensitive",
         "unset",
-        "invalid-defaults-skill",
         "fleet",
         "fleet-case-insensitive",
         "fleet-no-warning",
     ],
 )
-def test_session_type_resolver(
-    monkeypatch, env_val, expected, suppress_deprecation, strict_no_deprecation
-):
+def test_session_type_resolver(monkeypatch, env_val, expected, strict_no_deprecation):
     from autoskillit.core import SessionType, session_type
 
     if env_val is None:
@@ -52,22 +48,26 @@ def test_session_type_resolver(
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
             result = session_type()
-    elif suppress_deprecation:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            result = session_type()
     else:
         result = session_type()
 
     assert result is SessionType[expected]
 
 
-def test_session_type_invalid_emits_deprecation_warning(monkeypatch):
+def test_session_type_invalid_raises_value_error(monkeypatch):
     from autoskillit.core import session_type
 
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "bogus")
-    with pytest.warns(DeprecationWarning, match="Invalid AUTOSKILLIT_SESSION_TYPE"):
+    with pytest.raises(ValueError, match="AUTOSKILLIT_SESSION_TYPE"):
         session_type()
+
+
+@pytest.mark.parametrize("display_label", ["order", "cook"])
+def test_cli_display_labels_are_not_valid_session_type_members(display_label):
+    from autoskillit.core import SessionType
+
+    with pytest.raises(ValueError):
+        SessionType(display_label)
 
 
 def test_transitional_bridge_headless_without_type_warns(monkeypatch):

--- a/tests/core/test_session_type.py
+++ b/tests/core/test_session_type.py
@@ -66,7 +66,7 @@ def test_session_type_invalid_raises_value_error(monkeypatch):
 def test_cli_display_labels_are_not_valid_session_type_members(display_label):
     from autoskillit.core import SessionType
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="is not a valid SessionType"):
         SessionType(display_label)
 
 

--- a/tests/infra/test_pr_create_guard.py
+++ b/tests/infra/test_pr_create_guard.py
@@ -332,6 +332,15 @@ class TestOrchestratorSessionExemption:
         )
         assert _is_denied(out), "Missing session type must be denied"
 
+    def test_order_display_label_is_not_exempt(self, tmp_path):
+        out = _run_guard(
+            "gh pr create --base main --head feat",
+            kitchen_open=True,
+            tmpdir=tmp_path,
+            session_type="order",
+        )
+        assert _is_denied(out), "CLI display label 'order' must not be exempt from guard"
+
 
 # ---------------------------------------------------------------------------
 # Interactive kitchen exemption via recipe authorization

--- a/tests/server/test_helpers_tier_guards.py
+++ b/tests/server/test_helpers_tier_guards.py
@@ -71,9 +71,7 @@ def test_A6_require_orchestrator_or_higher_denies_headless_invalid_session_type(
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "bogus")
     from autoskillit.server._guards import _require_orchestrator_or_higher
 
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter("always")
-        result = _require_orchestrator_or_higher("run_cmd")
+    result = _require_orchestrator_or_higher("run_cmd")
     assert result is not None
     data = json.loads(result)
     assert data["subtype"] == "headless_error"


### PR DESCRIPTION
## Summary

CLI session launch functions (`_write_order_entry()` and `_cook.py:cook()`) set `AUTOSKILLIT_SESSION_TYPE` to display labels (`"order"`, `"cook"`) instead of valid `SessionType` enum values (`"orchestrator"`, `"skill"`). The server's `session_type()` resolver silently falls back to `SessionType.SKILL` via a `DeprecationWarning`, masking the invalid value. This causes order sessions (L2 orchestrators) to be misidentified as L1 skill sessions by all downstream infrastructure: visibility dispatch, lifespan boot, guard functions, and hook exemptions.

The architectural weakness is the absence of a **write-boundary contract** — the env var value is validated at the read point (server) but never at the write point (CLI). The fix decouples the two naming systems (CLI display labels vs. `SessionType` enum values) by introducing a typed boundary spec and a validation assertion at the env-assembly point.

Closes #3338

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-161415-545091/.autoskillit/temp/rectify/rectify_session_type_boundary_contract_2026-05-30_170000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.8k | 24.3k | 3.5M | 154.9k | 301 | 148.2k | 23m 1s |
| review_approach* | sonnet | 1 | 52 | 5.6k | 183.6k | 42.1k | 35 | 31.2k | 3m 4s |
| dry_walkthrough* | opus | 1 | 47 | 9.3k | 451.1k | 56.1k | 110 | 67.1k | 5m 9s |
| implement* | sonnet | 1 | 1.2k | 21.9k | 2.2M | 88.5k | 123 | 88.7k | 7m 17s |
| audit_impl* | sonnet | 1 | 427 | 11.4k | 246.4k | 43.7k | 49 | 41.1k | 5m 29s |
| prepare_pr* | sonnet | 1 | 81.2k | 4.0k | 213.8k | 30.9k | 21 | 15.7k | 1m 21s |
| compose_pr* | sonnet | 1 | 38.4k | 1.3k | 182.8k | 30.9k | 13 | 15.5k | 37s |
| review_pr* | sonnet | 1 | 142 | 31.2k | 848.9k | 82.9k | 87 | 67.3k | 8m 7s |
| resolve_review* | opus | 1 | 71 | 13.4k | 1.5M | 74.4k | 77 | 58.8k | 10m 5s |
| **Total** | | | 124.5k | 122.4k | 9.4M | 154.9k | | 533.5k | 1h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 145 | 15113.3 | 611.9 | 151.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 22 | 70443.9 | 2672.1 | 608.0 |
| **Total** | **167** | 56208.4 | 3194.8 | 733.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.8k | 24.3k | 3.5M | 148.2k | 23m 1s |
| sonnet | 6 | 121.5k | 75.4k | 3.9M | 259.5k | 25m 56s |
| opus | 2 | 118 | 22.7k | 2.0M | 125.9k | 15m 14s |