### PR TITLE
Add _require_fleet() Guards to Fleet Telemetry/Cleanup Tools

### DIFF
--- a/src/autoskillit/server/tools/tools_status.py
+++ b/src/autoskillit/server/tools/tools_status.py
@@ -14,7 +14,7 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import atomic_write, get_logger
 from autoskillit.pipeline import TelemetryFormatter
 from autoskillit.server import mcp
-from autoskillit.server._guards import _require_enabled
+from autoskillit.server._guards import _require_enabled, _require_fleet
 from autoskillit.server._misc import resolve_log_dir, write_telemetry_clear_marker
 from autoskillit.server._notify import _notify, track_response_size
 
@@ -98,6 +98,8 @@ async def get_pipeline_report(clear: bool = False) -> str:
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    if (fleet_gate := _require_fleet("get_pipeline_report")) is not None:
+        return fleet_gate
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_pipeline_report"):
         try:
@@ -180,6 +182,8 @@ async def get_token_summary(clear: bool = False, format: str = "json", order_id:
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    if (fleet_gate := _require_fleet("get_token_summary")) is not None:
+        return fleet_gate
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_token_summary"):
         try:
@@ -242,6 +246,8 @@ async def get_timing_summary(clear: bool = False, format: str = "json", order_id
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    if (fleet_gate := _require_fleet("get_timing_summary")) is not None:
+        return fleet_gate
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_timing_summary"):
         try:
@@ -401,6 +407,8 @@ async def get_quota_events(n: int = 50) -> str:
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    if (fleet_gate := _require_fleet("get_quota_events")) is not None:
+        return fleet_gate
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_quota_events"):
         try:

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -262,6 +262,59 @@ def test_gated_tools_call_require_enabled_first() -> None:
     )
 
 
+def test_fleet_tools_call_require_fleet() -> None:
+    """Every tool in FLEET_TOOLS (except batch_cleanup_clones) must call
+    _require_fleet() before any non-guard await/return in its function body."""
+    from autoskillit.core.types._type_constants_registries import FLEET_TOOLS
+
+    FLEET_GUARD_EXEMPT = {"batch_cleanup_clones"}
+    GUARD_FUNCS = {
+        "_require_enabled",
+        "_require_fleet",
+        "_require_orchestrator_or_higher",
+        "_require_orchestrator_exact",
+    }
+
+    server_dir = SRC_ROOT / "server"
+    violations: list[str] = []
+
+    for py_file in list(server_dir.glob("*.py")) + list((server_dir / "tools").glob("*.py")):
+        src = py_file.read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name not in FLEET_TOOLS - FLEET_GUARD_EXEMPT:
+                    continue
+                if not any(_is_mcp_tool_decorator(d) for d in node.decorator_list):
+                    continue
+
+                require_idx: int | None = None
+                action_idx: int | None = None
+
+                for i, stmt in enumerate(node.body):
+                    if require_idx is None and _has_call_to(stmt, "_require_fleet"):
+                        require_idx = i
+                    if (
+                        action_idx is None
+                        and _has_await_or_return(stmt)
+                        and not any(_has_call_to(stmt, g) for g in GUARD_FUNCS)
+                    ):
+                        action_idx = i
+
+                if require_idx is None:
+                    violations.append(f"{node.name}: _require_fleet() never called")
+                elif action_idx is not None and require_idx > action_idx:
+                    violations.append(
+                        f"{node.name}: _require_fleet() called at stmt {require_idx} "
+                        f"but await/return found at stmt {action_idx} first"
+                    )
+
+    assert not violations, (
+        "Fleet tools must call _require_fleet() before any non-guard await/return:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
 def test_ungated_tools_do_not_call_require_enabled() -> None:
     """No function named in UNGATED_TOOLS may call _require_enabled()."""
     import inspect

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -121,7 +121,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 144),
     ("src/autoskillit/server/tools/tools_kitchen.py", 689),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools/tools_status.py", 491),
+    ("src/autoskillit/server/tools/tools_status.py", 499),
     # tools_github.py — bug report dict
     ("src/autoskillit/server/tools/tools_github.py", 303),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)

--- a/tests/server/test_tools_status_kitchen.py
+++ b/tests/server/test_tools_status_kitchen.py
@@ -26,6 +26,11 @@ from tests.conftest import _make_result
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
+@pytest.fixture(autouse=True)
+def _fleet_session(monkeypatch):
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
+
 def _make_failure_record(**overrides: object) -> FailureRecord:
     defaults = dict(
         timestamp="2026-02-24T16:00:00Z",
@@ -161,10 +166,6 @@ class TestKitchenStatus:
 class TestGetPipelineReport:
     """get_pipeline_report is a gated tool that returns accumulated failures."""
 
-    @pytest.fixture(autouse=True)
-    def _fleet_session(self, monkeypatch):
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-
     @pytest.mark.anyio
     async def test_gate_closed_returns_gate_error(self, tool_ctx):
         """get_pipeline_report returns gate_error when kitchen gate is closed."""
@@ -245,10 +246,6 @@ def test_check_quota_absent_from_mcp_registry(tool_ctx):
 
 class TestTelemetryRecoveryData:
     """MCP status tools return data populated via load_from_log_dir recovery."""
-
-    @pytest.fixture(autouse=True)
-    def _fleet_session(self, monkeypatch):
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
 
     def _write_token_session(
         self, log_root: Path, dir_name: str, step_name: str, input_tokens: int

--- a/tests/server/test_tools_status_kitchen.py
+++ b/tests/server/test_tools_status_kitchen.py
@@ -161,6 +161,10 @@ class TestKitchenStatus:
 class TestGetPipelineReport:
     """get_pipeline_report is a gated tool that returns accumulated failures."""
 
+    @pytest.fixture(autouse=True)
+    def _fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_gate_closed_returns_gate_error(self, tool_ctx):
         """get_pipeline_report returns gate_error when kitchen gate is closed."""
@@ -199,6 +203,15 @@ class TestGetPipelineReport:
         result2 = json.loads(await get_pipeline_report())
         assert result2["total_failures"] == 0
 
+    @pytest.mark.feature("fleet")
+    @pytest.mark.anyio
+    async def test_get_pipeline_report_fleet_guard_denies_orchestrator(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        result = json.loads(await get_pipeline_report())
+        assert result["subtype"] == "headless_error"
+
     @pytest.mark.anyio
     async def test_get_pipeline_report_awaits_startup_ready(
         self, tool_ctx_kitchen_open, monkeypatch
@@ -232,6 +245,10 @@ def test_check_quota_absent_from_mcp_registry(tool_ctx):
 
 class TestTelemetryRecoveryData:
     """MCP status tools return data populated via load_from_log_dir recovery."""
+
+    @pytest.fixture(autouse=True)
+    def _fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
 
     def _write_token_session(
         self, log_root: Path, dir_name: str, step_name: str, input_tokens: int

--- a/tests/server/test_tools_status_mcp_response.py
+++ b/tests/server/test_tools_status_mcp_response.py
@@ -13,6 +13,10 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestGetTokenSummaryMcpResponses:
+    @pytest.fixture(autouse=True)
+    def _fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_includes_mcp_responses_section(self, tool_ctx_kitchen_open):
         """get_token_summary returns an mcp_responses key with per-tool data."""

--- a/tests/server/test_tools_status_quota_and_db.py
+++ b/tests/server/test_tools_status_quota_and_db.py
@@ -19,6 +19,19 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestGetQuotaEvents:
+    @pytest.fixture(autouse=True)
+    def _fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
+    @pytest.mark.feature("fleet")
+    @pytest.mark.anyio
+    async def test_get_quota_events_fleet_guard_denies_orchestrator(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        result = json.loads(await get_quota_events())
+        assert result["subtype"] == "headless_error"
+
     @pytest.mark.anyio
     async def test_returns_events_from_jsonl(self, tool_ctx_kitchen_open, tmp_path, monkeypatch):
         events = [

--- a/tests/server/test_tools_status_summaries.py
+++ b/tests/server/test_tools_status_summaries.py
@@ -18,6 +18,11 @@ from autoskillit.server.tools.tools_status import (
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
+@pytest.fixture(autouse=True)
+def _fleet_session(monkeypatch):
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
+
 class TestGetTokenSummary:
     """get_token_summary is a gated tool that returns accumulated token usage."""
 
@@ -28,6 +33,15 @@ class TestGetTokenSummary:
         result = json.loads(await get_token_summary())
         assert result.get("success") is False
         assert result.get("subtype") == "gate_error"
+
+    @pytest.mark.feature("fleet")
+    @pytest.mark.anyio
+    async def test_get_token_summary_fleet_guard_denies_orchestrator(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        result = json.loads(await get_token_summary())
+        assert result["subtype"] == "headless_error"
 
     @pytest.mark.anyio
     async def test_returns_empty_steps_initially(self, tool_ctx_kitchen_open):
@@ -190,6 +204,15 @@ class TestGetTimingSummary:
         result = json.loads(await get_timing_summary())
         assert result.get("success") is False
         assert result.get("subtype") == "gate_error"
+
+    @pytest.mark.feature("fleet")
+    @pytest.mark.anyio
+    async def test_get_timing_summary_fleet_guard_denies_orchestrator(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        result = json.loads(await get_timing_summary())
+        assert result["subtype"] == "headless_error"
 
     @pytest.mark.anyio
     async def test_returns_empty_steps_initially(self, tool_ctx_kitchen_open):


### PR DESCRIPTION
## Summary

Four MCP tools (`get_pipeline_report`, `get_token_summary`, `get_timing_summary`, `get_quota_events`) carry the `fleet` tag but only enforce `_require_enabled()` — they lack the `_require_fleet()` guard. This plan adds the fleet guard to those 4 tools, adds per-tool guard tests, and adds an AST arch test enforcing that `FLEET_TOOLS` call `_require_fleet()`. `batch_cleanup_clones` is explicitly excluded because it legitimately serves L2 orchestrator sessions (e.g., `process-issues` skill).

## Acceptance Criteria

- [ ] `get_pipeline_report`, `get_token_summary`, `get_timing_summary`, `get_quota_events` call `_require_fleet()` after `_require_enabled()`
- [ ] `batch_cleanup_clones` is NOT modified (retains only `_require_enabled()`)
- [ ] Each guarded tool returns `headless_error` when called from non-fleet sessions
- [ ] Each guarded tool still works when called from fleet sessions with an open gate
- [ ] Guard tests added for all 4 guarded tools
- [ ] `batch_cleanup_clones` continues to work in L2 orchestrator sessions (process-issues not broken)

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
- `src/autoskillit/server/tools/tools_status.py`
- `tests/arch/test_layer_enforcement.py`
- `tests/infra/test_schema_version_convention.py`
- `tests/server/test_tools_status_kitchen.py`
- `tests/server/test_tools_status_mcp_response.py`
- `tests/server/test_tools_status_quota_and_db.py`
- `tests/server/test_tools_status_summaries.py`

Closes #3339

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260530-161451-271542/.autoskillit/temp/make-plan/add_require_fleet_guards_plan_2026-05-30_163500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 104 | 15.3k | 2.7M | 155.7k | 154 | 77.7k | 14m 1s |
| review_approach* | sonnet | 1 | 52 | 5.0k | 181.6k | 42.1k | 58 | 31.0k | 3m 38s |
| verify* | sonnet | 1 | 78 | 8.7k | 336.8k | 55.0k | 97 | 36.5k | 3m 35s |
| implement* | sonnet | 1 | 9.1M | 46.0k | 3.1M | 31.0k | 241 | 47.2k | 37m 30s |
| audit_impl* | sonnet | 1 | 76 | 10.7k | 273.8k | 40.8k | 69 | 34.2k | 4m 16s |
| prepare_pr* | sonnet | 1 | 77.2k | 3.4k | 213.8k | 31.0k | 20 | 15.8k | 1m 25s |
| compose_pr* | sonnet | 1 | 42.5k | 1.9k | 182.8k | 31.0k | 14 | 15.5k | 44s |
| review_pr* | sonnet | 1 | 249 | 29.8k | 837.9k | 78.1k | 80 | 62.4k | 6m 33s |
| resolve_review* | sonnet | 1 | 173 | 6.9k | 1.0M | 60.5k | 47 | 45.1k | 3m 38s |
| **Total** | | | 9.2M | 127.6k | 8.8M | 155.7k | | 365.5k | 1h 15m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 79709.5 | 3468.7 | 531.5 |
| **Total** | **13** | 679535.7 | 28113.4 | 9817.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 104 | 15.3k | 2.7M | 77.7k | 14m 1s |
| sonnet | 8 | 9.2M | 112.3k | 6.2M | 287.8k | 1h 1m |