### PR TITLE
Rectify: Fleet Tag Visibility Leak — Startup Disable Invariant Immunity

### DIFF
--- a/src/autoskillit/server/CLAUDE.md
+++ b/src/autoskillit/server/CLAUDE.md
@@ -7,7 +7,7 @@ Sub-package: tools/ (see tools/CLAUDE.md).
 
 | File | Purpose |
 |------|---------|
-| `__init__.py` | Re-exports `mcp`, `ToolContext`, `make_context`; applies `mcp.disable(tags={'kitchen'})` at import |
+| `__init__.py` | Re-exports `mcp`, `ToolContext`, `make_context`; disables all `ALL_VISIBILITY_TAGS` at import |
 | `_editable_guard.py` | Pre-deletion editable install guard for `perform_merge()` — scans site-packages for PEP 610 direct_url.json links into the worktree |
 | `_factory.py` | Composition root — `make_context()` is the sole legal instantiation point for all 23 service contracts |
 | `_guards.py` | Orchestration-level gate functions for MCP tool access control |
@@ -48,10 +48,7 @@ Controls whether the tool appears in `tools/list` (whether the agent can see it)
   - **ORCHESTRATOR + HEADLESS**: `kitchen` (or `kitchen-core` + pack tags) revealed
   - **SKILL + HEADLESS**: `headless`-tagged tools revealed (`test_check`); with `HEADLESS_AUTO_GATE=1`, `kitchen-core` also revealed
   - **Interactive** (no HEADLESS): nothing pre-revealed; `open_kitchen` reveals `kitchen` tag
-- Tags not disabled at startup (`kitchen-core`, `fleet-dispatch`, `fleet`, `headless`) remain
-  visible unless a session-type or feature-gate transform explicitly disables them
-- `ALL_VISIBILITY_TAGS` in `core/types/_type_constants.py` is the canonical set:
-  `{"kitchen", "headless", "fleet", "fleet-dispatch", "kitchen-core"}`
+- All tags in `ALL_VISIBILITY_TAGS` are disabled at startup via `for tag in sorted(ALL_VISIBILITY_TAGS): mcp.disable(tags={tag})`. Session-type dispatch and `open_kitchen` selectively re-enable per session. `ALL_VISIBILITY_TAGS` is defined in `core/types/_type_constants_registries.py`.
 
 ### Application-Gate (Python layer)
 
@@ -64,11 +61,7 @@ Controls whether the tool succeeds when called (independent of visibility):
 
 ### The Anomalies
 
-1. **Fleet-dispatch tools are tag-visible but application-gated.** `fetch_github_issue`, `get_issue_title`,
-   `list_recipes`, and `load_recipe` carry the `fleet-dispatch` tag (not `kitchen`), so they are
-   NOT hidden by `mcp.disable(tags={"kitchen"})`. In interactive sessions they appear in `tools/list`
-   without `open_kitchen`. But they call `_require_enabled()` internally — an agent that sees them
-   and calls them gets an unexpected gate error.
+1. **Fleet-dispatch tools are hidden at startup (via `ALL_VISIBILITY_TAGS` loop) and revealed only for FLEET+dispatch sessions.** Application-gate (`_require_enabled()`) provides defense-in-depth.
 
 2. **`test_check` is tag-hidden but NOT application-gated.** It carries the `kitchen`, `kitchen-core`,
    `headless`, and `autoskillit` tags (hidden at startup), but does NOT call `_require_enabled()`. Headless skill sessions need
@@ -80,8 +73,8 @@ Controls whether the tool succeeds when called (independent of visibility):
 | Category | Tag(s) | Hidden at startup? | Application-gated? | Example tools |
 |----------|--------|-------------------|--------------------|--------------|
 | Standard kitchen | `kitchen` | Yes | Yes (`_require_enabled`) | `run_cmd`, `run_skill`, `report_bug` |
-| Fleet tool | `fleet`, `kitchen-core` | No (no `kitchen` tag) | Yes (`_require_fleet` or `_require_enabled`) | `dispatch_food_truck`, `record_gate_dispatch` |
-| Fleet-dispatch tool | `fleet-dispatch` (± `kitchen-core`) | No (no `kitchen` tag) | Yes (`_require_enabled`) | `fetch_github_issue`, `list_recipes` |
+| Fleet tool | `fleet`, `kitchen-core` | Yes (via `ALL_VISIBILITY_TAGS` loop) | Yes (`_require_fleet` or `_require_enabled`) | `dispatch_food_truck`, `record_gate_dispatch` |
+| Fleet-dispatch tool | `fleet-dispatch` (± `kitchen-core`) | Yes (via `ALL_VISIBILITY_TAGS` loop) | Yes (`_require_enabled`) | `fetch_github_issue`, `list_recipes` |
 | Headless-exempt | `kitchen`, `headless` | Yes | No | `test_check` |
 | Free-range | _(none of the above)_ | No | No | `open_kitchen`, `close_kitchen` |
 
@@ -94,4 +87,4 @@ The canonical tool sets are in `core/types/_type_constants.py`:
 - `HEADLESS_TOOLS` — `{"test_check"}` — kitchen-tagged but not application-gated
 - `FLEET_TOOLS` — fleet-session-only tools
 - `FLEET_DISPATCH_TOOLS` — fleet-dispatch-mode tools (always tag-visible, application-gated)
-- `ALL_VISIBILITY_TAGS` — `{"kitchen", "headless", "fleet", "fleet-dispatch", "kitchen-core"}`
+- `ALL_VISIBILITY_TAGS` — `{"kitchen", "headless", "fleet", "fleet-dispatch", "kitchen-core", "plan-review"}`

--- a/src/autoskillit/server/CLAUDE.md
+++ b/src/autoskillit/server/CLAUDE.md
@@ -80,11 +80,11 @@ Controls whether the tool succeeds when called (independent of visibility):
 
 ### Registry Constants
 
-The canonical tool sets are in `core/types/_type_constants.py`:
+The canonical tool sets are in `core/types/_type_constants_registries.py`:
 
 - `GATED_TOOLS` — all tools that call `_require_enabled()` (validated by arch test)
 - `UNGATED_TOOLS` = `FREE_RANGE_TOOLS` — tools with no gating at all
 - `HEADLESS_TOOLS` — `{"test_check"}` — kitchen-tagged but not application-gated
 - `FLEET_TOOLS` — fleet-session-only tools
-- `FLEET_DISPATCH_TOOLS` — fleet-dispatch-mode tools (always tag-visible, application-gated)
+- `FLEET_DISPATCH_TOOLS` — fleet-dispatch-mode tools (hidden at startup, application-gated)
 - `ALL_VISIBILITY_TAGS` — `{"kitchen", "headless", "fleet", "fleet-dispatch", "kitchen-core", "plan-review"}`

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -65,7 +65,13 @@ __all__ = [
 # Import all tool sub-modules to trigger @mcp.tool() registration.
 # These imports must come AFTER mcp, _get_ctx, _get_config are defined
 # because tool modules import `mcp` from this package at import time.
-from autoskillit.core import PIPELINE_FORBIDDEN_TOOLS  # noqa: E402, F401
+# All conditional visibility tags start disabled. Session-type dispatch and
+# open_kitchen selectively re-enable per session. Must appear after all tool
+# module imports so the registered tools are in place.
+from autoskillit.core import (  # noqa: E402
+    ALL_VISIBILITY_TAGS,
+    PIPELINE_FORBIDDEN_TOOLS,  # noqa: F401
+)
 from autoskillit.server import (  # noqa: E402, F401
     _misc,
     _notify,
@@ -128,10 +134,8 @@ from autoskillit.server.tools import (  # noqa: E402, F401
 )
 from autoskillit.server.tools.tools_kitchen import _build_tool_category_listing  # noqa: E402, F401
 
-# Apply global visibility transform: all sessions start with kitchen tools hidden.
-# Must appear after all tool module imports so the registered tools are in place.
-mcp.disable(tags={"kitchen"})
-mcp.disable(tags={"plan-review"})
+for tag in sorted(ALL_VISIBILITY_TAGS):
+    mcp.disable(tags={tag})
 
 # Wire-format sanitization: strip fields that trigger Claude Code #25081
 # (silent full-tool-list rejection when outputSchema/annotations are present).

--- a/tests/arch/test_transforms_hygiene.py
+++ b/tests/arch/test_transforms_hygiene.py
@@ -312,6 +312,97 @@ def test_session_type_visibility_uses_known_tags():
     )
 
 
+def test_startup_disables_all_visibility_tags():
+    """server/__init__.py must disable ALL_VISIBILITY_TAGS via a for-loop, not hardcoded calls.
+
+    Structural invariant: the startup disable block must iterate over ALL_VISIBILITY_TAGS
+    (directly or via sorted()) so that any new tag added to the constant is automatically
+    disabled. Standalone hardcoded mcp.disable(tags={<literal>}) calls at module level are
+    forbidden — they would silently bypass future tags.
+    """
+    server_init = _SRC_ROOT / "server" / "__init__.py"
+    source = server_init.read_text()
+    tree = ast.parse(source, filename=str(server_init))
+
+    canonical_loop_found = False
+    standalone_literal_disables = []
+
+    for node in tree.body:
+        if isinstance(node, ast.For):
+            iter_node = node.iter
+            uses_all_visibility_tags = (
+                isinstance(iter_node, ast.Name) and iter_node.id == "ALL_VISIBILITY_TAGS"
+            ) or (
+                isinstance(iter_node, ast.Call)
+                and isinstance(iter_node.func, ast.Name)
+                and iter_node.func.id == "sorted"
+                and len(iter_node.args) == 1
+                and isinstance(iter_node.args[0], ast.Name)
+                and iter_node.args[0].id == "ALL_VISIBILITY_TAGS"
+            )
+            if not uses_all_visibility_tags:
+                continue
+
+            loop_var = node.target.id if isinstance(node.target, ast.Name) else None
+            if loop_var is None:
+                continue
+
+            for stmt in node.body:
+                if not isinstance(stmt, ast.Expr):
+                    continue
+                call = stmt.value
+                if not (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "disable"
+                ):
+                    continue
+                for kw in call.keywords:
+                    if kw.arg != "tags":
+                        continue
+                    if (
+                        isinstance(kw.value, ast.Set)
+                        and len(kw.value.elts) == 1
+                        and isinstance(kw.value.elts[0], ast.Name)
+                        and kw.value.elts[0].id == loop_var
+                    ):
+                        canonical_loop_found = True
+
+        elif isinstance(node, ast.Expr):
+            call = node.value
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "disable"
+            ):
+                continue
+            for kw in call.keywords:
+                if kw.arg != "tags":
+                    continue
+                if isinstance(kw.value, ast.Set):
+                    tag_vals = {
+                        elt.value
+                        for elt in kw.value.elts
+                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    }
+                    if tag_vals:
+                        standalone_literal_disables.append(
+                            f"line {node.lineno}: mcp.disable(tags={sorted(tag_vals)})"
+                        )
+
+    assert canonical_loop_found, (
+        "server/__init__.py must have a top-level for-loop over ALL_VISIBILITY_TAGS "
+        "whose body calls mcp.disable(tags={<loop_var>}). "
+        "Replace manual per-tag mcp.disable() calls with: "
+        "for tag in sorted(ALL_VISIBILITY_TAGS): mcp.disable(tags={tag})"
+    )
+    assert not standalone_literal_disables, (
+        "server/__init__.py must not have standalone mcp.disable(tags={<literal>}) calls "
+        "at module level — they bypass future ALL_VISIBILITY_TAGS additions:\n"
+        + "\n".join(f"  {d}" for d in standalone_literal_disables)
+    )
+
+
 def test_tool_decorators_enforce_tag_partition():
     """No @mcp.tool() decorator may carry both 'kitchen' and 'fleet'/'fleet-dispatch'."""
     tools_dir = _SRC_ROOT / "server" / "tools"

--- a/tests/arch/test_transforms_hygiene.py
+++ b/tests/arch/test_transforms_hygiene.py
@@ -324,7 +324,7 @@ def test_startup_disables_all_visibility_tags():
     source = server_init.read_text()
     tree = ast.parse(source, filename=str(server_init))
 
-    canonical_loop_found = False
+    canonical_loop_count = 0
     standalone_literal_disables = []
 
     for node in tree.body:
@@ -366,7 +366,7 @@ def test_startup_disables_all_visibility_tags():
                         and isinstance(kw.value.elts[0], ast.Name)
                         and kw.value.elts[0].id == loop_var
                     ):
-                        canonical_loop_found = True
+                        canonical_loop_count += 1
 
         elif isinstance(node, ast.Expr):
             call = node.value
@@ -390,9 +390,10 @@ def test_startup_disables_all_visibility_tags():
                             f"line {node.lineno}: mcp.disable(tags={sorted(tag_vals)})"
                         )
 
-    assert canonical_loop_found, (
-        "server/__init__.py must have a top-level for-loop over ALL_VISIBILITY_TAGS "
+    assert canonical_loop_count == 1, (
+        "server/__init__.py must have exactly one top-level for-loop over ALL_VISIBILITY_TAGS "
         "whose body calls mcp.disable(tags={<loop_var>}). "
+        f"Found {canonical_loop_count}. "
         "Replace manual per-tag mcp.disable() calls with: "
         "for tag in sorted(ALL_VISIBILITY_TAGS): mcp.disable(tags={tag})"
     )

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -347,6 +347,102 @@ class TestSessionTypeVisibility:
         for name in GATED_TOOLS:
             assert name not in tool_names, f"{name} should be hidden after conftest reset"
 
+    @pytest.mark.anyio
+    async def test_orchestrator_headless_hides_fleet_tools(self, monkeypatch):
+        """Regression guard: fleet tools must NOT be visible in orchestrator+headless sessions."""
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_MODE_ENV_VAR, FLEET_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.delenv(FLEET_MODE_ENV_VAR, raising=False)
+        _apply_session_type_visibility()
+
+        visible = {t.name for t in await mcp.list_tools()}
+        assert visible.isdisjoint(FLEET_TOOLS), (
+            f"Fleet tools visible in orchestrator+headless: {visible & FLEET_TOOLS}"
+        )
+        assert visible.isdisjoint(FLEET_DISPATCH_TOOLS), (
+            f"Fleet-dispatch visible in orchestrator+headless: {visible & FLEET_DISPATCH_TOOLS}"
+        )
+
+    @pytest.mark.anyio
+    async def test_orchestrator_interactive_hides_fleet_tools(self, monkeypatch):
+        """Regression guard: fleet tools must NOT be visible in orchestrator+interactive
+        sessions."""
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_MODE_ENV_VAR, FLEET_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        monkeypatch.delenv(FLEET_MODE_ENV_VAR, raising=False)
+        _apply_session_type_visibility()
+
+        visible = {t.name for t in await mcp.list_tools()}
+        assert visible.isdisjoint(FLEET_TOOLS), (
+            f"Fleet tools visible in orchestrator+interactive: {visible & FLEET_TOOLS}"
+        )
+        assert visible.isdisjoint(FLEET_DISPATCH_TOOLS), (
+            f"Fleet-dispatch visible in orchestrator+interactive: {visible & FLEET_DISPATCH_TOOLS}"
+        )
+
+    @pytest.mark.anyio
+    async def test_skill_headless_hides_fleet_tools(self, monkeypatch):
+        """Regression guard: fleet tools must NOT be visible in skill+headless sessions."""
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_MODE_ENV_VAR, FLEET_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.delenv(FLEET_MODE_ENV_VAR, raising=False)
+        _apply_session_type_visibility()
+
+        visible = {t.name for t in await mcp.list_tools()}
+        assert visible.isdisjoint(FLEET_TOOLS), (
+            f"Fleet tools visible in skill+headless: {visible & FLEET_TOOLS}"
+        )
+        assert visible.isdisjoint(FLEET_DISPATCH_TOOLS), (
+            f"Fleet-dispatch tools visible in skill+headless: {visible & FLEET_DISPATCH_TOOLS}"
+        )
+
+    @pytest.mark.anyio
+    async def test_skill_interactive_hides_fleet_tools(self, monkeypatch):
+        """Regression guard: fleet tools must NOT be visible in skill+interactive sessions."""
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_MODE_ENV_VAR, FLEET_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        monkeypatch.delenv(FLEET_MODE_ENV_VAR, raising=False)
+        _apply_session_type_visibility()
+
+        visible = {t.name for t in await mcp.list_tools()}
+        assert visible.isdisjoint(FLEET_TOOLS), (
+            f"Fleet tools visible in skill+interactive: {visible & FLEET_TOOLS}"
+        )
+        assert visible.isdisjoint(FLEET_DISPATCH_TOOLS), (
+            f"Fleet-dispatch tools visible in skill+interactive: {visible & FLEET_DISPATCH_TOOLS}"
+        )
+
+    @pytest.mark.anyio
+    async def test_no_session_type_hides_fleet_tools(self, monkeypatch):
+        """Regression guard: fleet tools must NOT be visible when no session type is set."""
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_MODE_ENV_VAR, FLEET_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        monkeypatch.delenv(FLEET_MODE_ENV_VAR, raising=False)
+        _apply_session_type_visibility()
+
+        visible = {t.name for t in await mcp.list_tools()}
+        assert visible.isdisjoint(FLEET_TOOLS), (
+            f"Fleet tools visible with no session type: {visible & FLEET_TOOLS}"
+        )
+        assert visible.isdisjoint(FLEET_DISPATCH_TOOLS), (
+            f"Fleet-dispatch tools visible with no session type: {visible & FLEET_DISPATCH_TOOLS}"
+        )
+
 
 @pytest.mark.feature("fleet")
 class TestFleetAutoGateBoot:


### PR DESCRIPTION
## Summary

Fleet-tagged and fleet-dispatch-tagged MCP tools are visible in `tools/list` for ALL session types because `server/__init__.py` only disables `kitchen` and `plan-review` at startup — but `_apply_session_type_visibility()` assumes ALL conditional tags start disabled. The fix replaces manual per-tag `mcp.disable()` calls with a loop over `ALL_VISIBILITY_TAGS`, matching what the test conftest already does, and adds an arch test that structurally prevents regression by asserting the startup disable set covers all conditionally-enabled tags.

Closes #3337

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-161302-799487/.autoskillit/temp/rectify/rectify_fleet_tag_visibility_leak_2026-05-30_163500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 3.0k | 28.3k | 1.9M | 116.5k | 213 | 173.2k | 22m 21s |
| review_approach* | sonnet | 1 | 3.5k | 5.9k | 181.2k | 42.1k | 42 | 29.0k | 2m 58s |
| dry_walkthrough* | opus | 2 | 856 | 16.6k | 1.2M | 66.7k | 145 | 81.7k | 9m 29s |
| implement* | sonnet | 2 | 394 | 20.8k | 2.6M | 86.4k | 120 | 92.7k | 9m 36s |
| audit_impl* | sonnet | 2 | 580 | 21.5k | 574.3k | 53.7k | 95 | 93.8k | 11m 34s |
| make_plan* | sonnet | 1 | 111 | 6.4k | 478.6k | 48.7k | 29 | 35.0k | 1m 59s |
| prepare_pr* | sonnet | 1 | 72.5k | 3.2k | 185.7k | 31.0k | 19 | 43.9k | 1m 6s |
| compose_pr* | sonnet | 1 | 37.6k | 1.3k | 182.9k | 31.0k | 14 | 15.5k | 39s |
| review_pr* | sonnet | 1 | 150 | 41.1k | 807.7k | 87.6k | 67 | 73.8k | 9m 56s |
| resolve_review* | opus | 1 | 548 | 12.8k | 1.2M | 77.7k | 60 | 62.0k | 9m 42s |
| **Total** | | | 119.3k | 158.0k | 9.4M | 116.5k | | 700.7k | 1h 19m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 229 | 11395.9 | 405.0 | 90.9 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 309304.8 | 15498.2 | 3208.0 |
| **Total** | **233** | 40464.3 | 3007.4 | 678.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.0k | 28.3k | 1.9M | 173.2k | 22m 21s |
| sonnet | 7 | 114.9k | 100.3k | 5.0M | 383.8k | 37m 50s |
| opus | 2 | 1.4k | 29.4k | 2.5M | 143.7k | 19m 12s |