### PR TITLE
Rectify: Codex Config Schema Drift Immunity — TOML Key Quoting + Pre-Flight Validation

### DIFF
--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re as _re
 from pathlib import Path
 from typing import Any
 
@@ -40,8 +41,18 @@ def _format_toml_value(v: Any) -> str:
     raise TypeError(msg)
 
 
+_BARE_KEY_RE = _re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _quote_key(k: str) -> str:
+    if _BARE_KEY_RE.match(k):
+        return k
+    escaped = k.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def _format_inline_table(d: dict[str, Any]) -> str:
-    pairs = [f"{k} = {_format_toml_value(v)}" for k, v in d.items()]
+    pairs = [f"{_quote_key(k)} = {_format_toml_value(v)}" for k, v in d.items()]
     return "{" + ", ".join(pairs) + "}"
 
 
@@ -62,22 +73,22 @@ def _classify_list(key: str, lst: list) -> bool:
 
 def _emit_aot_entry(d: dict[str, Any], path: list[str], lines: list[str]) -> None:
     """Emit a single [[path]] array-of-tables entry."""
-    lines.append(f"\n[[{'.'.join(path)}]]")
+    lines.append(f"\n[[{'.'.join(_quote_key(p) for p in path)}]]")
     nested_aot: list[tuple[str, list[dict]]] = []
     for k, v in d.items():
         if isinstance(v, dict):
-            lines.append(f"{k} = {_format_inline_table(v)}")
+            lines.append(f"{_quote_key(k)} = {_format_inline_table(v)}")
         elif isinstance(v, list) and _classify_list(k, v):
             nested_aot.append((k, v))
         else:
-            lines.append(f"{k} = {_format_toml_value(v)}")
+            lines.append(f"{_quote_key(k)} = {_format_toml_value(v)}")
     for k, entries in nested_aot:
         for entry in entries:
             _emit_aot_entry(entry, [*path, k], lines)
 
 
 def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> None:
-    header = f"[{'.'.join(path)}]"
+    header = f"[{'.'.join(_quote_key(p) for p in path)}]"
 
     scalars: list[tuple[str, Any]] = []
     tables: list[tuple[str, dict]] = []
@@ -107,9 +118,9 @@ def _emit_toml_table(d: dict[str, Any], path: list[str], lines: list[str]) -> No
     if scalars or inline_tables:
         lines.append(f"\n{header}")
         for k, v in scalars:
-            lines.append(f"{k} = {_format_toml_value(v)}")
+            lines.append(f"{_quote_key(k)} = {_format_toml_value(v)}")
         for k, v in inline_tables:
-            lines.append(f"{k} = {_format_inline_table(v)}")
+            lines.append(f"{_quote_key(k)} = {_format_inline_table(v)}")
 
     for k, v in recurse_tables:
         _emit_toml_table(v, [*path, k], lines)
@@ -126,7 +137,7 @@ def _serialize_toml(data: dict[str, Any]) -> str:
             continue
         if isinstance(v, list) and _classify_list(k, v):
             continue
-        lines.append(f"{k} = {_format_toml_value(v)}")
+        lines.append(f"{_quote_key(k)} = {_format_toml_value(v)}")
     for k, v in data.items():
         if isinstance(v, dict):
             _emit_toml_table(v, [k], lines)

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import re as _re
 from pathlib import Path
 from typing import Any
+
+import regex as _re
 
 from autoskillit.core import (
     HEADLESS_AUTO_GATE_ENV_VAR,

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -45,10 +45,21 @@ def _format_toml_value(v: Any) -> str:
 _BARE_KEY_RE = _re.compile(r"^[A-Za-z0-9_-]+$")
 
 
+_CONTROL_CHAR_MAP = {
+    "\b": "\\b",
+    "\t": "\\t",
+    "\n": "\\n",
+    "\f": "\\f",
+    "\r": "\\r",
+}
+
+
 def _quote_key(k: str) -> str:
     if _BARE_KEY_RE.match(k):
         return k
     escaped = k.replace("\\", "\\\\").replace('"', '\\"')
+    for ch, seq in _CONTROL_CHAR_MAP.items():
+        escaped = escaped.replace(ch, seq)
     return f'"{escaped}"'
 
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -242,6 +242,44 @@ class CodexSessionLocator:
         return result
 
 
+def _validate_codex_config() -> list[str]:
+    """Run codex doctor --json and check config.load status."""
+    try:
+        result = subprocess.run(
+            ["codex", "doctor", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("codex_doctor_timeout")
+        return []
+    except OSError:
+        logger.warning("codex_doctor_unavailable", exc_info=True)
+        return []
+
+    try:
+        doc = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("codex_doctor_json_parse_failed")
+        return []
+
+    checks = doc.get("checks", {})
+    config_check = checks.get("config.load", {})
+    status = config_check.get("status")
+
+    if status is not None and status != "ok":
+        summary = config_check.get("summary", "unknown config error")
+        remediation = config_check.get("remediation", "")
+        parts = [f"Codex config validation failed: {summary}"]
+        if remediation:
+            parts.append(f"Remediation: {remediation}")
+        parts.append("Run 'codex doctor' for full diagnostics.")
+        return [" ".join(parts)]
+
+    return []
+
+
 @dataclass(frozen=True, slots=True)
 class CodexBackend:
     @property
@@ -676,4 +714,5 @@ class CodexBackend:
         except Exception as exc:
             logger.warning("codex_mcp_registration_failed", exc_info=True)
             return [f"Failed to ensure MCP registration: {exc}"]
-        return []
+
+        return _validate_codex_config()

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -258,9 +258,13 @@ def _validate_codex_config() -> list[str]:
         logger.warning("codex_doctor_unavailable", exc_info=True)
         return []
 
+    if result.returncode != 0:
+        logger.warning("codex_doctor_nonzero_exit", returncode=result.returncode)
+        return []
+
     try:
         doc = json.loads(result.stdout)
-    except (json.JSONDecodeError, ValueError):
+    except json.JSONDecodeError:
         logger.warning("codex_doctor_json_parse_failed")
         return []
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -258,12 +258,13 @@ def _validate_codex_config() -> list[str]:
         logger.warning("codex_doctor_unavailable", exc_info=True)
         return []
 
-    if result.returncode != 0:
-        logger.warning("codex_doctor_nonzero_exit", returncode=result.returncode)
+    if getattr(result, "returncode", -1) != 0:
+        logger.warning("codex_doctor_nonzero_exit", returncode=getattr(result, "returncode", None))
         return []
 
+    stdout = getattr(result, "stdout", None) or ""
     try:
-        doc = json.loads(result.stdout)
+        doc = json.loads(stdout)
     except json.JSONDecodeError:
         logger.warning("codex_doctor_json_parse_failed")
         return []

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -919,6 +919,137 @@ class TestCodexBuildFoodTruckCmd:
         assert "--json" in spec.cmd
 
 
+class TestCodexEnsurePreLaunchConfigValidation:
+    def test_ensure_pre_launch_returns_error_on_config_load_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        doctor_output = (
+            '{"checks": {"config.load": {"status": "error",'
+            ' "summary": "invalid type: map, expected u32",'
+            ' "remediation": "Delete [tui] section"}}}'
+        )
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout=doctor_output)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
+            lambda **kw: False,
+        )
+        errors = CodexBackend().ensure_pre_launch()
+        assert errors
+        combined = " ".join(errors)
+        assert "invalid type: map, expected u32" in combined
+        assert "Delete [tui] section" in combined
+
+    def test_ensure_pre_launch_returns_empty_on_config_load_ok(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        doctor_output = '{"checks": {"config.load": {"status": "ok"}}}'
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout=doctor_output)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
+            lambda **kw: False,
+        )
+        assert CodexBackend().ensure_pre_launch() == []
+
+    def test_ensure_pre_launch_returns_empty_on_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 20)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
+            lambda **kw: False,
+        )
+        assert CodexBackend().ensure_pre_launch() == []
+
+    def test_ensure_pre_launch_returns_empty_on_oserror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError("codex not found")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
+            lambda **kw: False,
+        )
+        assert CodexBackend().ensure_pre_launch() == []
+
+    def test_ensure_pre_launch_codex_doctor_runs_after_mcp_registration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        call_order: list[str] = []
+
+        def fake_register(**kw):
+            call_order.append("register")
+            return False
+
+        def fake_run(cmd, **kwargs):
+            call_order.append("doctor")
+            return subprocess.CompletedProcess(cmd, 0, stdout='{"checks": {}}')
+
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered", fake_register
+        )
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        CodexBackend().ensure_pre_launch()
+        assert call_order == ["register", "doctor"]
+
+    def test_ensure_pre_launch_returns_empty_on_malformed_json(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout="not json")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
+            lambda **kw: False,
+        )
+        assert CodexBackend().ensure_pre_launch() == []
+
+    def test_ensure_pre_launch_returns_empty_on_missing_config_check(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout='{"checks": {}}')
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
+            lambda **kw: False,
+        )
+        assert CodexBackend().ensure_pre_launch() == []
+
+    def test_ensure_pre_launch_integration_registration_succeeds_then_validates(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout='{"checks": {"config.load": {"status": "error", "summary": "bad config"}}}',
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        errors = CodexBackend().ensure_pre_launch()
+        assert errors
+        assert "bad config" in " ".join(errors)
+
+
 class TestCodexBackendVersion:
     def test_version_returns_stripped_stdout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def fake_run(cmd, *, capture_output, text, timeout):

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1004,6 +1004,19 @@ class TestCodexEnsurePreLaunchConfigValidation:
         CodexBackend().ensure_pre_launch()
         assert call_order == ["register", "doctor"]
 
+    def test_ensure_pre_launch_returns_empty_on_nonzero_returncode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="error output")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
+            lambda **kw: False,
+        )
+        assert CodexBackend().ensure_pre_launch() == []
+
     def test_ensure_pre_launch_returns_empty_on_malformed_json(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/execution/backends/test_codex_config.py
+++ b/tests/execution/backends/test_codex_config.py
@@ -323,6 +323,22 @@ class TestEnsureCodexMcpRegistered:
         assert config["mcp_servers"]["other"]["args"] == ["--stdio"]
         assert "autoskillit" in config["mcp_servers"]
 
+    def test_preserves_foreign_sections_with_dotted_keys(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('[tui]\n"gpt-5.5" = 4\n')
+        ensure_codex_mcp_registered(config_path=p)
+        data = _read_codex_config(p).data
+        assert data["tui"]["gpt-5.5"] == 4
+
+    def test_preserves_nested_sections_with_special_keys(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('[notice]\nmodel_migrations = {"gpt-5.3-codex" = "gpt-5.4"}\n')
+        ensure_codex_mcp_registered(config_path=p)
+        data = _read_codex_config(p).data
+        assert data["notice"]["model_migrations"]["gpt-5.3-codex"] == "gpt-5.4"
+
 
 class TestReadResultDiscrimination:
     def test_read_missing_file_returns_missing_variant(self, tmp_path):
@@ -453,6 +469,56 @@ class TestConfigEnvBoundary:
                 }
             }
         }
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+
+class TestSerializeTomlKeyQuoting:
+    def test_round_trip_key_with_dot(self):
+        original = {"tui": {"model_availability_nux": {"gpt-5.5": 1}}}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_key_with_multiple_dots(self):
+        original = {"notice": {"model_migrations": {"gpt-5.3-codex": "gpt-5.4"}}}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_key_with_space(self):
+        original = {"section": {"key with space": "val"}}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_key_with_equals(self):
+        original = {"section": {"key=val": "val"}}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_inline_table_key_with_dot(self):
+        original = {"sec": {"scalar": 1, "sub": {"gpt-5.5": "val"}}}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_aot_entry_key_with_dot(self):
+        original = {"hooks": [{"gpt-5.5": "val"}]}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_section_header_key_with_dot(self):
+        original = {"parent": {"child.name": {"key": "val"}}}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_aot_entry_inline_table_with_dotted_inner_key(self):
+        original = {"hooks": [{"options": {"gpt-5.5": "val"}, "event": "test"}]}
         serialized = _serialize_toml(original)
         parsed = tomllib.loads(serialized)
         assert parsed == original

--- a/tests/execution/backends/test_codex_config.py
+++ b/tests/execution/backends/test_codex_config.py
@@ -523,6 +523,18 @@ class TestSerializeTomlKeyQuoting:
         parsed = tomllib.loads(serialized)
         assert parsed == original
 
+    def test_round_trip_key_with_backslash(self):
+        original = {"section": {"path\\to\\file": "val"}}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
+    def test_round_trip_key_with_dot_and_double_quote(self):
+        original = {"section": {'key.with"quote': "val"}}
+        serialized = _serialize_toml(original)
+        parsed = tomllib.loads(serialized)
+        assert parsed == original
+
 
 class TestExports:
     def test_ensure_codex_mcp_registered_in_codex_all(self):


### PR DESCRIPTION
## Summary

Python's `tomllib` validates TOML syntax but cannot detect Codex's Rust `serde` schema rejections. The session config setup copies `~/.codex/config.toml` verbatim via `shutil.copy2`, propagating schema-drifted configs that crash Codex at launch. Additionally, `_serialize_toml()` emits dotted TOML keys unquoted, corrupting configs on round-trip writes.

This is crash #6 in a chain of 6 crashes in the same code path, indicating systemic architectural weakness. The immunity plan addresses the root causes: (1) add binary-driven pre-flight validation via `codex doctor --json`, (2) fix the TOML serializer's key quoting, and (3) add round-trip fidelity tests that catch serialization corruption by construction.

Part A (this PR): TOML key quoting fix (REQ-REM-005) + Pre-flight validation via `codex doctor --json` (REQ-REM-001).

## Requirements

### REQ-REM-001: Pre-flight config validation via `codex doctor --json`

Add a pre-flight check inside `CodexBackend.ensure_pre_launch()` at `codex.py:669-675` that runs `codex doctor --json` and parses the structured output for `checks["config.load"]["status"]`. If status is not `"ok"`, return a user-facing error string including the check's `summary` and `remediation` fields.

**Why `--json` instead of exit code:** `codex doctor` exits 0 even for some config errors (they appear as "Notes" not "Failures"). The `--json` output provides per-check structured status that is reliable regardless of exit-code semantics.

**Ordering:** The `codex doctor` call must come AFTER `ensure_codex_mcp_registered()` (which may write to config.toml), so the doctor validates the post-write config state.

**Edge cases:**
- `codex doctor --json` includes a websocket connectivity check with a 15-second timeout. Use `timeout=20` for the subprocess to avoid killing it before doctor finishes. Treat `subprocess.TimeoutExpired` as a non-blocking warning, not an error.
- `OSError` from the subprocess is NOT unreachable: catch `OSError` defensively.
- The user-facing error message should include: (a) the `summary` and `remediation` from the JSON output, and (b) a suggestion to run `codex doctor` for full diagnostics.

### REQ-REM-005: Fix `_serialize_toml` dotted-key quoting

`_serialize_toml()` in `_codex_config.py` must quote TOML keys that contain dots. Currently, a key like `gpt-5.5` is emitted unquoted, causing TOML to interpret it as nested keys on re-parse. The fix: quote any key string containing a `.` character (e.g., emit `"gpt-5.5" = 1` instead of `gpt-5.5 = 1`).

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None

Closes #3335

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-161302-198051/.autoskillit/temp/rectify/rectify_codex_config_schema_drift_immunity_2026-05-30_200000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 88 | 20.1k | 3.5M | 161.2k | 282 | 169.4k | 29m 28s |
| review_approach* | sonnet | 1 | 2.6k | 7.6k | 208.4k | 48.4k | 73 | 58.8k | 5m 12s |
| dry_walkthrough* | opus | 1 | 40 | 6.2k | 563.9k | 56.2k | 75 | 38.7k | 5m 18s |
| implement* | sonnet | 1 | 574 | 19.8k | 3.6M | 103.3k | 105 | 87.9k | 14m 38s |
| audit_impl* | sonnet | 1 | 514 | 5.9k | 203.0k | 35.3k | 35 | 28.1k | 3m 0s |
| prepare_pr* | sonnet | 1 | 154.2k | 5.8k | 278.6k | 31.0k | 28 | 43.9k | 2m 18s |
| compose_pr* | sonnet | 1 | 52.1k | 1.8k | 213.8k | 31.0k | 16 | 15.6k | 46s |
| review_pr* | sonnet | 2 | 324 | 86.3k | 2.2M | 116.0k | 139 | 195.4k | 21m 27s |
| resolve_review* | opus | 2 | 125 | 33.2k | 4.2M | 99.3k | 138 | 184.1k | 25m 36s |
| **Total** | | | 210.7k | 186.6k | 14.9M | 161.2k | | 822.0k | 1h 47m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 265 | 13533.1 | 331.8 | 74.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 45 | 93927.0 | 4092.2 | 736.8 |
| **Total** | **310** | 48186.2 | 2651.6 | 601.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 88 | 20.1k | 3.5M | 169.4k | 29m 28s |
| sonnet | 6 | 210.4k | 127.1k | 6.7M | 429.7k | 47m 23s |
| opus | 2 | 165 | 39.3k | 4.8M | 222.9k | 30m 55s |